### PR TITLE
feat(deploy): wire build-then-deploy pipeline with arch-tag gate (ENC-TSK-E28)

### DIFF
--- a/.github/workflows/build-lambda-artifacts.yml
+++ b/.github/workflows/build-lambda-artifacts.yml
@@ -91,7 +91,11 @@ jobs:
 
   upload-artifacts:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Upload on push to main (standalone) or when called via workflow_call (from deploy-orchestration)
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       artifact_prefix: ${{ steps.upload.outputs.artifact_prefix }}

--- a/.github/workflows/deploy-orchestration.yml
+++ b/.github/workflows/deploy-orchestration.yml
@@ -1,12 +1,16 @@
 name: Deploy Orchestration (Gamma-First)
 
-# ENC-TSK-D18 / ENC-PLN-020 Phase 2
+# ENC-TSK-D18 / ENC-PLN-020 Phase 2, wired by ENC-TSK-E28
 # Enforces gamma-first deploy sequencing:
-#   gamma deploy -> automated UAT gate -> manual approval -> prod deploy -> prod validation
+#   build artifacts -> gamma deploy -> UAT gate -> manual approval -> prod deploy -> prod validation
 #
 # Two modes:
 #   per-lambda:  Single function through the full sequence
 #   full-stack:  All manifest functions via matrix strategy
+#
+# S3 artifact keys (ENC-TSK-E20 split pipeline):
+#   lambda-artifacts/{git_sha}/arm64-py312/{fn}.zip  (gamma)
+#   lambda-artifacts/{git_sha}/x86_64-py311/{fn}.zip (prod)
 
 on:
   workflow_call:
@@ -71,13 +75,24 @@ permissions:
   id-token: write
 
 # ---------------------------------------------------------------------------
-# PER-LAMBDA MODE
+# BUILD ARTIFACTS (both architectures, all functions)
 # ---------------------------------------------------------------------------
 
 jobs:
 
+  # ENC-TSK-E28: Build all Lambda artifacts before any deploy job runs.
+  # Outputs artifact_prefix used to construct per-function S3 keys.
+  build-artifacts:
+    uses: ./.github/workflows/build-lambda-artifacts.yml
+    secrets: inherit
+
+  # ---------------------------------------------------------------------------
+  # PER-LAMBDA MODE
+  # ---------------------------------------------------------------------------
+
   # ---- Gamma deploy (per-lambda) ----
   gamma-deploy:
+    needs: build-artifacts
     if: inputs.deploy_mode == 'per-lambda'
     uses: ./.github/workflows/lambda-deploy-reusable.yml
     with:
@@ -86,6 +101,8 @@ jobs:
       deploy_script: ${{ inputs.deploy_script }}
       package_extra_files: ${{ inputs.package_extra_files }}
       environment_suffix: "-gamma"
+      artifact_s3_bucket: jreese-net
+      artifact_s3_key: ${{ needs.build-artifacts.outputs.artifact_prefix }}/arm64-py312/${{ inputs.function_name }}.zip
     secrets: inherit
 
   # ---- Gamma health gate (per-lambda) ----
@@ -139,7 +156,7 @@ jobs:
 
   # ---- Prod deploy (per-lambda, main only) ----
   prod-deploy:
-    needs: approval
+    needs: [approval, build-artifacts]
     if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/lambda-deploy-reusable.yml
     with:
@@ -148,6 +165,8 @@ jobs:
       deploy_script: ${{ inputs.deploy_script }}
       package_extra_files: ${{ inputs.package_extra_files }}
       environment_suffix: ""
+      artifact_s3_bucket: jreese-net
+      artifact_s3_key: ${{ needs.build-artifacts.outputs.artifact_prefix }}/x86_64-py311/${{ inputs.function_name }}.zip
     secrets: inherit
 
   # ---- Prod validation (per-lambda, main only) ----
@@ -222,7 +241,7 @@ jobs:
 
   # ---- Gamma deploy (full-stack matrix) ----
   gamma-deploy-matrix:
-    needs: setup-matrix
+    needs: [build-artifacts, setup-matrix]
     if: inputs.deploy_mode == 'full-stack'
     strategy:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -235,6 +254,8 @@ jobs:
       deploy_script: ${{ matrix.deploy_script }}
       package_extra_files: ${{ matrix.package_extra_files }}
       environment_suffix: "-gamma"
+      artifact_s3_bucket: jreese-net
+      artifact_s3_key: ${{ needs.build-artifacts.outputs.artifact_prefix }}/arm64-py312/${{ matrix.function_name }}.zip
     secrets: inherit
 
   # ---- Gamma health gate (full-stack) ----
@@ -288,7 +309,7 @@ jobs:
 
   # ---- Prod deploy (full-stack matrix, main only) ----
   prod-deploy-matrix:
-    needs: [approval-fullstack, setup-matrix]
+    needs: [approval-fullstack, setup-matrix, build-artifacts]
     if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
     strategy:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
@@ -301,6 +322,8 @@ jobs:
       deploy_script: ${{ matrix.deploy_script }}
       package_extra_files: ${{ matrix.package_extra_files }}
       environment_suffix: ""
+      artifact_s3_bucket: jreese-net
+      artifact_s3_key: ${{ needs.build-artifacts.outputs.artifact_prefix }}/x86_64-py311/${{ matrix.function_name }}.zip
     secrets: inherit
 
   # ---- Prod validation (full-stack, main only) ----

--- a/.github/workflows/lambda-deploy-reusable.yml
+++ b/.github/workflows/lambda-deploy-reusable.yml
@@ -108,6 +108,29 @@ jobs:
       - name: Verify AWS identity
         run: aws sts get-caller-identity
 
+      # ENC-TSK-E28: Arch-tag validation gate — reject cross-arch S3 artifacts
+      - name: Validate artifact architecture tag
+        if: ${{ inputs.artifact_s3_key != '' }}
+        run: |
+          set -euo pipefail
+          key="${{ inputs.artifact_s3_key }}"
+          suffix="${{ inputs.environment_suffix }}"
+
+          if [[ -n "${suffix}" ]]; then
+            # Gamma deploy: artifact key must contain arm64-py312
+            if [[ "${key}" != *"arm64-py312"* ]]; then
+              echo "::error::Arch-tag mismatch: gamma deploy (suffix='${suffix}') requires arm64-py312 in artifact key, got: ${key}"
+              exit 1
+            fi
+          else
+            # Prod deploy: artifact key must contain x86_64-py311
+            if [[ "${key}" != *"x86_64-py311"* ]]; then
+              echo "::error::Arch-tag mismatch: prod deploy (no suffix) requires x86_64-py311 in artifact key, got: ${key}"
+              exit 1
+            fi
+          fi
+          echo "Artifact arch-tag validated: ${key}"
+
       - name: Deploy via explicit script
         if: ${{ inputs.deploy_script != '' }}
         env:


### PR DESCRIPTION
## Summary

Phase 3 of the split Lambda build pipeline (ENC-TSK-E20). Wires `build-lambda-artifacts.yml` as a predecessor job in `deploy-orchestration.yml`, threading arch-tagged S3 artifact keys to all deploy jobs.

- **deploy-orchestration.yml**: `build-artifacts` job at top of dependency graph; all 4 deploy jobs (`gamma-deploy`, `prod-deploy`, `gamma-deploy-matrix`, `prod-deploy-matrix`) have `needs: build-artifacts` and receive `artifact_s3_bucket` + `artifact_s3_key`
- **lambda-deploy-reusable.yml**: Arch-tag validation gate step rejects gamma deploys without `arm64-py312` and prod deploys without `x86_64-py311` in the artifact key
- **build-lambda-artifacts.yml**: Upload condition updated to support `workflow_call` and `workflow_dispatch` triggers (not just `push` to `main`)

S3 key threading: gamma gets `arm64-py312/{fn}.zip`, prod gets `x86_64-py311/{fn}.zip` — both from `build-artifacts` output prefix.

CCI-380cfcc409f349e7af76947ae47e79b5

Satisfies ENC-TSK-E20 AC-3 (complete).

## Test plan

- [ ] CI passes (arch parity + workflow coverage validators)
- [ ] Verify arch-tag gate would reject mismatched keys (gamma + x86_64, prod + arm64)
- [ ] Verify build-artifacts job is in needs: chain for all deploy jobs
- [ ] Verify S3 key construction uses correct arch tags per environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)