### PR TITLE
ENC-TSK-C69: Phase 4 engine access remediation

### DIFF
--- a/infra/iam/product-lead-inspect-policy.json
+++ b/infra/iam/product-lead-inspect-policy.json
@@ -130,6 +130,54 @@
       }
     },
     {
+      "Sid": "AthenaQuery",
+      "Effect": "Allow",
+      "Action": [
+        "athena:StartQueryExecution",
+        "athena:GetQueryExecution",
+        "athena:GetQueryResults",
+        "athena:StopQueryExecution",
+        "athena:ListWorkGroups",
+        "athena:GetWorkGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "us-west-2"
+        }
+      }
+    },
+    {
+      "Sid": "GlueCatalogRead",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetDatabase",
+        "glue:GetDatabases",
+        "glue:GetTable",
+        "glue:GetTables",
+        "glue:GetPartitions"
+      ],
+      "Resource": [
+        "arn:aws:glue:us-west-2:356364570033:catalog",
+        "arn:aws:glue:us-west-2:356364570033:database/devops_agentcli_db",
+        "arn:aws:glue:us-west-2:356364570033:table/devops_agentcli_db/*"
+      ]
+    },
+    {
+      "Sid": "AthenaResultBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::devops-agentcli-compute",
+        "arn:aws:s3:::devops-agentcli-compute/athena-results/*"
+      ]
+    },
+    {
       "Sid": "SqsInspect",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
# ENC-TSK-C69: Phase 4 engine access remediation
Closes ENC-ISS-194.
CAI: CAI-c81c09fdcf684aaf85d4a28cc12d4ad6
CCI: CCI-ddd057f939b4438e9cdc7e5ea185d9ef

## Summary
- Extend `product-lead-inspect` with Athena query access and an explicit Athena results path
- Restore `data.jreese.net` Trino `/v1/*` and `/ui/*` routing to the live coordinator on port 8080
- Add governed runbook DOC-AABBDA18079B with Athena canonical fallback guidance

## Test plan
- [x] Managed policy default version matches `infra/iam/product-lead-inspect-policy.json`
- [x] Athena smoke from `product-lead-inspect` returns row count 34 for `devops_agentcli_db.lessons`
- [x] Trino smoke from `https://data.jreese.net/v1/statement` finishes with row count 34 for `hive.devops_agentcli_db.lessons`
