### PR TITLE
Use dedicated backend deploy IAM role (ENC-TSK-564)

### DIFF
--- a/.github/workflows/api-mcp-backend-deploy.yml
+++ b/.github/workflows/api-mcp-backend-deploy.yml
@@ -40,20 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials (OIDC role)
-        id: aws_oidc
-        continue-on-error: true
+      - name: Configure AWS credentials (OIDC backend deploy role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Configure AWS credentials (static keys fallback)
-        if: ${{ steps.aws_oidc.outcome != 'success' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Verify AWS identity


### PR DESCRIPTION
## Summary
- Switch API MCP Backend Deploy workflow from shared `enceladus-ui-deploy-github-role` to new `enceladus-backend-deploy-github-role`
- New role has proper permissions for backend Lambda deployment (including DynamoDB table management for infrastructure tables)
- Explicit deny on governed tables (devops-project-tracker, projects, documents) and governance S3 prefixes
- Remove static key fallback — OIDC-only authentication
- New GitHub secret `AWS_BACKEND_ROLE_TO_ASSUME` set with the role ARN

## Context
Phase 1 of Three-Role IAM Model (ENC-TSK-564, DOC-2F0AC0F85B2B). The previous run of this workflow (run 22385425266) failed because `enceladus-ui-deploy-github-role` lacked `dynamodb:CreateTable` permission.

## Test plan
- [ ] PR merge triggers the workflow on main
- [ ] Workflow should successfully deploy coordination_api Lambda
- [ ] Verify Validate deployed Lambda state step shows Active + Successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)