### PR TITLE
feat: switch Docs page to S3-backed documents feed

### DIFF
--- a/ui/src/api/feeds.ts
+++ b/ui/src/api/feeds.ts
@@ -1,4 +1,4 @@
-import type { Task, Issue, Feature, ProjectsFeed, TasksFeed, IssuesFeed, FeaturesFeed } from '../types/feeds'
+import type { Task, Issue, Feature, ProjectsFeed, TasksFeed, IssuesFeed, FeaturesFeed, DocumentsFeed } from '../types/feeds'
 import { fetchFeed, fetchWithAuth } from './client'
 
 const BASE_URL = import.meta.env.VITE_FEED_BASE_URL || '/mobile/v1'
@@ -8,6 +8,7 @@ export const feedKeys = {
   tasks: ['feed', 'tasks'] as const,
   issues: ['feed', 'issues'] as const,
   features: ['feed', 'features'] as const,
+  documents: ['feed', 'documents'] as const,
   liveFeed: ['feed', 'live'] as const,
   reference: (projectId: string) => ['feed', 'reference', projectId] as const,
 }
@@ -31,6 +32,7 @@ export const fetchProjects = () => fetchFeed<ProjectsFeed>('projects')
 export const fetchTasks = () => fetchFeed<TasksFeed>('tasks')
 export const fetchIssues = () => fetchFeed<IssuesFeed>('issues')
 export const fetchFeatures = () => fetchFeed<FeaturesFeed>('features')
+export const fetchDocumentsFeed = () => fetchFeed<DocumentsFeed>('documents')
 
 export async function fetchProjectReference(projectId: string): Promise<string> {
   const url = `${BASE_URL}/reference/${projectId}.md`

--- a/ui/src/pages/DocumentsListPage.tsx
+++ b/ui/src/pages/DocumentsListPage.tsx
@@ -22,9 +22,9 @@ export function DocumentsListPage() {
   const { filters, toggleArrayFilter, setFilter } = useFilterState<DocumentFilters>({})
   const { projects } = useProjects()
 
-  // Documents require a project selection — default to first available
+  // Default to first available project; projectId is now part of filters for the S3 feed hook
   const selectedProject = filters.projectId ?? projects[0]?.project_id ?? ''
-  const { documents, isPending, isError } = useDocuments(selectedProject, filters, { polling: true })
+  const { documents, isPending, isError } = useDocuments({ ...filters, projectId: selectedProject }, { polling: true })
   const { visible, sentinelRef, hasMore, total } = useInfiniteList(documents)
 
   if (!projects.length) return <LoadingState />

--- a/ui/src/types/feeds.ts
+++ b/ui/src/types/feeds.ts
@@ -106,6 +106,10 @@ export interface FeaturesFeed extends FeedEnvelope<Feature> {
   features: Feature[]
 }
 
+export interface DocumentsFeed extends FeedEnvelope<Document> {
+  documents: Document[]
+}
+
 export interface Document {
   document_id: string
   project_id: string


### PR DESCRIPTION
## Summary
- Switches the Documents page from direct DynamoDB API calls to the new S3-backed `documents.json` feed
- The feed publisher Lambda (`devops-feed-publisher`) now generates `documents.json` alongside `tasks.json`/`issues.json`/`features.json`
- Documents are served via CloudFront CDN instead of per-request Lambda→DynamoDB calls

## Backend changes (already deployed)
- `feed_utils.py`: Added `fetch_documents_from_dynamodb()`, `_transform_document()`, `generate_documents_feed()`
- `devops-feed-publisher` Lambda: Fetches documents from `documents` DynamoDB table and generates `documents.json` in S3
- IAM policy: Added `dynamodb:Query` on `documents` table and `project-updated-index` GSI
- Verified: `mobile/v1/documents.json` now contains 329 documents across 10 projects (including DOC-84F058066EB9)

## PWA changes (this PR)
- `types/feeds.ts`: Add `DocumentsFeed` interface
- `api/feeds.ts`: Add `feedKeys.documents` query key and `fetchDocumentsFeed()` function
- `hooks/useDocuments.ts`: Switch from `fetchDocumentsByProject()` (DynamoDB API) to `fetchDocumentsFeed()` (S3 feed). All filtering (project, status, search, sort) is now client-side
- `pages/DocumentsListPage.tsx`: Update `useDocuments` call to pass `projectId` inside filters

## Test plan
- [ ] Open PWA at `/documents` → documents load from S3 feed (faster initial load)
- [ ] Select different projects → client-side filter works instantly (no new API call)
- [ ] Search for "Ontology" → DOC-84F058066EB9 appears in results
- [ ] Verify existing Feed page (`/feed`) behavior unchanged (no document type)
- [ ] Verify document detail pages still work (they use `api/documents.ts`, not the feed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)