### PR TITLE
fix(graph_query_api): AGA Sessions API compliance for GDS PPR (ENC-TSK-F35 / ENC-ISS-265 Problems C + C.2)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -4539,7 +4539,11 @@
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
+        },
+        "aga_sessions_contract": {
+          "type": "object",
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "iam_contract": {
           "type": "array",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -667,6 +667,14 @@ def _hybrid_graph_ranks_gds(
             ).consume()
 
             # Create the projection with weighted edges.
+            # ENC-ISS-265 Problem C: the live instance is Aura Graph Analytics
+            # (Sessions-based GDS compute plane), not in-process AuraDB-Pro GDS.
+            # AGA requires the caller to pass {memory: '<size>'} (auto-create
+            # session) or {sessionId: '<id>'} on every gds.graph.project call.
+            # The governed corpus is currently <10k nodes / <50k edges; 2GB is
+            # the documented smallest viable session. Subsequent calls within
+            # the same query session (gds.graph.exists/drop, gds.pageRank.stream)
+            # inherit the session and do NOT need to re-specify memory.
             session.run(
                 f"""
                 MATCH (src) WHERE src.project_id = $project_id
@@ -676,7 +684,8 @@ def _hybrid_graph_ranks_gds(
                     $name,
                     src,
                     tgt,
-                    {{relationshipProperties: {{weight: {weight_case_sql}}}}}
+                    {{relationshipProperties: {{weight: {weight_case_sql}}}}},
+                    {{memory: '2GB'}}
                 ) AS g
                 RETURN g.graphName
                 """,
@@ -694,7 +703,13 @@ def _hybrid_graph_ranks_gds(
             if anchor_rec is None or anchor_rec.get("nodeId") is None:
                 return []
 
-            result = session.run(
+            # ENC-ISS-265 Problem C.2: gds.util.asNode is not supported under
+            # the AGA Sessions API surface, and the projection above does not
+            # expose record_id as a node property anyway. Return raw (nodeId,
+            # score) from pageRank.stream, then resolve record_ids via a
+            # single follow-up MATCH that hits the main DB (not the session
+            # projection). Preserves score order; one extra roundtrip.
+            stream_result = session.run(
                 """
                 CALL gds.pageRank.stream(
                     $name,
@@ -706,7 +721,7 @@ def _hybrid_graph_ranks_gds(
                     }
                 )
                 YIELD nodeId, score
-                RETURN gds.util.asNode(nodeId).record_id AS rid, score
+                RETURN nodeId, score
                 ORDER BY score DESC
                 LIMIT $limit
                 """,
@@ -716,15 +731,34 @@ def _hybrid_graph_ranks_gds(
                 maxIter=PPR_MAX_ITERATIONS,
                 limit=top_n,
             )
-            for idx, rec in enumerate(result, start=1):
-                rid = rec.get("rid")
-                if not rid or rid == anchor_record_id:
-                    continue
-                ranked.append({
-                    "record_id": rid,
-                    "score": float(rec.get("score") or 0.0),
-                    "rank": idx,
-                })
+            node_rows: List[tuple] = [(r.get("nodeId"), float(r.get("score") or 0.0)) for r in stream_result]
+            if not node_rows:
+                ranked = []
+            else:
+                node_ids = [nid for nid, _ in node_rows if nid is not None]
+                rid_map: Dict[int, str] = {}
+                if node_ids:
+                    resolved = session.run(
+                        "MATCH (n) WHERE id(n) IN $node_ids "
+                        "RETURN id(n) AS nodeId, n.record_id AS rid",
+                        node_ids=node_ids,
+                    )
+                    for rec in resolved:
+                        rid = rec.get("rid")
+                        nid = rec.get("nodeId")
+                        if rid and nid is not None:
+                            rid_map[nid] = rid
+                rank_counter = 0
+                for nid, score in node_rows:
+                    rid = rid_map.get(nid)
+                    if not rid or rid == anchor_record_id:
+                        continue
+                    rank_counter += 1
+                    ranked.append({
+                        "record_id": rid,
+                        "score": score,
+                        "rank": rank_counter,
+                    })
 
             # Clean up projection.
             session.run(


### PR DESCRIPTION
## Summary

- Fixes ENC-ISS-265 Problem C + C.2 (the second-order root cause revealed after ENC-TSK-F20's Problem B rename landed).
- **Problem C**: live instance is Aura Graph Analytics (AGA, Sessions-based), not in-process GDS. `gds.graph.project` now requires a 5th-arg map `{memory: '<size>'}` or `{sessionId: '<id>'}`. Added `{memory: '2GB'}` — minimum viable session size for the <10k-node corpus.
- **Problem C.2**: AGA doesn't expose `gds.util.asNode` and the projection has no node properties, so the RETURN `gds.util.asNode(nodeId).record_id` cannot resolve. Decoupled nodeId→record_id resolution via a follow-up MATCH on the main DB (one extra roundtrip, preserves ordering).
- **Problem D**: prod Lambda has been lagging since 2026-04-16T21:50Z (pre-PR #387). This merge triggers the combined deploy catching up both F20's literal rename and F35's sessions fix in a single prod deploy.
- **Governance dict** (CLAUDE.md gate for graph_query_api/lambda_function.py): added `aga_sessions_contract` entry cross-linked from `gds_availability_probe`.

CCI-2193557903264e5cb869ca4123faa601

## Test plan

- [x] CloudWatch evidence on prod `devops-graph-query-api` confirms the `Either sessionId or memory parameter must be specified` failure mode pre-fix.
- [x] `gds.list()` probe returns True on the live instance (GDS IS present, contrary to DOC-5A161704BB9F v1 Problem A analysis).
- [x] Neo4j AGA Cypher API docs confirm `{memory: '<size>'}` as the minimal valid sessions-mode parameter.
- [ ] Merge + auto-deploy.
- [ ] Post-deploy: three probes on mcp.jreese.net return `graph_algorithm='gds_pagerank'` with `signal_availability.graph=true` and ≥50% per-signal-ranks graph coverage.
- [ ] Append probe evidence to DOC-5A161704BB9F.
- [ ] Stamp F35 ACs; advance F35 through lifecycle to closed.
- [ ] Close ENC-ISS-265 with evidence bundle.

## Related

- ENC-TSK-F20 (Problem B — literal rename, landed at 83fa50b)
- ENC-ISS-265 (primary issue — closes on F35 verification)
- ENC-TSK-B62 (Phase 1 Gate unblocked)
- ENC-FTR-082/083/084/087 (downstream features unblocked)
- DOC-5A161704BB9F v3 (revised root cause analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)