### PR TITLE
ENC-TSK-C68: checkout_service self-diagnoses install-scope 404s (ENC-ISS-183)

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -199,6 +199,15 @@ _PRIVATE_KEY_TTL: float = 3600.0  # re-fetch private key from SM every hour
 _installation_token_cache: Optional[str] = None
 _installation_token_expires_at: float = 0.0
 
+# ENC-TSK-C68 / ENC-ISS-183: cached set of 'owner/repo' full names accessible to
+# the GitHub App installation. Used by _validate_commit to self-diagnose
+# installation-scope 404s (repo missing from installation scope vs. commit
+# genuinely not found). Short TTL so a grant via the org admin UI is picked up
+# without a Lambda cold restart.
+_installation_repos_cache: Optional[set] = None
+_installation_repos_expires_at: float = 0.0
+_INSTALLATION_REPOS_TTL: float = 300.0
+
 
 def _get_secretsmanager():
     global _sm_client
@@ -598,12 +607,104 @@ def _github_request(path: str) -> Tuple[int, dict]:
         return 503, {"error": str(exc)}
 
 
+def _list_installation_repos() -> set:
+    """Return a cached set of 'owner/repo' full names accessible to the
+    installation, or an empty set on any error.
+
+    ENC-TSK-C68 / ENC-ISS-183: used by _validate_commit to distinguish an
+    installation-scope 404 from a missing-commit 404. Paginates through
+    /installation/repositories up to 20 pages (2000 repos). Cached for
+    _INSTALLATION_REPOS_TTL seconds so we do not hammer GitHub on every
+    failing commit validation. Cache is populated lazily on first call after
+    expiry; a probe failure returns an empty set so the caller falls back to
+    the generic 'commit not found' error rather than masking a real problem
+    with a misleading installation-scope message.
+    """
+    global _installation_repos_cache, _installation_repos_expires_at
+    now = time.time()
+    if _installation_repos_cache is not None and now < _installation_repos_expires_at:
+        return _installation_repos_cache
+
+    try:
+        token = _get_installation_token()
+    except Exception as exc:
+        logger.warning(
+            "[ENC-ISS-183] Could not mint installation token for repo scope probe: %s", exc
+        )
+        return set()
+
+    accessible: set = set()
+    page = 1
+    while page <= 20:
+        url = f"{GITHUB_API_BASE}/installation/repositories?per_page=100&page={page}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "checkout-service/1.0",
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=8) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception as exc:
+            logger.warning(
+                "[ENC-ISS-183] Failed to list installation repos at page=%d: %s", page, exc
+            )
+            return set()
+
+        repos = data.get("repositories") or []
+        for r in repos:
+            full = r.get("full_name")
+            if full:
+                accessible.add(full)
+        total = int(data.get("total_count") or 0)
+        if not repos or len(accessible) >= total:
+            break
+        page += 1
+
+    _installation_repos_cache = accessible
+    _installation_repos_expires_at = now + _INSTALLATION_REPOS_TTL
+    return accessible
+
+
 def _validate_commit(owner: str, repo: str, commit_sha: str) -> Tuple[bool, str]:
-    """Verify commit SHA exists on GitHub. Returns (valid, reason)."""
+    """Verify commit SHA exists on GitHub. Returns (valid, reason).
+
+    ENC-TSK-C68 / ENC-ISS-183: on a 404 response, probe the GitHub App
+    installation's accessible-repositories list to distinguish between:
+
+      1. the commit genuinely not existing in the repo, and
+      2. the installation not having access to the repo at all (which GitHub
+         surfaces as a bare 404 on /repos/{owner}/{repo}/commits/{sha}).
+
+    When the repo is not in the installation scope, return a descriptive
+    self-correcting error pointing at the installation management URL so
+    operators do not re-live the original Blocker A confusion where every
+    devops-project task stalled at coding-complete with the ambiguous
+    "Commit <sha> not found in NX-2021-L/devops" message.
+    """
     status, body = _github_request(f"/repos/{owner}/{repo}/commits/{commit_sha}")
     if status == 200:
         return True, ""
     if status == 404:
+        full_name = f"{owner}/{repo}"
+        accessible = _list_installation_repos()
+        if accessible and full_name not in accessible:
+            installation_id = GITHUB_INSTALLATION_ID or "<unset>"
+            manage_url = (
+                f"https://github.com/organizations/{owner}/settings/installations/{installation_id}"
+                if installation_id and installation_id != "<unset>"
+                else f"https://github.com/organizations/{owner}/settings/installations"
+            )
+            return False, (
+                f"GitHub App 'enceladus-integration' (installation {installation_id}) does not "
+                f"have access to {full_name}. The commit {commit_sha} may exist but is not "
+                f"visible to the App. Grant access at {manage_url} (Organization Owner required), "
+                f"then retry. Currently accessible: {sorted(accessible)}."
+            )
         return False, f"Commit {commit_sha} not found in {owner}/{repo}"
     return False, f"GitHub API returned {status}: {body.get('message', 'unknown error')}"
 

--- a/backend/lambda/checkout_service/test_validate_commit_installation_scope.py
+++ b/backend/lambda/checkout_service/test_validate_commit_installation_scope.py
@@ -1,0 +1,161 @@
+"""Unit tests for _validate_commit installation-scope self-diagnosis.
+
+ENC-TSK-C68 / ENC-ISS-183: on a GitHub 404 during commit validation, the
+checkout service should probe the installation's accessible-repositories list
+and, when the target repo is not in scope, return a descriptive error
+pointing at the installation management URL instead of the ambiguous
+"Commit <sha> not found" message.
+
+Root cause these tests are guarding against: the enceladus-integration App
+installation on NX-2021-L was scoped `repository_selection=selected` and did
+not list NX-2021-L/devops, so every devops-project task stalled at
+coding-complete for weeks. The error surfaced by _validate_commit looked like
+a commit resolution bug, but the actual fix was an Organization Owner click
+in the GitHub UI. The new error path makes that root cause immediately
+discoverable from the advance-task-status response body.
+"""
+
+import importlib.util
+import os
+import unittest
+from unittest.mock import patch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_service",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_service = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(checkout_service)
+
+
+class ValidateCommitInstallationScopeTests(unittest.TestCase):
+    def setUp(self):
+        # Clear the installation-repos cache between tests so each case sees a
+        # fresh lookup path.
+        checkout_service._installation_repos_cache = None
+        checkout_service._installation_repos_expires_at = 0.0
+
+    @patch.object(checkout_service, "GITHUB_INSTALLATION_ID", "112392089")
+    @patch.object(
+        checkout_service,
+        "_list_installation_repos",
+        return_value={"NX-2021-L/enceladus", "NX-2021-L/mod"},
+    )
+    @patch.object(
+        checkout_service,
+        "_github_request",
+        return_value=(404, {"message": "Not Found"}),
+    )
+    def test_installation_scope_404_returns_descriptive_error(
+        self, _mock_gh, _mock_list
+    ):
+        ok, reason = checkout_service._validate_commit(
+            "NX-2021-L", "devops", "bb92ce0459259d7c3ae21a4189e227cf8c5fa19f"
+        )
+        self.assertFalse(ok)
+        self.assertIn("enceladus-integration", reason)
+        self.assertIn("does not have access to NX-2021-L/devops", reason)
+        self.assertIn("112392089", reason)
+        self.assertIn(
+            "https://github.com/organizations/NX-2021-L/settings/installations/112392089",
+            reason,
+        )
+        self.assertIn("Organization Owner required", reason)
+        # Currently accessible list is included to help the operator confirm
+        # which repos the installation can see.
+        self.assertIn("NX-2021-L/enceladus", reason)
+
+    @patch.object(checkout_service, "GITHUB_INSTALLATION_ID", "112392089")
+    @patch.object(
+        checkout_service,
+        "_list_installation_repos",
+        return_value={"NX-2021-L/devops", "NX-2021-L/enceladus"},
+    )
+    @patch.object(
+        checkout_service,
+        "_github_request",
+        return_value=(404, {"message": "Not Found"}),
+    )
+    def test_in_scope_404_returns_generic_commit_not_found(
+        self, _mock_gh, _mock_list
+    ):
+        """If the repo IS in the installation scope, the 404 really means the
+        commit does not exist. Preserve the original error for that case so
+        we do not mislead operators into chasing a non-existent access bug.
+        """
+        missing_sha = "0" * 40
+        ok, reason = checkout_service._validate_commit(
+            "NX-2021-L", "devops", missing_sha
+        )
+        self.assertFalse(ok)
+        self.assertEqual(reason, f"Commit {missing_sha} not found in NX-2021-L/devops")
+        self.assertNotIn("enceladus-integration", reason)
+
+    @patch.object(
+        checkout_service,
+        "_list_installation_repos",
+        return_value=set(),
+    )
+    @patch.object(
+        checkout_service,
+        "_github_request",
+        return_value=(404, {"message": "Not Found"}),
+    )
+    def test_probe_failure_falls_back_to_generic_error(
+        self, _mock_gh, _mock_list
+    ):
+        """If the installation-repos probe returns an empty set (probe failed
+        or installation is legitimately empty), fall back to the generic
+        'commit not found' error rather than inventing a misleading
+        installation-scope message.
+        """
+        ok, reason = checkout_service._validate_commit(
+            "NX-2021-L", "devops", "a" * 40
+        )
+        self.assertFalse(ok)
+        self.assertIn("not found in NX-2021-L/devops", reason)
+        self.assertNotIn("enceladus-integration", reason)
+
+    @patch.object(
+        checkout_service,
+        "_github_request",
+        return_value=(200, {"sha": "a" * 40}),
+    )
+    def test_commit_found_returns_success_without_probing(self, _mock_gh):
+        """Happy path: a 200 response bypasses the installation probe entirely
+        and returns success. Guards against accidentally introducing a probe
+        call on the fast path."""
+        with patch.object(
+            checkout_service, "_list_installation_repos"
+        ) as probe_mock:
+            ok, reason = checkout_service._validate_commit(
+                "NX-2021-L", "devops", "a" * 40
+            )
+            self.assertTrue(ok)
+            self.assertEqual(reason, "")
+            probe_mock.assert_not_called()
+
+    @patch.object(
+        checkout_service,
+        "_github_request",
+        return_value=(500, {"message": "Internal Server Error"}),
+    )
+    def test_non_404_error_returns_api_error_without_probing(self, _mock_gh):
+        """Non-404 errors (500, 502, timeouts surfaced as 503) should not
+        trigger the installation-scope probe — the repo access check is only
+        meaningful on 404."""
+        with patch.object(
+            checkout_service, "_list_installation_repos"
+        ) as probe_mock:
+            ok, reason = checkout_service._validate_commit(
+                "NX-2021-L", "devops", "a" * 40
+            )
+            self.assertFalse(ok)
+            self.assertIn("GitHub API returned 500", reason)
+            probe_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-07.66",
-  "updated_at": "2026-04-08T10:20:00Z",
+  "version": "2026-04-08.67",
+  "updated_at": "2026-04-09T00:55:00Z",
   "owners": [
     "enceladus-platform"
   ],
@@ -1599,6 +1599,32 @@
           ],
           "definition": "Missing location context fields (hypothesis, technical_notes, location_hint) produce warnings in the response but do not block issue creation.",
           "usage_guidance": "Ontology scoring already penalizes missing fields. Hard 400 enforcement was removed in ENC-ISS-105 because MCP client bindings did not expose these parameters, causing a self-inflicted regression."
+        }
+      }
+    },
+    "checkout_service.install_scope_diagnostic": {
+      "description": "Self-correcting 404 diagnostic for GitHub commit validation (ENC-TSK-C68, ENC-ISS-183). When _validate_commit() receives a 404 from /repos/{owner}/{repo}/commits/{sha}, the checkout service now probes /installation/repositories via the cached App installation token and, if the target repo is not in the installation's accessible-repo list, returns a descriptive error that names the installation id, links to the installation management URL, lists currently accessible repos, and explicitly calls out Organization Owner as the required role. Prevents repeats of the devops-project stall where the ambiguous 'Commit not found' error masked an App installation scope gap for weeks. Probe result cached for 300s to avoid hammering GitHub; probe failures return the generic 'commit not found' error so real 404s are not masked by a misleading installation-scope message.",
+      "fields": {
+        "probe_ttl_seconds": {
+          "type": "integer",
+          "definition": "Seconds the installation-repo probe result is cached before re-probing. Controls how quickly a newly-granted repo becomes visible to the checkout service after the org admin updates the installation scope.",
+          "usage_guidance": "Default: 300. Do not set lower than ~60 to avoid probe-on-every-404 hammering."
+        },
+        "probe_pagination_cap": {
+          "type": "integer",
+          "definition": "Maximum number of pages (at 100 repos/page) the probe will fetch from /installation/repositories. Protects against runaway pagination if an installation ever exceeds 2000 repos.",
+          "usage_guidance": "Default: 20. Raise only if legitimately needed."
+        },
+        "generic_fallback_trigger": {
+          "type": "string",
+          "definition": "Conditions under which _validate_commit falls back to the pre-ENC-TSK-C68 generic 'Commit <sha> not found in {owner}/{repo}' error instead of the new installation-scope error. Triggers: (a) installation token mint failure, (b) /installation/repositories returns empty set, (c) any exception during pagination, (d) repo IS in the accessible list (meaning the 404 is a real missing-commit).",
+          "usage_guidance": "This fail-safe path ensures the new diagnostic never masks a real 404. Operators can distinguish the two error classes by whether the message mentions 'enceladus-integration' (new path) or just 'Commit ... not found' (legacy/fallback path)."
+        },
+        "unit_test_coverage": {
+          "type": "array",
+          "items": {"type": "string"},
+          "definition": "Test file path(s) covering the install-scope diagnostic.",
+          "usage_guidance": "Currently: backend/lambda/checkout_service/test_validate_commit_installation_scope.py with 5 tests covering installation-scope 404 -> descriptive error, in-scope 404 -> generic fallback, probe failure -> generic fallback, 200 fast path (probe never called), and non-404 errors (probe never called)."
         }
       }
     },


### PR DESCRIPTION
CCI-a4b8301c73ea4ca287d0ede44a51f1f3

## Summary

Defensive improvement to \`backend/lambda/checkout_service/lambda_function.py::_validate_commit\` motivated directly by ENC-ISS-183. When the GitHub commit validation returns a 404, the checkout service now probes \`/installation/repositories\` on the App installation and, if the target repo is not in scope, returns a descriptive self-correcting error that names the installation, points at the installation management URL, lists currently accessible repos, and explicitly calls out Organization Owner as the required role. If the repo IS in scope, the existing generic \"Commit not found\" error is preserved so operators are not misled into chasing an access bug for a commit that legitimately does not exist.

Root cause this prevents from recurring: ENC-ISS-183 documents how the ambiguous error message parked every devops-project task at coding-complete for weeks because the failure looked like a commit-resolution bug when the actual fix was an Organization Owner click in the GitHub UI to grant the \`enceladus-integration\` App access to \`NX-2021-L/devops\`. With this change, the same symptom would surface as \`GitHub App 'enceladus-integration' (installation <id>) does not have access to <owner>/<repo>. The commit <sha> may exist but is not visible to the App. Grant access at https://github.com/organizations/<owner>/settings/installations/<id> (Organization Owner required), then retry. Currently accessible: [...].\`

## Changes

- \`backend/lambda/checkout_service/lambda_function.py\`:
  - New \`_list_installation_repos()\` helper. Paginates \`/installation/repositories\` up to 20 pages (2000 repos), caches the set of accessible \`owner/repo\` full names for 5 minutes, and returns an empty set on any error so the caller falls back to the generic 404 path rather than masking a real issue.
  - \`_validate_commit()\` updated: on 404 from \`/repos/{owner}/{repo}/commits/{sha}\`, invoke \`_list_installation_repos()\` and, if the target repo is absent, return the new self-correcting error. Otherwise preserve the current generic error. 200 fast path and non-404 errors do not trigger the probe.
- \`backend/lambda/checkout_service/test_validate_commit_installation_scope.py\` (new): 5 unit tests covering installation-scope 404 \u2192 descriptive error, in-scope 404 \u2192 generic fallback, probe failure \u2192 generic fallback, 200 fast path (probe never called), non-404 errors (probe never called).

## Test plan

- [x] \`python3 -m unittest test_validate_commit_installation_scope test_checkout_error_context\` \u2192 13 tests pass (5 new + 8 existing)
- [x] Governance dictionary guard clean (no governed schema changes)
- [x] Secrets regex sweep clean
- [ ] Post-merge lambda-checkout-service deploy workflow completes green (required for deploy-success gate)
- [ ] Live smoke: intentionally probe a devops commit from a task whose components resolve to an out-of-scope repo and observe the new error surface (best-effort, not blocking)

## Tracker

- Task: ENC-TSK-C68
- Governing issue: ENC-ISS-183 (closed as of 2026-04-09T00:46:18Z)
- Component: comp-checkout-service
- Related work: devops #9 (Iss183Smoke* IAM), devops #11 (Blocker C verification), DVP-TSK-480 (closed), DVP-TSK-457 (retired in-place)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)