### PR TITLE
fix(infra): pin shared layer to python3.11/cp311 + add layer-ABI parity guard (ENC-TSK-D22)

### DIFF
--- a/backend/lambda/changelog_api/lambda_function.py
+++ b/backend/lambda/changelog_api/lambda_function.py
@@ -50,8 +50,20 @@ from boto3.dynamodb.types import TypeDeserializer
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 

--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -109,8 +109,20 @@ from transition_type_matrix import (
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 # ---------------------------------------------------------------------------

--- a/backend/lambda/coordination_api/auth.py
+++ b/backend/lambda/coordination_api/auth.py
@@ -20,7 +20,18 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except Exception:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 try:

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,7 @@
 {
-  "version": "2026-04-09.1",
-  "updated_at": "2026-04-09T01:56:30Z",
+  "version": "2026-04-11.1",
+  "updated_at": "2026-04-11T10:21:00Z",
+  "last_change_summary": "ENC-TSK-D22: H8 silent-failure import pattern fix added logger.exception() calls in 13 Lambda modules and shared_layer/auth.py; no schema/enum/field/evidence changes. Dictionary version bumped to satisfy the governance-dictionary-guard for trigger-file diffs (lambda_function.py modifications were observability-only). See ENC-ISS-198 / DOC-E9B160563B1C v6 §Addendum.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -64,7 +64,18 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except Exception:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 try:

--- a/backend/lambda/coordination_monitor_api/lambda_function.py
+++ b/backend/lambda/coordination_monitor_api/lambda_function.py
@@ -43,7 +43,18 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 # ---------------------------------------------------------------------------

--- a/backend/lambda/deploy_intake/lambda_function.py
+++ b/backend/lambda/deploy_intake/lambda_function.py
@@ -54,8 +54,20 @@ from boto3.dynamodb.types import TypeDeserializer
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -50,10 +50,21 @@ from botocore.exceptions import BotoCoreError, ClientError
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except Exception as _jwt_import_err:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
-    logging.getLogger().error("jwt import failed: %s", _jwt_import_err)
 
 
 def _normalize_api_keys(*raw_values: str) -> tuple[str, ...]:

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -45,7 +45,18 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 # ---------------------------------------------------------------------------

--- a/backend/lambda/github_integration/lambda_function.py
+++ b/backend/lambda/github_integration/lambda_function.py
@@ -49,8 +49,20 @@ from botocore.config import Config
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 

--- a/backend/lambda/project_service/lambda_function.py
+++ b/backend/lambda/project_service/lambda_function.py
@@ -46,8 +46,20 @@ from botocore.exceptions import BotoCoreError, ClientError
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 

--- a/backend/lambda/reference_search/lambda_function.py
+++ b/backend/lambda/reference_search/lambda_function.py
@@ -41,9 +41,19 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except Exception as _jwt_import_err:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
-    logging.getLogger().error("jwt import failed: %s", _jwt_import_err)
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/backend/lambda/shared_layer/deploy.sh
+++ b/backend/lambda/shared_layer/deploy.sh
@@ -14,7 +14,24 @@ ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGION="${REGION:-us-west-2}"
 LAYER_NAME="${LAYER_NAME:-enceladus-shared${ENVIRONMENT_SUFFIX}}"
-RUNTIME="python3.12"
+
+# ENC-ISS-198 / ENC-TSK-D22: build target is now keyed off ENVIRONMENT_SUFFIX so
+# prod (empty suffix) builds against python3.11/x86_64 (the V3 production lock)
+# and gamma (-gamma suffix) builds against python3.12/arm64. The consumer ABI is
+# overridden via pip --python-version / --abi / --platform — see build_layer().
+if [[ -z "${ENVIRONMENT_SUFFIX}" ]]; then
+    RUNTIME="python3.11"
+    PYTHON_VERSION="3.11"
+    PIP_ABI="cp311"
+    PIP_PLATFORM="manylinux2014_x86_64"
+    LAMBDA_ARCH="x86_64"
+else
+    RUNTIME="python3.12"
+    PYTHON_VERSION="3.12"
+    PIP_ABI="cp312"
+    PIP_PLATFORM="manylinux2014_aarch64"
+    LAMBDA_ARCH="arm64"
+fi
 
 # All Enceladus Lambda functions that should use this layer.
 ALL_FUNCTIONS=(
@@ -50,16 +67,41 @@ build_layer() {
     # Copy shared module.
     cp -r "${ROOT_DIR}/python" "${build_dir}/"
 
-    # CRITICAL: Install dependencies with platform targeting for Linux Lambda runtime.
-    # 🚨 NEVER build on macOS without --platform flag!
-    # Issue: macOS produces Mach-O binaries; Lambda runs Linux ELF.
-    # Silent failure: import jwt sets _JWT_AVAILABLE=False → all auth requests return 401.
-    # See: JWT_AUTHENTICATION_FORENSICS.md for ENC-ISS-041 root cause analysis.
-    # https://github.com/NX-2021-L/enceladus/commit/de33817
+    # CRITICAL: Pin EVERY dimension of the consumer ABI explicitly. Lambda layers
+    # are silently broken if any dimension drifts from the consuming function.
+    #
+    # 🚨 THREE FLAGS, NOT ONE.
+    #
+    #   --platform           pins the OS/arch (manylinux2014_x86_64 vs aarch64)
+    #   --python-version     pins the Python ABI version (3.11 vs 3.12)
+    #   --abi                pins the Python ABI tag (cp311 vs cp312)
+    #
+    # If any one of these is omitted, pip will fall back to the BUILDER's host
+    # Python and produce wheels that may not load on the consumer runtime. The
+    # failure is always silent: `import jwt` raises ImportError, the surrounding
+    # `except` swallows it, _JWT_AVAILABLE is set to False, and every Cognito
+    # request returns HTTP 401 "JWT library not available in Lambda package".
+    #
+    # Historical incidents (same failure class, three different drift axes):
+    #   - ENC-ISS-041 (2026-02): macOS Mach-O binaries vs Linux ELF
+    #     → fix: added --platform manylinux2014_x86_64
+    #     → JWT_AUTHENTICATION_FORENSICS.md, commit de33817
+    #   - ENC-ISS-044 (2026-02): rebuild from clean Linux base
+    #     → fix: republished as enceladus-shared:6 against python3.11/x86_64
+    #   - ENC-ISS-198 (2026-04): cpython-312 .so loaded on a python3.11 Lambda
+    #     → fix: added --python-version and --abi (THIS BLOCK)
+    #     → DOC-E9B160563B1C v6 §Addendum, ENC-TSK-D22
+    #
+    # The consumer ABI is selected at the top of this script via ENVIRONMENT_SUFFIX
+    # (PYTHON_VERSION / PIP_ABI / PIP_PLATFORM). DO NOT remove any of the three pip
+    # flags below — single-dimension fixes are not sufficient.
     python3 -m pip install \
         --quiet \
         --upgrade \
-        --platform manylinux2014_x86_64 \
+        --platform "${PIP_PLATFORM}" \
+        --implementation cp \
+        --python-version "${PYTHON_VERSION}" \
+        --abi "${PIP_ABI}" \
         --only-binary=:all: \
         -r "${ROOT_DIR}/requirements.txt" \
         -t "${build_dir}/python" >/dev/null
@@ -74,14 +116,16 @@ build_layer() {
 
 publish_layer() {
     local zip_path="$1"
+    local description="${LAYER_DESCRIPTION:-Enceladus shared utilities: auth, DDB, HTTP helpers — built for ${RUNTIME} / ${LAMBDA_ARCH} (ENC-TSK-D22)}"
 
-    log "[START] Publishing layer: ${LAYER_NAME}"
+    log "[START] Publishing layer: ${LAYER_NAME} (${RUNTIME} / ${LAMBDA_ARCH})"
     local version_arn
     version_arn="$(aws lambda publish-layer-version \
         --region "${REGION}" \
         --layer-name "${LAYER_NAME}" \
-        --description "Enceladus shared utilities: auth, DDB, HTTP helpers (ENC-TSK-525)" \
+        --description "${description}" \
         --compatible-runtimes "${RUNTIME}" \
+        --compatible-architectures "${LAMBDA_ARCH}" \
         --zip-file "fileb://${zip_path}" \
         --query 'LayerVersionArn' \
         --output text)"

--- a/backend/lambda/shared_layer/python/enceladus_shared/auth.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/auth.py
@@ -30,7 +30,18 @@ try:
     from jwt.algorithms import RSAAlgorithm
 
     _JWT_AVAILABLE = True
-except Exception:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 logger = logging.getLogger(__name__)

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -61,8 +61,20 @@ from transition_type_matrix import (
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
+
     _JWT_AVAILABLE = True
-except ImportError:
+except Exception:  # noqa: BLE001 — also catches RuntimeError/OSError from cffi backend ABI mismatch
+    # ENC-ISS-198 / ENC-TSK-D22: log the import failure so operators can
+    # diagnose PyJWT/cryptography ABI mismatches in CloudWatch instead of
+    # chasing the downstream HTTP 401 "JWT library not available in Lambda
+    # package" message. Historical incidents in this failure class:
+    # ENC-ISS-041, ENC-ISS-044, ENC-ISS-198. logger is not yet defined at
+    # module-load time, so use logging.getLogger(__name__) directly.
+    import logging as _enc_iss_198_logging
+    _enc_iss_198_logging.getLogger(__name__).exception(
+        "PyJWT import failed at module load — Cognito auth will be disabled "
+        "(ENC-ISS-198: usually a shared-layer .so ABI mismatch with the function runtime)"
+    )
     _JWT_AVAILABLE = False
 
 

--- a/docs/v3-production-lock.md
+++ b/docs/v3-production-lock.md
@@ -15,7 +15,8 @@
 | Architecture | x86_64 | CFN `!If [IsGamma, arm64, x86_64]`, CI guard, deploy.sh env guards |
 | Runtime | python3.11 | CFN `!If [IsGamma, python3.12, python3.11]`, CI guard |
 | Lambda count | 20 (CFN-managed) + checkout-service (standalone) | Lambda workflow manifest |
-| Shared layer | x86_64 | `backend/lambda/shared_layer/deploy.sh` hardcodes x86_64 |
+| Shared layer | `enceladus-shared:8` (python3.11 / x86_64) | `backend/lambda/shared_layer/deploy.sh` ENVIRONMENT_SUFFIX-conditional pip flags + CI guard |
+| Layer ABI parity | cp311 .so wheels only on prod | `tools/verify_lambda_arch_parity.py` shared-layer guard (ENC-ISS-198) |
 
 ### Production Rules
 
@@ -24,6 +25,9 @@
 3. All CFN Lambda declarations MUST use `!If [IsGamma, <gamma_val>, <prod_val>]` conditionals.
 4. Deploy scripts with binary dependencies MUST use `ENVIRONMENT_SUFFIX` conditional gating.
 5. The CI guard (`tools/verify_lambda_arch_parity.py`) blocks PRs that violate rules 3-4.
+6. **Shared layer build scripts MUST pass all three pip flags** — `--platform`, `--python-version`, and `--abi` — to override the consumer ABI on every dimension. Single-flag fixes are insufficient (ENC-ISS-198). Enforced by `_validate_shared_layer_deploy_script()` in the CI guard.
+7. **Lifeboat layer versions MUST be preserved.** `enceladus-shared:6` (the last clean python3.11/x86_64 build before the ENC-ISS-198 regression) is retained as a documented rollback target. Do not delete published layer versions that are referenced as lifeboats.
+8. **Recovery validation MUST include an authenticated probe.** Synthetic `aws lambda invoke` probes with no `Authorization` header land in the no-token path of `auth.py:_authenticate()` and return HTTP 401 *before* `_verify_token()` is ever called — this is structurally indistinguishable from the 401 a real Cognito request produces when JWT init has silently failed. Use `tools/probe_cognito_auth.sh` (or equivalent) to bootstrap a real Cognito IdToken and probe with `Authorization: Bearer`.
 
 ---
 
@@ -84,9 +88,61 @@ Script: `workspace/v3-recovery/02-cfn-rollback-to-x86.sh`
 
 ---
 
+## Layer ABI Parity Invariant (ENC-ISS-198 / ENC-TSK-D22)
+
+The original V3 production lock validated the CFN template's `Architectures` and `Runtime` declarations but did **not** validate that attached shared layers carry the matching ABI. ENC-ISS-198 was a 3-hour-latent bug caused by exactly that gap: `enceladus-shared:7` was published 2026-04-03 by ENC-TSK-B42 with a `cpython-312-x86_64-linux-gnu` cffi backend, the V3 lock recovery rolled prod Lambdas back to python3.11/x86_64 without rolling back the layer, and every Cognito-authenticated PWA write returned a misleading HTTP 401 *"JWT library not available in Lambda package"* — until the user surfaced it via a manual worklog write attempt against DVP-TSK-481 at `2026-04-11T09:17Z`.
+
+### Three-flag rule
+
+Lambda layer build scripts must override every dimension of the consumer ABI explicitly:
+
+| Dimension | pip flag | Prod value | Gamma value |
+|---|---|---|---|
+| OS / arch | `--platform` | `manylinux2014_x86_64` | `manylinux2014_aarch64` |
+| Python version | `--python-version` | `3.11` | `3.12` |
+| Python ABI tag | `--abi` | `cp311` | `cp312` |
+
+If any flag is omitted, pip falls back to the **builder's** Python ABI and produces wheels that may not load on the consumer runtime. The failure is always silent (`import jwt` raises ImportError, the surrounding `except` swallows it, `_JWT_AVAILABLE = False`, every Cognito request returns HTTP 401).
+
+`backend/lambda/shared_layer/deploy.sh` is now ENVIRONMENT_SUFFIX-aware: prod targets `python3.11 / cp311 / x86_64`, gamma targets `python3.12 / cp312 / aarch64`. The publish call also passes `--compatible-architectures` so the published layer metadata is honest and auditable.
+
+### CI guard extension
+
+`tools/verify_lambda_arch_parity.py` now includes `_validate_shared_layer_deploy_script()` which enforces:
+
+1. All three pip flags (`--platform`, `--python-version`, `--abi`) are present in the script.
+2. The prod build target (`manylinux2014_x86_64` / `3.11` / `cp311`) is fully pinned.
+3. `aws lambda publish-layer-version` is invoked with `--compatible-architectures` so the layer metadata is honest.
+4. The script's documentation comment references `ENC-ISS-198` so the historical precedent chain (ENC-ISS-041, ENC-ISS-044, ENC-ISS-198) is preserved for the next maintainer.
+
+Test fixtures in `tools/test_verify_lambda_arch_parity.py` cover both a known-bad case (the pre-fix script that produced ENC-ISS-198) and a known-good case (the post-fix script).
+
+### Lifeboat layer policy
+
+`enceladus-shared:6` (created `2026-02-24T19:09Z`, descriptor *"rebuilt for Linux x86_64 Python 3.11 (ENC-ISS-044)"*, `CompatibleRuntimes=[python3.11]`, `CompatibleArchitectures=[x86_64]`) is the documented rollback target for prod. **Do not delete it.** If a future layer publish breaks prod, re-attach v6 via `aws lambda update-function-configuration --layers arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:6 …` per function. v6's contents have been validated against the V3 lock.
+
+### Authenticated-probe requirement
+
+DOC-2CACF0D1E7E6 §3 Phase R3 used `aws lambda invoke` with no `Authorization` header for empirical validation. That probe lands in the no-token path of `auth.py:_authenticate()` and returns HTTP 401 *before* `_verify_token()` is ever called — structurally indistinguishable from the 401 a real Cognito request produces when JWT init has silently failed. The COE Lesson 4 ("empirical validation beats inference") is correct in spirit but the specific implementation was structurally blind to ENC-ISS-198.
+
+`tools/probe_cognito_auth.sh` is the new authenticated-probe primitive. It bootstraps a Cognito IdToken via the terminal-agent path (`devops/coordination/cognito/terminal-agent` Secrets Manager record → `cognito-idp:initiate-auth` → IdToken), then probes a configurable list of Cognito-protected routes with `Authorization: Bearer <IdToken>`. The probe FAILs on any response containing the canonical `"JWT library not available in Lambda package"` string, regardless of HTTP status.
+
+**All future v3 lock validation runs MUST include an authenticated probe.** Add it to `workspace/v3-recovery/03-validate-prod-health.sh` (or its successor).
+
+### Open follow-up
+
+Adding a runtime check to `verify_lambda_arch_parity.py` that fetches each Lambda's attached layer artifacts via `aws lambda get-layer-version` and inspects `.so` ABI tags directly is left as a future enhancement. It would close the remaining gap between source-of-truth validation (current static check) and live-attachment validation. The static check catches the regression at PR time; the runtime check would catch it at deploy time. Both layers of defense are valuable but the static check is sufficient to prevent the ENC-ISS-198 class of bug from reoccurring.
+
+---
+
 ## Related Documents
 
-- **COE:** DOC-2CACF0D1E7E6 (Sev1 MCP/PWA Outage 2026-04-11)
+- **COE (operational):** DOC-2CACF0D1E7E6 (Sev1 MCP/PWA Outage 2026-04-11)
+- **COE (strategic):** DOC-E9B160563B1C v6 §Addendum (ENC-ISS-198 — Shared Layer Build ABI Drift)
 - **Plan:** ENC-PLN-019 (DOC-191E709E43C5)
 - **CI Guard:** `tools/verify_lambda_arch_parity.py`
+- **CI Guard tests:** `tools/test_verify_lambda_arch_parity.py`
+- **Authenticated probe:** `tools/probe_cognito_auth.sh`
 - **Manifest:** `infrastructure/lambda_workflow_manifest.json`
+- **Issue:** ENC-ISS-198 (P1 — PWA Cognito writes broken by layer ABI mismatch)
+- **Fix task:** ENC-TSK-D22

--- a/tools/probe_cognito_auth.sh
+++ b/tools/probe_cognito_auth.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# probe_cognito_auth.sh — bootstrap a Cognito IdToken via the terminal-agent path
+# and probe Cognito-protected Lambda routes with `Authorization: Bearer <token>`.
+#
+# ENC-ISS-198 / ENC-TSK-D22 (H9): the COE Phase R3 empirical validation in
+# DOC-2CACF0D1E7E6 used a synthetic `aws lambda invoke` probe with no
+# Authorization header. That probe lands in the no-token path of
+# `auth.py:_authenticate()` and returns HTTP 401 *before* `_verify_token()` is
+# ever called — which is structurally indistinguishable from the 401 a real
+# Cognito-authenticated request produces when the JWT init has silently failed.
+# The COE recovery declared the platform healthy while every Cognito-protected
+# write was actually broken for ~3 hours.
+#
+# This script closes that gap. It actually exercises `_verify_token()` with a
+# real IdToken and confirms the response is NOT the misleading
+# "JWT library not available in Lambda package" 401.
+#
+# Usage:
+#   ./tools/probe_cognito_auth.sh                       # probe the default route set
+#   ./tools/probe_cognito_auth.sh --route /api/v1/...    # probe a specific route
+#   ./tools/probe_cognito_auth.sh --json                 # JSON output for CI
+#
+# Required:
+#   AWS_PROFILE pointing at io-dev-admin (or env credentials with secretsmanager:GetSecretValue
+#   on devops/coordination/cognito/terminal-agent and cognito-idp:InitiateAuth on the user pool).
+#
+# Output: PASS/FAIL summary per probed route. Exit 0 if all routes return non-401 OR a
+# non-JWT-related 401 (e.g. expired token retry). Exit 1 if any route returns the
+# canonical "JWT library not available in Lambda package" error.
+
+set -euo pipefail
+
+REGION="${REGION:-us-west-2}"
+COGNITO_REGION="${COGNITO_REGION:-us-east-1}"
+SECRET_ID="${TERMINAL_COGNITO_SECRET_ID:-devops/coordination/cognito/terminal-agent}"
+API_BASE="${API_BASE:-https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com}"
+
+# Default route set: one representative read path per Cognito-protected Lambda
+# in `backend/lambda/shared_layer/deploy.sh:ALL_FUNCTIONS`. Each route is chosen
+# to require auth but NOT require write permissions, so the probe is read-only.
+DEFAULT_ROUTES=(
+    "GET /api/v1/coordination/components"                          # devops-coordination-api
+    "GET /api/v1/tracker/enceladus"                                # devops-tracker-mutation-api (list path)
+    "GET /api/v1/documents?project_id=enceladus&limit=1"           # devops-document-api
+    "GET /api/v1/projects"                                         # devops-project-service
+    "GET /api/v1/feed?project_id=enceladus"                        # devops-feed-query-api
+    "GET /api/v1/coordination/sessions"                            # devops-coordination-monitor-api
+    "GET /api/v1/deploy/pending/enceladus"                         # devops-deploy-intake / orchestrator
+    "GET /api/v1/changelog/version/enceladus"                      # devops-changelog-api
+    "GET /api/v1/governance/dictionary"                            # devops-coordination-api governance
+    "GET /api/v1/coordination/auth/tokens"                         # devops-coordination-api auth
+)
+
+ROUTE_OVERRIDE=""
+JSON_OUT=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --route) ROUTE_OVERRIDE="$2"; shift 2 ;;
+        --json) JSON_OUT=1; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { [[ "$JSON_OUT" -eq 0 ]] && echo "[$(date -u +%H:%M:%SZ)] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Step 1: bootstrap a Cognito IdToken via the terminal-agent path
+# ---------------------------------------------------------------------------
+log "[START] Bootstrapping terminal-agent Cognito IdToken"
+
+if ! command -v aws >/dev/null 2>&1; then
+    echo "ERROR: aws CLI not found in PATH" >&2; exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    # Use python as a jq fallback so this works on stock macOS
+    JQ() { python3 -c "import sys, json; d=json.load(sys.stdin); print(${1})"; }
+else
+    JQ() { jq -r "$1"; }
+fi
+
+SECRET_JSON="$(aws secretsmanager get-secret-value \
+    --region "${REGION}" \
+    --secret-id "${SECRET_ID}" \
+    --query SecretString \
+    --output text 2>&1)" || {
+    echo "ERROR: failed to fetch ${SECRET_ID} from Secrets Manager: ${SECRET_JSON}" >&2
+    exit 2
+}
+
+USERNAME="$(echo "${SECRET_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['username'])")"
+PASSWORD="$(echo "${SECRET_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['password'])")"
+CLIENT_ID="$(echo "${SECRET_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['client_id'])")"
+AUTH_FLOW="$(echo "${SECRET_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('auth_flow','USER_PASSWORD_AUTH'))")"
+
+ID_TOKEN="$(aws cognito-idp initiate-auth \
+    --region "${COGNITO_REGION}" \
+    --auth-flow "${AUTH_FLOW}" \
+    --client-id "${CLIENT_ID}" \
+    --auth-parameters "USERNAME=${USERNAME},PASSWORD=${PASSWORD}" \
+    --query 'AuthenticationResult.IdToken' \
+    --output text)"
+
+if [[ -z "${ID_TOKEN}" || "${ID_TOKEN}" == "None" ]]; then
+    echo "ERROR: Cognito initiate-auth returned empty IdToken" >&2
+    exit 2
+fi
+
+log "[INFO] IdToken acquired (length=${#ID_TOKEN})"
+
+# ---------------------------------------------------------------------------
+# Step 2: probe each route
+# ---------------------------------------------------------------------------
+if [[ -n "${ROUTE_OVERRIDE}" ]]; then
+    ROUTES=("GET ${ROUTE_OVERRIDE}")
+else
+    ROUTES=("${DEFAULT_ROUTES[@]}")
+fi
+
+PASS=0
+FAIL=0
+RESULTS_JSON="["
+
+for entry in "${ROUTES[@]}"; do
+    METHOD="${entry%% *}"
+    PATH_PART="${entry#* }"
+    URL="${API_BASE}${PATH_PART}"
+
+    log "[PROBE] ${METHOD} ${PATH_PART}"
+
+    HTTP_CODE_AND_BODY="$(curl -sS -o /tmp/probe_body.txt -w "%{http_code}" \
+        -X "${METHOD}" \
+        -H "Authorization: Bearer ${ID_TOKEN}" \
+        "${URL}" 2>&1 || echo "000")"
+    HTTP_CODE="${HTTP_CODE_AND_BODY: -3}"
+    BODY_PREVIEW="$(head -c 400 /tmp/probe_body.txt 2>/dev/null || echo '')"
+
+    # FAIL if the body contains the canonical ENC-ISS-198 error string
+    if grep -q "JWT library not available in Lambda package" /tmp/probe_body.txt 2>/dev/null; then
+        FAIL=$((FAIL + 1))
+        STATUS="FAIL"
+        REASON="ENC-ISS-198 error string present in response body"
+    elif [[ "${HTTP_CODE}" =~ ^[2-3][0-9][0-9]$ ]]; then
+        PASS=$((PASS + 1))
+        STATUS="PASS"
+        REASON="HTTP ${HTTP_CODE} (success)"
+    elif [[ "${HTTP_CODE}" =~ ^4[0-9][0-9]$ ]] && [[ "${HTTP_CODE}" != "401" ]]; then
+        # 4xx other than 401 (e.g. 404 not found, 400 bad request, 405 method
+        # not allowed) is fine — we just confirmed auth was processed.
+        PASS=$((PASS + 1))
+        STATUS="PASS"
+        REASON="HTTP ${HTTP_CODE} (auth processed, non-auth error)"
+    elif [[ "${HTTP_CODE}" == "401" ]]; then
+        FAIL=$((FAIL + 1))
+        STATUS="FAIL"
+        REASON="HTTP 401 — token rejected (check token validity OR check for ENC-ISS-198 regression)"
+    else
+        FAIL=$((FAIL + 1))
+        STATUS="FAIL"
+        REASON="HTTP ${HTTP_CODE} (unexpected)"
+    fi
+
+    if [[ "${JSON_OUT}" -eq 1 ]]; then
+        RESULTS_JSON="${RESULTS_JSON}{\"method\":\"${METHOD}\",\"path\":\"${PATH_PART}\",\"http_code\":\"${HTTP_CODE}\",\"status\":\"${STATUS}\",\"reason\":\"${REASON}\"},"
+    else
+        printf "  [%s] %-3s %-50s HTTP %-4s — %s\n" "${STATUS}" "${METHOD}" "${PATH_PART}" "${HTTP_CODE}" "${REASON}"
+    fi
+done
+
+if [[ "${JSON_OUT}" -eq 1 ]]; then
+    RESULTS_JSON="${RESULTS_JSON%,}]"
+    printf '{"pass":%d,"fail":%d,"results":%s}\n' "${PASS}" "${FAIL}" "${RESULTS_JSON}"
+else
+    echo
+    echo "[SUMMARY] PASS=${PASS}  FAIL=${FAIL}  TOTAL=${#ROUTES[@]}"
+fi
+
+if [[ "${FAIL}" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/test_verify_lambda_arch_parity.py
+++ b/tools/test_verify_lambda_arch_parity.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Test fixtures for tools/verify_lambda_arch_parity.py.
+
+ENC-TSK-D22 AC8: cover the new _validate_shared_layer_deploy_script() check
+with both a known-bad case (the pre-fix script that produced ENC-ISS-198) and
+a known-good case (the post-fix script that targets the consumer ABI fully).
+
+Run from repo root:
+    python3 -m unittest tools.test_verify_lambda_arch_parity -v
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import verify_lambda_arch_parity as vlap  # noqa: E402
+
+
+# The pre-ENC-TSK-D22 script. This is the exact form that produced ENC-ISS-198:
+# RUNTIME hardcoded to python3.12, only --platform flag (no --python-version,
+# no --abi), and no --compatible-architectures on the publish call.
+KNOWN_BAD_SCRIPT = """\
+#!/usr/bin/env bash
+set -euo pipefail
+ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
+LAYER_NAME="enceladus-shared${ENVIRONMENT_SUFFIX}"
+RUNTIME="python3.12"
+
+build_layer() {
+    python3 -m pip install \\
+        --platform manylinux2014_x86_64 \\
+        --only-binary=:all: \\
+        -r requirements.txt \\
+        -t /tmp/build/python
+}
+
+publish_layer() {
+    aws lambda publish-layer-version \\
+        --layer-name "${LAYER_NAME}" \\
+        --description "Enceladus shared utilities" \\
+        --compatible-runtimes "${RUNTIME}" \\
+        --zip-file "fileb://layer.zip"
+}
+"""
+
+# The post-ENC-TSK-D22 script. All three pip flags present (--platform,
+# --python-version, --abi), the prod build target is fully pinned, the
+# publish call passes --compatible-architectures, and the comment block
+# references ENC-ISS-198 so the historical precedent chain is documented.
+KNOWN_GOOD_SCRIPT = """\
+#!/usr/bin/env bash
+set -euo pipefail
+ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
+LAYER_NAME="enceladus-shared${ENVIRONMENT_SUFFIX}"
+
+# ENC-ISS-198 / ENC-TSK-D22: build target is keyed off ENVIRONMENT_SUFFIX so
+# prod (empty) builds against python3.11/x86_64 and gamma builds against
+# python3.12/arm64.
+if [[ -z "${ENVIRONMENT_SUFFIX}" ]]; then
+    RUNTIME="python3.11"
+    PYTHON_VERSION="3.11"
+    PIP_ABI="cp311"
+    PIP_PLATFORM="manylinux2014_x86_64"
+    LAMBDA_ARCH="x86_64"
+else
+    RUNTIME="python3.12"
+    PYTHON_VERSION="3.12"
+    PIP_ABI="cp312"
+    PIP_PLATFORM="manylinux2014_aarch64"
+    LAMBDA_ARCH="arm64"
+fi
+
+build_layer() {
+    # 🚨 THREE FLAGS, NOT ONE. See ENC-ISS-198 for the failure class.
+    python3 -m pip install \\
+        --platform "${PIP_PLATFORM}" \\
+        --implementation cp \\
+        --python-version "${PYTHON_VERSION}" \\
+        --abi "${PIP_ABI}" \\
+        --only-binary=:all: \\
+        -r requirements.txt \\
+        -t /tmp/build/python
+}
+
+publish_layer() {
+    aws lambda publish-layer-version \\
+        --layer-name "${LAYER_NAME}" \\
+        --description "Enceladus shared utilities — built for ${RUNTIME} / ${LAMBDA_ARCH}" \\
+        --compatible-runtimes "${RUNTIME}" \\
+        --compatible-architectures "${LAMBDA_ARCH}" \\
+        --zip-file "fileb://layer.zip"
+}
+"""
+
+
+class TestSharedLayerDeployScriptValidator(unittest.TestCase):
+    """ENC-TSK-D22 AC8 — known-good and known-bad cases for the H7 layer-ABI guard."""
+
+    def _run_with_script(self, script_text: str) -> list[str]:
+        """Write script_text to a tempfile, point SHARED_LAYER_DEPLOY at it, run validator."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(script_text)
+            tmp_path = Path(fh.name)
+        try:
+            with mock.patch.object(vlap, "SHARED_LAYER_DEPLOY", tmp_path):
+                return vlap._validate_shared_layer_deploy_script()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_known_bad_pre_enc_iss_198_script_is_rejected(self):
+        """The pre-fix script that produced ENC-ISS-198 must fail the guard."""
+        errors = self._run_with_script(KNOWN_BAD_SCRIPT)
+        self.assertGreater(
+            len(errors), 0,
+            "Pre-ENC-ISS-198 script must fail the guard but did not — guard is broken",
+        )
+        joined = "\n".join(errors)
+        # The error must explicitly name the missing pip flags
+        self.assertIn("--python-version", joined)
+        self.assertIn("--abi", joined)
+        # And explicitly call out the ENC-ISS-198 precedent
+        self.assertIn("ENC-ISS-198", joined)
+
+    def test_known_good_post_enc_tsk_d22_script_is_accepted(self):
+        """The post-fix script must pass the guard cleanly."""
+        errors = self._run_with_script(KNOWN_GOOD_SCRIPT)
+        self.assertEqual(
+            errors, [],
+            f"Post-ENC-TSK-D22 script must pass the guard but produced errors:\n  "
+            + "\n  ".join(errors),
+        )
+
+    def test_real_repo_script_passes_after_fix(self):
+        """The actual on-disk shared_layer/deploy.sh in the worktree must pass.
+
+        This is a smoke test against the repo's current state — if it fails,
+        the fix to deploy.sh has been reverted or the validator is broken.
+        """
+        if not vlap.SHARED_LAYER_DEPLOY.is_file():
+            self.skipTest(f"Real script not present at {vlap.SHARED_LAYER_DEPLOY}")
+        errors = vlap._validate_shared_layer_deploy_script()
+        self.assertEqual(
+            errors, [],
+            f"On-disk shared_layer/deploy.sh failed the guard:\n  "
+            + "\n  ".join(errors),
+        )
+
+    def test_missing_compatible_architectures_is_rejected(self):
+        """A script that omits --compatible-architectures on publish must fail."""
+        bad = KNOWN_GOOD_SCRIPT.replace(
+            '--compatible-architectures "${LAMBDA_ARCH}" \\\n        ',
+            "",
+        )
+        errors = self._run_with_script(bad)
+        self.assertTrue(
+            any("--compatible-architectures" in e for e in errors),
+            f"Script missing --compatible-architectures must fail with a clear "
+            f"error message; got: {errors}",
+        )
+
+    def test_missing_enc_iss_198_marker_is_rejected(self):
+        """A script that drops the ENC-ISS-198 marker comment must fail.
+
+        This is part of the historical precedent chain enforcement: every layer
+        build script must reference all three of ENC-ISS-041, ENC-ISS-044, and
+        ENC-ISS-198 so the next maintainer understands why the three-flag form
+        is non-negotiable.
+        """
+        bad = KNOWN_GOOD_SCRIPT.replace("ENC-ISS-198", "ENC-ISS-XXX")
+        errors = self._run_with_script(bad)
+        self.assertTrue(
+            any("ENC-ISS-198" in e for e in errors),
+            f"Script missing ENC-ISS-198 marker must fail; got: {errors}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/verify_lambda_arch_parity.py
+++ b/tools/verify_lambda_arch_parity.py
@@ -23,6 +23,7 @@ from typing import List, NamedTuple
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMPUTE_TEMPLATE = REPO_ROOT / "infrastructure/cloudformation/02-compute.yaml"
 MANIFEST_PATH = REPO_ROOT / "infrastructure/lambda_workflow_manifest.json"
+SHARED_LAYER_DEPLOY = REPO_ROOT / "backend/lambda/shared_layer/deploy.sh"
 
 # Expected CFN conditional patterns for prod safety
 EXPECTED_ARCH_PATTERN = re.compile(
@@ -251,6 +252,94 @@ def _validate_deploy_scripts() -> List[str]:
     return errors
 
 
+def _validate_shared_layer_deploy_script() -> List[str]:
+    """Validate that shared_layer/deploy.sh targets the consumer's full ABI.
+
+    ENC-ISS-198 / ENC-TSK-D22: enceladus-shared:7 was published 2026-04-03 by
+    ENC-TSK-B42 with a python3.12-tagged cffi backend that prod (python3.11)
+    cannot load. The build script had only ``--platform`` to override OS/arch
+    but not ``--python-version``/``--abi`` to override the Python ABI tag.
+    Result: pip downloaded cp312 wheels on the python3.12 builder host and the
+    layer was silently broken on every prod Lambda using ``import jwt``.
+
+    This check enforces that shared_layer/deploy.sh has all three pip flags
+    AND that the prod and gamma paths target the right combinations.
+
+    Required prod targeting (ENVIRONMENT_SUFFIX empty):
+        --platform manylinux2014_x86_64
+        --python-version 3.11
+        --abi cp311
+
+    Required gamma targeting (ENVIRONMENT_SUFFIX=-gamma):
+        --platform manylinux2014_aarch64
+        --python-version 3.12
+        --abi cp312
+
+    The script must also pass --compatible-architectures explicitly to
+    aws lambda publish-layer-version so the published layer's compatibility
+    metadata is honest and the V3 production lock can audit it.
+    """
+    errors: List[str] = []
+
+    if not SHARED_LAYER_DEPLOY.is_file():
+        return [f"Shared layer deploy script missing: {SHARED_LAYER_DEPLOY}"]
+
+    content = SHARED_LAYER_DEPLOY.read_text(encoding="utf-8")
+
+    # Must pass all three pip flags (prefix with -- so substring match isn't fooled by comments)
+    required_flags = (
+        "--platform",
+        "--python-version",
+        "--abi",
+    )
+    for flag in required_flags:
+        if flag not in content:
+            errors.append(
+                f"shared_layer/deploy.sh: missing required pip flag '{flag}'. "
+                f"All three of --platform, --python-version, --abi must be present "
+                f"to override the consumer ABI (ENC-ISS-198 / ENC-TSK-D22)."
+            )
+
+    # Prod-path targeting must be present (either via conditional or hardcoded)
+    has_prod_platform = "manylinux2014_x86_64" in content
+    has_prod_pyver = '"3.11"' in content or "'3.11'" in content
+    has_prod_abi = "cp311" in content
+    if not (has_prod_platform and has_prod_pyver and has_prod_abi):
+        errors.append(
+            "shared_layer/deploy.sh: prod build target incomplete. Required values "
+            "manylinux2014_x86_64 / 3.11 / cp311 must all be present "
+            "(found platform=%s, pyver=%s, abi=%s)"
+            % (has_prod_platform, has_prod_pyver, has_prod_abi)
+        )
+
+    # publish-layer-version must declare --compatible-architectures explicitly
+    # so the V3 production lock can audit the metadata
+    if "--compatible-architectures" not in content:
+        errors.append(
+            "shared_layer/deploy.sh: aws lambda publish-layer-version must pass "
+            "--compatible-architectures so the layer metadata is honest and the "
+            "V3 production lock can audit it (ENC-ISS-198)."
+        )
+
+    # The legacy comment block referencing only ENC-ISS-041 is insufficient.
+    # The new comment must reference ENC-ISS-198 to surface the third recurrence.
+    if "ENC-ISS-198" not in content:
+        errors.append(
+            "shared_layer/deploy.sh: must reference ENC-ISS-198 in the build "
+            "script's documentation comment to surface the three-flags requirement "
+            "(historical precedents: ENC-ISS-041, ENC-ISS-044, ENC-ISS-198)."
+        )
+
+    if not errors:
+        print(
+            "[INFO] shared_layer/deploy.sh validated: all three pip flags "
+            "present (--platform, --python-version, --abi), prod build target "
+            "manylinux2014_x86_64/3.11/cp311 confirmed"
+        )
+
+    return errors
+
+
 def _validate_manifest_expectations() -> List[str]:
     """Cross-validate manifest expected_architecture/expected_runtime against CFN and deploy scripts.
 
@@ -330,6 +419,12 @@ def main() -> int:
     if deploy_errors:
         errors.append("=== Deploy script violations ===")
         errors.extend(deploy_errors)
+
+    # Validate shared layer build script (ENC-ISS-198 / ENC-TSK-D22)
+    shared_layer_errors = _validate_shared_layer_deploy_script()
+    if shared_layer_errors:
+        errors.append("=== Shared layer build script violations ===")
+        errors.extend(shared_layer_errors)
 
     # Cross-validate manifest expectations (ENC-TSK-D17 AC7)
     manifest_errors = _validate_manifest_expectations()


### PR DESCRIPTION
## Summary

Third recurrence of the silent JWT-init failure class (ENC-ISS-041, ENC-ISS-044, **ENC-ISS-198**). `enceladus-shared:7` was published 2026-04-03 by ENC-TSK-B42 with a `cpython-312-x86_64` cffi backend; under the V3 production lock (python3.11), every prod Lambda using `import jwt` rejected every Cognito request with HTTP 401 *"JWT library not available in Lambda package"* — masked for ~3 hours after the COE recovery completed because the COE Phase R3 empirical validation used a no-Authorization probe that landed in `_authenticate()`'s no-token path before ever reaching `_verify_token()`.

The user surfaced the regression at 2026-04-11T09:17Z while attempting a manual PWA worklog write to DVP-TSK-481 (the canonical reproduction).

## Root cause

`backend/lambda/shared_layer/deploy.sh` hardcoded `RUNTIME="python3.12"` and passed pip `--platform manylinux2014_x86_64` but did NOT pass `--python-version 3.11 --abi cp311`. When ENC-TSK-B42 ran the script on a python3.12 host, pip downloaded `cp312` wheels and the layer was silently broken on the consumer (python3.11) runtime. Two prior fixes for the same failure class (ENC-ISS-041 → `--platform`; ENC-ISS-044 → rebuild against py3.11) closed two of three drift dimensions but never closed the third (Python ABI tag).

This is a structural problem with the build script's targeting model, not a one-off regression. Full diagnosis: ENC-ISS-198.hypothesis, DOC-E9B160563B1C v6 §Addendum, DOC-2CACF0D1E7E6.

## Changes

**Build script (the structural fix):**
- `backend/lambda/shared_layer/deploy.sh` — three pip flags now (`--platform` AND `--python-version` AND `--abi`); ENVIRONMENT_SUFFIX-conditional build target so prod targets `python3.11/cp311/x86_64` and gamma targets `python3.12/cp312/aarch64`; publish call now passes `--compatible-architectures` so layer metadata is honest; the legacy ENC-ISS-041 comment block is rewritten to document all three historical incidents and the three-flags rule.

**Silent-failure import pattern → logging pattern (H8) across 13 Lambda modules:**
- `tracker_mutation`, `document_api`, `project_service`, `feed_query`, `reference_search`, `coordination_monitor_api`, `deploy_intake`, `checkout_service`, `changelog_api`, `github_integration`, `coordination_api/lambda_function.py`, `coordination_api/auth.py`, `shared_layer/python/enceladus_shared/auth.py` — every `try: import jwt … except: _JWT_AVAILABLE = False` now logs the exception via `logging.getLogger(__name__).exception(...)` so ABI mismatches surface in CloudWatch immediately at module load instead of being chased through misleading 401s.

**CI guard extension (H7):**
- `tools/verify_lambda_arch_parity.py` — new `_validate_shared_layer_deploy_script()` static check enforcing all three pip flags, the prod build target pins, the `--compatible-architectures` publish flag, and the ENC-ISS-198 marker comment.
- `tools/test_verify_lambda_arch_parity.py` — new test file with 5 cases: known-bad (pre-fix script), known-good (post-fix script), missing `--compatible-architectures`, missing ENC-ISS-198 marker, on-disk smoke test.

**Authenticated probe primitive (H9):**
- `tools/probe_cognito_auth.sh` — bootstraps a Cognito IdToken via the terminal-agent path (`devops/coordination/cognito/terminal-agent` → `cognito-idp:initiate-auth`), then probes Cognito-protected routes with `Authorization: Bearer`. FAILs on the canonical *"JWT library not available in Lambda package"* string regardless of HTTP status. Closes the COE Phase R3 empirical-validation gap.

**Documentation:**
- `docs/v3-production-lock.md` — new "Layer ABI Parity Invariant" section documenting the three-flag rule, CI guard extension, lifeboat layer policy (v6), and authenticated-probe requirement; adds rules 6/7/8 to the production rules list.

## Operational steps deferred to post-merge

Per the task ACs, the following operational steps run AFTER merge from a privileged terminal:

1. Build layer v8 locally via the corrected `shared_layer/deploy.sh`
2. Validate v8 contents (`unzip -l | grep cpython-` shows only cp311-x86_64 .so files)
3. Publish layer v8 with `CompatibleRuntimes=[python3.11]` and `CompatibleArchitectures=[x86_64]`
4. Attach v8 to all 16 prod functions in `ALL_FUNCTIONS`
5. Run `tools/probe_cognito_auth.sh` to validate
6. Re-run the canonical reproduction (DVP-TSK-481 worklog write) and confirm HTTP 200
7. Trigger per-Lambda deploys for the 15 affected Lambdas to pick up the auth.py logging changes
8. ENC-ISS-198 closeout
9. DOC-E9B160563B1C v6 → v7 patch with H6–H9 marked resolved
10. Draft lesson record (three-flags-not-one)
11. agents.md §15 governance sync handoff

## Test plan

- [x] Python AST parse on all 13 modified Lambda modules and `coordination_api/auth.py`
- [x] `bash -n shared_layer/deploy.sh` — syntax OK
- [x] `python3 tools/verify_lambda_arch_parity.py` — passes (20 CFN Lambdas, deploy scripts, shared_layer build script all valid)
- [x] `python3 -m unittest tools.test_verify_lambda_arch_parity` — 5/5 pass
- [ ] PR Commit Gate validates `CCI-bccda5629cfb47d4885a79a5516e03ad`
- [ ] CI / Secrets Scan / Governance Dictionary Guard / PR Commit Gate all green
- [ ] Post-merge: layer v8 published, attached, probe passes, canonical reproduction passes

## Refs

- **Issue:** ENC-ISS-198 (P1, hypothesis re-diagnosed against DOC-2CACF0D1E7E6)
- **Fix task:** ENC-TSK-D22 (this PR)
- **CCI token:** `CCI-bccda5629cfb47d4885a79a5516e03ad`
- **Strategic COE addendum:** DOC-E9B160563B1C v6 §Addendum
- **Operational COE:** DOC-2CACF0D1E7E6
- **V3 lock plan:** ENC-PLN-019
- **Historical precedents:** ENC-ISS-041, ENC-ISS-044
- **Regression-introducing change:** ENC-TSK-B42, commit `e687933`
- **Forensics:** `backend/lambda/JWT_AUTHENTICATION_FORENSICS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)