### PR TITLE
ENC-TSK-D43: PWA direct tracker API fallback for feed-capped records (ENC-ISS-200)

### DIFF
--- a/frontend/ui/src/api/tracker.ts
+++ b/frontend/ui/src/api/tracker.ts
@@ -1,0 +1,37 @@
+import type { Task, Issue, Feature, ProjectSummary } from '../types/feeds'
+import { fetchWithAuth } from './client'
+
+const BASE = import.meta.env.VITE_MUTATION_BASE_URL ?? '/api/v1/tracker'
+
+export const trackerKeys = {
+  task: (recordId: string) => ['tracker', 'task', recordId] as const,
+  issue: (recordId: string) => ['tracker', 'issue', recordId] as const,
+  feature: (recordId: string) => ['tracker', 'feature', recordId] as const,
+}
+
+async function fetchRecord<T>(projectId: string, recordType: 'task' | 'issue' | 'feature', recordId: string): Promise<T> {
+  const url = `${BASE}/${encodeURIComponent(projectId)}/${recordType}/${encodeURIComponent(recordId)}`
+  const res = await fetchWithAuth(url)
+  if (!res.ok) throw new Error(`Failed to fetch ${recordType} ${recordId}: ${res.status}`)
+  const data = await res.json()
+  return (data.record ?? data) as T
+}
+
+export const fetchTaskById = (projectId: string, recordId: string) =>
+  fetchRecord<Task>(projectId, 'task', recordId)
+
+export const fetchIssueById = (projectId: string, recordId: string) =>
+  fetchRecord<Issue>(projectId, 'issue', recordId)
+
+export const fetchFeatureById = (projectId: string, recordId: string) =>
+  fetchRecord<Feature>(projectId, 'feature', recordId)
+
+export function resolveProjectFromRecordId(
+  recordId: string,
+  projects: ProjectSummary[],
+): string | null {
+  const prefix = recordId.split('-')[0]
+  if (!prefix) return null
+  const match = projects.find((p) => p.prefix === prefix)
+  return match?.project_id ?? null
+}

--- a/frontend/ui/src/pages/DocumentDetailPage.tsx
+++ b/frontend/ui/src/pages/DocumentDetailPage.tsx
@@ -47,7 +47,10 @@ export function DocumentDetailPage() {
     return <ProjectPrimaryDocumentsPage projectId={normalizedId} />
   }
   if (isPending) return <LoadingState />
-  if (isError || !doc) return <ErrorState message="Document not found" />
+  // ENC-ISS-200: fetchDocument() is the direct tracker API path and already
+  // resolves documents that fall outside the feed cap. Surface the record ID
+  // when it fails so users can diagnose a genuine 404.
+  if (isError || !doc) return <ErrorState message={`Document not found: ${normalizedId}`} />
 
   const expectedSlug = documentSlugFromFileName(doc.file_name, doc.document_id)
   const currentSlug = decodeSlug(documentSlug)

--- a/frontend/ui/src/pages/FeatureDetailPage.tsx
+++ b/frontend/ui/src/pages/FeatureDetailPage.tsx
@@ -1,11 +1,14 @@
 import { useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useParams, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { useFeatures } from '../hooks/useFeatures'
 import { useTasks } from '../hooks/useTasks'
 import { useIssues } from '../hooks/useIssues'
+import { useProjects } from '../hooks/useProjects'
 import { useRecordMutation } from '../hooks/useRecordMutation'
 import { isMutationRetryExhaustedError } from '../api/mutations'
+import { fetchFeatureById, resolveProjectFromRecordId, trackerKeys } from '../api/tracker'
 import { StatusChip } from '../components/shared/StatusChip'
 import { GitHubLinkBadge } from '../components/shared/GitHubLinkBadge'
 import { GitHubOverlay } from '../components/shared/GitHubOverlay'
@@ -26,9 +29,10 @@ import { filterRelatedItems, getChildrenIds } from '../lib/relationshipFilters'
 
 export function FeatureDetailPage() {
   const { featureId } = useParams<{ featureId: string }>()
-  const { allFeatures, isPending, isError } = useFeatures()
+  const { allFeatures, isPending: feedPending, isError: feedError } = useFeatures()
   const { allTasks } = useTasks()
   const { allIssues } = useIssues()
+  const { projects } = useProjects()
   const { mutate, isPending: isMutating } = useRecordMutation()
 
   const [showNote, setShowNote] = useState(false)
@@ -37,7 +41,22 @@ export function FeatureDetailPage() {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [mutationSuccess, setMutationSuccess] = useState<string | null>(null)
 
-  const feature = allFeatures.find((f) => f.feature_id === featureId)
+  // ENC-ISS-200: feed_query caps features at 10 per project; direct-URL loads
+  // of older features need a tracker API fallback.
+  const cachedFeature = allFeatures.find((f) => f.feature_id === featureId)
+  const fallbackProjectId = !cachedFeature && featureId
+    ? resolveProjectFromRecordId(featureId, projects)
+    : null
+  const fallbackEnabled = !feedPending && !cachedFeature && !!featureId && !!fallbackProjectId
+
+  const fallbackQuery = useQuery({
+    queryKey: trackerKeys.feature(featureId ?? ''),
+    queryFn: () => fetchFeatureById(fallbackProjectId!, featureId!),
+    enabled: fallbackEnabled,
+    retry: 1,
+  })
+
+  const feature = cachedFeature ?? fallbackQuery.data
 
   const relatedTaskIds = useMemo(() => {
     if (!feature) return []
@@ -98,9 +117,9 @@ export function FeatureDetailPage() {
     return map
   }, [allTasks, allIssues, allFeatures])
 
-  if (isPending) return <LoadingState />
-  if (isError) return <ErrorState />
-  if (!feature) return <ErrorState message="Feature not found" />
+  if (feedPending || (fallbackEnabled && fallbackQuery.isPending)) return <LoadingState />
+  if (feedError && !feature) return <ErrorState />
+  if (!feature) return <ErrorState message={`Feature not found: ${featureId ?? 'unknown'}`} />
 
   function handleSubmitNote() {
     if (!note.trim()) return

--- a/frontend/ui/src/pages/IssueDetailPage.tsx
+++ b/frontend/ui/src/pages/IssueDetailPage.tsx
@@ -1,11 +1,14 @@
 import { useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useParams, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { useTasks } from '../hooks/useTasks'
 import { useIssues } from '../hooks/useIssues'
 import { useFeatures } from '../hooks/useFeatures'
+import { useProjects } from '../hooks/useProjects'
 import { useRecordMutation } from '../hooks/useRecordMutation'
 import { isMutationRetryExhaustedError } from '../api/mutations'
+import { fetchIssueById, resolveProjectFromRecordId, trackerKeys } from '../api/tracker'
 import { StatusChip } from '../components/shared/StatusChip'
 import { PriorityBadge } from '../components/shared/PriorityBadge'
 import { GitHubLinkBadge } from '../components/shared/GitHubLinkBadge'
@@ -29,8 +32,9 @@ import { filterRelatedItems, getChildrenIds } from '../lib/relationshipFilters'
 export function IssueDetailPage() {
   const { issueId } = useParams<{ issueId: string }>()
   const { allTasks } = useTasks()
-  const { allIssues, isPending, isError } = useIssues()
+  const { allIssues, isPending: feedPending, isError: feedError } = useIssues()
   const { allFeatures } = useFeatures()
+  const { projects } = useProjects()
   const { mutate, isPending: isMutating } = useRecordMutation()
 
   const [showNote, setShowNote] = useState(false)
@@ -39,7 +43,22 @@ export function IssueDetailPage() {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [mutationSuccess, setMutationSuccess] = useState<string | null>(null)
 
-  const issue = allIssues.find((i) => i.issue_id === issueId)
+  // ENC-ISS-200: feed_query caps issues at 10 per type; older records require
+  // a direct tracker API fetch when the URL is loaded cold.
+  const cachedIssue = allIssues.find((i) => i.issue_id === issueId)
+  const fallbackProjectId = !cachedIssue && issueId
+    ? resolveProjectFromRecordId(issueId, projects)
+    : null
+  const fallbackEnabled = !feedPending && !cachedIssue && !!issueId && !!fallbackProjectId
+
+  const fallbackQuery = useQuery({
+    queryKey: trackerKeys.issue(issueId ?? ''),
+    queryFn: () => fetchIssueById(fallbackProjectId!, issueId!),
+    enabled: fallbackEnabled,
+    retry: 1,
+  })
+
+  const issue = cachedIssue ?? fallbackQuery.data
 
   const recordMap = useMemo<Record<string, RecordInfo>>(() => {
     const map: Record<string, RecordInfo> = {}
@@ -61,9 +80,9 @@ export function IssueDetailPage() {
     return { features, tasks, issues, hasRelated: features.length > 0 || tasks.length > 0 || issues.length > 0 }
   }, [issue, allTasks, allIssues, allFeatures])
 
-  if (isPending) return <LoadingState />
-  if (isError) return <ErrorState />
-  if (!issue) return <ErrorState message="Issue not found" />
+  if (feedPending || (fallbackEnabled && fallbackQuery.isPending)) return <LoadingState />
+  if (feedError && !issue) return <ErrorState />
+  if (!issue) return <ErrorState message={`Issue not found: ${issueId ?? 'unknown'}`} />
 
   function handleSubmitNote() {
     if (!note.trim()) return

--- a/frontend/ui/src/pages/TaskDetailPage.tsx
+++ b/frontend/ui/src/pages/TaskDetailPage.tsx
@@ -1,11 +1,14 @@
 import { useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useParams, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { useTasks } from '../hooks/useTasks'
 import { useIssues } from '../hooks/useIssues'
 import { useFeatures } from '../hooks/useFeatures'
+import { useProjects } from '../hooks/useProjects'
 import { useRecordMutation } from '../hooks/useRecordMutation'
 import { isMutationRetryExhaustedError } from '../api/mutations'
+import { fetchTaskById, resolveProjectFromRecordId, trackerKeys } from '../api/tracker'
 import { StatusChip } from '../components/shared/StatusChip'
 import { PriorityBadge } from '../components/shared/PriorityBadge'
 import { ActiveSessionBadge } from '../components/shared/ActiveSessionBadge'
@@ -30,9 +33,10 @@ import { filterRelatedItems, getChildrenIds } from '../lib/relationshipFilters'
 
 export function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>()
-  const { allTasks, isPending, isError } = useTasks()
+  const { allTasks, isPending: feedPending, isError: feedError } = useTasks()
   const { allIssues } = useIssues()
   const { allFeatures } = useFeatures()
+  const { projects } = useProjects()
   const { mutate, isPending: isMutating } = useRecordMutation()
 
   const [showNote, setShowNote] = useState(false)
@@ -41,7 +45,22 @@ export function TaskDetailPage() {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [mutationSuccess, setMutationSuccess] = useState<string | null>(null)
 
-  const task = allTasks.find((t) => t.task_id === taskId)
+  // ENC-ISS-200: feed_query caps responses at 100 tasks; records outside the
+  // window must be fetched directly from the tracker API.
+  const cachedTask = allTasks.find((t) => t.task_id === taskId)
+  const fallbackProjectId = !cachedTask && taskId
+    ? resolveProjectFromRecordId(taskId, projects)
+    : null
+  const fallbackEnabled = !feedPending && !cachedTask && !!taskId && !!fallbackProjectId
+
+  const fallbackQuery = useQuery({
+    queryKey: trackerKeys.task(taskId ?? ''),
+    queryFn: () => fetchTaskById(fallbackProjectId!, taskId!),
+    enabled: fallbackEnabled,
+    retry: 1,
+  })
+
+  const task = cachedTask ?? fallbackQuery.data
 
   const recordMap = useMemo<Record<string, RecordInfo>>(() => {
     const map: Record<string, RecordInfo> = {}
@@ -63,9 +82,9 @@ export function TaskDetailPage() {
     return { features, tasks, issues, hasRelated: features.length > 0 || tasks.length > 0 || issues.length > 0 }
   }, [task, allTasks, allIssues, allFeatures])
 
-  if (isPending) return <LoadingState />
-  if (isError) return <ErrorState />
-  if (!task) return <ErrorState message="Task not found" />
+  if (feedPending || (fallbackEnabled && fallbackQuery.isPending)) return <LoadingState />
+  if (feedError && !task) return <ErrorState />
+  if (!task) return <ErrorState message={`Task not found: ${taskId ?? 'unknown'}`} />
 
   function handleSubmitNote() {
     if (!note.trim()) return


### PR DESCRIPTION
## Summary
- Adds a direct tracker API fallback to `TaskDetailPage`, `IssueDetailPage`, and `FeatureDetailPage` so direct-URL navigation to records outside the `feed_query` cap window (tasks=100, issues/features=10) still resolves against `GET /api/v1/tracker/{project}/{type}/{id}` instead of rendering an empty state.
- Introduces `frontend/ui/src/api/tracker.ts` with `fetchTaskById` / `fetchIssueById` / `fetchFeatureById` plus a `resolveProjectFromRecordId` helper that maps a record ID prefix to a `project_id` via `useProjects()`.
- `DocumentDetailPage` already resolved documents via direct `fetchDocument()` (strictly stronger than AC-4 requires); this PR also surfaces the record ID in its error state for AC-5 compliance. Task/Issue/Feature error states now include the record ID as well.

## Scope
- Fixes ENC-ISS-200 (direct URL navigation to older records returns empty state).
- PWA-only. No Lambda, infrastructure, or governance dictionary changes. `comp-enceladus-pwa` only.
- `transition_type: github_pr_deploy`, `deploy_target: prod`, targets `main`.

## Test plan
- [x] `tsc -b` clean on `frontend/ui`
- [x] `npm run build` clean (`vite` production bundle)
- [x] `vitest run` — 33/34 tests passing (the one failure in `src/api/client.test.ts` is a pre-existing fetchFeed cache-buster mismatch, unrelated to this change)
- [ ] Live UAT post-deploy: navigate directly to at least one older Task, Issue, and Document URL confirmed absent from the feed cache; confirm each renders correctly

## Evidence tokens
CCI-8cbf40ff83174307bc66e347ccff63b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)