### PR TITLE
fix(infra): restore prod to x86_64/py3.11 with gamma conditionals (ENC-TSK-D11)

### DIFF
--- a/backend/lambda/checkout_service/deploy.sh
+++ b/backend/lambda/checkout_service/deploy.sh
@@ -268,19 +268,26 @@ deploy_lambda() {
   local env_json="$5"
   local layer_arn="$6"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+  local arch_flag="x86_64" runtime_flag="python3.11"
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    arch_flag="arm64"; runtime_flag="python3.12"
+  fi
+
   if aws lambda get-function --function-name "${fn_name}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating code: ${fn_name}"
     aws lambda update-function-code \
       --function-name "${fn_name}" \
       --region "${REGION}" \
-      --zip-file "fileb://${zip_path}" >/dev/null
+      --zip-file "fileb://${zip_path}" \
+      --architectures "${arch_flag}" >/dev/null
     aws lambda wait function-updated-v2 --function-name "${fn_name}" --region "${REGION}"
 
     aws lambda update-function-configuration \
       --function-name "${fn_name}" \
       --region "${REGION}" \
       --handler "${handler}" \
-      --runtime python3.12 \
+      --runtime "${runtime_flag}" \
       --timeout 30 \
       --memory-size 256 \
       --environment "${env_json}" \
@@ -291,8 +298,8 @@ deploy_lambda() {
     aws lambda create-function \
       --function-name "${fn_name}" \
       --region "${REGION}" \
-      --runtime python3.12 \
-      --architectures arm64 \
+      --runtime "${runtime_flag}" \
+      --architectures "${arch_flag}" \
       --role "${role_arn}" \
       --handler "${handler}" \
       --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/graph_health_metrics/deploy.sh
+++ b/backend/lambda/graph_health_metrics/deploy.sh
@@ -30,16 +30,23 @@ ensure_role() {
 
 build_package() {
   log "[INFO] Building deployment package"
-  local build_dir
+  local build_dir pip_platform pip_pyver pip_abi
   build_dir="$(mktemp -d)"
   cp "${SCRIPT_DIR}/lambda_function.py" "${build_dir}/"
 
+  # Environment-conditional: prod=x86_64/py3.11, gamma=arm64/py3.12
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   # Install neo4j driver for Linux Lambda runtime
   pip install \
-    --platform manylinux2014_aarch64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.12 \
-    --abi cp312 \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
     --only-binary=:all: \
     neo4j -t "${build_dir}" --quiet 2>/dev/null || true
 
@@ -54,21 +61,26 @@ deploy_function() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating existing function ${FUNCTION_NAME}"
+    local arch_flag="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \
+      --architectures "${arch_flag}" \
       --region "${REGION}" >/dev/null
   else
+    local runtime="python3.11" arch="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && runtime="python3.12" && arch="arm64"
     log "[INFO] Creating new function ${FUNCTION_NAME}"
     aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.12 \
+      --runtime "${runtime}" \
       --handler lambda_function.handler \
       --role "${role_arn}" \
       --zip-file "fileb://${zip_path}" \
       --timeout 120 \
       --memory-size 256 \
-      --architectures arm64 \
+      --architectures "${arch}" \
       --environment "Variables={NEO4J_SECRET_NAME=${NEO4J_SECRET_NAME},CLOUDWATCH_NAMESPACE=${CLOUDWATCH_NAMESPACE},PROJECT_ID=enceladus,SECRETS_REGION=${REGION}}" \
       --region "${REGION}" >/dev/null
   fi

--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -79,19 +79,26 @@ resolve_internal_api_key() {
 }
 
 package_lambda() {
-  local build_dir zip_path
+  local build_dir zip_path pip_platform pip_pyver pip_abi
   build_dir="$(mktemp -d /tmp/graph-query-api-build-XXXXXX)"
   zip_path="/tmp/${FUNCTION_NAME}.zip"
+
+  # Environment-conditional: prod=x86_64/py3.11, gamma=arm64/py3.12
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
 
   cp "${ROOT_DIR}/lambda_function.py" "${build_dir}/"
 
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_aarch64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.12 \
-    --abi cp312 \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
     --only-binary=:all: \
     -r "${ROOT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -112,17 +119,22 @@ ensure_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    local arch_flag="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \
+      --architectures "${arch_flag}" \
       --zip-file "fileb://${zip_path}" >/dev/null
   else
+    local runtime="python3.11" arch="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && runtime="python3.12" && arch="arm64"
     log "[START] creating Lambda function: ${FUNCTION_NAME}"
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.12 \
-      --architectures arm64 \
+      --runtime "${runtime}" \
+      --architectures "${arch}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 10 \

--- a/backend/lambda/graph_sync/deploy.sh
+++ b/backend/lambda/graph_sync/deploy.sh
@@ -66,19 +66,26 @@ POLICY
 }
 
 package_lambda() {
-  local build_dir zip_path
+  local build_dir zip_path pip_platform pip_pyver pip_abi
   build_dir="$(mktemp -d /tmp/graph-sync-build-XXXXXX)"
   zip_path="/tmp/${FUNCTION_NAME}.zip"
+
+  # Environment-conditional: prod=x86_64/py3.11, gamma=arm64/py3.12
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
 
   cp "${ROOT_DIR}/lambda_function.py" "${build_dir}/"
 
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_aarch64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.12 \
-    --abi cp312 \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
     --only-binary=:all: \
     -r "${ROOT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -99,17 +106,22 @@ ensure_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    local arch_flag="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \
+      --architectures "${arch_flag}" \
       --zip-file "fileb://${zip_path}" >/dev/null
   else
+    local runtime="python3.11" arch="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && runtime="python3.12" && arch="arm64"
     log "[START] creating Lambda function: ${FUNCTION_NAME}"
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.12 \
-      --architectures arm64 \
+      --runtime "${runtime}" \
+      --architectures "${arch}" \
       --handler lambda_function.handler \
       --role "${role_arn}" \
       --timeout 60 \

--- a/backend/lambda/mcp_code/deploy.sh
+++ b/backend/lambda/mcp_code/deploy.sh
@@ -150,13 +150,21 @@ package_lambda() {
   # ENC-FTR-050: Context Node scoring engine (imported dynamically by server.py)
   cp "${REPO_ROOT}/backend/lambda/coordination_api/context_node_scoring.py" "${build_dir}/context_node_scoring.py"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+  local pip_platform pip_pyver pip_abi
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   python3 -m pip install \
     --quiet \
     --upgrade \
     -r "${SCRIPT_DIR}/requirements.txt" \
-    --platform manylinux2014_aarch64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.12 \
+    --python-version "${pip_pyver}" \
     --only-binary=:all: \
     -t "${build_dir}" >/dev/null
 
@@ -365,12 +373,19 @@ deploy_lambda() {
   CUSTOM_DOMAIN="${CUSTOM_DOMAIN}" \
   build_environment_payload "${env_file}"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+  local arch_flag="x86_64" runtime_flag="python3.11"
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    arch_flag="arm64"; runtime_flag="python3.12"
+  fi
+
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \
-      --zip-file "fileb://${ZIP_FILE}" >/dev/null
+      --zip-file "fileb://${ZIP_FILE}" \
+      --architectures "${arch_flag}" >/dev/null
     aws lambda wait function-updated-v2 \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}"
@@ -381,7 +396,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "server.lambda_handler" \
-      --runtime "python3.12" \
+      --runtime "${runtime_flag}" \
       --timeout 30 \
       --memory-size 512 \
       --environment "file://${env_file}" >/dev/null
@@ -390,8 +405,8 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime "python3.12" \
-      --architectures arm64 \
+      --runtime "${runtime_flag}" \
+      --architectures "${arch_flag}" \
       --handler "server.lambda_handler" \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/mcp_streamable/deploy.sh
+++ b/backend/lambda/mcp_streamable/deploy.sh
@@ -132,13 +132,21 @@ package_lambda() {
   # ENC-FTR-050: Context Node scoring engine (imported dynamically by server.py)
   cp "${REPO_ROOT}/backend/lambda/coordination_api/context_node_scoring.py" "${build_dir}/context_node_scoring.py"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+  local pip_platform pip_pyver pip_abi
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   python3 -m pip install \
     --quiet \
     --upgrade \
     -r "${SCRIPT_DIR}/requirements.txt" \
-    --platform manylinux2014_aarch64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.12 \
+    --python-version "${pip_pyver}" \
     --only-binary=:all: \
     -t "${build_dir}" >/dev/null
 
@@ -211,12 +219,19 @@ deploy_lambda() {
   OAUTH_CLIENT_SECRET="${OAUTH_CLIENT_SECRET}" \
   build_environment_payload "${env_file}"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+  local arch_flag="x86_64" runtime_flag="python3.11"
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    arch_flag="arm64"; runtime_flag="python3.12"
+  fi
+
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \
-      --zip-file "fileb://${ZIP_FILE}" >/dev/null
+      --zip-file "fileb://${ZIP_FILE}" \
+      --architectures "${arch_flag}" >/dev/null
     aws lambda wait function-updated-v2 \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}"
@@ -227,7 +242,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "server.lambda_handler" \
-      --runtime "python3.12" \
+      --runtime "${runtime_flag}" \
       --timeout 30 \
       --memory-size 512 \
       --environment "file://${env_file}" >/dev/null
@@ -236,8 +251,8 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime "python3.12" \
-      --architectures arm64 \
+      --runtime "${runtime_flag}" \
+      --architectures "${arch_flag}" \
       --handler "server.lambda_handler" \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/neo4j_backup/deploy.sh
+++ b/backend/lambda/neo4j_backup/deploy.sh
@@ -59,16 +59,23 @@ ensure_role() {
 }
 
 package_lambda() {
-  local build_dir zip_path
+  local build_dir zip_path pip_platform pip_pyver pip_abi
   build_dir="$(mktemp -d /tmp/deploy-${FUNCTION_NAME}-build-XXXXXX)"
   zip_path="/tmp/${FUNCTION_NAME}.zip"
+
+  # Environment-conditional: prod=x86_64/py3.11, gamma=arm64/py3.12
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
 
   cp "${SCRIPT_DIR}/lambda_function.py" "${build_dir}/"
 
   python3 -m pip install \
     --quiet --upgrade \
-    --platform manylinux2014_aarch64 \
-    --implementation cp --python-version 3.12 --abi cp312 \
+    --platform "${pip_platform}" \
+    --implementation cp --python-version "${pip_pyver}" --abi "${pip_abi}" \
     --only-binary=:all: \
     -r "${SCRIPT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -84,14 +91,16 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating existing function ${FUNCTION_NAME}"
+    local arch_flag="x86_64" runtime_flag="python3.11"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64" && runtime_flag="python3.12"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \
-      --region "${REGION}" --architectures arm64 >/dev/null
+      --region "${REGION}" --architectures "${arch_flag}" >/dev/null
     aws lambda wait function-updated-v2 --function-name "${FUNCTION_NAME}" --region "${REGION}"
     aws lambda update-function-configuration \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.12 \
+      --runtime "${runtime_flag}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 300 \
@@ -102,8 +111,8 @@ deploy_lambda() {
     log "[INFO] Creating new function ${FUNCTION_NAME}"
     aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.12 \
-      --architectures arm64 \
+      --runtime "${runtime_flag}" \
+      --architectures "${arch_flag}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --zip-file "fileb://${zip_path}" \

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -48,6 +48,7 @@ Parameters:
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
 
 Resources:
   # ---------------------------------------------------------------------------
@@ -61,11 +62,12 @@ Resources:
       FunctionName: !Sub "devops-coordination-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 512
       Timeout: 120
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -100,11 +102,12 @@ Resources:
       FunctionName: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 10
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -132,11 +135,12 @@ Resources:
       FunctionName: !Sub "devops-document-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -169,11 +173,12 @@ Resources:
       FunctionName: !Sub "devops-project-service${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -203,11 +208,12 @@ Resources:
       FunctionName: !Sub "devops-feed-query-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 60  # ENC-TSK-797: increased from 15 for synchronous feed_publisher invoke
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -236,11 +242,12 @@ Resources:
       FunctionName: !Sub "devops-coordination-monitor-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -267,11 +274,12 @@ Resources:
       FunctionName: !Sub "devops-deploy-intake${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 512
       Timeout: 120
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -302,11 +310,12 @@ Resources:
       FunctionName: !Sub "devops-reference-search${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 10
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -333,11 +342,12 @@ Resources:
       FunctionName: !Sub "auth-refresh${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Timeout: 10
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -365,11 +375,12 @@ Resources:
       FunctionName: !Sub "devops-deploy-orchestrator${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 120
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -396,11 +407,12 @@ Resources:
       FunctionName: !Sub "devops-deploy-finalize${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 120
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -427,11 +439,12 @@ Resources:
       FunctionName: !Sub "devops-feed-publisher${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 512
       Timeout: 600
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -460,11 +473,12 @@ Resources:
       FunctionName: !Sub "enceladus-governance-audit${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 128
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -483,11 +497,12 @@ Resources:
       FunctionName: !Sub "devops-doc-prep${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -513,11 +528,12 @@ Resources:
       FunctionName: !Sub "enceladus-bedrock-agent-actions${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -546,11 +562,12 @@ Resources:
       FunctionName: !Sub "devops-changelog-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 30
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -580,11 +597,12 @@ Resources:
       FunctionName: !Sub "devops-graph-sync${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 60
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -607,11 +625,12 @@ Resources:
       FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Timeout: 10
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -641,11 +660,12 @@ Resources:
       FunctionName: !Sub "enceladus-neo4j-backup${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.lambda_handler
       MemorySize: 512
       Timeout: 300
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
         - IsProduction
         - !Ref AWS::NoValue
@@ -674,11 +694,12 @@ Resources:
       FunctionName: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 120
-      Architectures: [arm64]
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
       Role: !GetAtt GraphHealthMetricsRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
## Summary
- **CFN template**: Added `IsGamma` condition. All 20 Lambda `Runtime` and `Architectures` declarations now use `!If [IsGamma, arm64/py3.12, x86_64/py3.11]` — production stays x86_64/py3.11, gamma gets arm64/py3.12
- **7 deploy.sh scripts**: Reverted to env-conditional (ENVIRONMENT_SUFFIX empty=x86_64/py3.11, set=arm64/py3.12): graph_sync, graph_query_api, graph_health_metrics, mcp_code, mcp_streamable, checkout_service, neo4j_backup
- **All `update-function-code` calls** now pass `--architectures` flag based on ENVIRONMENT_SUFFIX for atomic arch flipping on deploy
- Zero hardcoded arm64 references remain in any prod deploy path

**Root cause**: ENC-TSK-B30 (commit 43db793) applied arm64/py3.12 to CFN as gamma prep, but prod shared layer is x86_64. The Sev1 applied these declarations to prod, causing binary incompatibility.

**Plan:** ENC-PLN-019 (V3 Full Restoration & Production Lockdown)
**Task:** ENC-TSK-D11 (Phase R1: Restore prod to x86_64/py3.11)

CCI-f2d6ddce4855417e9fb6ff3fe96c2bf4

## Test plan
- [ ] All CI checks pass
- [ ] After merge, dispatch all prod deploy workflows to restore x86_64/py3.11
- [ ] Validate all Lambdas on x86_64/py3.11, PWA healthy, MCP healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)