### PR TITLE
fix(mcp-server): include lesson fields in _tracker_create (ENC-TSK-C70)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-08.67",
-  "updated_at": "2026-04-09T00:55:00Z",
+  "version": "2026-04-09.1",
+  "updated_at": "2026-04-09T01:56:30Z",
   "owners": [
     "enceladus-platform"
   ],

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5437,7 +5437,14 @@ async def _tracker_create(args: dict) -> list[TextContent]:
                 # arcs (no_code, code_only) can actually be set on agent-created tasks.
                 "transition_type",
                 # ENC-TSK-A97: Plan-specific fields
-                "objectives_set", "attached_documents", "related_feature_id"):
+                "objectives_set", "attached_documents", "related_feature_id",
+                # ENC-TSK-C70 / ENC-ISS-192: forward lesson-specific fields so the
+                # generic execute(tracker.create) action properly routes lesson payloads
+                # to tracker_mutation. Without these, lesson creates fail with
+                # "Lesson creation requires observation" because the field is dropped
+                # before the downstream Lambda sees it.
+                "observation", "insight", "confidence", "evidence_chain",
+                "provenance", "pillar_scores", "analysis_reference"):
         if args.get(key) is not None:
             payload[key] = args[key]
 


### PR DESCRIPTION
Closes ENC-ISS-192. Part of ENC-PLN-017 Phase 1.

CCI-21862edeb9c941deb26ef5c24c401332

## Summary

Extend the `_tracker_create` field whitelist in `tools/enceladus-mcp-server/server.py` to include the lesson-specific fields (`observation`, `insight`, `confidence`, `evidence_chain`, `provenance`, `pillar_scores`, `analysis_reference`) so that `execute(tracker.create)` for `record_type=lesson` properly forwards them to `tracker_mutation`.

## Root cause

The generic `_tracker_create` handler used a hardcoded whitelist loop that omitted lesson-specific fields, causing them to be dropped before the downstream Lambda saw them. This produced "Lesson creation requires observation" errors even when the field was populated. The reference implementation in `_tracker_create_lesson` already handled the fields correctly; this brings the generic handler into parity.

## Test plan

- [ ] CI checks pass (PR Commit Gate validates CCI)
- [ ] After merge + Lambda deploy, run live `execute(tracker.create, {record_type: "lesson", observation: "...", insight: "...", evidence_chain: [...], confidence: 0.95})` and confirm via `tracker.get` that all fields round-trip.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>