### PR TITLE
fix(graph_query_api): align graph_algorithm literal with AC vocabulary (ENC-TSK-F20)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -4548,7 +4548,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "GET /api/v1/tracker/graphsearch?search_type=hybrid response includes the existing nodes/edges/paths/summary/query_cypher/duration_ms fields plus: signal_availability {vector,graph,keyword: bool}, graph_algorithm ('ppr_gds'|'cypher_fallback'|'unavailable'), rrf_k, embedding_coverage_sample {covered, total_ranked}, per_node_fusion {record_id: {fused_rank, fused_score, per_signal_ranks}}, fsrs_t3_threshold, include_below_threshold. The MCP server propagates these into get_compact_context.result.hybrid_retrieval verbatim."
+          "definition": "GET /api/v1/tracker/graphsearch?search_type=hybrid response includes the existing nodes/edges/paths/summary/query_cypher/duration_ms fields plus: signal_availability {vector,graph,keyword: bool}, graph_algorithm ('gds_pagerank'|'cypher_fallback'|'unavailable'), rrf_k, embedding_coverage_sample {covered, total_ranked}, per_node_fusion {record_id: {fused_rank, fused_score, per_signal_ranks}}, fsrs_t3_threshold, include_below_threshold. The MCP server propagates these into get_compact_context.result.hybrid_retrieval verbatim."
         },
         "context_assembly_integration": {
           "type": "string",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -984,7 +984,7 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         "summary":           "Hybrid: N nodes (vector=V, graph=G, keyword=K)",
         "query_cypher":      "<hybrid-multi-query marker>",
         "signal_availability": {vector: bool, graph: bool, keyword: bool},
-        "graph_algorithm":   "ppr_gds" | "cypher_fallback" | "unavailable",
+        "graph_algorithm":   "gds_pagerank" | "cypher_fallback" | "unavailable",
         "rrf_k":             60,
         "embedding_coverage_sample": {covered: N, total_ranked: N},
         "per_node_fusion":   {record_id: {fused_rank, per_signal_ranks}}
@@ -1031,7 +1031,7 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
                 driver, project_id, anchor_record_id, top_n=HYBRID_SIGNAL_TOP_N,
             )
             if graph_ranks:
-                graph_algorithm = "ppr_gds"
+                graph_algorithm = "gds_pagerank"
                 graph_available = True
         # Fall back to Cypher if GDS unavailable OR returned empty.
         if not graph_available:


### PR DESCRIPTION
## Summary

- Rename `graph_algorithm` literal `"ppr_gds"` → `"gds_pagerank"` on the GDS-success path of `_query_hybrid()` so the emitted value falls within the AC-required vocabulary `{ppr, personalized_pagerank, gds_pagerank}` (ENC-TSK-F20 AC #2).
- Update the response_envelope definition in `coordination_api/governance_data_dictionary.json` to match (governance dict gate, CLAUDE.md).

This is **Problem B** of the ENC-ISS-265 dual root-cause analysis (**DOC-5A161704BB9F**). **Problem A** (AuraDB GDS plugin absent) is a separate infrastructure concern staged as a HANDOFF to product-lead — the agent-session IAM cannot touch AuraDB tier/plugin configuration. This rename is inert while GDS is unavailable and becomes effective automatically once GDS is present.

## Test plan

- [x] Grep verified no other references to the old `ppr_gds` literal across the repo
- [x] `backend/lambda/graph_query_api/test_hybrid_retrieval.py` does not reference this literal — no test updates needed
- [x] No runtime behavior change in current production (GDS-success branch unreachable while plugin absent)
- [ ] Post-deploy, after Problem A is resolved and GDS becomes available, run the three-probe verification (probe templates in DOC-5A161704BB9F) and confirm `graph_algorithm == 'gds_pagerank'` on all three

## Checkout evidence

CCI-02801e66e323444ea57b3de5b8faa1be

🤖 Generated with [Claude Code](https://claude.com/claude-code)