### PR TITLE
fix: remove premature enceladus-prod-health-monitor manifest entry (ENC-ISS-220)

### DIFF
--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -137,12 +137,6 @@
       "lambda_dir": "backend/lambda/graph_health_metrics",
       "workflow_file": ".github/workflows/lambda-graph-health-metrics-deploy.yml",
       "deploy_script": "backend/lambda/graph_health_metrics/deploy.sh"
-    },
-    {
-      "function_name": "enceladus-prod-health-monitor",
-      "lambda_dir": "backend/lambda/prod_health_monitor",
-      "workflow_file": ".github/workflows/lambda-prod-health-monitor-deploy.yml",
-      "deploy_script": "backend/lambda/prod_health_monitor/deploy.sh"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the `enceladus-prod-health-monitor` entry from `infrastructure/lambda_workflow_manifest.json`
- Restores CI parity audit integrity: `verify_lambda_workflow_coverage.py` now passes (21 production Lambdas matched)
- Collateral artifacts (Lambda code, deploy workflow, 05-monitoring.yaml CFN template) remain in-tree for future governed rebuild

**Task:** ENC-TSK-D71 (Phase B of ENC-PLN-022) | **Parent:** ENC-TSK-D69 | **Issue:** ENC-ISS-220

CCI-7191264f83b54a829c5807d416d909a6