### PR TITLE
feat(neo4j): add HNSW vector index migration for Titan V2 embeddings (ENC-TSK-B90)

### DIFF
--- a/tools/backfill_graph.py
+++ b/tools/backfill_graph.py
@@ -219,6 +219,77 @@ def report_counts(driver):
     return node_count, edge_count
 
 
+def _split_cypher_statements(text: str) -> List[str]:
+    """Split a .cypher file into individual statements.
+
+    Strips `//` line comments before splitting on `;`. Ignores trailing
+    whitespace-only fragments. Does not attempt to honor semicolons inside
+    string literals -- the migration files under tools/neo4j-migrations/ do
+    not use them, and this helper is not a general-purpose Cypher parser.
+    """
+    scrubbed_lines = []
+    for line in text.splitlines():
+        comment_at = line.find("//")
+        if comment_at >= 0:
+            line = line[:comment_at]
+        scrubbed_lines.append(line)
+    blob = "\n".join(scrubbed_lines)
+    statements = []
+    for chunk in blob.split(";"):
+        chunk = chunk.strip()
+        if chunk:
+            statements.append(chunk)
+    return statements
+
+
+def run_migration_file(driver, path: str) -> int:
+    """Run each Cypher statement in `path` against the Neo4j driver.
+
+    Returns the count of statements executed. Each statement runs in its own
+    auto-commit transaction (migrations are expected to use `IF NOT EXISTS`
+    for idempotency, not transactional rollback).
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    statements = _split_cypher_statements(text)
+    if not statements:
+        logger.warning("[WARN] No executable statements in %s", path)
+        return 0
+    logger.info("[START] Running migration %s (%d statements)", path, len(statements))
+    with driver.session() as session:
+        for i, stmt in enumerate(statements, 1):
+            preview = " ".join(stmt.split())[:80]
+            logger.info("[INFO] [%d/%d] %s", i, len(statements), preview)
+            session.run(stmt).consume()
+    logger.info("[END] Migration complete: %d statements applied", len(statements))
+    return len(statements)
+
+
+def show_vector_indexes(driver) -> List[Dict[str, Any]]:
+    """Return all vector indexes currently defined on the Neo4j instance."""
+    with driver.session() as session:
+        result = session.run(
+            "SHOW VECTOR INDEXES "
+            "YIELD name, state, labelsOrTypes, properties, options"
+        )
+        rows = [dict(record) for record in result]
+    logger.info("[INFO] %d vector index(es) found", len(rows))
+    for row in rows:
+        index_config = (row.get("options") or {}).get("indexConfig") or {}
+        dim = index_config.get("vector.dimensions")
+        sim = index_config.get("vector.similarity_function")
+        logger.info(
+            "[INFO]   - %s state=%s labels=%s props=%s dim=%s sim=%s",
+            row.get("name"),
+            row.get("state"),
+            row.get("labelsOrTypes"),
+            row.get("properties"),
+            dim,
+            sim,
+        )
+    return rows
+
+
 def main():
     parser = argparse.ArgumentParser(description="Backfill Neo4j graph from DynamoDB tracker table")
     parser.add_argument("--region", default="us-west-2")
@@ -226,11 +297,35 @@ def main():
     parser.add_argument("--secret-name", default=None,
                         help="Secrets Manager secret name (default: env NEO4J_SECRET_NAME)")
     parser.add_argument("--dry-run", action="store_true", help="Scan only, no graph writes")
+    parser.add_argument("--run-migration", default=None,
+                        help="Path to a .cypher migration file; when set, runs only the migration "
+                             "and exits (no DynamoDB scan, no backfill). See "
+                             "tools/neo4j-migrations/ for managed migrations.")
+    parser.add_argument("--verify-vector-indexes", action="store_true",
+                        help="Run SHOW VECTOR INDEXES and print each index's name, state, "
+                             "labels, properties, and (dimensions, similarity_function). "
+                             "Implies skip-backfill; exits after printing.")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 
     secret_name = args.secret_name or os.environ.get("NEO4J_SECRET_NAME", "enceladus/neo4j/auradb-credentials")
+
+    # Migration / verification fast paths -- run before the DynamoDB scan and
+    # exit without touching the tracker table or backfilling any records.
+    if args.run_migration or args.verify_vector_indexes:
+        logger.info("[INFO] Connecting to Neo4j (secret=%s, region=%s)...",
+                    secret_name, args.region)
+        creds = get_neo4j_credentials(secret_name, args.region)
+        driver = get_neo4j_driver(creds)
+        try:
+            if args.run_migration:
+                run_migration_file(driver, args.run_migration)
+            if args.verify_vector_indexes:
+                show_vector_indexes(driver)
+        finally:
+            driver.close()
+        return
 
     logger.info("[START] Backfill graph from %s (region=%s)", args.table, args.region)
 

--- a/tools/neo4j-migrations/001-hnsw-vector-indexes-governed-records.cypher
+++ b/tools/neo4j-migrations/001-hnsw-vector-indexes-governed-records.cypher
@@ -1,0 +1,99 @@
+// ENC-TSK-B90 Neo4j HNSW vector indexes for Titan V2 embeddings
+//
+// Creates per-label HNSW vector indexes on the `embedding` property for the
+// six governed record types that participate in the Phase 1 hybrid retrieval
+// corpus (ENC-TSK-B62 / ENC-FTR-062):
+//
+//   Task, Issue, Feature, Plan, Lesson, Document
+//
+// Labels intentionally excluded:
+//   - Generation          (GMF metadata; not part of the retrieval corpus)
+//   - Project             (side node; not a governed record)
+//   - DeploymentDecision  (placeholder-only projection today)
+//
+// Index contract (mandated by ENC-TSK-B62 AC-2):
+//   - dimensions             = 256
+//   - similarity function    = cosine
+//   - target property name   = embedding
+//
+// Amazon Titan Text Embeddings V2 (amazon.titan-embed-text-v2:0) supports 256
+// via the `dimensions` invoke parameter. The ENC-TSK-B91 backfill worker MUST
+// invoke the model with `dimensions=256` for produced vectors to match the
+// indexes below. Any mismatch leaves the indexes live but unused.
+//
+// Idempotency: every statement uses `IF NOT EXISTS`. Re-running this file
+// against an AuraDB that already has the indexes is a no-op.
+//
+// Prerequisite: Neo4j 5.11+ (native vector index support). All current
+// AuraDB tiers (Free, Professional, Enterprise) meet this requirement as of
+// 2024. If the target is older, these statements will fail cleanly with a
+// syntax error and no index will be created.
+//
+// Operational notes:
+//   - Vector indexes are non-disruptive: creating them does not affect
+//     existing queries, and they sit unused until queried via
+//     db.index.vector.queryNodes(...) or a CALL db.index.vector.* procedure.
+//   - The shared prod+gamma AuraDB means running this migration affects
+//     production reads too. Verified a recent enceladus-neo4j-backup-gamma
+//     snapshot exists in s3://jreese-net/gamma/neo4j-backups/ before applying.
+//
+// Verification (run after applying):
+//   SHOW VECTOR INDEXES
+//     YIELD name, labelsOrTypes, properties, options
+//     WHERE name STARTS WITH 'governed_';
+//
+// ---------------------------------------------------------------------------
+
+CREATE VECTOR INDEX governed_task_embedding IF NOT EXISTS
+FOR (n:Task) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+
+CREATE VECTOR INDEX governed_issue_embedding IF NOT EXISTS
+FOR (n:Issue) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+
+CREATE VECTOR INDEX governed_feature_embedding IF NOT EXISTS
+FOR (n:Feature) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+
+CREATE VECTOR INDEX governed_plan_embedding IF NOT EXISTS
+FOR (n:Plan) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+
+CREATE VECTOR INDEX governed_lesson_embedding IF NOT EXISTS
+FOR (n:Lesson) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};
+
+CREATE VECTOR INDEX governed_document_embedding IF NOT EXISTS
+FOR (n:Document) ON n.embedding
+OPTIONS {
+  indexConfig: {
+    `vector.dimensions`: 256,
+    `vector.similarity_function`: 'cosine'
+  }
+};

--- a/tools/neo4j-migrations/README.md
+++ b/tools/neo4j-migrations/README.md
@@ -1,0 +1,40 @@
+ENC-TSK-B90 Neo4j Migrations
+
+Cypher migration files for the Enceladus governed graph on Neo4j AuraDB.
+
+Migrations are numbered sequentially (`NNN-description.cypher`). Each file is
+idempotent (`IF NOT EXISTS` / `MERGE`) so re-running is safe.
+
+The shared AuraDB instance backs both the prod `devops-graph-sync` Lambda and
+the gamma `devops-graph-sync-gamma` Lambda (both Lambdas resolve
+`NEO4J_SECRET_NAME=enceladus/neo4j/auradb-credentials`; the parallel
+`enceladus/neo4j/auradb-credentials-gamma` secret is not referenced by any
+deployed Lambda). Apply migrations with care and confirm a recent
+`enceladus-neo4j-backup-gamma` S3 snapshot exists before running.
+
+## Running a migration
+
+Two supported paths:
+
+1. Via the `backfill_graph.py` helper (recommended; reuses the existing
+   Secrets Manager and Neo4j driver plumbing):
+
+   ```bash
+   AWS_PROFILE=product-lead \
+   NEO4J_SECRET_NAME=enceladus/neo4j/auradb-credentials \
+   python3 tools/backfill_graph.py --region us-west-2 \
+     --run-migration tools/neo4j-migrations/001-hnsw-vector-indexes-governed-records.cypher
+   ```
+
+2. Directly via `cypher-shell` / Aura Browser by pasting the file contents.
+
+After running a migration, capture the `SHOW VECTOR INDEXES` (or equivalent)
+introspection output and attach it to the originating tracker task's
+`live_validation_evidence` field.
+
+## Governance
+
+This directory is not under a registered component in the component registry
+(ENC-FTR-041). Tasks that author or execute migrations should tag
+`comp-neo4j-backup` as the semantic Neo4j-schema steward, or `comp-graph-sync`
+when the migration is paired with a `graph_sync` Lambda change.


### PR DESCRIPTION
## Summary

Creates a first Cypher migration at `tools/neo4j-migrations/001-hnsw-vector-indexes-governed-records.cypher` that adds six native Neo4j HNSW vector indexes (Task, Issue, Feature, Plan, Lesson, Document) with 256 dimensions and cosine similarity on the `embedding` property. This is the Phase 1 Hybrid Retrieval prerequisite mandated by ENC-TSK-B62 AC-2.

Extends `tools/backfill_graph.py` with two no-backfill helper flags so a privileged terminal session can apply and verify the migration without pulling the DynamoDB corpus:

- `--run-migration <file.cypher>` — applies the migration against the connected AuraDB.
- `--verify-vector-indexes` — runs `SHOW VECTOR INDEXES` and logs each index's name, state, labels, properties, dimensions, and similarity function.

Both flags reuse the existing Secrets Manager and `neo4j` driver plumbing and exit without touching the tracker table.

## Design decisions

- **Per-label granularity** over an umbrella `:Record` label. Six native vector indexes instead of one, but zero `graph_sync` code change, zero `governance_data_dictionary.json` bump, and zero strictness upgrade. An umbrella label would require projecting `:Record` alongside each primary label in `graph_sync._upsert_node`, which is a Lambda deploy with a dictionary-guard trigger.
- **Scope**: Task, Issue, Feature, Plan, Lesson, Document. `Generation` (GMF metadata, not part of the retrieval corpus), `Project` (side node), and `DeploymentDecision` (placeholder-only today) are intentionally excluded.
- **Idempotent**: every statement uses `IF NOT EXISTS`. Safe to re-run.
- **Dimension contract**: 256 per B62 AC-2. The B91 backfill worker must invoke `amazon.titan-embed-text-v2:0` with `dimensions=256`; any mismatch leaves the indexes live but unused.

## Execution model

Indexes are a live-infrastructure change against the shared prod+gamma AuraDB (both `devops-graph-sync` and `devops-graph-sync-gamma` resolve `NEO4J_SECRET_NAME=enceladus/neo4j/auradb-credentials`). Vector indexes are non-disruptive — they do not affect existing queries until something calls `db.index.vector.queryNodes(...)`. A recent B85 S3 backup is on disk (`s3://jreese-net/gamma/neo4j-backups/2026/04/03/neo4j-snapshot-20260403T224425Z.json`, EventBridge rule enabled).

The agent session that authored this PR cannot execute Cypher against AuraDB — its IAM explicitly denies `secretsmanager:GetSecretValue` on the Neo4j credentials and `lambda:InvokeFunction` on all graph Lambdas. After merge, a privileged terminal session is expected to run:

```bash
AWS_PROFILE=product-lead \
NEO4J_SECRET_NAME=enceladus/neo4j/auradb-credentials \
python3 tools/backfill_graph.py --region us-west-2 \
  --run-migration tools/neo4j-migrations/001-hnsw-vector-indexes-governed-records.cypher \
  --verify-vector-indexes
```

The captured `SHOW VECTOR INDEXES` output will be stamped onto ENC-TSK-B90 AC-2 evidence, at which point the deploy-success gate can be satisfied and the task closed.

## Test plan

- [x] `python3 -m py_compile tools/backfill_graph.py` passes.
- [x] `python3 tools/backfill_graph.py --help` lists the two new flags.
- [x] Migration file parses into exactly six statements via the in-module Cypher splitter.
- [x] `tools/check_governance_dictionary_sync.py --base origin/main --head HEAD` reports "No schema-affecting files changed" (no Lambda touched, no dictionary bump required).
- [ ] Post-merge: privileged terminal session runs `--run-migration` and `--verify-vector-indexes`; six indexes land in state `ONLINE` with dim=256, sim=`cosine`.

## References

- Parent task: ENC-TSK-B62 (Phase 1 Gate — Hybrid Retrieval + Graph Projection Expansion)
- Task: ENC-TSK-B90
- Sibling (closed): ENC-TSK-B89 (graph_sync projection fix), ENC-TSK-B93 (GDS algorithm evaluation)
- Plan: ENC-PLN-006

CCI-5ee8ccb97b06421dbc73d48d79fecfc3