### PR TITLE
fix(document_api): self-correcting error envelope for subtype validation (ENC-TSK-E64)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-16.8",
-  "updated_at": "2026-04-16T21:00:00Z",
-  "last_change_summary": "ENC-TSK-E57 / ENC-ISS-243: Added approval_token, decided_by_email, bypass_reason fields to tracker.deployment_decision for deploy approval enforcement mesh. DAT token issued by deploy_decide on approve, validated by deploy-orchestration.yml workflow. Prior: ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
+  "version": "2026-04-16.9",
+  "updated_at": "2026-04-16T22:00:00Z",
+  "last_change_summary": "ENC-TSK-E64 / ENC-ISS-158 / ENC-PLN-030: Added document_api.error_envelope entity documenting the self-correcting error shape returned by document_api for subtype validation failures (handoff/coe/wave). Extends the ENC-TSK-D56 self-correcting-error pattern to the document surface: error_envelope.details now includes required_fields, optional_fields, dictionary_entity, document_subtype, example_fix, edge_density_requirements, format_constraint so agents can recover from missing subtype fields without additional calls. Prior: ENC-TSK-E57 / ENC-ISS-243: Added approval_token, decided_by_email, bypass_reason fields to tracker.deployment_decision for deploy approval enforcement mesh. DAT token issued by deploy_decide on approve, validated by deploy-orchestration.yml workflow. Prior: ENC-FTR-077 / ENC-TSK-E53: Added mcp_server.docstore_subtype_tools entity documenting 4 new execute actions for COE and wave docstore subtypes. document.create_coe creates COE documents with source_incident_id. document.create_wave creates wave documents with plan_anchor_id. document.append_handoff_reply appends structured reply blocks with frontmatter to handoff docs; product-lead-terminal layer triggers AC-5 dual-append to active wave doc. document.append_wave_entry appends wave entries with agent-layer classification. All 4 actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag (same as handoff tools). Prior: ENC-TSK-E50 / ENC-TSK-E51 / ENC-FTR-077: Added handoff reply block validation (AGENT_LAYERS constant, _parse_reply_frontmatter + _validate_reply_block helpers). Handoff append_content requires YAML-like frontmatter with reply_author, reply_timestamp, agent_layer, originating_handoff_ref (DOC-*). Tracks reply_count + last_reply_at. Wave append_content requires same frontmatter minus originating_handoff_ref. Tracks append_count + last_append_at. Non-handoff/wave documents use format-agnostic general append. Added plan_anchor_id immutability guard on PATCH. Added append_content mutual exclusion with content. New entities: document.wave_append. Extended document.handoff with reply block fields. MCP server passthrough updated for append_content. Prior: ENC-TSK-E52 / ENC-FTR-077: Graph edges for docstore subtypes (INVESTIGATES, TRACKS_WAVE_OF, HANDS_OFF). Prior: ENC-TSK-E49 / ENC-FTR-077: Subtype hardening + coe + wave. Prior: ENC-TSK-E48 / ENC-ISS-239: append_content S3 fix. Prior: ENC-TSK-E47 / ENC-ISS-242: subtask_ids fix.",
   "owners": [
     "enceladus-platform"
   ],
@@ -492,6 +492,46 @@
         "details": {
           "type": "object",
           "definition": "Self-correcting context for the next attempt. Standard keys: required_fields (list), allowed_values (dict), evidence_schema (dict), strictness_rank (list), example_fix (dict with tool+arguments). Post-D56 additions: allowed_plan_transitions (dict), plan_terminal_statuses (list), token_type/token_purpose/prerequisite_call (CAI/CCI), lesson_gate_requirements (dict), ogtm_compliance_template (dict with 4 requirements + evidence template), dpl_record_id_format/dpl_ddb_key_schema/dpl_label_conventions (GMF/DPL), governed_rules (list of rule strings)."
+        }
+      }
+    },
+    "document_api.error_envelope": {
+      "description": "Self-correcting error envelope emitted by document_api when documents.put rejects a request due to missing subtype-specific required fields (ENC-TSK-E64, ENC-ISS-158, ENC-PLN-030). Extends the ENC-TSK-D56 pattern to the document surface: every handoff/coe/wave validation failure packs enough context for an agent to self-correct on the next call without additional lookups. Returned as top-level error_envelope.details via the shared api.error_envelope contract.",
+      "fields": {
+        "required_fields": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Field names the caller must include to retry successfully. Example: [\"source_record_id\"] for handoff."
+        },
+        "optional_fields": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Field names that enrich but are not strictly required for the subtype. Example: [\"prerequisite_state\", \"verification_criteria\", \"action_checklist\", \"expires_at\"] for handoff."
+        },
+        "dictionary_entity": {
+          "type": "string",
+          "definition": "Reference to the governance dictionary entity defining the subtype schema. Expected values: document.handoff, document.coe, document.wave."
+        },
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "handoff",
+            "coe",
+            "wave"
+          ],
+          "definition": "The subtype that triggered the validation failure. Lets the agent select the correct self-correction strategy."
+        },
+        "example_fix": {
+          "type": "object",
+          "definition": "Fully-formed documents.put call showing the correct payload for this subtype. Shape: {tool: \"documents.put\", arguments: {...}} with project_id, title, content, document_subtype, and all subtype-required fields populated with placeholder values."
+        },
+        "edge_density_requirements": {
+          "type": "object",
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
+        },
+        "format_constraint": {
+          "type": "string",
+          "definition": "Only present for fields with pattern constraints. Plain-English rule describing what the value must contain. Example: 'plan_anchor_id must contain \\'-PLN-\\' substring' for wave docs."
         }
       }
     },

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -1309,7 +1309,33 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
     if document_subtype == "handoff":
         source_record_id = str(body.get("source_record_id", "")).strip()
         if not source_record_id:
-            return _error(400, "Field 'source_record_id' is required when document_subtype is 'handoff'.")
+            return _error(
+                400,
+                "Field 'source_record_id' is required when document_subtype is 'handoff'.",
+                required_fields=["source_record_id"],
+                optional_fields=[
+                    "prerequisite_state",
+                    "verification_criteria",
+                    "action_checklist",
+                    "expires_at",
+                ],
+                dictionary_entity="document.handoff",
+                document_subtype="handoff",
+                example_fix={
+                    "tool": "documents.put",
+                    "arguments": {
+                        "project_id": "<project_id>",
+                        "title": "HANDOFF \u2014 <brief description>",
+                        "content": "<full markdown body>",
+                        "document_subtype": "handoff",
+                        "source_record_id": "<ENC-TSK-XXX or similar>",
+                        "prerequisite_state": "<state required before executor begins>",
+                        "verification_criteria": "<how to verify success>",
+                        "action_checklist": ["step 1", "step 2"],
+                        "governance_hash": "<governance_hash>",
+                    },
+                },
+            )
         handoff_fields["source_record_id"] = source_record_id
         handoff_fields["handoff_status"] = "pending"
         handoff_fields["prerequisite_state"] = str(body.get("prerequisite_state", "")).strip()
@@ -1329,7 +1355,30 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
     if document_subtype == "coe":
         source_incident_id = str(body.get("source_incident_id", "")).strip()
         if not source_incident_id:
-            return _error(400, "Field 'source_incident_id' is required when document_subtype is 'coe'.")
+            return _error(
+                400,
+                "Field 'source_incident_id' is required when document_subtype is 'coe'.",
+                required_fields=["source_incident_id"],
+                edge_density_requirements={
+                    "feature": "at least 1 ENC-FTR-* in related_items",
+                    "lesson": "at least 1 ENC-LSN-* in related_items",
+                    "issue": "at least 1 ENC-ISS-* in related_items",
+                },
+                dictionary_entity="document.coe",
+                document_subtype="coe",
+                example_fix={
+                    "tool": "documents.put",
+                    "arguments": {
+                        "project_id": "<project_id>",
+                        "title": "COE \u2014 <brief incident summary>",
+                        "content": "<full COE markdown>",
+                        "document_subtype": "coe",
+                        "source_incident_id": "<ENC-ISS-XXX>",
+                        "related_items": ["ENC-FTR-XXX", "ENC-LSN-XXX", "ENC-ISS-XXX"],
+                        "governance_hash": "<governance_hash>",
+                    },
+                },
+            )
         coe_fields["source_incident_id"] = source_incident_id
         coe_fields["coe_status"] = "drafting"
         # Edge density validation: require at least 1 FTR, 1 LSN, 1 ISS in related_items
@@ -1360,6 +1409,21 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
                 400,
                 "Field 'plan_anchor_id' is required when document_subtype is 'wave' "
                 "and must contain '-PLN-' (e.g. ENC-PLN-029).",
+                required_fields=["plan_anchor_id"],
+                format_constraint="plan_anchor_id must contain '-PLN-' substring",
+                dictionary_entity="document.wave",
+                document_subtype="wave",
+                example_fix={
+                    "tool": "documents.put",
+                    "arguments": {
+                        "project_id": "<project_id>",
+                        "title": "WAVE \u2014 <brief description>",
+                        "content": "<wave tracking content>",
+                        "document_subtype": "wave",
+                        "plan_anchor_id": "ENC-PLN-XXX",
+                        "governance_hash": "<governance_hash>",
+                    },
+                },
             )
         wave_fields["plan_anchor_id"] = plan_anchor_id
         wave_fields["wave_status"] = "active"


### PR DESCRIPTION
## Summary

Extends the three subtype validation error raises in `document_api/lambda_function.py` (handoff `source_record_id`, coe `source_incident_id`, wave `plan_anchor_id`) with the ENC-TSK-D56 self-correcting error envelope pattern. Each 400 response now embeds enough context for an agent to self-correct on the next attempt without additional tool calls.

### What changed

- `backend/lambda/document_api/lambda_function.py`
  - `_put` handler's handoff raise (~L1312): adds `required_fields`, `optional_fields`, `dictionary_entity`, `document_subtype`, `example_fix`
  - `_put` handler's coe raise (~L1332): same plus `edge_density_requirements`
  - `_put` handler's wave raise (~L1358): same plus `format_constraint`
  - No helper changes needed — `_error(**extra)` at line 757 already packs kwargs into `error_envelope.details`
- `backend/lambda/coordination_api/governance_data_dictionary.json`
  - Adds `document_api.error_envelope` entity documenting the new details keys
  - Version bump: `2026-04-16.8` → `2026-04-16.9`; `last_change_summary` updated

### Governance ids (CCI required by PR Commit Gate)

- ENC-TSK-E64 (lambda_deploy, document-api): **CCI-85783b01f1ae42188a69ed471112d989**

### Plan

Governing plan: **ENC-PLN-030** — Document Pipeline Reliability. Plan document: **DOC-8BB0D5531B47**.

## Test plan

- [x] python ast.parse validates document_api/lambda_function.py post-edit
- [x] json.load validates governance_data_dictionary.json post-edit
- [x] CCI issued by checkout service
- [ ] CI: PR Commit Gate green (CCI validation)
- [ ] CI: Governance Dictionary Guard green (dictionary update in same PR)
- [ ] CI: Lambda Workflow Coverage + Secrets Scan green
- [ ] Post-deploy: `documents.put(document_subtype=handoff)` without source_record_id → 400 with `error_envelope.details.required_fields=["source_record_id"]`, `dictionary_entity="document.handoff"`, valid `example_fix`
- [ ] Post-deploy: same pattern for coe (edge_density_requirements present) and wave (format_constraint present)
- [ ] Error response latency unchanged (no extra API calls in error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)