### PR TITLE
fix: fence-aware compliance checker + MCP YAML guidance (ENC-LSN-026)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-13.2",
-  "updated_at": "2026-04-13T03:48:00Z",
-  "last_change_summary": "ENC-TSK-D63: Defensive fix only \u2014 isinstance guard for transition_evidence in tracker_mutation. No new fields, no schema changes.",
+  "version": "2026-04-13.3",
+  "updated_at": "2026-04-13T05:37:00Z",
+  "last_change_summary": "ENC-LSN-026 integration: Added compliance_score, compliance_warnings, and format_convention fields to docstore.document. Compliance checker now fence-aware (skips fenced code block content). MCP server injects YAML format guidance on pipe-table warnings.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3388,6 +3388,23 @@
           "write_authority": "Any governed session or CEE automation.",
           "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
+        },
+        "compliance_score": {
+          "type": "integer",
+          "definition": "0-100 score computed by _evaluate_markdown_compliance in document_api. Deducts 10 points per warning. Stored on every PUT and PATCH. Returned in API response to agents.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "compliance_warnings": {
+          "type": "array",
+          "items": "string",
+          "definition": "List of compliance warnings from _evaluate_markdown_compliance. Common warnings: missing metadata fields, pipe-table false positives, unclosed fences, heading hierarchy violations.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "format_convention": {
+          "type": "rule",
+          "definition": "Structured agent-session output in docstore .md documents MUST use comment-free YAML code blocks (```yaml ... ```) instead of GFM pipe tables. Pipe tables are permitted only for purely presentational content where renderer-dependence is explicitly acknowledged. YAML hash-comments (# ...) must be omitted inside fenced blocks to avoid compliance checker heading false positives. MCP server injects format_guidance in document.put/patch responses when pipe-table warnings are detected.",
+          "governing_lesson": "ENC-LSN-026",
+          "enforcement": "Advisory via MCP format_guidance response field. Compliance checker fence-awareness prevents false positives on conforming documents."
         }
       }
     },

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -414,6 +414,39 @@ def _now_z() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _fenced_line_set(lines: List[str]) -> Tuple[set, List[str]]:
+    """Pre-scan to identify line indices inside fenced code blocks.
+
+    Returns (set of 0-based indices inside fences, list of fence warnings).
+    ENC-LSN-026: enables other compliance rules to skip fenced content,
+    preventing false-positive pipe-table and heading warnings on YAML blocks.
+    """
+    fenced: set = set()
+    warnings: List[str] = []
+    in_fence = False
+    fence_start = 0
+    for idx, line in enumerate(lines):
+        if not line.strip().startswith("```"):
+            if in_fence:
+                fenced.add(idx)
+            continue
+        if not in_fence:
+            in_fence = True
+            fence_start = idx
+            lang = line.strip()[3:].strip()
+            if not lang:
+                warnings.append(
+                    f"Code fence at line {idx + 1} should include a language identifier."
+                )
+            fenced.add(idx)  # opening fence line itself
+        else:
+            fenced.add(idx)  # closing fence line
+            in_fence = False
+    if in_fence:
+        warnings.append(f"Unclosed code fence opened at line {fence_start + 1}.")
+    return fenced, warnings
+
+
 def _is_heading(line: str) -> Optional[Tuple[int, str]]:
     m = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
     if not m:
@@ -436,6 +469,12 @@ def _is_table_divider(line: str) -> bool:
 def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
     warnings: List[str] = []
     lines = content.splitlines()
+
+    # Pre-scan: identify fenced code block boundaries (ENC-LSN-026).
+    # Other rules skip lines inside fences to prevent false positives
+    # on YAML blocks, code samples, etc.
+    fenced_lines, fence_warnings = _fenced_line_set(lines)
+    warnings.extend(fence_warnings)
 
     # Rule 1 + 7: title and metadata block.
     first_non_empty_idx = None
@@ -462,10 +501,12 @@ def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
         if f"**{field}**:" not in metadata_window:
             warnings.append(f"Metadata block missing '**{field}**:' near top of document.")
 
-    # Rule 1: heading hierarchy.
+    # Rule 1: heading hierarchy (skip fenced lines — ENC-LSN-026).
     last_level = 0
     h1_count = 0
     for idx, line in enumerate(lines, start=1):
+        if (idx - 1) in fenced_lines:
+            continue
         parsed = _is_heading(line)
         if not parsed:
             continue
@@ -482,24 +523,7 @@ def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
     if h1_count > 1:
         warnings.append("Multiple level-1 headings found; use exactly one document title.")
 
-    # Rule 3: fenced code blocks should be closed and include language on opening fence.
-    in_fence = False
-    fence_line = 0
-    for idx, line in enumerate(lines, start=1):
-        if not line.strip().startswith("```"):
-            continue
-        fence = line.strip()
-        if not in_fence:
-            in_fence = True
-            fence_line = idx
-            lang = fence[3:].strip()
-            if not lang:
-                warnings.append(f"Code fence at line {idx} should include a language identifier.")
-        else:
-            in_fence = False
-            fence_line = 0
-    if in_fence:
-        warnings.append(f"Unclosed code fence opened at line {fence_line}.")
+    # Rule 3: fenced code block warnings (now handled by _fenced_line_set pre-scan above).
 
     # Rule 5: list marker consistency inside contiguous list blocks per indentation level.
     active_markers: Dict[int, str] = {}
@@ -517,8 +541,10 @@ def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
                 f"Inconsistent list marker at line {idx} for indent {indent} (expected '{existing}', found '{marker}')."
             )
 
-    # Rule 2: table header/divider structure when a table block starts.
+    # Rule 2: table header/divider structure (skip fenced lines — ENC-LSN-026).
     for idx in range(len(lines) - 1):
+        if idx in fenced_lines:
+            continue
         current = lines[idx]
         nxt = lines[idx + 1]
         if "|" not in current:
@@ -531,8 +557,10 @@ def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
                 f"Possible table header at line {idx + 1} missing valid divider row at line {idx + 2}."
             )
 
-    # Rule 4 (alerts): warn-only heuristic if uppercase callout markers are malformed.
+    # Rule 4 (alerts): warn-only heuristic (skip fenced lines — ENC-LSN-026).
     for idx, line in enumerate(lines, start=1):
+        if (idx - 1) in fenced_lines:
+            continue
         if "[!" in line and not re.search(r"^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$", line):
             warnings.append(f"Malformed alert syntax at line {idx}.")
 

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5530,6 +5530,31 @@ async def _documents_list(args: dict) -> list[TextContent]:
     return _result_text(result)
 
 
+def _enrich_document_compliance_response(result: dict) -> dict:
+    """Inject YAML format guidance when compliance warnings contain pipe-table patterns.
+
+    ENC-LSN-026: agents should use comment-free YAML code blocks for structured
+    output instead of GFM pipe tables. When the compliance checker flags pipe-table
+    issues, this guidance helps agents self-correct.
+    """
+    if not isinstance(result, dict):
+        return result
+    warnings = result.get("compliance_warnings")
+    if not warnings or not isinstance(warnings, list):
+        return result
+    pipe_patterns = ("Possible table header", "missing valid divider row")
+    has_pipe_warnings = any(
+        any(p in w for p in pipe_patterns) for w in warnings if isinstance(w, str)
+    )
+    if has_pipe_warnings:
+        result["format_guidance"] = {
+            "reference": "ENC-LSN-026",
+            "convention": "Use comment-free YAML code blocks (```yaml ... ```) for structured session output instead of GFM pipe tables.",
+            "remediation": "Replace pipe-table formatted data with a fenced YAML block. Omit YAML hash-comments (# ...) inside the block to avoid compliance false positives.",
+        }
+    return result
+
+
 async def _documents_put(args: dict) -> list[TextContent]:
     governance_error = _require_governance_hash_envelope(args)
     if governance_error:
@@ -5559,6 +5584,7 @@ async def _documents_put(args: dict) -> list[TextContent]:
             "Direct datastore fallback is disabled (agent IAM denies all DynamoDB/S3 writes).",
             body.get("project_id"),
         )
+    result = _enrich_document_compliance_response(result)
     return _result_text(result)
 
 
@@ -5601,6 +5627,7 @@ async def _documents_patch(args: dict) -> list[TextContent]:
             "Direct datastore fallback is disabled (agent IAM denies all DynamoDB/S3 writes).",
             document_id,
         )
+    result = _enrich_document_compliance_response(result)
     return _result_text(result)
 
 


### PR DESCRIPTION
## Summary
- **Compliance checker** (`document_api`): New `_fenced_line_set()` pre-scan identifies fenced code block boundaries. Rules 1 (heading), 2 (pipe table), and 4 (alerts) skip lines inside fences. Eliminates false-positive warnings on YAML blocks with pipes or `#` comments.
- **MCP server**: `_enrich_document_compliance_response()` injects `format_guidance` with ENC-LSN-026 reference when compliance warnings contain pipe-table patterns.
- **Governance dictionary**: `docstore.document` updated with `compliance_score`, `compliance_warnings`, and `format_convention` fields.

**Plan:** ENC-PLN-024 | **Tasks:** ENC-TSK-D83 (Phase A), ENC-TSK-D84 (Phase B) | **Lesson:** ENC-LSN-026

CCI-8e336d117b034cffa9be88db1a883736