### PR TITLE
feat(iam): ENC-ISS-257 follow-up — grant s3:PutObject on cfn-staging to CloudFormationDeployRole

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -212,6 +212,19 @@ Resources:
                   - logs:DescribeLogStreams
                 Resource: "*"
 
+              # S3 staging for `aws cloudformation deploy --s3-bucket` path.
+              # Required since 02-compute.yaml crossed the 51,200-byte inline
+              # limit (ENC-ISS-257). The CLI uploads the template to
+              # s3://jreese-net/cfn-staging/<stack>/<hash>.template before
+              # creating the changeset. Used by all three CFN workflows:
+              # cloudformation-{compute,api,monitoring}-stack-deploy.yml.
+              - Sid: S3CfnStagingAccess
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: "arn:aws:s3:::jreese-net/cfn-staging/*"
+
   # ---------------------------------------------------------------------------
   # Backend Deploy Role (ENC-TSK-E31 / ENC-ISS-237)
   # Used by:


### PR DESCRIPTION
## Summary

- Follow-up to [ENC-TSK-E82 PR #379](https://github.com/NX-2021-L/enceladus/pull/379) (merged as `b56075b6`). The workflow-level fix (--s3-bucket flag) now triggers a staged upload via `aws cloudformation deploy`, but the first post-merge Compute Stack Deploy run ([24614280633](https://github.com/NX-2021-L/enceladus/actions/runs/24614280633)) failed with `AccessDenied: s3:PutObject`: the OIDC role `enceladus-cloudformation-deploy-github-role` has no S3 write permission at all.
- Fix: add a single Sid `S3CfnStagingAccess` to `CloudFormationDeployPolicy` in `infrastructure/cloudformation/04-github-roles.yaml` granting `s3:PutObject` + `s3:GetObject` on `arn:aws:s3:::jreese-net/cfn-staging/*`. Scope is tight: one file, 13 additive lines.

## Scope

- Single-file diff: `infrastructure/cloudformation/04-github-roles.yaml` only.
- No source edits, no governance-dictionary touch, no workflow changes.
- Resource scoped to the `cfn-staging/*` prefix — no bucket-wide write.

## Deploy path

`04-github-roles.yaml` is NOT auto-deployed by a GitHub workflow. After merge, io runs manually from product-lead terminal:

```bash
aws --profile product-lead --region us-west-2 cloudformation deploy \
  --stack-name enceladus-github-roles \
  --template-file infrastructure/cloudformation/04-github-roles.yaml \
  --capabilities CAPABILITY_NAMED_IAM
```

Then re-trigger the Compute Stack Deploy workflow via `workflow_dispatch` to verify ENC-TSK-E82 AC 3 (CFN end-to-end success) and AC 4 (CONFIG_PREFIX=deploy-config preserved post-apply).

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge product-lead `aws cloudformation deploy --stack-name enceladus-github-roles` succeeds.
- [ ] Re-triggered Compute Stack Deploy workflow run `Deploy Compute stack (02-compute)` step conclusion=success.
- [ ] Cross-check: `aws lambda get-function-configuration devops-deploy-finalize` still returns `CONFIG_PREFIX=deploy-config`.

## Tracker

- Task: ENC-TSK-E83
- Issue: ENC-ISS-257 (follows ENC-TSK-E82 PR #379)
- CCI-eb08a144d91248729db04a0dd5462602

🤖 Generated with [Claude Code](https://claude.com/claude-code)