### PR TITLE
ENC-TSK-1292: unblock compute stack deploy validation

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -44,7 +44,7 @@ Parameters:
     Default: https://jreese.net
   SharedLayerArn:
     Type: String
-    Default: arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:2
+    Default: arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:7
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
@@ -669,6 +669,7 @@ Resources:
 
   GraphHealthMetricsFunction:
     Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
     Properties:
       FunctionName: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"
       Code:
@@ -1391,6 +1392,7 @@ Resources:
   # ENC-TSK-C10: Graph Health Metrics Lambda IAM Role
   GraphHealthMetricsRole:
     Type: AWS::IAM::Role
+    DeletionPolicy: Retain
     Properties:
       RoleName: !Sub "enceladus-graph-health-metrics-role${EnvironmentSuffix}"
       AssumeRolePolicyDocument:

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -114,6 +114,32 @@ Resources:
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:enceladus-*"
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:auth-refresh*"
 
+              # Read-only validation permissions required by CloudFormation
+              # pre-deployment validation when new rules, pipes, and alarms are
+              # introduced in stack updates.
+              - Sid: EventBridgeValidationReadOnly
+                Effect: Allow
+                Action:
+                  - events:DescribeRule
+                Resource:
+                  - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/devops-*"
+                  - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/enceladus-*"
+                  - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/on-project-json-sync*"
+
+              - Sid: PipesValidationReadOnly
+                Effect: Allow
+                Action:
+                  - pipes:DescribePipe
+                Resource:
+                  - !Sub "arn:aws:pipes:us-west-2:${AWS::AccountId}:pipe/devops-*"
+                  - !Sub "arn:aws:pipes:us-west-2:${AWS::AccountId}:pipe/enceladus-*"
+
+              - Sid: CloudWatchValidationReadOnly
+                Effect: Allow
+                Action:
+                  - cloudwatch:DescribeAlarms
+                Resource: "*"
+
               # CloudWatch Logs (for error reporting in workflow)
               - Sid: LogsReadOnly
                 Effect: Allow


### PR DESCRIPTION
CCI-d07ff0c474e844f1b5228874e8a92422

## Summary
- import-ready fix for orphaned graph-health resources in `02-compute.yaml`
- update compute shared layer default to `enceladus-shared:7` for Python 3.12 compatibility
- add CloudFormation validation read permissions to the GitHub deploy role in `04-github-roles.yaml`

## Validation
- `aws --profile product-lead cloudformation validate-template --template-body file:///Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/02-compute.yaml --region us-west-2`
- `aws --profile product-lead cloudformation validate-template --template-body file:///Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/04-github-roles.yaml --region us-west-2`
- `aws --profile product-lead cloudformation deploy --template-file /Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/02-compute.yaml --stack-name enceladus-compute --capabilities CAPABILITY_NAMED_IAM --parameter-overrides EnvironmentSuffix=\"\" --region us-west-2 --no-execute-changeset`
- `aws --profile product-lead cloudformation deploy --template-file /Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/04-github-roles.yaml --stack-name enceladus-github-roles --capabilities CAPABILITY_NAMED_IAM --region us-west-2 --no-execute-changeset`

## Operational Note
- executed one-time production import change set `enc-tsk-1292-prod-import` to bring pre-existing orphan resources under `enceladus-compute`: `DocumentsToGraphPipe`, `GraphHealthMetricsFunction`, `GraphHealthMetricsRole`, `Neo4jBackupFunction`, `Neo4jBackupRole`
