### PR TITLE
feat(ci): gamma-first deploy orchestration with automated UAT gates (ENC-TSK-D18)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -127,6 +127,8 @@ jobs:
             --output table
 
       - name: Validate Lambda CodeSize (detect CFN stub stomp)
+        # Informational only — full-stack orchestration below handles restoration
+        continue-on-error: true
         run: |
           set -euo pipefail
           # Read function names from the manifest (source of truth for CFN-managed Lambdas)
@@ -140,14 +142,23 @@ jobs:
               --query 'CodeSize' \
               --output text 2>/dev/null || echo "0")
             if [ "${code_size}" -lt 1024 ]; then
-              echo "::error::Lambda ${effective_name} has CodeSize=${code_size} (< 1024) — likely CFN ZipFile stub. Deploy workflows must re-deploy this function."
+              echo "::warning::Lambda ${effective_name} has CodeSize=${code_size} (< 1024) — likely CFN ZipFile stub. Full-stack orchestration will restore."
               failed=1
             else
               echo "✓ ${effective_name}: CodeSize=${code_size}"
             fi
           done < <(jq -r '.functions[].function_name' infrastructure/lambda_workflow_manifest.json)
           if [ "${failed}" -eq 1 ]; then
-            echo "::error::One or more Lambda functions have stub-sized code packages after CFN stack update. This indicates a CFN ZipFile stomp — trigger per-Lambda deploy workflows to restore."
-            exit 1
+            echo "::warning::One or more Lambda functions have stub-sized code packages after CFN stack update. Full-stack deploy orchestration will restore all Lambdas."
           fi
-          echo "All Lambda functions have valid CodeSize (>= 1024)."
+          echo "CodeSize validation complete. Full-stack orchestration follows."
+
+  # After CFN stack update, run full-stack deploy orchestration to restore
+  # any Lambdas that may have been overwritten with CFN ZipFile stubs.
+  # This closes the path-filter coverage gap from the Sev1 incident (ENC-TSK-1292).
+  full-stack-restore:
+    needs: deploy
+    uses: ./.github/workflows/deploy-orchestration.yml
+    with:
+      deploy_mode: "full-stack"
+    secrets: inherit

--- a/.github/workflows/deploy-orchestration.yml
+++ b/.github/workflows/deploy-orchestration.yml
@@ -1,0 +1,342 @@
+name: Deploy Orchestration (Gamma-First)
+
+# ENC-TSK-D18 / ENC-PLN-020 Phase 2
+# Enforces gamma-first deploy sequencing:
+#   gamma deploy -> automated UAT gate -> manual approval -> prod deploy -> prod validation
+#
+# Two modes:
+#   per-lambda:  Single function through the full sequence
+#   full-stack:  All manifest functions via matrix strategy
+
+on:
+  workflow_call:
+    inputs:
+      function_name:
+        description: Lambda function name (required for per-lambda mode)
+        required: false
+        type: string
+        default: ""
+      lambda_dir:
+        description: Relative path to lambda source directory (required for per-lambda mode)
+        required: false
+        type: string
+        default: ""
+      deploy_mode:
+        description: "per-lambda or full-stack"
+        required: false
+        type: string
+        default: "per-lambda"
+      deploy_script:
+        description: Optional deploy script path
+        required: false
+        type: string
+        default: ""
+      package_extra_files:
+        description: Optional comma-separated extra files for generic packaging
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      function_name:
+        description: Lambda function name (required for per-lambda mode)
+        type: string
+        required: false
+        default: ""
+      lambda_dir:
+        description: Relative path to lambda source directory (required for per-lambda mode)
+        type: string
+        required: false
+        default: ""
+      deploy_mode:
+        description: "per-lambda or full-stack"
+        type: choice
+        options:
+          - per-lambda
+          - full-stack
+        default: "per-lambda"
+      deploy_script:
+        description: Optional deploy script path
+        type: string
+        required: false
+        default: ""
+      package_extra_files:
+        description: Optional comma-separated extra files for generic packaging
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+# ---------------------------------------------------------------------------
+# PER-LAMBDA MODE
+# ---------------------------------------------------------------------------
+
+jobs:
+
+  # ---- Gamma deploy (per-lambda) ----
+  gamma-deploy:
+    if: inputs.deploy_mode == 'per-lambda'
+    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    with:
+      function_name: ${{ inputs.function_name }}
+      lambda_dir: ${{ inputs.lambda_dir }}
+      deploy_script: ${{ inputs.deploy_script }}
+      package_extra_files: ${{ inputs.package_extra_files }}
+      environment_suffix: "-gamma"
+    secrets: inherit
+
+  # ---- Gamma health gate (per-lambda) ----
+  gamma-health-gate:
+    needs: gamma-deploy
+    if: inputs.deploy_mode == 'per-lambda'
+    name: Gamma Health Gate (${{ inputs.function_name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Install dependencies
+        run: pip install --quiet boto3
+
+      - name: Run gamma UAT suite
+        run: |
+          set -euo pipefail
+          python3 tools/gamma_uat_suite.py \
+            --environment gamma \
+            --function-name "${{ inputs.function_name }}" \
+            --output-json /tmp/gamma-uat-report.json
+          echo "=== Gamma UAT Report ==="
+          cat /tmp/gamma-uat-report.json | python3 -m json.tool
+
+      - name: Upload UAT report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gamma-uat-report-${{ inputs.function_name }}
+          path: /tmp/gamma-uat-report.json
+          retention-days: 30
+
+  # ---- Manual approval (per-lambda, main only) ----
+  approval:
+    needs: gamma-health-gate
+    if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
+    name: Production Approval (${{ inputs.function_name }})
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Approved
+        run: echo "Production deployment approved for ${{ inputs.function_name }}"
+
+  # ---- Prod deploy (per-lambda, main only) ----
+  prod-deploy:
+    needs: approval
+    if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    with:
+      function_name: ${{ inputs.function_name }}
+      lambda_dir: ${{ inputs.lambda_dir }}
+      deploy_script: ${{ inputs.deploy_script }}
+      package_extra_files: ${{ inputs.package_extra_files }}
+      environment_suffix: ""
+    secrets: inherit
+
+  # ---- Prod validation (per-lambda, main only) ----
+  prod-validation:
+    needs: prod-deploy
+    if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
+    name: Production Validation (${{ inputs.function_name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Install dependencies
+        run: pip install --quiet boto3
+
+      - name: Run production validation
+        run: |
+          set -euo pipefail
+          python3 tools/gamma_uat_suite.py \
+            --environment production \
+            --function-name "${{ inputs.function_name }}" \
+            --output-json /tmp/prod-validation-report.json
+          echo "=== Production Validation Report ==="
+          cat /tmp/prod-validation-report.json | python3 -m json.tool
+
+      - name: Upload validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-validation-report-${{ inputs.function_name }}
+          path: /tmp/prod-validation-report.json
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # FULL-STACK MODE
+  # ---------------------------------------------------------------------------
+
+  # ---- Setup matrix from manifest ----
+  setup-matrix:
+    if: inputs.deploy_mode == 'full-stack'
+    name: Setup Lambda Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read manifest and build matrix
+        id: set-matrix
+        run: |
+          set -euo pipefail
+          matrix=$(jq -c '{
+            include: [
+              .functions[] | {
+                function_name,
+                lambda_dir,
+                deploy_script: (.deploy_script // ""),
+                package_extra_files: ((.package_extra_files // []) | join(","))
+              }
+            ]
+          }' infrastructure/lambda_workflow_manifest.json)
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          echo "Matrix entries: $(echo "${matrix}" | jq '.include | length')"
+
+  # ---- Gamma deploy (full-stack matrix) ----
+  gamma-deploy-matrix:
+    needs: setup-matrix
+    if: inputs.deploy_mode == 'full-stack'
+    strategy:
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 5
+    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    with:
+      function_name: ${{ matrix.function_name }}
+      lambda_dir: ${{ matrix.lambda_dir }}
+      deploy_script: ${{ matrix.deploy_script }}
+      package_extra_files: ${{ matrix.package_extra_files }}
+      environment_suffix: "-gamma"
+    secrets: inherit
+
+  # ---- Gamma health gate (full-stack) ----
+  gamma-health-gate-fullstack:
+    needs: gamma-deploy-matrix
+    if: inputs.deploy_mode == 'full-stack'
+    name: Gamma Health Gate (full-stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Install dependencies
+        run: pip install --quiet boto3
+
+      - name: Run full-stack gamma UAT suite
+        run: |
+          set -euo pipefail
+          python3 tools/gamma_uat_suite.py \
+            --environment gamma \
+            --full-stack \
+            --output-json /tmp/gamma-fullstack-uat-report.json
+          echo "=== Full-Stack Gamma UAT Report ==="
+          cat /tmp/gamma-fullstack-uat-report.json | python3 -m json.tool
+
+      - name: Upload UAT report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gamma-fullstack-uat-report
+          path: /tmp/gamma-fullstack-uat-report.json
+          retention-days: 30
+
+  # ---- Manual approval (full-stack, main only) ----
+  approval-fullstack:
+    needs: gamma-health-gate-fullstack
+    if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
+    name: Production Approval (full-stack)
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Approved
+        run: echo "Full-stack production deployment approved"
+
+  # ---- Prod deploy (full-stack matrix, main only) ----
+  prod-deploy-matrix:
+    needs: [approval-fullstack, setup-matrix]
+    if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
+    strategy:
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 5
+    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    with:
+      function_name: ${{ matrix.function_name }}
+      lambda_dir: ${{ matrix.lambda_dir }}
+      deploy_script: ${{ matrix.deploy_script }}
+      package_extra_files: ${{ matrix.package_extra_files }}
+      environment_suffix: ""
+    secrets: inherit
+
+  # ---- Prod validation (full-stack, main only) ----
+  prod-validation-fullstack:
+    needs: prod-deploy-matrix
+    if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
+    name: Production Validation (full-stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Install dependencies
+        run: pip install --quiet boto3
+
+      - name: Run full-stack production validation
+        run: |
+          set -euo pipefail
+          python3 tools/gamma_uat_suite.py \
+            --environment production \
+            --full-stack \
+            --output-json /tmp/prod-fullstack-validation-report.json
+          echo "=== Full-Stack Production Validation Report ==="
+          cat /tmp/prod-fullstack-validation-report.json | python3 -m json.tool
+
+      - name: Upload validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-fullstack-validation-report
+          path: /tmp/prod-fullstack-validation-report.json
+          retention-days: 30

--- a/.github/workflows/lambda-auth-refresh-deploy.yml
+++ b/.github/workflows/lambda-auth-refresh-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/auth_refresh/**"
       - ".github/workflows/lambda-auth-refresh-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "auth-refresh"
       lambda_dir: "backend/lambda/auth_refresh"
       deploy_script: "backend/lambda/auth_refresh/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-bedrock-agent-actions-deploy.yml
+++ b/.github/workflows/lambda-bedrock-agent-actions-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/bedrock_agent_actions/**"
       - ".github/workflows/lambda-bedrock-agent-actions-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-bedrock-agent-actions"
       lambda_dir: "backend/lambda/bedrock_agent_actions"
       deploy_script: "backend/lambda/bedrock_agent_actions/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-changelog-api-deploy.yml
+++ b/.github/workflows/lambda-changelog-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/changelog_api/**"
       - ".github/workflows/lambda-changelog-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-changelog-api"
       lambda_dir: "backend/lambda/changelog_api"
       deploy_script: "backend/lambda/changelog_api/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-checkout-service-deploy.yml
+++ b/.github/workflows/lambda-checkout-service-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/checkout_service/**"
       - ".github/workflows/lambda-checkout-service-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -24,22 +25,20 @@ permissions:
 jobs:
   deploy-http:
     name: Deploy enceladus-checkout-service (HTTP handler)
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-checkout-service"
       lambda_dir: "backend/lambda/checkout_service"
       package_extra_files: "transition_type_matrix.py"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+      deploy_mode: "per-lambda"
+    secrets: inherit
 
   deploy-auto:
     name: Deploy enceladus-checkout-service-auto (EventBridge handler)
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-checkout-service-auto"
       lambda_dir: "backend/lambda/checkout_service"
       package_extra_files: "transition_type_matrix.py"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-coordination-monitor-api-deploy.yml
+++ b/.github/workflows/lambda-coordination-monitor-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/coordination_monitor_api/**"
       - ".github/workflows/lambda-coordination-monitor-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-coordination-monitor-api"
       lambda_dir: "backend/lambda/coordination_monitor_api"
       deploy_script: "backend/lambda/coordination_monitor_api/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-deploy-finalize-deploy.yml
+++ b/.github/workflows/lambda-deploy-finalize-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/deploy_finalize/**"
       - ".github/workflows/lambda-deploy-finalize-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-deploy-finalize"
       lambda_dir: "backend/lambda/deploy_finalize"
       deploy_script: "backend/lambda/deploy_finalize/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-deploy-intake-deploy.yml
+++ b/.github/workflows/lambda-deploy-intake-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/deploy_intake/**"
       - ".github/workflows/lambda-deploy-intake-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,15 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-deploy-intake"
       lambda_dir: "backend/lambda/deploy_intake"
       deploy_script: "backend/lambda/deploy_intake/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_SCOPES: ${{ secrets.COORDINATION_INTERNAL_API_KEY_SCOPES }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-deploy-orchestrator-deploy.yml
+++ b/.github/workflows/lambda-deploy-orchestrator-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/deploy_orchestrator/**"
       - ".github/workflows/lambda-deploy-orchestrator-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-deploy-orchestrator"
       lambda_dir: "backend/lambda/deploy_orchestrator"
       deploy_script: "backend/lambda/deploy_orchestrator/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-doc-prep-deploy.yml
+++ b/.github/workflows/lambda-doc-prep-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/doc_prep/**"
       - ".github/workflows/lambda-doc-prep-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-doc-prep"
       lambda_dir: "backend/lambda/doc_prep"
       deploy_script: "backend/lambda/doc_prep/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-document-api-deploy.yml
+++ b/.github/workflows/lambda-document-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/document_api/**"
       - ".github/workflows/lambda-document-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,15 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-document-api"
       lambda_dir: "backend/lambda/document_api"
       deploy_script: "backend/lambda/document_api/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_SCOPES: ${{ secrets.COORDINATION_INTERNAL_API_KEY_SCOPES }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-feed-publisher-deploy.yml
+++ b/.github/workflows/lambda-feed-publisher-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/feed_publisher/**"
       - ".github/workflows/lambda-feed-publisher-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,15 +24,11 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-feed-publisher"
       lambda_dir: "backend/lambda/feed_publisher"
       deploy_script: "backend/lambda/feed_publisher/deploy.sh"
+      deploy_mode: "per-lambda"
       package_extra_files: "feed_utils.py"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+    secrets: inherit

--- a/.github/workflows/lambda-feed-query-api-deploy.yml
+++ b/.github/workflows/lambda-feed-query-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/feed_query/**"
       - ".github/workflows/lambda-feed-query-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-feed-query-api"
       lambda_dir: "backend/lambda/feed_query"
       deploy_script: "backend/lambda/feed_query/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-governance-audit-deploy.yml
+++ b/.github/workflows/lambda-governance-audit-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/governance_audit/**"
       - ".github/workflows/lambda-governance-audit-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-governance-audit"
       lambda_dir: "backend/lambda/governance_audit"
       deploy_script: "backend/lambda/governance_audit/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-graph-health-metrics-deploy.yml
+++ b/.github/workflows/lambda-graph-health-metrics-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/graph_health_metrics/**"
       - ".github/workflows/lambda-graph-health-metrics-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-graph-health-metrics"
       lambda_dir: "backend/lambda/graph_health_metrics"
       deploy_script: "backend/lambda/graph_health_metrics/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-graph-query-api-deploy.yml
+++ b/.github/workflows/lambda-graph-query-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/graph_query_api/**"
       - ".github/workflows/lambda-graph-query-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-graph-query-api"
       lambda_dir: "backend/lambda/graph_query_api"
       deploy_script: "backend/lambda/graph_query_api/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-graph-sync-deploy.yml
+++ b/.github/workflows/lambda-graph-sync-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/graph_sync/**"
       - ".github/workflows/lambda-graph-sync-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-graph-sync"
       lambda_dir: "backend/lambda/graph_sync"
       deploy_script: "backend/lambda/graph_sync/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-mcp-code-deploy.yml
+++ b/.github/workflows/lambda-mcp-code-deploy.yml
@@ -9,6 +9,7 @@ on:
       - "backend/lambda/mcp_code/**"
       - "tools/enceladus-mcp-server/server.py"
       - ".github/workflows/lambda-mcp-code-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -24,19 +25,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-mcp-code"
       lambda_dir: "backend/lambda/mcp_code"
       deploy_script: "backend/lambda/mcp_code/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_PREVIOUS: ${{ secrets.COORDINATION_INTERNAL_API_KEY_PREVIOUS }}
-      ENCELADUS_COGNITO_USER_POOL_ID: ${{ secrets.ENCELADUS_COGNITO_USER_POOL_ID }}
-      ENCELADUS_COGNITO_CLIENT_ID: ${{ secrets.ENCELADUS_COGNITO_CLIENT_ID }}
-      ENCELADUS_COGNITO_CLIENT_SECRET: ${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}
-      ENCELADUS_COGNITO_DOMAIN: ${{ secrets.ENCELADUS_COGNITO_DOMAIN }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-mcp-streamable-deploy.yml
+++ b/.github/workflows/lambda-mcp-streamable-deploy.yml
@@ -9,6 +9,7 @@ on:
       - "backend/lambda/mcp_streamable/**"
       - "tools/enceladus-mcp-server/server.py"
       - ".github/workflows/lambda-mcp-streamable-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -24,17 +25,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-mcp-streamable"
       lambda_dir: "backend/lambda/mcp_streamable"
       deploy_script: "backend/lambda/mcp_streamable/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_PREVIOUS: ${{ secrets.COORDINATION_INTERNAL_API_KEY_PREVIOUS }}
-      ENCELADUS_OAUTH_CLIENT_ID: ${{ secrets.ENCELADUS_OAUTH_CLIENT_ID }}
-      ENCELADUS_OAUTH_CLIENT_SECRET: ${{ secrets.ENCELADUS_OAUTH_CLIENT_SECRET }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-neo4j-backup-deploy.yml
+++ b/.github/workflows/lambda-neo4j-backup-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/neo4j_backup/**"
       - ".github/workflows/lambda-neo4j-backup-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "enceladus-neo4j-backup"
       lambda_dir: "backend/lambda/neo4j_backup"
       deploy_script: "backend/lambda/neo4j_backup/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-project-service-deploy.yml
+++ b/.github/workflows/lambda-project-service-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/project_service/**"
       - ".github/workflows/lambda-project-service-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,16 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-project-service"
       lambda_dir: "backend/lambda/project_service"
       deploy_script: "backend/lambda/project_service/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_PREVIOUS: ${{ secrets.COORDINATION_INTERNAL_API_KEY_PREVIOUS }}
-      COORDINATION_INTERNAL_API_KEY_SCOPES: ${{ secrets.COORDINATION_INTERNAL_API_KEY_SCOPES }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-reference-search-deploy.yml
+++ b/.github/workflows/lambda-reference-search-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/reference_search/**"
       - ".github/workflows/lambda-reference-search-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,14 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-reference-search"
       lambda_dir: "backend/lambda/reference_search"
       deploy_script: "backend/lambda/reference_search/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/.github/workflows/lambda-tracker-mutation-api-deploy.yml
+++ b/.github/workflows/lambda-tracker-mutation-api-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "backend/lambda/tracker_mutation/**"
       - ".github/workflows/lambda-tracker-mutation-api-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
       - ".github/workflows/lambda-deploy-reusable.yml"
   workflow_dispatch:
     inputs:
@@ -23,16 +24,10 @@ permissions:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/lambda-deploy-reusable.yml
+    uses: ./.github/workflows/deploy-orchestration.yml
     with:
       function_name: "devops-tracker-mutation-api"
       lambda_dir: "backend/lambda/tracker_mutation"
       deploy_script: "backend/lambda/tracker_mutation/deploy.sh"
-      environment_suffix: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
-    secrets:
-      AWS_BACKEND_ROLE_TO_ASSUME: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
-      COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
-      COORDINATION_INTERNAL_API_KEY_PREVIOUS: ${{ secrets.COORDINATION_INTERNAL_API_KEY_PREVIOUS }}
-      COORDINATION_INTERNAL_API_KEY_SCOPES: ${{ secrets.COORDINATION_INTERNAL_API_KEY_SCOPES }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      deploy_mode: "per-lambda"
+    secrets: inherit


### PR DESCRIPTION
## Summary

- **New:** `deploy-orchestration.yml` — gamma-first deploy sequencing workflow with per-lambda and full-stack modes
- **Updated:** All 22 `lambda-*-deploy.yml` workflows route through orchestration instead of calling `lambda-deploy-reusable.yml` directly
- **Updated:** `cloudformation-compute-stack-deploy.yml` triggers full-stack orchestration after CFN stack updates (closes Sev1 path-filter gap)
- **Created:** GitHub Environment `production` with required reviewer (`me-jreese`) for manual approval gates

### Orchestration Sequence
```
gamma deploy → automated UAT gate → manual approval → prod deploy → prod validation
```

- v4/** branches: gamma deploy + gate only (no approval, no prod)
- `secrets: inherit` replaces per-workflow secret forwarding
- Full-stack mode reads `lambda_workflow_manifest.json` for all 20 functions via matrix strategy

### Acceptance Criteria (11)
- AC1-AC11 per ENC-TSK-D18

CCI-33fc03e01bc847509753f12036ec072f

## Test plan

- [ ] Verify workflow YAML syntax is valid (actionlint or GitHub Actions validator)
- [ ] Push to v4/test branch to validate gamma-only path
- [ ] Manual workflow_dispatch of deploy-orchestration.yml with full-stack mode
- [ ] Verify production approval gate shows "Waiting for review" on main

**Plan:** ENC-PLN-020 | **Feature:** ENC-FTR-068 | **Task:** ENC-TSK-D18
**Plan doc:** DOC-62C2971DC58B | **COE:** DOC-2CACF0D1E7E6

🤖 Generated with [Claude Code](https://claude.com/claude-code)