### PR TITLE
fix(titan_embedding_backfill): short-circuit gamma UAT probe (ENC-TSK-B91)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-15.4",
-  "updated_at": "2026-04-15T08:35:00Z",
-  "last_change_summary": "ENC-TSK-B91: Added embedding.titan_v2_backfill entity documenting the devops-titan-embedding-backfill Lambda (one-shot full-corpus embedding). Backfill imports build_embedding_text/hash_embedding_text/invoke_titan_v2 from backend/lambda/graph_sync/embedding.py (the canonical module introduced by ENC-TSK-B94) so incremental and batch paths produce identical vectors for identical text. Lambda scans the governed DynamoDB corpus (tracker + documents), invokes amazon.titan-embed-text-v2:0 per record at 256 dim / normalize=true, and writes {embedding, embedding_text_hash} to the per-label Neo4j node. Feeds the HNSW indexes created by ENC-TSK-B90 migration 001. skip_existing flag enables resume-after-throttle via hash comparison. Response payload includes per-label coverage with meets_ac1_threshold (>=95%) for live validation.",
+  "version": "2026-04-15.5",
+  "updated_at": "2026-04-15T08:40:00Z",
+  "last_change_summary": "ENC-TSK-B91 hotfix: Added uat_probe_handler field to embedding.titan_v2_backfill documenting the {rawPath: '/__uat_probe__'} short-circuit added to devops-titan-embedding-backfill.lambda_handler. The first deploy run failed the Gamma Health Gate UAT probe with a 30-second timeout because the Lambda treated the probe as a real invocation. Short-circuit returns a lightweight {status: ok, probe: uat, model_id, dimensions} payload before any DynamoDB scan / Neo4j connect / Bedrock invoke. Pattern is reusable for any scanner-style Lambda that must satisfy tools/gamma_uat_suite.py:check_lambda_invoke without producing side effects. No upstream embedding contract change.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3747,6 +3747,10 @@
         "invocation_contract": {
           "type": "string",
           "definition": "Agent-CLI IAM denies all required scopes; the backfill Lambda must be invoked manually by a product-lead terminal session (io-dev-admin) via `aws lambda invoke --function-name devops-titan-embedding-backfill-gamma --payload '{}' out.json` or EventBridge rule. Follow-on B91 live validation is routed via HANDOFF document pattern identical to ENC-TSK-B90 (DOC-BEFDB681C218)."
+        },
+        "uat_probe_handler": {
+          "type": "object",
+          "definition": "Gamma UAT probe short-circuit (ENC-PLN-020 / ENC-TSK-D19 contract). tools/gamma_uat_suite.py:check_lambda_invoke invokes every Lambda with {rawPath: '/__uat_probe__', requestContext: {http: {method: GET}}, headers: {}} and asserts no FunctionError within a 30-second timeout. The backfill Lambda detects this event shape via _is_uat_probe(event) at the top of lambda_handler and returns {status: ok, probe: uat, handler: lambda_function.lambda_handler, model_id, dimensions, helper_module: 'embedding'} before any DynamoDB scan, Neo4j connection, or Bedrock invoke. Required because a real backfill scan + per-record invoke far exceeds the UAT 30s budget. Pattern is reusable for any scanner-style Lambda that must coexist with the automated UAT health gate."
         }
       }
     }

--- a/backend/lambda/titan_embedding_backfill/lambda_function.py
+++ b/backend/lambda/titan_embedding_backfill/lambda_function.py
@@ -366,9 +366,37 @@ def _coverage_for_label(driver, label: str) -> Dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
+def _is_uat_probe(event: Dict[str, Any]) -> bool:
+    """Return True when the invocation is the gamma UAT health probe.
+
+    The tools/gamma_uat_suite.py Lambda-invoke check (ENC-PLN-020 / ENC-TSK-D19)
+    sends `{"rawPath":"/__uat_probe__","requestContext":{"http":{"method":"GET"}},"headers":{}}`
+    to every deployed Lambda and asserts no FunctionError / ImportModuleError
+    with a 30-second timeout. For a scanner-style Lambda, running the real
+    workflow would always exceed that timeout. Recognise the probe shape and
+    return a lightweight health response so the deploy orchestration gates
+    can validate import + handler wiring without triggering a backfill.
+    """
+    if not isinstance(event, dict):
+        return False
+    return str(event.get("rawPath") or "") == "/__uat_probe__"
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """One-shot backfill entrypoint. See module docstring for event / response."""
     logger.info("[START] Titan V2 backfill invoked event=%s", json.dumps(event or {}))
+
+    # UAT health probe short-circuit (see _is_uat_probe docstring).
+    if _is_uat_probe(event or {}):
+        logger.info("[INFO] UAT probe detected; returning health response without scan")
+        return {
+            "status": "ok",
+            "probe": "uat",
+            "handler": "lambda_function.lambda_handler",
+            "model_id": TITAN_MODEL_ID,
+            "dimensions": EMBEDDING_DIMENSIONS,
+            "helper_module": "embedding",
+        }
 
     started_at = time.time()
     event = event or {}

--- a/backend/lambda/titan_embedding_backfill/test_lambda_function.py
+++ b/backend/lambda/titan_embedding_backfill/test_lambda_function.py
@@ -278,6 +278,30 @@ def test_handler_dry_run_emits_expected_response(monkeypatch):
     assert result["per_label_processed"]["Issue"] == 1
 
 
+def test_handler_uat_probe_short_circuits(monkeypatch):
+    import lambda_function  # noqa: E402
+
+    # Set up a trap: if the handler doesn't short-circuit, _iter_corpus will
+    # be called and this test will fail with a deterministic message.
+    def _trap(*_args, **_kwargs):
+        raise AssertionError("_iter_corpus must NOT be called for UAT probe events")
+
+    monkeypatch.setattr(lambda_function, "_iter_corpus", _trap)
+
+    result = lambda_function.lambda_handler(
+        {
+            "rawPath": "/__uat_probe__",
+            "requestContext": {"http": {"method": "GET"}},
+            "headers": {},
+        },
+        None,
+    )
+    assert result["status"] == "ok"
+    assert result["probe"] == "uat"
+    assert result["model_id"] == "amazon.titan-embed-text-v2:0"
+    assert result["dimensions"] == 256
+
+
 def test_handler_rejects_unknown_label_in_event():
     import lambda_function  # noqa: E402
 


### PR DESCRIPTION
## Summary

Hotfix to ENC-TSK-B91 (PR #325) gamma deploy. The first deploy run succeeded at the gamma deploy step (`devops-titan-embedding-backfill-gamma` is `Active` on AWS) but the post-deploy `Gamma Health Gate` failed with a 30-second invocation timeout.

`tools/gamma_uat_suite.py:check_lambda_invoke` invokes every Lambda with the HTTP-shaped probe event:

```json
{"rawPath":"/__uat_probe__","requestContext":{"http":{"method":"GET"}},"headers":{}}
```

Without short-circuit handling, the backfill Lambda treated the probe as a real invocation and attempted a full DynamoDB scan + Neo4j connection + Bedrock invocations, exceeding the 30s timeout.

## Fix

Add `_is_uat_probe(event)` detector and short-circuit at the top of `lambda_handler` that returns a lightweight payload (`{status: ok, probe: uat, handler, model_id, dimensions, helper_module}`). This satisfies the UAT contract (no FunctionError, no ImportModuleError, fast response) without triggering any backfill side effects.

Test: `test_handler_uat_probe_short_circuits` installs a trap on `_iter_corpus` that fails the test if the handler does not short-circuit. Total: 15/15 pytest cases passing locally.

## Lifecycle

CCI-ce5037dcea3447fc8d5ba00634cdc97d

(Re-using the CCI issued on the original ENC-TSK-B91 commit; B91 task has not yet advanced to deploy-success, so the CCI token is still valid per the checkout service contract.)

Related: ENC-TSK-B91, ENC-TSK-B62, ENC-PLN-006, ENC-PLN-020 (UAT contract).