### PR TITLE
fix(infra): default prod Lambda runtime to python3.11 (ENC-TSK-D16)

### DIFF
--- a/.github/workflows/lambda-deploy-reusable.yml
+++ b/.github/workflows/lambda-deploy-reusable.yml
@@ -180,6 +180,22 @@ jobs:
             --region "us-west-2" \
             --function-name "${function_name}"
 
+          # Env-conditional runtime: gamma=python3.12, prod=python3.11
+          if [ -n "${{ inputs.environment_suffix }}" ]; then
+            runtime="python3.12"
+          else
+            runtime="python3.11"
+          fi
+
+          aws lambda update-function-configuration \
+            --region "us-west-2" \
+            --function-name "${function_name}" \
+            --runtime "${runtime}" >/dev/null
+
+          aws lambda wait function-updated-v2 \
+            --region "us-west-2" \
+            --function-name "${function_name}"
+
           rm -rf "${build_dir}" "${zip_file}"
 
       - name: Validate deployed Lambda state

--- a/backend/lambda/deploy_finalize/deploy.sh
+++ b/backend/lambda/deploy_finalize/deploy.sh
@@ -5,8 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 REGION="${REGION:-us-west-2}"
 FUNCTION_NAME="${FUNCTION_NAME:-devops-deploy-finalize${ENVIRONMENT_SUFFIX}}"
-RUNTIME="${RUNTIME:-python3.12}"
-ARCHITECTURE="${ARCHITECTURE:-arm64}"
+# Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  RUNTIME="${RUNTIME:-python3.12}"
+  ARCHITECTURE="${ARCHITECTURE:-arm64}"
+else
+  RUNTIME="${RUNTIME:-python3.11}"
+  ARCHITECTURE="${ARCHITECTURE:-x86_64}"
+fi
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"

--- a/backend/lambda/doc_prep/deploy.sh
+++ b/backend/lambda/doc_prep/deploy.sh
@@ -5,8 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 REGION="${REGION:-us-west-2}"
 FUNCTION_NAME="${FUNCTION_NAME:-devops-doc-prep${ENVIRONMENT_SUFFIX}}"
-RUNTIME="${RUNTIME:-python3.12}"
-ARCHITECTURE="${ARCHITECTURE:-arm64}"
+# Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  RUNTIME="${RUNTIME:-python3.12}"
+  ARCHITECTURE="${ARCHITECTURE:-arm64}"
+else
+  RUNTIME="${RUNTIME:-python3.11}"
+  ARCHITECTURE="${ARCHITECTURE:-x86_64}"
+fi
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"


### PR DESCRIPTION
## Summary
- **deploy_finalize/deploy.sh** and **doc_prep/deploy.sh**: replaced hardcoded `RUNTIME=python3.12` / `ARCHITECTURE=arm64` defaults with env-conditional pattern (prod=python3.11/x86_64, gamma=python3.12/arm64), matching checkout_service and graph_sync
- **lambda-deploy-reusable.yml**: generic code-only deploy path now includes `update-function-configuration` with env-conditional runtime so Lambdas deployed without a custom deploy_script also get the correct runtime

## Root cause
4 prod Lambdas on python3.12 instead of v3 baseline python3.11:
- `devops-deploy-finalize` and `devops-doc-prep`: deploy.sh defaulted RUNTIME to python3.12
- `enceladus-checkout-service` and `enceladus-checkout-service-auto`: reusable workflow generic path never set runtime at all

## Test plan
- [x] `tools/verify_lambda_arch_parity.py` passes (CI guard)
- [ ] CI, Secrets Scan, PR Commit Gate pass
- [ ] After merge, dispatch deploy workflows for all 4 affected Lambdas
- [ ] Verify all 4 running python3.11 via `aws lambda get-function-configuration`
- [ ] Run `03-validate-prod-health.sh` for full baseline check

CCI-3b486474dee1423ea27dad9fe167bc09

🤖 Generated with [Claude Code](https://claude.com/claude-code)