### PR TITLE
feat(E57): deploy approval enforcement mesh — close GitHub env bypass path (ENC-ISS-243)

### DIFF
--- a/.github/workflows/deploy-orchestration.yml
+++ b/.github/workflows/deploy-orchestration.yml
@@ -143,20 +143,74 @@ jobs:
           path: /tmp/gamma-uat-report.json
           retention-days: 30
 
-  # ---- Manual approval (per-lambda, main only) ----
-  approval:
+  # ---- Enceladus approval gate (per-lambda, main only) ----
+  # ENC-TSK-E57: Replaces GitHub environment approval with Enceladus DAT
+  # token verification. Calls /api/v1/deploy/validate/approval/{prNumber}
+  # to confirm the PR was approved via the Deployment Manager PWA.
+  enceladus-approval-gate:
     needs: gamma-health-gate
     if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
-    name: Production Approval (${{ inputs.function_name }})
+    name: Enceladus Approval Gate (${{ inputs.function_name }})
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Approved
-        run: echo "Production deployment approved for ${{ inputs.function_name }}"
+      - name: Resolve PR from merge commit
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --search "$GITHUB_SHA" --state merged \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::No merged PR found for commit $GITHUB_SHA. Cannot verify Enceladus approval."
+            exit 1
+          fi
+          echo "Resolved PR #${PR_NUMBER} for commit ${GITHUB_SHA}"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Enceladus approval token
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          DEPLOY_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/deploy
+          COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
+        run: |
+          set -euo pipefail
+          VALIDATE_URL="${DEPLOY_API_BASE}/validate/approval/${PR_NUMBER}"
+          echo "Validating: $VALIDATE_URL"
+
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -H "X-Coordination-Internal-Key: ${COORDINATION_INTERNAL_API_KEY}" \
+            -H "Accept: application/json" \
+            "$VALIDATE_URL" || echo -e "\n000")
+          HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+          HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n 1)
+
+          echo "Response (HTTP $HTTP_CODE): $HTTP_BODY"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Enceladus approval API unreachable (HTTP $HTTP_CODE). Failing closed."
+            exit 1
+          fi
+
+          VALID=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('valid',False)))" 2>/dev/null || echo "False")
+          if [ "$VALID" != "True" ]; then
+            REASON=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+            echo "::error::Production deploy blocked: $REASON"
+            echo "::error::Approve this PR via the Enceladus Deployment Manager before deploying to production."
+            exit 1
+          fi
+
+          DECIDED_BY=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('decided_by_email','unknown'))" 2>/dev/null || echo "unknown")
+          TOKEN=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('approval_token',''))" 2>/dev/null || echo "")
+          echo "✅ Enceladus approval verified for PR #${PR_NUMBER}"
+          echo "   Approved by: ${DECIDED_BY}"
+          echo "   Token: ${TOKEN}"
 
   # ---- Prod deploy (per-lambda, main only) ----
   prod-deploy:
-    needs: [approval, build-artifacts]
+    needs: [enceladus-approval-gate, build-artifacts]
     if: inputs.deploy_mode == 'per-lambda' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/lambda-deploy-reusable.yml
     with:
@@ -296,20 +350,67 @@ jobs:
           path: /tmp/gamma-fullstack-uat-report.json
           retention-days: 30
 
-  # ---- Manual approval (full-stack, main only) ----
-  approval-fullstack:
+  # ---- Enceladus approval gate (full-stack, main only) ----
+  # ENC-TSK-E57: Same DAT verification as per-lambda gate.
+  enceladus-approval-gate-fullstack:
     needs: gamma-health-gate-fullstack
     if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
-    name: Production Approval (full-stack)
+    name: Enceladus Approval Gate (full-stack)
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Approved
-        run: echo "Full-stack production deployment approved"
+      - name: Resolve PR from merge commit
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --search "$GITHUB_SHA" --state merged \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::No merged PR found for commit $GITHUB_SHA. Cannot verify Enceladus approval."
+            exit 1
+          fi
+          echo "Resolved PR #${PR_NUMBER} for commit ${GITHUB_SHA}"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Enceladus approval token
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          DEPLOY_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/deploy
+          COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
+        run: |
+          set -euo pipefail
+          VALIDATE_URL="${DEPLOY_API_BASE}/validate/approval/${PR_NUMBER}"
+          echo "Validating: $VALIDATE_URL"
+
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -H "X-Coordination-Internal-Key: ${COORDINATION_INTERNAL_API_KEY}" \
+            -H "Accept: application/json" \
+            "$VALIDATE_URL" || echo -e "\n000")
+          HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+          HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n 1)
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Enceladus approval API unreachable (HTTP $HTTP_CODE). Failing closed."
+            exit 1
+          fi
+
+          VALID=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('valid',False)))" 2>/dev/null || echo "False")
+          if [ "$VALID" != "True" ]; then
+            REASON=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+            echo "::error::Full-stack production deploy blocked: $REASON"
+            echo "::error::Approve this PR via the Enceladus Deployment Manager before deploying to production."
+            exit 1
+          fi
+
+          DECIDED_BY=$(echo "$HTTP_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('decided_by_email','unknown'))" 2>/dev/null || echo "unknown")
+          echo "✅ Full-stack Enceladus approval verified for PR #${PR_NUMBER} (approved by ${DECIDED_BY})"
 
   # ---- Prod deploy (full-stack matrix, main only) ----
   prod-deploy-matrix:
-    needs: [approval-fullstack, setup-matrix, build-artifacts]
+    needs: [enceladus-approval-gate-fullstack, setup-matrix, build-artifacts]
     if: inputs.deploy_mode == 'full-stack' && github.ref == 'refs/heads/main'
     strategy:
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}

--- a/.github/workflows/pr-commit-gate.yml
+++ b/.github/workflows/pr-commit-gate.yml
@@ -85,6 +85,31 @@ jobs:
             exit 1
           fi
 
+      # ENC-TSK-E57 AC1: Reject PRs with undeclared deploy target
+      - name: Validate deploy target declaration
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEPLOY_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/deploy
+          COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
+        run: |
+          VALIDATE_URL="${DEPLOY_API_BASE}/validate/approval/${PR_NUMBER}"
+          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -H "X-Coordination-Internal-Key: ${COORDINATION_INTERNAL_API_KEY}" \
+            -H "Accept: application/json" \
+            "$VALIDATE_URL" || echo -e "\n000")
+          HTTP_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+          HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n 1)
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            TARGET=$(echo "$HTTP_BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('original_target',''))" 2>/dev/null || echo "")
+            if [ "$TARGET" = "undeclared" ]; then
+              echo "::error::Deploy target is 'undeclared'. Add a target:prod or target:gamma label to this PR before merge."
+              exit 1
+            fi
+            echo "Deploy target: ${TARGET:-no DPL record}"
+          fi
+          # If DPL not found or API error, pass silently (non-deploy PRs have no DPL)
+
       # ENC-TSK-963: Agent provenance validation for Bedrock-authored PRs
       - name: Validate agent provenance (Bedrock PRs)
         if: startsWith(github.event.pull_request.head.ref, 'agent/')

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-16.7",
+  "version": "2026-04-16.8",
   "updated_at": "2026-04-16T21:00:00Z",
-  "last_change_summary": "ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
+  "last_change_summary": "ENC-TSK-E57 / ENC-ISS-243: Added approval_token, decided_by_email, bypass_reason fields to tracker.deployment_decision for deploy approval enforcement mesh. DAT token issued by deploy_decide on approve, validated by deploy-orchestration.yml workflow. Prior: ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4071,6 +4071,18 @@
         "created_at": {
           "type": "string",
           "definition": "ISO 8601 timestamp when the decision record was created (typically on PR open)."
+        },
+        "approval_token": {
+          "type": "string",
+          "definition": "Deploy Approval Token (DAT-{uuid4_hex}) issued by deploy_decide on approve action (ENC-TSK-E57). Validated by deploy-orchestration.yml workflow before any production mutation. Empty until approved via Deployment Manager PWA."
+        },
+        "decided_by_email": {
+          "type": "string",
+          "definition": "Email address from the Cognito JWT of the person who made the decision (ENC-TSK-E57). Used for four-eyes audit comparison against pr_author."
+        },
+        "bypass_reason": {
+          "type": "string",
+          "definition": "If set, indicates this deployment bypassed the Enceladus approval gate (ENC-TSK-E57 AC8). Populated retroactively for pre-E57 deploys via backfill_dpl_bypass_markers.py."
         }
       }
     },

--- a/backend/lambda/deploy_decide/deploy.sh
+++ b/backend/lambda/deploy_decide/deploy.sh
@@ -147,7 +147,8 @@ main() {
       GITHUB_INSTALLATION_ID=${GITHUB_INSTALLATION_ID},
       GITHUB_PRIVATE_KEY_SECRET=devops/github-app/private-key,
       ALLOWED_REPOS=NX-2021-L/enceladus,
-      GAMMA_INTEGRATION_BRANCH=v4/main
+      GAMMA_INTEGRATION_BRANCH=v4/main,
+      ENFORCE_FOUR_EYES=false
     }" >/dev/null
 
   aws lambda wait function-updated \

--- a/backend/lambda/deploy_decide/lambda_function.py
+++ b/backend/lambda/deploy_decide/lambda_function.py
@@ -23,6 +23,7 @@ import re
 import time
 import urllib.error
 import urllib.request
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
@@ -52,6 +53,12 @@ ALLOWED_REPOS = [
     if r.strip()
 ]
 GAMMA_INTEGRATION_BRANCH = os.environ.get("GAMMA_INTEGRATION_BRANCH", "v4/main")
+
+# ENC-TSK-E57: Four-eyes enforcement for deploy approvals.
+# When true, deploy_decide rejects approval if the Cognito user's email
+# matches the PR author (self-approval). Defaults to false (warning only)
+# until additional operators exist.
+ENFORCE_FOUR_EYES = os.environ.get("ENFORCE_FOUR_EYES", "false").lower() == "true"
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -155,6 +162,8 @@ def _update_decision(
     final_target: str,
     decided_by: str,
     decision_reason: str = "",
+    approval_token: str = "",
+    decided_by_email: str = "",
 ) -> Dict:
     """Update a deployment_decision record with the decision."""
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -180,6 +189,17 @@ def _update_decision(
         expr_names["#dr"] = "decision_reason"
         expr_values[":dr"] = {"S": decision_reason}
         update_expr += ", #dr = :dr"
+
+    # ENC-TSK-E57: Store approval token and email on the DPL record
+    if approval_token:
+        expr_names["#at"] = "approval_token"
+        expr_values[":at"] = {"S": approval_token}
+        update_expr += ", #at = :at"
+
+    if decided_by_email:
+        expr_names["#dbe"] = "decided_by_email"
+        expr_values[":dbe"] = {"S": decided_by_email}
+        update_expr += ", #dbe = :dbe"
 
     resp = _get_ddb().update_item(
         TableName=DEPLOY_TABLE,
@@ -389,7 +409,7 @@ def _github_api(
 # ---------------------------------------------------------------------------
 
 
-def _handle_approve(decision: Dict, user_sub: str, reason: str) -> dict:
+def _handle_approve(decision: Dict, user_sub: str, reason: str, user_email: str = "") -> dict:
     """Approve a deployment — merge the PR via GitHub API."""
     pr_number = decision.get("github_pr_number")
     repo = decision.get("github_repo", "NX-2021-L/enceladus")
@@ -397,6 +417,22 @@ def _handle_approve(decision: Dict, user_sub: str, reason: str) -> dict:
 
     if f"{owner}/{repo_name}" not in ALLOWED_REPOS:
         return _error(403, f"Repository {owner}/{repo_name} not in allowed repos")
+
+    # ENC-TSK-E57 AC9: Four-eyes enforcement — detect self-approval
+    pr_author = decision.get("pr_author", "")
+    if user_email and pr_author and user_email.lower() == pr_author.lower():
+        if ENFORCE_FOUR_EYES:
+            return _error(
+                403,
+                f"Self-approval blocked: {user_email} authored PR #{pr_number} and cannot also approve it.",
+                four_eyes_violation=True,
+                pr_author=pr_author,
+                decided_by_email=user_email,
+            )
+        logger.warning(
+            f"Self-approval detected: {user_email} authored and approved PR #{pr_number}. "
+            f"ENFORCE_FOUR_EYES is disabled — logging only."
+        )
 
     # Merge the PR
     status, gh_resp = _github_api(
@@ -415,6 +451,10 @@ def _handle_approve(decision: Dict, user_sub: str, reason: str) -> dict:
             github_response=gh_resp,
         )
 
+    # ENC-TSK-E57 AC4: Generate Deploy Approval Token (DAT)
+    dat = f"DAT-{uuid.uuid4().hex}"
+    logger.info(f"Generated approval token {dat} for PR #{pr_number}")
+
     # Update DynamoDB record
     updated = _update_decision(
         project_id=decision["project_id"],
@@ -423,6 +463,8 @@ def _handle_approve(decision: Dict, user_sub: str, reason: str) -> dict:
         final_target="prod",
         decided_by=user_sub,
         decision_reason=reason,
+        approval_token=dat,
+        decided_by_email=user_email,
     )
 
     logger.info(f"PR #{pr_number} approved and merged by {user_sub}")
@@ -431,6 +473,7 @@ def _handle_approve(decision: Dict, user_sub: str, reason: str) -> dict:
         "pr_number": pr_number,
         "merged": True,
         "merge_sha": gh_resp.get("sha", ""),
+        "approval_token": dat,
         "decision": updated,
     })
 
@@ -665,7 +708,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict:
     )
 
     if action == "approve":
-        return _handle_approve(decision, user_sub, reason)
+        return _handle_approve(decision, user_sub, reason, user_email=user_email)
     elif action == "divert":
         return _handle_divert(decision, user_sub, reason)
     elif action == "revert":

--- a/backend/lambda/deploy_intake/lambda_function.py
+++ b/backend/lambda/deploy_intake/lambda_function.py
@@ -1110,6 +1110,58 @@ def _handle_get_pending(project_id: str, limit: int = 50) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# Route: GET /api/v1/deploy/validate/approval/{prNumber}
+# ENC-TSK-E57: Validates whether a PR has been approved via the Enceladus
+# Deployment Manager by checking for a DAT (Deploy Approval Token) on the
+# corresponding DPL record.  Called by deploy-orchestration.yml and
+# pr-commit-gate.yml workflows via internal API key auth.
+# ---------------------------------------------------------------------------
+
+
+def _handle_validate_approval(pr_number: int) -> Dict:
+    """Check whether a DPL record for a given PR carries an approval token."""
+    record_id = f"decision#ENC-DPL-{pr_number}"
+    ddb = _get_ddb()
+    resp = ddb.get_item(
+        TableName=DEPLOY_TABLE,
+        Key={
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": record_id},
+        },
+    )
+    item = resp.get("Item")
+    if not item:
+        return _ok({
+            "valid": False,
+            "reason": f"No deployment decision record found for PR #{pr_number}",
+            "pr_number": pr_number,
+        })
+
+    data = _ddb_deser(item)
+    approval_token = data.get("approval_token", "")
+    if not approval_token:
+        return _ok({
+            "valid": False,
+            "reason": "PR not approved via Enceladus Deployment Manager",
+            "pr_number": pr_number,
+            "status": data.get("status", ""),
+            "original_target": data.get("original_target", ""),
+        })
+
+    return _ok({
+        "valid": True,
+        "approval_token": approval_token,
+        "pr_number": pr_number,
+        "pr_author": data.get("pr_author", ""),
+        "decided_by": data.get("decided_by", ""),
+        "decided_by_email": data.get("decided_by_email", ""),
+        "decided_at": data.get("decided_at", ""),
+        "status": data.get("status", ""),
+        "original_target": data.get("original_target", ""),
+    })
+
+
+# ---------------------------------------------------------------------------
 # Route: GET /api/v1/deploy/queue
 # Returns deployment_decision records in pending_approval status.
 # Part of the Generational Metabolism Framework (DOC-63420302EF65 §6).
@@ -1229,6 +1281,10 @@ _HISTORY_PATTERN = re.compile(r"(?:/api/v1/deploy)?/history/(?P<projectId>[a-z0-
 _PENDING_PATTERN = re.compile(r"(?:/api/v1/deploy)?/pending/(?P<projectId>[a-z0-9_-]+)$")
 _QUEUE_PATTERN = re.compile(r"(?:/api/v1/deploy)?/queue$")
 _TRIGGER_PATTERN = re.compile(r"(?:/api/v1/deploy)?/trigger/(?P<projectId>[a-z0-9_-]+)$")
+# ENC-TSK-E57: Approval token validation for deploy-orchestration workflow
+_VALIDATE_APPROVAL_PATTERN = re.compile(
+    r"(?:/api/v1/deploy)?/validate/approval/(?P<prNumber>\d+)$"
+)
 _OPTIONS_PATTERN = re.compile(r"(?:/api/v1/deploy)?/")
 
 
@@ -1305,6 +1361,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict:
                 qs = event.get("queryStringParameters") or {}
                 limit = _parse_limit(qs.get("limit"), default=50, min_value=1, max_value=200)
                 return _handle_get_pending(project_id, limit)
+
+        # GET /validate/approval/{prNumber} — ENC-TSK-E57 approval token check
+        if method == "GET":
+            m = _VALIDATE_APPROVAL_PATTERN.search(path)
+            if m:
+                return _handle_validate_approval(int(m.group("prNumber")))
 
         # GET /queue — deployment_decision records pending approval
         if method == "GET":

--- a/frontend/ui/src/pages/DeploymentManagerPage.tsx
+++ b/frontend/ui/src/pages/DeploymentManagerPage.tsx
@@ -161,6 +161,25 @@ function DecisionCard({
               &ldquo;{decision.decision_reason}&rdquo;
             </div>
           )}
+          {/* ENC-TSK-E57: Show approval token for approved decisions */}
+          {decision.approval_token && (
+            <div className="mt-1">
+              <span className="text-slate-500">Token: </span>
+              <code className="text-emerald-400 font-mono text-xs select-all">
+                {decision.approval_token}
+              </code>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ENC-TSK-E57: Bypass marker for pre-E57 deploys */}
+      {decision.bypass_reason && (
+        <div className="flex items-center gap-1 text-xs">
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400 border border-amber-500/30">
+            bypass
+          </span>
+          <span className="text-slate-500">{decision.bypass_reason}</span>
         </div>
       )}
 

--- a/frontend/ui/src/types/deployments.ts
+++ b/frontend/ui/src/types/deployments.ts
@@ -22,6 +22,10 @@ export interface DeploymentDecision {
   created_at: string
   related_enceladus_task_ids: string[]
   related_enceladus_feature_ids: string[]
+  // ENC-TSK-E57: Deploy approval enforcement fields
+  approval_token?: string
+  decided_by_email?: string
+  bypass_reason?: string
 }
 
 export type DeploymentStatus =
@@ -53,6 +57,7 @@ export interface DeployDecideResponse {
   pr_number: number
   merged?: boolean
   merge_sha?: string
+  approval_token?: string
   new_base?: string
   closed?: boolean
   decision?: DeploymentDecision

--- a/tools/backfill_dpl_bypass_markers.py
+++ b/tools/backfill_dpl_bypass_markers.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+ENC-TSK-E57 AC8: Retroactive bypass logging for PLN-029 deploys.
+
+Marks DPL records for PRs #351-356 (and #80) with bypass_reason to record
+that these production deploys were approved via GitHub environment protection
+rules rather than the Enceladus Deployment Manager PWA.
+
+Usage (product-lead IAM only — agent-cli IAM denies DynamoDB writes):
+    python3 tools/backfill_dpl_bypass_markers.py [--dry-run]
+
+Idempotent: skips records that already have a bypass_reason field.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+import boto3
+
+DEPLOY_TABLE = "devops-deployment-manager"
+REGION = "us-west-2"
+PROJECT_ID = "enceladus"
+
+# PRs that traversed the GitHub environment approval bypass path
+BYPASS_PR_NUMBERS = [80, 351, 352, 353, 354, 355, 356]
+BYPASS_REASON = "github_environment_approval_bypass_pre_E57"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill DPL bypass_reason markers")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without writing")
+    args = parser.parse_args()
+
+    ddb = boto3.client("dynamodb", region_name=REGION)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    updated = 0
+    skipped = 0
+    not_found = 0
+
+    for pr_number in BYPASS_PR_NUMBERS:
+        record_id = f"decision#ENC-DPL-{pr_number}"
+        print(f"[INFO] Checking {record_id}...")
+
+        resp = ddb.get_item(
+            TableName=DEPLOY_TABLE,
+            Key={
+                "project_id": {"S": PROJECT_ID},
+                "record_id": {"S": record_id},
+            },
+        )
+        item = resp.get("Item")
+        if not item:
+            print(f"  [SKIP] No DPL record found for PR #{pr_number}")
+            not_found += 1
+            continue
+
+        existing_reason = item.get("bypass_reason", {}).get("S", "")
+        if existing_reason:
+            print(f"  [SKIP] Already has bypass_reason: {existing_reason}")
+            skipped += 1
+            continue
+
+        if args.dry_run:
+            print(f"  [DRY-RUN] Would set bypass_reason={BYPASS_REASON}")
+            updated += 1
+            continue
+
+        ddb.update_item(
+            TableName=DEPLOY_TABLE,
+            Key={
+                "project_id": {"S": PROJECT_ID},
+                "record_id": {"S": record_id},
+            },
+            UpdateExpression="SET bypass_reason = :br, bypass_logged_at = :bla, updated_at = :ua",
+            ExpressionAttributeValues={
+                ":br": {"S": BYPASS_REASON},
+                ":bla": {"S": now},
+                ":ua": {"S": now},
+            },
+            ConditionExpression="attribute_exists(project_id)",
+        )
+        print(f"  [SUCCESS] bypass_reason set on {record_id}")
+        updated += 1
+
+    print(f"\n[END] Updated: {updated}, Skipped: {skipped}, Not found: {not_found}")
+    return 0 if not_found == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **deploy_decide**: Generate DAT (Deploy Approval Token) on approve, store on DPL record. Add `ENFORCE_FOUR_EYES` self-approval detection (AC4, AC9)
- **deploy_intake**: New `GET /validate/approval/{prNumber}` endpoint for workflow token verification (AC2)
- **deploy-orchestration.yml**: Replace `approval`/`approval-fullstack` jobs with `enceladus-approval-gate` that resolves PR number and validates DAT via API (AC2, AC6)
- **pr-commit-gate.yml**: Reject PRs with undeclared deploy target (AC1)
- **governance_data_dictionary.json**: New DPL fields — `approval_token`, `decided_by_email`, `bypass_reason`
- **Frontend**: Extended `DeploymentDecision` type + approval token display + bypass badge
- **tools/backfill_dpl_bypass_markers.py**: Retroactive bypass logging for PLN-029 deploys (AC8)

## Test plan

- [ ] Verify `deploy_decide` generates DAT on approve and stores on DPL record
- [ ] Verify `deploy_intake` `/validate/approval/{prNumber}` returns valid=true with DAT, valid=false without
- [ ] Verify `deploy-orchestration.yml` enceladus-approval-gate resolves PR and validates DAT
- [ ] Run `backfill_dpl_bypass_markers.py --dry-run` under product-lead IAM
- [ ] After deploy: verify token gate on next real deploy, then remove GitHub `production` environment reviewer requirement

CCI-166c0fbd1b56494a92dfd0b20255e8b1

🤖 Generated with [Claude Code](https://claude.com/claude-code)