### PR TITLE
feat(ci): ENC-ISS-257 follow-up — us-west-2 cfn-staging bucket + repoint CFN workflows

### DIFF
--- a/.github/workflows/cloudformation-api-stack-deploy.yml
+++ b/.github/workflows/cloudformation-api-stack-deploy.yml
@@ -104,8 +104,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
-            --s3-bucket jreese-net \
-            --s3-prefix cfn-staging/03-api/ \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 03-api/ \
             --parameter-overrides \
               ComputeStackName="${{ steps.params.outputs.compute_stack_name }}" \
               ApiName="${{ steps.params.outputs.api_name }}"

--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -94,8 +94,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
-            --s3-bucket jreese-net \
-            --s3-prefix cfn-staging/02-compute/ \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 02-compute/ \
             --parameter-overrides \
               DataStackName="${{ steps.params.outputs.data_stack_name }}"
 

--- a/.github/workflows/cloudformation-monitoring-stack-deploy.yml
+++ b/.github/workflows/cloudformation-monitoring-stack-deploy.yml
@@ -89,8 +89,8 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
-            --s3-bucket jreese-net \
-            --s3-prefix cfn-staging/05-monitoring/ \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 05-monitoring/ \
             --parameter-overrides \
               EnvironmentSuffix="${ENVIRONMENT_SUFFIX}"
 

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -215,15 +215,17 @@ Resources:
               # S3 staging for `aws cloudformation deploy --s3-bucket` path.
               # Required since 02-compute.yaml crossed the 51,200-byte inline
               # limit (ENC-ISS-257). The CLI uploads the template to
-              # s3://jreese-net/cfn-staging/<stack>/<hash>.template before
-              # creating the changeset. Used by all three CFN workflows:
+              # s3://enceladus-cfn-staging-us-west-2/<stack>/<hash>.template
+              # before creating the changeset. Used by all three CFN workflows:
               # cloudformation-{compute,api,monitoring}-stack-deploy.yml.
+              # Bucket must be in us-west-2 so CFN CreateChangeSet can fetch
+              # the template without cross-region redirect (ENC-TSK-E84).
               - Sid: S3CfnStagingAccess
                 Effect: Allow
                 Action:
                   - s3:PutObject
                   - s3:GetObject
-                Resource: "arn:aws:s3:::jreese-net/cfn-staging/*"
+                Resource: !Sub "arn:aws:s3:::${CfnStagingBucket}/*"
 
   # ---------------------------------------------------------------------------
   # Backend Deploy Role (ENC-TSK-E31 / ENC-ISS-237)
@@ -529,6 +531,43 @@ Resources:
                   - "arn:aws:s3:::jreese-net/governance/*"
                   - "arn:aws:s3:::jreese-net/agent-documents/*"
 
+  # ---------------------------------------------------------------------------
+  # CloudFormation Staging Bucket (ENC-TSK-E84 / ENC-ISS-257)
+  # Used by:
+  #   - .github/workflows/cloudformation-compute-stack-deploy.yml
+  #   - .github/workflows/cloudformation-api-stack-deploy.yml
+  #   - .github/workflows/cloudformation-monitoring-stack-deploy.yml
+  # Purpose: hosts the transient template bodies that `aws cloudformation
+  # deploy --s3-bucket` uploads before creating the changeset, so that CFN
+  # templates larger than the 51,200-byte inline limit can be applied.
+  # MUST live in us-west-2 so CreateChangeSet in the same region can fetch
+  # the object without a cross-region redirect.
+  # Objects are ephemeral; lifecycle rule expires them after 7 days.
+  # ---------------------------------------------------------------------------
+  CfnStagingBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: enceladus-cfn-staging-us-west-2
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireStagedTemplates
+            Status: Enabled
+            ExpirationInDays: 7
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Purpose
+          Value: cfn-template-staging
+
 Outputs:
   CloudFormationDeployRoleArn:
     Description: >
@@ -542,3 +581,10 @@ Outputs:
     Value: !GetAtt BackendDeployRole.Arn
     Export:
       Name: !Sub "${AWS::StackName}-BackendDeployRoleArn"
+  CfnStagingBucketName:
+    Description: >
+      Name of the us-west-2 S3 bucket used by aws cloudformation deploy
+      --s3-bucket to stage templates that exceed the 51,200-byte inline limit.
+    Value: !Ref CfnStagingBucket
+    Export:
+      Name: !Sub "${AWS::StackName}-CfnStagingBucketName"


### PR DESCRIPTION
## Summary

Third and final part of the ENC-ISS-257 remediation chain (after [PR #379](https://github.com/NX-2021-L/enceladus/pull/379) = flags, [PR #380](https://github.com/NX-2021-L/enceladus/pull/380) = IAM).

The first workflow_dispatch run after #380's manual apply ([run 24614948474](https://github.com/NX-2021-L/enceladus/actions/runs/24614948474)) uploaded the template successfully (53,864 bytes — IAM fix verified) but CFN `CreateChangeSet` rejected it:

```
S3 error: The bucket you are attempting to access must be addressed using the specified endpoint.
```

Root cause: `jreese-net` is in us-east-1 (`LocationConstraint=None`); the CFN stack is us-west-2. CloudFormation does not follow cross-region S3 redirects for template reads.

## Fix

- **New AWS::S3::Bucket resource** `CfnStagingBucket` in `infrastructure/cloudformation/04-github-roles.yaml` with `BucketName=enceladus-cfn-staging-us-west-2`, full `PublicAccessBlockConfiguration`, and a 7-day object-expiration lifecycle rule (templates are ephemeral). Lives alongside the `CloudFormationDeployRole` that consumes it — single-source-of-truth for the deploy pipeline.
- **`S3CfnStagingAccess` Sid** retargeted via `!Sub "arn:aws:s3:::${CfnStagingBucket}/*"` — decoupled from the literal bucket name.
- **Three CFN workflows** (`compute`, `api`, `monitoring`) repointed: `--s3-bucket jreese-net` → `--s3-bucket enceladus-cfn-staging-us-west-2`, with the redundant `cfn-staging/` path component stripped from `--s3-prefix` (the bucket name already expresses that purpose).
- **New Output** `CfnStagingBucketName` so other stacks / tooling can reference the bucket by import.

## Scope

- 4 files, 55 insertions, 9 deletions.
- No governance-dictionary or Lambda source changes.
- No IAM role ARN change; the policy already had the right Sid shape.

## Deploy path (post-merge)

1. io runs product-lead manual apply:
   ```bash
   aws --profile product-lead --region us-west-2 cloudformation deploy \
     --stack-name enceladus-github-roles \
     --template-file /Users/jreese/enceladus/repo/infrastructure/cloudformation/04-github-roles.yaml \
     --capabilities CAPABILITY_NAMED_IAM
   ```
   Expected: changeset creates `CfnStagingBucket` + updates `CloudFormationDeployRole` policy in one go.
2. I re-trigger `CloudFormation Compute Stack Deploy` via `workflow_dispatch`.
3. Expected success; close E82 + E83 + E84 + ENC-ISS-257.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge product-lead `aws cloudformation deploy --stack-name enceladus-github-roles` succeeds and creates the bucket.
- [ ] Re-triggered Compute Stack Deploy workflow run: `Deploy Compute stack (02-compute)` step conclusion=success, changeset applied.
- [ ] Cross-check: `aws lambda get-function-configuration devops-deploy-finalize` returns `CONFIG_PREFIX=deploy-config`.

## Tracker

- Task: ENC-TSK-E84
- Follows: ENC-TSK-E82 (PR #379), ENC-TSK-E83 (PR #380)
- Issue: ENC-ISS-257
- CCI-023e24a54b7f46e29849b6c1718c8b43

🤖 Generated with [Claude Code](https://claude.com/claude-code)