### PR TITLE
hotfix(feed-query): reduce history cap from 50 to 10 for Lambda 6MB limit

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-04.51",
-  "updated_at": "2026-04-04T18:50:00Z",
+  "version": "2026-04-04.52",
+  "updated_at": "2026-04-04T18:55:00Z",
   "owners": [
     "enceladus-platform"
   ],
@@ -3080,7 +3080,7 @@
       "fields": {
         "max_history_entries": {
           "type": "integer",
-          "definition": "Maximum number of history entries returned per record in the feed API response. When a record has more entries, only the most recent N are included. Current value: 50."
+          "definition": "Maximum number of history entries returned per record in the feed API response. When a record has more entries, only the most recent N are included. Current value: 10. Reduced from initial 50 due to Lambda 6MB response payload limit with 3000+ records."
         },
         "entry_shape": {
           "type": "object",

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-04.50",
-  "updated_at": "2026-04-04T02:48:00Z",
+  "version": "2026-04-04.51",
+  "updated_at": "2026-04-04T18:50:00Z",
   "owners": [
     "enceladus-platform"
   ],
@@ -3072,6 +3072,23 @@
             "deprecated"
           ],
           "definition": "Whitelist of valid lesson status values."
+        }
+      }
+    },
+    "feed_query.history_inclusion": {
+      "description": "Feed query Lambda history array population behavior (ENC-TSK-C01). All 5 record-type transform functions (_transform_task_from_ddb, _transform_issue_from_ddb, _transform_feature_from_ddb, _transform_plan_from_ddb, _transform_lesson_from_ddb) now extract history entries from DynamoDB L-type attributes via _ddb_history(). Previously hardcoded as empty arrays, blocking PWA history display.",
+      "fields": {
+        "max_history_entries": {
+          "type": "integer",
+          "definition": "Maximum number of history entries returned per record in the feed API response. When a record has more entries, only the most recent N are included. Current value: 50."
+        },
+        "entry_shape": {
+          "type": "object",
+          "definition": "Each history entry is normalized to {timestamp: string, status: string, description: string}, matching the HistoryEntry TypeScript interface consumed by the PWA HistoryFeed component."
+        },
+        "extraction_source": {
+          "type": "string",
+          "definition": "History is extracted from the DynamoDB 'history' attribute (L type containing M entries). Missing or malformed entries are skipped gracefully."
         }
       }
     },

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -349,7 +349,7 @@ def _ddb_str_set(item: Dict[str, Any], key: str) -> List[str]:
     return []
 
 
-MAX_HISTORY_ENTRIES = 50
+MAX_HISTORY_ENTRIES = 10
 
 
 def _ddb_history(item: Dict[str, Any], key: str = "history") -> List[Dict[str, str]]:

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -349,6 +349,35 @@ def _ddb_str_set(item: Dict[str, Any], key: str) -> List[str]:
     return []
 
 
+MAX_HISTORY_ENTRIES = 50
+
+
+def _ddb_history(item: Dict[str, Any], key: str = "history") -> List[Dict[str, str]]:
+    """Extract history entries from a DynamoDB item, capped at MAX_HISTORY_ENTRIES.
+
+    Returns a list of {timestamp, status, description} dicts matching the
+    HistoryEntry TypeScript interface consumed by the PWA HistoryFeed component.
+    Only the most recent entries are returned when the list exceeds the cap.
+    """
+    attr = item.get(key, {})
+    raw_list = attr.get("L")
+    if not isinstance(raw_list, list):
+        return []
+    entries: List[Dict[str, str]] = []
+    for entry in raw_list:
+        if not isinstance(entry, dict) or "M" not in entry:
+            continue
+        m = entry["M"]
+        entries.append({
+            "timestamp": m.get("timestamp", {}).get("S", ""),
+            "status": m.get("status", {}).get("S", ""),
+            "description": m.get("description", {}).get("S", ""),
+        })
+    if len(entries) > MAX_HISTORY_ENTRIES:
+        entries = entries[-MAX_HISTORY_ENTRIES:]
+    return entries
+
+
 def _ddb_list_of_maps(item: Dict[str, Any], key: str) -> List[Dict[str, Any]]:
     """Extract a list of maps from a DynamoDB item (L type containing M types).
 
@@ -827,7 +856,7 @@ def _transform_task_from_ddb(item: Dict[str, Any], project_id: str) -> Dict[str,
         "checklist_total": _ddb_int(item, "checklist_total"),
         "checklist_done": _ddb_int(item, "checklist_done"),
         "checklist": [],
-        "history": [],
+        "history": _ddb_history(item),
         "updated_at": _ddb_str(item, "updated_at") or None,
         "last_update_note": _ddb_str(item, "last_update_note") or None,
         "created_at": _ddb_str(item, "created_at") or None,
@@ -867,7 +896,7 @@ def _transform_issue_from_ddb(item: Dict[str, Any], project_id: str) -> Dict[str
         "related_feature_ids": _ddb_str_set(item, "related_feature_ids"),
         "related_task_ids": _ddb_str_set(item, "related_task_ids"),
         "related_issue_ids": _ddb_str_set(item, "related_issue_ids"),
-        "history": [],
+        "history": _ddb_history(item),
         "updated_at": _ddb_str(item, "updated_at") or None,
         "last_update_note": _ddb_str(item, "last_update_note") or None,
         "created_at": _ddb_str(item, "created_at") or None,
@@ -894,7 +923,7 @@ def _transform_feature_from_ddb(item: Dict[str, Any], project_id: str) -> Dict[s
         "related_task_ids": _ddb_str_set(item, "related_task_ids"),
         "related_feature_ids": _ddb_str_set(item, "related_feature_ids"),
         "related_issue_ids": _ddb_str_set(item, "related_issue_ids"),
-        "history": [],
+        "history": _ddb_history(item),
         "updated_at": _ddb_str(item, "updated_at") or None,
         "last_update_note": _ddb_str(item, "last_update_note") or None,
         "created_at": _ddb_str(item, "created_at") or None,
@@ -933,7 +962,7 @@ def _transform_plan_from_ddb(item: Dict[str, Any], project_id: str) -> Dict[str,
         "related_task_ids": _ddb_str_set(item, "related_task_ids"),
         "related_issue_ids": _ddb_str_set(item, "related_issue_ids"),
         "related_feature_ids": _ddb_str_set(item, "related_feature_ids"),
-        "history": [],
+        "history": _ddb_history(item),
         "updated_at": _ddb_str(item, "updated_at") or None,
         "last_update_note": _ddb_str(item, "last_update_note") or None,
         "created_at": _ddb_str(item, "created_at") or None,
@@ -977,7 +1006,7 @@ def _transform_lesson_from_ddb(item: Dict[str, Any], project_id: str) -> Dict[st
         "related_task_ids": _ddb_str_set(item, "related_task_ids"),
         "related_issue_ids": _ddb_str_set(item, "related_issue_ids"),
         "related_feature_ids": _ddb_str_set(item, "related_feature_ids"),
-        "history": [],
+        "history": _ddb_history(item),
         "updated_at": _ddb_str(item, "updated_at") or None,
         "last_update_note": _ddb_str(item, "last_update_note") or None,
         "created_at": _ddb_str(item, "created_at") or None,


### PR DESCRIPTION
## Summary
- Reduces MAX_HISTORY_ENTRIES from 50 to 10 to prevent Lambda 6MB response payload overflow
- Initial deploy with 50 entries caused production 413 (3000+ records × 50 entries ≈ 30MB)
- Updates governance dictionary to document reduced cap

## Urgency
**Production hotfix** — GET /api/v1/feed currently returns 500/413, blocking the PWA

## Task
ENC-TSK-C01 (re-entry arc from deploy-success)

## Commit Gate
CCI-4103997c368a4b42958de551ae35b928

🤖 Generated with [Claude Code](https://claude.com/claude-code)