### PR TITLE
ENC-TSK-C58: add product-lead-inspect IAM deploy assets

### DIFF
--- a/infra/iam/product-lead-inspect-policy.json
+++ b/infra/iam/product-lead-inspect-policy.json
@@ -1,0 +1,228 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "IdentityAndCloudWatchRead",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DynamoDbReadAcrossEnceladusTables",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:ListTables",
+        "dynamodb:Query",
+        "dynamodb:Scan"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3ListAllBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3BucketMetadataRead",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::devops-agentcli-compute",
+        "arn:aws:s3:::jreese-net"
+      ]
+    },
+    {
+      "Sid": "S3ObjectRead",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::devops-agentcli-compute/*",
+        "arn:aws:s3:::jreese-net/*"
+      ]
+    },
+    {
+      "Sid": "ScopedS3WriteForAnalyticsAndExports",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::devops-agentcli-compute/projects/sync-stage/*",
+        "arn:aws:s3:::jreese-net/exports/*"
+      ]
+    },
+    {
+      "Sid": "ExplicitlyDenyS3DeleteAndAclMutation",
+      "Effect": "Deny",
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:PutBucketAcl",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "LambdaInspect",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:ListFunctions"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InvokeParquetTransformer",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": [
+        "arn:aws:lambda:us-west-2:356364570033:function:devops-json-to-parquet-transformer",
+        "arn:aws:lambda:us-west-2:356364570033:function:devops-json-to-parquet-transformer:*"
+      ]
+    },
+    {
+      "Sid": "GlueReadAndCrawlerOps",
+      "Effect": "Allow",
+      "Action": [
+        "glue:CreateCrawler",
+        "glue:GetCrawler",
+        "glue:GetCrawlers",
+        "glue:GetDatabase",
+        "glue:GetDatabases",
+        "glue:GetTable",
+        "glue:GetTables",
+        "glue:StartCrawler"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassOnlyTheExistingGlueCrawlerRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::356364570033:role/GlueCrawlerDevOpsRole",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "glue.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SqsInspect",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:GetQueueAttributes",
+        "sqs:ListQueues",
+        "sqs:ReceiveMessage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SnsInspect",
+      "Effect": "Allow",
+      "Action": [
+        "sns:GetTopicAttributes",
+        "sns:ListSubscriptions",
+        "sns:ListSubscriptionsByTopic",
+        "sns:ListTopics"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsDescribeOnly",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ApiGatewayRead",
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:GET"
+      ],
+      "Resource": "arn:aws:apigateway:us-west-2::/*"
+    },
+    {
+      "Sid": "CognitoRead",
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPool",
+        "cognito-idp:ListUserPools",
+        "cognito-idp:ListUsers"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:GetRole",
+        "iam:GetUser",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListAttachedUserPolicies",
+        "iam:ListPolicies",
+        "iam:ListRoles"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyDynamoDbWrites",
+      "Effect": "Deny",
+      "Action": [
+        "dynamodb:BatchWriteItem",
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteItem",
+        "dynamodb:DeleteTable",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyLambdaMutations",
+      "Effect": "Deny",
+      "Action": [
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyAssumeRole",
+      "Effect": "Deny",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infrastructure/scripts/deploy_product_lead_inspect.sh
+++ b/infrastructure/scripts/deploy_product_lead_inspect.sh
@@ -11,7 +11,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 POLICY_FILE="${ROOT_DIR}/infra/iam/product-lead-inspect-policy.json"
 
 log() {
-  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
 }
 
 usage() {

--- a/infrastructure/scripts/deploy_product_lead_inspect.sh
+++ b/infrastructure/scripts/deploy_product_lead_inspect.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="product-lead"
+USER_NAME="product-lead-inspect"
+POLICY_NAME="product-lead-inspect-policy"
+CREATE_ACCESS_KEY="false"
+ACCESS_KEY_OUTPUT=""
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POLICY_FILE="${ROOT_DIR}/infra/iam/product-lead-inspect-policy.json"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: deploy_product_lead_inspect.sh [options]
+
+Creates or updates the product-lead-inspect IAM user and managed policy.
+
+Options:
+  --profile <name>            AWS CLI profile to use (default: product-lead)
+  --user-name <name>          IAM user name (default: product-lead-inspect)
+  --policy-name <name>        Managed policy name (default: product-lead-inspect-policy)
+  --policy-file <path>        Policy JSON path (default: infra/iam/product-lead-inspect-policy.json)
+  --create-access-key         Create a fresh access key for the IAM user
+  --access-key-output <path>  Write create-access-key JSON to this path
+  --help                      Show this help text
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  }
+}
+
+aws_cli() {
+  aws --profile "${PROFILE}" "$@"
+}
+
+ensure_user() {
+  if aws_cli iam get-user --user-name "${USER_NAME}" >/dev/null 2>&1; then
+    log "[OK] user exists: ${USER_NAME}"
+    return
+  fi
+
+  log "[START] creating IAM user ${USER_NAME}"
+  aws_cli iam create-user \
+    --user-name "${USER_NAME}" \
+    --tags \
+      Key=Purpose,Value="Enceladus inspect access with scoped S3 write" \
+      Key=CreatedBy,Value="ENC-TSK-C58" \
+      Key=ManagedBy,Value="deploy_product_lead_inspect.sh" >/dev/null
+  log "[END] created IAM user ${USER_NAME}"
+}
+
+get_policy_arn() {
+  local account_id
+  account_id="$(aws_cli sts get-caller-identity --query 'Account' --output text)"
+  printf 'arn:aws:iam::%s:policy/%s\n' "${account_id}" "${POLICY_NAME}"
+}
+
+delete_oldest_nondefault_policy_version() {
+  local policy_arn="$1"
+  local removable
+  removable="$(
+    aws_cli iam list-policy-versions --policy-arn "${policy_arn}" --output json \
+      | jq -r '.Versions | map(select(.IsDefaultVersion | not)) | sort_by(.CreateDate) | .[0].VersionId // empty'
+  )"
+  if [[ -n "${removable}" ]]; then
+    log "[INFO] deleting oldest non-default policy version ${removable}"
+    aws_cli iam delete-policy-version --policy-arn "${policy_arn}" --version-id "${removable}"
+  fi
+}
+
+ensure_policy() {
+  local policy_arn current_version current_doc current_sorted desired_sorted version_count
+  policy_arn="$(get_policy_arn)"
+
+  if ! aws_cli iam get-policy --policy-arn "${policy_arn}" >/dev/null 2>&1; then
+    log "[START] creating managed policy ${POLICY_NAME}"
+    aws_cli iam create-policy \
+      --policy-name "${POLICY_NAME}" \
+      --description "Wide Enceladus inspect access with scoped S3 write (ENC-TSK-C58)" \
+      --policy-document "file://${POLICY_FILE}" >/dev/null
+    log "[END] created managed policy ${POLICY_NAME}"
+    printf '%s\n' "${policy_arn}"
+    return
+  fi
+
+  current_version="$(
+    aws_cli iam get-policy --policy-arn "${policy_arn}" \
+      --query 'Policy.DefaultVersionId' --output text
+  )"
+  current_doc="$(
+    aws_cli iam get-policy-version --policy-arn "${policy_arn}" --version-id "${current_version}" \
+      --query 'PolicyVersion.Document' --output json
+  )"
+  current_sorted="$(printf '%s\n' "${current_doc}" | jq -S .)"
+  desired_sorted="$(jq -S . "${POLICY_FILE}")"
+
+  if [[ "${current_sorted}" == "${desired_sorted}" ]]; then
+    log "[OK] managed policy already matches repo file"
+    printf '%s\n' "${policy_arn}"
+    return
+  fi
+
+  version_count="$(
+    aws_cli iam list-policy-versions --policy-arn "${policy_arn}" --query 'length(Versions)' --output text
+  )"
+  if [[ "${version_count}" -ge 5 ]]; then
+    delete_oldest_nondefault_policy_version "${policy_arn}"
+  fi
+
+  log "[START] publishing new default version for ${POLICY_NAME}"
+  aws_cli iam create-policy-version \
+    --policy-arn "${policy_arn}" \
+    --policy-document "file://${POLICY_FILE}" \
+    --set-as-default >/dev/null
+  log "[END] updated managed policy ${POLICY_NAME}"
+  printf '%s\n' "${policy_arn}"
+}
+
+ensure_policy_attachment() {
+  local policy_arn="$1"
+  local attached
+
+  attached="$(
+    aws_cli iam list-attached-user-policies --user-name "${USER_NAME}" --output json \
+      | jq -r --arg arn "${policy_arn}" '.AttachedPolicies[]?.PolicyArn | select(. == $arn)'
+  )"
+
+  if [[ -n "${attached}" ]]; then
+    log "[OK] policy already attached to ${USER_NAME}"
+    return
+  fi
+
+  log "[START] attaching policy to ${USER_NAME}"
+  aws_cli iam attach-user-policy --user-name "${USER_NAME}" --policy-arn "${policy_arn}"
+  log "[END] attached policy to ${USER_NAME}"
+}
+
+create_access_key() {
+  local active_keys output_path="$1"
+  active_keys="$(
+    aws_cli iam list-access-keys --user-name "${USER_NAME}" --query 'length(AccessKeyMetadata)' --output text
+  )"
+
+  if [[ "${active_keys}" -ge 2 ]]; then
+    printf 'User %s already has %s access keys; refusing to create a third.\n' "${USER_NAME}" "${active_keys}" >&2
+    exit 1
+  fi
+
+  log "[START] creating access key for ${USER_NAME}"
+  if [[ -n "${output_path}" ]]; then
+    aws_cli iam create-access-key --user-name "${USER_NAME}" --output json > "${output_path}"
+    log "[END] wrote access key JSON to ${output_path}"
+    return
+  fi
+
+  aws_cli iam create-access-key --user-name "${USER_NAME}" --output json
+  log "[END] created access key for ${USER_NAME}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --user-name)
+      USER_NAME="$2"
+      shift 2
+      ;;
+    --policy-name)
+      POLICY_NAME="$2"
+      shift 2
+      ;;
+    --policy-file)
+      POLICY_FILE="$2"
+      shift 2
+      ;;
+    --create-access-key)
+      CREATE_ACCESS_KEY="true"
+      shift
+      ;;
+    --access-key-output)
+      ACCESS_KEY_OUTPUT="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd aws
+require_cmd jq
+
+if [[ ! -f "${POLICY_FILE}" ]]; then
+  printf 'Policy file not found: %s\n' "${POLICY_FILE}" >&2
+  exit 1
+fi
+
+log "[INFO] using profile ${PROFILE}"
+log "[INFO] policy file ${POLICY_FILE}"
+
+ensure_user
+policy_arn="$(ensure_policy)"
+ensure_policy_attachment "${policy_arn}"
+
+aws_cli iam get-user --user-name "${USER_NAME}" --query 'User.{UserName:UserName,Arn:Arn,CreateDate:CreateDate}' --output table
+aws_cli iam list-attached-user-policies --user-name "${USER_NAME}" --output table
+
+if [[ "${CREATE_ACCESS_KEY}" == "true" ]]; then
+  create_access_key "${ACCESS_KEY_OUTPUT}"
+fi
+
+log "[SUCCESS] product-lead-inspect deployment complete"


### PR DESCRIPTION
## Summary
- add canonical product-lead-inspect IAM policy JSON under infra/iam
- add repeatable deploy script to create/update the IAM user, managed policy, and optional access key
- preserve the enceladus-agent-cli MCP boundary by introducing a separate inspect principal

## Governance
- repo lifecycle for this PR is governed by ENC-TSK-C67 because ENC-TSK-C58 was created as sealed `no_code`
- live IAM deployment and operational validation remain tracked on ENC-TSK-C58
- rationale for the split is documented on ENC-ISS-182

## Testing
- jq empty infra/iam/product-lead-inspect-policy.json
- bash -n infrastructure/scripts/deploy_product_lead_inspect.sh
- aws --profile product-lead accessanalyzer validate-policy --policy-type IDENTITY_POLICY --policy-document file://infra/iam/product-lead-inspect-policy.json

CCI-4a2d113863c94052811970953f01f433
