### PR TITLE
chore(graph_query_api): bump Lambda timeout/memory for hybrid search_type (ENC-TSK-E07)

### DIFF
--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -148,8 +148,8 @@ ensure_lambda() {
       --architectures "${arch}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
-      --timeout 10 \
-      --memory-size 256 \
+      --timeout 30 \
+      --memory-size 1024 \
       --zip-file "fileb://${zip_path}" >/dev/null
   fi
 
@@ -179,8 +179,8 @@ ENV_JSON
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
       --role "${role_arn}" \
-      --timeout 10 \
-      --memory-size 256 \
+      --timeout 30 \
+      --memory-size 1024 \
       --environment "file://${env_file}" >/dev/null; then
       break
     fi


### PR DESCRIPTION
## Summary

Wave 4.5 operational follow-on to ENC-TSK-B92 (hybrid retrieval scoring).

Bumps `devops-graph-query-api` Lambda config in `backend/lambda/graph_query_api/deploy.sh`:

- Timeout: 10s -> 30s
- Memory: 256MB -> 1024MB

Changes both `aws lambda create-function` and `aws lambda update-function-configuration` paths so the config applies on both new-function and existing-function deploy runs. `ENVIRONMENT_SUFFIX` gates only runtime/architecture (prod=python3.11/x86_64, gamma=python3.12/arm64); timeout/memory are shared, so this single pair of edits propagates to both environments.

## Why

The new `hybrid` search_type (B92) exercises Bedrock Titan V2 (cold-start ~150-350ms), GDS PPR projection build, and per-label HNSW ANN candidate retrieval — comfortably exceeding the 10s default on cold starts. Existing fast-path search_types (traversal/neighbors/path/keyword) are sub-second and unaffected; the larger budget only matters for the hybrid path.

## Risks / Cost

- Cold-start cost increase: memory 256 -> 1024 is ~4x per-invocation cost. Acceptable for the hybrid query path which is already expensive.
- Fast-path queries unaffected.
- Shared prod+gamma Lambda — verified `ENVIRONMENT_SUFFIX` conditional in deploy.sh only gates arch/runtime, not timeout/memory.

## Test plan

- [ ] PR Commit Gate validates CCI
- [ ] Auto-triggered `Lambda Deploy - devops-graph-query-api` workflow fires on merge
- [ ] Post-deploy: `aws lambda get-function-configuration --function-name devops-graph-query-api` shows Timeout=30, MemorySize=1024
- [ ] Live anchored hybrid retrieval query (anchor_record_id supplied) returns within 30s with `signal_availability.graph=true`

## Task

ENC-TSK-E07
CCI-0f90a1d0c89e4391b175835bcac1a46c