### PR TITLE
feat(infra): add post-deploy Lambda CodeSize validation to CFN workflow (ENC-TSK-C99)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -125,3 +125,29 @@ jobs:
             --stack-name "${{ steps.params.outputs.stack_name }}" \
             --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
             --output table
+
+      - name: Validate Lambda CodeSize (detect CFN stub stomp)
+        run: |
+          set -euo pipefail
+          # Read function names from the manifest (source of truth for CFN-managed Lambdas)
+          suffix="${ENVIRONMENT_SUFFIX}"
+          failed=0
+          while IFS= read -r fn_name; do
+            effective_name="${fn_name}${suffix}"
+            code_size=$(aws lambda get-function-configuration \
+              --function-name "${effective_name}" \
+              --region "${AWS_REGION}" \
+              --query 'CodeSize' \
+              --output text 2>/dev/null || echo "0")
+            if [ "${code_size}" -lt 1024 ]; then
+              echo "::error::Lambda ${effective_name} has CodeSize=${code_size} (< 1024) — likely CFN ZipFile stub. Deploy workflows must re-deploy this function."
+              failed=1
+            else
+              echo "✓ ${effective_name}: CodeSize=${code_size}"
+            fi
+          done < <(jq -r '.functions[].function_name' infrastructure/lambda_workflow_manifest.json)
+          if [ "${failed}" -eq 1 ]; then
+            echo "::error::One or more Lambda functions have stub-sized code packages after CFN stack update. This indicates a CFN ZipFile stomp — trigger per-Lambda deploy workflows to restore."
+            exit 1
+          fi
+          echo "All Lambda functions have valid CodeSize (>= 1024)."


### PR DESCRIPTION
## Summary
- Add a post-deploy Lambda CodeSize validation step to `cloudformation-compute-stack-deploy.yml`
- After every CFN compute stack update, checks all Lambda functions from the manifest for CodeSize >= 1024
- Fails the workflow if any function has a stub-sized code package (< 1024 bytes), indicating a CFN ZipFile stomp
- Prevents silent recurrence of the 2026-04-11 Sev1 where CFN overwrote 17 prod Lambdas with 164-byte inline stubs

**Note:** CFN stack policy (AC1) requires product-lead IAM — documented as handoff in task worklog.

**Plan:** ENC-PLN-018 (V3 Stack Health Recovery)
**Task:** ENC-TSK-C99 (Phase 3: CFN stomp prevention)

CCI-6baf7cd1fd7d4da09889488d7b6840fc

## Test plan
- [ ] All CI checks pass
- [ ] Next CFN stack update triggers the validation step
- [ ] Product-lead applies stack policy separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)