### PR TITLE
Graph edge projection + OGTM for docstore subtypes (ENC-TSK-E52)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
   "version": "2026-04-16.5",
   "updated_at": "2026-04-16T18:00:00Z",
-  "last_change_summary": "ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave enumeration and validation. Made document_subtype required on PUT (no default), added 'doc' subtype replacing deprecated 'general' for new creates, added semantic handoff-detection guard for doc subtype (confirm_subtype bypass), added 'coe' subtype with source_incident_id + coe_status lifecycle (drafting/under-review/accepted/archived) + edge density enforcement (>= 1 FTR + 1 LSN + 1 ISS), added 'wave' subtype with required plan_anchor_id (must contain -PLN-, immutable after creation) + wave_status lifecycle (active/concluded/archived). PATCH handler extended with coe_status/wave_status transition validation, plan_anchor_id immutability guard, COE edge density re-validation on related_items change. Compliance checker adds COE-specific section warnings. MCP server passthrough updated for confirm_subtype, source_incident_id, plan_anchor_id, coe_status, wave_status. Added document.doc, document.coe, document.wave entities. Updated document.handoff document_subtype enum to full set. Prior: ENC-TSK-E47 / ENC-ISS-242: No schema change \u2014 fixed subtask_ids immutability validation to use deserialized Python list format instead of raw DynamoDB .get('L')/.get('S') accessors. Added defensive try-except. Prior: ENC-TSK-E33 / ENC-ISS-240: No schema change \u2014 fixed _component_propose URL path from full '/api/v1/coordination/components/propose' to relative '/components/propose' (doubled prefix bug). Prior: ENC-TSK-E30 / ENC-TSK-E20 AC-7: Added deploy.artifact_pipeline entity documenting the centralized Lambda build/deploy pipeline — S3 key format (lambda-artifacts/{sha}/{arch_tag}/{fn}.zip), arch tags (prod=x86_64-py311, gamma=arm64-py312), build workflow, deploy helper, and validation gate. Prior: ENC-TSK-E29 / ENC-TSK-E20 AC-6: Added source_artifact_s3_key field to deploy.request entity documenting the optional S3 artifact key validation in deploy_intake _handle_submit(). Format: lambda-artifacts/{git_sha}/{arch_tag}/{function_name}.zip. Arch tag validated against target environment (prod=x86_64-py311, gamma=arm64-py312). Also added to MCP server deploy_submit tool schema. Prior: ENC-FTR-076 / ENC-TSK-E11: Extended component_registry.propose_contract with sns_notification field documenting the ComponentRegistryEventsTopic SNS topic added to infrastructure/cloudformation/01-data.yaml + ComponentRegistryEventsTopicArn export. coordination_api inline IAM policy adds ComponentEventsTopicPublish Sid scoped to that topic ARN; deploy.sh plumbs COMPONENT_EVENTS_TOPIC_ARN env var. _handle_components_propose calls _publish_component_proposed_event after the DynamoDB TransactWrite succeeds; failure is logged and never raised so SNS is best-effort and the 201 response always reaches the caller. Payload schema: {event_type: 'component.proposed', component_id, project_id, proposing_agent_session_id, requested_minimum_transition_type, pwa_deep_link='https://jreese.net/components?filter=pending'}. Prior ENC-FTR-076 / ENC-TSK-E09: Extended component_registry.propose_contract with approve_route + reject_route fields documenting POST /api/v1/coordination/components/{id}/approve and /reject. Both Cognito-only (403 to internal-key callers), gated by ENABLE_COMPONENT_PROPOSAL, atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'` — non-proposed records return 409 with current_lifecycle_status echoed, missing returns 404. Approve writes lifecycle_status=active + approved_at + approved_by (Cognito email/username/sub) and accepts an optional transition_type override. Reject requires rejection_reason >= 10 chars and writes lifecycle_status=rejected + rejected_at + rejected_by + rejection_reason. Routes registered above the generic /components/{id} matcher. Prior ENC-FTR-076 / ENC-TSK-E10: Extended checkout_service.component_enforcement entity with the lifecycle_status pre-check inside _handle_advance(). New helper _get_components_lifecycle() returns per-component {lifecycle_status, rejection_reason}; advances are blocked when any component is `proposed` (HTTP 400 component_not_approved) or `rejected` (HTTP 400 component_rejected echoing rejection_reason). active is the happy path; approved is observed-then-treated-as-active with a [WARNING] log; user_initiated=true bypasses the gate. Prior ENC-FTR-076 / ENC-TSK-E08: Added component_registry.propose_contract entity documenting the agent-proposable component registry surface. New lifecycle_status field on component records (proposed/approved/active/rejected/deprecated/archived); new POST /api/v1/coordination/components/propose route + ENABLE_COMPONENT_PROPOSAL feature flag on coordination_api; new `component.propose` MCP action with requires_governance_hash=True; new component-proposed-by/proposes-component typed-relationship pair registered in tracker_mutation._RELATIONSHIP_TYPES + _INVERSE_PAIRS, graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL, and graph_query_api._ALLOWED_EDGE_TYPES so the COMPONENT_PROPOSED_BY edge is queryable via tracker.graphsearch. Atomic write via TransactWriteItems across component-registry + devops-project-tracker. Prior ENC-TSK-E06 / ENC-ISS-230: Added neo4j.placeholder_node entity documenting the is_placeholder boolean property contract on Neo4j nodes. graph_sync._reconcile_edges() placeholder MERGE sites (PLAN_CONTAINS, PLAN_ATTACHED_DOC, PLAN_IMPLEMENTS, LEARNED_FROM, RELATED_TO, INFORMED_BY source) now set `is_placeholder=true` via ON CREATE SET so downstream consumers can distinguish edge-target stub nodes from real DynamoDB-backed records. _upsert_node clears is_placeholder to false on the real record's projection. embedding.titan_v2_backfill._coverage_for_label adds WHERE n.is_placeholder IS NULL OR n.is_placeholder = false so coverage metrics reflect the active corpus only — closes the B91 denominator inflation (229 orphan stubs pulled Task to 93.72% and Issue to 90.69% despite 100% active-corpus coverage).",
+  "last_change_summary": "ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3690,7 +3690,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -3716,6 +3716,54 @@
           "type": "edge",
           "target_label": "Plan",
           "source_field": "plan.attached_documents (inverse)"
+        },
+        "INVESTIGATES": {
+          "type": "edge",
+          "target_label": "Issue/Task",
+          "source_field": "source_incident_id",
+          "source_subtype": "coe",
+          "definition": "Document (coe) -> Issue/Task. Links a Correction of Errors document to the incident it investigates.",
+          "edge_weight": 0.85
+        },
+        "INVESTIGATED_BY": {
+          "type": "edge",
+          "target_label": "Document (coe)",
+          "source_field": "source_incident_id (inverse)",
+          "source_subtype": "coe",
+          "definition": "Issue/Task -> Document (coe). Inverse of INVESTIGATES.",
+          "edge_weight": 0.85
+        },
+        "TRACKS_WAVE_OF": {
+          "type": "edge",
+          "target_label": "Plan",
+          "source_field": "plan_anchor_id",
+          "source_subtype": "wave",
+          "definition": "Document (wave) -> Plan. Links a wave progress document to the plan it tracks.",
+          "edge_weight": 0.50
+        },
+        "HAS_WAVE_DOC": {
+          "type": "edge",
+          "target_label": "Document (wave)",
+          "source_field": "plan_anchor_id (inverse)",
+          "source_subtype": "wave",
+          "definition": "Plan -> Document (wave). Inverse of TRACKS_WAVE_OF.",
+          "edge_weight": 0.50
+        },
+        "HANDS_OFF": {
+          "type": "edge",
+          "target_label": "Task/Issue/Feature",
+          "source_field": "source_record_id",
+          "source_subtype": "handoff",
+          "definition": "Document (handoff) -> Task/Issue/Feature. Links a handoff document to the record it hands off from. Document-specific handler added in ENC-FTR-077 (was only in typed-rel flow).",
+          "edge_weight": 0.65
+        },
+        "HANDED_OFF_BY": {
+          "type": "edge",
+          "target_label": "Document (handoff)",
+          "source_field": "source_record_id (inverse)",
+          "source_subtype": "handoff",
+          "definition": "Task/Issue/Feature -> Document (handoff). Inverse of HANDS_OFF.",
+          "edge_weight": 0.65
         }
       },
       "governing_feature": "ENC-FTR-065",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -71,10 +71,15 @@ HYBRID_SIGNAL_TOP_N = 25
 GRAPH_EDGE_WEIGHTS: Dict[str, float] = {
     "IMPLEMENTS": 1.00,
     "ADDRESSES": 0.90,
+    "INVESTIGATES": 0.85,
+    "INVESTIGATED_BY": 0.85,
     "RELATED_TO": 0.75,
     "LEARNED_FROM": 0.70,
+    "HANDS_OFF": 0.65,
     "CHILD_OF": 0.60,
     "PLAN_CONTAINS": 0.55,
+    "TRACKS_WAVE_OF": 0.50,
+    "HAS_WAVE_DOC": 0.50,
     "BELONGS_TO": 0.30,
 }
 GRAPH_FALLBACK_DEFAULT_WEIGHT = 0.40
@@ -257,6 +262,11 @@ _ALLOWED_EDGE_TYPES = frozenset({
     "DOC_ATTACHED_TO_PLAN",  # inverse of PLAN_ATTACHED_DOC
     "INFORMED_BY",            # GDMP provenance (Document -> Document)
     "INFORMS",                # inverse GDMP provenance
+    # ENC-FTR-077: Docstore subtype edges
+    "INVESTIGATES",           # Document (coe) -> Issue/Task
+    "INVESTIGATED_BY",        # Issue/Task -> Document (coe)
+    "TRACKS_WAVE_OF",         # Document (wave) -> Plan
+    "HAS_WAVE_DOC",           # Plan -> Document (wave)
     # GMF: Generational Metabolism Framework (DOC-63420302EF65 §8.2)
     "SUCCEEDS",               # Generation -> Generation (lineage)
     "BELONGS_TO_GENERATION",  # Feature -> Generation

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -610,6 +610,79 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
                 did=doc_id, sid=informed_id,
             )
 
+        # --- Subtype-specific document edges (ENC-FTR-077) ---
+        doc_subtype = record.get("document_subtype", "")
+
+        # COE: INVESTIGATES / INVESTIGATED_BY (source_incident_id -> Issue/Task)
+        if doc_subtype == "coe":
+            source_incident_id = record.get("source_incident_id", "")
+            if source_incident_id:
+                source_incident_id = _bare_id(source_incident_id)
+                target_label = _infer_label_from_id(source_incident_id)
+                if target_label:
+                    tx.run(
+                        f"MERGE (t:{target_label} {{record_id: $target_id}}) "
+                        "ON CREATE SET t.is_placeholder = true",
+                        target_id=source_incident_id,
+                    )
+                    tx.run(
+                        f"MATCH (d:Document), (t:{target_label}) "
+                        "WHERE d.record_id = $did AND t.record_id = $target_id "
+                        "MERGE (d)-[:INVESTIGATES]->(t) "
+                        "MERGE (t)-[:INVESTIGATED_BY]->(d)",
+                        did=doc_id, target_id=source_incident_id,
+                    )
+                else:
+                    logger.warning(
+                        "[WARNING] COE document %s source_incident_id %s has unrecognised "
+                        "ID prefix; skipping INVESTIGATES edge",
+                        doc_id, source_incident_id,
+                    )
+
+        # Wave: TRACKS_WAVE_OF / HAS_WAVE_DOC (plan_anchor_id -> Plan)
+        if doc_subtype == "wave":
+            plan_anchor_id = record.get("plan_anchor_id", "")
+            if plan_anchor_id:
+                plan_anchor_id = _bare_id(plan_anchor_id)
+                tx.run(
+                    "MERGE (p:Plan {record_id: $plan_id}) "
+                    "ON CREATE SET p.is_placeholder = true",
+                    plan_id=plan_anchor_id,
+                )
+                tx.run(
+                    "MATCH (d:Document), (p:Plan) "
+                    "WHERE d.record_id = $did AND p.record_id = $plan_id "
+                    "MERGE (d)-[:TRACKS_WAVE_OF]->(p) "
+                    "MERGE (p)-[:HAS_WAVE_DOC]->(d)",
+                    did=doc_id, plan_id=plan_anchor_id,
+                )
+
+        # Handoff: HANDS_OFF / HANDED_OFF_BY (source_record_id -> Task/Issue/Feature)
+        if doc_subtype == "handoff":
+            source_record_id = record.get("source_record_id", "")
+            if source_record_id:
+                source_record_id = _bare_id(source_record_id)
+                target_label = _infer_label_from_id(source_record_id)
+                if target_label:
+                    tx.run(
+                        f"MERGE (t:{target_label} {{record_id: $source_rec_id}}) "
+                        "ON CREATE SET t.is_placeholder = true",
+                        source_rec_id=source_record_id,
+                    )
+                    tx.run(
+                        f"MATCH (d:Document), (t:{target_label}) "
+                        "WHERE d.record_id = $did AND t.record_id = $source_rec_id "
+                        "MERGE (d)-[:HANDS_OFF]->(t) "
+                        "MERGE (t)-[:HANDED_OFF_BY]->(d)",
+                        did=doc_id, source_rec_id=source_record_id,
+                    )
+                else:
+                    logger.warning(
+                        "[WARNING] Handoff document %s source_record_id %s has unrecognised "
+                        "ID prefix; skipping HANDS_OFF edge",
+                        doc_id, source_record_id,
+                    )
+
     # GMF: Generation edge projections (DOC-63420302EF65 §8.2)
     if record_type == "generation":
         gen_id = record_id
@@ -680,6 +753,11 @@ RELATIONSHIP_TYPE_TO_EDGE_LABEL = {
     "doc-attached-to-plan": "DOC_ATTACHED_TO_PLAN",  # Document -> Plan (inverse of plan-attached-doc)
     "informed-by": "INFORMED_BY",                      # Document -> Document (GDMP provenance)
     "informs": "INFORMS",                              # Document -> Document (inverse provenance)
+    # ENC-FTR-077: Docstore subtype edges
+    "investigates": "INVESTIGATES",                    # Document (coe) -> Issue/Task
+    "investigated-by": "INVESTIGATED_BY",              # Issue/Task -> Document (coe)
+    "tracks-wave-of": "TRACKS_WAVE_OF",                # Document (wave) -> Plan
+    "has-wave-doc": "HAS_WAVE_DOC",                    # Plan -> Document (wave)
     # GMF: Generational Metabolism Framework (DOC-63420302EF65 §8.2)
     "succeeds": "SUCCEEDS",                            # Generation -> Generation (lineage)
     "belongs-to-generation": "BELONGS_TO_GENERATION",  # Feature -> Generation

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -4111,6 +4111,9 @@ _RELATIONSHIP_TYPES = frozenset({
     "dispatches", "dispatched-by",
     # ENC-FTR-076 / ENC-TSK-E08: Component proposal provenance
     "component-proposed-by", "proposes-component",
+    # ENC-FTR-077: Docstore subtype edges
+    "investigates", "investigated-by",
+    "tracks-wave-of", "has-wave-doc",
 })
 
 _INVERSE_PAIRS: Dict[str, str] = {
@@ -4137,6 +4140,9 @@ _INVERSE_PAIRS: Dict[str, str] = {
     # ENC-FTR-076 / ENC-TSK-E08: Component proposal provenance
     "component-proposed-by": "proposes-component",
     "proposes-component": "component-proposed-by",
+    # ENC-FTR-077: Docstore subtype edges
+    "investigates": "investigated-by", "investigated-by": "investigates",
+    "tracks-wave-of": "has-wave-doc", "has-wave-doc": "tracks-wave-of",
 }
 
 _OWL_CHARACTERISTICS: Dict[str, Dict[str, bool]] = {


### PR DESCRIPTION
## Summary
- Adds COE edge projection: INVESTIGATES/INVESTIGATED_BY from source_incident_id
- Adds wave edge projection: TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id
- Adds handoff document-specific HANDS_OFF projection from source_record_id
- Registers 4 new edge types in _ALLOWED_EDGE_TYPES and RELATIONSHIP_TYPE_TO_EDGE_LABEL
- Assigns edge weights (INVESTIGATES: 0.85, TRACKS_WAVE_OF: 0.50, HANDS_OFF: 0.65)
- Updates governance_data_dictionary.json

## OGTM Compliance (ENC-FTR-066)
| Edge | Criterion 1 (handler) | Criterion 2 (label map) | Criterion 3 (allowed) | Criterion 4 (E2E) |
|------|----------------------|------------------------|----------------------|-------------------|
| INVESTIGATES | ✅ | ✅ | ✅ | Deferred to E2E task |
| INVESTIGATED_BY | ✅ | ✅ | ✅ | Deferred |
| TRACKS_WAVE_OF | ✅ | ✅ | ✅ | Deferred |
| HAS_WAVE_DOC | ✅ | ✅ | ✅ | Deferred |
| HANDS_OFF (doc) | ✅ | Already exists | Already exists | Deferred |

## Test plan
- [ ] Governance dictionary guard CI passes
- [ ] No syntax errors in Cypher statements
- [ ] Edge types registered in all required locations

**Plan**: ENC-PLN-029 | **Feature**: ENC-FTR-077
**Depends on**: PR #352 (subtype hardening — for DynamoDB attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-472299004cc24e2a98e6181409c25473