### PR TITLE
fix: persist GMF gate hotfixes — IAM policy and GSI key constraint

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-11.3",
-  "updated_at": "2026-04-11T22:55:00Z",
-  "last_change_summary": "ENC-TSK-D38: Added tracker.stack_generation (ENC-GEN), tracker.deployment_decision (ENC-DPL), and gmf.graph_edges entities for the Generational Metabolism Framework (DOC-63420302EF65). Part of ENC-PLN-012 Gate 5.",
+  "version": "2026-04-12.1",
+  "updated_at": "2026-04-12T09:30:00Z",
+  "last_change_summary": "ENC-TSK-D46: Bug fix — _gmf_create_decision omits generation_id and final_target from initial PutItem when empty (GSI key constraint). Fields still populated via UpdateItem on subsequent status transitions. IAM policy for devops-deployment-manager added to github-integration Lambda role.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/github_integration/deploy.sh
+++ b/backend/lambda/github_integration/deploy.sh
@@ -54,6 +54,12 @@ ensure_role() {
       "Effect": "Allow",
       "Action": ["secretsmanager:GetSecretValue"],
       "Resource": "arn:aws:secretsmanager:${REGION}:${ACCOUNT_ID}:secret:devops/github-app/*"
+    },
+    {
+      "Sid": "GMFDeploymentManagerAccess",
+      "Effect": "Allow",
+      "Action": ["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:Scan"],
+      "Resource": "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/devops-deployment-manager"
     }
   ]
 }

--- a/backend/lambda/github_integration/lambda_function.py
+++ b/backend/lambda/github_integration/lambda_function.py
@@ -1032,8 +1032,6 @@ def _gmf_create_decision(pr: Dict, repo_full: str, delivery_id: str) -> Dict:
         "head_branch": {"S": pr.get("head", {}).get("ref", "")},
         "head_sha": {"S": pr.get("head", {}).get("sha", "")},
         "original_target": {"S": original_target},
-        "final_target": {"S": ""},
-        "generation_id": {"S": ""},
         "decided_by": {"S": ""},
         "decided_at": {"S": ""},
         "decision_reason": {"S": ""},


### PR DESCRIPTION
## Summary

- Add DynamoDB permissions (PutItem, UpdateItem, Scan on devops-deployment-manager) to the github-integration Lambda role inline policy in deploy.sh
- Remove empty-string `generation_id` and `final_target` from `_gmf_create_decision` PutItem — both are GSI key attributes that DynamoDB rejects as empty strings

## Context

During ENC-TSK-D45 diagnostic, two hotfixes were applied directly to production to unblock GMF gate validation. This PR persists both changes in the repo so they survive the next deploy.

Addresses: ENC-ISS-206

CCI-49fc4c361c324343a59aa16a188477db

## Test plan

- [ ] Verify deploy.sh inline policy includes GMFDeploymentManagerAccess statement
- [ ] Verify lambda_function.py _gmf_create_decision no longer sets empty generation_id or final_target
- [ ] CI passes (Secrets Scan, PR Commit Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)