### PR TITLE
fix: TS imports, CFN params, deploy.sh env var + runtime bugs

### DIFF
--- a/backend/lambda/auth_refresh/deploy.sh
+++ b/backend/lambda/auth_refresh/deploy.sh
@@ -5,8 +5,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 REGION="${REGION:-us-west-2}"
 FUNCTION_NAME="${FUNCTION_NAME:-auth-refresh${ENVIRONMENT_SUFFIX}}"
-RUNTIME="${RUNTIME:-python3.12}"
-ARCHITECTURE="${ARCHITECTURE:-arm64}"
+# ENC-ISS-202 / ENC-PLN-019: v3 production lock — conditional runtime/arch
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  RUNTIME="${RUNTIME:-python3.12}"; ARCHITECTURE="${ARCHITECTURE:-arm64}"
+else
+  RUNTIME="${RUNTIME:-python3.11}"; ARCHITECTURE="${ARCHITECTURE:-x86_64}"
+fi
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"

--- a/backend/lambda/deploy_decide/deploy.sh
+++ b/backend/lambda/deploy_decide/deploy.sh
@@ -26,6 +26,21 @@ log() { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
 # Resolve GitHub App config from coordination-api if not set
 # ---------------------------------------------------------------------------
 resolve_github_config() {
+  # ENC-ISS-204: Read existing Lambda env vars first to avoid clearing CFN-set values.
+  # Priority: shell env > existing Lambda config > coordination-api fallback
+  if [[ -z "${GITHUB_APP_ID}" ]]; then
+    GITHUB_APP_ID="$(aws lambda get-function-configuration \
+      --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+      --query 'Environment.Variables.GITHUB_APP_ID' --output text 2>/dev/null || true)"
+    [[ "${GITHUB_APP_ID}" == "None" ]] && GITHUB_APP_ID=""
+  fi
+  if [[ -z "${GITHUB_INSTALLATION_ID}" ]]; then
+    GITHUB_INSTALLATION_ID="$(aws lambda get-function-configuration \
+      --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+      --query 'Environment.Variables.GITHUB_INSTALLATION_ID' --output text 2>/dev/null || true)"
+    [[ "${GITHUB_INSTALLATION_ID}" == "None" ]] && GITHUB_INSTALLATION_ID=""
+  fi
+  # Fallback to coordination-api if still empty (first deploy before CFN sets values)
   local coord_fn="devops-coordination-api${ENVIRONMENT_SUFFIX}"
   if [[ -z "${GITHUB_APP_ID}" ]]; then
     GITHUB_APP_ID="$(aws lambda get-function-configuration \

--- a/frontend/ui/src/components/layout/AppShell.tsx
+++ b/frontend/ui/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Outlet, useNavigate } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 import { Header } from './Header'
 import { BottomNav } from './BottomNav'
 import { DeployApprovalBanner } from '../shared/DeployApprovalBanner'

--- a/frontend/ui/src/hooks/useDeploymentManager.ts
+++ b/frontend/ui/src/hooks/useDeploymentManager.ts
@@ -7,7 +7,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { deployKeys, fetchDeployQueue, submitDeployDecision } from '../api/deploy'
-import type { DeployDecideRequest, DeploymentDecision } from '../types/deployments'
+import type { DeployDecideRequest } from '../types/deployments'
 import { isSessionExpiredError } from '../lib/authSession'
 
 const POLL_INTERVAL = 5_000

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -45,6 +45,15 @@ Parameters:
   SharedLayerArn:
     Type: String
     Default: arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:7
+  # ENC-ISS-197: Referenced by deploy_decide Lambda env vars but were missing from Parameters
+  GitHubAppId:
+    Type: String
+    Default: "2946766"
+    Description: GitHub App numeric ID for deploy_decide Lambda.
+  GitHubInstallationId:
+    Type: String
+    Default: "112392089"
+    Description: GitHub App installation ID for NX-2021-L org.
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]


### PR DESCRIPTION
## Summary

- Remove unused `useNavigate` import from AppShell.tsx (TS6133 build error on strict tsconfig)
- Remove unused `DeploymentDecision` import from useDeploymentManager.ts (TS6196)
- Add `GitHubAppId` + `GitHubInstallationId` parameters to 02-compute.yaml (ENC-ISS-197 — blocked all CFN compute stack deploys + GH Actions)
- Fix deploy_decide deploy.sh to read existing Lambda env vars before overwriting, preventing CFN-set values from being cleared (ENC-ISS-204)
- Fix auth_refresh deploy.sh hardcoded python3.12 default with ENVIRONMENT_SUFFIX conditional guard (ENC-ISS-202)

## Commit Complete ID

CCI-ac00fdb74e7640d3ab2d335468957a3b

## Test plan

- [ ] CI passes (arch parity guard should now pass for deploy_decide + auth_refresh)
- [ ] Governance Dictionary Guard passes (no lambda_function.py changes)
- [ ] PR Commit Gate validates CCI
- [ ] After merge: CFN compute stack deploy succeeds without temporary template workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Task: ENC-TSK-D39 | Plan: ENC-PLN-012 Gate 6
Fixes: ENC-ISS-197, ENC-ISS-202, ENC-ISS-204