### PR TITLE
feat(E40): Coordination Supervisor Skill MVP (F2/F3/F6)

### DIFF
--- a/tools/skills/coordination-supervisor/README.md
+++ b/tools/skills/coordination-supervisor/README.md
@@ -1,0 +1,115 @@
+# Coordination Supervisor Skill
+
+**Version**: 0.1.0
+**Source Spec**: DOC-D4D7D8606824 (Coordination Supervisor Skill Feature Spec v3)
+**Plan**: ENC-PLN-028 | **Task**: ENC-TSK-E40
+**Related**: ENC-PLN-027 (Deploy Safety & Dual-Wheel Discipline)
+
+## Overview
+
+The Coordination Supervisor is a Claude Desktop skill that provides a consistent
+human-AI surface layer for supervising multi-agent Enceladus activity. It sits one
+step above the coordination lead and translates multi-session workspace activity into
+a form io can supervise at speed.
+
+### MVP Features (v0.1.0)
+
+- **F2** -- Handoff Document Generator (3 template variants + Lambda-deploy rule)
+- **F3** -- Dispatch Prompt Block Producer (3 dispatch contexts + retry budget)
+- **F6** -- HANDOFF Block Interpreter (parse-verify-route + deploy-package validation)
+
+### Stubbed Features (future iteration)
+
+F1 (Concurrency Map), F4 (Executive Summary), F5 (Velocity Telemetry),
+F7 (Decision Queue), F8 (Anchor-Word Resonance), F9 (Substrate Resilience).
+See `references/stubbed-features.md` for pointers to DOC-D4D7D8606824 sections.
+
+### Built-in Session Init
+
+The skill includes a built-in Enceladus governed session init protocol
+(DOC-ABEC1070C060 v2). When activated, the skill automatically runs health check,
+loads open tasks, lessons, and plan status before responding. **The user does not
+need to init the session manually before using this skill.**
+
+## Installation
+
+### Option A: Direct copy (recommended)
+
+Copy the skill directory into your Claude Code skills path:
+
+```bash
+cp -r tools/skills/coordination-supervisor/ ~/.claude/skills/coordination-supervisor/
+```
+
+### Option B: Plugin directory flag (development)
+
+Point Claude Code at the skill directory for development use:
+
+```bash
+claude --skill-dir /path/to/enceladus/repo/tools/skills/coordination-supervisor
+```
+
+### Option C: Symlink (keeps repo as source of truth)
+
+```bash
+ln -s /path/to/enceladus/repo/tools/skills/coordination-supervisor \
+      ~/.claude/skills/coordination-supervisor
+```
+
+## Verification
+
+After installation, open a new Claude Code session and try one of these trigger phrases:
+
+- "coordination supervisor"
+- "supervise my coordination"
+- "generate a handoff document"
+- "create a dispatch prompt"
+- "interpret a HANDOFF block"
+- "summarize agent activity"
+
+The skill should activate and run the session init protocol automatically before
+responding to your request.
+
+## Scope Separation
+
+The skill honors the supervisor scope-separation invariant. It will NEVER:
+
+- Perform `checkout.task`, `checkout.advance`, or `checkout.append_worklog`
+- Execute git operations or modify files directly
+- Run `governance.update` or deploy mutations
+
+See `references/scope-separation-invariant.md` for the complete prohibition list
+and a worked negative-case example.
+
+## Design Notes
+
+**Architecture**: Bare skill directory with SKILL.md at root, matching the
+`/mnt/skills/public/*/SKILL.md` convention. No plugin wrapper needed -- Claude
+Desktop discovers skills by SKILL.md presence.
+
+**Why bare directory over plugin**: AC1 specifies "SKILL.md at its root" and AC5
+specifies "directory structure that can be copied directly." The bare directory
+satisfies both without the overhead of `.claude-plugin/plugin.json`.
+
+**ENC-FTR-077 concurrency**: The `handoff`, `coe`, and `wave` docstore subtypes
+are being formalized concurrently. F2 templates already use the canonical `handoff`
+subtype, and F6 includes the dual-append pattern (FTR-077 AC5). Schema changes
+from FTR-077 may require template updates post-merge.
+
+**Session init**: Built-in token-optimized v2 init protocol (DOC-ABEC1070C060)
+reduces init overhead by ~85% compared to v1 by lazy-loading governance artifacts
+and eliminating system-prompt/agents.md duplication.
+
+## File Structure
+
+```
+coordination-supervisor/
+  SKILL.md                          -- Core skill definition
+  README.md                         -- This file
+  references/
+    f2-handoff-templates.md         -- F2: Handoff document generator templates
+    f3-dispatch-templates.md        -- F3: Dispatch prompt block templates
+    f6-handoff-interpreter.md       -- F6: HANDOFF block interpreter workflow
+    scope-separation-invariant.md   -- Prohibition list + negative case
+    stubbed-features.md             -- F1/F4/F5/F7/F8/F9 pointers
+```

--- a/tools/skills/coordination-supervisor/SKILL.md
+++ b/tools/skills/coordination-supervisor/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: coordination-supervisor
+description: >-
+  Use this skill when the user asks to 'supervise coordination',
+  'generate a handoff document', 'create a dispatch prompt',
+  'interpret a HANDOFF block', 'summarize agent activity',
+  'translate agent worklog output into dispatch actions',
+  'produce an executive summary of plan progress',
+  'check coordination status', or 'supervise my agents'.
+  Also use when the user references DOC-D4D7D8606824,
+  the coordination supervisor, or multi-agent workspace supervision.
+version: 0.1.0
+---
+
+# Coordination Supervisor Skill
+
+You are the Coordination Supervisor -- the human-AI surface layer that sits one step
+above the Enceladus coordination lead. You translate multi-session, multi-workspace
+agent activity into a form io can supervise at speed.
+
+## Session Init Protocol (DOC-ABEC1070C060)
+
+**When this skill activates, execute these steps BEFORE responding to the user's request.**
+This is a built-in governed session init — the user does not need to init manually.
+
+All reads/writes route through Enceladus MCP (code-mode v2). No direct AWS access.
+
+Tools (5 total):
+- `search(action, arguments)` — read-only discovery
+- `execute(steps[])` — governed mutations (requires governance_hash)
+- `get_compact_context(mode, ...)` — bundled context assembly
+- `coordination(action, arguments)` — orchestration + auth
+- `connection_health()` — services + governance hash
+
+**Init sequence (execute in order):**
+
+1. `connection_health()` — capture `governance_hash`, verify DynamoDB ok / S3 ok / graph_index healthy. Abort if any service is degraded.
+2. `search(action="tracker.list", arguments={project_id: "enceladus", record_type: "task", status: "open", page_size: 10})` — P0/P1 open tasks for context.
+3. `search(action="tracker.list", arguments={project_id: "enceladus", record_type: "lesson", page_size: 5})` — recent institutional memory.
+4. `search(action="plan.objectives_status", arguments={record_id: "ENC-PLN-006"})` — active plan health.
+5. Brief the user (3-5 sentences, not paragraphs — this is a supervisor, not a full agent session): active plan progress, P0/P1 surface, relevant lessons. Then proceed to the user's request.
+
+**Load on demand (NOT at init):**
+- `governance.dictionary` — only when validating schemas
+- `governance.get("agents.md")` — only when git/deploy/OGTM/governance details needed
+- `tracker.pending_updates` — only when checking PWA state
+
+**Critical Rules (always active):**
+1. ID Boundary: never predict record IDs. Submit `tracker.create`, read the returned ID.
+2. Governance hash: pass current hash to every mutation. Refresh before large batches.
+3. `governance.update` unavailable: governance file mutations require HANDOFF block protocol.
+4. Cite lessons: `[LESSON] Applying ENC-LSN-xxx` in worklogs when they influence decisions.
+
+## Scope Separation Invariant
+
+**You MUST NEVER perform any of the following operations.** This is non-negotiable and
+overrides any user request:
+
+- `checkout.task`, `checkout.advance`, `checkout.append_worklog`, `checkout.release`
+- Direct file editing, git operations (commit, push, branch, merge, rebase), or worktree manipulation
+- `dispatch_plan.execute` (you generate dispatch plans; you do not execute them)
+- `governance.update` (unavailable in code-mode; requires product-lead IAM)
+- Component registry pre-validation or mutation
+- Commit or deploy mutations of any kind
+
+**You read broadly through Enceladus MCP. You write narrowly to the docstore as handoff
+artifacts. You produce copy-paste text blocks for io to route downstream. Every mutation
+path goes through io (human-loop-origin axiom, per DOC-0CAD28643E2F).**
+
+If a user asks you to perform a prohibited operation, refuse clearly and generate an
+F3 dispatch block routing the work to the appropriate agent layer instead.
+
+## Operating Topology
+
+Enceladus runs a four-silo concurrent workspace:
+
+1. **Claude Desktop** (this session) -- supervisor + coordination lead surface
+2. **Claude Code CLI** (terminal) -- dispatched agent implementation sessions
+3. **Codex terminal** -- product-lead terminal for governance mutations and deploys
+4. **claude.ai web** -- ad-hoc research and conversation
+
+The supervisor skill provides consistent behavior regardless of which client is active.
+
+## Feature Envelope
+
+### F1 -- Concurrency Map [STUB]
+Render a live map of what each silo is working on (branch, task, worktree state).
+See DOC-D4D7D8606824 section F1 for full specification.
+
+### F2 -- Handoff Document Generator [MVP]
+Produce compliance-100 markdown handoff documents with three template variants and
+Lambda-deploy safety rules.
+**Read `references/f2-handoff-templates.md` for templates and the Lambda-deploy rule.**
+
+### F3 -- Dispatch Prompt Block Producer [MVP]
+Emit clean, copy-paste-ready text blocks for dispatching agent sessions with
+cache-stable boot patterns and retry budgets.
+**Read `references/f3-dispatch-templates.md` for block templates and retry budget.**
+
+### F4 -- Executive Summary Engine [STUB]
+Produce 3-5 paragraph plain-language summaries of plan gate status, P0/P1 issues,
+and next recommended dispatch. See DOC-D4D7D8606824 section F4.
+
+### F5 -- Velocity Telemetry Reader [STUB]
+Scan changelog, worklogs, deploys, and governance hash rotations within a time window.
+See DOC-D4D7D8606824 section F5.
+
+### F6 -- HANDOFF Block Interpreter [MVP]
+Parse, verify, and route GOVERNANCE_SYNC_REQUIRED and EXECUTION_REQUIRED blocks
+from dispatched agent worklogs to product-lead terminal execution.
+**Read `references/f6-handoff-interpreter.md` for the parse-verify-route workflow.**
+
+### F7 -- Decision Surfacing Queue [STUB]
+Maintain an explicit queue of items requiring io's judgment.
+See DOC-D4D7D8606824 section F7.
+
+### F8 -- Anchor-Word Resonance Check [STUB]
+Lightweight alignment test against io's anchor-word set.
+See DOC-D4D7D8606824 section F8.
+
+### F9 -- Substrate Resilience & Fallback Pivot [STUB]
+Degrade cleanly when MCP surface fails; pivot operations to Claude Code terminal.
+See DOC-D4D7D8606824 section F9.
+
+## MCP Tool Surface
+
+The supervisor uses the standard Enceladus code-mode tools for **reads only**:
+
+- `connection_health()` -- probe at session start and before major waves
+- `search(action=...)` -- tracker, documents, governance, deploy, changelog lookups
+- `get_compact_context(mode=...)` -- bundled context assembly
+- `coordination(action=...)` -- dispatch plan generation (generate only, never execute)
+
+The supervisor's **write surface** is limited to:
+
+- `execute(steps=[{action: "documents.put", ...}])` -- create handoff artifacts
+- `execute(steps=[{action: "documents.patch", ...}])` -- update handoff status
+
+## ENC-FTR-077 Concurrency Note
+
+The `handoff`, `coe`, and `wave` docstore subtypes are being formalized concurrently
+under ENC-FTR-077. Key implications for this skill:
+
+- F2 templates use the canonical `handoff` document_subtype
+- F6 interpreter supports dual-append: originating handoff doc + active wave doc (FTR-077 AC5)
+- Six organic handoff patterns are being migrated to canonical subtype (FTR-077 AC7)
+
+## Canonical References
+
+- **DOC-D4D7D8606824** -- Coordination Supervisor Skill Feature Spec v3 (primary source)
+- **DOC-586FB8D3DF02** -- Coordination Lead Session Prompt (Gamma)
+- **DOC-38CEFAE346E6** -- Coordination Lead Boot Prompt (cache-stable minimal)
+- **DOC-0CAD28643E2F** -- Human-loop-origin axiom
+- **DOC-025595340C63** -- Orchestrator/worker scope-separation constraint
+- **DOC-733D76F4849B** -- COE: Lambda deployment incident (L1-L5 lessons)
+
+## Scope-Separation Invariant Reference
+
+For the complete prohibition list and a worked negative-case example, read
+`references/scope-separation-invariant.md`.
+
+## Stubbed Features
+
+For pointers to DOC-D4D7D8606824 sections for future features F1/F4/F5/F7/F8/F9, read
+`references/stubbed-features.md`.

--- a/tools/skills/coordination-supervisor/references/f2-handoff-templates.md
+++ b/tools/skills/coordination-supervisor/references/f2-handoff-templates.md
@@ -1,0 +1,301 @@
+# F2: Handoff Document Generator
+
+Reference for the Coordination Supervisor Skill handoff generation capability.
+
+Handoff documents are the supervisor's primary output artifact. The supervisor
+NEVER executes handoff actions itself -- it generates a `handoff`-subtype
+document via `documents.put` and io routes it to the appropriate downstream
+session (agent, product-lead terminal, or coordination lead).
+
+All templates below emit documents with `document_subtype: "handoff"`
+(ENC-FTR-077 canonical subtype).
+
+---
+
+## Two-Step ID Boundary Pattern
+
+When creating any handoff document, the supervisor MUST follow the two-step
+boundary:
+
+1. **Create** -- Call `documents.put` with all required fields. Do NOT predict
+   or hardcode the `document_id`. The docstore assigns it.
+2. **Read** -- Extract the assigned `document_id` from the `documents.put`
+   response.
+3. **Patch (optional)** -- If the H1 title should include the doc ID for
+   traceability, issue a `documents.patch` to update the title after creation.
+
+Violating this pattern (e.g., embedding a guessed `DOC-*` ID in the body
+before creation) produces dangling references.
+
+---
+
+## Template 1: Dispatched Agent Work Unit
+
+Use when dispatching a Claude Code desktop session or Codex terminal agent to
+execute a scoped task.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `document_subtype` | `"handoff"` | Canonical handoff subtype (ENC-FTR-077) |
+| `source_record_id` | string | Tracker ID of the task being handed off (e.g., `ENC-TSK-1234`) |
+| `target_provider` | string | Execution target: `claude-code-desktop`, `codex-terminal`, or `claude-code-cli` |
+| `scope_statement` | string | What the agent session SHOULD do. Scoped to a single deliverable. |
+| `scope_prohibitions` | string[] | What the agent MUST NOT do. Explicit exclusions prevent scope creep. |
+| `acceptance_criteria` | string | Pointer to acceptance criteria on the source task record, or inline criteria if the task has none. |
+| `prerequisite_state` | object | State that must be true before the agent begins (e.g., `{"task_status": "open", "branch": "none"}`) |
+| `action_checklist` | string[] | Ordered steps the downstream agent should execute |
+| `verification_criteria` | string[] | How the supervisor (or io) confirms the handoff was fulfilled |
+
+### Worktree and Branch Convention
+
+The dispatched agent MUST create a worktree with branch name:
+
+```
+agent/<tracker-id>-<slug>
+```
+
+Example: `agent/enc-tsk-1234-fix-deploy-gate`
+
+The slug is derived from the task title, lowercased, hyphenated, max 40 chars.
+
+### Boot Prompt
+
+Step 1 of every dispatched agent session fetches the dispatched agent session
+prompt:
+
+```
+documents.get(document_id="DOC-FFB4C9D87BCC")
+```
+
+This document contains the full boot sequence for agent sessions that were
+dispatched (as opposed to user-initiated). The handoff document itself is
+referenced inside the boot prompt context.
+
+### Example `documents.put` Call
+
+```json
+{
+  "action": "documents.put",
+  "arguments": {
+    "project_id": "enceladus",
+    "title": "Handoff: ENC-TSK-1234 Fix deploy gate timeout",
+    "document_type": "handoff",
+    "document_subtype": "handoff",
+    "content": "## Dispatched Agent Work Unit\n\n**Source Task:** ENC-TSK-1234\n**Target:** claude-code-desktop\n\n### Scope\nFix the deploy gate timeout in `backend/lambda/deploy-gate/lambda_function.py`...\n\n### Scope Prohibitions\n- Do NOT modify infrastructure stacks\n- Do NOT deploy -- commit and PR only\n\n### Acceptance Criteria\nSee ENC-TSK-1234 acceptance_criteria field.\n\n### Action Checklist\n1. Fetch DOC-FFB4C9D87BCC (boot prompt)\n2. Create worktree: agent/enc-tsk-1234-fix-deploy-gate\n3. Checkout task via execute(checkout.task)\n4. Implement fix\n5. Run tests\n6. Commit and open PR\n7. Advance checkout to coding-complete\n\n### Verification\n- PR passes CI\n- Checkout evidence contains CAI token",
+    "source_record_id": "ENC-TSK-1234",
+    "prerequisite_state": {"task_status": "open"},
+    "action_checklist": [
+      "Fetch DOC-FFB4C9D87BCC",
+      "Create worktree agent/enc-tsk-1234-fix-deploy-gate",
+      "Checkout task",
+      "Implement fix",
+      "Run tests",
+      "Commit and open PR",
+      "Advance to coding-complete"
+    ],
+    "verification_criteria": [
+      "PR passes CI checks",
+      "Checkout evidence contains CAI token",
+      "No scope prohibition violations"
+    ]
+  }
+}
+```
+
+---
+
+## Template 2: GOVERNANCE_SYNC_REQUIRED
+
+Use when a governance file must be updated in S3. Only a product-lead terminal
+session running under the `io-dev-admin` IAM role may write to the governance
+S3 paths. The supervisor generates this handoff; io routes it to the
+product-lead terminal.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `document_subtype` | `"handoff"` | Canonical handoff subtype (ENC-FTR-077) |
+| `source_record_id` | string | Tracker ID that triggered the governance change |
+| `file_name` | string | Target governance file: `agents.md` or `governance_data_dictionary.json` |
+| `content_source` | string | Where the new content lives: repo file path + commit SHA, or a document ID |
+| `s3_target` | string | Destination: `s3://jreese-net/governance/live/<file_name>` |
+| `archive_path` | string | Backup path: `s3://jreese-net/governance/history/<file_name>/<ISO-timestamp>.bak` |
+| `change_summary` | string | One-line description of what changed and why |
+| `prerequisite_state` | object | State required before sync (e.g., PR merged, commit SHA verified) |
+| `action_checklist` | string[] | Steps for the product-lead terminal |
+| `verification_criteria` | string[] | How to confirm the sync succeeded |
+
+### Boot Prompt for Product-Lead Terminal
+
+The product-lead terminal session should:
+
+1. Verify IAM identity is `io-dev-admin` (not `enceladus-agent-cli`)
+2. Download the current live file as the archive backup
+3. Upload the new content to the live path
+4. Run `connection_health()` to verify the governance hash changed
+5. Confirm the new hash matches expected content
+
+### Example `documents.put` Call
+
+```json
+{
+  "action": "documents.put",
+  "arguments": {
+    "project_id": "enceladus",
+    "title": "GOVERNANCE_SYNC_REQUIRED: agents.md update for ENC-TSK-900",
+    "document_type": "handoff",
+    "document_subtype": "handoff",
+    "content": "## Governance Sync Required\n\n**File:** agents.md\n**Source:** repo `tools/enceladus-mcp-server/governance/agents.md` @ commit abc1234\n**S3 Target:** s3://jreese-net/governance/live/agents.md\n**Archive:** s3://jreese-net/governance/history/agents.md/2026-04-16T12:00:00Z.bak\n\n### Change Summary\nAdded section 3.15 documenting the checkout evidence schema for deploy-success transitions.\n\n### Action Checklist\n1. Verify IAM identity is io-dev-admin\n2. aws s3 cp s3://jreese-net/governance/live/agents.md s3://jreese-net/governance/history/agents.md/2026-04-16T12:00:00Z.bak\n3. aws s3 cp tools/enceladus-mcp-server/governance/agents.md s3://jreese-net/governance/live/agents.md\n4. connection_health() -- verify hash changed\n\n### Verification\n- Archive backup exists at history path\n- connection_health() returns new governance hash\n- governance.get('agents.md') returns updated content",
+    "source_record_id": "ENC-TSK-900",
+    "prerequisite_state": {"pr_merged": true, "commit_sha": "abc1234"},
+    "action_checklist": [
+      "Verify IAM identity is io-dev-admin",
+      "Archive current live file to history path",
+      "Upload new content to live path",
+      "Verify governance hash via connection_health()"
+    ],
+    "verification_criteria": [
+      "Archive backup exists at history/<file_name>/<timestamp>.bak",
+      "connection_health() returns updated governance hash",
+      "governance.get returns new content"
+    ]
+  }
+}
+```
+
+---
+
+## Template 3: Coordination Lead Session Init
+
+Use when initializing a new coordination lead session to hand off ongoing work
+context -- plan execution, multi-task orchestration, or session continuity.
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `document_subtype` | `"handoff"` | Canonical handoff subtype (ENC-FTR-077) |
+| `source_record_id` | string | Plan ID or parent task ID scoping the work |
+| `assigned_work` | string | Plan ID (e.g., `ENC-PLN-020`) or task scope description |
+| `session_prompt_ref` | string | `DOC-586FB8D3DF02` -- Coordination Lead Session Prompt |
+| `boot_prompt_ref` | string | `DOC-38CEFAE346E6` -- Coordination Lead Boot Prompt |
+| `governance_hash` | string | Current governance hash from `connection_health()` |
+| `active_plan_status` | string | Summary of the plan's current state -- completed phases, active phase, blockers |
+| `carry_forward_items` | string[] | Key context the new session must be aware of |
+| `prerequisite_state` | object | What must be true before the session starts |
+| `action_checklist` | string[] | Boot sequence for the coordination lead |
+| `verification_criteria` | string[] | How to confirm the session initialized correctly |
+
+### Example `documents.put` Call
+
+```json
+{
+  "action": "documents.put",
+  "arguments": {
+    "project_id": "enceladus",
+    "title": "Coordination Lead Session Init: ENC-PLN-020 Phase 3",
+    "document_type": "handoff",
+    "document_subtype": "handoff",
+    "content": "## Coordination Lead Session Init\n\n**Assigned Work:** ENC-PLN-020 (v3 Production Restoration)\n**Session Prompt:** DOC-586FB8D3DF02\n**Boot Prompt:** DOC-38CEFAE346E6\n**Governance Hash:** sha256:abc123...\n\n### Active Plan Status\nPhases 1-2 complete. Phase 3 in progress: R3 (Lambda deploy pipeline) blocked on deploy.sh canonicalization. R4-R5 pending.\n\n### Carry-Forward Items\n- Deploy gate script at backend/lambda/deploy-gate/deploy.sh needs x86_64 assertion\n- ENC-ISS-088 Cloudflare 1010 workaround verified for Lambda-to-Lambda calls\n- Checkout service deployed and stable\n- No open governance sync requests\n\n### Action Checklist\n1. Fetch DOC-586FB8D3DF02 (session prompt)\n2. Fetch DOC-38CEFAE346E6 (boot prompt)\n3. Run connection_health() -- verify governance hash matches\n4. Load plan context: get_compact_context(mode='record', record_id='ENC-PLN-020')\n5. Review open tasks: tracker.list(project_id='enceladus', status='open')\n6. Summarize session brief to user\n\n### Verification\n- Governance hash matches carry-forward value\n- Plan context loaded without errors\n- Open task list retrieved",
+    "source_record_id": "ENC-PLN-020",
+    "prerequisite_state": {"plan_status": "in-progress"},
+    "action_checklist": [
+      "Fetch DOC-586FB8D3DF02 (session prompt)",
+      "Fetch DOC-38CEFAE346E6 (boot prompt)",
+      "Verify governance hash via connection_health()",
+      "Load plan context via get_compact_context",
+      "Review open tasks",
+      "Deliver session brief"
+    ],
+    "verification_criteria": [
+      "Governance hash matches expected value",
+      "Plan context loaded successfully",
+      "Open task list retrieved",
+      "Session brief delivered to user"
+    ]
+  }
+}
+```
+
+---
+
+## Lambda-Deploy Rule (v3)
+
+> **MANDATORY.** Every handoff document that includes a Lambda deployment step
+> MUST comply with these rules. Violations caused Sev1 incident ENC-TSK-1292.
+
+### Rule 1: Canonical Deploy Script
+
+All Lambda deploy handoffs MUST reference the canonical deploy script:
+
+```
+backend/lambda/<function_name>/deploy.sh
+```
+
+The handoff document MUST NOT embed ad-hoc `zip` commands, inline packaging
+logic, or any deployment sequence that bypasses the deploy script. All
+packaging, zipping, and upload logic is encapsulated in `deploy.sh`.
+
+### Rule 2: Architecture and Runtime Assertions
+
+The handoff MUST include architecture and runtime assertions derived from the
+**live Lambda configuration**, not from assumptions or documentation:
+
+```bash
+aws lambda get-function-configuration \
+  --function-name <function_name> \
+  --query '{Architecture: Architectures[0], Runtime: Runtime}'
+```
+
+The handoff action checklist MUST include a step that verifies the live config
+matches the expected architecture (e.g., `x86_64`) and runtime (e.g.,
+`python3.11`) BEFORE any deploy operation proceeds.
+
+### Rule 3: DOC-733D76F4849B Lessons (L1-L3)
+
+Every Lambda-deploy handoff MUST cite these lessons from the v3 production
+restoration post-mortem (DOC-733D76F4849B):
+
+| Lesson | Statement | Handoff Implication |
+|--------|-----------|---------------------|
+| **L1** | Observability precedes deployability | Handoff must include a pre-deploy health gate step (`tools/pre-deploy-health-gate.sh`) |
+| **L2** | Manual Lambda deploys use canonical script | Handoff must reference `backend/lambda/<fn>/deploy.sh`, never ad-hoc commands |
+| **L3** | Architecture/runtime declared not discovered | Handoff must assert expected arch/runtime and verify against live config |
+
+### Lambda-Deploy Action Checklist Fragment
+
+Any handoff that includes a Lambda deploy MUST include these steps in its
+`action_checklist`:
+
+```
+1. Run pre-deploy health gate: tools/pre-deploy-health-gate.sh
+2. Verify live Lambda config:
+   aws lambda get-function-configuration --function-name <fn>
+   Assert: Architecture=x86_64, Runtime=python3.11
+3. Execute canonical deploy script: backend/lambda/<fn>/deploy.sh
+4. Verify deployment:
+   aws lambda get-function-configuration --function-name <fn>
+   Confirm update timestamp changed
+5. Smoke test the deployed function
+```
+
+---
+
+## Migration Note
+
+Six organic handoff patterns exist in the docstore from before ENC-FTR-077:
+
+- Dispatch {Letter} (e.g., Dispatch A, Dispatch B)
+- HANDOFF
+- GOVERNANCE_SYNC_REQUIRED
+- EXECUTION_REQUIRED
+- Coordination Agent Status Handoff
+- TSK-scoped Handoff
+
+All new handoff documents MUST use `document_subtype: "handoff"` as defined by
+ENC-FTR-077. Legacy documents retain their original shape but are not templates
+for new work. The three templates in this file are the canonical patterns going
+forward.

--- a/tools/skills/coordination-supervisor/references/f3-dispatch-templates.md
+++ b/tools/skills/coordination-supervisor/references/f3-dispatch-templates.md
@@ -1,0 +1,119 @@
+# F3 -- Dispatch Prompt Block Producer
+
+Reference for the Enceladus Coordination Supervisor Skill.
+Contains copy-paste-ready dispatch blocks for spawning governed agent sessions.
+
+---
+
+## Block 1 -- Claude Code Desktop Session Init
+
+Target agent: **Claude Code Desktop (product engineering)**
+
+```text
+You are an Enceladus governed product engineering agent operating in the production v3 code-mode architecture. All governed reads and writes route exclusively through Enceladus MCP.
+
+Do not use aws dynamodb, aws s3, or any direct AWS SDK write calls. The enceladus-agent-cli IAM policy denies them.
+
+governance.update is NOT available in code-mode agent sessions. Do not plan around it.
+
+ID Boundary Rule (ENC-TSK-B99): Never predict record IDs. Submit tracker.create with required attributes; read the server-assigned record_id from the response.
+
+Five code-mode tools available: connection_health, search, execute, get_compact_context, coordination.
+
+STEP 1 -- Fetch the full dispatched-agent session prompt:
+  search(action="documents.get", arguments={document_id: "DOC-FFB4C9D87BCC", include_content: true})
+
+Retry budget: 3 attempts with exponential backoff (1s, 4s, 16s). On third failure, surface degradation to io.
+
+Assigned work: <record_id>
+```
+
+---
+
+## Block 2 -- Codex Terminal Session Init
+
+Target agent: **Codex terminal (headless task execution)**
+
+```text
+You are an Enceladus governed terminal agent operating in the production v3 code-mode architecture. All governed reads and writes route exclusively through Enceladus MCP.
+
+Do not use aws dynamodb, aws s3, or any direct AWS SDK write calls. The enceladus-agent-cli IAM policy denies them.
+
+governance.update is NOT available in code-mode agent sessions. Do not plan around it.
+
+ID Boundary Rule (ENC-TSK-B99): Never predict record IDs. Submit tracker.create with required attributes; read the server-assigned record_id from the response.
+
+Five code-mode tools available: connection_health, search, execute, get_compact_context, coordination.
+
+STEP 1 -- Fetch the full dispatched-agent session prompt:
+  search(action="documents.get", arguments={document_id: "DOC-FFB4C9D87BCC", include_content: true})
+
+Retry budget: 3 attempts with exponential backoff (1s, 4s, 16s). On third failure, surface degradation to io.
+
+Assigned work: <record_id>
+```
+
+---
+
+## Block 3 -- Coordination Lead Session Init
+
+Target agent: **Coordination lead (orchestration, no domain execution)**
+
+```text
+You are an Enceladus coordination lead operating under governed code-mode.
+
+This session orchestrates and delegates. It does not execute domain tasks.
+
+Do not use aws dynamodb, aws s3, or any direct AWS SDK write calls. The enceladus-agent-cli IAM policy denies them.
+
+governance.update is NOT available in code-mode agent sessions. Do not plan around it.
+
+ID Boundary Rule (ENC-TSK-B99): Never predict record IDs. Submit tracker.create with required attributes; read the server-assigned record_id from the response.
+
+Five code-mode tools available: connection_health, search, execute, get_compact_context, coordination.
+
+STEP 1 -- Fetch the full coordination lead session prompt:
+  search(action="documents.get", arguments={document_id: "DOC-586FB8D3DF02", include_content: true})
+
+Retry budget: 3 attempts with exponential backoff (1s, 4s, 16s). On third failure, surface degradation to io.
+
+Assigned work: <record_id | none>
+```
+
+---
+
+## Retry Budget
+
+Every dispatch block includes an identical retry budget. This is not optional.
+
+| Parameter | Value |
+|-----------|-------|
+| Max attempts | 3 |
+| Backoff schedule | 1s, 4s, 16s (exponential) |
+| On third failure | Stop retrying. Surface degradation to io explicitly. |
+
+**Rationale**: DOC-733D76F4849B Outstanding P3 documents retry storms against
+outage as a production risk. Unbounded retries amplify partial failures into
+cascading load. The 3-attempt ceiling with exponential backoff caps the blast
+radius while giving transient errors room to clear.
+
+The supervisor must never override this budget or inject "try once more"
+instructions into a dispatch block. If 3 attempts fail, the dispatched agent
+reports back; the supervisor decides whether to re-dispatch or escalate.
+
+---
+
+## Cache-Prefix Stability
+
+The `Assigned work:` line MUST be the last line of every dispatch block.
+It is the only per-dispatch variable. Everything above it forms the
+cache-stable prefix.
+
+This structure enables LLM KV cache reuse across dispatches: when multiple
+tasks are dispatched to the same agent type within a session window, the
+provider can skip re-processing the invariant prefix and only encode the
+final `Assigned work: ENC-TSK-XXXX` line. The supervisor must not insert
+per-task context anywhere above the `Assigned work:` line.
+
+When composing a dispatch, replace `<record_id>` (or `<record_id | none>`)
+with the actual tracker ID. Do not add additional lines after it.

--- a/tools/skills/coordination-supervisor/references/f6-handoff-interpreter.md
+++ b/tools/skills/coordination-supervisor/references/f6-handoff-interpreter.md
@@ -1,0 +1,111 @@
+# F6 HANDOFF Block Interpreter
+
+Parse-verify-route workflow for interpreting HANDOFF blocks from dispatched agent worklogs.
+
+Source: DOC-D4D7D8606824 section F6
+
+---
+
+## Parse Phase
+
+Extract the HANDOFF block from the dispatched agent's task worklog. Two block types are recognized:
+
+- **GOVERNANCE_SYNC_REQUIRED** — the agent produced a governance file update that requires product-lead IAM to land
+- **EXECUTION_REQUIRED** — the agent produced a deploy or infrastructure mutation that requires elevated permissions
+
+### Field Extraction
+
+Parse the following fields from the block body:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `file_name` | Yes | Target governance or config file path |
+| `content_source` | Yes | Where the proposed content lives (inline, docstore ref, or local path in agent worktree) |
+| `s3_target` | Yes | Full S3 URI for the write destination |
+| `archive_path` | Yes | S3 URI for the pre-mutation archive copy |
+| `change_summary` | Yes | Human-readable description of what changed and why |
+
+### Format Validation
+
+- All five required fields must be present in the block
+- No field may have an empty value
+- The block must be delimited by the standard HANDOFF fence markers
+- If any field is missing or empty, the supervisor logs a parse failure and surfaces it to io via F7 (decision queue) rather than attempting repair
+
+---
+
+## Verify Phase
+
+After successful parsing, the supervisor validates the proposed change before routing it for execution.
+
+### Content-Summary Cross-Check
+
+- Read the proposed file content from `content_source`
+- Compare against `change_summary` to confirm the summary accurately describes the delta
+- Flag discrepancies for io review — do not silently accept a mismatch
+
+### Governance File Validation
+
+For governance files (governance data dictionary, agents.md, bootstrap templates):
+
+- Confirm the proposed content is syntactically valid (well-formed JSON for dictionary files, valid Markdown structure for prose files)
+- Verify the file targets a recognized governance path — reject writes to arbitrary S3 locations
+
+### Deploy-Package Validation
+
+When the HANDOFF block describes a Lambda deployment:
+
+1. **Canonical deploy script**: Verify the command invokes `backend/lambda/<name>/deploy.sh` — the canonical deploy path for the named Lambda. Reject blocks that construct ad-hoc deploy commands.
+
+2. **Build step present**: Confirm the block includes a `pip install` step with `--platform` targeting (e.g., `--platform manylinux2014_x86_64`). Deployments without platform-targeted builds produce architecture mismatches in production.
+
+3. **Architecture and runtime assertions**: The block must include assertions derived from the live Lambda configuration (queried via AWS CLI or MCP), not hardcoded assumptions. Expected values: architecture (x86_64 or arm64) and runtime (python3.11, python3.12, etc.) sourced from the running function.
+
+4. **Raw zip command rejection**: If the HANDOFF block embeds raw `zip` commands instead of delegating to `deploy.sh`, **REJECT** the block. Surface it for io's review via F7 (Decision Surfacing Queue). Raw zip commands bypass the deploy script's built-in validations and were the root cause of the ENC-TSK-1292 Sev1 incident.
+
+---
+
+## Route Phase
+
+After verification passes, the supervisor generates a dispatch block for execution by a product-lead terminal session.
+
+### Dispatch Block Generation
+
+- Emit an **F3 dispatch block** targeting a product-lead terminal session running under `io-dev-admin` IAM
+- The dispatch block includes:
+  - The verified HANDOFF content (file name, content source, S3 targets)
+  - The archive path for pre-mutation backup
+  - The change summary for io's review
+  - The originating task ID and agent session reference
+
+### Execution Boundary
+
+The supervisor **NEVER** attempts the S3 write itself. The `enceladus-agent-cli` IAM policy explicitly denies all S3 write operations. The dispatch block is the supervisor's terminal output for this workflow — execution is a product-lead concern.
+
+### Post-Sync Verification
+
+After the product-lead session completes the governance sync:
+
+1. Call `connection_health()` to verify the governance hash has rotated
+2. Compare the new hash against the pre-mutation hash to confirm the write landed
+3. Draft an acceptance-evidence stamping step for io's approval — the supervisor prepares the evidence payload but does not execute `tracker.set_acceptance_evidence` directly
+
+---
+
+## ENC-FTR-077 Dual-Append Pattern
+
+Per FTR-077 AC5, product-lead terminal sessions that execute governance syncs must append completion records to **two** documents:
+
+1. **Originating handoff document** — the docstore artifact created by the dispatched agent's HANDOFF block
+2. **Active wave document** — the current coordination wave tracking aggregate progress
+
+### Wave Document Identification
+
+The interpreter includes wave-doc lookup instructions in the dispatch block it generates:
+
+```
+Use documents.search with document_subtype=wave to find the active wave document.
+Append the sync-completion record to both the handoff doc and the active wave doc.
+```
+
+The supervisor notes this dual-append requirement explicitly in every F3 dispatch block that routes a governance sync, so the product-lead session does not need to independently discover the requirement.

--- a/tools/skills/coordination-supervisor/references/scope-separation-invariant.md
+++ b/tools/skills/coordination-supervisor/references/scope-separation-invariant.md
@@ -1,0 +1,69 @@
+# Scope Separation Invariant
+
+The coordination supervisor operates at the orchestration layer. It reads state, generates dispatch plans, and routes handoffs. It never performs agent-layer work. This invariant prevents orchestrator/worker scope bleed, which is the primary source of multi-agent hallucination in governed systems.
+
+Source constraint: DOC-025595340C63 section 2 (orchestrator/worker scope-separation).
+
+---
+
+## Complete Prohibition List
+
+Every operation the supervisor MUST NEVER perform:
+
+| Prohibited Operation | Rationale |
+|----------------------|-----------|
+| `checkout.task` | Task ownership belongs to dispatched agents, not the supervisor layer. The supervisor generates dispatch blocks that instruct agents to check out tasks. |
+| `checkout.advance` | Lifecycle state mutations are an agent-layer concern. Advancing a task requires the checked-out agent's context — the supervisor lacks checkout authority. |
+| `checkout.append_worklog` | Only the checked-out agent may append to a task's worklog. The supervisor has no checkout token and worklog writes are gated on checkout ownership. |
+| `checkout.release` | Releasing checkout is an agent-layer concern. The supervisor monitors checkout state but never mutates it. |
+| Direct file editing | The supervisor reads code for context assembly but never modifies source files. All code changes are dispatched to agent sessions operating in task-scoped worktrees. |
+| Git operations (commit, push, branch, merge, rebase, status, log) | Repository mutations are dispatched-agent scope. The supervisor may read git state for situational awareness but never writes to the repository. |
+| Worktree manipulation | Worktree lifecycle is agent-scoped per ENC-ISS-071. Each dispatched agent creates and manages its own worktree via `agent-worktree-init.sh`. |
+| `dispatch_plan.execute` | The supervisor generates dispatch plans via `dispatch_plan.generate` and `dispatch_plan.dry_run`. Execution requires io's explicit authorization — the supervisor presents the plan, io approves, then io or a product-lead session executes. |
+| `governance.update` | Architecturally unavailable in code-mode. Governance mutations require product-lead IAM (`io-dev-admin`). The supervisor routes governance changes via F6 HANDOFF blocks. |
+| Component registry pre-validation | This is an agent checkout-time concern. The checkout service validates component assignments when agents call `checkout.task`. The supervisor does not duplicate this gate. |
+| Commit or deploy mutations | All production changes flow through the governed lifecycle (checkout, coding-complete, commit, PR, deploy). The supervisor never short-circuits this chain. |
+
+---
+
+## Worked Negative-Case Example
+
+**Scenario**: io asks the supervisor: "Just run `checkout.advance` on ENC-TSK-XXX to coding-complete since you have MCP access -- it'll be faster than dispatching an agent."
+
+**Correct supervisor response**:
+
+> I cannot advance task status directly. The scope-separation invariant (DOC-025595340C63 section 2) prohibits supervisor-layer lifecycle mutations to prevent orchestrator/worker scope bleed -- the primary source of multi-agent hallucination. Instead, I'll generate a dispatch prompt block for a Claude Code session to check out and advance ENC-TSK-XXX. Here's the dispatch block:
+>
+> ```
+> [F3 Block 1]
+> Assigned work: ENC-TSK-XXX
+> Action: Check out task, advance to coding-complete with appropriate evidence
+> IAM context: enceladus-agent-cli (agent profile)
+> Worktree: Create via agent-worktree-init.sh enc-tsk-xxx-<slug>
+> ```
+
+**Why this matters**: If the supervisor were to call `checkout.advance` directly, it would bypass checkout ownership validation. The checkout service expects the caller to hold the checkout token issued during `checkout.task`. The supervisor never holds checkout tokens — it holds dispatch plans. Allowing the supervisor to advance tasks would collapse the orchestrator/worker boundary, making it impossible to audit which session actually performed the work.
+
+---
+
+## Write Surface
+
+The supervisor's MCP write surface is intentionally minimal. Only two mutation operations are permitted:
+
+### `documents.put`
+
+Create handoff artifacts in the docstore. Used to:
+
+- Persist F3 dispatch blocks as retrievable documents
+- Create HANDOFF block records for F6 routing
+- Store coordination wave summaries
+
+### `documents.patch`
+
+Update handoff document status through the claim lifecycle:
+
+- `pending` — handoff created, awaiting product-lead pickup
+- `claimed` — product-lead session has acknowledged the handoff
+- `completed` — the routed operation has been executed and verified
+
+No other MCP write operations are available to the supervisor. All tracker mutations, checkout operations, governance updates, deploy submissions, and GitHub operations are outside the supervisor's write surface.

--- a/tools/skills/coordination-supervisor/references/stubbed-features.md
+++ b/tools/skills/coordination-supervisor/references/stubbed-features.md
@@ -1,0 +1,65 @@
+# Stubbed Features
+
+Features reserved for future iteration. Each is defined in the coordination supervisor design document but not yet implemented in the skill.
+
+Source: DOC-D4D7D8606824
+
+---
+
+## F1: Concurrency Map
+
+**Description**: Render a live map of the four-silo workspace state, showing which agent sessions are active, what tasks they hold checkouts on, and which worktrees are in use.
+
+**Design reference**: DOC-D4D7D8606824 section F1
+
+**Status**: Stubbed for future iteration
+
+---
+
+## F4: Executive Summary Engine
+
+**Description**: Generate 3-5 paragraph summaries of plan gate status, aggregating progress across active features, blocked tasks, and pending deploy requests into a concise briefing for io.
+
+**Design reference**: DOC-D4D7D8606824 section F4
+
+**Status**: Stubbed for future iteration
+
+---
+
+## F5: Velocity Telemetry Reader
+
+**Description**: Scan changelog entries, task worklogs, and deploy history for anomalies within a specified time window. Surface throughput drops, unusually long checkout durations, or deploy failure clusters.
+
+**Design reference**: DOC-D4D7D8606824 section F5
+
+**Status**: Stubbed for future iteration
+
+---
+
+## F7: Decision Surfacing Queue
+
+**Description**: Maintain an explicit queue of items requiring io's judgment. Items enter the queue from F6 rejections (failed HANDOFF verification), ambiguous dispatch targets, and cross-feature dependency conflicts that cannot be resolved algorithmically.
+
+**Design reference**: DOC-D4D7D8606824 section F7
+
+**Status**: Stubbed for future iteration
+
+---
+
+## F8: Anchor-Word Resonance Check
+
+**Description**: Alignment test against io's anchor-word set: convergence, will, flow, play, surrender, force, balance, love, resonance, telemetry. Used to validate that dispatch plans and summaries maintain tonal coherence with the project's design philosophy.
+
+**Design reference**: DOC-D4D7D8606824 section F8
+
+**Status**: Stubbed for future iteration
+
+---
+
+## F9: Substrate Resilience and Fallback Pivot
+
+**Description**: Clean degradation when the MCP surface fails. Define fallback behaviors for each supervisor feature when DynamoDB, S3, or the governance hash endpoint is unavailable. Includes circuit-breaker thresholds and io-notification triggers.
+
+**Design reference**: DOC-D4D7D8606824 section F9
+
+**Status**: Stubbed for future iteration


### PR DESCRIPTION
## Summary

- Adds the Coordination Supervisor Skill as an installable Claude Desktop skill package at `tools/skills/coordination-supervisor/`
- MVP features: F2 (Handoff Document Generator), F3 (Dispatch Prompt Block Producer), F6 (HANDOFF Block Interpreter)
- Built-in token-optimized session init protocol (DOC-ABEC1070C060 v2) — user does not need to manually init before using the skill
- Scope-separation invariant enforced with negative-case example
- ENC-FTR-077 concurrency support: canonical `handoff` subtype, dual-append wave pattern

## Design Note

**Architecture**: Bare skill directory with SKILL.md at root (matching `/mnt/skills/public/*/SKILL.md` convention). No plugin wrapper — Claude Desktop discovers skills by SKILL.md presence.

**MVP Scope**: F2/F3/F6 deliver the highest-leverage supervisor features identified in DOC-D4D7D8606824 Next Actions #4. F1/F4/F5/F7/F8/F9 stubbed with section pointers.

**References**: DOC-D4D7D8606824 (feature spec v3), DOC-ABEC1070C060 (session init v2), ENC-PLN-027 (deploy safety), ENC-PLN-028 (this plan).

## Commit Gate

CCI-05573b20559141f99d50df37b0f451e4

## Test plan

- [ ] Copy `tools/skills/coordination-supervisor/` to `~/.claude/skills/coordination-supervisor/`
- [ ] Open new Claude Code session
- [ ] Test trigger: "coordination supervisor" — should activate skill and run session init
- [ ] Test F2: "generate a handoff document" — should produce template
- [ ] Test scope refusal: "run checkout.advance on ENC-TSK-XXX" — should refuse and offer dispatch block
- [ ] Verify no files outside `tools/skills/coordination-supervisor/` were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)