### PR TITLE
fix(pwa): strip decision# at render boundary + mutation response (ENC-TSK-E76 / ENC-ISS-208)

### DIFF
--- a/frontend/ui/src/api/deploy.test.ts
+++ b/frontend/ui/src/api/deploy.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fetchDeployQueue } from './deploy'
+import { fetchDeployQueue, submitDeployDecision } from './deploy'
 
 describe('fetchDeployQueue record_id normalization', () => {
   const fetchMock = vi.fn()
@@ -53,5 +53,44 @@ describe('fetchDeployQueue record_id normalization', () => {
     respondWith([{ record_id: 'decision#ENC-DPL-9#extra' }])
     const data = await fetchDeployQueue('enceladus')
     expect(data.decisions[0].record_id).toBe('ENC-DPL-9#extra')
+  })
+})
+
+describe('submitDeployDecision response normalization', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function respondWith(body: unknown): void {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  }
+
+  it('strips decision# from an echoed decision.record_id on the mutation response', async () => {
+    respondWith({
+      success: true,
+      action: 'approve',
+      pr_number: 42,
+      decision: { record_id: 'decision#ENC-DPL-42', status: 'approved' },
+    })
+    const data = await submitDeployDecision({ action: 'approve', pr_number: 42 })
+    expect(data.decision?.record_id).toBe('ENC-DPL-42')
+  })
+
+  it('leaves a response with no decision field untouched', async () => {
+    respondWith({ success: true, action: 'approve', pr_number: 42 })
+    const data = await submitDeployDecision({ action: 'approve', pr_number: 42 })
+    expect(data.decision).toBeUndefined()
   })
 })

--- a/frontend/ui/src/api/deploy.ts
+++ b/frontend/ui/src/api/deploy.ts
@@ -46,9 +46,18 @@ export async function submitDeployDecision(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
   })
-  const data = await res.json()
+  const data: DeployDecideResponse = await res.json()
   if (!res.ok || !data.success) {
     throw new Error(data.error || `Deploy decision failed: ${res.status}`)
+  }
+  // ENC-ISS-208 defense-in-depth: mirror the fetchDeployQueue strip on the
+  // mutation response so the full DPL record echoed back to the UI is already
+  // prefix-free before it can re-enter React Query cache or any consumer.
+  if (data.decision && typeof data.decision.record_id === 'string') {
+    data.decision = {
+      ...data.decision,
+      record_id: data.decision.record_id.replace(/^decision#/, ''),
+    }
   }
   return data
 }

--- a/frontend/ui/src/api/deploy.ts
+++ b/frontend/ui/src/api/deploy.ts
@@ -26,6 +26,7 @@ export async function fetchDeployQueue(
   )
   if (!res.ok) throw new Error(`Failed to fetch deploy queue: ${res.status}`)
   const data: DeployQueueResponse = await res.json()
+  // ISS-208 AC3 validation — safe to remove
   // ENC-ISS-208: Strip DynamoDB composite key prefix from record_id.
   // The "decision#" prefix contains a # that breaks native browser
   // input validation (url/email types reject it). The backend

--- a/frontend/ui/src/pages/DeploymentManagerPage.tsx
+++ b/frontend/ui/src/pages/DeploymentManagerPage.tsx
@@ -6,12 +6,23 @@
  * and a deployment history timeline.
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useDeployQueue, useDeployDecision, timeInQueue } from '../hooks/useDeploymentManager'
 import { LoadingState } from '../components/shared/LoadingState'
 import { ErrorState } from '../components/shared/ErrorState'
 import { EmptyState } from '../components/shared/EmptyState'
 import type { DeploymentDecision } from '../types/deployments'
+
+// ENC-TSK-E76 / ENC-ISS-208: Render-boundary strip for the DynamoDB
+// composite-key prefix on DPL record_id. D51 normalizes the fetchDeployQueue
+// response; this layer guarantees the `#` separator can never reach any
+// DOM-validated attribute (form input pattern/type, CSS selector, etc.)
+// even if a mutation response, React Query cache, or downstream component
+// delivers a raw `decision#ENC-DPL-N` value.
+function sanitizeDecision(d: DeploymentDecision): DeploymentDecision {
+  if (!d.record_id || !d.record_id.startsWith('decision#')) return d
+  return { ...d, record_id: d.record_id.replace(/^decision#/, '') }
+}
 
 // ---------------------------------------------------------------------------
 // Status badge colors
@@ -261,7 +272,10 @@ export function DeploymentManagerPage() {
   const decideMutation = useDeployDecision()
   const [actionError, setActionError] = useState<string | null>(null)
 
-  const pendingDecisions = decisions.filter((d) => d.status === 'pending_approval')
+  const pendingDecisions = useMemo(
+    () => decisions.filter((d) => d.status === 'pending_approval').map(sanitizeDecision),
+    [decisions],
+  )
 
   const handleAction = useCallback(
     async (action: 'approve' | 'divert' | 'revert', prNumber: number, reason?: string) => {


### PR DESCRIPTION
## Summary

AC3 re-test on DPL-372 reported `"The string did not match the expected pattern"` firing on the approve action, even though the D51 fix is live at `api/deploy.ts:33-36` and the ISS-211 chunk guard confirms the deployed bundle contains the strip. This PR adds two defense-in-depth layers so the DDB composite-key separator cannot reach any DOM-validated surface regardless of which path delivers the `DeploymentDecision` to a consumer.

**Scope changed mid-session:** this branch began as the AC3 validation probe (one-line comment in `api/deploy.ts`). After AC3 failed, it was promoted to the actual deliverable carrying both the probe and the fix.

## Changes

- **`pages/DeploymentManagerPage.tsx`** — new `sanitizeDecision()` helper + `useMemo` on `pendingDecisions` so every `DeploymentDecision` is normalized at the render boundary before any React key, prop, or child component touches it.
- **`api/deploy.ts`** — `submitDeployDecision()` now mirrors the `fetchDeployQueue` strip on any `data.decision.record_id` echoed in the mutation response. Previously untreated — if React Query or any downstream consumer ever read the mutation's returned decision, it would carry the raw prefix.
- **`api/deploy.test.ts`** — 2 new vitest cases covering `submitDeployDecision` response normalization (stripped when present, no-op when absent). 5/5 pass locally.
- Probe comment from the AC3 validation run remains in place per the in-flight session plan.

## Validation

- `npm run test -- src/api/deploy.test.ts` → 5/5 passed
- `npm run build` → `DeploymentManagerPage-DCDyyKZD.js` (9.81 kB) emitted, post-build chunk guard satisfied
- DPL-372 is the live AC3 probe; io will re-test the approve surface after this deploys

## Test plan

- [x] Unit tests pass locally (5/5)
- [x] Build guard satisfied locally
- [ ] CI: PR Commit Gate passes with CCI below
- [ ] Post-deploy AC3: io clicks Approve on fresh DPL against the new bundle, confirms no browser validation error

CCI-56dd459eed9140fcb2571a372deb2ad8

---

Related: ENC-TSK-E76, ENC-ISS-208, ENC-TSK-D51, ENC-ISS-211, ENC-PLN-033