### PR TITLE
chore(pwa): ENC-ISS-255 Pass 1 MutationObserver+fiber-key probe on #root

### DIFF
--- a/frontend/ui/src/main.tsx
+++ b/frontend/ui/src/main.tsx
@@ -1,3 +1,37 @@
+// ENC-ISS-255 Pass 1 probe — REMOVE AFTER DIAGNOSIS
+(() => {
+  if (typeof window === 'undefined') return;
+  const rootEl = document.getElementById('root');
+  if (!rootEl) return;
+  const mutLog: any[] = [];
+  const fiberLog: any[] = [];
+  (window as any).__iss255_mutlog = mutLog;
+  (window as any).__iss255_fiberLog = fiberLog;
+  const obs = new MutationObserver((records) => {
+    for (const r of records) {
+      const tgt = r.target as Element;
+      mutLog.push({
+        t: performance.now(),
+        type: r.type,
+        target: `${tgt.tagName}#${tgt.id || ''}.${String(tgt.className || '').slice(0, 40)}`,
+        added: r.addedNodes.length,
+        removed: r.removedNodes.length,
+        attr: r.attributeName || undefined,
+        stack: (new Error('iss255-mut')).stack?.slice(0, 2000) || '',
+      });
+      if (mutLog.length > 500) obs.disconnect();
+    }
+  });
+  obs.observe(rootEl, { childList: true, subtree: true, characterData: true, attributes: true });
+  const tick = () => {
+    const keys = Object.getOwnPropertyNames(rootEl).filter(k => /^(__react|_reactListening)/.test(k));
+    fiberLog.push({ t: performance.now(), keys });
+    if (fiberLog.length < 600) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+  console.log('[ISS-255] Pass 1 probe armed');
+})();
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'


### PR DESCRIPTION
## Summary

- Adds a diagnostic-only IIFE at the top of [frontend/ui/src/main.tsx](frontend/ui/src/main.tsx), armed before `createRoot` runs, that wires a `MutationObserver` on `#root` (with per-mutation `(new Error()).stack` capture into `window.__iss255_mutlog`) plus a `requestAnimationFrame` poll logging `__reactContainer$*` / `_reactListening*` own-property keys on `#root` per frame into `window.__iss255_fiberLog`.
- **Observe-only**. No root-cause fix in this PR. Pass 1 of the ENC-ISS-255 diagnostic strategy.
- Follow-up dispatch (Pass 1 fix or Pass 2 prototype trap) will be emitted by the supervisor layer after Pass 1 evidence lands.

## Why

The Deployment Manager PWA is a zombie tree on the deployed build — `#root` has rendered markup but zero React fiber attachments (`__reactFiber$*`, `__reactProps$*`, `__reactContainer$*`, `_reactListening*` all absent); clicks never dispatch; a control-mount of the exact bundle expression against a freshly-created off-screen `<div>` attaches fibers cleanly. Something external clobbers `#root` after createRoot().render() commits at least one post-mount re-render. Static analysis cannot locate the clobber site — a live runtime probe is required.

This probe runs in production, writes only two `window` globals, and is `REMOVE AFTER DIAGNOSIS` marked. It never modifies DOM, never throws, and auto-disconnects after 500 mutations or 600 rAF frames.

## Links

- ENC-ISS-255 — Deployment Manager PWA: React event delegation lost — fiber keys stripped from #root after mount (supersedes ENC-ISS-208)
- ENC-TSK-E77 — this task
- ENC-TSK-E76 — blocked-by: ENC-ISS-255 (typed relationship edge; E76 checkout untouched)
- DOC-17AF10A6BD87 — Pass 1 work unit
- DOC-78F7D333D63B — coord-lead F6 diagnostic redirect

## Commit Complete ID

CCI-2334bcc5fa5440a0b8ae855f7a31136e

## Test plan

- [x] Vite production build green; probe markers survive minification in `dist/assets/index-ypHwC_yX.js` (`__iss255_mutlog`, `__iss255_fiberLog`, `Pass 1 probe armed`, `iss255-mut` Error identifier)
- [x] No existing test regressions (change is additive, pre-imports IIFE only)
- [ ] Post-merge: UI Backend Deploy GitHub Actions workflow green; CloudFront invalidation confirmed
- [ ] Post-deploy: `curl -s https://jreese.net/enceladus/assets/index-*.js | grep __iss255_mutlog` returns a match
- [ ] Post-deploy: Fresh Chromium tab with cache+SW cleared; load `?cachebust=iss255-pass1`; wait 10s; dump `__iss255_mutlog` + `__iss255_fiberLog`; attach to ENC-TSK-E77 worklog