### PR TITLE
Fix append_content S3 write in document_api PATCH (ENC-TSK-E48, ENC-ISS-239)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -3565,6 +3565,12 @@
           "definition": "List of compliance warnings from _evaluate_markdown_compliance. Common warnings: missing metadata fields, pipe-table false positives, unclosed fences, heading hierarchy violations.",
           "write_authority": "document_api Lambda (computed, not agent-settable)."
         },
+        "append_content": {
+          "type": "string",
+          "definition": "PATCH-only request field (ENC-ISS-239). When present, document_api performs a read-modify-write cycle: fetches existing S3 content, concatenates with double-newline separator, re-uploads merged content, and recomputes content_hash, size_bytes, and compliance_score. Mutually exclusive with 'content' — the API returns HTTP 400 if both are specified. Not stored in DynamoDB; the result is written to S3 and metadata fields are updated. MCP server documents.patch passthrough includes this key.",
+          "write_authority": "Agent sessions via MCP documents.patch or direct PATCH API.",
+          "governing_issue": "ENC-ISS-239"
+        },
         "format_convention": {
           "type": "rule",
           "definition": "Structured agent-session output in docstore .md documents MUST use comment-free YAML code blocks (```yaml ... ```) instead of GFM pipe tables. Pipe tables are permitted only for purely presentational content where renderer-dependence is explicitly acknowledged. YAML hash-comments (# ...) must be omitted inside fenced blocks to avoid compliance checker heading false positives. MCP server injects format_guidance in document.put/patch responses when pipe-table warnings are detected.",

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -1472,6 +1472,13 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
             expr_parts.append("expires_at = :exp")
             attr_values[":exp"] = {"S": str(body["expires_at"]).strip()}
 
+    # Mutual exclusion: content vs append_content (ENC-ISS-239)
+    if "content" in body and "append_content" in body:
+        return _error(
+            400,
+            "Cannot specify both 'content' and 'append_content' — they are mutually exclusive.",
+        )
+
     # Content update — re-upload to S3
     if "content" in body:
         content = body["content"]
@@ -1507,6 +1514,36 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
         except Exception as exc:
             logger.error("S3 upload (edit) failed: %s", exc)
             return _error(500, "Failed to update document content.")
+
+    # Append content — read-modify-write cycle (ENC-ISS-239)
+    if "append_content" in body:
+        append_text = body["append_content"]
+        if append_text is None or not isinstance(append_text, str) or not append_text:
+            return _error(400, "Field 'append_content' must be a non-empty string.")
+        try:
+            existing_content = _get_content(project_id, document_id)
+            if existing_content is None:
+                existing_content = ""
+            new_content = existing_content + "\n\n" + str(append_text)
+            if len(new_content.encode("utf-8")) > MAX_CONTENT_SIZE:
+                return _error(400, f"Appended content exceeds maximum size of {MAX_CONTENT_SIZE} bytes.")
+            compliance = _evaluate_markdown_compliance(new_content)
+            s3_key, content_hash, size_bytes = _upload_content(project_id, document_id, new_content)
+            expr_parts.append("content_hash = :hash")
+            expr_parts.append("size_bytes = :size")
+            expr_parts.append("s3_key = :s3k")
+            expr_parts.append("compliance_score = :cscore")
+            expr_parts.append("compliance_warnings = :cwarnings")
+            expr_parts.append("compliance_checked_at = :cchecked")
+            attr_values[":hash"] = {"S": content_hash}
+            attr_values[":size"] = {"N": str(size_bytes)}
+            attr_values[":s3k"] = {"S": s3_key}
+            attr_values[":cscore"] = {"N": str(compliance["compliance_score"])}
+            attr_values[":cwarnings"] = _serialize_list(compliance["compliance_warnings"])
+            attr_values[":cchecked"] = {"S": now}
+        except Exception as exc:
+            logger.error("S3 append content failed: %s", exc)
+            return _error(500, "Failed to append document content.")
 
     update_expr = "SET " + ", ".join(expr_parts)
 

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3949,6 +3949,10 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Optional updated markdown content.",
                     },
+                    "append_content": {
+                        "type": "string",
+                        "description": "Optional content to append to existing document. Mutually exclusive with 'content'.",
+                    },
                     "description": {
                         "type": "string",
                         "description": "Optional updated description.",
@@ -5646,7 +5650,7 @@ async def _documents_patch(args: dict) -> list[TextContent]:
         )
 
     body: Dict[str, Any] = {}
-    for key in ("title", "content", "description", "keywords", "related_items", "status", "file_name", "document_maturity_state"):
+    for key in ("title", "content", "append_content", "description", "keywords", "related_items", "status", "file_name", "document_maturity_state"):
         if key in args and args.get(key) is not None:
             body[key] = args.get(key)
     if not body:


### PR DESCRIPTION
## Summary
- Fixes ENC-ISS-239: `documents.patch` `append_content` parameter now actually writes appended content to S3
- Implements read-modify-write cycle: fetch existing S3 content, concatenate append, re-upload
- Recomputes content_hash, size_bytes, and compliance_score on appended content
- Rejects requests with both `content` and `append_content` (HTTP 400, mutually exclusive)
- Adds `append_content` to MCP server passthrough keys and Tool inputSchema
- Updates governance data dictionary with `append_content` field definition

## Test plan
- [ ] Verify append_content writes to S3 (create doc, append, verify S3 content)
- [ ] Verify content + append_content returns 400
- [ ] Verify existing content preserved verbatim after append
- [ ] Verify DynamoDB metadata updated (content_hash, size_bytes, version incremented)
- [ ] Governance dictionary guard CI passes

**Plan**: ENC-PLN-029 | **Feature**: ENC-FTR-077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-af519bfd79434e1a8bfffc20eb1e69c9