### PR TITLE
Subtype hardening + coe + wave in document_api (ENC-TSK-E49)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-16.4",
-  "updated_at": "2026-04-16T10:25:00Z",
-  "last_change_summary": "ENC-TSK-E47 / ENC-ISS-242: No schema change \u2014 fixed subtask_ids immutability validation to use deserialized Python list format instead of raw DynamoDB .get('L')/.get('S') accessors. Added defensive try-except. Prior: ENC-TSK-E33 / ENC-ISS-240: No schema change \u2014 fixed _component_propose URL path from full '/api/v1/coordination/components/propose' to relative '/components/propose' (doubled prefix bug). Prior: ENC-TSK-E30 / ENC-TSK-E20 AC-7: Added deploy.artifact_pipeline entity documenting the centralized Lambda build/deploy pipeline — S3 key format (lambda-artifacts/{sha}/{arch_tag}/{fn}.zip), arch tags (prod=x86_64-py311, gamma=arm64-py312), build workflow, deploy helper, and validation gate. Prior: ENC-TSK-E29 / ENC-TSK-E20 AC-6: Added source_artifact_s3_key field to deploy.request entity documenting the optional S3 artifact key validation in deploy_intake _handle_submit(). Format: lambda-artifacts/{git_sha}/{arch_tag}/{function_name}.zip. Arch tag validated against target environment (prod=x86_64-py311, gamma=arm64-py312). Also added to MCP server deploy_submit tool schema. Prior: ENC-FTR-076 / ENC-TSK-E11: Extended component_registry.propose_contract with sns_notification field documenting the ComponentRegistryEventsTopic SNS topic added to infrastructure/cloudformation/01-data.yaml + ComponentRegistryEventsTopicArn export. coordination_api inline IAM policy adds ComponentEventsTopicPublish Sid scoped to that topic ARN; deploy.sh plumbs COMPONENT_EVENTS_TOPIC_ARN env var. _handle_components_propose calls _publish_component_proposed_event after the DynamoDB TransactWrite succeeds; failure is logged and never raised so SNS is best-effort and the 201 response always reaches the caller. Payload schema: {event_type: 'component.proposed', component_id, project_id, proposing_agent_session_id, requested_minimum_transition_type, pwa_deep_link='https://jreese.net/components?filter=pending'}. Prior ENC-FTR-076 / ENC-TSK-E09: Extended component_registry.propose_contract with approve_route + reject_route fields documenting POST /api/v1/coordination/components/{id}/approve and /reject. Both Cognito-only (403 to internal-key callers), gated by ENABLE_COMPONENT_PROPOSAL, atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'` — non-proposed records return 409 with current_lifecycle_status echoed, missing returns 404. Approve writes lifecycle_status=active + approved_at + approved_by (Cognito email/username/sub) and accepts an optional transition_type override. Reject requires rejection_reason >= 10 chars and writes lifecycle_status=rejected + rejected_at + rejected_by + rejection_reason. Routes registered above the generic /components/{id} matcher. Prior ENC-FTR-076 / ENC-TSK-E10: Extended checkout_service.component_enforcement entity with the lifecycle_status pre-check inside _handle_advance(). New helper _get_components_lifecycle() returns per-component {lifecycle_status, rejection_reason}; advances are blocked when any component is `proposed` (HTTP 400 component_not_approved) or `rejected` (HTTP 400 component_rejected echoing rejection_reason). active is the happy path; approved is observed-then-treated-as-active with a [WARNING] log; user_initiated=true bypasses the gate. Prior ENC-FTR-076 / ENC-TSK-E08: Added component_registry.propose_contract entity documenting the agent-proposable component registry surface. New lifecycle_status field on component records (proposed/approved/active/rejected/deprecated/archived); new POST /api/v1/coordination/components/propose route + ENABLE_COMPONENT_PROPOSAL feature flag on coordination_api; new `component.propose` MCP action with requires_governance_hash=True; new component-proposed-by/proposes-component typed-relationship pair registered in tracker_mutation._RELATIONSHIP_TYPES + _INVERSE_PAIRS, graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL, and graph_query_api._ALLOWED_EDGE_TYPES so the COMPONENT_PROPOSED_BY edge is queryable via tracker.graphsearch. Atomic write via TransactWriteItems across component-registry + devops-project-tracker. Prior ENC-TSK-E06 / ENC-ISS-230: Added neo4j.placeholder_node entity documenting the is_placeholder boolean property contract on Neo4j nodes. graph_sync._reconcile_edges() placeholder MERGE sites (PLAN_CONTAINS, PLAN_ATTACHED_DOC, PLAN_IMPLEMENTS, LEARNED_FROM, RELATED_TO, INFORMED_BY source) now set `is_placeholder=true` via ON CREATE SET so downstream consumers can distinguish edge-target stub nodes from real DynamoDB-backed records. _upsert_node clears is_placeholder to false on the real record's projection. embedding.titan_v2_backfill._coverage_for_label adds WHERE n.is_placeholder IS NULL OR n.is_placeholder = false so coverage metrics reflect the active corpus only — closes the B91 denominator inflation (229 orphan stubs pulled Task to 93.72% and Issue to 90.69% despite 100% active-corpus coverage).",
+  "version": "2026-04-16.5",
+  "updated_at": "2026-04-16T18:00:00Z",
+  "last_change_summary": "ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave enumeration and validation. Made document_subtype required on PUT (no default), added 'doc' subtype replacing deprecated 'general' for new creates, added semantic handoff-detection guard for doc subtype (confirm_subtype bypass), added 'coe' subtype with source_incident_id + coe_status lifecycle (drafting/under-review/accepted/archived) + edge density enforcement (>= 1 FTR + 1 LSN + 1 ISS), added 'wave' subtype with required plan_anchor_id (must contain -PLN-, immutable after creation) + wave_status lifecycle (active/concluded/archived). PATCH handler extended with coe_status/wave_status transition validation, plan_anchor_id immutability guard, COE edge density re-validation on related_items change. Compliance checker adds COE-specific section warnings. MCP server passthrough updated for confirm_subtype, source_incident_id, plan_anchor_id, coe_status, wave_status. Added document.doc, document.coe, document.wave entities. Updated document.handoff document_subtype enum to full set. Prior: ENC-TSK-E47 / ENC-ISS-242: No schema change \u2014 fixed subtask_ids immutability validation to use deserialized Python list format instead of raw DynamoDB .get('L')/.get('S') accessors. Added defensive try-except. Prior: ENC-TSK-E33 / ENC-ISS-240: No schema change \u2014 fixed _component_propose URL path from full '/api/v1/coordination/components/propose' to relative '/components/propose' (doubled prefix bug). Prior: ENC-TSK-E30 / ENC-TSK-E20 AC-7: Added deploy.artifact_pipeline entity documenting the centralized Lambda build/deploy pipeline — S3 key format (lambda-artifacts/{sha}/{arch_tag}/{fn}.zip), arch tags (prod=x86_64-py311, gamma=arm64-py312), build workflow, deploy helper, and validation gate. Prior: ENC-TSK-E29 / ENC-TSK-E20 AC-6: Added source_artifact_s3_key field to deploy.request entity documenting the optional S3 artifact key validation in deploy_intake _handle_submit(). Format: lambda-artifacts/{git_sha}/{arch_tag}/{function_name}.zip. Arch tag validated against target environment (prod=x86_64-py311, gamma=arm64-py312). Also added to MCP server deploy_submit tool schema. Prior: ENC-FTR-076 / ENC-TSK-E11: Extended component_registry.propose_contract with sns_notification field documenting the ComponentRegistryEventsTopic SNS topic added to infrastructure/cloudformation/01-data.yaml + ComponentRegistryEventsTopicArn export. coordination_api inline IAM policy adds ComponentEventsTopicPublish Sid scoped to that topic ARN; deploy.sh plumbs COMPONENT_EVENTS_TOPIC_ARN env var. _handle_components_propose calls _publish_component_proposed_event after the DynamoDB TransactWrite succeeds; failure is logged and never raised so SNS is best-effort and the 201 response always reaches the caller. Payload schema: {event_type: 'component.proposed', component_id, project_id, proposing_agent_session_id, requested_minimum_transition_type, pwa_deep_link='https://jreese.net/components?filter=pending'}. Prior ENC-FTR-076 / ENC-TSK-E09: Extended component_registry.propose_contract with approve_route + reject_route fields documenting POST /api/v1/coordination/components/{id}/approve and /reject. Both Cognito-only (403 to internal-key callers), gated by ENABLE_COMPONENT_PROPOSAL, atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'` — non-proposed records return 409 with current_lifecycle_status echoed, missing returns 404. Approve writes lifecycle_status=active + approved_at + approved_by (Cognito email/username/sub) and accepts an optional transition_type override. Reject requires rejection_reason >= 10 chars and writes lifecycle_status=rejected + rejected_at + rejected_by + rejection_reason. Routes registered above the generic /components/{id} matcher. Prior ENC-FTR-076 / ENC-TSK-E10: Extended checkout_service.component_enforcement entity with the lifecycle_status pre-check inside _handle_advance(). New helper _get_components_lifecycle() returns per-component {lifecycle_status, rejection_reason}; advances are blocked when any component is `proposed` (HTTP 400 component_not_approved) or `rejected` (HTTP 400 component_rejected echoing rejection_reason). active is the happy path; approved is observed-then-treated-as-active with a [WARNING] log; user_initiated=true bypasses the gate. Prior ENC-FTR-076 / ENC-TSK-E08: Added component_registry.propose_contract entity documenting the agent-proposable component registry surface. New lifecycle_status field on component records (proposed/approved/active/rejected/deprecated/archived); new POST /api/v1/coordination/components/propose route + ENABLE_COMPONENT_PROPOSAL feature flag on coordination_api; new `component.propose` MCP action with requires_governance_hash=True; new component-proposed-by/proposes-component typed-relationship pair registered in tracker_mutation._RELATIONSHIP_TYPES + _INVERSE_PAIRS, graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL, and graph_query_api._ALLOWED_EDGE_TYPES so the COMPONENT_PROPOSED_BY edge is queryable via tracker.graphsearch. Atomic write via TransactWriteItems across component-registry + devops-project-tracker. Prior ENC-TSK-E06 / ENC-ISS-230: Added neo4j.placeholder_node entity documenting the is_placeholder boolean property contract on Neo4j nodes. graph_sync._reconcile_edges() placeholder MERGE sites (PLAN_CONTAINS, PLAN_ATTACHED_DOC, PLAN_IMPLEMENTS, LEARNED_FROM, RELATED_TO, INFORMED_BY source) now set `is_placeholder=true` via ON CREATE SET so downstream consumers can distinguish edge-target stub nodes from real DynamoDB-backed records. _upsert_node clears is_placeholder to false on the real record's projection. embedding.titan_v2_backfill._coverage_for_label adds WHERE n.is_placeholder IS NULL OR n.is_placeholder = false so coverage metrics reflect the active corpus only — closes the B91 denominator inflation (229 orphan stubs pulled Task to 93.72% and Issue to 90.69% despite 100% active-corpus coverage).",
   "owners": [
     "enceladus-platform"
   ],
@@ -549,14 +549,17 @@
         "document_subtype": {
           "type": "enum",
           "enum": [
-            "general",
+            "doc",
             "handoff",
+            "coe",
+            "wave",
             "blueprint",
             "narrative",
-            "session-log"
+            "session-log",
+            "general"
           ],
-          "definition": "Document subtype classification. Stored on all documents (defaults to 'general' for existing docs). When 'handoff', additional handoff-specific fields are required/available.",
-          "usage_guidance": "Set at creation via document_api PUT body. Cannot be changed after creation."
+          "definition": "Document subtype classification. Required on all new documents (ENC-FTR-077). 'general' is deprecated for new creates — use 'doc' for standard unstructured documents. 'coe' for correction-of-errors, 'wave' for coordination wave tracking. Existing documents may still have 'general'.",
+          "usage_guidance": "Set at creation via document_api PUT body. Cannot be changed after creation. ENC-FTR-077: document_subtype is now required (no default). 'general' returns 400 for new documents."
         },
         "source_record_id": {
           "type": "string",
@@ -620,6 +623,113 @@
           "type": "string",
           "definition": "ENC-ISS-158: When documents.patch receives a handoff lifecycle value (pending/claimed/completed/stale) in the status field for a handoff document, it routes the value to handoff_status instead of rejecting it. This enables MCP callers to use the standard status field for handoff lifecycle transitions without knowing about the separate handoff_status field.",
           "usage_guidance": "Callers can use either documents.patch(status='claimed') or documents.patch(handoff_status='claimed') on handoff documents. Both produce the same result. Non-handoff documents still enforce status in {active, archived}."
+        }
+      }
+    },
+    "document.doc": {
+      "description": "Standard document subtype (ENC-FTR-077). Default subtype for general-purpose documents. Includes a semantic handoff-detection guard that warns when title or content matches handoff patterns. Replaces deprecated 'general' subtype for new document creation.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "doc"
+          ],
+          "definition": "Fixed value 'doc' for standard documents. ENC-FTR-077 requires explicit document_subtype on all new creates; 'general' is rejected with 400.",
+          "usage_guidance": "Use 'doc' for standard unstructured documents that are not handoffs, COEs, or waves."
+        },
+        "confirm_subtype": {
+          "type": "boolean",
+          "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
+        },
+        "semantic_guard_patterns": {
+          "type": "string",
+          "definition": "Informational: the semantic handoff-detection guard checks HANDOFF_TITLE_PATTERNS (HANDOFF, Dispatch [A-Z], GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, Coordination.*Handoff, Handoff.*dispatch) and HANDOFF_CONTENT_PATTERNS (action_checklist, verification_criteria, prerequisite_state, ## Scope Statement, ## Acceptance Criteria.*dispatch). Any match triggers the guard unless confirm_subtype=true.",
+          "usage_guidance": "Read-only reference. Patterns are defined as constants in document_api lambda_function.py."
+        }
+      }
+    },
+    "document.coe": {
+      "description": "Correction-of-errors document subtype (ENC-FTR-077). Structured COE documents tied to incident records with lifecycle status tracking and minimum edge density requirements. Created via document_api PUT with document_subtype=coe.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "coe"
+          ],
+          "definition": "Fixed value 'coe' for correction-of-errors documents."
+        },
+        "source_incident_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "definition": "Tracker record ID of the incident that triggered this COE (e.g. ENC-ISS-242). Required when document_subtype=coe.",
+          "usage_guidance": "Set at creation. Stored as a DynamoDB attribute. Creates the incident anchor for the COE document."
+        },
+        "coe_status": {
+          "type": "enum",
+          "enum": [
+            "drafting",
+            "under-review",
+            "accepted",
+            "archived"
+          ],
+          "definition": "COE lifecycle status. drafting: initial creation/editing. under-review: submitted for peer review. accepted: COE findings accepted. archived: completed and archived.",
+          "usage_guidance": "Auto-set to 'drafting' on creation. Transition via PATCH with coe_status field. Valid transitions: drafting->{under-review}, under-review->{accepted, drafting}, accepted->{archived}. archived is terminal."
+        },
+        "edge_density_validation": {
+          "type": "string",
+          "definition": "COE documents enforce minimum edge density on related_items: at least 1 feature (*-FTR-*), 1 lesson (*-LSN-*), and 1 issue (*-ISS-*) must be present. Validated on both PUT (creation) and PATCH (when related_items is modified). Returns HTTP 400 listing which edge types are missing.",
+          "usage_guidance": "Ensure related_items includes references like ENC-FTR-077, ENC-LSN-026, ENC-ISS-242 before creating or updating a COE document."
+        },
+        "required_sections": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "COE documents are checked for recommended markdown sections during compliance evaluation: '## Root-Cause Analysis', '## Timeline', '## Remediation Status', '## Systemic Lessons', '## Outstanding Questions'. Missing sections generate compliance warnings (not hard blocks).",
+          "usage_guidance": "Include these sections in COE document content for best compliance scores. Warnings appear in compliance_warnings array."
+        }
+      }
+    },
+    "document.wave": {
+      "description": "Coordination wave tracking document subtype (ENC-FTR-077). Wave documents are anchored to a plan record and track coordination wave lifecycle. Created via document_api PUT with document_subtype=wave.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "wave"
+          ],
+          "definition": "Fixed value 'wave' for coordination wave documents."
+        },
+        "plan_anchor_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "pattern": ".*-PLN-.*"
+          },
+          "definition": "Plan record ID that this wave is anchored to (e.g. ENC-PLN-029). Required when document_subtype=wave. Must contain '-PLN-'. Immutable after creation.",
+          "usage_guidance": "Set at creation. Cannot be modified via PATCH (returns HTTP 400). Stored as a DynamoDB attribute."
+        },
+        "wave_status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "concluded",
+            "archived"
+          ],
+          "definition": "Wave lifecycle status. active: wave is in progress. concluded: wave coordination complete. archived: finalized and archived.",
+          "usage_guidance": "Auto-set to 'active' on creation. Transition via PATCH with wave_status field. Valid transitions: active->{concluded}, concluded->{archived}. archived is terminal."
+        },
+        "agent_layer_classification": {
+          "type": "enum",
+          "enum": [
+            "coordination",
+            "execution",
+            "review",
+            "monitoring"
+          ],
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
+          "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
     },

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -144,7 +144,7 @@ ALLOWED_FILE_EXTENSIONS = {".md", ".markdown"}
 # Handoff document schema (ENC-FTR-061 / ENC-TSK-B52)
 # ---------------------------------------------------------------------------
 
-DOCUMENT_SUBTYPES = {"general", "handoff", "blueprint", "narrative", "session-log"}
+DOCUMENT_SUBTYPES = {"doc", "handoff", "coe", "wave", "blueprint", "narrative", "session-log", "general"}
 HANDOFF_STATUSES = {"pending", "claimed", "completed", "stale"}
 HANDOFF_STATUS_TRANSITIONS = {
     "pending": {"claimed", "stale"},
@@ -153,6 +153,59 @@ HANDOFF_STATUS_TRANSITIONS = {
     "stale": set(),
 }
 HANDOFF_REQUIRED_FIELDS = {"source_record_id"}  # required when subtype=handoff
+
+# ---------------------------------------------------------------------------
+# COE (correction-of-errors) document schema (ENC-FTR-077)
+# ---------------------------------------------------------------------------
+
+COE_STATUSES = {"drafting", "under-review", "accepted", "archived"}
+COE_STATUS_TRANSITIONS = {
+    "drafting": {"under-review"},
+    "under-review": {"accepted", "drafting"},
+    "accepted": {"archived"},
+    "archived": set(),
+}
+
+# ---------------------------------------------------------------------------
+# Wave (coordination wave tracking) document schema (ENC-FTR-077)
+# ---------------------------------------------------------------------------
+
+WAVE_STATUSES = {"active", "concluded", "archived"}
+WAVE_STATUS_TRANSITIONS = {
+    "active": {"concluded"},
+    "concluded": {"archived"},
+    "archived": set(),
+}
+
+# ---------------------------------------------------------------------------
+# Semantic handoff-detection patterns (ENC-FTR-077)
+# ---------------------------------------------------------------------------
+
+HANDOFF_TITLE_PATTERNS = [
+    r'(?i)\bHANDOFF\b',
+    r'(?i)\bDispatch\s+[A-Z]\b',
+    r'(?i)GOVERNANCE_SYNC_REQUIRED',
+    r'(?i)EXECUTION_REQUIRED',
+    r'(?i)Coordination.*Handoff',
+    r'(?i)Handoff.*dispatch',
+]
+
+HANDOFF_CONTENT_PATTERNS = [
+    r'(?i)\baction_checklist\b',
+    r'(?i)\bverification_criteria\b',
+    r'(?i)\bprerequisite_state\b',
+    r'(?i)##\s*Scope\s+Statement',
+    r'(?i)##\s*Acceptance\s+Criteria.*dispatch',
+]
+
+# Required COE sections (compliance warnings, not hard blocks)
+COE_REQUIRED_SECTIONS = [
+    "## Root-Cause Analysis",
+    "## Timeline",
+    "## Remediation Status",
+    "## Systemic Lessons",
+    "## Outstanding Questions",
+]
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -466,7 +519,7 @@ def _is_table_divider(line: str) -> bool:
     return bool(re.match(r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$", line))
 
 
-def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
+def _evaluate_markdown_compliance(content: str, document_subtype: str = "") -> Dict[str, Any]:
     warnings: List[str] = []
     lines = content.splitlines()
 
@@ -563,6 +616,14 @@ def _evaluate_markdown_compliance(content: str) -> Dict[str, Any]:
             continue
         if "[!" in line and not re.search(r"^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$", line):
             warnings.append(f"Malformed alert syntax at line {idx}.")
+
+    # COE-specific section warnings (ENC-FTR-077): warn when required sections
+    # are missing. These are advisory, not hard blocks.
+    if document_subtype == "coe":
+        content_lower = content.lower()
+        for section in COE_REQUIRED_SECTIONS:
+            if section.lower() not in content_lower:
+                warnings.append(f"COE document missing recommended section: '{section}'.")
 
     warnings = warnings[:MAX_COMPLIANCE_WARNINGS]
     score = max(0, 100 - (len(warnings) * 10))
@@ -1055,18 +1116,6 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
     if len(content.encode("utf-8")) > MAX_CONTENT_SIZE:
         return _error(400, f"Content exceeds {MAX_CONTENT_SIZE} bytes.")
 
-    compliance = _evaluate_markdown_compliance(content)
-    if MIN_COMPLIANCE_SCORE > 0 and compliance["compliance_score"] < MIN_COMPLIANCE_SCORE:
-        return _error(
-            400,
-            (
-                f"Document compliance_score {compliance['compliance_score']} is below "
-                f"minimum required score {MIN_COMPLIANCE_SCORE}."
-            ),
-            compliance_score=compliance["compliance_score"],
-            compliance_warnings=compliance["compliance_warnings"],
-        )
-
     # Validate project
     project_err = _validate_project_exists(project_id)
     if project_err:
@@ -1090,10 +1139,43 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
     related_items = [str(r).strip() for r in related_items[:MAX_RELATED_ITEMS] if str(r).strip()]
     keywords = [str(k).strip().lower() for k in keywords[:MAX_KEYWORDS] if str(k).strip()]
 
-    # Document subtype (ENC-FTR-061)
-    document_subtype = str(body.get("document_subtype", "general")).strip().lower()
+    # Document subtype (ENC-FTR-061 / ENC-FTR-077)
+    if "document_subtype" not in body:
+        return _error(
+            400,
+            "document_subtype is required. Use 'doc' for standard documents, "
+            "'handoff' for dispatch/report-back, 'coe' for correction-of-errors, "
+            "'wave' for coordination wave tracking.",
+        )
+    document_subtype = str(body.get("document_subtype", "")).strip().lower()
+    if not document_subtype:
+        return _error(
+            400,
+            "document_subtype is required. Use 'doc' for standard documents, "
+            "'handoff' for dispatch/report-back, 'coe' for correction-of-errors, "
+            "'wave' for coordination wave tracking.",
+        )
     if document_subtype not in DOCUMENT_SUBTYPES:
         return _error(400, f"Invalid document_subtype '{document_subtype}'. Must be one of: {', '.join(sorted(DOCUMENT_SUBTYPES))}")
+    if document_subtype == "general":
+        return _error(
+            400,
+            "document_subtype 'general' is deprecated for new documents. "
+            "Use 'doc' for standard unstructured documents.",
+        )
+
+    # Compliance check (pass subtype for COE section warnings — ENC-FTR-077)
+    compliance = _evaluate_markdown_compliance(content, document_subtype=document_subtype)
+    if MIN_COMPLIANCE_SCORE > 0 and compliance["compliance_score"] < MIN_COMPLIANCE_SCORE:
+        return _error(
+            400,
+            (
+                f"Document compliance_score {compliance['compliance_score']} is below "
+                f"minimum required score {MIN_COMPLIANCE_SCORE}."
+            ),
+            compliance_score=compliance["compliance_score"],
+            compliance_warnings=compliance["compliance_warnings"],
+        )
 
     # ENC-TSK-C10 / ENC-FTR-065: Document maturity state (GDMP pipeline)
     VALID_MATURITY_STATES = {"raw", "compliant", "contextualized", "mature"}
@@ -1105,7 +1187,29 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
             f"Must be one of: {', '.join(sorted(VALID_MATURITY_STATES))}",
         )
 
-    # Handoff-specific fields
+    # --- Semantic handoff-detection guard (ENC-FTR-077) ---
+    # When subtype is 'doc', check for handoff-like patterns in title/content.
+    if document_subtype == "doc":
+        confirm_subtype = body.get("confirm_subtype")
+        if not confirm_subtype:
+            handoff_detected = False
+            for pattern in HANDOFF_TITLE_PATTERNS:
+                if re.search(pattern, title):
+                    handoff_detected = True
+                    break
+            if not handoff_detected:
+                for pattern in HANDOFF_CONTENT_PATTERNS:
+                    if re.search(pattern, content):
+                        handoff_detected = True
+                        break
+            if handoff_detected:
+                return _error(
+                    400,
+                    "Document title/structure suggests this should use document_subtype='handoff'. "
+                    "If 'doc' is intentionally correct, retry with confirm_subtype=true.",
+                )
+
+    # --- Handoff-specific fields (ENC-FTR-061) ---
     handoff_fields: Dict[str, Any] = {}
     if document_subtype == "handoff":
         source_record_id = str(body.get("source_record_id", "")).strip()
@@ -1124,6 +1228,46 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
         expires_at = str(body.get("expires_at", "")).strip()
         if expires_at:
             handoff_fields["expires_at"] = expires_at
+
+    # --- COE-specific validation (ENC-FTR-077) ---
+    coe_fields: Dict[str, Any] = {}
+    if document_subtype == "coe":
+        source_incident_id = str(body.get("source_incident_id", "")).strip()
+        if not source_incident_id:
+            return _error(400, "Field 'source_incident_id' is required when document_subtype is 'coe'.")
+        coe_fields["source_incident_id"] = source_incident_id
+        coe_fields["coe_status"] = "drafting"
+        # Edge density validation: require at least 1 FTR, 1 LSN, 1 ISS in related_items
+        missing_edges = []
+        has_ftr = any("-FTR-" in item for item in related_items)
+        has_lsn = any("-LSN-" in item for item in related_items)
+        has_iss = any("-ISS-" in item for item in related_items)
+        if not has_ftr:
+            missing_edges.append("feature (*-FTR-*)")
+        if not has_lsn:
+            missing_edges.append("lesson (*-LSN-*)")
+        if not has_iss:
+            missing_edges.append("issue (*-ISS-*)")
+        if missing_edges:
+            return _error(
+                400,
+                "COE requires minimum edge density: related_items must include "
+                ">= 1 feature (*-FTR-*), >= 1 lesson (*-LSN-*), >= 1 issue (*-ISS-*). "
+                f"Missing: {', '.join(missing_edges)}",
+            )
+
+    # --- Wave-specific validation (ENC-FTR-077) ---
+    wave_fields: Dict[str, Any] = {}
+    if document_subtype == "wave":
+        plan_anchor_id = str(body.get("plan_anchor_id", "")).strip()
+        if not plan_anchor_id or "-PLN-" not in plan_anchor_id:
+            return _error(
+                400,
+                "Field 'plan_anchor_id' is required when document_subtype is 'wave' "
+                "and must contain '-PLN-' (e.g. ENC-PLN-029).",
+            )
+        wave_fields["plan_anchor_id"] = plan_anchor_id
+        wave_fields["wave_status"] = "active"
 
     # Generate document ID
     document_id = f"DOC-{uuid.uuid4().hex[:12].upper()}"
@@ -1181,6 +1325,16 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
             item["action_checklist"] = _serialize_list(handoff_fields["action_checklist"])
         if handoff_fields.get("expires_at"):
             item["expires_at"] = {"S": handoff_fields["expires_at"]}
+
+    # Add COE-specific fields to DynamoDB item (ENC-FTR-077)
+    if coe_fields:
+        item["source_incident_id"] = {"S": coe_fields["source_incident_id"]}
+        item["coe_status"] = {"S": coe_fields["coe_status"]}
+
+    # Add wave-specific fields to DynamoDB item (ENC-FTR-077)
+    if wave_fields:
+        item["plan_anchor_id"] = {"S": wave_fields["plan_anchor_id"]}
+        item["wave_status"] = {"S": wave_fields["wave_status"]}
 
     try:
         ddb.put_item(TableName=DOCUMENTS_TABLE, Item=item)
@@ -1479,6 +1633,64 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
             "Cannot specify both 'content' and 'append_content' — they are mutually exclusive.",
         )
 
+    # COE status transitions (ENC-FTR-077)
+    if "coe_status" in body:
+        if current_subtype != "coe":
+            return _error(400, "Cannot set coe_status on a non-COE document.")
+        new_coe_status = str(body["coe_status"]).strip().lower()
+        if new_coe_status not in COE_STATUSES:
+            return _error(400, f"Invalid coe_status '{new_coe_status}'. Must be one of: {', '.join(sorted(COE_STATUSES))}")
+        current_coe_status = existing.get("coe_status", {}).get("S", "drafting")
+        allowed_coe = COE_STATUS_TRANSITIONS.get(current_coe_status, set())
+        if new_coe_status != current_coe_status and new_coe_status not in allowed_coe:
+            return _error(
+                400,
+                f"Cannot transition coe_status from '{current_coe_status}' to '{new_coe_status}'. "
+                f"Allowed transitions: {', '.join(sorted(allowed_coe)) if allowed_coe else 'none (terminal state)'}",
+            )
+        expr_parts.append("coe_status = :cs")
+        attr_values[":cs"] = {"S": new_coe_status}
+
+    # Wave status transitions (ENC-FTR-077)
+    if "wave_status" in body:
+        if current_subtype != "wave":
+            return _error(400, "Cannot set wave_status on a non-wave document.")
+        new_wave_status = str(body["wave_status"]).strip().lower()
+        if new_wave_status not in WAVE_STATUSES:
+            return _error(400, f"Invalid wave_status '{new_wave_status}'. Must be one of: {', '.join(sorted(WAVE_STATUSES))}")
+        current_wave_status = existing.get("wave_status", {}).get("S", "active")
+        allowed_wave = WAVE_STATUS_TRANSITIONS.get(current_wave_status, set())
+        if new_wave_status != current_wave_status and new_wave_status not in allowed_wave:
+            return _error(
+                400,
+                f"Cannot transition wave_status from '{current_wave_status}' to '{new_wave_status}'. "
+                f"Allowed transitions: {', '.join(sorted(allowed_wave)) if allowed_wave else 'none (terminal state)'}",
+            )
+        expr_parts.append("wave_status = :ws")
+        attr_values[":ws"] = {"S": new_wave_status}
+
+    # plan_anchor_id immutability (ENC-FTR-077)
+    if "plan_anchor_id" in body:
+        return _error(400, "plan_anchor_id is immutable after wave document creation.")
+
+    # COE edge density re-validation on related_items change (ENC-FTR-077)
+    if "related_items" in body and current_subtype == "coe":
+        patched_items = [str(r).strip() for r in body["related_items"][:MAX_RELATED_ITEMS] if str(r).strip()]
+        missing_edges = []
+        if not any("-FTR-" in item for item in patched_items):
+            missing_edges.append("feature (*-FTR-*)")
+        if not any("-LSN-" in item for item in patched_items):
+            missing_edges.append("lesson (*-LSN-*)")
+        if not any("-ISS-" in item for item in patched_items):
+            missing_edges.append("issue (*-ISS-*)")
+        if missing_edges:
+            return _error(
+                400,
+                "COE requires minimum edge density: related_items must include "
+                ">= 1 feature (*-FTR-*), >= 1 lesson (*-LSN-*), >= 1 issue (*-ISS-*). "
+                f"Missing: {', '.join(missing_edges)}",
+            )
+
     # Content update — re-upload to S3
     if "content" in body:
         content = body["content"]
@@ -1487,7 +1699,7 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
         if len(content.encode("utf-8")) > MAX_CONTENT_SIZE:
             return _error(400, f"Content must be 1-{MAX_CONTENT_SIZE} bytes.")
         try:
-            compliance = _evaluate_markdown_compliance(content)
+            compliance = _evaluate_markdown_compliance(content, document_subtype=current_subtype)
             if MIN_COMPLIANCE_SCORE > 0 and compliance["compliance_score"] < MIN_COMPLIANCE_SCORE:
                 return _error(
                     400,

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5615,7 +5615,11 @@ async def _documents_put(args: dict) -> list[TextContent]:
         "title": args["title"],
         "content": args["content"],
     }
-    for key in ("description", "keywords", "related_items", "file_name"):
+    for key in (
+        "description", "keywords", "related_items", "file_name",
+        "document_subtype", "confirm_subtype",
+        "source_incident_id", "plan_anchor_id",
+    ):
         if key in args and args.get(key) is not None:
             body[key] = args.get(key)
 
@@ -5650,7 +5654,11 @@ async def _documents_patch(args: dict) -> list[TextContent]:
         )
 
     body: Dict[str, Any] = {}
-    for key in ("title", "content", "append_content", "description", "keywords", "related_items", "status", "file_name", "document_maturity_state"):
+    for key in (
+        "title", "content", "append_content", "description", "keywords", "related_items",
+        "status", "file_name", "document_maturity_state",
+        "handoff_status", "coe_status", "wave_status",
+    ):
         if key in args and args.get(key) is not None:
             body[key] = args.get(key)
     if not body:


### PR DESCRIPTION
## Summary
- Makes `document_subtype` required on document creation (no default)
- Adds `doc` subtype for standard docs; deprecates `general` for new creates
- Adds semantic handoff-detection guard: rejects `doc` when title/content looks like a handoff
- Adds `coe` subtype with edge density enforcement (>= 1 feature + 1 lesson + 1 issue)
- Adds `wave` subtype with required `plan_anchor_id` and immutable anchor
- Implements COE and wave status lifecycles with transition enforcement
- Updates governance_data_dictionary.json with document.doc, document.coe, document.wave entities

## Test plan
- [ ] Verify PUT without document_subtype returns 400
- [ ] Verify doc subtype works, general rejected for new creates
- [ ] Verify semantic guard triggers on handoff-like titles, bypassed with confirm_subtype=true
- [ ] Verify COE edge density validation (reject when missing FTR/LSN/ISS refs)
- [ ] Verify COE/wave status lifecycles
- [ ] Verify wave plan_anchor_id immutability
- [ ] Governance dictionary guard CI passes

**Plan**: ENC-PLN-029 | **Feature**: ENC-FTR-077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-3da4c50f25304d02ade9adac0ad4bd2a