### PR TITLE
fix: add ENVIRONMENT_SUFFIX arch conditional to 6 Category A deploy.sh scripts (ENC-ISS-224)

### DIFF
--- a/backend/lambda/changelog_api/deploy.sh
+++ b/backend/lambda/changelog_api/deploy.sh
@@ -14,6 +14,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGION="${REGION:-us-west-2}"
 ACCOUNT_ID="${ACCOUNT_ID:-356364570033}"
@@ -127,7 +134,7 @@ deploy_lambda() {
     --quiet \
     --upgrade \
     "PyJWT[crypto]>=2.8.0" \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
     --python-version 3.11 \
     --only-binary=:all: \
@@ -158,7 +165,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "lambda_function.lambda_handler" \
-      --runtime python3.11 \
+      --runtime "${DEPLOY_RUNTIME}" \
       --timeout 30 \
       --memory-size 256 \
       --environment "Variables=${env_vars}" >/dev/null
@@ -167,7 +174,7 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler "lambda_function.lambda_handler" \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGION="${REGION:-us-west-2}"
 ACCOUNT_ID="${ACCOUNT_ID:-356364570033}"
@@ -571,7 +578,7 @@ package_lambda() {
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
     --python-version 3.11 \
     --abi cp311 \
@@ -604,7 +611,7 @@ ensure_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 120 \

--- a/backend/lambda/coordination_monitor_api/deploy.sh
+++ b/backend/lambda/coordination_monitor_api/deploy.sh
@@ -13,6 +13,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGION="${REGION:-us-west-2}"
 ACCOUNT_ID="${ACCOUNT_ID:-356364570033}"
@@ -95,7 +102,7 @@ deploy_lambda() {
     --quiet \
     --upgrade \
     "PyJWT[crypto]>=2.8.0" \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
     --python-version 3.11 \
     --only-binary=:all: \
@@ -131,7 +138,7 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler "lambda_function.lambda_handler" \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/deploy_intake/deploy.sh
+++ b/backend/lambda/deploy_intake/deploy.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 # ---------------------------------------------------------------------------
 # deploy.sh — Deploy deploy_intake Lambda (ENC-TSK-506)
 # ---------------------------------------------------------------------------
@@ -120,7 +127,7 @@ package_lambda() {
       --quiet \
       --upgrade \
       -r "${SCRIPT_DIR}/requirements.txt" \
-      --platform manylinux2014_x86_64 \
+      --platform "${pip_platform}" \
       --implementation cp \
       --python-version 3.11 \
       --only-binary=:all: \
@@ -216,7 +223,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "lambda_function.lambda_handler" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --timeout 120 \
       --memory-size 512 \
       --environment "Variables=${env_vars}" >/dev/null
@@ -225,7 +232,7 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler "lambda_function.lambda_handler" \
       --role "${role_arn}" \
       --timeout 120 \

--- a/backend/lambda/deploy_orchestrator/deploy.sh
+++ b/backend/lambda/deploy_orchestrator/deploy.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 # ---------------------------------------------------------------------------
 # deploy.sh — Deploy deploy_orchestrator Lambda (ENC-ISS-102)
 # ---------------------------------------------------------------------------
@@ -124,7 +131,7 @@ package_lambda() {
       --quiet \
       --upgrade \
       -r "${SCRIPT_DIR}/requirements.txt" \
-      --platform manylinux2014_x86_64 \
+      --platform "${pip_platform}" \
       --implementation cp \
       --python-version 3.11 \
       --only-binary=:all: \
@@ -158,7 +165,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "lambda_function.handler" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --timeout 120 \
       --memory-size 256 \
       --environment "Variables=${env_vars}" >/dev/null
@@ -167,7 +174,7 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler "lambda_function.handler" \
       --role "${role_arn}" \
       --timeout 120 \

--- a/backend/lambda/document_api/deploy.sh
+++ b/backend/lambda/document_api/deploy.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
 
+# ENC-ISS-224 / ENC-FTR-072: architecture bifurcation for gamma (arm64/py3.12) vs prod (x86_64/py3.11)
+if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+  pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; DEPLOY_RUNTIME="python3.12"
+else
+  pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; DEPLOY_RUNTIME="python3.11"
+fi
+
 # ---------------------------------------------------------------------------
 # deploy.sh — Deploy document_api Lambda (ENC-TSK-506)
 # ---------------------------------------------------------------------------
@@ -140,7 +147,7 @@ package_lambda() {
     --quiet \
     --upgrade \
     -r "${SCRIPT_DIR}/requirements.txt" \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
     --python-version 3.11 \
     --only-binary=:all: \
@@ -210,7 +217,7 @@ deploy_lambda() {
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
       --handler "lambda_function.lambda_handler" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --timeout 30 \
       --memory-size 256 \
       --environment "Variables=${env_vars}" >/dev/null
@@ -219,7 +226,7 @@ deploy_lambda() {
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime "python3.11" \
+      --runtime "${DEPLOY_RUNTIME}" \
       --handler "lambda_function.lambda_handler" \
       --role "${role_arn}" \
       --timeout 30 \


### PR DESCRIPTION
## Summary
6 deploy.sh scripts hardcoded x86_64/py3.11 with no ENVIRONMENT_SUFFIX conditional, blocking all gamma deploys (SnapStart requires py3.12). Adds the checkout_service pattern to all 6:

- `backend/lambda/document_api/deploy.sh`
- `backend/lambda/coordination_api/deploy.sh`
- `backend/lambda/coordination_monitor_api/deploy.sh`
- `backend/lambda/deploy_intake/deploy.sh`
- `backend/lambda/deploy_orchestrator/deploy.sh`
- `backend/lambda/changelog_api/deploy.sh`

**Self-bootstrapping**: CI runs the NEW deploy.sh from the merged commit, so gamma deploys work immediately on merge. Also deploys all pending code from PRs #312 and #313.

**Task:** ENC-TSK-D86 | **Issue:** ENC-ISS-224 | **Feature:** ENC-FTR-072

CCI-5627d6b245d54160888cb51aa98df64f