### PR TITLE
fix(coordination_api): harden dispatch_plan_generator packaging in deploy.sh

### DIFF
--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -533,11 +533,12 @@ package_lambda() {
   zip_path="/tmp/${FUNCTION_NAME}.zip"
   local mcp_server_src="" mcp_dispatch_src=""
 
+  # ENC-TSK-E02 / ENC-ISS-185: canonical relative paths only. Stale hardcoded
+  # /Users/jreese/agents-dev/... fallbacks were removed because they never
+  # match in CI runners and silently masked workspace-layout drift.
   for candidate in \
     "${ROOT_DIR}/../../../tools/enceladus-mcp-server/server.py" \
-    "${ROOT_DIR}/../../../../tools/enceladus-mcp-server/server.py" \
-    "/Users/jreese/agents-dev/projects/enceladus/repo/tools/enceladus-mcp-server/server.py" \
-    "/Users/jreese/agents-dev/tools/enceladus-mcp-server/server.py"; do
+    "${ROOT_DIR}/../../../../tools/enceladus-mcp-server/server.py"; do
     if [[ -f "${candidate}" ]]; then
       mcp_server_src="${candidate}"
       break
@@ -546,9 +547,7 @@ package_lambda() {
 
   for candidate in \
     "${ROOT_DIR}/../../../tools/enceladus-mcp-server/dispatch_plan_generator.py" \
-    "${ROOT_DIR}/../../../../tools/enceladus-mcp-server/dispatch_plan_generator.py" \
-    "/Users/jreese/agents-dev/projects/enceladus/repo/tools/enceladus-mcp-server/dispatch_plan_generator.py" \
-    "/Users/jreese/agents-dev/tools/enceladus-mcp-server/dispatch_plan_generator.py"; do
+    "${ROOT_DIR}/../../../../tools/enceladus-mcp-server/dispatch_plan_generator.py"; do
     if [[ -f "${candidate}" ]]; then
       mcp_dispatch_src="${candidate}"
       break
@@ -557,8 +556,15 @@ package_lambda() {
 
   if [[ -z "${mcp_server_src}" || -z "${mcp_dispatch_src}" ]]; then
     echo "[ERROR] Unable to locate canonical Enceladus MCP runtime sources for packaging." >&2
+    echo "[ERROR]   ROOT_DIR=${ROOT_DIR}" >&2
+    echo "[ERROR]   server.py search root: ${ROOT_DIR}/../../../tools/enceladus-mcp-server/" >&2
+    echo "[ERROR]   dispatch_plan_generator.py search root: same as above" >&2
     exit 1
   fi
+
+  log "[OK] Resolved MCP runtime sources for packaging:"
+  log "[OK]   server.py                  -> ${mcp_server_src}"
+  log "[OK]   dispatch_plan_generator.py -> ${mcp_dispatch_src}"
 
   find "${ROOT_DIR}" -maxdepth 1 -type f -name '*.py' ! -name 'test_*' -exec cp {} "${build_dir}/" \;
   if [[ -f "${ROOT_DIR}/governance_data_dictionary.json" ]]; then
@@ -566,6 +572,17 @@ package_lambda() {
   fi
   cp "${mcp_server_src}" "${build_dir}/server.py"
   cp "${mcp_dispatch_src}" "${build_dir}/dispatch_plan_generator.py"
+
+  # ENC-TSK-E02: post-copy verification that the dispatch_plan_generator
+  # module is in the build artifact root before zipping. Catches future
+  # regressions where copy logic silently no-ops.
+  if [[ ! -f "${build_dir}/dispatch_plan_generator.py" ]]; then
+    echo "[ERROR] dispatch_plan_generator.py missing from build dir after copy step." >&2
+    echo "[ERROR]   build_dir=${build_dir}" >&2
+    echo "[ERROR]   src=${mcp_dispatch_src}" >&2
+    exit 1
+  fi
+  log "[OK] dispatch_plan_generator.py present in build_dir ($(wc -c < "${build_dir}/dispatch_plan_generator.py") bytes)"
 
   # Include architecture docs for get_architecture_excerpts Lambda fallback (ENC-ISS-111)
   local arch_dir


### PR DESCRIPTION
## Summary

Hardens `backend/lambda/coordination_api/deploy.sh` `package_lambda()` to lock in the existing fix for ENC-ISS-185 ("No module named dispatch_plan_generator") and prevent regression.

- Removes stale hardcoded `/Users/jreese/agents-dev/...` fallback paths that never matched in CI runners and would have masked future workspace-layout drift.
- Adds richer error output (ROOT_DIR, search root) when MCP runtime sources cannot be located.
- Adds post-copy verification asserting `dispatch_plan_generator.py` is present in `build_dir` before zipping, with file size logged on success.

## Background

ENC-ISS-185 reported `coordination(action='dispatch_plan.generate')` failing with `"No module named dispatch_plan_generator"` on 2026-04-08. The packaging logic that copies the module from `tools/enceladus-mcp-server/` already existed (added 2026-02-23). The 2026-04-13 deploy of `coordination_api` (triggered by ENC-TSK-D80) ran the corrected `deploy.sh` and shipped the module. Live invocation today returns a complete plan; the underlying ImportError is gone.

This PR locks in that fix by removing dead paths and adding a post-copy assert so any future regression fails the deploy fast and loud.

## Test plan

- [x] `bash -n backend/lambda/coordination_api/deploy.sh` (syntax check passes)
- [x] Path resolution simulated against worktree ROOT_DIR — resolves to `tools/enceladus-mcp-server/dispatch_plan_generator.py`
- [x] Path resolution simulated against GitHub Actions checkout layout — resolves correctly
- [x] Pre-deploy live verification: `coordination(action='dispatch_plan.dry_run', arguments={project_id:'enceladus', outcomes:['test'], provider:'claude_code'})` returns a complete plan structure (no ImportError)
- [ ] Post-deploy live verification: re-run the same `dispatch_plan.dry_run` and a `dispatch_plan.generate` invocation; expect non-ImportError responses (handled via task lifecycle gates)

## Governance

- Touches `deploy.sh` only; `lambda_function.py` is unchanged so the governance dictionary guard does not fire.
- Task: ENC-TSK-E02
- Issue: ENC-ISS-185
- Feature: ENC-FTR-005
- Component: comp-coordination-api (transition_type: github_pr_deploy)

CCI-f6e3ddefe237460a8238f011db0bf667