### PR TITLE
feat(pwa): ENC-FTR-073 Phase 2 — useRecordFallback hook, normalizers, UX primitives

### DIFF
--- a/frontend/ui/src/api/documents.ts
+++ b/frontend/ui/src/api/documents.ts
@@ -20,8 +20,18 @@ export async function fetchDocumentsByProject(projectId: string): Promise<Docume
   return data.documents ?? []
 }
 
-export async function fetchDocument(documentId: string): Promise<Document> {
-  const res = await fetchWithAuth(`${API_BASE}/${encodeURIComponent(documentId)}`)
+export async function fetchDocument(
+  documentId: string,
+  init?: { signal?: AbortSignal },
+): Promise<Document> {
+  const res = await fetchWithAuth(`${API_BASE}/${encodeURIComponent(documentId)}`, init)
+  if (res.status === 404) {
+    // ENC-FTR-073: align document fetch with the NotFoundError contract used
+    // by the tracker-API fetchers so useRecordFallback can distinguish 404
+    // from generic transport failures.
+    const { NotFoundError } = await import('./tracker')
+    throw new NotFoundError(`document ${documentId} not found`)
+  }
   if (!res.ok) throw new Error(`Failed to fetch document: ${res.status}`)
   const data = await res.json()
   return data.document ?? data

--- a/frontend/ui/src/api/tracker.ts
+++ b/frontend/ui/src/api/tracker.ts
@@ -1,30 +1,89 @@
-import type { Task, Issue, Feature, ProjectSummary } from '../types/feeds'
+import type { Task, Issue, Feature, Plan, Lesson, ProjectSummary } from '../types/feeds'
 import { fetchWithAuth } from './client'
 
 const BASE = import.meta.env.VITE_MUTATION_BASE_URL ?? '/api/v1/tracker'
+
+/**
+ * ENC-FTR-073: NotFoundError distinguishes 404 responses from generic network
+ * failures so detail-page fallback consumers can render a "record not found"
+ * UX rather than a generic error state. Thrown by `fetchRecord` for HTTP 404.
+ */
+export class NotFoundError extends Error {
+  readonly status: number
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+    this.status = 404
+  }
+}
+
+export function isNotFoundError(err: unknown): err is NotFoundError {
+  if (err instanceof NotFoundError) return true
+  // String match fallback for callers that construct generic errors with the
+  // legacy " 404" suffix (keeps parity with older fetch helpers until fully
+  // migrated).
+  if (err instanceof Error && /\b404\b/.test(err.message)) return true
+  return false
+}
 
 export const trackerKeys = {
   task: (recordId: string) => ['tracker', 'task', recordId] as const,
   issue: (recordId: string) => ['tracker', 'issue', recordId] as const,
   feature: (recordId: string) => ['tracker', 'feature', recordId] as const,
+  plan: (recordId: string) => ['tracker', 'plan', recordId] as const,
+  lesson: (recordId: string) => ['tracker', 'lesson', recordId] as const,
+  document: (recordId: string) => ['tracker', 'document', recordId] as const,
 }
 
-async function fetchRecord<T>(projectId: string, recordType: 'task' | 'issue' | 'feature', recordId: string): Promise<T> {
+type RecordTypeSlug = 'task' | 'issue' | 'feature' | 'plan' | 'lesson'
+
+async function fetchRecord<T>(
+  projectId: string,
+  recordType: RecordTypeSlug,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+): Promise<T> {
   const url = `${BASE}/${encodeURIComponent(projectId)}/${recordType}/${encodeURIComponent(recordId)}`
-  const res = await fetchWithAuth(url)
-  if (!res.ok) throw new Error(`Failed to fetch ${recordType} ${recordId}: ${res.status}`)
+  const res = await fetchWithAuth(url, init)
+  if (res.status === 404) {
+    throw new NotFoundError(`${recordType} ${recordId} not found`)
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${recordType} ${recordId}: ${res.status}`)
+  }
   const data = await res.json()
   return (data.record ?? data) as T
 }
 
-export const fetchTaskById = (projectId: string, recordId: string) =>
-  fetchRecord<Task>(projectId, 'task', recordId)
+export const fetchTaskById = (
+  projectId: string,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+) => fetchRecord<Task>(projectId, 'task', recordId, init)
 
-export const fetchIssueById = (projectId: string, recordId: string) =>
-  fetchRecord<Issue>(projectId, 'issue', recordId)
+export const fetchIssueById = (
+  projectId: string,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+) => fetchRecord<Issue>(projectId, 'issue', recordId, init)
 
-export const fetchFeatureById = (projectId: string, recordId: string) =>
-  fetchRecord<Feature>(projectId, 'feature', recordId)
+export const fetchFeatureById = (
+  projectId: string,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+) => fetchRecord<Feature>(projectId, 'feature', recordId, init)
+
+export const fetchPlanById = (
+  projectId: string,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+) => fetchRecord<Plan>(projectId, 'plan', recordId, init)
+
+export const fetchLessonById = (
+  projectId: string,
+  recordId: string,
+  init?: { signal?: AbortSignal },
+) => fetchRecord<Lesson>(projectId, 'lesson', recordId, init)
 
 export function resolveProjectFromRecordId(
   recordId: string,

--- a/frontend/ui/src/components/shared/RecordFallback.test.tsx
+++ b/frontend/ui/src/components/shared/RecordFallback.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the ENC-FTR-073 Phase 2c UX primitives (ENC-TSK-D96):
+ *   - RecordFallbackLoading
+ *   - RecordNotFound
+ *   - RecordFallbackError
+ *
+ * Assertions focus on accessibility and props-driven rendering — these
+ * components are pure presentational, so the tests serve as the visual
+ * reference required by AC6 (Storybook or equivalent).
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { RecordFallbackError } from './RecordFallbackError'
+import { RecordFallbackLoading } from './RecordFallbackLoading'
+import { RecordNotFound } from './RecordNotFound'
+
+describe('RecordFallbackLoading', () => {
+  it('sets aria-busy=true and role=status for screen readers', () => {
+    render(<RecordFallbackLoading />)
+    const container = screen.getByRole('status')
+    expect(container).toHaveAttribute('aria-busy', 'true')
+    expect(container).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('renders the default label as SR-only text', () => {
+    render(<RecordFallbackLoading />)
+    expect(screen.getByText('Loading record...')).toBeInTheDocument()
+  })
+
+  it('accepts a custom label', () => {
+    render(<RecordFallbackLoading label="Fetching plan" />)
+    expect(screen.getByText('Fetching plan')).toBeInTheDocument()
+  })
+})
+
+describe('RecordNotFound', () => {
+  function withRouter(ui: React.ReactElement) {
+    return <MemoryRouter>{ui}</MemoryRouter>
+  }
+
+  it('surfaces the attempted record ID and type in the detail copy', () => {
+    render(withRouter(<RecordNotFound recordType="plan" recordId="ENC-PLN-006" />))
+    expect(screen.getByRole('heading', { name: /record not found/i })).toBeInTheDocument()
+    expect(screen.getByText('ENC-PLN-006')).toBeInTheDocument()
+    expect(screen.getByText(/No plan with ID/i)).toBeInTheDocument()
+  })
+
+  it('links back to the type index page', () => {
+    render(withRouter(<RecordNotFound recordType="lesson" recordId="ENC-LSN-001" />))
+    const link = screen.getByRole('link', { name: /back to lessons/i })
+    expect(link).toHaveAttribute('href', '/lessons')
+  })
+
+  it('is announced as a polite live region', () => {
+    render(withRouter(<RecordNotFound recordType="task" recordId="ENC-TSK-1" />))
+    const region = screen.getByRole('status')
+    expect(region).toHaveAttribute('aria-live', 'polite')
+  })
+})
+
+describe('RecordFallbackError', () => {
+  it('renders an alert-role region with assertive announcement', () => {
+    render(<RecordFallbackError />)
+    const region = screen.getByRole('alert')
+    expect(region).toHaveAttribute('aria-live', 'assertive')
+  })
+
+  it('renders the default message when none is supplied', () => {
+    render(<RecordFallbackError />)
+    expect(
+      screen.getByText(/we could not load this record\. check your connection/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Retry button only when onRetry is provided', async () => {
+    const onRetry = vi.fn()
+    render(<RecordFallbackError onRetry={onRetry} />)
+    const button = screen.getByRole('button', { name: /retry/i })
+    await userEvent.click(button)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the Retry button when onRetry is undefined', () => {
+    render(<RecordFallbackError />)
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/ui/src/components/shared/RecordFallbackError.tsx
+++ b/frontend/ui/src/components/shared/RecordFallbackError.tsx
@@ -1,0 +1,57 @@
+/**
+ * RecordFallbackError — transient-failure state for the direct-API fallback
+ * path (ENC-FTR-073 Phase 2c / ENC-TSK-D96).
+ *
+ * Displayed for non-404 failures (network timeout, 5xx, auth error once the
+ * session has already rehydrated). Provides a retry affordance when the
+ * caller wires `onRetry` to the hook's `refetch` callback.
+ *
+ * Pure presentational — no hooks, no data coupling. Accessibility:
+ *   - role="alert" + aria-live="assertive" so the transition is announced by
+ *     screen readers.
+ *   - Retry button is only rendered when `onRetry` is provided.
+ */
+
+interface Props {
+  onRetry?: () => void
+  message?: string
+}
+
+export function RecordFallbackError({ onRetry, message }: Props) {
+  const detail = message && message.length > 0
+    ? message
+    : 'We could not load this record. Check your connection and try again.'
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex flex-col items-center justify-center py-16 px-4 text-center"
+    >
+      <svg
+        className="w-12 h-12 text-red-400 mb-3"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+        />
+      </svg>
+      <h2 className="text-slate-200 text-base font-semibold">Failed to load record</h2>
+      <p className="text-slate-400 text-sm mt-1 max-w-sm">{detail}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/ui/src/components/shared/RecordFallbackLoading.tsx
+++ b/frontend/ui/src/components/shared/RecordFallbackLoading.tsx
@@ -1,0 +1,36 @@
+/**
+ * RecordFallbackLoading — accessible loading indicator for the fallback-fetch
+ * path (ENC-FTR-073 Phase 2c / ENC-TSK-D96).
+ *
+ * Pure presentational. Matches the existing <LoadingState /> visual grammar
+ * (slate spinner, 16 py) so detail pages render identically regardless of
+ * whether the record came from the feed or the direct API.
+ *
+ * Accessibility:
+ *   - role="status" + aria-live="polite" so screen readers announce the
+ *     transition into loading state.
+ *   - aria-busy="true" on the container while the fetch is in flight.
+ *   - Visible label is an SR-only text by default but can be overridden via
+ *     the `label` prop.
+ */
+
+interface Props {
+  label?: string
+}
+
+export function RecordFallbackLoading({ label = 'Loading record...' }: Props) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className="flex items-center justify-center py-16"
+    >
+      <div
+        className="w-8 h-8 border-2 border-slate-600 border-t-blue-400 rounded-full animate-spin"
+        aria-hidden="true"
+      />
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}

--- a/frontend/ui/src/components/shared/RecordNotFound.tsx
+++ b/frontend/ui/src/components/shared/RecordNotFound.tsx
@@ -1,0 +1,88 @@
+/**
+ * RecordNotFound — explicit 404 state for the direct-API fallback path
+ * (ENC-FTR-073 Phase 2c / ENC-TSK-D96).
+ *
+ * Replaces the ad-hoc `<ErrorState message="Plan X not found">` pattern with
+ * a typed, accessible component. Pure presentational — no hooks, no data
+ * coupling. Phase 3 wires it into each detail page from the hook's return
+ * values.
+ *
+ * Props:
+ *   - recordType: task/issue/feature/plan/lesson/document — surfaces in the
+ *     detail copy.
+ *   - recordId: the attempted ID. Required so the user can verify they pasted
+ *     the right URL.
+ *   - projectId: optional; not currently rendered but reserved for future
+ *     navigation.
+ */
+
+import { Link } from 'react-router-dom'
+import type { RecordType } from '../../lib/recordNormalizers'
+
+interface Props {
+  recordType: RecordType
+  recordId: string
+  projectId?: string
+}
+
+const TYPE_LABEL: Record<RecordType, string> = {
+  task: 'task',
+  issue: 'issue',
+  feature: 'feature',
+  plan: 'plan',
+  lesson: 'lesson',
+  document: 'document',
+}
+
+const BACK_PATH: Record<RecordType, string> = {
+  task: '/tasks',
+  issue: '/issues',
+  feature: '/features',
+  plan: '/plans',
+  lesson: '/lessons',
+  document: '/documents',
+}
+
+export function RecordNotFound({ recordType, recordId, projectId }: Props) {
+  const label = TYPE_LABEL[recordType]
+  const backPath = BACK_PATH[recordType] ?? '/'
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center py-16 px-4 text-center"
+    >
+      <svg
+        className="w-12 h-12 text-amber-400 mb-3"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      <h2 className="text-slate-200 text-base font-semibold">Record not found</h2>
+      <p className="text-slate-400 text-sm mt-1">
+        No {label} with ID <span className="font-mono text-slate-300">{recordId}</span>{' '}
+        {projectId ? (
+          <>
+            exists in project <span className="font-mono text-slate-300">{projectId}</span>.
+          </>
+        ) : (
+          <>exists.</>
+        )}
+      </p>
+      <Link
+        to={backPath}
+        className="mt-4 text-xs text-blue-400 hover:text-blue-300 hover:underline"
+      >
+        Back to {label}s
+      </Link>
+    </div>
+  )
+}

--- a/frontend/ui/src/hooks/useRecordFallback.test.tsx
+++ b/frontend/ui/src/hooks/useRecordFallback.test.tsx
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for useRecordFallback (ENC-FTR-073 Phase 2a / ENC-TSK-D94).
+ *
+ * Covers the AC set:
+ *   - in-feed shortcut: cached record bypasses network I/O
+ *   - out-of-feed fetch: triggers exactly one request
+ *   - 404 handling: NotFoundError surfaces as isNotFound, not isError
+ *   - network error handling: non-404 surfaces as isError
+ *   - unmount abort: fallbackQuery cancels via signal
+ *   - re-fetch on recordId change: TanStack Query keys by recordId
+ *   - StrictMode double-mount de-duplication: cache key de-dupes
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Plan, ProjectSummary, Task } from '../types/feeds'
+
+const PROJECTS: ProjectSummary[] = [
+  {
+    project_id: 'enceladus',
+    name: 'enceladus',
+    prefix: 'ENC',
+    status: 'active',
+    summary: '',
+    last_sprint: '',
+    open_tasks: 0,
+    closed_tasks: 0,
+    total_tasks: 0,
+    open_issues: 0,
+    closed_issues: 0,
+    total_issues: 0,
+    in_progress_features: 0,
+    completed_features: 0,
+    total_features: 0,
+    planned_tasks: 0,
+    updated_at: null,
+    last_update_note: null,
+  },
+]
+
+const {
+  mockFetchTaskById,
+  mockFetchPlanById,
+  mockUseProjects,
+} = vi.hoisted(() => ({
+  mockFetchTaskById: vi.fn(),
+  mockFetchPlanById: vi.fn(),
+  mockUseProjects: vi.fn(() => ({ projects: PROJECTS, isPending: false, isError: false })),
+}))
+
+vi.mock('../api/tracker', async () => {
+  const actual = await vi.importActual<typeof import('../api/tracker')>('../api/tracker')
+  return {
+    ...actual,
+    fetchTaskById: mockFetchTaskById,
+    fetchPlanById: mockFetchPlanById,
+  }
+})
+
+vi.mock('./useProjects', () => ({
+  useProjects: mockUseProjects,
+}))
+
+import { NotFoundError } from '../api/tracker'
+import { useRecordFallback } from './useRecordFallback'
+
+function createWrapper(client?: QueryClient) {
+  const queryClient =
+    client ??
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    })
+
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+const TASK_PAYLOAD = {
+  item_id: 'ENC-TSK-C08',
+  project_id: 'enceladus',
+  title: 'Task',
+  description: 'desc',
+  status: 'open',
+  priority: 'P1',
+}
+
+const PLAN_PAYLOAD = {
+  item_id: 'ENC-PLN-006',
+  project_id: 'enceladus',
+  title: 'Plan',
+  description: 'desc',
+  status: 'started',
+  priority: 'P0',
+}
+
+describe('useRecordFallback', () => {
+  beforeEach(() => {
+    mockFetchTaskById.mockReset()
+    mockFetchPlanById.mockReset()
+    mockUseProjects.mockReturnValue({ projects: PROJECTS, isPending: false, isError: false })
+  })
+
+  it('returns cached data immediately and issues zero requests (in-feed shortcut)', async () => {
+    const cached = { task_id: 'ENC-TSK-1', title: 'Cached' } as Task
+
+    const { result } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-1',
+          cached,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    expect(result.current.data).toBe(cached)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isNotFound).toBe(false)
+    expect(mockFetchTaskById).not.toHaveBeenCalled()
+  })
+
+  it('fires exactly one fetch when cached is undefined and feed has settled', async () => {
+    mockFetchTaskById.mockResolvedValue(TASK_PAYLOAD)
+
+    const { result } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-C08',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(result.current.data?.task_id).toBe('ENC-TSK-C08')
+    expect(result.current.isNotFound).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(mockFetchTaskById).toHaveBeenCalledTimes(1)
+    expect(mockFetchTaskById).toHaveBeenCalledWith(
+      'enceladus',
+      'ENC-TSK-C08',
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+  })
+
+  it('does not fetch while the feed is still pending (fetch gate)', async () => {
+    const { result } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-C08',
+          cached: undefined,
+          feedPending: true,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(mockFetchTaskById).not.toHaveBeenCalled()
+  })
+
+  it('surfaces isNotFound when the fallback fetch throws NotFoundError (404)', async () => {
+    mockFetchTaskById.mockRejectedValue(new NotFoundError('task ENC-TSK-MISSING not found'))
+
+    const { result } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-MISSING',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isNotFound).toBe(true))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data).toBeUndefined()
+    // 404 must not trigger a retry.
+    expect(mockFetchTaskById).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces isError for non-404 network failures (after retry budget exhausts)', async () => {
+    mockFetchTaskById.mockRejectedValue(new Error('network offline'))
+
+    const { result } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-NET',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    // Retry budget = 1, so expect up to 2 call attempts before isError flips.
+    await waitFor(
+      () => expect(result.current.isError).toBe(true),
+      { timeout: 5000 },
+    )
+    expect(result.current.isNotFound).toBe(false)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('re-fetches when recordId changes', async () => {
+    mockFetchTaskById.mockImplementation(async (_project: string, id: string) => ({
+      ...TASK_PAYLOAD,
+      item_id: id,
+    }))
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+
+    const { result, rerender } = renderHook(
+      ({ recordId }: { recordId: string }) =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId,
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      {
+        wrapper: createWrapper(client),
+        initialProps: { recordId: 'ENC-TSK-1' },
+      },
+    )
+
+    await waitFor(() => expect(result.current.data?.task_id).toBe('ENC-TSK-1'))
+    expect(mockFetchTaskById).toHaveBeenCalledTimes(1)
+
+    rerender({ recordId: 'ENC-TSK-2' })
+
+    await waitFor(() => expect(result.current.data?.task_id).toBe('ENC-TSK-2'))
+    expect(mockFetchTaskById).toHaveBeenCalledTimes(2)
+    expect(mockFetchTaskById.mock.calls[0][1]).toBe('ENC-TSK-1')
+    expect(mockFetchTaskById.mock.calls[1][1]).toBe('ENC-TSK-2')
+  })
+
+  it('aborts the in-flight request on unmount (AbortSignal propagation)', async () => {
+    let capturedSignal: AbortSignal | undefined
+    mockFetchTaskById.mockImplementation((_project: string, _id: string, init?: { signal?: AbortSignal }) => {
+      capturedSignal = init?.signal
+      return new Promise<unknown>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'))
+        })
+      })
+    })
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+
+    const { unmount } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-ABORT',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper(client) },
+    )
+
+    await waitFor(() => expect(mockFetchTaskById).toHaveBeenCalled())
+    expect(capturedSignal).toBeDefined()
+    expect(capturedSignal?.aborted).toBe(false)
+
+    await act(async () => {
+      unmount()
+      // TanStack Query cancels queries when their consumers unmount; the
+      // signal passed into queryFn is aborted as part of that cleanup.
+      client.cancelQueries()
+    })
+
+    await waitFor(() => expect(capturedSignal?.aborted).toBe(true))
+  })
+
+  it('dispatches to fetchPlanById for plan recordType', async () => {
+    mockFetchPlanById.mockResolvedValue(PLAN_PAYLOAD)
+
+    const { result } = renderHook(
+      () =>
+        useRecordFallback<'plan'>({
+          recordType: 'plan',
+          recordId: 'ENC-PLN-006',
+          cached: undefined as Plan | undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.plan_id).toBe('ENC-PLN-006')
+    expect(mockFetchPlanById).toHaveBeenCalledTimes(1)
+  })
+
+  it('de-duplicates concurrent consumers of the same recordId via the query key', async () => {
+    mockFetchTaskById.mockResolvedValue(TASK_PAYLOAD)
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+
+    const wrapper = createWrapper(client)
+
+    const { result: r1 } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-DUP',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper },
+    )
+
+    const { result: r2 } = renderHook(
+      () =>
+        useRecordFallback({
+          recordType: 'task',
+          recordId: 'ENC-TSK-DUP',
+          cached: undefined,
+          feedPending: false,
+          feedError: false,
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(r1.current.data).toBeDefined())
+    await waitFor(() => expect(r2.current.data).toBeDefined())
+
+    // One shared query — at most one network round-trip even with two mounts.
+    expect(mockFetchTaskById).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/ui/src/hooks/useRecordFallback.ts
+++ b/frontend/ui/src/hooks/useRecordFallback.ts
@@ -1,0 +1,169 @@
+/**
+ * useRecordFallback — Shared hook that wraps the direct-API fallback pattern
+ * previously inlined in Task/Issue/FeatureDetailPage (ENC-ISS-200 remediation).
+ *
+ * ENC-FTR-073 Phase 2a / ENC-TSK-D94.
+ *
+ * Behavior contract (DOC-BB658D8644DF §5):
+ *   - No-op when the feed cache already holds the record (`cached` truthy).
+ *     Returns { data: cached, isLoading: feedPending, isError: false,
+ *     isNotFound: false }. No network I/O is issued.
+ *   - Fetch gate: `!feedPending && !cached && !!recordId && !!projectId`.
+ *   - Internally wraps TanStack Query (queryKey ['tracker', recordType,
+ *     recordId]) so repeated mounts de-duplicate and AbortSignal cleanup on
+ *     unmount is handled by the library.
+ *   - Response is projected into feed shape via recordNormalizers.
+ *   - `isNotFound` returns true when the fallback fetch throws a NotFoundError
+ *     (or any error whose message matches /\b404\b/ for legacy parity).
+ *   - `isError` returns true for non-404 failures when no data is available.
+ */
+
+import { useMemo } from 'react'
+import { useQuery, type QueryFunctionContext } from '@tanstack/react-query'
+import { useProjects } from './useProjects'
+import {
+  fetchDocument,
+} from '../api/documents'
+import {
+  fetchFeatureById,
+  fetchIssueById,
+  fetchLessonById,
+  fetchPlanById,
+  fetchTaskById,
+  isNotFoundError,
+  resolveProjectFromRecordId,
+  trackerKeys,
+} from '../api/tracker'
+import {
+  normalizeRecord,
+  type RecordType,
+  type RecordTypeMap,
+} from '../lib/recordNormalizers'
+
+export interface UseRecordFallbackArgs<T extends RecordType> {
+  recordType: T
+  recordId: string | undefined
+  /** Feed-cache lookup result. If present, the hook returns immediately
+   *  without issuing any API request. */
+  cached: RecordTypeMap[T] | undefined
+  /** Loading flag for the owning feed hook (useTasks.isPending, etc.). */
+  feedPending: boolean
+  /** Error flag for the owning feed hook. Surfaces as `isError` only when no
+   *  fallback data was returned. */
+  feedError: boolean
+}
+
+export interface UseRecordFallbackResult<T extends RecordType> {
+  data: RecordTypeMap[T] | undefined
+  isLoading: boolean
+  isError: boolean
+  isNotFound: boolean
+  /** Non-fatal warning from the normalizer (e.g. missing identifier). */
+  warning?: string
+  /** Callback for RecordFallbackError retry affordance. No-op when the
+   *  fallback query is not active. */
+  refetch: () => void
+}
+
+function queryKeyFor(recordType: RecordType, recordId: string) {
+  switch (recordType) {
+    case 'task':
+      return trackerKeys.task(recordId)
+    case 'issue':
+      return trackerKeys.issue(recordId)
+    case 'feature':
+      return trackerKeys.feature(recordId)
+    case 'plan':
+      return trackerKeys.plan(recordId)
+    case 'lesson':
+      return trackerKeys.lesson(recordId)
+    case 'document':
+      return trackerKeys.document(recordId)
+  }
+}
+
+async function fetchForType(
+  recordType: RecordType,
+  projectId: string,
+  recordId: string,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  switch (recordType) {
+    case 'task':
+      return fetchTaskById(projectId, recordId, { signal })
+    case 'issue':
+      return fetchIssueById(projectId, recordId, { signal })
+    case 'feature':
+      return fetchFeatureById(projectId, recordId, { signal })
+    case 'plan':
+      return fetchPlanById(projectId, recordId, { signal })
+    case 'lesson':
+      return fetchLessonById(projectId, recordId, { signal })
+    case 'document':
+      return fetchDocument(recordId, { signal })
+  }
+}
+
+export function useRecordFallback<T extends RecordType>(
+  args: UseRecordFallbackArgs<T>,
+): UseRecordFallbackResult<T> {
+  const { recordType, recordId, cached, feedPending, feedError } = args
+  const { projects } = useProjects()
+
+  const projectId = useMemo(() => {
+    if (!recordId || cached) return null
+    return resolveProjectFromRecordId(recordId, projects)
+  }, [recordId, cached, projects])
+
+  const fallbackEnabled = !feedPending && !cached && !!recordId && !!projectId
+
+  const query = useQuery<unknown, Error>({
+    queryKey: recordId ? queryKeyFor(recordType, recordId) : ['tracker', recordType, 'disabled'],
+    queryFn: async ({ signal }: QueryFunctionContext) => {
+      // projectId/recordId guaranteed present by `enabled` gate.
+      return fetchForType(recordType, projectId as string, recordId as string, signal)
+    },
+    enabled: fallbackEnabled,
+    retry: (failureCount, err) => {
+      if (isNotFoundError(err)) return false
+      return failureCount < 1
+    },
+  })
+
+  const normalized = useMemo(() => {
+    if (cached) return { data: cached, warning: undefined as string | undefined }
+    if (query.data === undefined) return { data: undefined, warning: undefined as string | undefined }
+    const result = normalizeRecord(recordType, query.data)
+    return { data: result.data as RecordTypeMap[T], warning: result.warning }
+  }, [cached, query.data, recordType])
+
+  // Derived state
+  const isNotFound =
+    !cached && fallbackEnabled && query.isError && isNotFoundError(query.error)
+
+  // Still loading while feed is pending, or while fallback is actively
+  // fetching and no cached data is available. If no fallback path is
+  // available (no projectId, invalid recordId), we do not spin forever —
+  // instead collapse to isNotFound once the feed settles.
+  const isLoading =
+    (feedPending && !cached) ||
+    (fallbackEnabled && query.isPending && !cached)
+
+  // Error only when we have no data and the source is not a 404. Feed error
+  // counts only when we have no fallback data either.
+  const isError =
+    !normalized.data && !isLoading && !isNotFound &&
+    ((feedError && !fallbackEnabled) ||
+      (fallbackEnabled && query.isError && !isNotFoundError(query.error)))
+
+  return {
+    data: normalized.data,
+    isLoading,
+    isError,
+    isNotFound: Boolean(isNotFound),
+    warning: normalized.warning,
+    refetch: () => {
+      if (fallbackEnabled) void query.refetch()
+    },
+  }
+}

--- a/frontend/ui/src/lib/recordNormalizers.test.ts
+++ b/frontend/ui/src/lib/recordNormalizers.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for recordNormalizers (ENC-FTR-073 Phase 2b / ENC-TSK-D95).
+ *
+ * Fixtures are derived from the representative API payloads documented in
+ * DOC-BB658D8644DF §3 (live samples captured during Phase 1 discovery). Each
+ * normalizer is exercised against:
+ *   - a realistic raw tracker-API payload with the fields a live record
+ *     actually carries
+ *   - a minimal/partial payload (missing optional fields) to verify safe
+ *     defaults
+ *   - a malformed/empty payload to verify the no-throw contract
+ *
+ * Critical cross-cuts verified per the design contract:
+ *   - item_id -> {type}_id rename
+ *   - acceptance_criteria / evidence / pillar_scores / objectives_set shapes
+ *   - lesson `extensions` non-trivial remap: author -> provider, content ->
+ *     description, evidence_ids dropped
+ *   - missing-array defaults flatten to [] (not undefined)
+ *   - empty-string checkout fields coerce to null
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeDocument,
+  normalizeFeature,
+  normalizeIssue,
+  normalizeLesson,
+  normalizePlan,
+  normalizeRecord,
+  normalizeTask,
+} from './recordNormalizers'
+
+describe('normalizeTask', () => {
+  it('renames item_id to task_id and preserves the feed-shape scalar set', () => {
+    const raw = {
+      item_id: 'ENC-TSK-C08',
+      record_id: 'task#ENC-TSK-C08',
+      record_type: 'task',
+      project_id: 'enceladus',
+      title: 'Task title',
+      description: 'Body',
+      status: 'in-progress',
+      priority: 'P1',
+      category: 'implementation',
+      intent: 'ship it',
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-02T00:00:00Z',
+      acceptance_criteria: [
+        { description: 'AC1', evidence: '', evidence_acceptance: false },
+      ],
+      coordination: false,
+      active_agent_session: true,
+      active_agent_session_id: 'sess-1',
+      active_agent_session_parent: false,
+      related_feature_ids: ['ENC-FTR-073'],
+      related_plan_ids: ['ENC-PLN-025'],
+      checkout_state: 'checked_out',
+      transition_type: 'web_deploy',
+      components: ['comp-enceladus-pwa'],
+      subtask_ids: ['ENC-TSK-D94'],
+    }
+    const { data, warning } = normalizeTask(raw)
+    expect(warning).toBeUndefined()
+    expect(data.task_id).toBe('ENC-TSK-C08')
+    // record_id / record_type / related_plan_ids must not bleed onto the
+    // feed-shape Task interface.
+    expect((data as unknown as Record<string, unknown>).record_id).toBeUndefined()
+    expect(data.transition_type).toBe('web_deploy')
+    expect(data.checkout_state).toBe('checked_out')
+    expect(data.active_agent_session).toBe(true)
+    expect(data.acceptance_criteria).toHaveLength(1)
+    expect(data.related_feature_ids).toEqual(['ENC-FTR-073'])
+    expect(data.subtask_ids).toEqual(['ENC-TSK-D94'])
+  })
+
+  it('coerces empty-string checkout fields to null (feed parity)', () => {
+    const { data } = normalizeTask({ item_id: 'ENC-TSK-1', checked_out_by: '', checked_out_at: '' })
+    expect(data.checked_out_by).toBeNull()
+    expect(data.checked_out_at).toBeNull()
+  })
+
+  it('fills default arrays and defaults status/priority for minimal payloads', () => {
+    const { data } = normalizeTask({ item_id: 'ENC-TSK-2', project_id: 'enceladus' })
+    expect(data.task_id).toBe('ENC-TSK-2')
+    expect(data.status).toBe('open')
+    expect(data.priority).toBe('P2')
+    expect(data.related_feature_ids).toEqual([])
+    expect(data.related_task_ids).toEqual([])
+    expect(data.history).toEqual([])
+    expect(data.acceptance_criteria).toEqual([])
+    expect(data.typed_relationships).toEqual([])
+    expect(data.context_node).toBeUndefined()
+  })
+
+  it('emits a warning and never throws when the identifier is missing', () => {
+    const { data, warning } = normalizeTask({})
+    expect(data.task_id).toBe('')
+    expect(warning).toContain('task record missing identifier')
+  })
+
+  it('tolerates non-object input without throwing', () => {
+    expect(() => normalizeTask(null)).not.toThrow()
+    expect(() => normalizeTask('not a record')).not.toThrow()
+    expect(() => normalizeTask(42)).not.toThrow()
+  })
+})
+
+describe('normalizeIssue', () => {
+  it('renames item_id to issue_id and defaults severity to medium', () => {
+    const raw = {
+      item_id: 'ENC-ISS-200',
+      record_id: 'issue#ENC-ISS-200',
+      project_id: 'enceladus',
+      title: 'Feed cap regression',
+      description: 'Body',
+      status: 'open',
+      priority: 'P1',
+      evidence: [
+        {
+          description: 'Repro',
+          steps_to_duplicate: ['Navigate to plan'],
+          observed_by: 'user',
+          timestamp: '2026-03-01T00:00:00Z',
+        },
+      ],
+    }
+    const { data } = normalizeIssue(raw)
+    expect(data.issue_id).toBe('ENC-ISS-200')
+    expect(data.severity).toBe('medium')
+    expect(data.evidence).toHaveLength(1)
+    expect(data.evidence?.[0].steps_to_duplicate).toEqual(['Navigate to plan'])
+  })
+
+  it('preserves severity when provided', () => {
+    const { data } = normalizeIssue({ item_id: 'ENC-ISS-1', severity: 'high' })
+    expect(data.severity).toBe('high')
+  })
+})
+
+describe('normalizeFeature', () => {
+  it('renames item_id, fills success_metrics / owners arrays, preserves acceptance_criteria', () => {
+    const raw = {
+      item_id: 'ENC-FTR-073',
+      record_id: 'feature#ENC-FTR-073',
+      project_id: 'enceladus',
+      title: 'PWA direct-API fallback',
+      description: 'Body',
+      status: 'in-progress',
+      user_story: 'As a user...',
+      acceptance_criteria: [
+        { description: 'AC1', evidence: '', evidence_acceptance: false },
+      ],
+    }
+    const { data } = normalizeFeature(raw)
+    expect(data.feature_id).toBe('ENC-FTR-073')
+    expect(data.owners).toEqual([])
+    expect(data.success_metrics).toEqual([])
+    expect(data.success_metrics_count).toBe(0)
+    expect(data.acceptance_criteria).toHaveLength(1)
+  })
+
+  it('derives success_metrics_count from array length when omitted', () => {
+    const { data } = normalizeFeature({
+      item_id: 'ENC-FTR-1',
+      success_metrics: ['m1', 'm2', 'm3'],
+    })
+    expect(data.success_metrics_count).toBe(3)
+  })
+})
+
+describe('normalizePlan', () => {
+  it('renames item_id to plan_id and preserves objectives/attached_documents', () => {
+    const raw = {
+      item_id: 'ENC-PLN-006',
+      record_id: 'plan#ENC-PLN-006',
+      project_id: 'enceladus',
+      title: 'Plan title',
+      description: 'Body',
+      status: 'started',
+      priority: 'P0',
+      objectives_set: ['ENC-TSK-1', 'ENC-TSK-2'],
+      attached_documents: ['DOC-ABC'],
+      related_feature_id: 'ENC-FTR-073',
+      checkout_state: '',
+      checked_out_by: '',
+      checked_out_at: '',
+    }
+    const { data } = normalizePlan(raw)
+    expect(data.plan_id).toBe('ENC-PLN-006')
+    expect(data.status).toBe('started')
+    expect(data.priority).toBe('P0')
+    expect(data.objectives_set).toEqual(['ENC-TSK-1', 'ENC-TSK-2'])
+    expect(data.attached_documents).toEqual(['DOC-ABC'])
+    expect(data.related_feature_id).toBe('ENC-FTR-073')
+    // Empty-string checkout fields must collapse to null (design §4).
+    expect(data.checkout_state).toBeNull()
+    expect(data.checked_out_by).toBeNull()
+    expect(data.checked_out_at).toBeNull()
+  })
+
+  it('defaults status drafted, priority P2 for minimal payloads', () => {
+    const { data } = normalizePlan({ item_id: 'ENC-PLN-1' })
+    expect(data.status).toBe('drafted')
+    expect(data.priority).toBe('P2')
+    expect(data.category).toBeNull()
+    expect(data.objectives_set).toEqual([])
+  })
+})
+
+describe('normalizeLesson', () => {
+  it('remaps API-shape extensions (author/content) to feed shape (provider/description)', () => {
+    // From DOC-BB658D8644DF §3.5 — real API response for ENC-LSN-001
+    const raw = {
+      item_id: 'ENC-LSN-001',
+      record_id: 'lesson#ENC-LSN-001',
+      project_id: 'enceladus',
+      title: 'Lesson',
+      observation: 'obs',
+      insight: 'insight',
+      evidence_chain: ['E1', 'E2'],
+      provenance: 'pro',
+      confidence: 0.9,
+      pillar_scores: {
+        efficiency: 0.8,
+        alignment: 0.7,
+        human_protection: 0.9,
+        intention: 0.85,
+      },
+      resonance_score: 0.88,
+      pillar_composite: 0.82,
+      extensions: [
+        {
+          evidence_ids: ['E1'],
+          author: 'analysis-lead',
+          content: 'Extension observation',
+          timestamp: '2026-03-01T00:00:00Z',
+        },
+      ],
+      lesson_version: 2,
+      category: 'governance',
+      status: 'active',
+      related_task_ids: ['ENC-TSK-1'],
+    }
+    const { data } = normalizeLesson(raw)
+    expect(data.lesson_id).toBe('ENC-LSN-001')
+    expect(data.extensions).toHaveLength(1)
+    const ext = data.extensions[0]
+    expect(ext.description).toBe('Extension observation')
+    expect(ext.provider).toBe('analysis-lead')
+    expect(ext.timestamp).toBe('2026-03-01T00:00:00Z')
+    // evidence_ids must be dropped per the Phase 1 contract.
+    expect((ext as unknown as Record<string, unknown>).evidence_ids).toBeUndefined()
+    // pillar_scores float pass-through
+    expect(data.pillar_scores.alignment).toBe(0.7)
+    expect(data.resonance_score).toBe(0.88)
+    expect(data.lesson_version).toBe(2)
+  })
+
+  it('accepts already-feed-shape extensions (provider/description) idempotently', () => {
+    const { data } = normalizeLesson({
+      item_id: 'ENC-LSN-2',
+      extensions: [{ description: 'feed shape', provider: 'feed', timestamp: '2026-01-01' }],
+    })
+    expect(data.extensions[0].description).toBe('feed shape')
+    expect(data.extensions[0].provider).toBe('feed')
+  })
+
+  it('fills pillar_scores with zero defaults when missing', () => {
+    const { data } = normalizeLesson({ item_id: 'ENC-LSN-3' })
+    expect(data.pillar_scores).toEqual({
+      efficiency: 0,
+      alignment: 0,
+      human_protection: 0,
+      intention: 0,
+    })
+    expect(data.lesson_version).toBe(1)
+    expect(data.status).toBe('active')
+  })
+})
+
+describe('normalizeDocument', () => {
+  it('produces a feed-shape Document that is behaviorally indistinguishable from the live document_api payload', () => {
+    // From DOC-BB658D8644DF §3.6 — documents are already feed-shape; this is
+    // the identity contract.
+    const raw = {
+      document_id: 'DOC-FFB4C9D87BCC',
+      project_id: 'enceladus',
+      title: 'Title',
+      description: 'Desc',
+      file_name: 'file.md',
+      content_type: 'text/markdown',
+      content_hash: 'abc',
+      size_bytes: 1000,
+      keywords: ['k1'],
+      related_items: ['ENC-TSK-D89'],
+      status: 'active',
+      created_by: 'internal-key',
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-02T00:00:00Z',
+      version: 9,
+      content: '# Title',
+    }
+    const { data } = normalizeDocument(raw)
+    expect(data.document_id).toBe('DOC-FFB4C9D87BCC')
+    expect(data.size_bytes).toBe(1000)
+    expect(data.version).toBe(9)
+    expect(data.content).toBe('# Title')
+    expect(data.keywords).toEqual(['k1'])
+  })
+
+  it('defaults status to active and version to 1 when missing', () => {
+    const { data, warning } = normalizeDocument({})
+    expect(data.document_id).toBe('')
+    expect(data.status).toBe('active')
+    expect(data.version).toBe(1)
+    expect(warning).toContain('document record missing identifier')
+  })
+})
+
+describe('normalizeRecord dispatch', () => {
+  it('dispatches to the correct normalizer by recordType', () => {
+    const { data: task } = normalizeRecord('task', { item_id: 'ENC-TSK-X' })
+    expect(task.task_id).toBe('ENC-TSK-X')
+
+    const { data: lesson } = normalizeRecord('lesson', {
+      item_id: 'ENC-LSN-X',
+      extensions: [{ author: 'a', content: 'c', timestamp: 't' }],
+    })
+    expect(lesson.extensions[0].provider).toBe('a')
+    expect(lesson.extensions[0].description).toBe('c')
+  })
+})

--- a/frontend/ui/src/lib/recordNormalizers.ts
+++ b/frontend/ui/src/lib/recordNormalizers.ts
@@ -1,0 +1,487 @@
+/**
+ * recordNormalizers — Per-record-type projection from raw tracker API payloads
+ * into the feed-shape-compatible objects that existing detail page renderers
+ * expect (ENC-FTR-073 Phase 2b / ENC-TSK-D95).
+ *
+ * Background:
+ *   The live feed transforms (`backend/lambda/feed_query/lambda_function.py
+ *   ::_transform_*_from_ddb`) produce typed, field-renamed, back-filled views.
+ *   The tracker API (`backend/lambda/tracker_mutation/lambda_function.py
+ *   ::_handle_get_record`) returns the raw DDB item with no projection applied.
+ *   A record fetched via direct-API fallback must be projected into the feed
+ *   shape so the existing render paths do not need to branch on data origin.
+ *
+ * Contract (per DOC-BB658D8644DF §4):
+ *   - Baseline shim applied to every type:
+ *       - `item_id` → `{type}_id`
+ *       - discard `record_id` DDB sort-key echo
+ *       - missing arrays default to `[]`
+ *       - missing scalars default to `null` (matching types/feeds.ts)
+ *       - status/priority enum defaults per type
+ *       - computed ENC-TSK-A57 fields (`typed_relationships`, `context_node`)
+ *         default safely: `[]` and `undefined` respectively.
+ *   - The lesson normalizer is the only type with a non-trivial field-level
+ *     remap due to `extensions` schema drift between feed (LessonExtension) and
+ *     API (raw DDB shape).
+ *
+ * Safety:
+ *   - Every normalizer is total on Record<string, unknown>|undefined|null.
+ *     It never throws on malformed input; instead it returns a best-effort
+ *     object and emits an optional `warning` signal for the UX layer to
+ *     surface if desired.
+ */
+
+import type {
+  Document,
+  Feature,
+  HistoryEntry,
+  Issue,
+  Lesson,
+  LessonExtension,
+  PillarScores,
+  Plan,
+  Task,
+  TypedRelationshipEdge,
+} from '../types/feeds'
+
+// ---------------------------------------------------------------------------
+// Result envelope
+// ---------------------------------------------------------------------------
+
+export interface NormalizationResult<T> {
+  /** Feed-shape-compatible record (best effort). Always defined — the
+   *  normalizer never returns undefined here; if the input is unusable the
+   *  normalizer emits a warning and returns a minimally-valid record. */
+  data: T
+  /** Non-fatal warning describing what the normalizer had to patch up. */
+  warning?: string
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+type RawRecord = Record<string, unknown>
+
+function asRecord(value: unknown): RawRecord {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as RawRecord
+  }
+  return {}
+}
+
+function asString(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return fallback
+}
+
+function asOptionalString(value: unknown, fallback: string | null = null): string | null {
+  if (typeof value === 'string' && value.length > 0) return value
+  return fallback
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+function asBool(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value
+  return fallback
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const out: string[] = []
+  for (const entry of value) {
+    if (typeof entry === 'string') out.push(entry)
+  }
+  return out
+}
+
+function asArray<T = unknown>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : []
+}
+
+function emptyToNull(value: unknown): string | null {
+  if (typeof value === 'string') return value.length > 0 ? value : null
+  return null
+}
+
+function normalizeHistory(value: unknown): HistoryEntry[] {
+  const arr = asArray<RawRecord>(value)
+  return arr.map((raw) => ({
+    timestamp: asString(raw.timestamp),
+    status: asString(raw.status),
+    description: asString(raw.description),
+  }))
+}
+
+function normalizeTypedRelationships(value: unknown): TypedRelationshipEdge[] {
+  const arr = asArray<RawRecord>(value)
+  return arr.map((raw) => ({
+    relationship_type: asString(raw.relationship_type),
+    target_id: asString(raw.target_id),
+    weight: asNumber(raw.weight, 1),
+    confidence: asNumber(raw.confidence, 1),
+    reason: asOptionalString(raw.reason, null),
+    created_at: asOptionalString(raw.created_at, null),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Task (ENC-FTR-073 §4.1)
+// ---------------------------------------------------------------------------
+
+export function normalizeTask(input: unknown): NormalizationResult<Task> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const taskId = asString(raw.task_id ?? raw.item_id)
+  if (!taskId) warnings.push('task record missing identifier (item_id/task_id)')
+
+  const data: Task = {
+    task_id: taskId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    description: asString(raw.description),
+    status: (asOptionalString(raw.status) ?? 'open') as Task['status'],
+    priority: (asOptionalString(raw.priority) ?? 'P2') as Task['priority'],
+    assigned_to: asOptionalString(raw.assigned_to, null),
+    related_feature_ids: asStringArray(raw.related_feature_ids),
+    related_task_ids: asStringArray(raw.related_task_ids),
+    related_issue_ids: asStringArray(raw.related_issue_ids),
+    checklist_total: asNumber(raw.checklist_total, 0),
+    checklist_done: asNumber(raw.checklist_done, 0),
+    checklist: asStringArray(raw.checklist),
+    history: normalizeHistory(raw.history),
+    parent: asOptionalString(raw.parent, null),
+    updated_at: asOptionalString(raw.updated_at, null),
+    last_update_note: asOptionalString(raw.last_update_note, null),
+    created_at: asOptionalString(raw.created_at, null),
+    active_agent_session: raw.active_agent_session != null ? asBool(raw.active_agent_session) : undefined,
+    active_agent_session_id: typeof raw.active_agent_session_id === 'string' ? raw.active_agent_session_id : undefined,
+    active_agent_session_parent:
+      raw.active_agent_session_parent != null ? asBool(raw.active_agent_session_parent) : undefined,
+    checkout_state: (emptyToNull(raw.checkout_state) as Task['checkout_state']) ?? null,
+    checked_out_by: emptyToNull(raw.checked_out_by),
+    checked_out_at: emptyToNull(raw.checked_out_at),
+    checked_in_by: emptyToNull(raw.checked_in_by),
+    checked_in_at: emptyToNull(raw.checked_in_at),
+    coordination: raw.coordination != null ? asBool(raw.coordination) : undefined,
+    github_issue_url: typeof raw.github_issue_url === 'string' ? raw.github_issue_url : undefined,
+    category: asOptionalString(raw.category, null),
+    intent: asOptionalString(raw.intent, null),
+    acceptance_criteria: Array.isArray(raw.acceptance_criteria)
+      ? (raw.acceptance_criteria as Task['acceptance_criteria'])
+      : [],
+    subtask_ids: asStringArray(raw.subtask_ids),
+    transition_type: asOptionalString(raw.transition_type, null),
+    typed_relationships: normalizeTypedRelationships(raw.typed_relationships),
+    context_node: raw.context_node != null ? (raw.context_node as Task['context_node']) : undefined,
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Issue (ENC-FTR-073 §4.2)
+// ---------------------------------------------------------------------------
+
+export function normalizeIssue(input: unknown): NormalizationResult<Issue> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const issueId = asString(raw.issue_id ?? raw.item_id)
+  if (!issueId) warnings.push('issue record missing identifier (item_id/issue_id)')
+
+  const data: Issue = {
+    issue_id: issueId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    description: asString(raw.description),
+    status: (asOptionalString(raw.status) ?? 'open') as Issue['status'],
+    priority: (asOptionalString(raw.priority) ?? 'P2') as Issue['priority'],
+    severity: (asOptionalString(raw.severity) ?? 'medium') as Issue['severity'],
+    hypothesis: asOptionalString(raw.hypothesis, null),
+    related_feature_ids: asStringArray(raw.related_feature_ids),
+    related_task_ids: asStringArray(raw.related_task_ids),
+    related_issue_ids: asStringArray(raw.related_issue_ids),
+    history: normalizeHistory(raw.history),
+    parent: asOptionalString(raw.parent, null),
+    updated_at: asOptionalString(raw.updated_at, null),
+    last_update_note: asOptionalString(raw.last_update_note, null),
+    created_at: asOptionalString(raw.created_at, null),
+    coordination: raw.coordination != null ? asBool(raw.coordination) : undefined,
+    github_issue_url: typeof raw.github_issue_url === 'string' ? raw.github_issue_url : undefined,
+    category: asOptionalString(raw.category, null),
+    intent: asOptionalString(raw.intent, null),
+    primary_task: asOptionalString(raw.primary_task, null),
+    evidence: Array.isArray(raw.evidence)
+      ? (raw.evidence as Issue['evidence'])
+      : [],
+    typed_relationships: normalizeTypedRelationships(raw.typed_relationships),
+    context_node: raw.context_node != null ? (raw.context_node as Issue['context_node']) : undefined,
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Feature (ENC-FTR-073 §4.3)
+// ---------------------------------------------------------------------------
+
+export function normalizeFeature(input: unknown): NormalizationResult<Feature> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const featureId = asString(raw.feature_id ?? raw.item_id)
+  if (!featureId) warnings.push('feature record missing identifier (item_id/feature_id)')
+
+  const successMetrics = asStringArray(raw.success_metrics)
+
+  const data: Feature = {
+    feature_id: featureId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    description: asString(raw.description),
+    status: (asOptionalString(raw.status) ?? 'planned') as Feature['status'],
+    owners: asStringArray(raw.owners),
+    success_metrics_count: asNumber(raw.success_metrics_count, successMetrics.length),
+    success_metrics: successMetrics,
+    related_task_ids: asStringArray(raw.related_task_ids),
+    related_feature_ids: asStringArray(raw.related_feature_ids),
+    related_issue_ids: asStringArray(raw.related_issue_ids),
+    history: normalizeHistory(raw.history),
+    parent: asOptionalString(raw.parent, null),
+    updated_at: asOptionalString(raw.updated_at, null),
+    last_update_note: asOptionalString(raw.last_update_note, null),
+    created_at: asOptionalString(raw.created_at, null),
+    coordination: raw.coordination != null ? asBool(raw.coordination) : undefined,
+    github_issue_url: typeof raw.github_issue_url === 'string' ? raw.github_issue_url : undefined,
+    category: asOptionalString(raw.category, null),
+    intent: asOptionalString(raw.intent, null),
+    user_story: asOptionalString(raw.user_story, null),
+    primary_task: asOptionalString(raw.primary_task, null),
+    acceptance_criteria: Array.isArray(raw.acceptance_criteria)
+      ? (raw.acceptance_criteria as Feature['acceptance_criteria'])
+      : [],
+    typed_relationships: normalizeTypedRelationships(raw.typed_relationships),
+    context_node: raw.context_node != null ? (raw.context_node as Feature['context_node']) : undefined,
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Plan (ENC-FTR-073 §4.4)
+// ---------------------------------------------------------------------------
+
+export function normalizePlan(input: unknown): NormalizationResult<Plan> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const planId = asString(raw.plan_id ?? raw.item_id)
+  if (!planId) warnings.push('plan record missing identifier (item_id/plan_id)')
+
+  const data: Plan = {
+    plan_id: planId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    description: asString(raw.description),
+    status: (asOptionalString(raw.status) ?? 'drafted') as Plan['status'],
+    priority: (asOptionalString(raw.priority) ?? 'P2') as Plan['priority'],
+    category: asOptionalString(raw.category, null),
+    objectives_set: asStringArray(raw.objectives_set),
+    attached_documents: asStringArray(raw.attached_documents),
+    related_feature_id: asOptionalString(raw.related_feature_id, null),
+    checkout_state: emptyToNull(raw.checkout_state),
+    checked_out_by: emptyToNull(raw.checked_out_by),
+    checked_out_at: emptyToNull(raw.checked_out_at),
+    related_task_ids: asStringArray(raw.related_task_ids),
+    related_issue_ids: asStringArray(raw.related_issue_ids),
+    related_feature_ids: asStringArray(raw.related_feature_ids),
+    history: normalizeHistory(raw.history),
+    updated_at: asOptionalString(raw.updated_at, null),
+    last_update_note: asOptionalString(raw.last_update_note, null),
+    created_at: asOptionalString(raw.created_at, null),
+    typed_relationships: normalizeTypedRelationships(raw.typed_relationships),
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Lesson (ENC-FTR-073 §4.5)
+// ---------------------------------------------------------------------------
+//
+// Only record type with a non-trivial field-level remap: the raw DDB shape
+// for `extensions` is `{evidence_ids, author, content, timestamp}` while the
+// feed shape (LessonDetailPage render contract) is `{description, timestamp,
+// provider?}`. Rename author -> provider, content -> description, drop
+// evidence_ids.
+
+function normalizeLessonExtensions(value: unknown): LessonExtension[] {
+  const arr = asArray<RawRecord>(value)
+  return arr.map((raw) => {
+    // Accept already-normalized feed shape unchanged (description/provider).
+    // Accept API shape (author/content) with the documented remap.
+    const description =
+      typeof raw.description === 'string'
+        ? raw.description
+        : typeof raw.content === 'string'
+          ? raw.content
+          : ''
+    const provider =
+      typeof raw.provider === 'string'
+        ? raw.provider
+        : typeof raw.author === 'string'
+          ? raw.author
+          : undefined
+    return {
+      description,
+      timestamp: asString(raw.timestamp),
+      provider,
+    }
+  })
+}
+
+function normalizePillarScores(value: unknown): PillarScores {
+  const raw = asRecord(value)
+  return {
+    efficiency: asNumber(raw.efficiency, 0),
+    human_protection: asNumber(raw.human_protection, 0),
+    intention: asNumber(raw.intention, 0),
+    alignment: asNumber(raw.alignment, 0),
+  }
+}
+
+export function normalizeLesson(input: unknown): NormalizationResult<Lesson> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const lessonId = asString(raw.lesson_id ?? raw.item_id)
+  if (!lessonId) warnings.push('lesson record missing identifier (item_id/lesson_id)')
+
+  const analysisReference =
+    typeof raw.analysis_reference === 'string' && raw.analysis_reference.length > 0
+      ? raw.analysis_reference
+      : undefined
+  const governanceProposal =
+    typeof raw.governance_proposal === 'string' && raw.governance_proposal.length > 0
+      ? raw.governance_proposal
+      : undefined
+
+  const data: Lesson = {
+    lesson_id: lessonId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    observation: asString(raw.observation),
+    insight: asString(raw.insight),
+    evidence_chain: asStringArray(raw.evidence_chain),
+    provenance: asString(raw.provenance),
+    confidence: asNumber(raw.confidence, 0),
+    pillar_scores: normalizePillarScores(raw.pillar_scores),
+    resonance_score: asNumber(raw.resonance_score, 0),
+    pillar_composite: asNumber(raw.pillar_composite, 0),
+    extensions: normalizeLessonExtensions(raw.extensions),
+    category: asString(raw.category),
+    status: (asOptionalString(raw.status) ?? 'active') as Lesson['status'],
+    lesson_version: asNumber(raw.lesson_version, 1),
+    analysis_reference: analysisReference,
+    governance_proposal: governanceProposal,
+    related_task_ids: asStringArray(raw.related_task_ids),
+    related_issue_ids: asStringArray(raw.related_issue_ids),
+    related_feature_ids: asStringArray(raw.related_feature_ids),
+    history: normalizeHistory(raw.history),
+    updated_at: asOptionalString(raw.updated_at, null),
+    last_update_note: asOptionalString(raw.last_update_note, null),
+    created_at: asOptionalString(raw.created_at, null),
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Document (ENC-FTR-073 §4.6)
+// ---------------------------------------------------------------------------
+//
+// Identity-ish normalizer — the document_api already returns feed-shape
+// objects. Provided for symmetry so useRecordFallback can dispatch by
+// recordType without a special-case.
+
+export function normalizeDocument(input: unknown): NormalizationResult<Document> {
+  const raw = asRecord(input)
+  const warnings: string[] = []
+  const documentId = asString(raw.document_id ?? raw.item_id)
+  if (!documentId) warnings.push('document record missing identifier (document_id/item_id)')
+
+  const data: Document = {
+    document_id: documentId,
+    project_id: asString(raw.project_id),
+    title: asString(raw.title),
+    description: asString(raw.description),
+    file_name: asString(raw.file_name),
+    content_type: asString(raw.content_type),
+    content_hash: asString(raw.content_hash),
+    size_bytes: asNumber(raw.size_bytes, 0),
+    keywords: asStringArray(raw.keywords),
+    related_items: asStringArray(raw.related_items),
+    status: (asOptionalString(raw.status) ?? 'active') as Document['status'],
+    created_by: asString(raw.created_by),
+    created_at: asString(raw.created_at),
+    updated_at: asString(raw.updated_at),
+    version: asNumber(raw.version, 1),
+    content: typeof raw.content === 'string' ? raw.content : undefined,
+    document_subtype: typeof raw.document_subtype === 'string'
+      ? (raw.document_subtype as Document['document_subtype'])
+      : undefined,
+    source_record_id: typeof raw.source_record_id === 'string' ? raw.source_record_id : undefined,
+    handoff_status: typeof raw.handoff_status === 'string'
+      ? (raw.handoff_status as Document['handoff_status'])
+      : undefined,
+    prerequisite_state: typeof raw.prerequisite_state === 'string' ? raw.prerequisite_state : undefined,
+    action_checklist: asStringArray(raw.action_checklist),
+    verification_criteria: typeof raw.verification_criteria === 'string' ? raw.verification_criteria : undefined,
+    expires_at: typeof raw.expires_at === 'string' ? raw.expires_at : undefined,
+    claimed_by: typeof raw.claimed_by === 'string' ? raw.claimed_by : undefined,
+    claimed_at: typeof raw.claimed_at === 'string' ? raw.claimed_at : undefined,
+    created_by_session: typeof raw.created_by_session === 'string' ? raw.created_by_session : undefined,
+  }
+
+  return warnings.length > 0 ? { data, warning: warnings.join('; ') } : { data }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch map — useful for the useRecordFallback hook.
+// ---------------------------------------------------------------------------
+
+export type RecordType = 'task' | 'issue' | 'feature' | 'plan' | 'lesson' | 'document'
+
+export interface RecordTypeMap {
+  task: Task
+  issue: Issue
+  feature: Feature
+  plan: Plan
+  lesson: Lesson
+  document: Document
+}
+
+const NORMALIZERS = {
+  task: normalizeTask,
+  issue: normalizeIssue,
+  feature: normalizeFeature,
+  plan: normalizePlan,
+  lesson: normalizeLesson,
+  document: normalizeDocument,
+} as const
+
+export function normalizeRecord<T extends RecordType>(
+  recordType: T,
+  input: unknown,
+): NormalizationResult<RecordTypeMap[T]> {
+  const fn = NORMALIZERS[recordType]
+  // Runtime dispatch; cast is safe because NORMALIZERS[recordType] is the
+  // normalizer returning NormalizationResult<RecordTypeMap[T]>.
+  return fn(input) as NormalizationResult<RecordTypeMap[T]>
+}


### PR DESCRIPTION
## Summary

Phase 2 of ENC-FTR-073 (PWA direct-API fallback for detail pages outside the feed cap). Implements the core primitives frozen in the Phase 1 design document (DOC-BB658D8644DF) so Phase 3 can wire them into Plan/Lesson pages.

- **useRecordFallback hook** (ENC-TSK-D94): typed React hook wrapping TanStack Query for direct-API fallback. No-op when cached; gate = `!feedPending && !cached && !!recordId && !!projectId`; retry budget = 1 (404 skips retry); AbortSignal propagation; query key `['tracker', recordType, recordId]` de-dupes concurrent mounts.
- **recordNormalizers** (ENC-TSK-D95): six per-type normalizers (task, issue, feature, plan, lesson, document) projecting raw tracker-API payloads into feed-shape. Lesson normalizer performs the non-trivial extensions remap (author → provider, content → description, drop evidence_ids). Safe on malformed input.
- **UX primitives** (ENC-TSK-D96): `RecordFallbackLoading` (aria-busy), `RecordNotFound` (polite live region + back link), `RecordFallbackError` (alert role + optional retry). Pure presentational — props-driven.

No detail pages change in this PR. Phase 3 integrates them into `PlanDetailPage` and `LessonDetailPage`.

## Scope

- `frontend/ui/src/hooks/useRecordFallback.ts` + test (9 cases)
- `frontend/ui/src/lib/recordNormalizers.ts` + test (17 cases)
- `frontend/ui/src/components/shared/RecordFallbackLoading.tsx`, `RecordNotFound.tsx`, `RecordFallbackError.tsx` + test (10 cases)
- `frontend/ui/src/api/tracker.ts` — adds `NotFoundError`, `fetchPlanById`, `fetchLessonById`, AbortSignal support, extended `trackerKeys`
- `frontend/ui/src/api/documents.ts` — `fetchDocument` accepts AbortSignal; throws `NotFoundError` on 404

Component: `comp-enceladus-pwa` (registered `web_deploy`).
No backend Lambda or governance dictionary changes.

## Governance tokens

- CCI-dd8d777f4faf44d7bab2f9e14d938280 — ENC-TSK-D94 (hook)
- CCI-fb14e4493fe54e3dac21fdcae4349625 — ENC-TSK-D95 (normalizers)
- CCI-7001c5b524e747c7b65af122a8d91642 — ENC-TSK-D96 (UX primitives)

Commit SHA (all three tasks): `9e40036772fb4bb4b201d7345b3738b1e997db96`

## Test plan

- [x] `npm run test` — 36 new tests pass (17 normalizers + 9 hook + 10 UX). Full suite 69/70 pass; 1 failure is pre-existing on `origin/main` (`src/api/client.test.ts` `fetchFeed` URL assertion, fixed upstream in cache-bust commit `219a91d` which did not update its test).
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npm run build` — full PWA build succeeds (37 precache entries, 824 KiB)
- [ ] CI `PR Commit Gate` must pass (validates CCI tokens in this body)

## References

- Parent: ENC-TSK-D90 (Phase 2 parent, web_deploy)
- Children: ENC-TSK-D94, ENC-TSK-D95, ENC-TSK-D96
- Feature: ENC-FTR-073 (PWA direct-API fallback)
- Plan: ENC-PLN-025 (5-phase roadmap)
- Design: DOC-BB658D8644DF (Phase 1 spec — authoritative contract)
- Root cause: ENC-ISS-200 (feed cap regression from ENC-TSK-C34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)