### PR TITLE
chore(pwa): AC3 probe — remove ENC-TSK-E76 validation marker

### DIFF
--- a/frontend/ui/src/api/deploy.ts
+++ b/frontend/ui/src/api/deploy.ts
@@ -26,7 +26,6 @@ export async function fetchDeployQueue(
   )
   if (!res.ok) throw new Error(`Failed to fetch deploy queue: ${res.status}`)
   const data: DeployQueueResponse = await res.json()
-  // ISS-208 AC3 validation — safe to remove
   // ENC-ISS-208: Strip DynamoDB composite key prefix from record_id.
   // The "decision#" prefix contains a # that breaks native browser
   // input validation (url/email types reject it). The backend


### PR DESCRIPTION
## Purpose

**AC3 probe + cleanup.** Two-in-one:

1. Generates a fresh `decision#ENC-DPL-N` in `pending_approval` so io can exercise the Deployment Manager approve surface against the now-deployed `DeploymentManagerPage-DCDyyKZD.js` bundle (carries `sanitizeDecision()` + mutation-response strip).
2. Removes the `// ISS-208 AC3 validation — safe to remove` comment placed during the earlier probe wave.

## Expected flow

1. Webhook creates a fresh DPL on PR open
2. io hard-refreshes PWA, navigates to Deployment Manager, clicks Approve
3. If no browser validation error fires → **AC3 closed**
4. io either merges this PR (doubles as the cleanup deliverable) or closes it — either is fine

## Not expected to pass CI (unless lifecycle is driven)

No CCI in this body. PR Commit Gate will fail, which is acceptable because the DPL record creation is webhook-driven and independent of CI state. If you want to merge this as cleanup, I can drive E76's lifecycle again to issue a CCI.

---

Related: ENC-TSK-E76, ENC-ISS-208, ENC-PLN-033