### PR TITLE
fix(graph_sync): emit PLAN_CONTAINS via labelled-target placeholder MERGE (ENC-TSK-E01)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-13.3",
-  "updated_at": "2026-04-13T05:37:00Z",
+  "version": "2026-04-15.1",
+  "updated_at": "2026-04-15T05:30:00Z",
   "last_change_summary": "ENC-TSK-D81: Updated api.error_envelope entity to reflect D56 enrichment scope (6 Lambdas + MCP normalization). Expanded details definition with post-D56 standard keys.",
   "owners": [
     "enceladus-platform"
@@ -3143,22 +3143,25 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records.",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
           "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
-          "inverse": "contained-by-plan"
+          "inverse": "contained-by-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
           "definition": "Plan → document. Attaches a document as reference material for the plan.",
-          "inverse": "doc-attached-to-plan"
+          "inverse": "doc-attached-to-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
           "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
-          "inverse": "implemented-by-plan"
+          "inverse": "implemented-by-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
       }
     },
@@ -3409,7 +3412,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -125,6 +125,26 @@ RECORD_TYPE_TO_LABEL = {
     "generation": "Generation",  # GMF DOC-63420302EF65
 }
 
+# ENC-TSK-E01 / ENC-ISS-184: ID-prefix to Neo4j label mapping for placeholder
+# node creation. When a plan emits a PLAN_CONTAINS edge to an objective task
+# that has not yet been projected (race window after plan.add_objective is
+# called before the target task's own DDB stream event reaches graph_sync),
+# we MERGE a placeholder node with the inferred label so the edge always
+# lands. The target's own stream event later MERGEs by the same label and
+# record_id, augmenting the placeholder with full properties without
+# creating a duplicate node.
+ID_PREFIX_TO_LABEL = {
+    "TSK": "Task",
+    "ISS": "Issue",
+    "FTR": "Feature",
+    "PLN": "Plan",
+    "LSN": "Lesson",
+    "DOC": "Document",
+    "GEN": "Generation",
+    "DPL": "DeploymentDecision",
+}
+
+
 def _bare_id(record_id: str) -> str:
     """Strip 'type#' prefix from composite DynamoDB record_id.
 
@@ -132,6 +152,26 @@ def _bare_id(record_id: str) -> str:
     Bare IDs pass through unchanged.
     """
     return record_id.split("#", 1)[-1] if "#" in record_id else record_id
+
+
+def _infer_label_from_id(record_id: str) -> str:
+    """Infer a Neo4j node label from a bare record_id like 'ENC-TSK-C59'.
+
+    Returns '' when the prefix is not recognised so callers can skip
+    placeholder creation rather than spawning unlabelled nodes.
+    Document IDs may be 'DOC-XXXX' (no project prefix); both single- and
+    triple-segment IDs are handled.
+    """
+    if not record_id:
+        return ""
+    parts = record_id.split("-")
+    # Document IDs: 'DOC-XXXX' (2 segments) or PROJECT-DOC-XXXX (3+)
+    if parts[0].upper() == "DOC":
+        return "Document"
+    if len(parts) < 2:
+        return ""
+    type_code = parts[1].upper()
+    return ID_PREFIX_TO_LABEL.get(type_code, "")
 
 
 # Properties to copy from DynamoDB record to Neo4j node
@@ -267,33 +307,76 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
             )
 
     # ENC-ISS-150 / ENC-TSK-B14: Plan-specific edge projections
+    # ENC-TSK-E01 / ENC-ISS-184: emit edges via labelled-target MERGE so the
+    # PLAN_CONTAINS / PLAN_ATTACHED_DOC edges land even when the target node
+    # is not yet projected. The previous Cartesian MATCH pattern silently
+    # produced zero rows (and zero edges) when the objective task or
+    # attached document had not been processed yet by graph_sync, leaving
+    # plans like ENC-PLN-016 with zero PLAN_CONTAINS edges despite a
+    # populated objectives_set. Placeholder MERGE attaches a label-correct
+    # node by record_id; the target's own stream event later MERGEs by the
+    # same (label, record_id) pair and augments the placeholder with full
+    # properties without duplicating it.
     if record_type == "plan":
+        objectives_set = record.get("objectives_set", []) or []
+        attached_documents = record.get("attached_documents", []) or []
+        logger.info(
+            "[INFO] Plan reconcile %s: objectives_set=%d attached_documents=%d",
+            record_id, len(objectives_set), len(attached_documents),
+        )
+
         # PLAN_CONTAINS -> each objective (Task/Issue/Feature)
-        for obj_id in record.get("objectives_set", []) or []:
+        for obj_id in objectives_set:
             obj_id = _bare_id(obj_id) if obj_id else ""
             if not obj_id:
                 continue
-            tx.run(
-                "MATCH (p:Plan), (t {record_id: $tid}) "
-                "WHERE p.record_id = $pid "
-                "MERGE (p)-[:PLAN_CONTAINS]->(t)",
-                pid=record_id, tid=obj_id,
-            )
+            target_label = _infer_label_from_id(obj_id)
+            if target_label:
+                # Ensure a label-correct target node exists. Placeholder is
+                # idempotent with the target's own _upsert_node MERGE.
+                tx.run(
+                    f"MERGE (t:{target_label} {{record_id: $tid}})",
+                    tid=obj_id,
+                )
+                tx.run(
+                    f"MATCH (p:Plan), (t:{target_label}) "
+                    "WHERE p.record_id = $pid AND t.record_id = $tid "
+                    "MERGE (p)-[:PLAN_CONTAINS]->(t)",
+                    pid=record_id, tid=obj_id,
+                )
+            else:
+                # Unknown ID prefix: fall back to the legacy unlabelled
+                # MATCH so we do not silently lose the edge if the prefix
+                # registry is incomplete.
+                logger.warning(
+                    "[WARNING] Plan %s objective %s has unrecognised ID prefix; "
+                    "falling back to unlabelled MATCH (edge may not land if target absent)",
+                    record_id, obj_id,
+                )
+                tx.run(
+                    "MATCH (p:Plan), (t {record_id: $tid}) "
+                    "WHERE p.record_id = $pid "
+                    "MERGE (p)-[:PLAN_CONTAINS]->(t)",
+                    pid=record_id, tid=obj_id,
+                )
 
         # PLAN_ATTACHED_DOC -> each document
-        for doc_id in record.get("attached_documents", []) or []:
+        for doc_id in attached_documents:
             doc_id = str(doc_id).strip() if doc_id else ""
             if not doc_id:
                 continue
+            # Documents always project to the :Document label.
             tx.run(
-                "MATCH (p:Plan), (d {record_id: $did}) "
-                "WHERE p.record_id = $pid "
+                "MERGE (d:Document {record_id: $did})",
+                did=doc_id,
+            )
+            tx.run(
+                "MATCH (p:Plan), (d:Document) "
+                "WHERE p.record_id = $pid AND d.record_id = $did "
                 "MERGE (p)-[:PLAN_ATTACHED_DOC]->(d)",
                 pid=record_id, did=doc_id,
             )
             # ENC-PLN-014 / ENC-FTR-065: inverse DOC_ATTACHED_TO_PLAN
-            # Requires a :Document node to exist; harmless no-op until backfill
-            # projects the documents (see ENC-TSK-C45).
             tx.run(
                 "MATCH (p:Plan), (d:Document) "
                 "WHERE p.record_id = $pid AND d.record_id = $did "
@@ -304,6 +387,12 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
         # PLAN_IMPLEMENTS -> related feature
         feat_id = _bare_id(record.get("related_feature_id", "") or "")
         if feat_id:
+            # Placeholder MERGE so the edge lands even if the Feature node
+            # has not been projected yet (ENC-TSK-E01).
+            tx.run(
+                "MERGE (f:Feature {record_id: $fid})",
+                fid=feat_id,
+            )
             tx.run(
                 "MATCH (p:Plan), (f:Feature) "
                 "WHERE p.record_id = $pid AND f.record_id = $fid "
@@ -323,22 +412,48 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
         # so re-running graph_sync on a backfill is idempotent.
 
         # RELATED_TO -> each related_items target (any node label)
+        # ENC-TSK-E01: placeholder MERGE on inferred label so the edge lands
+        # even when the target has not been projected yet.
         for related_id in record.get("related_items", []) or []:
             related_id = _bare_id(related_id) if related_id else ""
             if not related_id:
                 continue
-            tx.run(
-                "MATCH (d:Document), (t {record_id: $tid}) "
-                "WHERE d.record_id = $did "
-                "MERGE (d)-[:RELATED_TO]->(t)",
-                did=doc_id, tid=related_id,
-            )
+            target_label = _infer_label_from_id(related_id)
+            if target_label:
+                tx.run(
+                    f"MERGE (t:{target_label} {{record_id: $tid}})",
+                    tid=related_id,
+                )
+                tx.run(
+                    f"MATCH (d:Document), (t:{target_label}) "
+                    "WHERE d.record_id = $did AND t.record_id = $tid "
+                    "MERGE (d)-[:RELATED_TO]->(t)",
+                    did=doc_id, tid=related_id,
+                )
+            else:
+                logger.warning(
+                    "[WARNING] Document %s related_item %s has unrecognised ID prefix; "
+                    "falling back to unlabelled MATCH",
+                    doc_id, related_id,
+                )
+                tx.run(
+                    "MATCH (d:Document), (t {record_id: $tid}) "
+                    "WHERE d.record_id = $did "
+                    "MERGE (d)-[:RELATED_TO]->(t)",
+                    did=doc_id, tid=related_id,
+                )
 
         # INFORMED_BY -> source document; INFORMS inverse from source -> this doc
+        # ENC-TSK-E01: placeholder MERGE so edges land even if the source
+        # document has not been projected yet.
         for informed_id in record.get("informed_by", []) or []:
             informed_id = _bare_id(informed_id) if informed_id else ""
             if not informed_id:
                 continue
+            tx.run(
+                "MERGE (s:Document {record_id: $sid})",
+                sid=informed_id,
+            )
             tx.run(
                 "MATCH (d:Document), (s:Document) "
                 "WHERE d.record_id = $did AND s.record_id = $sid "


### PR DESCRIPTION
## Summary

- Fix the silent zero-edge race window in `graph_sync._reconcile_edges()` plan and document branches by MERGEing label-correct placeholder target nodes before MERGEing edges.
- ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objective tasks despite a populated `objectives_set`. The plan branch's previous Cartesian-product MATCH `MATCH (p:Plan), (t {record_id: $tid})` produced zero rows when the target node had not yet been projected by graph_sync, so the MERGE never created the edge. PLN-016 INSERT preceded its objectives by ~2 minutes and lost every PLAN_CONTAINS emission.
- Adds `_infer_label_from_id()` helper (TSK -> Task, ISS -> Issue, FTR -> Feature, PLN -> Plan, LSN -> Lesson, DOC -> Document, GEN -> Generation, DPL -> DeploymentDecision) so the plan branch (PLAN_CONTAINS, PLAN_ATTACHED_DOC, PLAN_IMPLEMENTS) and the document branch (RELATED_TO, INFORMED_BY) can stand up a placeholder before MERGEing the edge. The target's own `_upsert_node` MERGE matches by `(label, record_id)` and augments the placeholder with full properties without duplicating.
- Adds an `[INFO] Plan reconcile ...: objectives_set=N attached_documents=N` log line so future regressions are visible without redeploy.
- Updates `governance_data_dictionary.json` (`tracker.plan.relationship_types`, `document.graph_edges`) with the new `graph_projection` contract; bumps dictionary version to `2026-04-15.1`.

Refs: ENC-ISS-184, ENC-FTR-066 OGTM, ENC-PLN-006 Phase 1 (B62) AC-6
Commit Complete ID: CCI-28339d218c4c485ea7a08e99447287f9

## Test plan

- [x] Local: `python3 -m py_compile backend/lambda/graph_sync/lambda_function.py`
- [x] Local: governance dictionary parses as valid JSON
- [x] Local: mock-tx exercise of `_reconcile_edges` confirms placeholder + edge MERGE pairs are emitted for plan and document branches
- [ ] Live (post deploy-success): `tracker.graphsearch(record_id="ENC-PLN-006", search_type="neighbors", depth=1, edge_types=["PLAN_CONTAINS"])` returns >=1 PLAN_CONTAINS edge to ENC-TSK-B62
- [ ] Live (post deploy-success): `tracker.graphsearch(record_id="ENC-PLN-016", search_type="neighbors", depth=1, edge_types=["PLAN_CONTAINS"])` returns >=1 PLAN_CONTAINS edge to ENC-TSK-C59 (after a touch-update on PLN-016 to fire a fresh DDB stream event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)