### PR TITLE
ENC-TSK-1292: fix feed queue visibility timeout

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -355,7 +355,9 @@ Resources:
       QueueName: !Sub "devops-feed-publish-queue${EnvironmentSuffix}.fifo"
       FifoQueue: true
       ContentBasedDeduplication: true
-      VisibilityTimeout: 60
+      # Must be >= devops-feed-publisher Timeout (600) or Lambda rejects the
+      # event source mapping update during compute-stack deploys.
+      VisibilityTimeout: 600
       MessageRetentionPeriod: 86400
       ReceiveMessageWaitTimeSeconds: 20
       SqsManagedSseEnabled: true


### PR DESCRIPTION
## Summary
- raise FeedPublishQueue visibility timeout in 01-data.yaml from 60s to 600s
- align the queue with the existing devops-feed-publisher Lambda timeout so compute-stack event source mapping updates stop failing
- preserve the queue names and all other data-layer settings

## Validation
- aws --profile product-lead cloudformation validate-template --template-body file:///Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/01-data.yaml --region us-west-2
- aws --profile product-lead cloudformation deploy --template-file /Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/01-data.yaml --stack-name enceladus-data --capabilities CAPABILITY_NAMED_IAM --region us-west-2 --no-fail-on-empty-changeset --no-execute-changeset
- aws --profile product-lead cloudformation deploy --template-file /Users/jreese/enceladus/repo/.claude/worktrees/ENC-TSK-1292-cfn-compute/infrastructure/cloudformation/01-data.yaml --stack-name enceladus-data-gamma --capabilities CAPABILITY_NAMED_IAM --parameter-overrides Environment=gamma EnvironmentSuffix=-gamma S3EnvPrefix=gamma/ --region us-west-2 --no-fail-on-empty-changeset --no-execute-changeset

CCI-d07ff0c474e844f1b5228874e8a92422