### PR TITLE
Hotfix ENC-TSK-E21: CWD-independent E19_REPO_ROOT resolution (unblocks Lambda deploys)

### DIFF
--- a/backend/lambda/auth_edge/deploy.sh
+++ b/backend/lambda/auth_edge/deploy.sh
@@ -33,7 +33,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/auth_refresh/deploy.sh
+++ b/backend/lambda/auth_refresh/deploy.sh
@@ -37,7 +37,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/bedrock_agent_actions/deploy.sh
+++ b/backend/lambda/bedrock_agent_actions/deploy.sh
@@ -152,7 +152,7 @@ ensure_function() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/changelog_api/deploy.sh
+++ b/backend/lambda/changelog_api/deploy.sh
@@ -155,7 +155,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/checkout_service/deploy.sh
+++ b/backend/lambda/checkout_service/deploy.sh
@@ -277,7 +277,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${fn_name}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating code: ${fn_name}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -625,7 +625,7 @@ ensure_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/coordination_monitor_api/deploy.sh
+++ b/backend/lambda/coordination_monitor_api/deploy.sh
@@ -119,7 +119,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/deploy_decide/deploy.sh
+++ b/backend/lambda/deploy_decide/deploy.sh
@@ -107,7 +107,7 @@ main() {
 
   log "Updating Lambda code..."
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/deploy_finalize/deploy.sh
+++ b/backend/lambda/deploy_finalize/deploy.sh
@@ -39,7 +39,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/deploy_intake/deploy.sh
+++ b/backend/lambda/deploy_intake/deploy.sh
@@ -213,7 +213,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/deploy_orchestrator/deploy.sh
+++ b/backend/lambda/deploy_orchestrator/deploy.sh
@@ -155,7 +155,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/doc_prep/deploy.sh
+++ b/backend/lambda/doc_prep/deploy.sh
@@ -39,7 +39,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/document_api/deploy.sh
+++ b/backend/lambda/document_api/deploy.sh
@@ -207,7 +207,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/feed_publisher/deploy.sh
+++ b/backend/lambda/feed_publisher/deploy.sh
@@ -50,7 +50,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/feed_query/deploy.sh
+++ b/backend/lambda/feed_query/deploy.sh
@@ -45,7 +45,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/github_integration/deploy.sh
+++ b/backend/lambda/github_integration/deploy.sh
@@ -158,7 +158,7 @@ ensure_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/glue_crawler_launcher/deploy.sh
+++ b/backend/lambda/glue_crawler_launcher/deploy.sh
@@ -33,7 +33,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/governance_audit/deploy.sh
+++ b/backend/lambda/governance_audit/deploy.sh
@@ -19,7 +19,7 @@ echo "[INFO] Package ready: ${ZIP_FILE} ($(du -h "${ZIP_FILE}" | cut -f1))"
 
 echo "[INFO] Updating Lambda function code"
 # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 E19_EXPECTED_ARCH="x86_64"
 [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
 python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/graph_health_metrics/deploy.sh
+++ b/backend/lambda/graph_health_metrics/deploy.sh
@@ -64,7 +64,7 @@ deploy_function() {
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/graph_query_api/deploy.sh
+++ b/backend/lambda/graph_query_api/deploy.sh
@@ -133,7 +133,7 @@ ensure_lambda() {
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/graph_sync/deploy.sh
+++ b/backend/lambda/graph_sync/deploy.sh
@@ -120,7 +120,7 @@ ensure_lambda() {
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/json_to_parquet_transformer/deploy.sh
+++ b/backend/lambda/json_to_parquet_transformer/deploy.sh
@@ -33,7 +33,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/mcp_code/deploy.sh
+++ b/backend/lambda/mcp_code/deploy.sh
@@ -382,7 +382,7 @@ deploy_lambda() {
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/mcp_streamable/deploy.sh
+++ b/backend/lambda/mcp_streamable/deploy.sh
@@ -228,7 +228,7 @@ deploy_lambda() {
   if function_exists; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/neo4j_backup/deploy.sh
+++ b/backend/lambda/neo4j_backup/deploy.sh
@@ -94,7 +94,7 @@ deploy_lambda() {
     local arch_flag="x86_64" runtime_flag="python3.11"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64" && runtime_flag="python3.12"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/prod_health_monitor/deploy.sh
+++ b/backend/lambda/prod_health_monitor/deploy.sh
@@ -80,7 +80,7 @@ print(json.dumps(env))
     local arch_flag="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && arch_flag="arm64"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/project_service/deploy.sh
+++ b/backend/lambda/project_service/deploy.sh
@@ -138,7 +138,7 @@ PY
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/reference_search/deploy.sh
+++ b/backend/lambda/reference_search/deploy.sh
@@ -113,7 +113,7 @@ deploy_lambda() {
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/titan_embedding_backfill/deploy.sh
+++ b/backend/lambda/titan_embedding_backfill/deploy.sh
@@ -155,7 +155,7 @@ ENV_JSON
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[INFO] Updating existing Lambda: ${FUNCTION_NAME}"
     # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-    E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
     E19_EXPECTED_ARCH="x86_64"
     [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
     python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \

--- a/backend/lambda/tracker_mutation/deploy.sh
+++ b/backend/lambda/tracker_mutation/deploy.sh
@@ -143,7 +143,7 @@ deploy_lambda() {
 
   log "[START] updating Lambda code: ${FUNCTION_NAME}"
   # ENC-TSK-E19: verify package arch matches Lambda runtime before upload
-  E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
   E19_EXPECTED_ARCH="x86_64"
   [ -n "${ENVIRONMENT_SUFFIX:-}" ] && E19_EXPECTED_ARCH="arm64"
   python3 "${E19_REPO_ROOT}/tools/verify_lambda_package_arch.py" \


### PR DESCRIPTION
## Summary

Hotfix for **ENC-ISS-232** — the ENC-TSK-E19 injection's repo-root resolution broke Lambda deploys in GitHub Actions because the workflow cd's into each deploy script's directory before running it, rendering `$(dirname "${BASH_SOURCE[0]}")/../../..` a relative path that can't resolve from the new CWD.

Swap the BASH_SOURCE-relative form for `${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}`, which is CWD-independent.

## Blast radius of the original bug

3 Lambda deploys failed at the ENC-TSK-E19 merge SHA (`7ad14f1`):
- Lambda Deploy - enceladus-governance-audit (run 24450048714)
- Lambda Deploy - devops-project-service (run 24450048698)
- Lambda Deploy - devops-reference-search (run 24450048693)

10 more were stuck waiting in the gamma-first sequence. No Lambda code was actually corrupted — failures happened pre-upload.

## Fix

Replace in every `backend/lambda/*/deploy.sh`:
```bash
# Before (broken when CWD != repo root):
E19_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"

# After (CWD-independent):
E19_REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null)}"
```

- **CI path**: `GITHUB_WORKSPACE` is auto-set by GitHub Actions to the checkout root; the subshell never runs.
- **Local dev path**: `git rev-parse --show-toplevel` walks the git directory, not relative paths, so it works from anywhere inside the worktree.

## Diff scope

30 files changed, 30 insertions(+), 30 deletions(-). One line per deploy.sh. `shared_layer/deploy.sh` was never injected (publishes a layer, not a function) and is unchanged. No new files, no changes outside the affected line.

## Test plan

- [x] `python3 -m unittest tools.test_verify_lambda_package_arch tools.test_verify_lambda_arch_parity` — all passing
- [x] `python3 tools/verify_lambda_arch_parity.py` — SUCCESS (E19-block stripper unaffected; sentinel + closing line unchanged)
- [x] Local repro from `cd backend/lambda/governance_audit/` with `GITHUB_WORKSPACE` unset: `E19_REPO_ROOT` resolves to the worktree root; verifier file exists at resolved path
- [x] Local repro with `GITHUB_WORKSPACE=/some/ci/workspace` set: `E19_REPO_ROOT` matches `GITHUB_WORKSPACE` (correct for CI)
- [ ] CI green on this PR
- [ ] After merge: re-run the 3 failed Lambda deploys via `gh run rerun`; all reach `conclusion=success`

## Checkout tokens

- Task: ENC-TSK-E21 (P0, github_pr_deploy, deploy_target=prod)
- Component: comp-github-governance
- Closes: ENC-ISS-232
- Unblocks: ENC-TSK-E19 deploy arc (still at merged-main, deploy evidence pending on this fix)

CCI-3213766386c7491797eddc12dc1d985b

🤖 Generated with [Claude Code](https://claude.com/claude-code)