### PR TITLE
hotfix(coordination_api): redirect package_lambda log calls to stderr

### DIFF
--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -562,9 +562,13 @@ package_lambda() {
     exit 1
   fi
 
-  log "[OK] Resolved MCP runtime sources for packaging:"
-  log "[OK]   server.py                  -> ${mcp_server_src}"
-  log "[OK]   dispatch_plan_generator.py -> ${mcp_dispatch_src}"
+  # ENC-TSK-E02 hotfix: redirect log/echo to stderr because package_lambda()
+  # returns the zip path on stdout (consumed via $(package_lambda) by the caller
+  # at ensure_lambda()). Any stdout pollution corrupts the captured zip path and
+  # crashes `aws lambda update-function-code` with "No such file or directory".
+  log "[OK] Resolved MCP runtime sources for packaging:" >&2
+  log "[OK]   server.py                  -> ${mcp_server_src}" >&2
+  log "[OK]   dispatch_plan_generator.py -> ${mcp_dispatch_src}" >&2
 
   find "${ROOT_DIR}" -maxdepth 1 -type f -name '*.py' ! -name 'test_*' -exec cp {} "${build_dir}/" \;
   if [[ -f "${ROOT_DIR}/governance_data_dictionary.json" ]]; then
@@ -575,14 +579,15 @@ package_lambda() {
 
   # ENC-TSK-E02: post-copy verification that the dispatch_plan_generator
   # module is in the build artifact root before zipping. Catches future
-  # regressions where copy logic silently no-ops.
+  # regressions where copy logic silently no-ops. Errors and the success
+  # log line MUST go to stderr (see header comment above).
   if [[ ! -f "${build_dir}/dispatch_plan_generator.py" ]]; then
     echo "[ERROR] dispatch_plan_generator.py missing from build dir after copy step." >&2
     echo "[ERROR]   build_dir=${build_dir}" >&2
     echo "[ERROR]   src=${mcp_dispatch_src}" >&2
     exit 1
   fi
-  log "[OK] dispatch_plan_generator.py present in build_dir ($(wc -c < "${build_dir}/dispatch_plan_generator.py") bytes)"
+  log "[OK] dispatch_plan_generator.py present in build_dir ($(wc -c < "${build_dir}/dispatch_plan_generator.py") bytes)" >&2
 
   # Include architecture docs for get_architecture_excerpts Lambda fallback (ENC-ISS-111)
   local arch_dir


### PR DESCRIPTION
## Summary

Hotfix for PR #318 (ENC-TSK-E02) deploy failure.

The verification log calls I added to `package_lambda()` in PR #318 wrote to **stdout**. The function returns the zip path on stdout (line 612 `echo "${zip_path}"`), captured by the caller via `zip_path=$(package_lambda)` at `ensure_lambda()`. My log lines polluted that capture, producing a multi-line `zip_path` and crashing `aws lambda update-function-code --zip-file fileb://...` with `"No such file or directory"`.

**Fix**: redirect the new log lines and the post-copy success log to stderr (`>&2`) so `package_lambda()`'s stdout contract is preserved.

Verified locally with a stdout-cleanliness harness — captured `zip_path` is exactly `/tmp/devops-coordination-api.zip` (single line, no log noise).

## Why a separate PR

Task ENC-TSK-E02 is at `merged-main` with CCI-f6e3ddefe237460a8238f011db0bf667 issued for the original commit. The lifecycle does not cleanly support `merged-main → coding-updates` re-entry without first reaching `deploy-success`. The deploy is blocked by the bug this PR fixes, so a separate PR is required to break the deadlock. The CCI from the original task transition is still valid (CCI is cleared only at `deploy-success`, which the task has not yet reached).

## Test plan

- [x] `bash -n` syntax check passes
- [x] Stdout-cleanliness harness: `zip_path=$(package_lambda)` returns single-line path
- [ ] CI checks pass
- [ ] Deploy run succeeds (re-runs `api-mcp-backend-deploy.yml` with the hotfixed `deploy.sh`)
- [ ] Post-deploy: `coordination(action='dispatch_plan.dry_run', ...)` still returns valid plan

## Governance

- Touches `deploy.sh` only; `lambda_function.py` unchanged so governance dictionary guard does not fire
- Task: ENC-TSK-E02 (in `merged-main`)
- Related issue: ENC-ISS-185
- Prior PR: #318 (merged but deploy failed)

CCI-f6e3ddefe237460a8238f011db0bf667