### PR TITLE
fix(deploy-scripts): bifurcate pip_platform/pip_pyver/pip_abi in 4 Lambda deploy.sh (ENC-TSK-E24)

### DIFF
--- a/backend/lambda/bedrock_agent_actions/deploy.sh
+++ b/backend/lambda/bedrock_agent_actions/deploy.sh
@@ -167,10 +167,13 @@ ensure_function() {
       --region "${REGION}"
   else
     log "[START] creating Lambda function: ${FUNCTION_NAME}"
+    # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+    local runtime_flag="python3.11"
+    if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then runtime_flag="python3.12"; fi
     aws lambda create-function \
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}" \
-      --runtime python3.11 \
+      --runtime "${runtime_flag}" \
       --handler lambda_function.handler \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/github_integration/deploy.sh
+++ b/backend/lambda/github_integration/deploy.sh
@@ -130,13 +130,21 @@ package_lambda() {
 
   cp "${ROOT_DIR}/lambda_function.py" "${build_dir}/"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+  local pip_platform pip_pyver pip_abi
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.11 \
-    --abi cp311 \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
     --only-binary=:all: \
     -r "${ROOT_DIR}/requirements.txt" \
     -t "${build_dir}" >/dev/null
@@ -170,10 +178,13 @@ ensure_lambda() {
       --zip-file "fileb://${zip_path}" >/dev/null
   else
     log "[START] creating Lambda function: ${FUNCTION_NAME}"
+    # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+    local runtime_flag="python3.11"
+    if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then runtime_flag="python3.12"; fi
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime "${runtime_flag}" \
       --handler lambda_function.lambda_handler \
       --role "${role_arn}" \
       --timeout 30 \

--- a/backend/lambda/project_service/deploy.sh
+++ b/backend/lambda/project_service/deploy.sh
@@ -31,19 +31,22 @@ package_lambda() {
 
   cp "${SCRIPT_DIR}/lambda_function.py" "${build_dir}/"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+  local pip_platform pip_pyver pip_abi
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   # Install dependencies (PyJWT with crypto support for Cognito JWT validation)
-  # CRITICAL: Must target Lambda's Python 3.11 / Linux x86_64 runtime.
-  # Without --platform/--abi flags, pip installs for the runner's Python
-  # (3.12 on ubuntu-latest), producing .cpython-312 native extensions that
-  # fail to load on Lambda's 3.11 runtime (ENC-ISS-122, same class as
-  # ENC-ISS-041/DVP-ISS-059).
   python3 -m pip install \
     --quiet \
     --upgrade \
-    --platform manylinux2014_x86_64 \
+    --platform "${pip_platform}" \
     --implementation cp \
-    --python-version 3.11 \
-    --abi cp311 \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
     --only-binary=:all: \
     PyJWT>=2.8.0 \
     cryptography>=41.0.0 \

--- a/backend/lambda/reference_search/deploy.sh
+++ b/backend/lambda/reference_search/deploy.sh
@@ -88,10 +88,23 @@ package_lambda() {
 
   cp "${SCRIPT_DIR}/lambda_function.py" "${build_dir}/"
 
+  # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+  local pip_platform pip_pyver pip_abi
+  if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then
+    pip_platform="manylinux2014_aarch64"; pip_pyver="3.12"; pip_abi="cp312"
+  else
+    pip_platform="manylinux2014_x86_64"; pip_pyver="3.11"; pip_abi="cp311"
+  fi
+
   # Install PyJWT with crypto support
   python3 -m pip install \
     --quiet \
     --upgrade \
+    --platform "${pip_platform}" \
+    --implementation cp \
+    --python-version "${pip_pyver}" \
+    --abi "${pip_abi}" \
+    --only-binary=:all: \
     "PyJWT[crypto]>=2.8.0" \
     -t "${build_dir}" >/dev/null
 
@@ -136,10 +149,13 @@ deploy_lambda() {
       --environment "Variables=${env_vars}" >/dev/null
   else
     log "[START] creating Lambda function: ${FUNCTION_NAME}"
+    # Env-conditional: gamma=arm64/py3.12, prod=x86_64/py3.11.
+    local runtime_flag="python3.11"
+    if [ -n "${ENVIRONMENT_SUFFIX:-}" ]; then runtime_flag="python3.12"; fi
     aws lambda create-function \
       --region "${REGION}" \
       --function-name "${FUNCTION_NAME}" \
-      --runtime python3.11 \
+      --runtime "${runtime_flag}" \
       --handler "lambda_function.lambda_handler" \
       --role "${role_arn}" \
       --timeout 10 \


### PR DESCRIPTION
## Summary
- **ENC-TSK-E24** / **ENC-ISS-233** (P1)
- Applies the `ENVIRONMENT_SUFFIX`-conditional `pip_platform/pip_pyver/pip_abi` bifurcation to 4 deploy.sh scripts that hardcoded x86_64/py3.11/cp311 (or had no platform flags), causing the ENC-TSK-E19 arch guard to reject gamma zips:
  - `project_service/deploy.sh`: replace hardcoded `--platform/--abi/--python-version`
  - `reference_search/deploy.sh`: add all pip install flags (had none); bifurcate `--runtime`
  - `github_integration/deploy.sh`: same as project_service; bifurcate `--runtime`
  - `bedrock_agent_actions/deploy.sh`: bifurcate `--runtime` (no pip install with platform flags)
- Scope refined from original ISS-233 (4 Lambdas) per workflow-log triage: checkout_service + mcp_code deploy.sh are actually clean (separate root causes); github_integration + bedrock_agent_actions added per DOC-406F0E074649 (ENC-TSK-E22 v4/main debt inventory)

CCI-408480ba6ded42d1a5d07d0f58857025

## Test plan
- [x] `python3 tools/verify_lambda_arch_parity.py` passes locally (SUCCESS)
- [ ] CI green on PR
- [ ] Post-merge: project_service + reference_search + github_integration gamma deploys pass E19 arch guard (conclusion=success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)