### PR TITLE
fix(deploy): remove reserved AWS_REGION from Lambda env vars

### DIFF
--- a/backend/lambda/prod_health_monitor/deploy.sh
+++ b/backend/lambda/prod_health_monitor/deploy.sh
@@ -71,9 +71,9 @@ deploy_function() {
   env_json=$(python3 -c "
 import json, sys
 fn = json.loads(sys.argv[1])
-env = {'Variables': {'FUNCTION_NAMES': json.dumps(fn), 'AWS_REGION': sys.argv[2]}}
+env = {'Variables': {'FUNCTION_NAMES': json.dumps(fn)}}
 print(json.dumps(env))
-" "${fn_names}" "${REGION}")
+" "${fn_names}")
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating existing function ${FUNCTION_NAME}"

--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -74,7 +74,6 @@ Resources:
       Environment:
         Variables:
           FUNCTION_NAMES: "[]"
-          AWS_REGION_OVERRIDE: !Ref "AWS::Region"
 
   ProdHealthMonitorInvokePermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Summary
Remove AWS_REGION from custom env vars — Lambda runtime provides it automatically. Setting it causes InvalidParameterValueException.

CCI-c08182ddae174977bc533c3b46c8918b

Part of ENC-TSK-D20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)