### PR TITLE
fix(ci): ENC-ISS-257 — add --s3-bucket to CFN deploy workflows

### DIFF
--- a/.github/workflows/cloudformation-api-stack-deploy.yml
+++ b/.github/workflows/cloudformation-api-stack-deploy.yml
@@ -104,6 +104,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --s3-bucket jreese-net \
+            --s3-prefix cfn-staging/03-api/ \
             --parameter-overrides \
               ComputeStackName="${{ steps.params.outputs.compute_stack_name }}" \
               ApiName="${{ steps.params.outputs.api_name }}"

--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -94,6 +94,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --s3-bucket jreese-net \
+            --s3-prefix cfn-staging/02-compute/ \
             --parameter-overrides \
               DataStackName="${{ steps.params.outputs.data_stack_name }}"
 

--- a/.github/workflows/cloudformation-monitoring-stack-deploy.yml
+++ b/.github/workflows/cloudformation-monitoring-stack-deploy.yml
@@ -89,6 +89,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --s3-bucket jreese-net \
+            --s3-prefix cfn-staging/05-monitoring/ \
             --parameter-overrides \
               EnvironmentSuffix="${ENVIRONMENT_SUFFIX}"
 


### PR DESCRIPTION
## Summary

- ENC-ISS-257: the `CloudFormation Compute Stack Deploy` workflow has failed identically since 2026-04-11 (runs 24294180846, 24296937575, 24613177727) with `Templates with a size greater than 51,200 bytes must be deployed via an S3 Bucket. Please add the --s3-bucket parameter to your command.` 02-compute.yaml now exceeds the 51,200-byte CloudFormation inline-body limit, so every 02-compute.yaml change has been in main but never applied to live — including ENC-TSK-E81 PR #378 squash `2d1c005a`.
- Fix: add `--s3-bucket jreese-net --s3-prefix cfn-staging/02-compute/` to the `aws cloudformation deploy` invocation. The CLI will upload the template to S3 before creating the changeset, bypassing the 51,200-byte inline limit.
- Defense-in-depth: applied identical flags to `cloudformation-api-stack-deploy.yml` (`cfn-staging/03-api/`) and `cloudformation-monitoring-stack-deploy.yml` (`cfn-staging/05-monitoring/`). Neither currently exceeds the threshold; the flags prevent the next stack that crosses it from hitting an identical 11-second failure.

## Scope

- 3 workflow files, 6 insertions total (2 new flag lines each). No source or template edits — workflow-only.
- No `infrastructure/cloudformation/02-compute.yaml` change.
- No `backend/lambda/**/lambda_function.py` change.
- No governance dictionary change.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge `CloudFormation Compute Stack Deploy` workflow run succeeds end-to-end (step `Deploy Compute stack (02-compute)` conclusion=success, changeset applied).
- [ ] Post-apply cross-check: `aws lambda get-function-configuration --function-name devops-deploy-finalize --query 'Environment.Variables.CONFIG_PREFIX'` still returns `deploy-config` (ENC-TSK-E81 hotfix and CFN now agree; no drift re-assertion).

## Tracker

- Task: ENC-TSK-E82
- Issue: ENC-ISS-257
- CCI-4aca8f1b83da4f79a1835a271f09d3c6

🤖 Generated with [Claude Code](https://claude.com/claude-code)