### PR TITLE
Fix REPO_ROOT unbound variable in MCP deploy.sh (ENC-ISS-219)

### DIFF
--- a/backend/lambda/mcp_code/deploy.sh
+++ b/backend/lambda/mcp_code/deploy.sh
@@ -6,12 +6,12 @@
 
 set -euo pipefail
 
-source "${REPO_ROOT}/tools/lambda_artifact_helper.sh"
 FUNCTION_NAME="${FUNCTION_NAME:-enceladus-mcp-code}"
 SOURCE_FUNCTION_NAME="${SOURCE_FUNCTION_NAME:-devops-coordination-api}"
 REGION="${AWS_REGION:-us-west-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+source "${REPO_ROOT}/tools/lambda_artifact_helper.sh"
 ZIP_FILE="/tmp/${FUNCTION_NAME}.zip"
 
 MCP_TRANSPORT="${ENCELADUS_MCP_TRANSPORT:-streamable_http}"

--- a/backend/lambda/mcp_streamable/deploy.sh
+++ b/backend/lambda/mcp_streamable/deploy.sh
@@ -6,12 +6,12 @@
 
 set -euo pipefail
 
-source "${REPO_ROOT}/tools/lambda_artifact_helper.sh"
 FUNCTION_NAME="${FUNCTION_NAME:-enceladus-mcp-streamable}"
 SOURCE_FUNCTION_NAME="${SOURCE_FUNCTION_NAME:-devops-coordination-api}"
 REGION="${AWS_REGION:-us-west-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+source "${REPO_ROOT}/tools/lambda_artifact_helper.sh"
 ZIP_FILE="/tmp/${FUNCTION_NAME}.zip"
 
 MCP_TRANSPORT="${ENCELADUS_MCP_TRANSPORT:-streamable_http}"


### PR DESCRIPTION
## Summary
- Moves REPO_ROOT assignment before `source lambda_artifact_helper.sh` in mcp_streamable and mcp_code deploy.sh
- Fixes gamma deploy failure: `REPO_ROOT: unbound variable` under `set -euo pipefail`

## Test plan
- [ ] MCP streamable gamma deploy succeeds
- [ ] MCP code gamma deploy succeeds

CCI-472299004cc24e2a98e6181409c25473

🤖 Generated with [Claude Code](https://claude.com/claude-code)