### PR TITLE
feat(hybrid-retrieval): three-signal scoring in get_compact_context (ENC-TSK-B92)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-15.5",
-  "updated_at": "2026-04-15T08:40:00Z",
-  "last_change_summary": "ENC-TSK-B91 hotfix: Added uat_probe_handler field to embedding.titan_v2_backfill documenting the {rawPath: '/__uat_probe__'} short-circuit added to devops-titan-embedding-backfill.lambda_handler. The first deploy run failed the Gamma Health Gate UAT probe with a 30-second timeout because the Lambda treated the probe as a real invocation. Short-circuit returns a lightweight {status: ok, probe: uat, model_id, dimensions} payload before any DynamoDB scan / Neo4j connect / Bedrock invoke. Pattern is reusable for any scanner-style Lambda that must satisfy tools/gamma_uat_suite.py:check_lambda_invoke without producing side effects. No upstream embedding contract change.",
+  "version": "2026-04-15.6",
+  "updated_at": "2026-04-15T09:05:00Z",
+  "last_change_summary": "ENC-TSK-B92 Phase 1 hybrid retrieval: Added retrieval.hybrid_pipeline entity documenting the three-signal (vector + graph + keyword) Reciprocal Rank Fusion contract delivered by the new `hybrid` search_type in graph_query_api. Extended mcp_server.context_assembly.get_compact_context to note the optional hybrid_retrieval section that fires when `query` or `anchor_record_id` is passed. Backward compatibility: callers not supplying those parameters continue to receive the legacy context shape unchanged. RRF k=60 per ENC-TSK-B62 description; per-relationship-type weight projection per ENC-LSN-029 (IMPLEMENTS > ADDRESSES > RELATED_TO > LEARNED_FROM > CHILD_OF > PLAN_CONTAINS > BELONGS_TO); GDS Personalized PageRank with Cypher fallback when GDS unavailable; FSRS-6 T3 threshold at 0.7 suppresses below-threshold Lessons unless include_below_threshold=true. Query-side embedding uses the same backend/lambda/graph_sync/embedding.py module as incremental (ENC-TSK-B94) and batch (ENC-TSK-B91) index-side embedding to guarantee vector parity.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1556,8 +1556,8 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope.",
-          "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged."
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
           "type": "tool",
@@ -3751,6 +3751,52 @@
         "uat_probe_handler": {
           "type": "object",
           "definition": "Gamma UAT probe short-circuit (ENC-PLN-020 / ENC-TSK-D19 contract). tools/gamma_uat_suite.py:check_lambda_invoke invokes every Lambda with {rawPath: '/__uat_probe__', requestContext: {http: {method: GET}}, headers: {}} and asserts no FunctionError within a 30-second timeout. The backfill Lambda detects this event shape via _is_uat_probe(event) at the top of lambda_handler and returns {status: ok, probe: uat, handler: lambda_function.lambda_handler, model_id, dimensions, helper_module: 'embedding'} before any DynamoDB scan, Neo4j connection, or Bedrock invoke. Required because a real backfill scan + per-record invoke far exceeds the UAT 30s budget. Pattern is reusable for any scanner-style Lambda that must coexist with the automated UAT health gate."
+        }
+      }
+    },
+    "retrieval.hybrid_pipeline": {
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match — fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
+      "fields": {
+        "rrf_k": {
+          "type": "integer",
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
+        },
+        "signals": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Three signals contributing ranks to the RRF fusion: 'vector' (Neo4j db.index.vector.queryNodes per-label HNSW indexes from B90, query embedding via the same backend/lambda/graph_sync/embedding.py invoke_titan_v2 helper used by index-side embedding to guarantee vector parity), 'graph' (Personalized PageRank via gds.pageRank.stream with sourceNodes=[anchor], dampingFactor=0.85, maxIterations=25; Cypher fallback when GDS is unavailable), 'keyword' (case-insensitive title/intent/description CONTAINS with weighted scoring 3/2/1)."
+        },
+        "graph_edge_weights": {
+          "type": "object",
+          "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+        },
+        "fallback_modes": {
+          "type": "object",
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+        },
+        "fsrs_t3_threshold": {
+          "type": "number",
+          "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
+        },
+        "gds_availability_probe": {
+          "type": "object",
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise."
+        },
+        "iam_contract": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "graph_query_api Lambda role gains bedrock:InvokeModel on arn:aws:bedrock:us-west-2::foundation-model/amazon.titan-embed-text-v2:0 (Sid=BedrockTitanV2InvokeModel) in addition to the existing CloudWatchLogs and SecretsManagerNeo4j scopes. Required for query-side Titan V2 embedding. Same scope graph_sync (ENC-TSK-B94) and titan_embedding_backfill (ENC-TSK-B91) already hold."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "GET /api/v1/tracker/graphsearch?search_type=hybrid response includes the existing nodes/edges/paths/summary/query_cypher/duration_ms fields plus: signal_availability {vector,graph,keyword: bool}, graph_algorithm ('ppr_gds'|'cypher_fallback'|'unavailable'), rrf_k, embedding_coverage_sample {covered, total_ranked}, per_node_fusion {record_id: {fused_rank, fused_score, per_signal_ranks}}, fsrs_t3_threshold, include_below_threshold. The MCP server propagates these into get_compact_context.result.hybrid_retrieval verbatim."
+        },
+        "context_assembly_integration": {
+          "type": "string",
+          "definition": "get_compact_context auto-invokes hybrid retrieval when callers pass `query` and/or `anchor_record_id`. For record-oriented modes the anchor defaults to the record_id. project_id is inferred from args, then the assembled record_context, then by parsing the anchor record_id prefix. Result lives at context['hybrid_retrieval']. Set include_hybrid_retrieval=false to force-disable. Failures append a warning and never break the legacy context payload."
         }
       }
     }

--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -49,6 +49,12 @@ ensure_role() {
       "Effect": "Allow",
       "Action": ["secretsmanager:GetSecretValue"],
       "Resource": "arn:aws:secretsmanager:${REGION}:${ACCOUNT_ID}:secret:enceladus/neo4j/auradb-credentials*"
+    },
+    {
+      "Sid": "BedrockTitanV2InvokeModel",
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": "arn:aws:bedrock:${REGION}::foundation-model/amazon.titan-embed-text-v2:0"
     }
   ]
 }
@@ -91,6 +97,11 @@ package_lambda() {
   fi
 
   cp "${ROOT_DIR}/lambda_function.py" "${build_dir}/"
+  # ENC-TSK-B92: include the canonical embedding helper from graph_sync so
+  # query-side embeddings share the exact text/model contract (dimensions=256,
+  # normalize=true, title+intent+description extraction) used by the indexed
+  # node embeddings (ENC-TSK-B94 / ENC-TSK-B91).
+  cp "${ROOT_DIR}/../graph_sync/embedding.py" "${build_dir}/embedding.py"
 
   python3 -m pip install \
     --quiet \

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -8,6 +8,10 @@ Search types:
   - neighbors: All nodes within N hops via any edge type
   - path: Shortest path between two record_ids
   - keyword: Full-text title match + immediate neighbors
+  - hybrid:   ENC-TSK-B92 Phase 1 three-signal hybrid scoring
+              (vector cosine via HNSW + graph PPR/fallback + keyword) combined
+              with Reciprocal Rank Fusion (k=60). Backward-compat fallback
+              when embeddings are sparse or GDS unavailable.
 
 Auth: Cognito JWT cookie OR X-Coordination-Internal-Key header.
 
@@ -18,6 +22,7 @@ Environment variables:
   COGNITO_CLIENT_ID           Cognito client ID
   CORS_ORIGIN                 CORS allowed origin (default: https://jreese.net)
   COORDINATION_INTERNAL_API_KEY  Internal API key for service-to-service auth
+  BEDROCK_REGION              AWS region for Bedrock (default: us-west-2)
 """
 
 from __future__ import annotations
@@ -46,7 +51,58 @@ MAX_DEPTH = 5
 MAX_RESULTS = 100
 QUERY_TIMEOUT_SECONDS = 10
 
-VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword"}
+VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword", "hybrid"}
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-B92 Phase 1 hybrid retrieval constants
+# ---------------------------------------------------------------------------
+
+# Reciprocal Rank Fusion exponent offset (per ENC-TSK-B62 description).
+# score = Σ 1 / (RRF_K + rank_i) over signals where the record appears.
+RRF_K = 60
+
+# Per-signal top-N depth to consider when fusing ranks.
+HYBRID_SIGNAL_TOP_N = 25
+
+# Per-relationship-type weights for the graph PPR / fallback signal.
+# Order per LSN-029 / B93: IMPLEMENTS > ADDRESSES > RELATED_TO > LEARNED_FROM
+# > CHILD_OF > PLAN_CONTAINS > BELONGS_TO. Weights are multiplicative on the
+# PPR edge contribution and identical across fallback edge-walk scoring.
+GRAPH_EDGE_WEIGHTS: Dict[str, float] = {
+    "IMPLEMENTS": 1.00,
+    "ADDRESSES": 0.90,
+    "RELATED_TO": 0.75,
+    "LEARNED_FROM": 0.70,
+    "CHILD_OF": 0.60,
+    "PLAN_CONTAINS": 0.55,
+    "BELONGS_TO": 0.30,
+}
+GRAPH_FALLBACK_DEFAULT_WEIGHT = 0.40
+
+# Per-label HNSW index name template (matches B90 migration 001).
+LABEL_VECTOR_INDEXES: Dict[str, str] = {
+    "Task": "governed_task_embedding",
+    "Issue": "governed_issue_embedding",
+    "Feature": "governed_feature_embedding",
+    "Plan": "governed_plan_embedding",
+    "Lesson": "governed_lesson_embedding",
+    "Document": "governed_document_embedding",
+}
+
+# FSRS-6 retrieval-invisible threshold for Lesson records (B62 scope item #4).
+# Lessons with stability S < T3 are suppressed from default context unless the
+# caller passes include_below_threshold=true. The canonical FSRS-6 field name
+# is "stability"; fallback to resonance_score when stability is absent
+# (pre-FSRS-6 lesson records), matching the ENC-LSN-029 scoring convention.
+FSRS_T3_THRESHOLD = 0.7
+
+# Graph damping factor per LSN-029 implementation contract.
+PPR_DAMPING_FACTOR = 0.85
+PPR_MAX_ITERATIONS = 25
+
+# Cache the GDS availability probe so every hybrid call does not re-probe.
+_GDS_PROBE_CACHE_TTL_SECONDS = 300
+_gds_probe_state: Dict[str, Any] = {"checked_at": 0.0, "available": None}
 
 # ---------------------------------------------------------------------------
 # Lazy singletons
@@ -438,11 +494,661 @@ def _query_keyword(driver, project_id: str, params: Dict) -> Dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-B92 Phase 1: Three-signal hybrid retrieval
+# ---------------------------------------------------------------------------
+# Implements vector (HNSW cosine) + graph (PPR or Cypher fallback) + keyword
+# (full-text title/description) ranking, combined via Reciprocal Rank Fusion
+# (k=60). Backward-compatible: when target records lack embeddings the vector
+# rank is empty and RRF degrades to graph + keyword only. When GDS is not
+# available, graph signal degrades to native-Cypher edge-walk scoring using
+# per-relationship-type weights per LSN-029.
+#
+# FSRS-6 Lesson post-filter (B62 scope #3/#4): Lessons below the T3 retrieval-
+# invisible threshold (stability < 0.7) are suppressed from the fused result
+# unless include_below_threshold=true is passed.
+
+
+def _check_gds_available(driver) -> bool:
+    """Probe gamma AuraDB for the GDS plugin. Cached for 5 minutes.
+
+    Returns True if CALL gds.list() succeeds; False otherwise. Never raises.
+    """
+    import time as _time
+    now = _time.time()
+    if (
+        _gds_probe_state["available"] is not None
+        and (now - _gds_probe_state["checked_at"]) < _GDS_PROBE_CACHE_TTL_SECONDS
+    ):
+        return bool(_gds_probe_state["available"])
+
+    available = False
+    try:
+        with driver.session() as session:
+            session.run("CALL gds.list() YIELD name RETURN name LIMIT 1").consume()
+        available = True
+    except Exception as exc:
+        logger.info("[INFO] GDS plugin not available on AuraDB: %s", exc)
+        available = False
+
+    _gds_probe_state["checked_at"] = now
+    _gds_probe_state["available"] = available
+    return available
+
+
+def _compute_query_embedding(query_text: str) -> Optional[List[float]]:
+    """Invoke Titan V2 via the canonical graph_sync/embedding.py contract.
+
+    Import is deferred so the module can be packaged into the Lambda zip by
+    deploy.sh alongside the lambda_function.py entry point.
+    """
+    try:
+        import embedding as _embedding
+    except Exception:
+        logger.warning("[WARNING] embedding module unavailable — vector signal will be empty")
+        return None
+    try:
+        return _embedding.invoke_titan_v2(query_text)
+    except Exception:
+        logger.exception("[ERROR] query embedding failed")
+        return None
+
+
+def _hybrid_vector_ranks(
+    driver,
+    project_id: str,
+    query_embedding: List[float],
+    k_per_label: int,
+    record_type_filter: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Query each per-label HNSW index and return a merged ranked list.
+
+    Returns a list of {record_id, score, label, rank} dicts sorted by score
+    desc. Each label contributes up to k_per_label candidates; duplicates
+    (same record_id across labels) are kept by highest score.
+    """
+    # Scope to a single label when record_type is set.
+    if record_type_filter:
+        label = record_type_filter.capitalize()
+        labels_to_query = [label] if label in LABEL_VECTOR_INDEXES else []
+    else:
+        labels_to_query = list(LABEL_VECTOR_INDEXES.keys())
+
+    by_rid: Dict[str, Dict[str, Any]] = {}
+    for label in labels_to_query:
+        index_name = LABEL_VECTOR_INDEXES[label]
+        cypher = (
+            "CALL db.index.vector.queryNodes($index_name, $k, $query_embedding) "
+            "YIELD node, score "
+            "WHERE node.project_id = $project_id "
+            "RETURN node.record_id AS rid, score, labels(node) AS labels"
+        )
+        try:
+            with driver.session() as session:
+                result = session.run(
+                    cypher,
+                    index_name=index_name,
+                    k=k_per_label,
+                    query_embedding=query_embedding,
+                    project_id=project_id,
+                )
+                for rec in result:
+                    rid = rec.get("rid")
+                    if not rid:
+                        continue
+                    score = float(rec.get("score") or 0.0)
+                    prev = by_rid.get(rid)
+                    if prev is None or score > prev["score"]:
+                        by_rid[rid] = {
+                            "record_id": rid,
+                            "score": score,
+                            "label": label,
+                        }
+        except Exception as exc:
+            # Index missing or unreachable — log and continue with other labels.
+            logger.warning("[WARNING] vector index %s query failed: %s", index_name, exc)
+
+    ranked = sorted(by_rid.values(), key=lambda d: d["score"], reverse=True)
+    for idx, item in enumerate(ranked, start=1):
+        item["rank"] = idx
+    return ranked
+
+
+def _hybrid_graph_ranks_gds(
+    driver,
+    project_id: str,
+    anchor_record_id: str,
+    top_n: int,
+) -> List[Dict[str, Any]]:
+    """Personalized PageRank via GDS per LSN-029 contract.
+
+    Uses gds.pageRank.stream with the anchor record as the personalization
+    source, damping=0.85, maxIterations=25, per-relationship-type weight
+    projection. Never persists state (no gds.pageRank.write).
+    """
+    # Build a named graph projection on the fly. Projection name is scoped to
+    # the anchor + project to avoid cross-query collisions. GDS auto-cleans
+    # anonymous projections; we'll still drop on completion for safety.
+    projection_name = f"hybrid_{project_id}_{anchor_record_id}".replace("-", "_").lower()
+
+    # Build the edge-weight CASE for per-type weights.
+    weight_case_parts = []
+    for edge_type, weight in GRAPH_EDGE_WEIGHTS.items():
+        weight_case_parts.append(f"WHEN '{edge_type}' THEN {weight}")
+    weight_case_sql = (
+        "CASE type(r) " + " ".join(weight_case_parts)
+        + f" ELSE {GRAPH_FALLBACK_DEFAULT_WEIGHT} END"
+    )
+
+    edge_union = "|".join(list(GRAPH_EDGE_WEIGHTS.keys()))
+
+    ranked: List[Dict[str, Any]] = []
+    try:
+        with driver.session() as session:
+            # Drop any prior projection with this name.
+            session.run(
+                f"CALL gds.graph.exists($name) YIELD exists "
+                f"WITH exists WHERE exists "
+                f"CALL gds.graph.drop($name) YIELD graphName RETURN graphName",
+                name=projection_name,
+            ).consume()
+
+            # Create the projection with weighted edges.
+            session.run(
+                f"""
+                MATCH (src) WHERE src.project_id = $project_id
+                OPTIONAL MATCH (src)-[r:{edge_union}]->(tgt)
+                WHERE tgt IS NOT NULL AND tgt.project_id = $project_id
+                WITH gds.graph.project(
+                    $name,
+                    src,
+                    tgt,
+                    {{relationshipProperties: {{weight: {weight_case_sql}}}}}
+                ) AS g
+                RETURN g.graphName
+                """,
+                name=projection_name,
+                project_id=project_id,
+            ).consume()
+
+            # Resolve the anchor node id.
+            anchor_rec = session.run(
+                "MATCH (a) WHERE a.record_id = $rid AND a.project_id = $project_id "
+                "RETURN id(a) AS nodeId LIMIT 1",
+                rid=anchor_record_id,
+                project_id=project_id,
+            ).single()
+            if anchor_rec is None or anchor_rec.get("nodeId") is None:
+                return []
+
+            result = session.run(
+                """
+                CALL gds.pageRank.stream(
+                    $name,
+                    {
+                        sourceNodes: [$anchorId],
+                        dampingFactor: $damping,
+                        maxIterations: $maxIter,
+                        relationshipWeightProperty: 'weight'
+                    }
+                )
+                YIELD nodeId, score
+                RETURN gds.util.asNode(nodeId).record_id AS rid, score
+                ORDER BY score DESC
+                LIMIT $limit
+                """,
+                name=projection_name,
+                anchorId=anchor_rec["nodeId"],
+                damping=PPR_DAMPING_FACTOR,
+                maxIter=PPR_MAX_ITERATIONS,
+                limit=top_n,
+            )
+            for idx, rec in enumerate(result, start=1):
+                rid = rec.get("rid")
+                if not rid or rid == anchor_record_id:
+                    continue
+                ranked.append({
+                    "record_id": rid,
+                    "score": float(rec.get("score") or 0.0),
+                    "rank": idx,
+                })
+
+            # Clean up projection.
+            session.run(
+                "CALL gds.graph.drop($name, false) YIELD graphName RETURN graphName",
+                name=projection_name,
+            ).consume()
+    except Exception as exc:
+        logger.warning("[WARNING] GDS PPR query failed: %s — falling back to Cypher", exc)
+        return []
+
+    return ranked
+
+
+def _hybrid_graph_ranks_cypher_fallback(
+    driver,
+    project_id: str,
+    anchor_record_id: str,
+    top_n: int,
+) -> List[Dict[str, Any]]:
+    """Fallback graph-signal scoring using native Cypher weighted hop sum.
+
+    Approximates PPR by summing per-relationship-type weights across the
+    shortest accumulation of hops from the anchor within depth 3. Each
+    neighbor's score = Σ hop_weight * decay^distance over all edges reaching
+    it from the anchor (capped).
+    """
+    edge_union = "|".join(list(GRAPH_EDGE_WEIGHTS.keys()))
+    # Decay factor across hop distance — mimics the damping behavior of PPR.
+    decay = PPR_DAMPING_FACTOR
+
+    # Cypher-side weight CASE for edge types.
+    weight_case_parts = []
+    for edge_type, weight in GRAPH_EDGE_WEIGHTS.items():
+        weight_case_parts.append(f"WHEN '{edge_type}' THEN {weight}")
+    weight_case_sql = (
+        "CASE type(rel) " + " ".join(weight_case_parts)
+        + f" ELSE {GRAPH_FALLBACK_DEFAULT_WEIGHT} END"
+    )
+
+    cypher = (
+        f"MATCH path = (anchor)-[:{edge_union}*1..3]-(neighbor) "
+        f"WHERE anchor.record_id = $rid AND anchor.project_id = $project_id "
+        f"AND neighbor.project_id = $project_id "
+        f"AND neighbor.record_id <> $rid "
+        f"WITH neighbor, path, "
+        f"  reduce(s = 0.0, rel IN relationships(path) | s + {weight_case_sql}) "
+        f"  * ({decay} ^ length(path)) AS path_score "
+        f"WITH neighbor.record_id AS rid, sum(path_score) AS score "
+        f"RETURN rid, score ORDER BY score DESC LIMIT $limit"
+    )
+    ranked: List[Dict[str, Any]] = []
+    try:
+        with driver.session() as session:
+            result = session.run(
+                cypher, rid=anchor_record_id, project_id=project_id, limit=top_n,
+            )
+            for idx, rec in enumerate(result, start=1):
+                rid = rec.get("rid")
+                if not rid:
+                    continue
+                ranked.append({
+                    "record_id": rid,
+                    "score": float(rec.get("score") or 0.0),
+                    "rank": idx,
+                })
+    except Exception:
+        logger.exception("[ERROR] Cypher fallback graph-signal scoring failed")
+        return []
+    return ranked
+
+
+def _hybrid_keyword_ranks(
+    driver,
+    project_id: str,
+    query_text: str,
+    top_n: int,
+    record_type_filter: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Keyword signal via case-insensitive title/description/intent contains.
+
+    Uses a scoring tiebreaker: title match scores higher than description
+    match. Graceful when the fulltext index is absent — falls back to
+    CONTAINS which is correct (though slower) on a <1k-node corpus.
+    """
+    if not query_text:
+        return []
+
+    label_filter = ""
+    if record_type_filter:
+        label_map = {
+            "task": "Task",
+            "issue": "Issue",
+            "feature": "Feature",
+            "plan": "Plan",
+            "lesson": "Lesson",
+            "document": "Document",
+        }
+        label = label_map.get(record_type_filter.lower())
+        if label:
+            label_filter = f":{label}"
+
+    cypher = (
+        f"MATCH (n{label_filter}) "
+        "WHERE n.project_id = $project_id "
+        "AND ("
+        "  toLower(coalesce(n.title, '')) CONTAINS toLower($q) OR "
+        "  toLower(coalesce(n.intent, '')) CONTAINS toLower($q) OR "
+        "  toLower(coalesce(n.description, '')) CONTAINS toLower($q)"
+        ") "
+        "WITH n, "
+        "  CASE WHEN toLower(coalesce(n.title, '')) CONTAINS toLower($q) THEN 3.0 ELSE 0.0 END + "
+        "  CASE WHEN toLower(coalesce(n.intent, '')) CONTAINS toLower($q) THEN 2.0 ELSE 0.0 END + "
+        "  CASE WHEN toLower(coalesce(n.description, '')) CONTAINS toLower($q) THEN 1.0 ELSE 0.0 END "
+        "  AS score "
+        "WHERE score > 0.0 "
+        "RETURN n.record_id AS rid, score ORDER BY score DESC LIMIT $limit"
+    )
+    ranked: List[Dict[str, Any]] = []
+    try:
+        with driver.session() as session:
+            result = session.run(cypher, project_id=project_id, q=query_text, limit=top_n)
+            for idx, rec in enumerate(result, start=1):
+                rid = rec.get("rid")
+                if not rid:
+                    continue
+                ranked.append({
+                    "record_id": rid,
+                    "score": float(rec.get("score") or 0.0),
+                    "rank": idx,
+                })
+    except Exception:
+        logger.exception("[ERROR] keyword signal scoring failed")
+        return []
+    return ranked
+
+
+def _rrf_fuse(
+    signals: Dict[str, List[Dict[str, Any]]],
+    k: int = RRF_K,
+) -> List[Dict[str, Any]]:
+    """Reciprocal Rank Fusion across named signals.
+
+    Each signal contributes 1/(k + rank) to a record's fused score. Records
+    not present in a signal contribute 0 from that signal (no-contribution).
+    Returns a sorted list of {record_id, fused_score, per_signal_ranks} dicts.
+    """
+    fused: Dict[str, Dict[str, Any]] = {}
+    for signal_name, items in signals.items():
+        for item in items:
+            rid = item.get("record_id")
+            rank = item.get("rank")
+            if not rid or rank is None:
+                continue
+            entry = fused.setdefault(
+                rid,
+                {
+                    "record_id": rid,
+                    "fused_score": 0.0,
+                    "per_signal_ranks": {},
+                    "per_signal_scores": {},
+                },
+            )
+            entry["fused_score"] += 1.0 / (k + rank)
+            entry["per_signal_ranks"][signal_name] = rank
+            entry["per_signal_scores"][signal_name] = item.get("score")
+    ordered = sorted(fused.values(), key=lambda d: d["fused_score"], reverse=True)
+    for idx, item in enumerate(ordered, start=1):
+        item["fused_rank"] = idx
+    return ordered
+
+
+def _fetch_nodes_by_record_ids(
+    driver,
+    project_id: str,
+    record_ids: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Bulk-fetch full node payloads for a list of record_ids. Single query."""
+    if not record_ids:
+        return {}
+    cypher = (
+        "MATCH (n) WHERE n.project_id = $project_id "
+        "AND n.record_id IN $rids RETURN n"
+    )
+    out: Dict[str, Dict[str, Any]] = {}
+    try:
+        with driver.session() as session:
+            result = session.run(cypher, project_id=project_id, rids=record_ids)
+            for rec in result:
+                nd = _node_to_dict(rec["n"])
+                rid = nd.get("record_id")
+                if rid:
+                    out[rid] = nd
+    except Exception:
+        logger.exception("[ERROR] bulk node fetch failed")
+    return out
+
+
+def _apply_fsrs_t3_filter(
+    nodes: List[Dict[str, Any]],
+    include_below_threshold: bool,
+    t3: float = FSRS_T3_THRESHOLD,
+) -> List[Dict[str, Any]]:
+    """Suppress Lessons with stability < T3 unless include_below_threshold.
+
+    Reads `stability` when present (canonical FSRS-6 field); falls back to
+    `resonance_score` (pre-FSRS-6 Lesson convention, per LSN-029). Tags each
+    Lesson node with a `_below_t3` marker so callers can see what was
+    filtered.
+    """
+    if include_below_threshold:
+        # Still tag the nodes so the caller can distinguish.
+        for node in nodes:
+            labels = node.get("_labels") or []
+            if "Lesson" in labels:
+                s = node.get("stability")
+                if s is None:
+                    s = node.get("resonance_score")
+                node["_fsrs_stability"] = s
+                node["_below_t3"] = bool(s is not None and float(s) < t3)
+        return nodes
+
+    filtered: List[Dict[str, Any]] = []
+    for node in nodes:
+        labels = node.get("_labels") or []
+        if "Lesson" in labels:
+            s = node.get("stability")
+            if s is None:
+                s = node.get("resonance_score")
+            try:
+                s_val = float(s) if s is not None else None
+            except (TypeError, ValueError):
+                s_val = None
+            node["_fsrs_stability"] = s_val
+            if s_val is not None and s_val < t3:
+                node["_below_t3"] = True
+                continue
+            node["_below_t3"] = False
+        filtered.append(node)
+    return filtered
+
+
+def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
+    """Phase 1 hybrid retrieval: vector + graph + keyword fused via RRF.
+
+    Query parameters:
+      query            Text query (required for vector + keyword signals).
+      anchor_record_id Graph anchor node (required for graph signal).
+      record_type      Optional filter (task/issue/feature/plan/lesson/document).
+      top_n            Final result count (default 20, max 50).
+      include_below_threshold  When "true", includes Lessons below T3.
+
+    Response contract:
+      {
+        "nodes":             [...ordered by fused score...],
+        "edges":             [],
+        "paths":             [],
+        "summary":           "Hybrid: N nodes (vector=V, graph=G, keyword=K)",
+        "query_cypher":      "<hybrid-multi-query marker>",
+        "signal_availability": {vector: bool, graph: bool, keyword: bool},
+        "graph_algorithm":   "ppr_gds" | "cypher_fallback" | "unavailable",
+        "rrf_k":             60,
+        "embedding_coverage_sample": {covered: N, total_ranked: N},
+        "per_node_fusion":   {record_id: {fused_rank, per_signal_ranks}}
+      }
+    """
+    query_text = str(params.get("query", "")).strip()
+    anchor_record_id = str(params.get("anchor_record_id", "")).strip()
+    record_type_filter = params.get("record_type") or None
+    try:
+        top_n = int(params.get("top_n", 20))
+    except (TypeError, ValueError):
+        top_n = 20
+    top_n = max(1, min(top_n, 50))
+    include_below_threshold = str(params.get("include_below_threshold", "")).lower() == "true"
+
+    # At least one of query or anchor_record_id is required.
+    if not query_text and not anchor_record_id:
+        return {"error": "hybrid search requires at least one of: query, anchor_record_id"}
+
+    # ---- Vector signal -----------------------------------------------------
+    vector_ranks: List[Dict[str, Any]] = []
+    vector_available = False
+    if query_text:
+        query_embedding = _compute_query_embedding(query_text)
+        if query_embedding is not None:
+            vector_ranks = _hybrid_vector_ranks(
+                driver,
+                project_id,
+                query_embedding,
+                k_per_label=HYBRID_SIGNAL_TOP_N,
+                record_type_filter=record_type_filter,
+            )
+            vector_available = True
+        else:
+            logger.info("[INFO] vector signal skipped — embedding computation unavailable")
+
+    # ---- Graph signal ------------------------------------------------------
+    graph_ranks: List[Dict[str, Any]] = []
+    graph_available = False
+    graph_algorithm = "unavailable"
+    if anchor_record_id:
+        if _check_gds_available(driver):
+            graph_ranks = _hybrid_graph_ranks_gds(
+                driver, project_id, anchor_record_id, top_n=HYBRID_SIGNAL_TOP_N,
+            )
+            if graph_ranks:
+                graph_algorithm = "ppr_gds"
+                graph_available = True
+        # Fall back to Cypher if GDS unavailable OR returned empty.
+        if not graph_available:
+            graph_ranks = _hybrid_graph_ranks_cypher_fallback(
+                driver, project_id, anchor_record_id, top_n=HYBRID_SIGNAL_TOP_N,
+            )
+            if graph_ranks:
+                graph_algorithm = "cypher_fallback"
+                graph_available = True
+
+    # ---- Keyword signal ----------------------------------------------------
+    keyword_ranks: List[Dict[str, Any]] = []
+    keyword_available = False
+    if query_text:
+        keyword_ranks = _hybrid_keyword_ranks(
+            driver,
+            project_id,
+            query_text,
+            top_n=HYBRID_SIGNAL_TOP_N,
+            record_type_filter=record_type_filter,
+        )
+        keyword_available = bool(keyword_ranks)
+
+    # ---- RRF fusion --------------------------------------------------------
+    signals: Dict[str, List[Dict[str, Any]]] = {}
+    if vector_ranks:
+        signals["vector"] = vector_ranks
+    if graph_ranks:
+        signals["graph"] = graph_ranks
+    if keyword_ranks:
+        signals["keyword"] = keyword_ranks
+
+    if not signals:
+        return {
+            "nodes": [],
+            "edges": [],
+            "paths": [],
+            "summary": "No signals returned candidates. "
+                       "(vector=0, graph=0, keyword=0) — try a broader query or verify anchor is in the graph.",
+            "query_cypher": "hybrid/no-signals",
+            "signal_availability": {
+                "vector": vector_available,
+                "graph": graph_available,
+                "keyword": keyword_available,
+            },
+            "graph_algorithm": graph_algorithm,
+            "rrf_k": RRF_K,
+        }
+
+    fused = _rrf_fuse(signals, k=RRF_K)
+    # Cap to top_n + generous buffer so FSRS-6 T3 suppression doesn't starve results.
+    fetch_size = min(len(fused), top_n * 3)
+    top_fused = fused[:fetch_size]
+
+    # ---- Resolve full node payloads ---------------------------------------
+    top_rids = [item["record_id"] for item in top_fused]
+    node_by_rid = _fetch_nodes_by_record_ids(driver, project_id, top_rids)
+
+    # Ordered list of nodes matching the fused ranking.
+    nodes: List[Dict[str, Any]] = []
+    embedding_covered = 0
+    per_node_fusion: Dict[str, Any] = {}
+    for item in top_fused:
+        rid = item["record_id"]
+        node = node_by_rid.get(rid)
+        if not node:
+            # Record is in Neo4j but missing from bulk fetch (rare race); skip.
+            continue
+        # Annotate with fusion metadata for observability.
+        node["_fused_rank"] = item["fused_rank"]
+        node["_fused_score"] = item["fused_score"]
+        node["_per_signal_ranks"] = item["per_signal_ranks"]
+        if node.get(_EMBEDDING_PROPERTY):
+            embedding_covered += 1
+            # Drop the 256-float blob from the response to keep payloads small.
+            node = {k: v for k, v in node.items() if k != _EMBEDDING_PROPERTY}
+        per_node_fusion[rid] = {
+            "fused_rank": item["fused_rank"],
+            "fused_score": item["fused_score"],
+            "per_signal_ranks": item["per_signal_ranks"],
+        }
+        nodes.append(node)
+
+    # ---- FSRS-6 / T3 Lesson post-filter -----------------------------------
+    nodes = _apply_fsrs_t3_filter(nodes, include_below_threshold=include_below_threshold)
+
+    # Trim to final top_n after T3 suppression.
+    nodes = nodes[:top_n]
+
+    summary = (
+        f"Hybrid: {len(nodes)} nodes "
+        f"(vector={len(vector_ranks)}, graph={len(graph_ranks)}, keyword={len(keyword_ranks)}; "
+        f"graph_algo={graph_algorithm}; embedded={embedding_covered}/{len(top_fused)})"
+    )
+
+    return {
+        "nodes": nodes,
+        "edges": [],
+        "paths": [],
+        "summary": summary,
+        "query_cypher": "hybrid/multi-signal-rrf",
+        "signal_availability": {
+            "vector": vector_available,
+            "graph": graph_available,
+            "keyword": keyword_available,
+        },
+        "graph_algorithm": graph_algorithm,
+        "rrf_k": RRF_K,
+        "embedding_coverage_sample": {
+            "covered": embedding_covered,
+            "total_ranked": len(top_fused),
+        },
+        "per_node_fusion": per_node_fusion,
+        "fsrs_t3_threshold": FSRS_T3_THRESHOLD,
+        "include_below_threshold": include_below_threshold,
+    }
+
+
+# Embedding property name must mirror graph_sync/embedding.py EMBEDDING_PROPERTY
+# without forcing an import at module load time (deploy packages the helper at
+# the top level, so the import is deferred to _compute_query_embedding).
+_EMBEDDING_PROPERTY = "embedding"
+
+
 SEARCH_HANDLERS = {
     "traversal": _query_traversal,
     "neighbors": _query_neighbors,
     "path": _query_path,
     "keyword": _query_keyword,
+    "hybrid": _query_hybrid,
 }
 
 
@@ -513,7 +1219,7 @@ def _handle_search(event: Dict) -> Dict:
         })
     )
 
-    return _response(200, {
+    response_body: Dict[str, Any] = {
         "success": True,
         "nodes": result.get("nodes", []),
         "edges": result.get("edges", []),
@@ -521,7 +1227,20 @@ def _handle_search(event: Dict) -> Dict:
         "summary": result.get("summary", ""),
         "query_cypher": result.get("query_cypher", ""),
         "duration_ms": duration_ms,
-    })
+    }
+    # ENC-TSK-B92: hybrid-specific observability fields passed through verbatim.
+    for hybrid_key in (
+        "signal_availability",
+        "graph_algorithm",
+        "rrf_k",
+        "embedding_coverage_sample",
+        "per_node_fusion",
+        "fsrs_t3_threshold",
+        "include_below_threshold",
+    ):
+        if hybrid_key in result:
+            response_body[hybrid_key] = result[hybrid_key]
+    return _response(200, response_body)
 
 
 def _handle_health(event: Dict) -> Dict:

--- a/backend/lambda/graph_query_api/test_hybrid_retrieval.py
+++ b/backend/lambda/graph_query_api/test_hybrid_retrieval.py
@@ -1,0 +1,217 @@
+"""Unit tests for ENC-TSK-B92 Phase 1 hybrid retrieval helpers.
+
+Exercises:
+  - RRF fusion math (k=60 per-signal reciprocal-rank contribution)
+  - RRF handling of missing-signal records (no contribution)
+  - FSRS-6 T3 Lesson post-filter suppression + include_below_threshold
+  - Backward-compat: when embeddings are absent the vector signal is empty
+    and the pipeline degrades to graph + keyword only
+
+These tests do not require Neo4j or Bedrock — they exercise the pure-Python
+ranking and filtering logic.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Ensure the Lambda module directory is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lambda_function as lf  # noqa: E402
+
+
+class TestRRFFusion(unittest.TestCase):
+    def test_single_signal_rrf(self):
+        signals = {
+            "vector": [
+                {"record_id": "ENC-TSK-001", "score": 0.95, "rank": 1},
+                {"record_id": "ENC-TSK-002", "score": 0.80, "rank": 2},
+            ],
+        }
+        fused = lf._rrf_fuse(signals)
+        self.assertEqual(len(fused), 2)
+        self.assertEqual(fused[0]["record_id"], "ENC-TSK-001")
+        # 1 / (60 + 1) for rank 1
+        self.assertAlmostEqual(fused[0]["fused_score"], 1.0 / 61.0, places=8)
+        self.assertAlmostEqual(fused[1]["fused_score"], 1.0 / 62.0, places=8)
+        self.assertEqual(fused[0]["fused_rank"], 1)
+
+    def test_multi_signal_agreement(self):
+        """Record that appears in all three signals at rank 1 should win."""
+        signals = {
+            "vector": [{"record_id": "R1", "score": 0.99, "rank": 1}],
+            "graph": [{"record_id": "R1", "score": 10.0, "rank": 1}],
+            "keyword": [{"record_id": "R1", "score": 5.0, "rank": 1}],
+        }
+        fused = lf._rrf_fuse(signals)
+        self.assertEqual(fused[0]["record_id"], "R1")
+        # 3 * 1/(60+1)
+        self.assertAlmostEqual(fused[0]["fused_score"], 3.0 / 61.0, places=8)
+
+    def test_missing_signal_no_contribution(self):
+        """Record missing from a signal contributes 0 from that signal."""
+        signals = {
+            "vector": [
+                {"record_id": "A", "score": 0.9, "rank": 1},
+                {"record_id": "B", "score": 0.8, "rank": 2},
+            ],
+            "graph": [
+                {"record_id": "B", "score": 5.0, "rank": 1},
+                {"record_id": "C", "score": 4.0, "rank": 2},
+            ],
+            "keyword": [],
+        }
+        fused = lf._rrf_fuse(signals)
+        fused_by_rid = {item["record_id"]: item for item in fused}
+
+        # A: vector only at rank 1
+        self.assertAlmostEqual(fused_by_rid["A"]["fused_score"], 1.0 / 61.0, places=8)
+        # B: vector rank 2 + graph rank 1
+        self.assertAlmostEqual(
+            fused_by_rid["B"]["fused_score"],
+            1.0 / 62.0 + 1.0 / 61.0,
+            places=8,
+        )
+        # C: graph only at rank 2
+        self.assertAlmostEqual(fused_by_rid["C"]["fused_score"], 1.0 / 62.0, places=8)
+        # B wins because it's in two signals.
+        self.assertEqual(fused[0]["record_id"], "B")
+
+    def test_empty_signals_returns_empty(self):
+        fused = lf._rrf_fuse({})
+        self.assertEqual(fused, [])
+
+    def test_backward_compat_no_embeddings(self):
+        """When vector is empty, fusion degrades to graph + keyword only."""
+        signals = {
+            "vector": [],
+            "graph": [
+                {"record_id": "ENC-TSK-100", "score": 9.0, "rank": 1},
+            ],
+            "keyword": [
+                {"record_id": "ENC-TSK-100", "score": 3.0, "rank": 2},
+                {"record_id": "ENC-TSK-200", "score": 2.0, "rank": 3},
+            ],
+        }
+        fused = lf._rrf_fuse(signals)
+        # No crash, ENC-TSK-100 ranked first from two signals, ENC-TSK-200 present.
+        self.assertEqual(len(fused), 2)
+        self.assertEqual(fused[0]["record_id"], "ENC-TSK-100")
+
+
+class TestFSRSFilter(unittest.TestCase):
+    def _lesson(self, rid: str, stability=None, resonance=None):
+        node = {
+            "record_id": rid,
+            "_labels": ["Lesson"],
+        }
+        if stability is not None:
+            node["stability"] = stability
+        if resonance is not None:
+            node["resonance_score"] = resonance
+        return node
+
+    def test_suppresses_below_threshold_lessons(self):
+        nodes = [
+            self._lesson("ENC-LSN-001", stability=0.9),
+            self._lesson("ENC-LSN-002", stability=0.4),  # below T3=0.7
+            {"record_id": "ENC-TSK-100", "_labels": ["Task"]},
+        ]
+        filtered = lf._apply_fsrs_t3_filter(nodes, include_below_threshold=False)
+        rids = {n["record_id"] for n in filtered}
+        self.assertIn("ENC-LSN-001", rids)
+        self.assertIn("ENC-TSK-100", rids)
+        self.assertNotIn("ENC-LSN-002", rids)
+
+    def test_include_below_threshold_keeps_all(self):
+        nodes = [
+            self._lesson("ENC-LSN-001", stability=0.9),
+            self._lesson("ENC-LSN-002", stability=0.4),
+        ]
+        filtered = lf._apply_fsrs_t3_filter(nodes, include_below_threshold=True)
+        rids = [n["record_id"] for n in filtered]
+        self.assertEqual(set(rids), {"ENC-LSN-001", "ENC-LSN-002"})
+        # Both tagged, second marked below_t3
+        by_rid = {n["record_id"]: n for n in filtered}
+        self.assertFalse(by_rid["ENC-LSN-001"]["_below_t3"])
+        self.assertTrue(by_rid["ENC-LSN-002"]["_below_t3"])
+
+    def test_resonance_fallback_when_stability_missing(self):
+        """Pre-FSRS-6 Lessons use resonance_score as stability proxy."""
+        nodes = [
+            self._lesson("ENC-LSN-029", resonance=0.6438),  # below 0.7
+            self._lesson("ENC-LSN-100", resonance=0.85),    # above 0.7
+        ]
+        filtered = lf._apply_fsrs_t3_filter(nodes, include_below_threshold=False)
+        rids = {n["record_id"] for n in filtered}
+        self.assertNotIn("ENC-LSN-029", rids)
+        self.assertIn("ENC-LSN-100", rids)
+
+    def test_non_lessons_unaffected(self):
+        """Non-Lesson labels are never filtered by T3."""
+        nodes = [
+            {"record_id": "ENC-TSK-A", "_labels": ["Task"]},
+            {"record_id": "ENC-FTR-B", "_labels": ["Feature"]},
+        ]
+        filtered = lf._apply_fsrs_t3_filter(nodes, include_below_threshold=False)
+        self.assertEqual(len(filtered), 2)
+
+    def test_malformed_stability_tolerated(self):
+        """Non-numeric stability is treated as missing (does not suppress)."""
+        nodes = [
+            self._lesson("ENC-LSN-X", stability="not-a-number"),
+        ]
+        filtered = lf._apply_fsrs_t3_filter(nodes, include_below_threshold=False)
+        # Parse fails -> s_val None -> not suppressed.
+        self.assertEqual(len(filtered), 1)
+
+
+class TestEdgeWeights(unittest.TestCase):
+    def test_ppr_edge_weight_ordering_matches_lsn029(self):
+        """Per-rel-type weights must preserve LSN-029 ordering."""
+        ordered = (
+            "IMPLEMENTS",
+            "ADDRESSES",
+            "RELATED_TO",
+            "LEARNED_FROM",
+            "CHILD_OF",
+            "PLAN_CONTAINS",
+            "BELONGS_TO",
+        )
+        weights = [lf.GRAPH_EDGE_WEIGHTS[t] for t in ordered]
+        self.assertEqual(weights, sorted(weights, reverse=True))
+
+    def test_label_vector_index_names(self):
+        """B90 migration 001 created these exact index names."""
+        self.assertEqual(
+            set(lf.LABEL_VECTOR_INDEXES.values()),
+            {
+                "governed_task_embedding",
+                "governed_issue_embedding",
+                "governed_feature_embedding",
+                "governed_plan_embedding",
+                "governed_lesson_embedding",
+                "governed_document_embedding",
+            },
+        )
+
+
+class TestConstants(unittest.TestCase):
+    def test_rrf_k_is_60(self):
+        self.assertEqual(lf.RRF_K, 60)
+
+    def test_t3_threshold_is_0_7(self):
+        self.assertEqual(lf.FSRS_T3_THRESHOLD, 0.7)
+
+    def test_ppr_damping_0_85(self):
+        self.assertEqual(lf.PPR_DAMPING_FACTOR, 0.85)
+
+    def test_valid_search_types_includes_hybrid(self):
+        self.assertIn("hybrid", lf.VALID_SEARCH_TYPES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3269,7 +3269,12 @@ def _code_mode_tool_catalog() -> list[Tool]:
             name="get_compact_context",
             description=(
                 "Budgeted composite context assembly that reuses existing issue-context, codemap, "
-                "architecture, document, governance, and project helpers while preserving raw codemap payloads."
+                "architecture, document, governance, and project helpers while preserving raw codemap payloads. "
+                "ENC-TSK-B92: when `query` or `anchor_record_id` is supplied the response additionally "
+                "includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion "
+                "over three signals (vector cosine via HNSW, graph Personalized PageRank / Cypher fallback, "
+                "keyword title/intent/description match). Backward-compatible: callers who do not pass "
+                "`query`/`anchor_record_id` receive the legacy context shape unchanged."
             ),
             inputSchema={
                 "type": "object",
@@ -3309,7 +3314,23 @@ def _code_mode_tool_catalog() -> list[Tool]:
                     },
                     "query": {
                         "type": "string",
-                        "description": "Topic or reference search query.",
+                        "description": "Topic or reference search query. When supplied, enables the hybrid retrieval vector + keyword signals (ENC-TSK-B92).",
+                    },
+                    "anchor_record_id": {
+                        "type": "string",
+                        "description": "Optional record_id used as the graph anchor for Personalized PageRank / fallback edge-walk scoring in hybrid retrieval. Defaults to `record_id` for record modes. (ENC-TSK-B92)",
+                    },
+                    "top_n": {
+                        "type": "integer",
+                        "description": "Hybrid retrieval top-N result count (default 20, max 50). Applied after RRF fusion and FSRS-6 T3 Lesson filtering. (ENC-TSK-B92)",
+                    },
+                    "include_below_threshold": {
+                        "type": "boolean",
+                        "description": "If true, includes Lessons with FSRS-6 stability < T3 (0.7) in hybrid retrieval results. Default false suppresses below-threshold Lessons per B62 scope item #4. (ENC-TSK-B92)",
+                    },
+                    "record_type": {
+                        "type": "string",
+                        "description": "Optional record-type filter (task/issue/feature/plan/lesson/document) applied to hybrid retrieval. (ENC-TSK-B92)",
                     },
                     "include_code_map": {
                         "type": "boolean",
@@ -3322,6 +3343,10 @@ def _code_mode_tool_catalog() -> list[Tool]:
                     "include_related_documents": {
                         "type": "boolean",
                         "description": "If true, include related document summaries when available.",
+                    },
+                    "include_hybrid_retrieval": {
+                        "type": "boolean",
+                        "description": "If true (default when query/anchor_record_id is set), include three-signal hybrid retrieval results under hybrid_retrieval. Set false to disable. (ENC-TSK-B92)",
                     },
                 },
             },
@@ -7237,6 +7262,74 @@ async def _get_compact_context_meta(args: dict) -> list[TextContent]:
             mode=mode,
         )
 
+    # ENC-TSK-B92 Phase 1: three-signal hybrid retrieval.
+    # Opt-in by passing `query` and/or `anchor_record_id`. Backward-compat:
+    # callers who do not pass either receive exactly the legacy context shape.
+    include_hybrid_retrieval = args.get("include_hybrid_retrieval")
+    query_text = str(args.get("query") or "").strip()
+    anchor_id = str(args.get("anchor_record_id") or "").strip()
+    # Default anchor for record-oriented modes: use the primary record_id.
+    if not anchor_id and mode in _RECORD_CONTEXT_MODES:
+        anchor_id = str(args.get("record_id") or "").strip()
+    # Infer project_id from args first, then from the assembled context.
+    hybrid_project_id = str(args.get("project_id") or "").strip()
+    if not hybrid_project_id and isinstance(context.get("record_context"), dict):
+        rc = context["record_context"]
+        hybrid_project_id = str((rc or {}).get("project_id") or "").strip()
+    if not hybrid_project_id and anchor_id:
+        try:
+            hybrid_project_id, _rt, _rid = _parse_record_id(anchor_id)
+        except Exception:
+            hybrid_project_id = ""
+
+    # Auto-enable when the caller provided a query or anchor and did not
+    # explicitly opt out. Explicit True is honored regardless.
+    should_invoke_hybrid = (
+        include_hybrid_retrieval is True
+        or (include_hybrid_retrieval is not False and (query_text or anchor_id))
+    )
+    if should_invoke_hybrid and hybrid_project_id and (query_text or anchor_id):
+        try:
+            hybrid_resp = _invoke_hybrid_retrieval(
+                project_id=hybrid_project_id,
+                query_text=query_text or None,
+                anchor_record_id=anchor_id or None,
+                record_type_filter=args.get("record_type"),
+                top_n=args.get("top_n"),
+                include_below_threshold=bool(args.get("include_below_threshold", False)),
+            )
+            underlying_calls.append({
+                "tool": "graph_query_api.hybrid",
+                "status": "success" if hybrid_resp.get("success") else "error",
+                "arguments": {
+                    "project_id": hybrid_project_id,
+                    "query": query_text,
+                    "anchor_record_id": anchor_id,
+                    "record_type": args.get("record_type"),
+                    "top_n": args.get("top_n"),
+                    "include_below_threshold": bool(args.get("include_below_threshold", False)),
+                },
+            })
+            if hybrid_resp.get("error"):
+                warnings.append(
+                    "hybrid retrieval unavailable: " + str(hybrid_resp.get("error"))
+                )
+            else:
+                context["hybrid_retrieval"] = {
+                    "nodes": hybrid_resp.get("nodes", []),
+                    "summary": hybrid_resp.get("summary", ""),
+                    "signal_availability": hybrid_resp.get("signal_availability", {}),
+                    "graph_algorithm": hybrid_resp.get("graph_algorithm"),
+                    "rrf_k": hybrid_resp.get("rrf_k"),
+                    "embedding_coverage_sample": hybrid_resp.get("embedding_coverage_sample", {}),
+                    "per_node_fusion": hybrid_resp.get("per_node_fusion", {}),
+                    "fsrs_t3_threshold": hybrid_resp.get("fsrs_t3_threshold"),
+                    "include_below_threshold": hybrid_resp.get("include_below_threshold"),
+                    "duration_ms": hybrid_resp.get("duration_ms"),
+                }
+        except Exception as exc:
+            warnings.append(f"hybrid retrieval failed: {exc}")
+
     # ENC-FTR-050: Context Node assembly manifest (flagged off by default)
     if ENABLE_CONTEXT_NODES and args.get("max_tokens"):
         try:
@@ -7936,11 +8029,46 @@ async def _tracker_graphsearch(args: dict) -> list[TextContent]:
     for key in ("edge_types", "edge_type", "min_weight"):
         if args.get(key) is not None:
             query_params[key] = args[key]
+    # ENC-TSK-B92: hybrid-specific knobs (forwarded when search_type=hybrid)
+    for key in ("anchor_record_id", "top_n", "include_below_threshold"):
+        if args.get(key) is not None:
+            query_params[key] = args[key]
 
     resp = _graph_query_api_request(query=query_params)
     if resp.get("error"):
         return _result_text(resp)
     return _result_text(resp)
+
+
+def _invoke_hybrid_retrieval(
+    project_id: str,
+    query_text: Optional[str],
+    anchor_record_id: Optional[str],
+    record_type_filter: Optional[str] = None,
+    top_n: Optional[int] = None,
+    include_below_threshold: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Call the graph_query_api `hybrid` search_type via HTTP (ENC-TSK-B92).
+
+    Returns the raw response dict; callers inspect `error` / `success` keys.
+    """
+    params: Dict[str, Any] = {
+        "search_type": "hybrid",
+        "project_id": project_id,
+    }
+    q = (query_text or "").strip()
+    if q:
+        params["query"] = q
+    a = (anchor_record_id or "").strip()
+    if a:
+        params["anchor_record_id"] = a
+    if record_type_filter:
+        params["record_type"] = record_type_filter
+    if top_n is not None:
+        params["top_n"] = str(int(top_n))
+    if include_below_threshold:
+        params["include_below_threshold"] = "true"
+    return _graph_query_api_request(query=params)
 
 
 # --- ENC-FTR-049: Typed Relationship Edge Tools ---


### PR DESCRIPTION
## Summary

ENC-TSK-B92 — headline ENC-TSK-B62 Phase 1 deliverable (PLN-006 Wave 4). Adds three-signal hybrid retrieval to `get_compact_context`: vector cosine similarity (HNSW per-label indexes from B90), graph topology (Personalized PageRank via Neo4j GDS, native-Cypher edge-walk fallback), and keyword title/intent/description match — fused via Reciprocal Rank Fusion (k=60) per the B62 description.

## Architecture

- New `hybrid` search_type in `backend/lambda/graph_query_api/lambda_function.py`. Vector signal queries the six `governed_<label>_embedding` HNSW indexes from B90; graph signal runs `gds.pageRank.stream` with the LSN-029 weight contract (IMPLEMENTS > ADDRESSES > RELATED_TO > LEARNED_FROM > CHILD_OF > PLAN_CONTAINS > BELONGS_TO); keyword signal does case-insensitive title/intent/description CONTAINS with weighted scoring.
- Query-side embedding uses the canonical `backend/lambda/graph_sync/embedding.py` helper (B94), copied into the graph_query_api zip by `deploy.sh`. Guarantees vector parity with B91 batch and B94 incremental index-side embedding.
- `tools/enceladus-mcp-server/server.py` calls the new endpoint via the existing `_graph_query_api_request` HTTP path when `get_compact_context` receives `query` and/or `anchor_record_id`. Auto-anchors to `record_id` for record-oriented modes. Backward-compatible: callers not passing those params receive the legacy context shape.
- IAM: graph_query_api role gains `bedrock:InvokeModel` on `amazon.titan-embed-text-v2:0` (Sid=`BedrockTitanV2InvokeModel`).

## Resilience

- **Embedding sparsity**: when target nodes lack embeddings the vector signal returns empty and RRF degrades to graph + keyword only (B91 backfill is deployed but pending product-lead invocation, so most of the corpus is unembedded).
- **GDS unavailable**: probed once per 5min via `CALL gds.list()`. On failure, graph signal falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with `damping^distance` decay.
- **All signals empty**: response includes a `No signals returned candidates` summary instead of a 500.

## FSRS-6 / T3 Lesson filter

Lessons with `stability < 0.7` (or `resonance_score < 0.7` when `stability` is absent, per LSN-029 convention) are suppressed from default context windows. Override per-query via `include_below_threshold=true`.

## Governance

Dictionary bumped 2026-04-15.5 → 2026-04-15.6. Added `retrieval.hybrid_pipeline` entity (66 total). Extended `mcp_server.context_assembly.get_compact_context` to document the `hybrid_retrieval` section.

## Test plan

- [x] 16 new unit tests in `backend/lambda/graph_query_api/test_hybrid_retrieval.py` covering RRF math, missing-signal handling, FSRS-6 T3 filtering, edge-weight ordering, and constants. All pass.
- [x] Existing `tools/enceladus-mcp-server/test_code_mode.py` (5 tests) still passes.
- [x] `python3 -c 'import ast; ast.parse(...)'` syntax checks pass on all edited Python files.
- [x] `python3 -c 'import json; ...'` JSON validity confirmed for governance_data_dictionary.json.
- [ ] Live validation post-deploy: invoke `get_compact_context(query='graph projection edge integrity', anchor_record_id='ENC-PLN-006')` against gamma; verify `hybrid_retrieval` section returned with sensible ranking vs keyword-only baseline. Captured to ENC-TSK-B92 worklog as live_validation_evidence.

Refs: ENC-TSK-B62 (Phase 1 gate), ENC-LSN-029 (PPR decision), ENC-TSK-B90 (HNSW indexes), ENC-TSK-B91 (backfill), ENC-TSK-B94 (incremental embedding).

CCI-c3559f00aac14877a1b0170d05e743ea