### PR TITLE
fix: correct function_name in gamma MCP deploy workflow (ENC-TSK-D59)

### DIFF
--- a/.github/workflows/lambda-mcp-streamable-gamma-deploy.yml
+++ b/.github/workflows/lambda-mcp-streamable-gamma-deploy.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-orchestration.yml
     with:
-      function_name: "enceladus-mcp-streamable-gamma"
+      function_name: "enceladus-mcp-streamable"
       lambda_dir: "backend/lambda/mcp_streamable_gamma"
       deploy_script: "backend/lambda/mcp_streamable_gamma/deploy.sh"
       deploy_mode: "per-lambda"


### PR DESCRIPTION
## Summary
- Fixes double-suffix bug in gamma deploy workflow: `enceladus-mcp-streamable-gamma-gamma`
- The deploy orchestration appends `-gamma` automatically via `environment_suffix`
- Pass base function name `enceladus-mcp-streamable` instead

CCI-83686d01f2b84dea9cd3d24ae1d483c9

🤖 Generated with [Claude Code](https://claude.com/claude-code)