### PR TITLE
fix: ESM-compatible forcePageChunks plugin and CodeBuild deploy guard

### DIFF
--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build && node -e \"const f=require('fs').readdirSync('dist/assets');const m='DeploymentManagerPage';if(!f.some(x=>x.startsWith(m))){console.error('BUILD FAILED: '+m+' chunk missing from dist/assets');process.exit(1)}\"",
+    "build": "tsc -b && vite build && ls dist/assets/ | grep -q DeploymentManagerPage || (echo 'BUILD FAILED: DeploymentManagerPage chunk missing from dist/assets' && exit 1)",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/ui/vite.config.ts
+++ b/frontend/ui/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
-import type { Plugin } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
 
 // ---------------------------------------------------------------------------
 // ENC-ISS-211: Force-emit page chunks to prevent non-deterministic code
@@ -12,12 +12,19 @@ import type { Plugin } from 'vite'
 // DeploymentManagerPage chunk after a module graph shift in PR #293.
 // Rollup's emitFile API guarantees chunk inclusion regardless of tree-shaking
 // or module graph analysis.
+//
+// Uses config.root (not __dirname) to resolve paths — __dirname is unreliable
+// in Vite ESM config loading across Node versions (ENC-TSK-D54).
 // ---------------------------------------------------------------------------
 function forcePageChunks(): Plugin {
+  let root: string
   return {
     name: 'force-page-chunks',
+    configResolved(config: ResolvedConfig) {
+      root = config.root
+    },
     buildStart() {
-      const pagesDir = resolve(__dirname, 'src/pages')
+      const pagesDir = resolve(root, 'src/pages')
       const pages = readdirSync(pagesDir).filter((f) =>
         /^[A-Z].*Page\.tsx$/.test(f),
       )
@@ -37,6 +44,7 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
+    forcePageChunks(),
     VitePWA({
       registerType: 'autoUpdate',
       // Disable auto-generated registerSW.js — we register the SW manually
@@ -96,7 +104,6 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      plugins: [forcePageChunks()],
       output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {


### PR DESCRIPTION
## Summary
- Move `forcePageChunks` plugin from `rollupOptions.plugins` to top-level `plugins` array — plugins in `rollupOptions` don't receive Vite hooks like `configResolved`, so `config.root` was undefined
- Use `config.root` instead of `__dirname` which is unreliable in Vite ESM config loading on Node 20
- Replace `require('fs')` build verification with shell `grep` — ESM-compatible on all Node versions
- Updated `deploy_build_helper.py` on S3 to check `CODEBUILD_BUILD_SUCCEEDING` before uploading artifacts or signaling completion

## Root Cause (from ENC-TSK-D53/D54)
Three compounding ESM issues in the CodeBuild pipeline:
1. `forcePageChunks` was in `rollupOptions.plugins` which only gets Rollup hooks, not Vite hooks — `configResolved` never fired, `root` was undefined, `resolve(undefined, 'src/pages')` threw
2. Build verification used CJS `require('fs')` which crashes in ESM mode (`"type": "module"`)
3. CodeBuild `post_build` runs unconditionally — deployed broken `dist/` even when build failed

## Test plan
- [x] Local `npm run build` produces `DeploymentManagerPage-B9j06haF.js` chunk
- [x] Routes bundle references `DeploymentManagerPage` and `/deployments` path
- [x] Build verification passes (no `BUILD FAILED` message)
- [ ] CodeBuild deploy includes `DeploymentManagerPage` chunk in S3 (CI validation)
- [ ] `/deployments` route accessible in PWA after CI deploy

CCI-e1d58d155f2145f9b9bef8514ee6d449

🤖 Generated with [Claude Code](https://claude.com/claude-code)