### PR TITLE
feat(E31): add BackendDeployRole to CFN with S3 artifact permissions

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -212,6 +212,106 @@ Resources:
                   - logs:DescribeLogStreams
                 Resource: "*"
 
+  # ---------------------------------------------------------------------------
+  # Backend Deploy Role (ENC-TSK-E31 / ENC-ISS-237)
+  # Used by:
+  #   - .github/workflows/lambda-deploy-reusable.yml
+  #   - .github/workflows/build-lambda-artifacts.yml
+  #   - .github/workflows/api-mcp-backend-deploy.yml
+  #   - .github/workflows/deploy-orchestration.yml
+  # Secret:  AWS_BACKEND_ROLE_TO_ASSUME
+  #
+  # NOTE: This role pre-exists as a manually-created IAM role. To bring it
+  # under CloudFormation management, import it into the stack:
+  #   aws cloudformation create-change-set \
+  #     --stack-name enceladus-github-roles \
+  #     --template-body file://infrastructure/cloudformation/04-github-roles.yaml \
+  #     --change-set-name import-backend-deploy-role \
+  #     --change-set-type IMPORT \
+  #     --resources-to-import '[{"ResourceType":"AWS::IAM::Role","LogicalResourceId":"BackendDeployRole","ResourceIdentifier":{"RoleName":"enceladus-backend-deploy-github-role"}}]' \
+  #     --capabilities CAPABILITY_NAMED_IAM
+  # Then execute the change set, and subsequent stack updates will manage it.
+  # ---------------------------------------------------------------------------
+  BackendDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: enceladus-backend-deploy-github-role
+      Description: >
+        GitHub Actions OIDC role for Lambda backend deployments and
+        artifact build/upload. Used by lambda-deploy-reusable.yml,
+        build-lambda-artifacts.yml, and deploy-orchestration.yml.
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Ref OIDCProviderArn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/v4/*"
+      Policies:
+        - PolicyName: BackendDeployPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Lambda function deployment operations
+              - Sid: LambdaDeployOps
+                Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                  - lambda:GetFunction
+                  - lambda:GetFunctionConfiguration
+                  - lambda:PublishLayerVersion
+                  - lambda:GetLayerVersion
+                Resource: "*"
+
+              # S3 artifact read/write for split-artifact build pipeline
+              # (ENC-TSK-E20 / ENC-ISS-237)
+              - Sid: S3ArtifactReadWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource:
+                  - "arn:aws:s3:::jreese-net/lambda-artifacts/*"
+
+              # S3 read for deploy-config (deploy scripts read config)
+              - Sid: S3DeployConfigRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - "arn:aws:s3:::jreese-net/deploy-config/*"
+
+              # S3 list for artifact enumeration
+              - Sid: S3ArtifactList
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - "arn:aws:s3:::jreese-net"
+                Condition:
+                  StringLike:
+                    s3:prefix:
+                      - "lambda-artifacts/*"
+                      - "deploy-config/*"
+
+              # Secrets Manager for GitHub token (used by deploy scripts
+              # for PR validation and checkout service)
+              - Sid: SecretsManagerRead
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:devops/*"
+
 Outputs:
   CloudFormationDeployRoleArn:
     Description: >
@@ -219,3 +319,9 @@ Outputs:
     Value: !GetAtt CloudFormationDeployRole.Arn
     Export:
       Name: !Sub "${AWS::StackName}-CloudFormationDeployRoleArn"
+  BackendDeployRoleArn:
+    Description: >
+      ARN to set as the AWS_BACKEND_ROLE_TO_ASSUME repository secret.
+    Value: !GetAtt BackendDeployRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-BackendDeployRoleArn"


### PR DESCRIPTION
## Summary

- Add `BackendDeployRole` (`enceladus-backend-deploy-github-role`) to `infrastructure/cloudformation/04-github-roles.yaml`
- Grants `s3:PutObject` + `s3:GetObject` on `arn:aws:s3:::jreese-net/lambda-artifacts/*` (resolves ENC-ISS-237)
- Grants `s3:GetObject` on `deploy-config/*`, `s3:ListBucket` with prefix condition
- Lambda deploy ops, Secrets Manager read for deploy scripts
- OIDC trust scoped to `NX-2021-L/enceladus` on `main` and `v4/*` branches

**Post-merge action required:** The role pre-exists as a manually-created IAM resource. Import it into the `enceladus-github-roles` CFN stack via change set before the stack update can manage it (import instructions in template comments).

ENC-TSK-E31 / ENC-ISS-237.

CCI-96474897cd624243a03446f8b8bbacc4

## Test plan

- [x] CFN YAML validates (2 resources, 2 outputs)
- [ ] CI checks pass
- [ ] Post-merge: import existing role into CFN stack via change set
- [ ] Post-import: verify `build-lambda-artifacts.yml` Upload Artifacts to S3 step succeeds (no AccessDenied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)