### PR TITLE
fix: explicit page chunks in vite.config.ts to prevent CI build chunk drop

### DIFF
--- a/frontend/ui/vite.config.ts
+++ b/frontend/ui/vite.config.ts
@@ -86,6 +86,13 @@ export default defineConfig({
             return undefined
           }
 
+          // Pages get explicit chunks to prevent non-deterministic code
+          // splitting across Node versions (ENC-ISS-211: CodeBuild Node 20
+          // vs local Node 24 caused DeploymentManagerPage chunk to be
+          // silently dropped when the module graph shifted).
+          const pageMatch = id.match(/\/src\/pages\/([A-Z][^/]+?)\.tsx$/)
+          if (pageMatch) return pageMatch[1]
+
           if (id.includes('/src/lib/routes.tsx')) return 'routes'
           if (
             id.includes('/src/components/layout/AppShell.tsx') ||


### PR DESCRIPTION
## Summary
- Add `/src/pages/` pattern to `manualChunks` function in `vite.config.ts` so every page component gets an explicit named chunk
- Prevents non-deterministic Vite code-splitting across Node versions (CodeBuild Node 20 vs local Node 24)
- Fixes ENC-ISS-211: DeploymentManagerPage chunk was silently dropped by CodeBuild after PR #293 shifted the deploy.ts module graph

## Root Cause
The `manualChunks` function only handled `node_modules`, `routes.tsx`, and `shell` modules. Page components relied on Vite's default dynamic-import splitting, which produced different results between Node 20 (CodeBuild `aws/codebuild/standard:7.0`) and Node 24 (local dev). When PR #293 changed `frontend/ui/src/api/deploy.ts`, the module graph for `DeploymentManagerPage` (via `useDeploymentManager` → `deploy.ts`) shifted, causing Rollup on Node 20 to silently drop the chunk.

## Fix
A single regex rule in `manualChunks` assigns every file matching `/src/pages/[A-Z]*.tsx` to its own named chunk. This makes chunk assignment explicit and deterministic regardless of build environment.

## Test plan
- [x] Local `vite build` produces `DeploymentManagerPage-XXXX.js` chunk (7.50 kB)
- [x] Routes bundle references `DeploymentManagerPage` and `/deployments` path
- [x] 22 page chunks total in build output
- [ ] CI build (triggered by this PR merge) includes `DeploymentManagerPage` chunk
- [ ] `/deployments` route accessible in PWA after CI deploy

CCI-099fb74d25754081a99bf0bdffa3a563

🤖 Generated with [Claude Code](https://claude.com/claude-code)