### PR TITLE
feat(E62): IaC route + deploy.sh env-vars fix (PR-alpha)

### DIFF
--- a/backend/lambda/deploy_intake/deploy.sh
+++ b/backend/lambda/deploy_intake/deploy.sh
@@ -216,8 +216,28 @@ deploy_lambda() {
   if [[ -z "${effective_github_token}" ]]; then
     log "[WARNING] GITHUB_TOKEN resolved empty; PR merge validation will fail for private repos."
   fi
+  # ENC-TSK-E62 AC2: Build env_vars string from a key/value array so keys with
+  # empty values are omitted entirely. AWS CLI rejected prior `KEY=` trailing
+  # entries with "ParamValidation: Expected ',', received 'EOF'" when
+  # GITHUB_TOKEN resolved empty.
+  local -a env_entries=(
+    "DEPLOY_TABLE=${DEPLOY_TABLE}"
+    "DEPLOY_REGION=${REGION}"
+    "PROJECTS_TABLE=${PROJECTS_TABLE}"
+    "CONFIG_BUCKET=${CONFIG_BUCKET}"
+    "CONFIG_PREFIX=${CONFIG_PREFIX}"
+    "SQS_QUEUE_URL=${SQS_QUEUE_URL}"
+    "COGNITO_USER_POOL_ID=${COGNITO_USER_POOL_ID}"
+    "COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}"
+    "COORDINATION_INTERNAL_API_KEY_PREVIOUS=${COORDINATION_INTERNAL_API_KEY_PREVIOUS}"
+    "COORDINATION_INTERNAL_API_KEY_SCOPES=${COORDINATION_INTERNAL_API_KEY_SCOPES}"
+    "DOC_PREP_LAMBDA_NAME=${DOC_PREP_LAMBDA_NAME}"
+    "CORS_ORIGIN=${CORS_ORIGIN}"
+  )
+  [[ -n "${effective_internal_key}" ]] && env_entries+=("COORDINATION_INTERNAL_API_KEY=${effective_internal_key}")
+  [[ -n "${effective_github_token}" ]] && env_entries+=("GITHUB_TOKEN=${effective_github_token}")
   local env_vars
-  env_vars="{DEPLOY_TABLE=${DEPLOY_TABLE},DEPLOY_REGION=${REGION},PROJECTS_TABLE=${PROJECTS_TABLE},CONFIG_BUCKET=${CONFIG_BUCKET},CONFIG_PREFIX=${CONFIG_PREFIX},SQS_QUEUE_URL=${SQS_QUEUE_URL},COGNITO_USER_POOL_ID=${COGNITO_USER_POOL_ID},COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID},COORDINATION_INTERNAL_API_KEY=${effective_internal_key},COORDINATION_INTERNAL_API_KEY_PREVIOUS=${COORDINATION_INTERNAL_API_KEY_PREVIOUS},COORDINATION_INTERNAL_API_KEY_SCOPES=${COORDINATION_INTERNAL_API_KEY_SCOPES},DOC_PREP_LAMBDA_NAME=${DOC_PREP_LAMBDA_NAME},CORS_ORIGIN=${CORS_ORIGIN},GITHUB_TOKEN=${effective_github_token}}"
+  env_vars="{$(IFS=,; echo "${env_entries[*]}")}"
 
   if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
     log "[START] updating Lambda code: ${FUNCTION_NAME}"

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -459,6 +459,15 @@ Resources:
       RouteKey: POST /api/v1/deploy/trigger/{projectId}
       Target: !Sub integrations/${DeployIntakeIntegration}
 
+  # ENC-TSK-E57/E62: Deploy approval validation route for enceladus-approval-gate
+  # Supersedes CLI-created route zmra44n; makes the route IaC-managed.
+  RouteDeployValidateApproval:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/deploy/validate/approval/{prNumber}
+      Target: !Sub integrations/${DeployIntakeIntegration}
+
   # GMF routes (DOC-63420302EF65)
   RouteDeployQueue:
     Type: AWS::ApiGatewayV2::Route


### PR DESCRIPTION
## Summary
- **AC1**: Add CloudFormation-managed route `GET /api/v1/deploy/validate/approval/{prNumber}` targeting `DeployIntakeIntegration`. Supersedes CLI-created route `zmra44n` so the approval-gate validation endpoint is IaC-managed.
- **AC2**: Fix deploy_intake `deploy.sh` env-vars construction so keys with empty values are omitted entirely (previously `GITHUB_TOKEN=` caused AWS CLI ParamValidation failure per DOC-529413D3CBB0 §2 symptom_4).

Deferred to PR-β (after this one is deployed + verified): AC3 bootstrap-passthrough removal.
Out-of-code ACs already satisfied: AC5 (backfill executed under io-dev-admin, 6 DPL records), AC6 (path filter already clean on main).

## Test plan
- [ ] `cloudformation-api-stack-deploy.yml` succeeds; stack state `UPDATE_COMPLETE`
- [ ] `aws apigatewayv2 get-routes --api-id 8nkzqkmxqc` shows the new CFN-managed route
- [ ] `lambda-deploy-intake-deploy.yml` succeeds through `update-function-configuration` (no ParamValidation failure)
- [ ] `GET /api/v1/deploy/validate/approval/999999` returns structured JSON (not 404 from APIGW)

## Tracker
- Task: ENC-TSK-E62
- CCI-a71b2f4bd5ee465e89549ffb90442a87

## Note on route conflict
Route `zmra44n` (CLI-created) currently owns the same route key. It will be deleted under io-dev-admin immediately before merge to clear the path for the CFN-managed resource. During the ~60s between delete and CFN deploy completion, the enceladus-approval-gate will see HTTP 404 and treat it as a transition-period passthrough — no deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)