### PR TITLE
fix(lambda-deploy-reusable): bifurcate pip build flags by environment_suffix (ENC-TSK-E25)

### DIFF
--- a/.github/workflows/lambda-deploy-reusable.yml
+++ b/.github/workflows/lambda-deploy-reusable.yml
@@ -137,14 +137,21 @@ jobs:
 
           cp "${lambda_dir}/lambda_function.py" "${build_dir}/"
 
+          # Env-conditional build: gamma=arm64/py3.12, prod=x86_64/py3.11
+          if [ -n "${{ inputs.environment_suffix }}" ]; then
+            pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+          else
+            pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+          fi
+
           if [[ -f "${lambda_dir}/requirements.txt" ]]; then
             python3 -m pip install \
               --quiet \
               --upgrade \
-              --platform manylinux2014_x86_64 \
+              --platform "${pip_platform}" \
               --implementation cp \
-              --python-version 3.11 \
-              --abi cp311 \
+              --python-version "${pip_pyver}" \
+              --abi "${pip_abi}" \
               --only-binary=:all: \
               -r "${lambda_dir}/requirements.txt" \
               -t "${build_dir}" >/dev/null


### PR DESCRIPTION
## Summary
- **ENC-TSK-E25** / **ENC-ISS-235** (P0)
- The reusable Lambda deploy workflow's build step hardcoded `--platform manylinux2014_x86_64 / --python-version 3.11 / --abi cp311` for all invocations while the runtime config step already correctly branched on `inputs.environment_suffix`
- Mirrors the existing runtime bifurcation: empty suffix → x86_64/py3.11/cp311; `-gamma` suffix → aarch64/py3.12/cp312
- Systemic fix affecting ~7 Lambdas routed through the generic `deploy-orchestration.yml` path (identified by DOC-406F0E074649 / ENC-TSK-E22 v4/main debt scan, finding F-05)

CCI-8aec56281eac4cbaab4be51495ff4976

## Test plan
- [x] `python3 tools/verify_lambda_arch_parity.py` passes locally (SUCCESS)
- [ ] CI green on PR
- [ ] Post-merge: at least one gamma deploy through the reusable workflow completes `conclusion=success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)