### PR TITLE
MCP execute actions + dual-append for docstore subtypes (ENC-TSK-E53)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-16.6",
-  "updated_at": "2026-04-16T20:00:00Z",
-  "last_change_summary": "ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
+  "version": "2026-04-16.7",
+  "updated_at": "2026-04-16T21:00:00Z",
+  "last_change_summary": "ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1861,6 +1861,40 @@
         "feature_flag": {
           "type": "string",
           "definition": "ENABLE_HANDOFF_PRIMITIVE environment variable. When 'true', the 3 handoff actions are registered in the execute action registry. Default 'false'."
+        }
+      }
+    },
+    "mcp_server.docstore_subtype_tools": {
+      "description": "MCP execute actions for COE and wave docstore subtype lifecycle (ENC-FTR-077, ENC-TSK-E53). Four actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag. All route through document_api HTTP API. AC-5: product-lead-terminal append_handoff_reply dual-appends to both the handoff doc and the active wave doc (best-effort).",
+      "fields": {
+        "document.create_coe": {
+          "type": "execute_action",
+          "definition": "Creates a COE (Correction of Errors) document with document_subtype=coe. Requires project_id, title, content, source_incident_id. Optionally accepts description, keywords, related_items, file_name, informed_by. Validation of related_items composition (>= 1 FTR, >= 1 LSN, >= 1 ISS) is enforced by document_api. Returns document_id on success.",
+          "usage_guidance": "execute(steps=[{action: 'document.create_coe', arguments: {governance_hash, project_id, title, content, source_incident_id, ...}}])"
+        },
+        "document.create_wave": {
+          "type": "execute_action",
+          "definition": "Creates a wave coordination document with document_subtype=wave anchored to a plan. Requires project_id, title, content, plan_anchor_id. Optionally accepts description, keywords, related_items, file_name. Returns document_id on success.",
+          "usage_guidance": "execute(steps=[{action: 'document.create_wave', arguments: {governance_hash, project_id, title, content, plan_anchor_id, ...}}])"
+        },
+        "document.append_handoff_reply": {
+          "type": "execute_action",
+          "definition": "Appends a structured reply block with YAML frontmatter (reply_author, reply_timestamp, agent_layer, originating_handoff_ref) to a handoff document via append_content PATCH. Requires document_id, content, agent_layer (one of: supervisor, coord-lead, dispatched-agent, product-lead-terminal). Optionally accepts author, originating_handoff_ref. AC-5: when agent_layer is product-lead-terminal and the handoff append succeeds, a best-effort dual-append copies the reply to the active wave doc in the same project.",
+          "usage_guidance": "execute(steps=[{action: 'document.append_handoff_reply', arguments: {governance_hash, document_id, content, agent_layer, ...}}])"
+        },
+        "document.append_wave_entry": {
+          "type": "execute_action",
+          "definition": "Appends a wave entry with YAML frontmatter (reply_author, reply_timestamp, agent_layer, optional originating_handoff_ref) to a wave document via append_content PATCH. Requires document_id, content, agent_layer. Optionally accepts author, originating_handoff_ref for cross-document traceability.",
+          "usage_guidance": "execute(steps=[{action: 'document.append_wave_entry', arguments: {governance_hash, document_id, content, agent_layer, ...}}])"
+        },
+        "dual_append_behavior": {
+          "type": "rule",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "governing_feature": "ENC-FTR-077"
+        },
+        "feature_flag": {
+          "type": "string",
+          "definition": "ENABLE_HANDOFF_PRIMITIVE environment variable. When 'true', these 4 actions (plus the 3 handoff actions) are registered in the execute action registry. Default 'false'."
         }
       }
     },

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5777,6 +5777,289 @@ async def _document_complete_handoff(args: dict) -> list[TextContent]:
     return _result_text(result)
 
 
+# ---------------------------------------------------------------------------
+# ENC-FTR-077 / ENC-TSK-E53: COE + Wave docstore subtype MCP execute actions
+# ---------------------------------------------------------------------------
+
+
+async def _document_create_coe(args: dict) -> list[TextContent]:
+    """Create a COE document with required fields."""
+    governance_error = _require_governance_hash_envelope(args)
+    if governance_error:
+        return _result_text(governance_error)
+
+    project_id = str(args.get("project_id") or "").strip()
+    title = str(args.get("title") or "").strip()
+    content = str(args.get("content") or "").strip()
+    source_incident_id = str(args.get("source_incident_id") or "").strip()
+
+    if not project_id:
+        return _result_text(_error_payload("INVALID_INPUT", "project_id is required"))
+    if not title:
+        return _result_text(_error_payload("INVALID_INPUT", "title is required"))
+    if not content:
+        return _result_text(_error_payload("INVALID_INPUT", "content is required"))
+    if not source_incident_id:
+        return _result_text(_error_payload("INVALID_INPUT", "source_incident_id is required for COE documents"))
+
+    body: Dict[str, Any] = {
+        "project_id": project_id,
+        "title": title,
+        "content": content,
+        "document_subtype": "coe",
+        "source_incident_id": source_incident_id,
+    }
+    for key in ("description", "keywords", "related_items", "file_name", "informed_by"):
+        if key in args and args.get(key) is not None:
+            body[key] = args[key]
+
+    result = _document_api_request("PUT", payload=body)
+    if _is_authentication_required_error(result):
+        logger.error(
+            "[ERROR] document_create_coe: document API auth failed for project %s",
+            project_id,
+        )
+    return _result_text(result)
+
+
+async def _document_create_wave(args: dict) -> list[TextContent]:
+    """Create a wave coordination document anchored to a plan."""
+    governance_error = _require_governance_hash_envelope(args)
+    if governance_error:
+        return _result_text(governance_error)
+
+    project_id = str(args.get("project_id") or "").strip()
+    title = str(args.get("title") or "").strip()
+    content = str(args.get("content") or "").strip()
+    plan_anchor_id = str(args.get("plan_anchor_id") or "").strip()
+
+    if not project_id:
+        return _result_text(_error_payload("INVALID_INPUT", "project_id is required"))
+    if not title:
+        return _result_text(_error_payload("INVALID_INPUT", "title is required"))
+    if not content:
+        return _result_text(_error_payload("INVALID_INPUT", "content is required"))
+    if not plan_anchor_id:
+        return _result_text(_error_payload("INVALID_INPUT", "plan_anchor_id is required for wave documents"))
+
+    body: Dict[str, Any] = {
+        "project_id": project_id,
+        "title": title,
+        "content": content,
+        "document_subtype": "wave",
+        "plan_anchor_id": plan_anchor_id,
+    }
+    for key in ("description", "keywords", "related_items", "file_name"):
+        if key in args and args.get(key) is not None:
+            body[key] = args[key]
+
+    result = _document_api_request("PUT", payload=body)
+    if _is_authentication_required_error(result):
+        logger.error(
+            "[ERROR] document_create_wave: document API auth failed for project %s",
+            project_id,
+        )
+    return _result_text(result)
+
+
+async def _document_append_handoff_reply(args: dict) -> list[TextContent]:
+    """Append a structured reply block to a handoff document."""
+    governance_error = _require_governance_hash_envelope(args)
+    if governance_error:
+        return _result_text(governance_error)
+
+    document_id = str(args.get("document_id") or "").strip()
+    content = str(args.get("content") or "").strip()
+    agent_layer = str(args.get("agent_layer") or "").strip()
+
+    if not document_id:
+        return _result_text(_error_payload("INVALID_INPUT", "document_id is required"))
+    if not content:
+        return _result_text(_error_payload("INVALID_INPUT", "content is required"))
+    if not agent_layer:
+        return _result_text(_error_payload("INVALID_INPUT", "agent_layer is required"))
+
+    valid_layers = {"supervisor", "coord-lead", "dispatched-agent", "product-lead-terminal"}
+    if agent_layer not in valid_layers:
+        return _result_text(_error_payload(
+            "INVALID_INPUT",
+            f"agent_layer must be one of: {', '.join(sorted(valid_layers))}",
+        ))
+
+    from datetime import datetime as _dt, timezone as _tz
+    now = _dt.now(_tz.utc).isoformat()
+    author = str(args.get("author") or agent_layer).strip()
+    originating_ref = str(args.get("originating_handoff_ref") or document_id).strip()
+
+    reply_block = (
+        f"---\n"
+        f"reply_author: {author}\n"
+        f"reply_timestamp: {now}\n"
+        f"agent_layer: {agent_layer}\n"
+        f"originating_handoff_ref: {originating_ref}\n"
+        f"---\n\n"
+        f"{content}"
+    )
+
+    patch_body: Dict[str, Any] = {"append_content": reply_block}
+    encoded_id = urllib.parse.quote(document_id, safe="")
+    result = _document_api_request("PATCH", path=f"/{encoded_id}", payload=patch_body)
+    if _is_authentication_required_error(result):
+        logger.error(
+            "[ERROR] document_append_handoff_reply: document API auth failed for document %s",
+            document_id,
+        )
+
+    # AC-5: Dual-append for product-lead-terminal
+    is_success = isinstance(result, dict) and (
+        result.get("success") or result.get("document_id")
+    )
+    if agent_layer == "product-lead-terminal" and is_success:
+        await _dual_append_to_wave(args, content, now, author, document_id)
+
+    return _result_text(result)
+
+
+async def _document_append_wave_entry(args: dict) -> list[TextContent]:
+    """Append a wave entry with agent-layer classification."""
+    governance_error = _require_governance_hash_envelope(args)
+    if governance_error:
+        return _result_text(governance_error)
+
+    document_id = str(args.get("document_id") or "").strip()
+    content = str(args.get("content") or "").strip()
+    agent_layer = str(args.get("agent_layer") or "").strip()
+
+    if not document_id:
+        return _result_text(_error_payload("INVALID_INPUT", "document_id is required"))
+    if not content:
+        return _result_text(_error_payload("INVALID_INPUT", "content is required"))
+    if not agent_layer:
+        return _result_text(_error_payload("INVALID_INPUT", "agent_layer is required"))
+
+    from datetime import datetime as _dt, timezone as _tz
+    now = _dt.now(_tz.utc).isoformat()
+    author = str(args.get("author") or agent_layer).strip()
+    originating_handoff_ref = str(args.get("originating_handoff_ref") or "").strip()
+
+    # Construct wave entry with frontmatter
+    frontmatter_lines = [
+        "---",
+        f"reply_author: {author}",
+        f"reply_timestamp: {now}",
+        f"agent_layer: {agent_layer}",
+    ]
+    if originating_handoff_ref:
+        frontmatter_lines.append(f"originating_handoff_ref: {originating_handoff_ref}")
+    frontmatter_lines.append("---")
+
+    entry_block = "\n".join(frontmatter_lines) + f"\n\n{content}"
+
+    patch_body: Dict[str, Any] = {"append_content": entry_block}
+    encoded_id = urllib.parse.quote(document_id, safe="")
+    result = _document_api_request("PATCH", path=f"/{encoded_id}", payload=patch_body)
+    if _is_authentication_required_error(result):
+        logger.error(
+            "[ERROR] document_append_wave_entry: document API auth failed for document %s",
+            document_id,
+        )
+    return _result_text(result)
+
+
+async def _dual_append_to_wave(
+    args: dict,
+    content: str,
+    timestamp: str,
+    author: str,
+    handoff_doc_id: str,
+) -> None:
+    """Best-effort append to active wave doc when product-lead appends to handoff.
+
+    AC-5 (ENC-FTR-077): product-lead terminal sessions append to BOTH the
+    originating handoff doc AND the active wave doc. Handoff append always
+    succeeds even if wave append fails.
+    """
+    try:
+        # Fetch the handoff document to get project_id for wave search
+        encoded_id = urllib.parse.quote(handoff_doc_id, safe="")
+        doc_resp = _document_api_request(
+            "GET", f"/{encoded_id}", query={"include_content": "false"},
+        )
+        if not isinstance(doc_resp, dict):
+            logger.warning("Dual-append: could not fetch handoff %s", handoff_doc_id)
+            return
+
+        # Extract project_id from the document or its nested document key
+        doc = doc_resp.get("document", doc_resp)
+        project_id = doc.get("project_id", "")
+        if not project_id:
+            logger.warning("Dual-append: handoff %s has no project_id", handoff_doc_id)
+            return
+
+        # Search for wave docs in the same project
+        search_resp = _document_api_request(
+            "GET", "/search",
+            query={"project": project_id, "keyword": "wave"},
+        )
+        if not isinstance(search_resp, dict):
+            logger.warning("Dual-append: wave search failed for project %s", project_id)
+            return
+
+        wave_docs = (
+            search_resp.get("documents")
+            or search_resp.get("results")
+            or []
+        )
+
+        # Find an active wave doc (wave_status == "active" or status == "active")
+        active_wave = None
+        for wd in wave_docs:
+            subtype = wd.get("document_subtype", "")
+            if subtype != "wave":
+                continue
+            wave_status = wd.get("wave_status") or wd.get("status") or ""
+            if wave_status == "active":
+                active_wave = wd
+                break
+
+        if not active_wave:
+            logger.info("Dual-append: no active wave doc found for project %s, skipping", project_id)
+            return
+
+        wave_doc_id = active_wave.get("document_id") or active_wave.get("id")
+        if not wave_doc_id:
+            logger.warning("Dual-append: active wave doc has no document_id")
+            return
+
+        # Construct wave entry from the handoff reply
+        wave_entry = (
+            f"---\n"
+            f"reply_author: {author}\n"
+            f"reply_timestamp: {timestamp}\n"
+            f"agent_layer: product-lead-terminal\n"
+            f"originating_handoff_ref: {handoff_doc_id}\n"
+            f"---\n\n"
+            f"{content}"
+        )
+
+        wave_encoded_id = urllib.parse.quote(str(wave_doc_id), safe="")
+        wave_result = _document_api_request(
+            "PATCH", path=f"/{wave_encoded_id}",
+            payload={"append_content": wave_entry},
+        )
+
+        if isinstance(wave_result, dict) and (
+            wave_result.get("success") or wave_result.get("document_id")
+        ):
+            logger.info("Dual-append: successfully appended to wave %s", wave_doc_id)
+        else:
+            error_detail = wave_result.get("error", "unknown") if isinstance(wave_result, dict) else str(wave_result)
+            logger.warning("Dual-append: wave append failed: %s", error_detail)
+
+    except Exception as exc:
+        logger.warning("Dual-append: best-effort failed: %s", exc)
+
+
 async def _check_document_policy(args: dict) -> list[TextContent]:
     operation = str(args.get("operation") or "").strip()
     storage_target = str(args.get("storage_target") or "").strip()
@@ -6710,6 +6993,19 @@ if ENABLE_HANDOFF_PRIMITIVE:
     }
     _EXECUTE_ACTIONS["document.complete_handoff"] = {
         "tool": "document_complete_handoff", "requires_governance_hash": True,
+    }
+    # ENC-FTR-077 / ENC-TSK-E53: COE + Wave docstore subtype actions
+    _EXECUTE_ACTIONS["document.create_coe"] = {
+        "tool": "document_create_coe", "requires_governance_hash": True,
+    }
+    _EXECUTE_ACTIONS["document.create_wave"] = {
+        "tool": "document_create_wave", "requires_governance_hash": True,
+    }
+    _EXECUTE_ACTIONS["document.append_handoff_reply"] = {
+        "tool": "document_append_handoff_reply", "requires_governance_hash": True,
+    }
+    _EXECUTE_ACTIONS["document.append_wave_entry"] = {
+        "tool": "document_append_wave_entry", "requires_governance_hash": True,
     }
 
 # ENC-FTR-076 / ENC-TSK-E08: Conditionally register component.propose behind feature flag
@@ -9146,6 +9442,11 @@ _TOOL_HANDLERS = {
     "document_create_handoff": _document_create_handoff,
     "document_claim_handoff": _document_claim_handoff,
     "document_complete_handoff": _document_complete_handoff,
+    # ENC-FTR-077 / ENC-TSK-E53: COE + Wave docstore subtype tools
+    "document_create_coe": _document_create_coe,
+    "document_create_wave": _document_create_wave,
+    "document_append_handoff_reply": _document_append_handoff_reply,
+    "document_append_wave_entry": _document_append_wave_entry,
     # ENC-FTR-076 / ENC-TSK-E08: Agent-proposable component registry
     "component_propose": _component_propose,
 }


### PR DESCRIPTION
## Summary
- Adds `document.create_coe` execute action (convenience wrapper for COE creation with `source_incident_id`)
- Adds `document.create_wave` execute action (convenience wrapper for wave creation with `plan_anchor_id`)
- Adds `document.append_handoff_reply` execute action (structured reply block construction with YAML frontmatter + `append_content` PATCH)
- Adds `document.append_wave_entry` execute action (wave entry construction with agent-layer classification)
- Implements AC-5: product-lead terminal `append_handoff_reply` dual-appends to both handoff and active wave doc
- Dual-append is best-effort — handoff append always succeeds even if wave append fails
- Updates governance_data_dictionary.json with `mcp_server.docstore_subtype_tools` entity

## Test plan
- [ ] document.create_coe creates a COE doc with correct subtype
- [ ] document.create_wave creates a wave doc with plan_anchor_id
- [ ] document.append_handoff_reply constructs valid reply block and appends
- [ ] document.append_wave_entry constructs valid wave entry and appends
- [ ] Product-lead terminal append triggers dual-append to wave doc
- [ ] Dual-append gracefully handles missing/concluded wave docs
- [ ] Governance dictionary guard CI passes

**Plan**: ENC-PLN-029 | **Feature**: ENC-FTR-077
**Depends on**: PR #351, PR #352, PR #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-15aba28a6eab42468e9d9295e0fea794