### PR TITLE
fix: Lambda layer platform + redirect timer (ENC-ISS-044)

### DIFF
--- a/frontend/ui/src/pages/CreateProjectPage.tsx
+++ b/frontend/ui/src/pages/CreateProjectPage.tsx
@@ -176,7 +176,7 @@ export function CreateProjectPage() {
         });
         setSubmission({ isLoading: false, success: false });
         navigate(`/projects/${createdProjectId}`, { replace: true });
-      }, 2000);
+      }, 3000);
     } catch (error) {
       let errorMessage = 'Failed to create project';
 


### PR DESCRIPTION
## Summary
- **Root cause fix**: Rebuilt `enceladus-shared` Lambda layer (v3→v6) — layer v3 was compiled on macOS (darwin) with cpython-310 binaries, but all 14 Lambdas run on Linux x86_64 Python 3.11. The `cryptography` and `cffi` C extensions couldn't load, causing `import jwt` to fail silently. This made every authenticated request return 401 "JWT library not available in Lambda package".
- **UI enhancement**: Increased post-creation success redirect timer from 2s to 3s per user request.

## What was broken
Every POST to `/api/v1/projects` failed at JWT validation because `_JWT_AVAILABLE = False` (the `import jwt` at module load caught an `ImportError` from the macOS-compiled `_cffi_backend.cpython-310-darwin.so`). The Lambda returned 401 on every request regardless of valid credentials.

## Fix applied
1. Rebuilt `enceladus-shared` layer v6 with `manylinux2014_x86_64` binaries for Python 3.11
2. Updated all 14 Lambdas to use layer v6 (infrastructure change, already deployed)
3. Updated redirect timer from 2000ms to 3000ms (frontend change, this PR)

## Test plan
- [x] Lambda layer rebuilt with correct platform binaries
- [x] All 14 Lambdas updated to layer v6
- [x] Test invocation confirms proper auth error (no more "JWT library not available")
- [ ] End-to-end: create a project via UI and verify success message + 3s redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)