### PR TITLE
fix(deploy): remove invalid --architectures from update-function-configuration (ENC-TSK-C98)

### DIFF
--- a/backend/lambda/auth_edge/deploy.sh
+++ b/backend/lambda/auth_edge/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/auth_refresh/deploy.sh
+++ b/backend/lambda/auth_refresh/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/checkout_service/deploy.sh
+++ b/backend/lambda/checkout_service/deploy.sh
@@ -281,7 +281,6 @@ deploy_lambda() {
       --region "${REGION}" \
       --handler "${handler}" \
       --runtime python3.12 \
-      --architectures arm64 \
       --timeout 30 \
       --memory-size 256 \
       --environment "${env_json}" \

--- a/backend/lambda/deploy_finalize/deploy.sh
+++ b/backend/lambda/deploy_finalize/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/doc_prep/deploy.sh
+++ b/backend/lambda/doc_prep/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/glue_crawler_launcher/deploy.sh
+++ b/backend/lambda/glue_crawler_launcher/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/json_to_parquet_transformer/deploy.sh
+++ b/backend/lambda/json_to_parquet_transformer/deploy.sh
@@ -45,8 +45,7 @@ deploy_lambda() {
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \
-    --runtime "${RUNTIME}" \
-    --architectures "${ARCHITECTURE}" >/dev/null
+    --runtime "${RUNTIME}" >/dev/null
 
   aws lambda wait function-updated-v2 \
     --function-name "${FUNCTION_NAME}" \

--- a/backend/lambda/neo4j_backup/deploy.sh
+++ b/backend/lambda/neo4j_backup/deploy.sh
@@ -92,7 +92,6 @@ deploy_lambda() {
     aws lambda update-function-configuration \
       --function-name "${FUNCTION_NAME}" \
       --runtime python3.12 \
-      --architectures arm64 \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 300 \


### PR DESCRIPTION
## Summary
- Remove invalid `--architectures` flag from `update-function-configuration` calls in 8 deploy.sh scripts
- This flag is only valid on `update-function-code` and `create-function`
- The bug caused 6/18 deploy workflows to report failure (exit code 252) even when code upload succeeded

**Plan:** ENC-PLN-018 (V3 Stack Health Recovery)
**Task:** ENC-TSK-C98 (Phase 2: Deploy pipeline hardening)

CCI-27e555c5a55b4dcaab6be5dfa8486510

## Test plan
- [ ] All CI checks pass
- [ ] Future deploy workflow dispatches complete without exit code 252

🤖 Generated with [Claude Code](https://claude.com/claude-code)