### PR TITLE
fix(mcp): open passthrough for documents.put/patch FTR-077 fields (ENC-TSK-C71, ENC-TSK-E63)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-16.9",
-  "updated_at": "2026-04-16T22:00:00Z",
-  "last_change_summary": "ENC-TSK-E64 / ENC-ISS-158 / ENC-PLN-030: Added document_api.error_envelope entity documenting the self-correcting error shape returned by document_api for subtype validation failures (handoff/coe/wave). Extends the ENC-TSK-D56 self-correcting-error pattern to the document surface: error_envelope.details now includes required_fields, optional_fields, dictionary_entity, document_subtype, example_fix, edge_density_requirements, format_constraint so agents can recover from missing subtype fields without additional calls. Prior: ENC-TSK-E57 / ENC-ISS-243: Added approval_token, decided_by_email, bypass_reason fields to tracker.deployment_decision for deploy approval enforcement mesh. DAT token issued by deploy_decide on approve, validated by deploy-orchestration.yml workflow. Prior: ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
+  "version": "2026-04-16.10",
+  "updated_at": "2026-04-16T22:30:00Z",
+  "last_change_summary": "ENC-TSK-C71 / ENC-TSK-E63 / ENC-ISS-158 / ENC-PLN-030: Added mcp_server.documents_passthrough entity documenting the denylist-based open-passthrough pattern now used by _documents_put and _documents_patch. Replaces the prior explicit field whitelist that silently dropped ENC-FTR-077 subtype fields. Tool schemas for documents.put and documents.patch now expose 14 FTR-077 subtype fields (document_subtype, source_record_id, handoff_status, prerequisite_state, verification_criteria, action_checklist, expires_at, source_incident_id, coe_status, plan_anchor_id, wave_status, informed_by, document_maturity_state, confirm_subtype) with dictionary-linked descriptions. Mirrors _tracker_create pattern so the MCP layer stays maintenance-free for future subtype additions. Prior: ENC-TSK-E64 / ENC-ISS-158 / ENC-PLN-030: Added document_api.error_envelope entity documenting the self-correcting error shape returned by document_api for subtype validation failures (handoff/coe/wave). Extends the ENC-TSK-D56 self-correcting-error pattern to the document surface: error_envelope.details now includes required_fields, optional_fields, dictionary_entity, document_subtype, example_fix, edge_density_requirements, format_constraint so agents can recover from missing subtype fields without additional calls. Prior: ENC-TSK-E57 / ENC-ISS-243: Added approval_token, decided_by_email, bypass_reason fields to tracker.deployment_decision for deploy approval enforcement mesh. DAT token issued by deploy_decide on approve, validated by deploy-orchestration.yml workflow. Prior: ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1935,6 +1935,34 @@
         "feature_flag": {
           "type": "string",
           "definition": "ENABLE_HANDOFF_PRIMITIVE environment variable. When 'true', these 4 actions (plus the 3 handoff actions) are registered in the execute action registry. Default 'false'."
+        }
+      }
+    },
+    "mcp_server.documents_passthrough": {
+      "description": "Open-passthrough body construction pattern for the MCP-to-document_api bridge (ENC-TSK-C71 / ENC-TSK-E63 / ENC-ISS-158 / ENC-PLN-030). Replaces the prior explicit whitelist in _documents_put and _documents_patch with a denylist-driven loop mirroring _tracker_create. Every FTR-077 subtype field (document_subtype, source_record_id, handoff_status, prerequisite_state, verification_criteria, action_checklist, expires_at, source_incident_id, coe_status, plan_anchor_id, wave_status, informed_by, document_maturity_state, confirm_subtype) now forwards automatically from execute args to the document_api HTTP body. Eliminates the recurring failure mode where new subtype fields landed in document_api but not the MCP layer (rediscovered four times: ENC-TSK-B82, ENC-PLN-016 dispatch wave 1, ENC-TSK-E57 deploy session, ENC-TSK-E62 handoff attempts).",
+      "fields": {
+        "put_body_denylist": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Keys NOT forwarded from execute args to document_api PUT body. Single entry: governance_hash (handled by the HTTP auth layer, never goes in body)."
+        },
+        "patch_body_denylist": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Keys NOT forwarded from execute args to document_api PATCH body. Two entries: governance_hash (HTTP auth layer) and document_id (URL path parameter, not body)."
+        },
+        "tool_schema_coverage": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "FTR-077 subtype fields newly declared in the documents_put and documents_patch tool schemas: document_subtype, confirm_subtype, source_record_id, handoff_status, prerequisite_state, verification_criteria, action_checklist, expires_at, source_incident_id, coe_status, plan_anchor_id, wave_status, informed_by, document_maturity_state. Each field's description references its dictionary entity (document.handoff / document.coe / document.wave / docstore.document)."
+        },
+        "reference_pattern": {
+          "type": "string",
+          "definition": "Mirrors _tracker_create's open-passthrough loop at tools/enceladus-mcp-server/server.py (currently lines 5458-5495). The invariant: MCP should forward anything the caller declares and let document_api be the single source of validation truth."
+        },
+        "governing_records": {
+          "type": "object",
+          "definition": "Plan: ENC-PLN-030. Issue: ENC-ISS-158. Tasks: ENC-TSK-C71 (lambda_deploy vehicle), ENC-TSK-E63 (code_only companion). Doc: DOC-8BB0D5531B47."
         }
       }
     },

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3920,6 +3920,69 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Optional output file name (.md/.markdown).",
                     },
+                    "document_subtype": {
+                        "type": "string",
+                        "enum": ["doc", "handoff", "coe", "wave", "general"],
+                        "description": "Document subtype classification (ENC-FTR-077). Default 'doc'. 'handoff' requires source_record_id; 'coe' requires source_incident_id; 'wave' requires plan_anchor_id.",
+                    },
+                    "confirm_subtype": {
+                        "type": "boolean",
+                        "description": "Override semantic guard when title/content match handoff patterns but subtype=doc is intentional.",
+                    },
+                    "source_record_id": {
+                        "type": "string",
+                        "description": "Tracker record ID the handoff targets (e.g. ENC-TSK-XXX). Required when document_subtype=handoff. (ref: document.handoff)",
+                    },
+                    "handoff_status": {
+                        "type": "string",
+                        "enum": ["pending", "claimed", "completed", "stale"],
+                        "description": "Handoff lifecycle state; defaults to 'pending' on creation. (ref: document.handoff)",
+                    },
+                    "prerequisite_state": {
+                        "type": "string",
+                        "description": "Plain-English description of state required before handoff executor begins. (ref: document.handoff)",
+                    },
+                    "verification_criteria": {
+                        "type": "string",
+                        "description": "Plain-English description of how handoff success is verified. (ref: document.handoff)",
+                    },
+                    "action_checklist": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Ordered checklist the handoff executor should follow. (ref: document.handoff)",
+                    },
+                    "expires_at": {
+                        "type": "string",
+                        "description": "Optional handoff expiry in ISO 8601 format. (ref: document.handoff)",
+                    },
+                    "source_incident_id": {
+                        "type": "string",
+                        "description": "Tracker record ID of the incident a COE investigates. Required when document_subtype=coe. (ref: document.coe)",
+                    },
+                    "coe_status": {
+                        "type": "string",
+                        "enum": ["drafting", "investigating", "published", "superseded"],
+                        "description": "COE lifecycle status. (ref: document.coe)",
+                    },
+                    "plan_anchor_id": {
+                        "type": "string",
+                        "description": "Plan record ID this wave tracks (must contain '-PLN-', e.g. ENC-PLN-029). Required when document_subtype=wave. (ref: document.wave)",
+                    },
+                    "wave_status": {
+                        "type": "string",
+                        "enum": ["active", "complete", "archived"],
+                        "description": "Wave lifecycle status. (ref: document.wave)",
+                    },
+                    "informed_by": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Source documents that informed this one (GDMP provenance). Array of document IDs. (ref: document.graph_edges)",
+                    },
+                    "document_maturity_state": {
+                        "type": "string",
+                        "enum": ["raw", "compliant", "contextualized", "mature"],
+                        "description": "GDMP maturity lifecycle; 'raw' on creation, advances via documents.patch. (ref: docstore.document)",
+                    },
                     "governance_hash": {
                         "type": "string",
                         "description": "Current governance hash for write authorization.",
@@ -3970,11 +4033,70 @@ async def list_tools() -> list[Tool]:
                     "status": {
                         "type": "string",
                         "enum": ["active", "archived"],
-                        "description": "Optional status change.",
+                        "description": "Optional document-level status change. Subtype-specific lifecycle fields (handoff_status/coe_status/wave_status) are separate.",
                     },
                     "file_name": {
                         "type": "string",
                         "description": "Optional updated file name (.md/.markdown).",
+                    },
+                    "document_subtype": {
+                        "type": "string",
+                        "enum": ["doc", "handoff", "coe", "wave", "general"],
+                        "description": "Document subtype classification (ENC-FTR-077). Usually immutable after creation.",
+                    },
+                    "source_record_id": {
+                        "type": "string",
+                        "description": "Tracker record ID the handoff targets (e.g. ENC-TSK-XXX). (ref: document.handoff)",
+                    },
+                    "handoff_status": {
+                        "type": "string",
+                        "enum": ["pending", "claimed", "completed", "stale"],
+                        "description": "Handoff lifecycle state. Canonical path to advance handoff docs. (ref: document.handoff)",
+                    },
+                    "prerequisite_state": {
+                        "type": "string",
+                        "description": "Plain-English description of state required before handoff executor begins. (ref: document.handoff)",
+                    },
+                    "verification_criteria": {
+                        "type": "string",
+                        "description": "Plain-English description of how handoff success is verified. (ref: document.handoff)",
+                    },
+                    "action_checklist": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Ordered checklist the handoff executor should follow. (ref: document.handoff)",
+                    },
+                    "expires_at": {
+                        "type": "string",
+                        "description": "Optional handoff expiry in ISO 8601 format. (ref: document.handoff)",
+                    },
+                    "source_incident_id": {
+                        "type": "string",
+                        "description": "Tracker record ID of the incident a COE investigates. (ref: document.coe)",
+                    },
+                    "coe_status": {
+                        "type": "string",
+                        "enum": ["drafting", "investigating", "published", "superseded"],
+                        "description": "COE lifecycle status. (ref: document.coe)",
+                    },
+                    "plan_anchor_id": {
+                        "type": "string",
+                        "description": "Plan record ID this wave tracks (must contain '-PLN-'). (ref: document.wave)",
+                    },
+                    "wave_status": {
+                        "type": "string",
+                        "enum": ["active", "complete", "archived"],
+                        "description": "Wave lifecycle status. (ref: document.wave)",
+                    },
+                    "informed_by": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Source documents that informed this one (GDMP provenance). (ref: document.graph_edges)",
+                    },
+                    "document_maturity_state": {
+                        "type": "string",
+                        "enum": ["raw", "compliant", "contextualized", "mature"],
+                        "description": "GDMP maturity lifecycle. Canonical path to advance maturity via patch. (ref: docstore.document)",
                     },
                     "governance_hash": {
                         "type": "string",
@@ -5598,6 +5720,14 @@ def _enrich_document_compliance_response(result: dict) -> dict:
     return result
 
 
+# ENC-TSK-E63 / ENC-TSK-C71: open-passthrough body construction for the
+# document_api bridge. Mirror _tracker_create's denylist-driven pattern so
+# new subtype fields land in document_api automatically instead of silently
+# dropping on an outdated whitelist (ENC-ISS-158).
+_DOCUMENTS_PUT_BODY_DENYLIST = frozenset({"governance_hash"})
+_DOCUMENTS_PATCH_BODY_DENYLIST = frozenset({"governance_hash", "document_id"})
+
+
 async def _documents_put(args: dict) -> list[TextContent]:
     governance_error = _require_governance_hash_envelope(args)
     if governance_error:
@@ -5615,13 +5745,12 @@ async def _documents_put(args: dict) -> list[TextContent]:
         "title": args["title"],
         "content": args["content"],
     }
-    for key in (
-        "description", "keywords", "related_items", "file_name",
-        "document_subtype", "confirm_subtype",
-        "source_incident_id", "plan_anchor_id",
-    ):
-        if key in args and args.get(key) is not None:
-            body[key] = args.get(key)
+    for key in args:
+        if key in _DOCUMENTS_PUT_BODY_DENYLIST:
+            continue
+        if args.get(key) is None:
+            continue
+        body[key] = args[key]
 
     result = _document_api_request("PUT", payload=body)
     if _is_authentication_required_error(result):
@@ -5654,13 +5783,12 @@ async def _documents_patch(args: dict) -> list[TextContent]:
         )
 
     body: Dict[str, Any] = {}
-    for key in (
-        "title", "content", "append_content", "description", "keywords", "related_items",
-        "status", "file_name", "document_maturity_state",
-        "handoff_status", "coe_status", "wave_status",
-    ):
-        if key in args and args.get(key) is not None:
-            body[key] = args.get(key)
+    for key in args:
+        if key in _DOCUMENTS_PATCH_BODY_DENYLIST:
+            continue
+        if args.get(key) is None:
+            continue
+        body[key] = args[key]
     if not body:
         return _result_text(
             _error_payload(


### PR DESCRIPTION
## Summary

Closes **ENC-ISS-158** (document_subtype=handoff not honored — stored as general) by removing the whitelist that dropped FTR-077 subtype fields in the MCP server's document bridge. The bug has been rediscovered four times (ENC-TSK-B82, ENC-PLN-016 wave 1, ENC-TSK-E57 deploy session, ENC-TSK-E62 handoff attempts). The open-passthrough pattern mirrors `_tracker_create` and makes the MCP layer maintenance-free for future subtype additions.

### What changed

- `tools/enceladus-mcp-server/server.py`
  - `_documents_put`: whitelist replaced with denylist-based open passthrough (denylist: `governance_hash`)
  - `_documents_patch`: same pattern (denylist: `governance_hash`, `document_id`)
  - `documents_put` + `documents_patch` tool schemas: add 14 FTR-077 properties (document_subtype, source_record_id, handoff_status, prerequisite_state, verification_criteria, action_checklist, expires_at, source_incident_id, coe_status, plan_anchor_id, wave_status, informed_by, document_maturity_state, confirm_subtype) — each references the matching governance dictionary entity

### Governance ids (CCIs required by PR Commit Gate)

- ENC-TSK-C71 (lambda_deploy, primary vehicle): **CCI-f2859bb13e0a491dbbdc634ac159730f**
- ENC-TSK-E63 (code_only, same commit): **CCI-df2f32b2726d4af89cf9f6a5bb37d191**

### Plan

Governing plan: **ENC-PLN-030** — Document Pipeline Reliability. Plan document: **DOC-8BB0D5531B47**.

## Test plan

- [x] python ast.parse validates server.py post-edit
- [x] Both CCIs issued by checkout service (commit SHA validated against GitHub)
- [ ] CI: PR Commit Gate validates CCI-C71 via /api/v1/checkout/validate/commit-complete
- [ ] CI: Secrets Scan + Lambda Workflow Coverage + Governance Dictionary Guard green
- [ ] Post-deploy: `documents.put(document_subtype=handoff, source_record_id=..., ...)` round-trips all fields
- [ ] Post-deploy: `documents.put(document_subtype=coe, source_incident_id=..., related_items=[FTR,LSN,ISS])` creates COE
- [ ] Post-deploy: `documents.put(document_subtype=wave, plan_anchor_id=ENC-PLN-...)` creates wave doc
- [ ] Post-deploy: `documents.patch(handoff_status=claimed)` transitions handoff lifecycle
- [ ] No regression: `documents.put(document_subtype=doc)` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)