### PR TITLE
feat(graph_sync): incremental Titan V2 embedding on record mutation (ENC-TSK-B94)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-15.2",
-  "updated_at": "2026-04-15T07:45:00Z",
-  "last_change_summary": "ENC-TSK-B89: Added lesson record-body edge projection to graph_sync. tracker.lesson entity description now references the graph_projection contract; evidence_chain and extensions fields annotated with graph_projection stanzas documenting the LEARNED_FROM edge emission via _infer_label_from_id + placeholder MERGE pattern (same as ENC-TSK-E01 plan/document branch). Prior to B89, lesson records produced zero LEARNED_FROM edges from record-body (only rel# typed-relationship items projected via _upsert_relationship_edge), leaving every lesson with exactly one graph edge (BELONGS_TO->Project) and zero relationship neighbors. See ENC-ISS-189 for the canonical legacy-ID manifestation.",
+  "version": "2026-04-15.3",
+  "updated_at": "2026-04-15T08:20:00Z",
+  "last_change_summary": "ENC-TSK-B94: Added incremental Titan V2 embedding to graph_sync. New entity 'neo4j.incremental_embedding' documents the sync-inline embedding contract (model=amazon.titan-embed-text-v2:0, dimensions=256, normalize=true, property=embedding, hash property=embedding_text_hash) and the text-extraction contract shared with ENC-TSK-B91 backfill (title + intent + description + user_story, double-newline joined, deduped, 24KB cap). The graph_sync Lambda now invokes Bedrock inline after node upsert + edge reconciliation, wrapped in try/except so embedding failures never break the primary projection; no-op MODIFY events (status transitions that do not change embedding text) are skipped via hash comparison against the existing node. IAM role devops-graph-sync-lambda-role gained bedrock:InvokeModel on arn:aws:bedrock:us-west-2::foundation-model/amazon.titan-embed-text-v2:0 via deploy.sh put-role-policy. Embedding helpers live at backend/lambda/graph_sync/embedding.py and are colocated with lambda_function.py (packaged by deploy.sh:package_lambda). The ENC-TSK-B91 batch backfill worker MUST import build_embedding_text/hash_embedding_text/compute_embedding_for_record from the same module to guarantee vector parity across the incremental and batch paths.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3265,6 +3265,39 @@
         "restore_strategy": {
           "type": "string",
           "definition": "Primary restore path for Enceladus graph recovery. Backup artifacts serve as audit/reference snapshots; governed recovery uses DynamoDB re-projection via tools/backfill_graph.py with a target rebuild window of under 15 minutes for the current corpus."
+        }
+      }
+    },
+    "neo4j.incremental_embedding": {
+      "description": "Incremental Titan V2 embedding contract for graph_sync (ENC-TSK-B94). Every INSERT/MODIFY DDB stream event for Task/Issue/Feature/Plan/Lesson/Document record types produces a 256-dim Titan V2 embedding that is written to the node's `embedding` property in Neo4j alongside an `embedding_text_hash` used to short-circuit re-embedding on no-op MODIFY events (e.g. status transitions). The embedding is invoked inline on the graph_sync SQS consumer after the node upsert and edge reconciliation steps, wrapped in try/except so Bedrock, IAM, or network failures never break the primary projection. Pairs with ENC-TSK-B90 vector indexes and ENC-TSK-B91 batch backfill; all three must share the text-extraction contract implemented in backend/lambda/graph_sync/embedding.py.",
+      "fields": {
+        "model_contract": {
+          "type": "object",
+          "definition": "Bedrock model invocation parameters: modelId=amazon.titan-embed-text-v2:0, request body {inputText, dimensions: 256, normalize: true}, contentType=application/json. Response body carries 'embedding' as a list of 256 floats. Mandated by ENC-TSK-B62 AC-2 and matched by ENC-TSK-B90 vector index config (256 dims, cosine)."
+        },
+        "text_extraction_contract": {
+          "type": "string",
+          "definition": "embedding.build_embedding_text(record) concatenates title + intent + description + user_story with double-newline separators, stripping blanks and deduping lines, capped at 24,000 chars. Same function used by both the incremental (B94) and batch (B91) paths so vectors from the two sources are comparable. Contract is deliberately narrow (four well-known fields) so it works uniformly across all six embeddable record types without branching."
+        },
+        "embedding_property": {
+          "type": "string",
+          "definition": "Neo4j node property name carrying the 256-float vector. Matches the target property declared by ENC-TSK-B90 migration 001. Constant EMBEDDING_PROPERTY='embedding' in backend/lambda/graph_sync/embedding.py."
+        },
+        "embedding_hash_property": {
+          "type": "string",
+          "definition": "Neo4j node property carrying a 16-char sha256 hex prefix of the embedding input text. Used by graph_sync to skip re-invoking Bedrock when a MODIFY event's title/intent/description/user_story are unchanged from the last embedding. Constant EMBEDDING_HASH_PROPERTY='embedding_text_hash' in backend/lambda/graph_sync/embedding.py."
+        },
+        "iam_contract": {
+          "type": "string",
+          "definition": "Role devops-graph-sync-lambda-role gained bedrock:InvokeModel on Resource arn:aws:bedrock:${REGION}::foundation-model/amazon.titan-embed-text-v2:0 via deploy.sh:ensure_role() put-role-policy Sid=BedrockTitanV2InvokeModel. Same statement applied to gamma role devops-graph-sync-lambda-role-gamma when ENVIRONMENT_SUFFIX is set."
+        },
+        "failure_mode": {
+          "type": "string",
+          "definition": "Any Bedrock, IAM, or parser failure is caught by the try/except wrapper in _process_record() and logged with [ERROR] prefix. The primary node upsert and edge reconciliation steps complete regardless. A future MODIFY event on the same record re-attempts the embedding; eventual consistency is acceptable because the vector index simply ignores nodes without embeddings until they are written."
+        },
+        "no_op_skip": {
+          "type": "string",
+          "definition": "Before invoking Bedrock, graph_sync reads the node's existing embedding_text_hash and compares against a hash of the newly-built input text. If they match, compute_embedding_for_record() returns None and the Bedrock call is skipped. This keeps spend on status-transition heavy workloads (e.g. checkout.advance cycles) bounded to one invocation per record per title/intent/description/user_story change."
         }
       }
     },

--- a/backend/lambda/graph_sync/deploy.sh
+++ b/backend/lambda/graph_sync/deploy.sh
@@ -53,6 +53,14 @@ ensure_role() {
       "Effect": "Allow",
       "Action": ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
       "Resource": "arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${SQS_QUEUE_NAME}"
+    },
+    {
+      "Sid": "BedrockTitanV2InvokeModel",
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": [
+        "arn:aws:bedrock:${REGION}::foundation-model/amazon.titan-embed-text-v2:0"
+      ]
     }
   ]
 }
@@ -78,6 +86,9 @@ package_lambda() {
   fi
 
   cp "${ROOT_DIR}/lambda_function.py" "${build_dir}/"
+  # ENC-TSK-B94: colocated Titan V2 embedding helpers imported by
+  # lambda_function.py. Must be packaged alongside the handler module.
+  cp "${ROOT_DIR}/embedding.py" "${build_dir}/"
 
   python3 -m pip install \
     --quiet \

--- a/backend/lambda/graph_sync/embedding.py
+++ b/backend/lambda/graph_sync/embedding.py
@@ -1,0 +1,238 @@
+"""Amazon Titan V2 incremental embedding helpers for graph_sync (ENC-TSK-B94).
+
+Provides the text-extraction contract, Bedrock client accessor, and
+`amazon.titan-embed-text-v2:0` invocation shape used to populate the
+`embedding` property on Neo4j record nodes. The B91 batch backfill should
+import the SAME helpers to guarantee parity between the continuous (stream)
+and bulk (backfill) paths.
+
+Contract (mandated by ENC-TSK-B62 AC-2 / ENC-TSK-B90):
+  - model_id       = "amazon.titan-embed-text-v2:0"
+  - dimensions     = 256
+  - normalize      = True
+  - property name  = "embedding"
+
+Text contract (shared between B94 incremental and B91 backfill):
+  `build_embedding_text(record)` concatenates the title-first, intent-second,
+  description-third fields with double-newline separators, stripping blanks
+  and deduping lines. The extractor is deliberately conservative: only
+  fields guaranteed to exist across Task/Issue/Feature/Plan/Lesson/Document
+  are consulted. Extending this contract later must be coordinated with
+  B91 so vectors from the two paths remain comparable.
+
+Latency budget notes (sync inline with try/except):
+  - Titan V2 typical invoke time: 150-350ms cold, 80-180ms warm
+  - Batch-1 single-record invocations only (input text size <10KB)
+  - Wrapped in try/except in the caller so Bedrock failure never breaks
+    the primary node+edge projection
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants (shared with B91 backfill)
+# ---------------------------------------------------------------------------
+
+TITAN_MODEL_ID = "amazon.titan-embed-text-v2:0"
+EMBEDDING_DIMENSIONS = 256
+EMBEDDING_NORMALIZE = True
+EMBEDDING_PROPERTY = "embedding"
+EMBEDDING_HASH_PROPERTY = "embedding_text_hash"
+
+# Governed record types that participate in Phase 1 hybrid retrieval.
+# Matches the six labels indexed by B90 migration 001.
+EMBEDDABLE_RECORD_TYPES = {"task", "issue", "feature", "plan", "lesson", "document"}
+
+# Bedrock runtime region. us-west-2 is the canonical Enceladus region;
+# Titan V2 is available in us-west-2 per AWS region coverage.
+BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-west-2")
+
+# Max input text chars. Titan V2 token limit is 8192 tokens (~32KB chars in
+# English). We cap at 24KB to leave safety margin for multi-byte content.
+MAX_INPUT_CHARS = 24_000
+
+# ---------------------------------------------------------------------------
+# Lazy Bedrock runtime client (cold-start cached)
+# ---------------------------------------------------------------------------
+
+_bedrock_runtime = None
+
+
+def get_bedrock_runtime():
+    """Return a lazily-created bedrock-runtime client, cached at module scope."""
+    global _bedrock_runtime
+    if _bedrock_runtime is None:
+        import boto3
+        from botocore.config import Config
+        _bedrock_runtime = boto3.client(
+            "bedrock-runtime",
+            region_name=BEDROCK_REGION,
+            config=Config(
+                retries={"max_attempts": 3, "mode": "standard"},
+                read_timeout=10,
+                connect_timeout=5,
+            ),
+        )
+    return _bedrock_runtime
+
+
+# ---------------------------------------------------------------------------
+# Text extraction (shared with B91 backfill)
+# ---------------------------------------------------------------------------
+
+def build_embedding_text(record: Dict[str, Any]) -> str:
+    """Concatenate the canonical embedding text from a governed record.
+
+    Order: title, intent, description. Each part is stripped, blanks are
+    dropped, and lines are deduped so an accidental title=description copy
+    does not waste context. The returned string is the exact input sent to
+    Titan V2; downstream hashing uses it directly.
+
+    The contract is intentionally narrow (three fields) so it works
+    uniformly across Task/Issue/Feature/Plan/Lesson/Document without
+    record-type branching. B91 backfill MUST call this same function.
+    """
+    if not isinstance(record, dict):
+        return ""
+
+    parts: List[str] = []
+    seen: set = set()
+
+    def _add(val: Any) -> None:
+        if val is None:
+            return
+        text = str(val).strip()
+        if not text:
+            return
+        if text in seen:
+            return
+        seen.add(text)
+        parts.append(text)
+
+    # Title is always first to anchor similarity on the short high-signal
+    # field; intent is second because it captures the "why"; description is
+    # third for bulk semantic content. user_story appended for features.
+    _add(record.get("title"))
+    _add(record.get("intent"))
+    _add(record.get("description"))
+    _add(record.get("user_story"))
+
+    combined = "\n\n".join(parts)
+    if len(combined) > MAX_INPUT_CHARS:
+        combined = combined[:MAX_INPUT_CHARS]
+    return combined
+
+
+def hash_embedding_text(text: str) -> str:
+    """Return a stable short hash of the embedding input text.
+
+    Used to skip re-embedding on no-op MODIFY events (e.g. status transitions
+    that do not change title/intent/description). Stored alongside the
+    embedding as `embedding_text_hash` on the Neo4j node.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Bedrock invocation
+# ---------------------------------------------------------------------------
+
+def invoke_titan_v2(text: str) -> Optional[List[float]]:
+    """Invoke `amazon.titan-embed-text-v2:0` with the Phase 1 contract.
+
+    Returns a 256-float list on success or None on any failure. Callers
+    MUST handle None gracefully (log + skip; never raise).
+    """
+    if not text:
+        return None
+
+    try:
+        client = get_bedrock_runtime()
+    except Exception:
+        logger.exception("[ERROR] Failed to instantiate Bedrock runtime client")
+        return None
+
+    request_body = {
+        "inputText": text,
+        "dimensions": EMBEDDING_DIMENSIONS,
+        "normalize": EMBEDDING_NORMALIZE,
+    }
+
+    try:
+        resp = client.invoke_model(
+            modelId=TITAN_MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(request_body),
+        )
+    except Exception:
+        logger.exception("[ERROR] Bedrock invoke_model failed for model=%s", TITAN_MODEL_ID)
+        return None
+
+    try:
+        payload = json.loads(resp["body"].read())
+    except Exception:
+        logger.exception("[ERROR] Failed to parse Bedrock response body")
+        return None
+
+    embedding = payload.get("embedding")
+    if not isinstance(embedding, list) or len(embedding) != EMBEDDING_DIMENSIONS:
+        logger.error(
+            "[ERROR] Bedrock response missing or malformed 'embedding' "
+            "(type=%s len=%s expected=%d)",
+            type(embedding).__name__,
+            len(embedding) if isinstance(embedding, list) else "n/a",
+            EMBEDDING_DIMENSIONS,
+        )
+        return None
+
+    return embedding
+
+
+# ---------------------------------------------------------------------------
+# Public embedding entry-point for graph_sync
+# ---------------------------------------------------------------------------
+
+def compute_embedding_for_record(
+    record: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Build text, check cache against hash, invoke Titan V2 if needed.
+
+    Returns a dict of {embedding: [...256 floats...], embedding_text_hash: str}
+    when a fresh embedding is produced, or None when nothing should be
+    written (empty text, non-embeddable record, or Bedrock failure).
+
+    The caller supplies the existing hash via the record dict under key
+    `_existing_embedding_hash` to short-circuit no-op MODIFY events. If the
+    hash matches the newly-computed one, this function returns None (skip).
+    """
+    record_type = record.get("record_type", "")
+    if record_type not in EMBEDDABLE_RECORD_TYPES:
+        return None
+
+    text = build_embedding_text(record)
+    if not text:
+        return None
+
+    text_hash = hash_embedding_text(text)
+    existing_hash = record.get("_existing_embedding_hash") or ""
+    if existing_hash and existing_hash == text_hash:
+        # No-op MODIFY: title/intent/description unchanged, skip Bedrock call.
+        return None
+
+    embedding = invoke_titan_v2(text)
+    if embedding is None:
+        return None
+
+    return {
+        EMBEDDING_PROPERTY: embedding,
+        EMBEDDING_HASH_PROPERTY: text_hash,
+    }

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -21,6 +21,7 @@ Edge types: CHILD_OF, RELATED_TO, BELONGS_TO, ADDRESSES, IMPLEMENTS
 Environment variables:
   NEO4J_SECRET_NAME    Secrets Manager secret ID (default: enceladus/neo4j/auradb-credentials)
   SECRETS_REGION       AWS region for Secrets Manager (default: us-west-2)
+  BEDROCK_REGION       AWS region for Bedrock runtime (default: us-west-2)
 """
 
 from __future__ import annotations
@@ -29,6 +30,18 @@ import json
 import logging
 import os
 from typing import Any, Dict, List, Optional
+
+# ENC-TSK-B94: Incremental Titan V2 embedding helpers. build_embedding_text,
+# hash_embedding_text, compute_embedding_for_record, and the model/property
+# constants are the shared contract between this incremental path and the
+# ENC-TSK-B91 backfill path. Keep imports colocated with lambda_function.py
+# so the helper module is packaged automatically by deploy.sh.
+from embedding import (
+    EMBEDDABLE_RECORD_TYPES,
+    EMBEDDING_HASH_PROPERTY,
+    EMBEDDING_PROPERTY,
+    compute_embedding_for_record,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -211,6 +224,44 @@ def _upsert_project_node(tx, project_id: str) -> None:
     tx.run(
         "MERGE (p:Project {project_id: $pid})",
         pid=project_id,
+    )
+
+
+def _read_existing_embedding_hash(tx, label: str, record_id: str) -> str:
+    """Return the current `embedding_text_hash` on the node, or '' if absent.
+
+    Used by the incremental embedding path to short-circuit no-op MODIFY
+    events (e.g. status transitions) without invoking Bedrock when the
+    embedding input text has not changed.
+    """
+    result = tx.run(
+        f"MATCH (n:{label} {{record_id: $rid}}) "
+        f"RETURN n.{EMBEDDING_HASH_PROPERTY} AS h",
+        rid=record_id,
+    )
+    record = result.single()
+    if record is None:
+        return ""
+    hash_val = record.get("h")
+    return str(hash_val) if hash_val is not None else ""
+
+
+def _write_embedding(tx, label: str, record_id: str, payload: Dict[str, Any]) -> None:
+    """Set `embedding` and `embedding_text_hash` on the node.
+
+    Payload is the dict returned by `compute_embedding_for_record`:
+    `{embedding: [256 floats], embedding_text_hash: str}`. The node is
+    assumed to already exist (upserted by `_upsert_node` earlier in the
+    same session); SET on a non-existent match is a no-op and that is
+    acceptable — the next stream event will retry.
+    """
+    tx.run(
+        f"MATCH (n:{label} {{record_id: $rid}}) "
+        f"SET n.{EMBEDDING_PROPERTY} = $embedding, "
+        f"    n.{EMBEDDING_HASH_PROPERTY} = $hash",
+        rid=record_id,
+        embedding=payload[EMBEDDING_PROPERTY],
+        hash=payload[EMBEDDING_HASH_PROPERTY],
     )
 
 
@@ -756,6 +807,44 @@ def _process_record(driver, stream_record: Dict) -> None:
 
             session.execute_write(lambda tx: _upsert_node(tx, record))
             session.execute_write(lambda tx: _reconcile_edges(tx, record))
+
+            # ENC-TSK-B94: Incremental Titan V2 embedding. Runs inline on the
+            # already-async SQS consumer so the user-visible mutation path is
+            # unaffected. Wrapped in try/except so Bedrock, IAM, or vector
+            # model failures NEVER break the primary node + edge projection.
+            # Skip non-embeddable record types (e.g. "generation") fast.
+            if record_type in EMBEDDABLE_RECORD_TYPES:
+                try:
+                    bare = _bare_id(record_id)
+                    label = RECORD_TYPE_TO_LABEL.get(record_type)
+                    existing_hash = session.execute_read(
+                        lambda tx: _read_existing_embedding_hash(tx, label, bare)
+                    )
+                    # Thread the existing hash into the record so the helper
+                    # can short-circuit no-op MODIFY events (e.g. status
+                    # transitions that do not change title/intent/description).
+                    record["_existing_embedding_hash"] = existing_hash
+                    payload = compute_embedding_for_record(record)
+                    if payload is not None:
+                        session.execute_write(
+                            lambda tx: _write_embedding(tx, label, bare, payload)
+                        )
+                        logger.info(
+                            "[INFO] Embedded %s %s (dims=%d, hash=%s)",
+                            record_type, bare, len(payload[EMBEDDING_PROPERTY]),
+                            payload[EMBEDDING_HASH_PROPERTY],
+                        )
+                    else:
+                        logger.info(
+                            "[INFO] Skipped embedding for %s %s (no-op or empty text or bedrock failure)",
+                            record_type, bare,
+                        )
+                except Exception:
+                    logger.exception(
+                        "[ERROR] Incremental embedding failed for %s %s; "
+                        "primary projection preserved",
+                        record_type, record_id,
+                    )
 
         logger.info(
             "[INFO] Synced %s %s (event=%s, project=%s)",


### PR DESCRIPTION
## Summary
- Wires `amazon.titan-embed-text-v2:0` (256 dim, cosine, normalized) into the graph_sync SQS consumer so every INSERT/MODIFY DDB stream event for Task/Issue/Feature/Plan/Lesson/Document records writes a `embedding` property to the corresponding Neo4j node.
- Pairs with ENC-TSK-B90 (HNSW vector indexes merged at aa1b0aa) and the pending ENC-TSK-B91 batch backfill. All three paths share the text-extraction contract in the new `backend/lambda/graph_sync/embedding.py` module.
- IAM role `devops-graph-sync-lambda-role` gains `bedrock:InvokeModel` on the Titan V2 foundation model via `deploy.sh:ensure_role()` (same script-managed IAM pattern as github_integration per ENC-TSK-E03).
- Governance dict bumped to 2026-04-15.3 with new `neo4j.incremental_embedding` entity documenting the model/text/property/IAM/failure-mode/no-op-skip contract (schema-affecting guard trigger).

## Implementation notes
- **Pattern: sync inline with try/except**. graph_sync already runs asynchronously from the user mutation path (DDB Streams -> EventBridge Pipe -> SQS FIFO -> Lambda); the user never waits for graph_sync completion. Adding ~200-400ms Bedrock latency to the SQS consumer is non-user-visible. Failure isolation via try/except preserves the primary node+edge projection regardless of Bedrock outcome.
- **No-op skip**: before invoking Bedrock, graph_sync reads the node's existing `embedding_text_hash` and compares against a hash of the newly-built input text. If they match (e.g. status transitions that do not change title/intent/description/user_story), the Bedrock call is skipped.
- **Shared helper contract**: `build_embedding_text` / `hash_embedding_text` / `compute_embedding_for_record` + constants are the public surface that ENC-TSK-B91 backfill MUST import to guarantee vector parity across the incremental and batch paths.

## Test plan
- [x] Static: `ast.parse` + import + helper smoke tests all pass
- [x] Dictionary JSON validates + new entity present + field count=7
- [x] Governance-dict sync guard passes on diff
- [x] Branch pushed; awaiting auto-triggered Lambda Deploy workflow
- [ ] Post-deploy live validation: create a fresh test task, wait ~5s, verify `size(n.embedding) = 256` via tracker.graphsearch introspection or direct Cypher; confirm re-embedding on title update; clean up

CCI-5ae586975cfc42f090538bb0e6a102c7