### PR TITLE
fix(tracker_mutation): isinstance guard for transition_evidence (ENC-ISS-215)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-12.2",
-  "updated_at": "2026-04-12T21:05:00Z",
-  "last_change_summary": "ENC-TSK-D37: GMF Phase 0 — Register docstore.evolution_chapter entity, add missing fields to tracker.stack_generation (title, production_stack, gamma_stack, promoted_at, chapter_promotion_id) and tracker.deployment_decision (generation_id, head_sha, head_branch, pr_author, github_pr_url, decision_reason, created_at). Field extensions: tracker.lesson (generation_scope, lesson_class), tracker.feature (target_generation, promoted_at, chapter_promotion_id), tracker.plan (target_generation), tracker.task (deploy_target).",
+  "version": "2026-04-13.1",
+  "updated_at": "2026-04-13T02:00:00Z",
+  "last_change_summary": "ENC-TSK-D63: Defensive fix only — isinstance guard for transition_evidence in tracker_mutation. No new fields, no schema changes.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -3016,6 +3016,8 @@ def _handle_update_field(
         new_lower = value.strip().lower()
         closing = new_lower in ("closed", "completed", "complete")
         transition_evidence = body.get("transition_evidence", {})
+        if not isinstance(transition_evidence, dict):
+            transition_evidence = {}
 
         if record_type == "task" and current_status != new_lower:
             ws = _normalize_write_source(body)


### PR DESCRIPTION
## Summary
- Adds `isinstance(transition_evidence, dict)` guard after line 3018 in tracker_mutation Lambda
- Prevents `AttributeError` crash at line 3070 when `transition_evidence` is a string instead of a dict
- Consistent with existing safe pattern at line 2587
- Governance dictionary version bump (no schema changes, defensive fix only)

## Related
- Fixes: ENC-ISS-215
- Task: ENC-TSK-D63
- Plan: ENC-PLN-021

## Test plan
- [ ] CI governance dictionary guard passes (no new fields/schema changes)
- [ ] Lambda deploys successfully via CI workflow
- [ ] String transition_evidence no longer causes 500

CCI-5af9d5e693b148db83075fa6d8d6a558

🤖 Generated with [Claude Code](https://claude.com/claude-code)