### PR TITLE
fix: add v4/main branch trigger to PR Commit Gate and Governance Dictionary Guard (ENC-ISS-223)

### DIFF
--- a/.github/workflows/governance-dictionary-guard.yml
+++ b/.github/workflows/governance-dictionary-guard.yml
@@ -2,9 +2,9 @@ name: Governance Dictionary Guard
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'v[0-9]*/main']
   push:
-    branches: [main]
+    branches: [main, 'v[0-9]*/main']
 
 permissions:
   contents: read

--- a/.github/workflows/pr-commit-gate.yml
+++ b/.github/workflows/pr-commit-gate.yml
@@ -17,6 +17,7 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+      - 'v[0-9]*/main'
 
 jobs:
   commit-gate:


### PR DESCRIPTION
## Summary
- Add `v[0-9]*/main` to the `branches` filter in `pr-commit-gate.yml` and `governance-dictionary-guard.yml`
- Matches the `git-governance` ruleset's include pattern: `[refs/heads/main, refs/heads/v[0-9]*/main]`
- Unblocks all v4/main PRs (currently permanently blocked because required checks never fire)

**Task:** ENC-TSK-D82 | **Issue:** ENC-ISS-223 | **Unblocks:** PR #310 (ENC-TSK-D74)

CCI-e7023822974041dfbca59bc0f04e1320