### PR TITLE
fix(graph): align deploy.sh arch/runtime to arm64/py3.12 (ENC-TSK-C97)

### DIFF
--- a/backend/lambda/graph_health_metrics/deploy.sh
+++ b/backend/lambda/graph_health_metrics/deploy.sh
@@ -36,7 +36,10 @@ build_package() {
 
   # Install neo4j driver for Linux Lambda runtime
   pip install \
-    --platform manylinux2014_x86_64 \
+    --platform manylinux2014_aarch64 \
+    --implementation cp \
+    --python-version 3.12 \
+    --abi cp312 \
     --only-binary=:all: \
     neo4j -t "${build_dir}" --quiet 2>/dev/null || true
 

--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -88,10 +88,10 @@ package_lambda() {
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_x86_64 \
+    --platform manylinux2014_aarch64 \
     --implementation cp \
-    --python-version 3.11 \
-    --abi cp311 \
+    --python-version 3.12 \
+    --abi cp312 \
     --only-binary=:all: \
     -r "${ROOT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -121,7 +121,8 @@ ensure_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime python3.12 \
+      --architectures arm64 \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 10 \

--- a/backend/lambda/graph_sync/deploy.sh
+++ b/backend/lambda/graph_sync/deploy.sh
@@ -75,10 +75,10 @@ package_lambda() {
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_x86_64 \
+    --platform manylinux2014_aarch64 \
     --implementation cp \
-    --python-version 3.11 \
-    --abi cp311 \
+    --python-version 3.12 \
+    --abi cp312 \
     --only-binary=:all: \
     -r "${ROOT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -108,7 +108,8 @@ ensure_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime python3.12 \
+      --architectures arm64 \
       --handler lambda_function.handler \
       --role "${role_arn}" \
       --timeout 60 \


### PR DESCRIPTION
## Summary
- Fix architecture mismatch in graph Lambda deploy.sh scripts that were packaging x86_64/py3.11 binaries for arm64/py3.12 runtimes
- `graph_sync/deploy.sh`: pip target x86_64→aarch64, py3.11→3.12, cp311→cp312; create-function runtime + arch aligned
- `graph_query_api/deploy.sh`: same pattern
- `graph_health_metrics/deploy.sh`: pip target x86_64→aarch64, added py3.12/cp312 flags

**Plan:** ENC-PLN-018 (V3 Stack Health Recovery)
**Task:** ENC-TSK-C97 (Phase 1: Graph stack recovery)
**COE:** DOC-2CACF0D1E7E6

CCI-fb652474f2794b95852700c5983d2654

## Test plan
- [ ] Merge to main
- [ ] Dispatch `lambda-graph-sync-deploy.yml` from main
- [ ] Dispatch `lambda-graph-query-api-deploy.yml` from main
- [ ] Dispatch `lambda-graph-health-metrics-deploy.yml` from main
- [ ] Verify all 3 graph Lambda CodeSize >> 164
- [ ] Verify `connection_health()` returns `graph_index != unreachable`
- [ ] Verify `tracker.graphsearch` keyword query returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)