### PR TITLE
fix: add 15s polling to Documents page (ENC-ISS-019)

### DIFF
--- a/ui/src/pages/DocumentsListPage.tsx
+++ b/ui/src/pages/DocumentsListPage.tsx
@@ -24,7 +24,7 @@ export function DocumentsListPage() {
 
   // Documents require a project selection — default to first available
   const selectedProject = filters.projectId ?? projects[0]?.project_id ?? ''
-  const { documents, isPending, isError } = useDocuments(selectedProject, filters)
+  const { documents, isPending, isError } = useDocuments(selectedProject, filters, { polling: true })
   const { visible, sentinelRef, hasMore, total } = useInfiniteList(documents)
 
   if (!projects.length) return <LoadingState />


### PR DESCRIPTION
## Summary

- Adds 15-second automatic polling (`refetchInterval`) to the Documents page via `useDocuments` hook, matching the Feed page's real-time update pattern
- Newly created documents now appear within 15 seconds without requiring manual refresh or window focus change
- Includes session-expired-aware error handling consistent with the Feed page (`useFeed`)

## Root Cause Analysis

The Documents page (`DocumentsListPage`) used `useDocuments` which only fetched documents once on mount, relying on TanStack Query's default `staleTime` (2 min) and `refetchOnWindowFocus` for updates. Unlike the Feed page which polls every 3 seconds via `refetchInterval`, documents created during an active session would not appear until the user:
- Switched away and back (triggering window focus refetch)
- Waited 2+ minutes and navigated to the page
- Did a full page refresh

## Changes

| File | Change |
|------|--------|
| `ui/src/hooks/useDocuments.ts` | Added `UseDocumentsOptions` interface with `polling` flag; wired `refetchInterval: 15_000` when enabled; added session-expired retry handling |
| `ui/src/pages/DocumentsListPage.tsx` | Enabled polling: `useDocuments(project, filters, { polling: true })` |

## Design Decisions

- **15s interval** (vs Feed's 3s): The document API queries DynamoDB directly via the `project-updated-index` GSI, while the Feed reads from a pre-generated S3 file. 15s balances freshness with DynamoDB read cost.
- **Opt-in polling**: The `{ polling }` option keeps the hook backward-compatible — other consumers (e.g., `ProjectPrimaryDocumentsPage`) continue with default behavior.

## Test Plan

- [ ] Navigate to Docs page → verify documents load initially
- [ ] Create a new document via `docstore.py` → verify it appears within 15s on the Docs page without refresh
- [ ] Switch browser tabs away and back → verify no duplicate requests or errors
- [ ] Verify session expiry is handled gracefully (no overlay from background polling)
- [ ] Verify Feed page 3s polling still works independently

Resolves: ENC-ISS-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)