### PR TITLE
fix: move plans to documents page (ENC-TSK-B25 / ENC-ISS-152)

### DIFF
--- a/frontend/ui/src/components/cards/FeedRow.tsx
+++ b/frontend/ui/src/components/cards/FeedRow.tsx
@@ -3,14 +3,12 @@ import { TaskRow } from './TaskRow'
 import { IssueRow } from './IssueRow'
 import { FeatureRow } from './FeatureRow'
 import { LessonRow } from './LessonRow'
-import { PlanRow } from './PlanRow'
 
 const BORDER_COLOR: Record<string, string> = {
   task: 'border-l-blue-400',
   issue: 'border-l-amber-400',
   feature: 'border-l-emerald-400',
   lesson: 'border-l-purple-400',
-  plan: 'border-l-indigo-400',
 }
 
 export function FeedRow({ item }: { item: FeedItem }) {
@@ -20,7 +18,6 @@ export function FeedRow({ item }: { item: FeedItem }) {
       {item._type === 'issue' && <IssueRow issue={item.data} />}
       {item._type === 'feature' && <FeatureRow feature={item.data} />}
       {item._type === 'lesson' && <LessonRow lesson={item.data} />}
-      {item._type === 'plan' && <PlanRow plan={item.data} />}
     </div>
   )
 }

--- a/frontend/ui/src/hooks/useFeed.ts
+++ b/frontend/ui/src/hooks/useFeed.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { feedKeys, fetchTasks, fetchIssues, fetchFeatures } from '../api/feeds'
 import { useLiveFeed } from '../contexts/LiveFeedContext'
 import { PRIORITY_ORDER } from '../lib/constants'
-import type { Task, Issue, Feature, Lesson, Plan } from '../types/feeds'
+import type { Task, Issue, Feature, Lesson } from '../types/feeds'
 import type { FeedItem } from '../types/feed'
 import type { FeedFilters } from '../types/filters'
 
@@ -26,7 +26,7 @@ interface UseFeedOptions {
 
 export function useFeed(filters?: FeedFilters, _options?: UseFeedOptions) {
   // Live data from the global delta-polling provider (ENC-TSK-609).
-  const { tasks: liveTasks, issues: liveIssues, features: liveFeatures, lessons: liveLessons, plans: livePlans, generatedAt: liveGeneratedAt } = useLiveFeed()
+  const { tasks: liveTasks, issues: liveIssues, features: liveFeatures, lessons: liveLessons, generatedAt: liveGeneratedAt } = useLiveFeed()
   const hasLiveSnapshot = liveGeneratedAt !== null
 
   // S3 feeds as fallback for initial load before LiveFeedProvider hydrates.
@@ -38,7 +38,6 @@ export function useFeed(filters?: FeedFilters, _options?: UseFeedOptions) {
   const issues: Issue[] = hasLiveSnapshot ? liveIssues : (issuesQuery.data?.issues ?? [])
   const features: Feature[] = hasLiveSnapshot ? liveFeatures : (featuresQuery.data?.features ?? [])
   const lessons: Lesson[] = hasLiveSnapshot ? liveLessons : []
-  const plans: Plan[] = hasLiveSnapshot ? livePlans : []
 
   // Pending only while live context hasn't loaded AND S3 feeds are still loading.
   const isPending = !hasLiveSnapshot
@@ -55,7 +54,7 @@ export function useFeed(filters?: FeedFilters, _options?: UseFeedOptions) {
   const items = useMemo(() => {
     const merged: FeedItem[] = []
 
-    const types = filters?.recordType?.length ? filters.recordType : ['task', 'issue', 'feature', 'lesson', 'plan']
+    const types = filters?.recordType?.length ? filters.recordType : ['task', 'issue', 'feature', 'lesson']
 
     if (types.includes('task') && tasks.length) {
       for (const t of tasks) {
@@ -77,12 +76,6 @@ export function useFeed(filters?: FeedFilters, _options?: UseFeedOptions) {
         merged.push({ _type: 'lesson', _id: l.lesson_id, _updated_at: l.updated_at, _created_at: l.created_at, data: l })
       }
     }
-    if (types.includes('plan') && plans.length) {
-      for (const p of plans) {
-        merged.push({ _type: 'plan', _id: p.plan_id, _updated_at: p.updated_at, _created_at: p.created_at, data: p })
-      }
-    }
-
     let result = merged
 
     if (filters?.projectId) {
@@ -132,7 +125,6 @@ export function useFeed(filters?: FeedFilters, _options?: UseFeedOptions) {
     issues,
     features,
     lessons,
-    plans,
     filters?.projectId,
     filters?.recordType,
     filters?.status,

--- a/frontend/ui/src/lib/constants.ts
+++ b/frontend/ui/src/lib/constants.ts
@@ -127,7 +127,7 @@ export const PRIORITY_ORDER: Record<string, number> = {
 
 export const LESSON_STATUSES = ['draft', 'active', 'graduated', 'deprecated'] as const
 
-export const FEED_RECORD_TYPES = ['task', 'issue', 'feature', 'lesson', 'plan'] as const
+export const FEED_RECORD_TYPES = ['task', 'issue', 'feature', 'lesson'] as const
 
 export const RECORD_TYPE_LABELS: Record<string, string> = {
   task: 'Tasks',

--- a/frontend/ui/src/pages/DocumentsListPage.tsx
+++ b/frontend/ui/src/pages/DocumentsListPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useDocs2 } from '../hooks/useDocuments'
 import { useProjects } from '../hooks/useProjects'
 import { useFilterState } from '../hooks/useFilterState'
 import { useInfiniteList } from '../hooks/useInfiniteList'
+import { useLiveFeed } from '../contexts/LiveFeedContext'
 import { DocumentRow } from '../components/cards/DocumentRow'
+import { PlanRow } from '../components/cards/PlanRow'
 import { SearchInput } from '../components/shared/SearchInput'
 import { FilterBar } from '../components/shared/FilterBar'
 import { SortPicker } from '../components/shared/SortPicker'
@@ -32,6 +34,22 @@ export function DocumentsListPage() {
     refetch,
   } = useDocs2(filters)
 
+  // Plans from live feed (ENC-FTR-058 / ENC-ISS-152)
+  const { plans: allPlans } = useLiveFeed()
+  const filteredPlans = useMemo(() => {
+    let result = allPlans
+    if (filters.projectId) {
+      result = result.filter((p) => p.project_id === filters.projectId)
+    }
+    if (filters.search) {
+      const q = filters.search.toLowerCase()
+      result = result.filter(
+        (p) => p.title.toLowerCase().includes(q) || p.plan_id.toLowerCase().includes(q),
+      )
+    }
+    return result
+  }, [allPlans, filters.projectId, filters.search])
+
   const selectedProject = filters.projectId ?? defaultProject
 
   const { visible, sentinelRef, hasMore, resetPage } = useInfiniteList(documents)
@@ -49,7 +67,7 @@ export function DocumentsListPage() {
       {/* Header with count + refresh */}
       <div className="flex items-center justify-between">
         <span className="text-xs text-slate-500">
-          {visible.length} of {totalMatches} documents
+          {filteredPlans.length + visible.length} of {filteredPlans.length + totalMatches} items
         </span>
         <button
           onClick={() => refetch()}
@@ -106,12 +124,36 @@ export function DocumentsListPage() {
         onChange={(v) => setFilter('sortBy', v)}
       />
 
+      {/* Plans section (ENC-FTR-058 / ENC-ISS-152) */}
+      {filteredPlans.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold text-indigo-400 uppercase tracking-wider">
+              Plans
+            </span>
+            <span className="text-xs text-slate-500">({filteredPlans.length})</span>
+          </div>
+          {filteredPlans.map((p) => (
+            <PlanRow key={p.plan_id} plan={p} />
+          ))}
+        </div>
+      )}
+
+      {/* Documents section */}
       {isPending ? (
         <LoadingState />
       ) : isError ? (
         <ErrorState />
       ) : (
         <div className="space-y-2">
+          {filteredPlans.length > 0 && (visible.length > 0) && (
+            <div className="flex items-center gap-2 pt-2">
+              <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+                Documents
+              </span>
+              <span className="text-xs text-slate-500">({totalMatches})</span>
+            </div>
+          )}
           {visible.length ? (
             <>
               {visible.map((d) => (
@@ -120,7 +162,7 @@ export function DocumentsListPage() {
               <ScrollSentinel sentinelRef={sentinelRef} hasMore={hasMore} />
             </>
           ) : (
-            <EmptyState message="No documents match your filters" />
+            !filteredPlans.length && <EmptyState message="No documents match your filters" />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add plans section to DocumentsListPage with PlanRow cards from useLiveFeed().plans
- Plans rendered above documents with "Plans" header, filtered by project and search
- Remove plan rendering from feed page (FeedRow, useFeed, constants)
- Plans are governance artifacts that belong on the documents page, not the feed

## Remediates
ENC-ISS-152: Plans render on feed page instead of documents page

## Tasks
- ENC-TSK-B25: Add plans section to DocumentsListPage and remove from feed page

## Commit Evidence
CAI-0196f66caf7f43c1a711ac913f995624
(CCI blocked by checkout service GitHub token expiry — commit SHA 9f41858 is on GitHub)

## Test plan
- [ ] CI passes
- [ ] UI Backend Deploy succeeds
- [ ] Plans visible on /documents page after hard-refresh
- [ ] Plans NOT visible on /feed page

🤖 Generated with [Claude Code](https://claude.com/claude-code)