### PR TITLE
chore: update MCP gateway URL to mcp.jreese.net (v2 code-mode)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Enceladus Workspace — Agent Bootstrap
 
-MCP server `enceladus` is configured in `~/.codex/config.toml`.
-Source: `tools/enceladus-mcp-server/server.py`
+Managed MCP profile: remote HTTP (code-mode only)
+Remote URL: `https://mcp.jreese.net`
+Source: `tools/enceladus-mcp-server/server.py` (deployed as Lambda)
 
 ## Initialization (REQUIRED — run in order every session)
 

--- a/tools/enceladus-mcp-server/install_profile.sh
+++ b/tools/enceladus-mcp-server/install_profile.sh
@@ -22,7 +22,7 @@ CLAUDE_SETTINGS_DIR="${ENCELADUS_MCP_CLAUDE_SETTINGS_DIR:-${HOME}/.claude}"
 CODEX_SETTINGS_DIR="${ENCELADUS_MCP_CODEX_SETTINGS_DIR:-${HOME}/.codex}"
 
 # Remote MCP gateway URL (ENC-TSK-862, ENC-TSK-864)
-MCP_GATEWAY_URL="${ENCELADUS_MCP_GATEWAY_URL:-https://jreese.net/api/v1/coordination/mcp}"
+MCP_GATEWAY_URL="${ENCELADUS_MCP_GATEWAY_URL:-https://mcp.jreese.net}"
 
 # Python is needed for JSON/TOML config file manipulation only (not for MCP runtime).
 PYTHON_BIN="${ENCELADUS_MCP_PYTHON_BIN:-$(command -v python3 || true)}"
@@ -256,7 +256,7 @@ if [ ! -f "${CODEX_GLOBAL_AGENTS_MD}" ] \
 # Codex Bootstrap
 
 Managed MCP profile: remote HTTP
-Remote URL: `https://jreese.net/api/v1/coordination/mcp`
+Remote URL: `https://mcp.jreese.net`
 
 MCP server `enceladus` is configured in `~/.codex/config.toml`.
 
@@ -298,7 +298,7 @@ if [ ! -f "${WORKSPACE_AGENTS_MD}" ] \
 # Enceladus Workspace — Agent Bootstrap
 
 Managed MCP profile: remote HTTP
-Remote URL: `https://jreese.net/api/v1/coordination/mcp`
+Remote URL: `https://mcp.jreese.net`
 
 MCP server `enceladus` is configured via remote HTTP gateway.
 Source: `tools/enceladus-mcp-server/server.py` (deployed as Lambda)
@@ -359,7 +359,7 @@ if [ ! -f "${CLAUDE_GLOBAL_MD}" ] \
 
 Source: `governance://agents/bootstrap-template.md`
 Managed MCP profile: remote HTTP
-Remote URL: `https://jreese.net/api/v1/coordination/mcp`
+Remote URL: `https://mcp.jreese.net`
 
 ## Session Init
 


### PR DESCRIPTION
## Summary
- Update `install_profile.sh` default gateway URL from `jreese.net/api/v1/coordination/mcp` to `mcp.jreese.net`
- Update all heredoc template URL references (AGENTS.md, CLAUDE.md templates) in the installer
- Update repo `AGENTS.md` to reflect remote HTTP code-mode endpoint

Part of the MCP v2 migration — all local configs have been updated separately (not in this PR) to point to the new endpoint.

## Test plan
- [ ] Run `install_profile.sh` on a clean machine / after wiping configs
- [ ] Verify generated configs contain `mcp.jreese.net` URL
- [ ] Verify MCP smoke test passes against new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)