### PR TITLE
fix: paginate S3 list in deploy_orchestrator to fix stale source zip selection

### DIFF
--- a/backend/lambda/deploy_orchestrator/lambda_function.py
+++ b/backend/lambda/deploy_orchestrator/lambda_function.py
@@ -938,12 +938,10 @@ def _write_spec(project_id: str, spec_id: str, status: str = "building", **kwarg
 
 def _latest_source_archive_key(source_bucket: str, source_prefix: str) -> str:
     """Return latest source zip key under the prefix."""
-    s3 = _get_s3()
-    resp = s3.list_objects_v2(Bucket=source_bucket, Prefix=f"{source_prefix}/", MaxKeys=100)
-    zips = [o for o in resp.get("Contents", []) if o["Key"].endswith(".zip")]
-    if not zips:
+    keys = _list_source_archive_keys(source_bucket, source_prefix)
+    if not keys:
         raise RuntimeError(f"No source archives found at s3://{source_bucket}/{source_prefix}/")
-    return sorted(zips, key=lambda o: o["Key"], reverse=True)[0]["Key"]
+    return keys[0]
 
 
 def _normalize_source_prefix(prefix: str) -> str:
@@ -979,9 +977,20 @@ def _candidate_source_locations(
 
 
 def _list_source_archive_keys(source_bucket: str, source_prefix: str) -> List[str]:
+    """List all .zip keys under prefix with full S3 pagination (ENC-ISS-212)."""
     s3 = _get_s3()
-    resp = s3.list_objects_v2(Bucket=source_bucket, Prefix=f"{source_prefix}/", MaxKeys=100)
-    zips = [str(obj.get("Key", "")) for obj in resp.get("Contents", []) if str(obj.get("Key", "")).endswith(".zip")]
+    zips: List[str] = []
+    kwargs: Dict[str, Any] = {"Bucket": source_bucket, "Prefix": f"{source_prefix}/"}
+    while True:
+        resp = s3.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []):
+            key = str(obj.get("Key", ""))
+            if key.endswith(".zip"):
+                zips.append(key)
+        if resp.get("IsTruncated"):
+            kwargs["ContinuationToken"] = resp["NextContinuationToken"]
+        else:
+            break
     return sorted(zips, reverse=True)
 
 


### PR DESCRIPTION
## Summary
- Replace `list_objects_v2(MaxKeys=100)` with paginated `ContinuationToken` loop in `_list_source_archive_keys()`
- Simplify `_latest_source_archive_key()` to delegate to the paginated function (was a duplicate unpaginated call)
- Fixes ENC-ISS-212: with 108 source zips accumulated, the newest 8 were beyond the 100-key page boundary, causing CodeBuild to silently build from a stale April 11 zip

## Root Cause
S3 `list_objects_v2` returns at most `MaxKeys` results per call. Without pagination, only the first 100 keys (alphabetically) were returned. Since zip filenames use timestamps (`YYYYMMDDTHHMMSSZ-...`), the newest keys sort last alphabetically and were truncated. The `sorted(reverse=True)` only sorted the truncated set.

## Test plan
- [x] Code review: `while True` loop with `IsTruncated` / `ContinuationToken` handling
- [x] `_latest_source_archive_key` now delegates to paginated function (no duplicate logic)
- [ ] Lambda deployed to production
- [ ] Trigger deploy and verify CodeBuild picks newest source zip from CloudWatch logs

CCI-310aecb6bafc400981b2a9e4ccd02c91

🤖 Generated with [Claude Code](https://claude.com/claude-code)