### PR TITLE
ENC: merge residual async coordination_api deploy deltas

### DIFF
--- a/backend/lambda/coordination_api/__init__.py
+++ b/backend/lambda/coordination_api/__init__.py
@@ -1,0 +1,1 @@
+"""coordination_api package — modularized Lambda function."""


### PR DESCRIPTION
## Summary
- merge remaining safe async snapshot deltas not included in PR #9
- add `coordination_api/__init__.py` package marker preserved from async snapshot
- apply deploy script improvements for Python file packaging and route reconciliation idempotency

## Validation
- `bash -n backend/lambda/coordination_api/deploy.sh`
- `python3 -m pytest -q backend/lambda/coordination_api/test_lambda_function.py`
  - Result: `123 passed`
