### PR TITLE
ENC-TSK-E19: Lambda package arch parity guard (defense-in-depth for ENC-ISS-213)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,8 @@ jobs:
         run: |
           set -euo pipefail
           python3 tools/verify_lambda_arch_parity.py
+
+      - name: Test Lambda package architecture parity guard (ENC-TSK-E19)
+        run: |
+          set -euo pipefail
+          python3 -m unittest tools.test_verify_lambda_package_arch -v

--- a/backend/lambda/auth_edge/deploy.sh
+++ b/backend/lambda/auth_edge/deploy.sh
@@ -32,6 +32,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/auth_refresh/deploy.sh
+++ b/backend/lambda/auth_refresh/deploy.sh
@@ -36,6 +36,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/bedrock_agent_actions/deploy.sh
+++ b/backend/lambda/bedrock_agent_actions/deploy.sh
@@ -151,6 +151,13 @@ ensure_function() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/changelog_api/deploy.sh
+++ b/backend/lambda/changelog_api/deploy.sh
@@ -154,6 +154,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/checkout_service/deploy.sh
+++ b/backend/lambda/checkout_service/deploy.sh
@@ -276,6 +276,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${fn_name}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating code: ${fn_name}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${fn_name}" \
       --region "${REGION}" \

--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -624,6 +624,13 @@ ensure_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-15.7",
-  "updated_at": "2026-04-15T09:25:00Z",
+  "version": "2026-04-15.8",
+  "updated_at": "2026-04-15T10:45:00Z",
   "last_change_summary": "ENC-TSK-E06 / ENC-ISS-230: Added neo4j.placeholder_node entity documenting the is_placeholder boolean property contract on Neo4j nodes. graph_sync._reconcile_edges() placeholder MERGE sites (PLAN_CONTAINS, PLAN_ATTACHED_DOC, PLAN_IMPLEMENTS, LEARNED_FROM, RELATED_TO, INFORMED_BY source) now set `is_placeholder=true` via ON CREATE SET so downstream consumers can distinguish edge-target stub nodes from real DynamoDB-backed records. _upsert_node clears is_placeholder to false on the real record's projection. embedding.titan_v2_backfill._coverage_for_label adds WHERE n.is_placeholder IS NULL OR n.is_placeholder = false so coverage metrics reflect the active corpus only — closes the B91 denominator inflation (229 orphan stubs pulled Task to 93.72% and Issue to 90.69% despite 100% active-corpus coverage).",
   "owners": [
     "enceladus-platform"
@@ -3826,6 +3826,45 @@
         "context_assembly_integration": {
           "type": "string",
           "definition": "get_compact_context auto-invokes hybrid retrieval when callers pass `query` and/or `anchor_record_id`. For record-oriented modes the anchor defaults to the record_id. project_id is inferred from args, then the assembled record_context, then by parsing the anchor record_id prefix. Result lives at context['hybrid_retrieval']. Set include_hybrid_retrieval=false to force-disable. Failures append a warning and never break the legacy context payload."
+        }
+      }
+    },
+    "deploy.package_arch_guard": {
+      "description": "CI + deploy-time guard that inspects Lambda deployment zip CONTENTS and rejects any package containing compiled shared objects (.so) for an architecture different from the target Lambda runtime. Implemented by tools/verify_lambda_package_arch.py and invoked from every backend/lambda/*/deploy.sh between zip creation and `aws lambda update-function-code`. Complements tools/verify_lambda_arch_parity.py (which checks CFN/deploy-script declarations) by verifying the actual artifact. Introduced by ENC-TSK-E19 as defense-in-depth for ENC-ISS-213.",
+      "fields": {
+        "expected_arch": {
+          "type": "enum",
+          "enum": [
+            "arm64",
+            "x86_64"
+          ],
+          "definition": "Target Lambda architecture. Derived from ENVIRONMENT_SUFFIX in each deploy.sh: empty suffix (prod) => x86_64; '-gamma' suffix => arm64. Must match the Architectures value resolved by the CFN !If [IsGamma, arm64, x86_64] conditional."
+        },
+        "enforcement_point": {
+          "type": "string",
+          "definition": "Where the check runs. Two invocation sites: (1) CI test suite in .github/workflows/ci.yml validates the verifier itself via `python3 -m unittest tools.test_verify_lambda_package_arch`; (2) every backend/lambda/*/deploy.sh invokes `python3 tools/verify_lambda_package_arch.py --package <zip> --expected-arch <arch>` immediately before `aws lambda update-function-code`, blocking upload on mismatch."
+        },
+        "rejection_conditions": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Conditions that cause the guard to exit non-zero and halt deployment.",
+          "enum": [
+            "Zip contains a .so file whose ELF e_machine header identifies a different architecture than --expected-arch (exit 1).",
+            "--package path does not exist, is not readable, or is not a valid zip archive (exit 2).",
+            "--expected-arch is not one of the supported values arm64, x86_64 (exit 2)."
+          ]
+        },
+        "trivial_pass_condition": {
+          "type": "string",
+          "definition": "Pure-Python packages (zero .so files) pass trivially. The guard is a no-op for Lambda functions that ship no compiled extensions."
+        },
+        "classification_method": {
+          "type": "string",
+          "definition": "Two-tier classification: (1) `file --brief` is invoked per .so when available (CodeBuild images, Amazon Linux, Ubuntu, macOS); (2) direct ELF magic-byte parsing (EM_X86_64=0x3E, EM_AARCH64=0xB7 at offset 0x12 of the ELF header) is used as a stdlib-only fallback. Either path alone is sufficient. Non-ELF .so files emit a WARN but do not fail the check."
+        },
+        "historical_precedent": {
+          "type": "string",
+          "definition": "ENC-ISS-213 (2026-04-12): devops-coordination-api-gamma Lambda shipped x86_64 pydantic_core wheels on an arm64 runtime despite the deploy.sh arch bifurcation from ENC-FTR-072 / ENC-ISS-224. Entire gamma MCP surface failed with 'No module named pydantic_core._pydantic_core'. Hot-fixed by ENC-TSK-D57; this guard is the structural prevention of recurrence."
         }
       }
     }

--- a/backend/lambda/coordination_monitor_api/deploy.sh
+++ b/backend/lambda/coordination_monitor_api/deploy.sh
@@ -118,6 +118,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/deploy_decide/deploy.sh
+++ b/backend/lambda/deploy_decide/deploy.sh
@@ -106,6 +106,13 @@ main() {
   log "Package: ${zip_path} ($(du -h "${zip_path}" | cut -f1))"
 
   log "Updating Lambda code..."
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/deploy_finalize/deploy.sh
+++ b/backend/lambda/deploy_finalize/deploy.sh
@@ -38,6 +38,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/deploy_intake/deploy.sh
+++ b/backend/lambda/deploy_intake/deploy.sh
@@ -212,6 +212,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/deploy_orchestrator/deploy.sh
+++ b/backend/lambda/deploy_orchestrator/deploy.sh
@@ -154,6 +154,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/doc_prep/deploy.sh
+++ b/backend/lambda/doc_prep/deploy.sh
@@ -38,6 +38,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/document_api/deploy.sh
+++ b/backend/lambda/document_api/deploy.sh
@@ -206,6 +206,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/feed_publisher/deploy.sh
+++ b/backend/lambda/feed_publisher/deploy.sh
@@ -49,6 +49,13 @@ deploy_lambda() {
   local zip_path="$1"
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/feed_query/deploy.sh
+++ b/backend/lambda/feed_query/deploy.sh
@@ -44,6 +44,13 @@ deploy_lambda() {
   local zip_path="$1"
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/github_integration/deploy.sh
+++ b/backend/lambda/github_integration/deploy.sh
@@ -157,6 +157,13 @@ ensure_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/glue_crawler_launcher/deploy.sh
+++ b/backend/lambda/glue_crawler_launcher/deploy.sh
@@ -32,6 +32,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/governance_audit/deploy.sh
+++ b/backend/lambda/governance_audit/deploy.sh
@@ -18,6 +18,13 @@ zip -q -j "${ZIP_FILE}" lambda_function.py
 echo "[INFO] Package ready: ${ZIP_FILE} ($(du -h "${ZIP_FILE}" | cut -f1))"
 
 echo "[INFO] Updating Lambda function code"
+# ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+E19_EXPECTED_ARCH="x86_64"
+[ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+  --package "${ZIP_FILE}" \
+  --expected-arch "${E19_EXPECTED_ARCH}"
 aws lambda update-function-code \
   --function-name "${FUNCTION_NAME}" \
   --zip-file "fileb://${ZIP_FILE}" \

--- a/backend/lambda/graph_health_metrics/deploy.sh
+++ b/backend/lambda/graph_health_metrics/deploy.sh
@@ -63,6 +63,13 @@ deploy_function() {
     log "[INFO] Updating existing function ${FUNCTION_NAME}"
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -132,6 +132,13 @@ ensure_lambda() {
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/graph_sync/deploy.sh
+++ b/backend/lambda/graph_sync/deploy.sh
@@ -119,6 +119,13 @@ ensure_lambda() {
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/json_to_parquet_transformer/deploy.sh
+++ b/backend/lambda/json_to_parquet_transformer/deploy.sh
@@ -32,6 +32,13 @@ deploy_lambda() {
     --region "${REGION}" >/dev/null
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/mcp_code/deploy.sh
+++ b/backend/lambda/mcp_code/deploy.sh
@@ -381,6 +381,13 @@ deploy_lambda() {
 
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${ZIP_FILE}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/mcp_streamable/deploy.sh
+++ b/backend/lambda/mcp_streamable/deploy.sh
@@ -227,6 +227,13 @@ deploy_lambda() {
 
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${ZIP_FILE}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/neo4j_backup/deploy.sh
+++ b/backend/lambda/neo4j_backup/deploy.sh
@@ -93,6 +93,13 @@ deploy_lambda() {
     log "[INFO] Updating existing function ${FUNCTION_NAME}"
     local arch_flag="x86_64" runtime_flag="python3.11"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64" && runtime_flag="python3.12"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/prod_health_monitor/deploy.sh
+++ b/backend/lambda/prod_health_monitor/deploy.sh
@@ -79,6 +79,13 @@ print(json.dumps(env))
     log "[INFO] Updating existing function ${FUNCTION_NAME}"
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/project_service/deploy.sh
+++ b/backend/lambda/project_service/deploy.sh
@@ -137,6 +137,13 @@ PY
   fi
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/backend/lambda/reference_search/deploy.sh
+++ b/backend/lambda/reference_search/deploy.sh
@@ -112,6 +112,13 @@ deploy_lambda() {
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \

--- a/backend/lambda/titan_embedding_backfill/deploy.sh
+++ b/backend/lambda/titan_embedding_backfill/deploy.sh
@@ -154,6 +154,13 @@ ENV_JSON
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating existing Lambda: ${FUNCTION_NAME}"
+    # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_EXPECTED_ARCH="x86_64"
+    [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+    python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+      --package "${zip_path}" \
+      --expected-arch "${E19_EXPECTED_ARCH}"
     aws lambda update-function-code \
       --function-name "${FUNCTION_NAME}" \
       --zip-file "fileb://${zip_path}" \

--- a/backend/lambda/tracker_mutation/deploy.sh
+++ b/backend/lambda/tracker_mutation/deploy.sh
@@ -142,6 +142,13 @@ deploy_lambda() {
   local zip_path="$1"
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
+  # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
+  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_EXPECTED_ARCH="x86_64"
+  [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
+  python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \
+    --package "${zip_path}" \
+    --expected-arch "${E19_EXPECTED_ARCH}"
   aws lambda update-function-code \
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}" \

--- a/tools/test_verify_lambda_package_arch.py
+++ b/tools/test_verify_lambda_package_arch.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Tests for tools/verify_lambda_package_arch.py.
+
+ENC-TSK-E19 AC-5: construct test Lambda zips with known-good and known-bad
+contents and confirm the verifier accepts/rejects each as expected.
+
+The tests synthesize minimal ELF 64-bit headers for both x86_64 and aarch64
+so they run anywhere Python runs -- no dependency on pre-built wheels or on
+the ``file`` command being present. Both classification paths are exercised:
+``file``-based (when present) and ELF-magic fallback (forced via
+``shutil.which`` patch).
+
+Run from repo root:
+    python3 -m unittest tools.test_verify_lambda_package_arch -v
+"""
+from __future__ import annotations
+
+import struct
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import verify_lambda_package_arch as vlpa  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# ELF fixture builder
+# ---------------------------------------------------------------------------
+
+# Minimal ELF64 header. We only care that the file starts with the magic
+# bytes and has a valid e_machine at offset 0x12. `file --brief` also only
+# needs e_ident + e_machine to classify; the rest can be zeros.
+#
+# Layout (20 bytes, matches what classify_so reads):
+#   0x00: \x7fELF        (magic)
+#   0x04: class=64       (0x02)
+#   0x05: data=LE        (0x01)
+#   0x06: version=1      (0x01)
+#   0x07..0x0F: padding  (zeros)
+#   0x10: e_type=ET_DYN  (0x03, 0x00 LE)
+#   0x12: e_machine      (2 bytes LE -- this is what we vary)
+#   0x14+: zeros
+def _build_elf_so(arch: str) -> bytes:
+    """Return a minimal 64-byte buffer that `file` and our fallback parser
+    both classify as an ELF shared object for the given arch."""
+    if arch == "x86_64":
+        e_machine = 0x3E
+    elif arch == "arm64":
+        e_machine = 0xB7
+    else:
+        raise ValueError(f"unsupported arch {arch!r}")
+    buf = bytearray(64)
+    buf[0:4] = b"\x7fELF"
+    buf[4] = 0x02      # EI_CLASS = ELFCLASS64
+    buf[5] = 0x01      # EI_DATA = ELFDATA2LSB
+    buf[6] = 0x01      # EI_VERSION = EV_CURRENT
+    struct.pack_into("<H", buf, 0x10, 0x03)          # e_type = ET_DYN
+    struct.pack_into("<H", buf, 0x12, e_machine)     # e_machine
+    struct.pack_into("<H", buf, 0x14, 0x01)          # e_version = EV_CURRENT
+    return bytes(buf)
+
+
+def _make_zip(path: Path, members: dict) -> None:
+    """Write a zip with the given {arcname: bytes} entries."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for arcname, data in members.items():
+            zf.writestr(arcname, data)
+
+
+# ---------------------------------------------------------------------------
+# Classification (unit) tests
+# ---------------------------------------------------------------------------
+
+class ClassifySoTests(unittest.TestCase):
+    """Low-level ELF magic-byte parsing, independent of `file`."""
+
+    def test_elf_magic_recognizes_x86_64(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "libx.so"
+            p.write_bytes(_build_elf_so("x86_64"))
+            self.assertEqual(vlpa._classify_with_elf_magic(p), "x86_64")
+
+    def test_elf_magic_recognizes_arm64(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "liba.so"
+            p.write_bytes(_build_elf_so("arm64"))
+            self.assertEqual(vlpa._classify_with_elf_magic(p), "arm64")
+
+    def test_elf_magic_rejects_non_elf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "fake.so"
+            p.write_bytes(b"this is not an ELF header at all" * 3)
+            self.assertIsNone(vlpa._classify_with_elf_magic(p))
+
+    def test_classify_so_falls_back_when_file_missing(self) -> None:
+        """When `file` is not on PATH, ELF-magic fallback still works."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "lib.so"
+            p.write_bytes(_build_elf_so("arm64"))
+            with mock.patch.object(vlpa.shutil, "which", return_value=None):
+                self.assertEqual(vlpa.classify_so(p), "arm64")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end verify_package tests
+# ---------------------------------------------------------------------------
+
+class VerifyPackageTests(unittest.TestCase):
+    """Round-trip tests against synthesized Lambda zips."""
+
+    def _tmp_zip(self, members: dict) -> Path:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        zp = Path(self._tmp.name) / "function.zip"
+        _make_zip(zp, members)
+        return zp
+
+    # --- AC-2: pure-Python -------------------------------------------------
+
+    def test_pure_python_package_passes(self) -> None:
+        """Zip with zero .so files is a trivial pass regardless of expected arch."""
+        zp = self._tmp_zip({
+            "lambda_function.py": b"def handler(e, c): return {}\n",
+            "package/__init__.py": b"",
+            "package/utils.py": b"x = 1\n",
+        })
+        for arch in ("x86_64", "arm64"):
+            with self.subTest(arch=arch):
+                r = vlpa.verify_package(zp, arch)
+                self.assertTrue(r.passed)
+                self.assertTrue(r.pure_python)
+                self.assertEqual(r.mismatches, [])
+
+    # --- AC-1 / AC-5: happy path + mismatch detection ----------------------
+
+    def test_matching_arch_passes(self) -> None:
+        """Zip whose .so files all match the expected arch passes."""
+        zp = self._tmp_zip({
+            "lambda_function.py": b"def handler(e, c): return {}\n",
+            "pydantic_core/_pydantic_core.cpython-311-x86_64-linux-gnu.so":
+                _build_elf_so("x86_64"),
+            "pydantic_core/__init__.py": b"",
+        })
+        r = vlpa.verify_package(zp, "x86_64")
+        self.assertTrue(r.passed, msg=f"mismatches={r.mismatches}")
+        self.assertEqual(len(r.matches), 1)
+
+    def test_wrong_arch_fails(self) -> None:
+        """The ENC-ISS-213 scenario: x86_64 .so files in an arm64 package."""
+        zp = self._tmp_zip({
+            "lambda_function.py": b"",
+            "pydantic_core/_pydantic_core.cpython-311-x86_64-linux-gnu.so":
+                _build_elf_so("x86_64"),
+        })
+        r = vlpa.verify_package(zp, "arm64")
+        self.assertFalse(r.passed)
+        self.assertEqual(len(r.mismatches), 1)
+        rel, actual = r.mismatches[0]
+        self.assertEqual(actual, "x86_64")
+        self.assertIn("pydantic_core", str(rel))
+
+    def test_mixed_arch_fails(self) -> None:
+        """A zip with one correct and one wrong .so still fails."""
+        zp = self._tmp_zip({
+            "ok/lib.so":   _build_elf_so("arm64"),
+            "bad/lib.so":  _build_elf_so("x86_64"),
+        })
+        r = vlpa.verify_package(zp, "arm64")
+        self.assertFalse(r.passed)
+        self.assertEqual(len(r.mismatches), 1)
+        self.assertEqual(len(r.matches), 1)
+
+    def test_versioned_so_extension_detected(self) -> None:
+        """libfoo.so.1.2 is still a shared object and must be inspected."""
+        zp = self._tmp_zip({
+            "lib/libfoo.so.1.2.3": _build_elf_so("x86_64"),
+        })
+        r = vlpa.verify_package(zp, "arm64")
+        self.assertFalse(r.passed)
+        self.assertEqual(len(r.mismatches), 1)
+
+    # --- AC-1: error paths -------------------------------------------------
+
+    def test_unsupported_arch_raises(self) -> None:
+        zp = self._tmp_zip({"lambda_function.py": b""})
+        with self.assertRaises(ValueError):
+            vlpa.verify_package(zp, "sparc64")
+
+    def test_missing_package_raises(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "does-not-exist.zip"
+        if missing.exists():
+            missing.unlink()
+        with self.assertRaises(FileNotFoundError):
+            vlpa.verify_package(missing, "x86_64")
+
+    def test_bad_zip_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "notazip.zip"
+            fake.write_bytes(b"garbage that is not a zip")
+            with self.assertRaises(ValueError):
+                vlpa.verify_package(fake, "x86_64")
+
+
+# ---------------------------------------------------------------------------
+# CLI (argparse + exit code) tests
+# ---------------------------------------------------------------------------
+
+class CLITests(unittest.TestCase):
+
+    def test_cli_exit_zero_on_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            zp = Path(tmp) / "fn.zip"
+            _make_zip(zp, {"lib/x.so": _build_elf_so("x86_64")})
+            rc = vlpa.main(["--package", str(zp), "--expected-arch", "x86_64"])
+            self.assertEqual(rc, 0)
+
+    def test_cli_exit_one_on_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            zp = Path(tmp) / "fn.zip"
+            _make_zip(zp, {"lib/x.so": _build_elf_so("x86_64")})
+            rc = vlpa.main(["--package", str(zp), "--expected-arch", "arm64"])
+            self.assertEqual(rc, 1)
+
+    def test_cli_exit_two_on_missing_package(self) -> None:
+        rc = vlpa.main([
+            "--package", "/nonexistent/path/to/fn.zip",
+            "--expected-arch", "x86_64",
+        ])
+        self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_lambda_arch_parity.py
+++ b/tools/verify_lambda_arch_parity.py
@@ -50,6 +50,18 @@ DEPLOY_ENV_CONDITIONAL = re.compile(
     r'if\s+\[\s+-n\s+"\$\{ENVIRONMENT_SUFFIX:-\}"\s+\]'
 )
 
+# ENC-TSK-E19: block inserted into every deploy.sh to invoke
+# tools/verify_lambda_package_arch.py. The block necessarily mentions both
+# "arm64" and "x86_64" (one is selected by ENVIRONMENT_SUFFIX at runtime).
+# Stripped from deploy-script content before the arch-literal scans below so
+# the verifier injection does not cause has_aarch64 to fire on x86_64-only
+# scripts (e.g. project_service/deploy.sh, github_integration/deploy.sh).
+_ENC_TSK_E19_BLOCK_RE = re.compile(
+    r'^[ \t]*# ENC-TSK-E19:.*?'
+    r'^[ \t]*--expected-arch "\$\{E19_EXPECTED_ARCH\}"\s*$',
+    re.MULTILINE | re.DOTALL,
+)
+
 
 class LambdaBlock(NamedTuple):
     """A Lambda function block parsed from the CFN template."""
@@ -215,12 +227,19 @@ def _validate_deploy_scripts() -> List[str]:
         if "--platform" not in content:
             continue
 
-        has_aarch64 = "aarch64" in content or "arm64" in content
-        has_x86 = "x86_64" in content
+        # ENC-TSK-E19: strip the package-arch verifier injection before running
+        # the arch-literal scan. The injection necessarily mentions both "arm64"
+        # and "x86_64" (it chooses one via ENVIRONMENT_SUFFIX at runtime), which
+        # would otherwise trip the has_aarch64 / DEPLOY_PROD_X86 rules on scripts
+        # that are otherwise x86_64-only in their build logic.
+        scan_content = _ENC_TSK_E19_BLOCK_RE.sub("", content)
+
+        has_aarch64 = "aarch64" in scan_content or "arm64" in scan_content
+        has_x86 = "x86_64" in scan_content
 
         # If script references arm64/aarch64, it MUST use conditional gating
         if has_aarch64:
-            if not DEPLOY_ENV_CONDITIONAL.search(content):
+            if not DEPLOY_ENV_CONDITIONAL.search(scan_content):
                 errors.append(
                     f"{fn_name} ({deploy_script}): references arm64/aarch64 "
                     f"without ENVIRONMENT_SUFFIX conditional guard"
@@ -228,14 +247,14 @@ def _validate_deploy_scripts() -> List[str]:
                 continue
 
             # Prod path must use x86_64/py3.11
-            if not DEPLOY_PROD_X86.search(content):
+            if not DEPLOY_PROD_X86.search(scan_content):
                 errors.append(
                     f"{fn_name} ({deploy_script}): production path must use "
                     f"manylinux2014_x86_64 with py3.11"
                 )
 
             # Gamma path must use arm64/py3.12
-            if not DEPLOY_GAMMA_ARM.search(content):
+            if not DEPLOY_GAMMA_ARM.search(scan_content):
                 errors.append(
                     f"{fn_name} ({deploy_script}): gamma path must use "
                     f"manylinux2014_aarch64 with py3.12"

--- a/tools/verify_lambda_package_arch.py
+++ b/tools/verify_lambda_package_arch.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Verify that a Lambda deployment zip contains no wrong-architecture C extensions.
+
+CI / deploy-time guard that inspects the *contents* of a built Lambda zip and
+rejects the package when any compiled shared object (.so) targets a different
+CPU architecture than the declared Lambda runtime.
+
+Part of ENC-TSK-E19 (follow-up to ENC-ISS-213).
+
+Context
+-------
+The existing ``tools/verify_lambda_arch_parity.py`` enforces the CFN and
+deploy-script declarations (every Lambda uses
+``!If [IsGamma, arm64, x86_64]`` for Architectures and the right
+``pip --platform`` flag in its deploy script). That check is necessary but
+not sufficient: it verifies the *declarations* are correct, not the *artifact*
+that actually gets uploaded.
+
+ENC-ISS-213 happened because the ``devops-coordination-api-gamma`` Lambda
+shipped x86_64-compiled ``pydantic_core`` wheels on an arm64 runtime. The
+deploy declarations were correct after ENC-FTR-072 / ENC-ISS-224, but the
+zip that got uploaded still contained x86_64 binaries -- likely due to a
+pip resolution path that silently fell through to a pre-cached wheel. No
+guard looked inside the zip, so the bug reached production.
+
+This tool closes that gap. Every ``deploy.sh`` invokes it between zip
+creation and ``aws lambda update-function-code``; the CI test suite runs
+the self-test against fixture zips.
+
+Design
+------
+* Stdlib only (``zipfile``, ``subprocess``, ``argparse``, ``tempfile``).
+* Uses ``file --brief`` to classify each .so (present on Amazon Linux,
+  Ubuntu, macOS, and the CodeBuild images used by the deploy orchestrator).
+* Falls back to direct ELF magic-byte parsing if ``file`` is unavailable.
+* Pure-Python packages (zero .so files) pass trivially -- the check is a
+  no-op for functions that ship no native extensions.
+* Non-ELF ``.so`` files (rare: Windows DLLs renamed, symlinks) emit a
+  warning but do not fail the check. We only fail on *definite* mismatches.
+
+Exit codes
+----------
+* 0 -- all .so files match expected arch (or package is pure-Python).
+* 1 -- at least one .so reports a mismatched architecture.
+* 2 -- invalid arguments, package not readable, or ``file`` unavailable
+       and ELF magic-byte parsing also failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Architecture constants
+# ---------------------------------------------------------------------------
+
+# `file` reports these substrings for the two Linux ELF architectures we ship.
+#
+# Example outputs:
+#   ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked
+#   ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked
+FILE_SIGNATURES = {
+    "x86_64": ("ELF", "x86-64"),
+    "arm64":  ("ELF", "aarch64"),
+}
+
+# ELF e_machine values (ELF header offset 0x12, 2 bytes little-endian).
+# Source: /usr/include/elf.h (EM_X86_64 = 62, EM_AARCH64 = 183).
+ELF_MACHINE_TO_ARCH = {
+    0x3E: "x86_64",   # EM_X86_64
+    0xB7: "arm64",    # EM_AARCH64
+}
+
+ELF_MAGIC = b"\x7fELF"
+
+SUPPORTED_ARCHES = tuple(sorted(FILE_SIGNATURES))
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+def _classify_with_file(path: Path) -> Optional[str]:
+    """Run `file --brief` on path, return 'x86_64' / 'arm64' / None."""
+    try:
+        out = subprocess.check_output(
+            ["file", "--brief", str(path)], text=True, stderr=subprocess.STDOUT
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    for arch, needles in FILE_SIGNATURES.items():
+        if all(n in out for n in needles):
+            return arch
+    return None
+
+
+def _classify_with_elf_magic(path: Path) -> Optional[str]:
+    """Parse ELF header directly. Returns 'x86_64' / 'arm64' / None.
+
+    Used as a fallback when `file` is unavailable. Reads the first 20 bytes
+    of the file and inspects the e_machine field at offset 0x12.
+    """
+    try:
+        with path.open("rb") as f:
+            header = f.read(20)
+    except OSError:
+        return None
+    if len(header) < 20 or header[:4] != ELF_MAGIC:
+        return None  # not an ELF file
+    # e_machine is at offset 0x12 (little-endian uint16 on all supported ELF)
+    e_machine = struct.unpack_from("<H", header, 0x12)[0]
+    return ELF_MACHINE_TO_ARCH.get(e_machine)
+
+
+def classify_so(path: Path) -> Optional[str]:
+    """Return 'x86_64', 'arm64', or None for an alleged .so file.
+
+    Tries the `file` command first (richer error messages), falls back
+    to ELF magic-byte parsing if `file` is unavailable.
+    """
+    if shutil.which("file"):
+        arch = _classify_with_file(path)
+        if arch is not None:
+            return arch
+    return _classify_with_elf_magic(path)
+
+
+# ---------------------------------------------------------------------------
+# Zip inspection
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VerifyResult:
+    """Outcome of a package arch verification."""
+    package: Path
+    expected_arch: str
+    so_files: List[Path]                          # extracted paths (for debugging)
+    matches: List[Path]
+    mismatches: List[Tuple[Path, str]]            # (path, actual_arch)
+    unknowns: List[Path]                          # `file`/ELF could not classify
+
+    @property
+    def passed(self) -> bool:
+        return not self.mismatches
+
+    @property
+    def pure_python(self) -> bool:
+        return not self.so_files
+
+
+def verify_package(package: Path, expected_arch: str) -> VerifyResult:
+    """Extract the zip and classify every .so file it contains.
+
+    Raises ValueError for invalid args, FileNotFoundError for missing package.
+    """
+    if expected_arch not in FILE_SIGNATURES:
+        raise ValueError(
+            f"unsupported expected-arch {expected_arch!r}; "
+            f"use one of: {', '.join(SUPPORTED_ARCHES)}"
+        )
+    if not package.is_file():
+        raise FileNotFoundError(f"package not found: {package}")
+
+    matches: List[Path] = []
+    mismatches: List[Tuple[Path, str]] = []
+    unknowns: List[Path] = []
+    so_files: List[Path] = []
+
+    with tempfile.TemporaryDirectory(prefix="verify_lambda_arch_") as tmp:
+        tmp_path = Path(tmp)
+        try:
+            with zipfile.ZipFile(package) as zf:
+                zf.extractall(tmp_path)
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"not a valid zip: {package} ({exc})") from exc
+
+        # Collect .so files (includes versioned suffixes like libfoo.so.1.2)
+        for pat in ("*.so", "*.so.*"):
+            so_files.extend(tmp_path.rglob(pat))
+
+        for so in so_files:
+            rel = so.relative_to(tmp_path)
+            arch = classify_so(so)
+            if arch is None:
+                unknowns.append(rel)
+            elif arch == expected_arch:
+                matches.append(rel)
+            else:
+                mismatches.append((rel, arch))
+
+    return VerifyResult(
+        package=package,
+        expected_arch=expected_arch,
+        so_files=[s.relative_to(tmp_path) for s in so_files] if so_files else [],
+        matches=matches,
+        mismatches=mismatches,
+        unknowns=unknowns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _format_success(result: VerifyResult) -> str:
+    if result.pure_python:
+        return (
+            f"[OK] {result.package.name} is pure-Python "
+            f"(0 .so files -- nothing to check)"
+        )
+    return (
+        f"[OK] {result.package.name} "
+        f"all {len(result.matches)} .so files match {result.expected_arch}"
+    )
+
+
+def _format_failure(result: VerifyResult) -> str:
+    lines = [
+        f"[FAIL] {result.package.name} expected {result.expected_arch}, "
+        f"found {len(result.mismatches)} mismatch(es):",
+    ]
+    for rel, actual in result.mismatches:
+        lines.append(f"  {rel}: {actual}")
+    return "\n".join(lines)
+
+
+def _format_warnings(result: VerifyResult) -> str:
+    if not result.unknowns:
+        return ""
+    lines = [
+        f"[WARN] {result.package.name} "
+        f"{len(result.unknowns)} .so file(s) could not be classified:",
+    ]
+    for rel in result.unknowns:
+        lines.append(f"  {rel}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Verify a Lambda deployment zip contains only the expected "
+            "architecture for its compiled C extensions."
+        )
+    )
+    ap.add_argument("--package", required=True, type=Path,
+                    help="Path to the Lambda zip to inspect.")
+    ap.add_argument("--expected-arch", required=True, choices=SUPPORTED_ARCHES,
+                    help="Expected Lambda runtime architecture.")
+    args = ap.parse_args(argv)
+
+    try:
+        result = verify_package(args.package, args.expected_arch)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+
+    warn = _format_warnings(result)
+    if warn:
+        print(warn, file=sys.stderr)
+
+    if result.passed:
+        print(_format_success(result))
+        return 0
+
+    print(_format_failure(result), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a CI + deploy-time guard that inspects Lambda deployment zip **contents** and rejects any package containing compiled shared objects (.so) for an architecture different from the target Lambda runtime. Closes the build-time isolation gap exposed by **ENC-ISS-213**.

- `tools/verify_lambda_arch_parity.py` (existing) validates CFN and deploy-script **declarations**
- `tools/verify_lambda_package_arch.py` (new, this PR) validates the **artifact**

ENC-ISS-213 happened because `devops-coordination-api-gamma` shipped x86_64-compiled `pydantic_core` wheels on an arm64 runtime *despite* correct declarations — nothing inspected the built zip. D57 hot-fixed the Lambda; this PR makes recurrence structurally impossible.

## Changes

- **New tool** `tools/verify_lambda_package_arch.py` — stdlib-only CLI, `file --brief` with ELF magic-byte fallback (EM_X86_64=0x3E, EM_AARCH64=0xB7)
- **New tests** `tools/test_verify_lambda_package_arch.py` — 15 tests, synthesizes minimal ELF64 fixtures for both arches so the suite runs anywhere; explicit ENC-ISS-213 repro case
- **CI** `.github/workflows/ci.yml` runs the new test suite alongside the existing arch parity check
- **30 deploy scripts** `backend/lambda/*/deploy.sh` now invoke the verifier just before `aws lambda update-function-code`, deriving expected arch from `ENVIRONMENT_SUFFIX` (empty→x86_64, `-gamma`→arm64). `shared_layer/deploy.sh` correctly skipped (uses `publish-layer-version`, not `update-function-code`)
- **Governance dictionary** bumped `2026-04-15.7 → 2026-04-15.8` with new `deploy.package_arch_guard` entity (6 fields: expected_arch, enforcement_point, rejection_conditions, trivial_pass_condition, classification_method, historical_precedent)
- **Existing guard patched** `tools/verify_lambda_arch_parity.py` now strips the `ENC-TSK-E19` injection block before its arm64-literal scan, preventing false positives on x86_64-only scripts (`project_service`, `github_integration`)

## Diffstat

35 files changed, 799 insertions(+), 7 deletions(-)

## Test plan

- [x] `python3 -m unittest tools.test_verify_lambda_package_arch -v` — 15/15 passing locally
- [x] `python3 -m unittest tools.test_verify_lambda_arch_parity -v` — still passing
- [x] `python3 tools/verify_lambda_arch_parity.py` — SUCCESS across all 21 CFN Lambdas
- [x] Idempotency: rerunning the deploy.sh injector is a no-op (sentinel comment detected)
- [x] Manual: synthetic x86_64 zip rejected when `--expected-arch arm64`; pure-Python zip passes trivially
- [ ] CI green on PR
- [ ] Post-merge: `GOVERNANCE_SYNC_REQUIRED` handoff to sync dictionary to S3

## Checkout tokens

- Task: ENC-TSK-E19 (P1, github_pr_deploy, deploy_target=prod)
- Components: comp-github-governance, comp-coordination-api
- Related: ENC-ISS-213 (closed, this is defense-in-depth)
- Sibling task: ENC-TSK-E20 (split build pipeline — starts after this merges)

CCI-abe7cfe830bf4cf19aabf4d1d3464459

🤖 Generated with [Claude Code](https://claude.com/claude-code)