### PR TITLE
fix: ISS-258 mcp_code/mcp_streamable deploy.sh env-var fallback + macOS mktemp pattern

### DIFF
--- a/backend/lambda/mcp_code/deploy.sh
+++ b/backend/lambda/mcp_code/deploy.sh
@@ -53,6 +53,37 @@ resolve_role_arn() {
   printf '%s' "${source_role}"
 }
 
+preflight_merge_live_env_vars() {
+  # ENC-ISS-258 Bug 1 fix: source Cognito env vars from the live Lambda's
+  # Environment.Variables when the operator's shell did not set them.
+  # Lets any product-lead operator deploy without out-of-band secret retrieval.
+  # No-op on first deploy (live Lambda absent); the validation block refuses
+  # as before if the secret is still empty after the merge attempt.
+  if ! function_exists; then
+    return 0
+  fi
+
+  _merge_one() {
+    local shell_var="$1" lambda_key="$2" value
+    if [[ -z "${!shell_var}" ]]; then
+      value="$(aws lambda get-function-configuration \
+        --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+        --query "Environment.Variables.${lambda_key}" \
+        --output text 2>/dev/null || true)"
+      if [[ -n "${value}" && "${value}" != "None" ]]; then
+        printf -v "${shell_var}" '%s' "${value}"
+        log "[INFO] ${shell_var} sourced from live Lambda ${FUNCTION_NAME}"
+      fi
+    fi
+  }
+
+  _merge_one COGNITO_USER_POOL_ID  ENCELADUS_COGNITO_USER_POOL_ID
+  _merge_one COGNITO_CLIENT_ID     ENCELADUS_COGNITO_CLIENT_ID
+  _merge_one COGNITO_CLIENT_SECRET ENCELADUS_COGNITO_CLIENT_SECRET
+  _merge_one COGNITO_DOMAIN        ENCELADUS_COGNITO_DOMAIN
+  unset -f _merge_one
+}
+
 build_environment_payload() {
   local out_file="$1"
   local source_json='{}'
@@ -357,7 +388,17 @@ deploy_lambda() {
     exit 1
   fi
 
-  env_file="$(mktemp /tmp/${FUNCTION_NAME}-env-XXXXXX.json)"
+  # ENC-ISS-258 Bug 1 fix: source missing Cognito vars from live Lambda if it exists.
+  preflight_merge_live_env_vars
+
+  # ENC-ISS-258 Bug 2 fix: BSD mktemp (macOS) only substitutes X characters at
+  # the end of the template. The prior `/tmp/${FN}-env-XXXXXX.json` pattern
+  # left a literal `XXXXXX.json` file on disk, causing `mkstemp: File exists`
+  # on subsequent runs. PID-based naming plus a trap on EXIT is portable and
+  # self-cleaning across macOS BSD and GNU coreutils.
+  env_file="/tmp/${FUNCTION_NAME}-env-$$.json"
+  trap 'rm -f "${env_file}"' EXIT
+
   if [[ -z "${COGNITO_USER_POOL_ID}" ]]; then
     echo "Refusing deploy with empty COGNITO_USER_POOL_ID for ${FUNCTION_NAME}." >&2
     exit 1

--- a/backend/lambda/mcp_streamable/deploy.sh
+++ b/backend/lambda/mcp_streamable/deploy.sh
@@ -51,6 +51,37 @@ resolve_role_arn() {
   printf '%s' "${source_role}"
 }
 
+preflight_merge_live_env_vars() {
+  # ENC-ISS-258 Bug 1 fix: source MCP API key and OAuth client secrets from
+  # the live Lambda's Environment.Variables when the operator's shell did not
+  # set them. Lets any product-lead operator deploy without out-of-band secret
+  # retrieval. No-op on first deploy (live Lambda absent); the validation
+  # block refuses as before if the secret is still empty after the merge.
+  if ! function_exists; then
+    return 0
+  fi
+
+  _merge_one() {
+    local shell_var="$1" lambda_key="$2" value
+    if [[ -z "${!shell_var}" ]]; then
+      value="$(aws lambda get-function-configuration \
+        --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+        --query "Environment.Variables.${lambda_key}" \
+        --output text 2>/dev/null || true)"
+      if [[ -n "${value}" && "${value}" != "None" ]]; then
+        printf -v "${shell_var}" '%s' "${value}"
+        log "[INFO] ${shell_var} sourced from live Lambda ${FUNCTION_NAME}"
+      fi
+    fi
+  }
+
+  _merge_one MCP_API_KEY          ENCELADUS_MCP_API_KEY
+  _merge_one MCP_API_KEY_PREVIOUS ENCELADUS_MCP_API_KEY_PREVIOUS
+  _merge_one OAUTH_CLIENT_ID      ENCELADUS_OAUTH_CLIENT_ID
+  _merge_one OAUTH_CLIENT_SECRET  ENCELADUS_OAUTH_CLIENT_SECRET
+  unset -f _merge_one
+}
+
 build_environment_payload() {
   local out_file="$1"
   local source_json='{}'
@@ -205,7 +236,17 @@ deploy_lambda() {
     exit 1
   fi
 
-  env_file="$(mktemp /tmp/${FUNCTION_NAME}-env-XXXXXX.json)"
+  # ENC-ISS-258 Bug 1 fix: source missing MCP API key / OAuth vars from live Lambda.
+  preflight_merge_live_env_vars
+
+  # ENC-ISS-258 Bug 2 fix: BSD mktemp (macOS) only substitutes X characters at
+  # the end of the template. The prior `/tmp/${FN}-env-XXXXXX.json` pattern
+  # left a literal `XXXXXX.json` file on disk, causing `mkstemp: File exists`
+  # on subsequent runs. PID-based naming plus a trap on EXIT is portable and
+  # self-cleaning across macOS BSD and GNU coreutils.
+  env_file="/tmp/${FUNCTION_NAME}-env-$$.json"
+  trap 'rm -f "${env_file}"' EXIT
+
   if [[ -z "${MCP_API_KEY}" && -z "${MCP_API_KEY_PREVIOUS}" ]]; then
     echo "Refusing deploy with empty MCP internal API key set for ${FUNCTION_NAME}." >&2
     exit 1


### PR DESCRIPTION
## Summary

Two concrete bugs in `backend/lambda/mcp_code/deploy.sh` and `backend/lambda/mcp_streamable/deploy.sh` fixed under ENC-ISS-258 via ENC-TSK-E97 (ENC-PLN-035, Compressed Sunset Phase B).

**Bug 1 — env-var dependency without fallback.** Both scripts exit 1 when the operator's shell is missing ENCELADUS_COGNITO_* (mcp_code) or ENCELADUS_MCP_API_KEY / ENCELADUS_OAUTH_CLIENT_* (mcp_streamable) env vars, even when the live Lambda already carries the canonical values. Added `preflight_merge_live_env_vars()` to each script — calls `aws lambda get-function-configuration --query 'Environment.Variables.<KEY>'` for each missing shell var and populates it from the live config. No-op on first deploy (live function absent); the existing refusal block still fires if the secret is still empty after merge.

**Bug 2 — macOS BSD mktemp leaves stale literal-XXXXXX files.** BSD `mktemp` only substitutes `X` characters that appear at the very end of the template. The prior `env_file="$(mktemp /tmp/${FUNCTION_NAME}-env-XXXXXX.json)"` pattern created a literal `/tmp/${FN}-env-XXXXXX.json` file on macOS, which persisted across runs and caused `mkstemp: File exists` on subsequent invocations from the same operator machine. Replaced with PID-based naming (`/tmp/${FN}-env-$$.json`) plus `trap 'rm -f "${env_file}"' EXIT` for self-cleaning behavior portable across macOS BSD and GNU coreutils.

## Governance

- Task: ENC-TSK-E97 (lambda_deploy, components=[comp-mcp-code, comp-mcp-streamable])
- Issue: ENC-ISS-258
- Plan: ENC-PLN-035 (Compressed Sunset) Phase B
- Governed mirror: DOC-DCD3CBE8E361
- Wave: DOC-15A538533C42
- CCI: CCI-61f514ce4cf540018b4610c513fd3665

## Test plan

- [x] \`bash -n\` passes on both scripts
- [x] \`shellcheck -S warning\` produces zero NEW warnings vs. main baseline (same pre-existing SC2034 on pip_abi in both files)
- [ ] Post-deploy: \`aws lambda get-function-configuration\` confirms both Lambdas' architecture + runtime match deploy.sh declarations
- [ ] Post-deploy E2E: running mcp_code/deploy.sh with ENCELADUS_COGNITO_USER_POOL_ID unset still succeeds (fetches from live)
- [ ] Post-deploy E2E: two consecutive mcp_streamable/deploy.sh runs leave no stale /tmp/*-env-XXXXXX.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)