### PR TITLE
test(pwa): lock in decision# prefix strip + bump v1.0.2 (ENC-TSK-E76)

### DIFF
--- a/frontend/ui/src/api/deploy.test.ts
+++ b/frontend/ui/src/api/deploy.test.ts
@@ -1,0 +1,57 @@
+/**
+ * deploy.test.ts — Regression tests for the `decision#` prefix strip in
+ * fetchDeployQueue (ENC-ISS-208 / ENC-TSK-D51, verified by ENC-TSK-E76).
+ *
+ * The DynamoDB composite key separator `#` in DPL record_id values
+ * (decision#ENC-DPL-N) leaks into PWA form input validation if not stripped
+ * before the data reaches UI components. The fetchDeployQueue response
+ * transformer must strip the prefix on every decision.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchDeployQueue } from './deploy'
+
+describe('fetchDeployQueue record_id normalization', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function respondWith(decisions: Array<{ record_id: string }>): void {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          project_id: 'enceladus',
+          count: decisions.length,
+          decisions,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+  }
+
+  it('strips the decision# prefix from composite-key record_id values', async () => {
+    respondWith([{ record_id: 'decision#ENC-DPL-42' }])
+    const data = await fetchDeployQueue('enceladus')
+    expect(data.decisions[0].record_id).toBe('ENC-DPL-42')
+  })
+
+  it('passes through record_id values that have no decision# prefix', async () => {
+    respondWith([{ record_id: 'ENC-DPL-7' }])
+    const data = await fetchDeployQueue('enceladus')
+    expect(data.decisions[0].record_id).toBe('ENC-DPL-7')
+  })
+
+  it('only strips the leading prefix, preserving any embedded # characters', async () => {
+    respondWith([{ record_id: 'decision#ENC-DPL-9#extra' }])
+    const data = await fetchDeployQueue('enceladus')
+    expect(data.decisions[0].record_id).toBe('ENC-DPL-9#extra')
+  })
+})

--- a/frontend/ui/src/lib/version.ts
+++ b/frontend/ui/src/lib/version.ts
@@ -18,7 +18,7 @@
  */
 
 /** Current release version — update this on every deployment */
-export const APP_VERSION = '1.0.1'
+export const APP_VERSION = '1.0.2'
 
 /** Structured release history — newest first */
 export interface ReleaseNote {
@@ -39,6 +39,17 @@ export interface ReleaseNote {
  * Do not delete until backfill (ENC-TSK-687-690) is complete and validated.
  */
 export const RELEASE_NOTES: ReleaseNote[] = [
+  {
+    version: '1.0.2',
+    date: '2026-04-17',
+    type: 'patch',
+    summary: 'Close ENC-ISS-208: PWA Deployment Manager approve surface restored (ENC-TSK-E76 / ENC-PLN-033 Wave W3)',
+    changes: [
+      'Add regression test for the decision# prefix strip in fetchDeployQueue (api/deploy.test.ts) — locks in D51 behavior so future refactors cannot silently regress the DPL record_id normalization',
+      'Verification of ENC-ISS-208 closure: ENC-TSK-D51 (PR #293) stripped the DynamoDB composite-key "decision#" prefix in fetchDeployQueue; ENC-ISS-211 (PRs #294-296) hardened the build pipeline with the forcePageChunks Rollup plugin, manualChunks page pattern, and package.json post-build chunk guard. Build 528c691 at 2026-04-17T01:08:17Z emitted DeploymentManagerPage-*.js (9.52 kB) and issued CloudFront invalidation I4XBIJ22Z8EYAYK55JG8KK0R3S',
+      'Unblocks ENC-PLN-032 Phase 2 (E73/E74) and resolves the ENC-ISS-243 deploy-approval bypass findings that accumulated while the PWA approve surface was dark',
+    ],
+  },
   {
     version: '1.0.1',
     date: '2026-04-07',


### PR DESCRIPTION
## Summary

Closes ENC-PLN-033 Wave W3 — PWA Deployment Manager approve surface restoration (ENC-ISS-208).

- **Adds regression test** `frontend/ui/src/api/deploy.test.ts` locking in the `decision#` prefix strip that [ENC-TSK-D51 (PR #293)](https://github.com/NX-2021-L/enceladus/pull/293) shipped. Three vitest cases cover: prefix stripped, bare record_id pass-through, and trailing `#` preserved.
- **Bumps `APP_VERSION` to 1.0.2** with a `RELEASE_NOTES` entry documenting the ISS-208 closure arc (D51 source fix + ENC-ISS-211 build-pipeline hardening across [PR #294](https://github.com/NX-2021-L/enceladus/pull/294), [#295](https://github.com/NX-2021-L/enceladus/pull/295), [#296](https://github.com/NX-2021-L/enceladus/pull/296)).

## Why now

The D51 fix + ISS-211 triple-guard (`forcePageChunks` Rollup plugin + `manualChunks` page pattern + `package.json` post-build `grep` guard) are already live as of commit `528c691` (CodeBuild build 2026-04-17T01:08:17Z, CloudFront invalidation `I4XBIJ22Z8EYAYK55JG8KK0R3S`, `DeploymentManagerPage-BTypsV_x.js` 9.52 kB chunk confirmed in build log). This PR hardens that outcome so future refactors cannot silently regress the DPL record_id normalization.

## Test plan

- [x] `npm run test -- src/api/deploy.test.ts` → 3/3 passed locally
- [x] `npm run build` → `DeploymentManagerPage-BTypsV_x.js` (9.52 kB) emitted, post-build chunk guard satisfied
- [ ] CI runs `npm run lint`, `npm run test`, `npm run build` (PR Commit Gate + UI Backend Deploy)
- [ ] Post-merge UI Backend Deploy workflow triggers CodeBuild → S3 → CloudFront invalidation
- [ ] Product-lead AC3 verification: hard-refresh PWA, navigate to Deployment Manager, approve one pending DPL without the `#` validation error

CCI-6d3596b7c63a4d2aaaa8c6a4b70ebd14

---

Related: ENC-TSK-E76, ENC-ISS-208, ENC-TSK-D51, ENC-ISS-211, ENC-PLN-033

🤖 Generated with [Claude Code](https://claude.com/claude-code)