### PR TITLE
fix: Rollup forcePageChunks plugin to guarantee CI build chunk inclusion

### DIFF
--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node -e \"const f=require('fs').readdirSync('dist/assets');const m='DeploymentManagerPage';if(!f.some(x=>x.startsWith(m))){console.error('BUILD FAILED: '+m+' chunk missing from dist/assets');process.exit(1)}\"",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/ui/vite.config.ts
+++ b/frontend/ui/vite.config.ts
@@ -1,7 +1,36 @@
+import { readdirSync } from 'fs'
+import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import type { Plugin } from 'vite'
+
+// ---------------------------------------------------------------------------
+// ENC-ISS-211: Force-emit page chunks to prevent non-deterministic code
+// splitting across Node versions. CodeBuild (Node 20) silently dropped the
+// DeploymentManagerPage chunk after a module graph shift in PR #293.
+// Rollup's emitFile API guarantees chunk inclusion regardless of tree-shaking
+// or module graph analysis.
+// ---------------------------------------------------------------------------
+function forcePageChunks(): Plugin {
+  return {
+    name: 'force-page-chunks',
+    buildStart() {
+      const pagesDir = resolve(__dirname, 'src/pages')
+      const pages = readdirSync(pagesDir).filter((f) =>
+        /^[A-Z].*Page\.tsx$/.test(f),
+      )
+      for (const page of pages) {
+        this.emitFile({
+          type: 'chunk',
+          id: resolve(pagesDir, page),
+          name: page.replace(/\.tsx$/, ''),
+        })
+      }
+    },
+  }
+}
 
 export default defineConfig({
   base: '/enceladus/',
@@ -67,6 +96,7 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      plugins: [forcePageChunks()],
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {
@@ -87,9 +117,7 @@ export default defineConfig({
           }
 
           // Pages get explicit chunks to prevent non-deterministic code
-          // splitting across Node versions (ENC-ISS-211: CodeBuild Node 20
-          // vs local Node 24 caused DeploymentManagerPage chunk to be
-          // silently dropped when the module graph shifted).
+          // splitting across Node versions (ENC-ISS-211).
           const pageMatch = id.match(/\/src\/pages\/([A-Z][^/]+?)\.tsx$/)
           if (pageMatch) return pageMatch[1]
 


### PR DESCRIPTION
## Summary
- Add `forcePageChunks` Rollup plugin that uses `emitFile` API to force-emit chunks for all page components in `src/pages/`
- Add post-build verification in `package.json` that fails the build if `DeploymentManagerPage` chunk is missing
- Supersedes the `manualChunks` regex from PR #294 which was insufficient — CodeBuild (Node 20) still dropped the chunk

## Root Cause (from ENC-TSK-D53 investigation)
CodeBuild uses `aws/codebuild/standard:7.0` with Node 20. Vite 7.3.1 + Rollup 4.57.1 on Node 20 handles dynamic imports differently than Node 24. The `manualChunks` function alone cannot prevent chunk dropping because Rollup resolves dynamic import targets before `manualChunks` runs. The `emitFile` API operates at a lower level — it registers chunks as explicit build entries that cannot be tree-shaken.

## Test plan
- [x] Local `vite build` produces `DeploymentManagerPage-B9j06haF.js` chunk (7.50 kB)
- [x] Routes bundle references `DeploymentManagerPage` and `/deployments` path
- [x] `npm run build` passes including post-build verification
- [ ] CodeBuild deploy includes `DeploymentManagerPage` chunk in S3 assets
- [ ] `/deployments` route accessible in PWA after CI deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)