### PR TITLE
fix(graph_sync): emit LEARNED_FROM from lesson evidence_chain (ENC-TSK-B89)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-15.1",
-  "updated_at": "2026-04-15T05:30:00Z",
-  "last_change_summary": "ENC-TSK-D81: Updated api.error_envelope entity to reflect D56 enrichment scope (6 Lambdas + MCP normalization). Expanded details definition with post-D56 standard keys.",
+  "version": "2026-04-15.2",
+  "updated_at": "2026-04-15T07:45:00Z",
+  "last_change_summary": "ENC-TSK-B89: Added lesson record-body edge projection to graph_sync. tracker.lesson entity description now references the graph_projection contract; evidence_chain and extensions fields annotated with graph_projection stanzas documenting the LEARNED_FROM edge emission via _infer_label_from_id + placeholder MERGE pattern (same as ENC-TSK-E01 plan/document branch). Prior to B89, lesson records produced zero LEARNED_FROM edges from record-body (only rel# typed-relationship items projected via _upsert_relationship_edge), leaving every lesson with exactly one graph edge (BELONGS_TO->Project) and zero relationship neighbors. See ENC-ISS-189 for the canonical legacy-ID manifestation.",
   "owners": [
     "enceladus-platform"
   ],
@@ -2639,7 +2639,7 @@
       }
     },
     "tracker.lesson": {
-      "description": "Governed Lesson primitive capturing institutional wisdom as a first-class record type (ENC-FTR-052). Lessons are evidence-gated, append-only, constitutionally scored against four pillars and a vibe board, and can propose governance amendments through human-approval handshake. Stored in devops-project-tracker with lesson# SK prefix. Gated behind ENABLE_LESSON_PRIMITIVE feature flag.",
+      "description": "Governed Lesson primitive capturing institutional wisdom as a first-class record type (ENC-FTR-052). Lessons are evidence-gated, append-only, constitutionally scored against four pillars and a vibe board, and can propose governance amendments through human-approval handshake. Stored in devops-project-tracker with lesson# SK prefix. Gated behind ENABLE_LESSON_PRIMITIVE feature flag. ENC-TSK-B89: graph_sync._reconcile_edges() now includes a dedicated lesson branch that emits (Lesson)-[:LEARNED_FROM]->(target) edges from evidence_chain entries and every extensions[].evidence_ids bag, via the ENC-TSK-E01 _infer_label_from_id + placeholder MERGE pattern so edges land even when the target node has not yet been projected. Unknown ID prefixes (pre-ENC-FTR-056 legacy forms such as JAP-*, MJR-*) fall back to unlabelled MATCH with a WARNING log line; see ENC-ISS-189 for the ENC-LSN-013 legacy-ID manifestation.",
       "fields": {
         "title": {
           "type": "string",
@@ -2679,7 +2679,8 @@
             "append_only": true
           },
           "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
-          "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended."
+          "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -2786,7 +2787,8 @@
             "append_only": true
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
-          "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain."
+          "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -400,6 +400,88 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
                 pid=record_id, fid=feat_id,
             )
 
+    # ENC-FTR-052 / ENC-TSK-B89: Lesson edge projections.
+    # Lesson records carry evidence_chain (list of tracker/document record IDs)
+    # as their canonical LEARNED_FROM source plus extensions[].evidence_ids for
+    # append-only extensions. Prior to ENC-TSK-B89, _reconcile_edges() had no
+    # lesson branch at all, so every lesson node landed with exactly one edge
+    # (BELONGS_TO->Project) and zero relationship neighbors. LEARNED_FROM edges
+    # existed only for the subset of lessons whose evidence_chain entries were
+    # historically backfilled into rel# DynamoDB items by ENC-TSK-C38 Phase 2;
+    # any lesson created or updated after that backfill had zero LEARNED_FROM
+    # edges in the graph, breaking depth-1 traversal from lessons (see
+    # ENC-ISS-189 for the canonical legacy-ID manifestation).
+    #
+    # Fix: iterate both evidence_chain and every extension's evidence_ids,
+    # dedupe, then emit (Lesson)-[:LEARNED_FROM]->(target) via the E01
+    # placeholder MERGE pattern so the edge lands even when the target node is
+    # not yet projected. Unrecognised ID prefixes (e.g. legacy JAP-*, MJR-*
+    # records or pre-ENC-FTR-056 flat IDs) fall back to the legacy unlabelled
+    # MATCH with a WARNING log line so OGTM does not silently drop the edge.
+    if record_type == "lesson":
+        evidence_ids_ordered: List[str] = []
+        seen_ev: set = set()
+
+        def _collect_evidence(eid: Any) -> None:
+            if eid is None:
+                return
+            if isinstance(eid, dict):
+                return
+            val = _bare_id(str(eid).strip())
+            if val and val not in seen_ev:
+                seen_ev.add(val)
+                evidence_ids_ordered.append(val)
+
+        for ev in record.get("evidence_chain", []) or []:
+            _collect_evidence(ev)
+        # Extensions are append-only lesson_version increments; each carries
+        # its own evidence_ids bag. Project every extension's evidence IDs as
+        # additional LEARNED_FROM edges so the corpus-wide lesson graph
+        # reflects the full provenance, not just the bootstrap chain.
+        for ext in record.get("extensions", []) or []:
+            if isinstance(ext, dict):
+                for ev in ext.get("evidence_ids", []) or []:
+                    _collect_evidence(ev)
+
+        logger.info(
+            "[INFO] Lesson reconcile %s: evidence_ids=%d (deduped)",
+            record_id, len(evidence_ids_ordered),
+        )
+
+        for ev_id in evidence_ids_ordered:
+            target_label = _infer_label_from_id(ev_id)
+            if target_label:
+                # Placeholder MERGE on inferred label so the edge lands even
+                # when the target node has not been projected yet
+                # (ENC-TSK-E01 pattern).
+                tx.run(
+                    f"MERGE (t:{target_label} {{record_id: $tid}})",
+                    tid=ev_id,
+                )
+                tx.run(
+                    f"MATCH (l:Lesson), (t:{target_label}) "
+                    "WHERE l.record_id = $lid AND t.record_id = $tid "
+                    "MERGE (l)-[:LEARNED_FROM]->(t)",
+                    lid=record_id, tid=ev_id,
+                )
+            else:
+                # Unknown/legacy ID prefix: fall back to unlabelled MATCH so
+                # pre-ENC-FTR-056 legacy IDs (JAP-*, MJR-*, bare non-canonical
+                # strings) still produce an edge when the target happens to
+                # be present. ENC-ISS-189 documents why the warning is
+                # useful for future rationalization work.
+                logger.warning(
+                    "[WARNING] Lesson %s evidence_id %s has unrecognised ID prefix; "
+                    "falling back to unlabelled MATCH (edge may not land if target absent)",
+                    record_id, ev_id,
+                )
+                tx.run(
+                    "MATCH (l:Lesson), (t {record_id: $tid}) "
+                    "WHERE l.record_id = $lid "
+                    "MERGE (l)-[:LEARNED_FROM]->(t)",
+                    lid=record_id, tid=ev_id,
+                )
+
     # ENC-FTR-065 / ENC-PLN-014: Document edge projections
     if record_type == "document":
         doc_id = record_id  # already _bare_id-stripped at the top of the function


### PR DESCRIPTION
## Summary

- Adds lesson record-body edge projection to `backend/lambda/graph_sync/lambda_function.py`. `_reconcile_edges()` now emits `(Lesson)-[:LEARNED_FROM]->(target)` for every unique ID in `evidence_chain` unioned with each extension's `evidence_ids` bag.
- Uses the ENC-TSK-E01 placeholder MERGE pattern (`_infer_label_from_id` + label-correct `MERGE (t:Label {record_id})` before the edge MERGE) so edges land even when the target node has not been projected yet. Unrecognised ID prefixes fall back to the legacy unlabelled MATCH with a WARNING log.
- Governance dictionary bumped to `2026-04-15.2`; `tracker.lesson` description plus `evidence_chain` and `extensions` fields now carry the `graph_projection` contract documenting LEARNED_FROM emission and dedup behavior.
- Pre-fix live evidence: `tracker.graphsearch(ENC-LSN-017, depth=1)` returned 0 nodes / 1 edge despite an 11-entry `evidence_chain`; every lesson in the enceladus corpus exhibited the same pattern (only `BELONGS_TO -> Project` fired).
- Registry labels already in place (`LEARNED_FROM` in `RELATIONSHIP_TYPE_TO_EDGE_LABEL` and `graph_query_api _ALLOWED_EDGE_TYPES`) — this PR only closes the record-body projection gap. No registry additions required.

Closes out ENC-PLN-006 Phase 1 (ENC-TSK-B62) AC-1 (`graph_sync projects plan and lesson node types to Neo4j`); also remediates ENC-ISS-189 (P1: ENC-LSN-013 depth-1 edges missing due to legacy JAP-* IDs) via the unlabelled fallback branch.

CCI-6fd9101403524df3baa99fcef4b46ccb

## Test plan

- [x] `ast.parse` on the modified `lambda_function.py` succeeds.
- [x] Existing `test_document_record_id_normalization.py` passes (3/3).
- [x] Mock-tx smoke test of `_reconcile_edges()` on five lesson shapes: LSN-017 (11 edges), LSN-013 legacy mix (3 edges incl. 1 unlabelled fallback), LSN-023 with DOC ref (3 edges), dedup across chain+extensions (4 unique edges), non-lesson record (0 false positives).
- [x] Governance dictionary JSON validates; `tools/check_governance_dictionary_sync.py --base origin/main --head <stash>` passes.
- [ ] Post-deploy live validation: `tracker.graphsearch(ENC-LSN-017, depth=1, edge_types=LEARNED_FROM)` returns >=11 LEARNED_FROM edges after graph_sync consumes a touch event on LSN-017.
- [ ] Post-deploy live validation: `tracker.graphsearch(ENC-LSN-023, depth=1, edge_types=LEARNED_FROM)` returns edges to ENC-TSK-1292, ENC-TSK-D11, DOC-2CACF0D1E7E6.
- [ ] Post-deploy live validation: `tracker.graphsearch(ENC-LSN-013, depth=1)` returns non-empty edge set (legacy-ID fallback path).

Refs: ENC-TSK-E01 (precedent), ENC-FTR-052 (Lesson primitive), ENC-FTR-066 (OGTM), ENC-ISS-189 (P1), ENC-TSK-B62 (Phase 1 gate), ENC-PLN-006.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>