### PR TITLE
fix(pwa-sw): NetworkOnly bypass for /api/v1/deploy/* — unblocks Deployment Manager (ENC-ISS-260, ENC-TSK-F10)

### DIFF
--- a/frontend/ui/vite.config.ts
+++ b/frontend/ui/vite.config.ts
@@ -82,14 +82,58 @@ export default defineConfig({
         // Do NOT cache /mobile/v1 feeds via service worker — they require
         // the auth cookie and are intercepted by Lambda@Edge. Network-only
         // fetches let the browser send cookies naturally through CloudFront.
-        runtimeCaching: [],
+        // ENC-ISS-260 / ENC-TSK-F10: explicit NetworkOnly bypass for
+        // /api/v1/deploy/* — the Deployment Manager posts decide/approve/
+        // divert/revert to these endpoints and the SW navigateFallback was
+        // catching same-origin POSTs and returning the index.html app-shell,
+        // producing "Unexpected token <" JSON-parse errors and silently
+        // breaking every governed deployment approval (which also definitionally
+        // blocks ENC-TSK-E76 AC3). NetworkOnly ensures every method on this
+        // prefix goes straight to CloudFront without SW cache involvement.
+        runtimeCaching: [
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+            method: 'POST',
+            options: { matchOptions: { ignoreSearch: true } },
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+            method: 'GET',
+            options: { matchOptions: { ignoreSearch: true } },
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+            method: 'DELETE',
+            options: { matchOptions: { ignoreSearch: true } },
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+            method: 'PATCH',
+            options: { matchOptions: { ignoreSearch: true } },
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+            method: 'PUT',
+            options: { matchOptions: { ignoreSearch: true } },
+          },
+        ],
         // Exclude /enceladus/callback from the NavigationRoute fallback.
         // Lambda@Edge handles /callback server-side (token exchange + cookie
         // set + 302 redirect). If the SW intercepts this navigation, the
         // Set-Cookie headers from the 302 chain may not be flushed to
         // document.cookie before the app bootstrap reads them, causing the
         // session to appear expired after a successful re-login.
-        navigateFallbackDenylist: [/\/callback/],
+        // ENC-ISS-260 / ENC-TSK-F10: also exclude /api/* from the navigation
+        // fallback as a belt-and-suspenders measure. Even though Workbox's
+        // NavigationRoute normally only fires on accept:text/html GETs, the
+        // denylist prevents any future misclassification from routing API
+        // calls into the precached app shell.
+        navigateFallbackDenylist: [/\/callback/, /\/api\//],
       },
     }),
   ],


### PR DESCRIPTION
## Summary

Deployment Manager PWA Approve clicks are silently broken: the VitePWA service worker's default NavigationRoute + empty `runtimeCaching` configuration catches same-origin POSTs to `/api/v1/deploy/decide` (and `/approve /divert /revert`) and returns the precached `index.html` app-shell. The Deployment Manager component then throws "Unexpected token `<`" on JSON parse, no network request ever reaches the backend, and no DPL advances. This is the definitional blocker for ENC-TSK-E76 AC3 — the live-browser Approve round-trip that Loop 1 of DOC-7BE8B8000B70 was staged to capture.

Surgical fix in `frontend/ui/vite.config.ts`:

- Add five `NetworkOnly` `runtimeCaching` entries (one per method: GET/POST/PATCH/PUT/DELETE) matching `/api/v1/deploy/*`. Workbox requires per-method registrations because NetworkOnly's default is GET-only.
- Add `/api/` to `navigateFallbackDenylist` as belt-and-suspenders against any future misclassification of API calls as navigation requests.

## Verification

- `npm run build` completes cleanly in `frontend/ui`.
- `grep -c 'api/v1/deploy' dist/sw.js` → `1` (URL pattern present).
- `grep -c 'NetworkOnly' dist/sw.js` → `5` (one per method).
- `grep -c 'registerRoute' dist/sw.js` → `6` (5 new + 1 NavigationRoute).

## Governance

- Task: ENC-TSK-F10 (github_pr_deploy, components=[comp-enceladus-pwa])
- Issue: ENC-ISS-260 (root cause) — also consumes ENC-TSK-E76 (AC3 blocker)
- Plan anchor: ENC-PLN-033 (W3) / ENC-PLN-035 (Compressed Sunset) Phase E Loop 1
- CCI: CCI-1cdb3f15610241fe8b87693e3582757a

## AC coverage (per task)

- [x] AC1 — NetworkOnly rule present for /api/v1/deploy/*: 5 `NetworkOnly` registrations + `navigateFallbackDenylist` entry in built sw.js.
- [ ] AC2 — Live PWA round-trip fires decide endpoint: requires post-deploy browser verification (covered by DOC-7BE8B8000B70 Loop 1 handoff to io / webui-alpha session).
- [ ] AC3 — ENC-TSK-E76 AC3 stampable post-fix: explicitly deferred to a separate follow-up session per the task ACs.
- [ ] AC4 — Playwright/Cypress E2E regression guard in CI: DEFERRED — no Playwright or Cypress infrastructure exists in `frontend/ui` today (only vitest unit tests). Adding it requires new dependencies, a headless-browser CI runner, dev-server harness, and per-route fixtures. Ships as a follow-on task to avoid scope creep on the urgent Loop 1 unblocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)