### PR TITLE
fix: strip decision# prefix from DPL record_id in PWA deploy layer (ENC-ISS-208)

### DIFF
--- a/frontend/ui/src/api/deploy.ts
+++ b/frontend/ui/src/api/deploy.ts
@@ -25,7 +25,16 @@ export async function fetchDeployQueue(
     `/api/v1/deploy/queue?project_id=${encodeURIComponent(projectId)}&limit=50`,
   )
   if (!res.ok) throw new Error(`Failed to fetch deploy queue: ${res.status}`)
-  return res.json()
+  const data: DeployQueueResponse = await res.json()
+  // ENC-ISS-208: Strip DynamoDB composite key prefix from record_id.
+  // The "decision#" prefix contains a # that breaks native browser
+  // input validation (url/email types reject it). The backend
+  // reconstructs the full key from pr_number, so the UI never needs it.
+  data.decisions = data.decisions.map((d) => ({
+    ...d,
+    record_id: d.record_id.replace(/^decision#/, ''),
+  }))
+  return data
 }
 
 export async function submitDeployDecision(


### PR DESCRIPTION
## Summary

- Strips the DynamoDB composite key prefix `decision#` from `record_id` in the PWA deploy queue API response layer (`fetchDeployQueue`)
- The `#` character in `decision#ENC-DPL-N` breaks native browser input validation (url/email types) when bound to form inputs
- The backend `deploy_decide` Lambda already reconstructs the full key from `pr_number`, so the prefix is never needed client-side

## Change

Single file: `frontend/ui/src/api/deploy.ts` — `fetchDeployQueue` now maps response decisions to strip the `decision#` prefix from `record_id` before returning to UI components.

## References

- **Task:** ENC-TSK-D51
- **Issue:** ENC-ISS-208
- **Component:** comp-jwo-web-infra-enc

CCI-b748b495664c4d70b7b8ed2abf8deac1

## Test plan

- [ ] CI passes (lint, type-check, build)
- [ ] PR Commit Gate validates CCI token
- [ ] After deploy: click Approve on DPL record in PWA — no browser pattern validation error
- [ ] Product lead confirms approve flow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)