### PR TITLE
fix(infra): use inline IAM policy for monitoring Lambda role

### DIFF
--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -36,13 +36,17 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: ProdHealthMonitorPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "arn:aws:logs:*:*:*"
               - Effect: Allow
                 Action:
                   - lambda:GetFunctionConfiguration


### PR DESCRIPTION
## Summary
Replace ManagedPolicyArns with inline policy for the monitoring Lambda role. The CFN deploy OIDC role lacks iam:AttachRolePolicy permissions.

CCI-c08182ddae174977bc533c3b46c8918b

Part of ENC-TSK-D20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)