### PR TITLE
Parameterize NEO4J_SECRET_NAME for gamma isolation

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -592,7 +592,7 @@ Resources:
       Role: !GetAtt GraphSyncRole.Arn
       Environment:
         Variables:
-          NEO4J_SECRET_NAME: enceladus/neo4j/auradb-credentials
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           SECRETS_REGION: !Ref AWS::Region
       Tags:
         - Key: Project
@@ -619,7 +619,7 @@ Resources:
       Role: !GetAtt GraphQueryApiRole.Arn
       Environment:
         Variables:
-          NEO4J_SECRET_NAME: enceladus/neo4j/auradb-credentials
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           SECRETS_REGION: !Ref AWS::Region
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
@@ -653,7 +653,7 @@ Resources:
       Role: !GetAtt Neo4jBackupRole.Arn
       Environment:
         Variables:
-          NEO4J_SECRET_NAME: enceladus/neo4j/auradb-credentials
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           S3_BUCKET: !Ref S3Bucket
           S3_PREFIX: !Sub "${S3EnvPrefix}neo4j-backups/"
           SECRETS_REGION: !Ref "AWS::Region"
@@ -681,7 +681,7 @@ Resources:
       Role: !GetAtt GraphHealthMetricsRole.Arn
       Environment:
         Variables:
-          NEO4J_SECRET_NAME: enceladus/neo4j/auradb-credentials
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
           PROJECT_ID: enceladus
           SECRETS_REGION: !Ref "AWS::Region"
@@ -1378,7 +1378,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials*"
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
               - Sid: S3BackupWrite
                 Effect: Allow
                 Action:
@@ -1421,7 +1421,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials*"
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary
- Parameterizes `NEO4J_SECRET_NAME` env var with `${EnvironmentSuffix}` on the 4 Lambda definitions in `02-compute.yaml` (`GraphSyncFunction`, `GraphQueryApiFunction`, `Neo4jBackupFunction`, `GraphHealthMetricsFunction`)
- Updates the IAM policy `Resource:` ARNs in `Neo4jBackupRole` and `GraphHealthMetricsRole` so the gamma roles can read the gamma secret
- Production stack (`EnvironmentSuffix=""`) is a semantic no-op — existing secret name unchanged
- Gamma stack (`EnvironmentSuffix="-gamma"`) resolves `enceladus/neo4j/auradb-credentials-gamma`
- Resolves ENC-ISS-196: gamma and production were sharing a single Neo4j AuraDB instance, contaminating production with gamma-seeded records

## Test plan
- [x] `aws cloudformation validate-template` passes
- [x] Production stack (`EnvironmentSuffix=""`) produces no functional change — all 6 substitutions collapse to the existing string
- [ ] Gamma stack update sets `NEO4J_SECRET_NAME` to `enceladus/neo4j/auradb-credentials-gamma` on the 3 deployed gamma Lambdas (4th `enceladus-graph-health-metrics-gamma` will be created by this stack update — currently absent)
- [ ] Gamma graph-sync Lambda resolves the gamma secret and connects to the gamma AuraDB instance after deploy

ENC-TSK-1291

CCI-38b92b6f06b24a3d8e53f5305747cc60

🤖 Generated with [Claude Code](https://claude.com/claude-code)