### PR TITLE
ENC-TSK-F44: PWA lifecycle UI (FTR-076 v2)

### DIFF
--- a/frontend/ui/src/api/components.ts
+++ b/frontend/ui/src/api/components.ts
@@ -22,6 +22,19 @@ export type ComponentTransitionType =
   | 'code_only'
   | 'no_code'
 
+// ENC-FTR-076 v2 / DOC-546B896390EA §3 — 8-status lifecycle.
+// Source of truth: governance_data_dictionary.json v2026-04-19.04
+//   entities.component_registry.component.fields.lifecycle_status
+export type ComponentLifecycleStatus =
+  | 'proposed'
+  | 'approved'
+  | 'designed'
+  | 'development'
+  | 'production'
+  | 'code-red'
+  | 'deprecated'
+  | 'archived'
+
 export interface RegistryComponent {
   component_id: string
   component_name: string
@@ -33,6 +46,25 @@ export interface RegistryComponent {
   status: ComponentStatus
   created_at: string
   updated_at: string
+  // --- ENC-FTR-076 v2 fields (optional for backward compat with v1 records) ---
+  lifecycle_status?: ComponentLifecycleStatus
+  // Governed strictness (DOC-546B896390EA §6). `transition_type` remains the
+  // legacy write-path field; `required_transition_type` is the v2 override.
+  required_transition_type?: ComponentTransitionType
+  // Optional CloudWatch alarm hook (DOC-546B896390EA §8 — v5 scaffolding).
+  alarm_arn?: string
+  // Revert metadata (archived via revert modal)
+  reverted_at?: string
+  reverted_reason?: string
+  reverted_by?: string
+  // Approve / deprecate / restore metadata (may be absent on pre-v2 records)
+  approved_at?: string
+  approved_by?: string
+  deprecated_at?: string
+  deprecated_by?: string
+  deprecated_reason?: string
+  restored_at?: string
+  restored_by?: string
 }
 
 export interface ComponentFilters {
@@ -134,6 +166,8 @@ export async function deleteComponent(componentId: string): Promise<void> {
 }
 
 // ENC-FTR-076 Phase 6: Component proposal types and approval/rejection API
+// ENC-FTR-076 v2 / ENC-TSK-F44: extended with required_transition_type,
+// alarm_arn, revert/deprecate/restore/advance operations.
 
 export interface ComponentProposal {
   component_id: string
@@ -144,6 +178,9 @@ export interface ComponentProposal {
   source_paths: string[]
   proposing_agent_session_id: string
   requested_minimum_transition_type: ComponentTransitionType
+  // Optional v2 field — proposing agent may request a stricter required type.
+  // Absent on pre-v2 proposals; approve modal falls back to minimum.
+  requested_required_transition_type?: ComponentTransitionType
   lifecycle_status: 'proposed'
   created_at: string
   updated_at: string
@@ -151,24 +188,60 @@ export interface ComponentProposal {
 
 export interface ApproveComponentInput {
   id: string
+  // Optional: io may override minimum_transition_type (legacy write field)
   minimum_transition_type?: ComponentTransitionType
+  // Optional: io may override required_transition_type (v2 strictness)
+  required_transition_type?: ComponentTransitionType
+  // Optional: io may attach a CloudWatch alarm ARN (DOC-546B896390EA §8 v5 scaffold)
+  alarm_arn?: string
 }
 
+// Legacy Phase 6 reject — preserved for backward compat while F40 ships.
 export interface RejectComponentInput {
   id: string
   rejection_reason: string
 }
 
+// ENC-FTR-076 v2 / AC[3]-d — revert is terminal (archives component).
+export interface RevertComponentInput {
+  id: string
+  reverted_reason: string
+}
+
+// ENC-FTR-076 v2 / AC[3]-e — deprecate (io only, Cognito-gated).
+export interface DeprecateComponentInput {
+  id: string
+  deprecated_reason?: string
+}
+
+// ENC-FTR-076 v2 / AC[3]-e — restore deprecated → production (io only).
+export interface RestoreComponentInput {
+  id: string
+}
+
+// ENC-FTR-076 v2 — advance lifecycle (approved → designed → development → production).
+// Target resolved server-side based on current lifecycle_status.
+export interface AdvanceComponentInput {
+  id: string
+  target_lifecycle_status?: ComponentLifecycleStatus
+}
+
 export async function approveComponent(
   input: ApproveComponentInput,
 ): Promise<{ success: boolean }> {
+  const body: Record<string, string> = {}
+  if (input.minimum_transition_type) {
+    body.transition_type = input.minimum_transition_type
+  }
+  if (input.required_transition_type) {
+    body.required_transition_type = input.required_transition_type
+  }
+  if (input.alarm_arn && input.alarm_arn.trim()) {
+    body.alarm_arn = input.alarm_arn.trim()
+  }
   return apiFetch<{ success: boolean }>(`/components/${input.id}/approve`, {
     method: 'POST',
-    body: JSON.stringify({
-      ...(input.minimum_transition_type && {
-        transition_type: input.minimum_transition_type,
-      }),
-    }),
+    body: JSON.stringify(body),
   })
 }
 
@@ -178,6 +251,50 @@ export async function rejectComponent(
   return apiFetch<{ success: boolean }>(`/components/${input.id}/reject`, {
     method: 'POST',
     body: JSON.stringify({ rejection_reason: input.rejection_reason }),
+  })
+}
+
+export async function revertComponent(
+  input: RevertComponentInput,
+): Promise<{ success: boolean }> {
+  return apiFetch<{ success: boolean }>(`/components/${input.id}/revert`, {
+    method: 'POST',
+    body: JSON.stringify({ reverted_reason: input.reverted_reason }),
+  })
+}
+
+export async function deprecateComponent(
+  input: DeprecateComponentInput,
+): Promise<{ success: boolean }> {
+  const body: Record<string, string> = {}
+  if (input.deprecated_reason && input.deprecated_reason.trim()) {
+    body.deprecated_reason = input.deprecated_reason.trim()
+  }
+  return apiFetch<{ success: boolean }>(`/components/${input.id}/deprecate`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export async function restoreComponent(
+  input: RestoreComponentInput,
+): Promise<{ success: boolean }> {
+  return apiFetch<{ success: boolean }>(`/components/${input.id}/restore`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+}
+
+export async function advanceComponent(
+  input: AdvanceComponentInput,
+): Promise<{ success: boolean }> {
+  const body: Record<string, string> = {}
+  if (input.target_lifecycle_status) {
+    body.target_lifecycle_status = input.target_lifecycle_status
+  }
+  return apiFetch<{ success: boolean }>(`/components/${input.id}/advance`, {
+    method: 'POST',
+    body: JSON.stringify(body),
   })
 }
 

--- a/frontend/ui/src/hooks/useComponentRegistry.ts
+++ b/frontend/ui/src/hooks/useComponentRegistry.ts
@@ -10,12 +10,20 @@ import {
   deleteComponent,
   approveComponent,
   rejectComponent,
+  revertComponent,
+  deprecateComponent,
+  restoreComponent,
+  advanceComponent,
   componentKeys,
   type ComponentFilters,
   type CreateComponentInput,
   type UpdateComponentInput,
   type ApproveComponentInput,
   type RejectComponentInput,
+  type RevertComponentInput,
+  type DeprecateComponentInput,
+  type RestoreComponentInput,
+  type AdvanceComponentInput,
 } from '../api/components'
 
 export function useComponentRegistry(filters: ComponentFilters = {}) {
@@ -70,6 +78,41 @@ export function useRejectComponent() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (input: RejectComponentInput) => rejectComponent(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: componentKeys.all }),
+  })
+}
+
+// ENC-FTR-076 v2 / ENC-TSK-F44 — lifecycle action hooks
+// These POST to endpoints that F40 delivers. Pre-F40-deploy they 404 (UI only).
+
+export function useRevertComponent() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: RevertComponentInput) => revertComponent(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: componentKeys.all }),
+  })
+}
+
+export function useDeprecateComponent() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: DeprecateComponentInput) => deprecateComponent(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: componentKeys.all }),
+  })
+}
+
+export function useRestoreComponent() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: RestoreComponentInput) => restoreComponent(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: componentKeys.all }),
+  })
+}
+
+export function useAdvanceComponent() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: AdvanceComponentInput) => advanceComponent(input),
     onSuccess: () => qc.invalidateQueries({ queryKey: componentKeys.all }),
   })
 }

--- a/frontend/ui/src/lib/constants.ts
+++ b/frontend/ui/src/lib/constants.ts
@@ -320,3 +320,48 @@ export const COMPONENT_TRANSITION_TYPE_RANK: Record<string, number> = {
 }
 
 export const COMPONENT_STATUSES = ['active', 'deprecated', 'archived'] as const
+
+// ENC-FTR-076 v2 / DOC-546B896390EA §3 — 8-status component lifecycle.
+// Source of truth: governance_data_dictionary.json
+//   entities.component_registry.component.fields.lifecycle_status (v2026-04-19.04)
+// Distinct colors per AC[3]-b:
+//   proposed / approved → neutral gray (awaiting further action)
+//   designed / development → blue (in-flight)
+//   production → green (live)
+//   code-red → red (incident)
+//   deprecated → amber (fork required)
+//   archived → slate (terminal)
+export const COMPONENT_LIFECYCLE_STATUSES = [
+  'proposed',
+  'approved',
+  'designed',
+  'development',
+  'production',
+  'code-red',
+  'deprecated',
+  'archived',
+] as const
+
+export type ComponentLifecycleStatus = (typeof COMPONENT_LIFECYCLE_STATUSES)[number]
+
+export const COMPONENT_LIFECYCLE_STATUS_LABELS: Record<string, string> = {
+  proposed: 'Proposed',
+  approved: 'Approved',
+  designed: 'Designed',
+  development: 'Development',
+  production: 'Production',
+  'code-red': 'Code Red',
+  deprecated: 'Deprecated',
+  archived: 'Archived',
+}
+
+export const COMPONENT_LIFECYCLE_STATUS_COLORS: Record<string, string> = {
+  proposed: 'bg-slate-500/20 text-slate-300',
+  approved: 'bg-slate-400/20 text-slate-200',
+  designed: 'bg-blue-500/20 text-blue-400',
+  development: 'bg-indigo-500/20 text-indigo-400',
+  production: 'bg-emerald-500/20 text-emerald-400',
+  'code-red': 'bg-rose-500/20 text-rose-400',
+  deprecated: 'bg-amber-500/20 text-amber-400',
+  archived: 'bg-slate-700/40 text-slate-500',
+}

--- a/frontend/ui/src/pages/ComponentRegistryPage.test.tsx
+++ b/frontend/ui/src/pages/ComponentRegistryPage.test.tsx
@@ -1,0 +1,395 @@
+/**
+ * ComponentRegistryPage smoke test — ENC-TSK-F44 / FTR-076 v2.
+ *
+ * Scope (per AC[3]-f):
+ *   - Render Pending Approval section with a seeded proposed component.
+ *   - Verify the 8-status lifecycle badges render with distinct colors when
+ *     components carry lifecycle_status.
+ *   - Open each of 4 modals (approve / revert / deprecate / restore) and
+ *     validate required-field gating.
+ *
+ * Mocks:
+ *   - useComponentRegistry / useCreateComponent / useUpdateComponent /
+ *     useDeleteComponent / useApproveComponent / useRevertComponent /
+ *     useDeprecateComponent / useRestoreComponent are stubbed so the page
+ *     renders without hitting the network.
+ *   - useAuthState is mocked to return 'authenticated' so canEdit=true and
+ *     the io-only action surfaces are present.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  COMPONENT_LIFECYCLE_STATUSES,
+  COMPONENT_LIFECYCLE_STATUS_LABELS,
+} from '../lib/constants'
+import type { ComponentLifecycleStatus, RegistryComponent } from '../api/components'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — fix the hook surface at the page import boundary.
+// ---------------------------------------------------------------------------
+
+const {
+  mockUseComponentRegistry,
+  mockCreateMutation,
+  mockUpdateMutation,
+  mockDeleteMutation,
+  mockApproveMutation,
+  mockRevertMutation,
+  mockDeprecateMutation,
+  mockRestoreMutation,
+  mockUseAuthState,
+} = vi.hoisted(() => ({
+  mockUseComponentRegistry: vi.fn(),
+  mockCreateMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockUpdateMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockDeleteMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockApproveMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockRevertMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockDeprecateMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockRestoreMutation: { mutateAsync: vi.fn(), isPending: false },
+  mockUseAuthState: vi.fn(),
+}))
+
+vi.mock('../hooks/useComponentRegistry', () => ({
+  useComponentRegistry: mockUseComponentRegistry,
+  useCreateComponent: () => mockCreateMutation,
+  useUpdateComponent: () => mockUpdateMutation,
+  useDeleteComponent: () => mockDeleteMutation,
+  useApproveComponent: () => mockApproveMutation,
+  useRevertComponent: () => mockRevertMutation,
+  useDeprecateComponent: () => mockDeprecateMutation,
+  useRestoreComponent: () => mockRestoreMutation,
+}))
+
+vi.mock('../lib/authState', () => ({
+  useAuthState: mockUseAuthState,
+}))
+
+import { ComponentRegistryPage } from './ComponentRegistryPage'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeComponent(
+  overrides: Partial<RegistryComponent> & { lifecycle_status?: ComponentLifecycleStatus },
+): RegistryComponent {
+  return {
+    component_id: 'comp-test',
+    component_name: 'Test Component',
+    project_id: 'enceladus',
+    category: 'lambda',
+    transition_type: 'github_pr_deploy',
+    description: 'Test',
+    status: 'active',
+    created_at: '2026-04-10T00:00:00Z',
+    updated_at: '2026-04-10T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const PROPOSED_A: RegistryComponent = makeComponent({
+  component_id: 'comp-older-proposal',
+  component_name: 'Older Proposal',
+  description: 'Older proposal body',
+  lifecycle_status: 'proposed',
+  created_at: '2026-04-01T00:00:00Z',
+  // Cast-to-any so we can add the proposal-only fields without widening the
+  // RegistryComponent type surface at rest.
+  ...({
+    proposing_agent_session_id: 'claude-older-2026-04-01T00Z',
+    requested_minimum_transition_type: 'lambda_deploy',
+    requested_required_transition_type: 'github_pr_deploy',
+    source_paths: ['backend/lambda/older/lambda_function.py'],
+  } as Partial<RegistryComponent>),
+})
+
+const PROPOSED_B: RegistryComponent = makeComponent({
+  component_id: 'comp-newer-proposal',
+  component_name: 'Newer Proposal',
+  description: 'Newer proposal body',
+  lifecycle_status: 'proposed',
+  created_at: '2026-04-15T00:00:00Z',
+  ...({
+    proposing_agent_session_id: 'claude-newer-2026-04-15T00Z',
+    requested_minimum_transition_type: 'web_deploy',
+    source_paths: ['frontend/ui/src/newer.tsx'],
+  } as Partial<RegistryComponent>),
+})
+
+const PRODUCTION_COMPONENT = makeComponent({
+  component_id: 'comp-prod-ready',
+  component_name: 'Production Ready',
+  lifecycle_status: 'production',
+})
+
+const DEPRECATED_COMPONENT = makeComponent({
+  component_id: 'comp-deprecated-one',
+  component_name: 'Deprecated One',
+  lifecycle_status: 'deprecated',
+  status: 'deprecated',
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+function setRegistry(list: RegistryComponent[]) {
+  mockUseComponentRegistry.mockReturnValue({
+    components: list,
+    count: list.length,
+    isPending: false,
+    isError: false,
+    dataUpdatedAt: Date.now(),
+  })
+}
+
+function renderPage() {
+  return render(<ComponentRegistryPage />, { wrapper: createWrapper() })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreateMutation.isPending = false
+  mockUpdateMutation.isPending = false
+  mockDeleteMutation.isPending = false
+  mockApproveMutation.isPending = false
+  mockRevertMutation.isPending = false
+  mockDeprecateMutation.isPending = false
+  mockRestoreMutation.isPending = false
+  mockUseAuthState.mockReturnValue({ authStatus: 'authenticated' })
+})
+
+describe('ComponentRegistryPage — FTR-076 v2 lifecycle UI (AC[3])', () => {
+  it('renders the Pending Approval section at the top with oldest-first ordering', () => {
+    // Seed with newer first to verify the component re-sorts oldest-first.
+    setRegistry([PROPOSED_B, PROPOSED_A])
+    renderPage()
+
+    const section = screen.getByTestId('pending-approval-section')
+    expect(section).toBeInTheDocument()
+
+    const header = within(section).getByTestId('pending-approval-header')
+    expect(header.textContent).toContain('Pending Approval (2)')
+
+    // Cards should render in oldest-first order: older (2026-04-01) before newer (2026-04-15).
+    const cards = within(section).getAllByTestId(/proposal-card-comp-/)
+    expect(cards.map((c) => c.getAttribute('data-testid'))).toEqual([
+      'proposal-card-comp-older-proposal',
+      'proposal-card-comp-newer-proposal',
+    ])
+
+    // Proposing session ID + requested transition types are surfaced (AC[3]-a).
+    expect(
+      within(cards[0]).getByText('claude-older-2026-04-01T00Z'),
+    ).toBeInTheDocument()
+    expect(
+      within(cards[0]).getByTestId('requested-minimum-transition-type').textContent,
+    ).toContain('Lambda Deploy')
+    expect(
+      within(cards[0]).getByTestId('requested-required-transition-type').textContent,
+    ).toContain('GitHub PR + Deploy')
+  })
+
+  it('renders lifecycle_status badges for all 8 statuses with distinct colors (AC[3]-b)', () => {
+    // Seed one component per lifecycle status (proposed included so AC[3]-b
+    // coverage spans the full 8-status enum).
+    const allEightSeeded = COMPONENT_LIFECYCLE_STATUSES.map((s, i) =>
+      makeComponent({
+        component_id: `comp-life-${s}`,
+        component_name: `Lifecycle ${s}`,
+        lifecycle_status: s,
+        created_at: `2026-04-0${i + 1}T00:00:00Z`,
+        // Seed proposal-shape fields for 'proposed' so the PendingApproval path
+        // renders without throwing (not strictly needed for badge assertion).
+        ...(s === 'proposed'
+          ? ({
+              proposing_agent_session_id: 'claude-test',
+              requested_minimum_transition_type: 'github_pr_deploy',
+              source_paths: [],
+            } as Partial<RegistryComponent>)
+          : {}),
+      }),
+    )
+    setRegistry(allEightSeeded)
+    renderPage()
+
+    // lifecycle-status-badge is rendered by ComponentCard — proposed variants
+    // render inside the Pending Approval ProposalCard (no badge there by design).
+    const badges = screen.getAllByTestId('lifecycle-status-badge')
+    const statuses = badges.map((b) => b.getAttribute('data-lifecycle-status'))
+    expect(new Set(statuses)).toEqual(
+      new Set(COMPONENT_LIFECYCLE_STATUSES.filter((s) => s !== 'proposed')),
+    )
+
+    // AC[3]-b requires distinct colors per lifecycle status. Our palette maps
+    // 8 statuses across 7 tailwind color families (approved shares slate with
+    // proposed + archived but at a different opacity band).
+    const colorClasses = badges.map(
+      (b) => b.className.match(/bg-[a-z]+-\d{2,3}\/\d{2}/)?.[0],
+    )
+    expect(new Set(colorClasses).size).toBeGreaterThanOrEqual(5)
+
+    // Label sanity: each non-proposed badge label matches the constant table.
+    const labels = badges.map((b) => b.textContent)
+    for (const s of COMPONENT_LIFECYCLE_STATUSES) {
+      if (s === 'proposed') continue
+      expect(labels).toContain(COMPONENT_LIFECYCLE_STATUS_LABELS[s])
+    }
+
+    // Verify Pending Approval renders for the seeded proposal too (AC[3]-a)
+    expect(screen.getByTestId('pending-approval-section')).toBeInTheDocument()
+  })
+
+  it('opens the approve modal with minimum/required transition-type + alarm_arn fields (AC[3]-c)', async () => {
+    const user = userEvent.setup()
+    setRegistry([PROPOSED_A])
+    renderPage()
+
+    await user.click(screen.getByTestId('approve-button-comp-older-proposal'))
+
+    const modal = screen.getByTestId('approve-modal')
+    expect(modal).toBeInTheDocument()
+
+    // Shows proposing_agent_session_id + requested_minimum + requested_required
+    expect(within(modal).getByText(/claude-older-2026-04-01T00Z/)).toBeInTheDocument()
+    // Label text appears in both the summary block and the select options —
+    // scope the summary-block assertions to the span following the label.
+    expect(within(modal).getByText(/Requested minimum:/).textContent).toContain(
+      'Lambda Deploy',
+    )
+    expect(within(modal).getByText(/Requested required:/).textContent).toContain(
+      'GitHub PR + Deploy',
+    )
+
+    // Minimum + Required + Alarm-ARN inputs are all present.
+    const minSelect = within(modal).getByTestId(
+      'approve-minimum-transition-type',
+    ) as HTMLSelectElement
+    const reqSelect = within(modal).getByTestId(
+      'approve-required-transition-type',
+    ) as HTMLSelectElement
+    expect(minSelect).toBeInTheDocument()
+    expect(reqSelect).toBeInTheDocument()
+    expect(within(modal).getByTestId('approve-alarm-arn')).toBeInTheDocument()
+
+    // Defaults honor the proposal's requested values.
+    expect(minSelect.value).toBe('lambda_deploy')
+    expect(reqSelect.value).toBe('github_pr_deploy')
+
+    // Submitting fires the mutation with overrides.
+    await user.click(within(modal).getByTestId('approve-confirm'))
+    expect(mockApproveMutation.mutateAsync).toHaveBeenCalledTimes(1)
+    const call = mockApproveMutation.mutateAsync.mock.calls[0][0]
+    expect(call.id).toBe('comp-older-proposal')
+    expect(call.minimum_transition_type).toBe('lambda_deploy')
+    expect(call.required_transition_type).toBe('github_pr_deploy')
+  })
+
+  it('revert modal requires min-10-char reason and invokes revertMutation (AC[3]-d)', async () => {
+    const user = userEvent.setup()
+    setRegistry([PROPOSED_A])
+    renderPage()
+
+    await user.click(screen.getByTestId('revert-button-comp-older-proposal'))
+    const modal = screen.getByTestId('revert-modal')
+    expect(modal).toBeInTheDocument()
+
+    // Terminal-archive warning visible (AC[3]-d requires the warning).
+    expect(within(modal).getByRole('alert').textContent).toMatch(/terminal/i)
+
+    const confirm = within(modal).getByTestId('revert-confirm')
+    // Short input — button disabled.
+    await user.type(within(modal).getByTestId('revert-reason'), 'too short')
+    expect(confirm).toBeDisabled()
+
+    // Extend to >=10 chars — button enables.
+    await user.type(within(modal).getByTestId('revert-reason'), ' but now enough characters')
+    expect(confirm).not.toBeDisabled()
+
+    await user.click(confirm)
+    expect(mockRevertMutation.mutateAsync).toHaveBeenCalledTimes(1)
+    const call = mockRevertMutation.mutateAsync.mock.calls[0][0]
+    expect(call.id).toBe('comp-older-proposal')
+    expect(call.reverted_reason.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('deprecate modal appears on production components and invokes deprecateMutation (AC[3]-e)', async () => {
+    const user = userEvent.setup()
+    setRegistry([PRODUCTION_COMPONENT])
+    renderPage()
+
+    // Deprecate action button surfaces only for production components.
+    const deprecateButton = screen.getByRole('button', {
+      name: `Deprecate ${PRODUCTION_COMPONENT.component_name}`,
+    })
+    await user.click(deprecateButton)
+
+    const modal = screen.getByTestId('deprecate-modal')
+    expect(modal).toBeInTheDocument()
+    expect(within(modal).getByRole('alert').textContent).toMatch(/io-only/i)
+
+    await user.type(
+      within(modal).getByTestId('deprecate-reason'),
+      'superseded by comp-prod-ready-v2',
+    )
+    await user.click(within(modal).getByTestId('deprecate-confirm'))
+
+    expect(mockDeprecateMutation.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(mockDeprecateMutation.mutateAsync.mock.calls[0][0]).toMatchObject({
+      id: 'comp-prod-ready',
+      deprecated_reason: 'superseded by comp-prod-ready-v2',
+    })
+  })
+
+  it('restore modal appears on deprecated components and targets production (AC[3]-e)', async () => {
+    const user = userEvent.setup()
+    setRegistry([DEPRECATED_COMPONENT])
+    renderPage()
+
+    const restoreButton = screen.getByRole('button', {
+      name: `Restore ${DEPRECATED_COMPONENT.component_name}`,
+    })
+    await user.click(restoreButton)
+
+    const modal = screen.getByTestId('restore-modal')
+    expect(modal).toBeInTheDocument()
+    expect(within(modal).getByRole('alert').textContent).toMatch(/production/)
+
+    await user.click(within(modal).getByTestId('restore-confirm'))
+    expect(mockRestoreMutation.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(mockRestoreMutation.mutateAsync.mock.calls[0][0]).toEqual({
+      id: 'comp-deprecated-one',
+    })
+  })
+
+  it('does not show deprecate/restore buttons for components outside the production/deprecated states', () => {
+    setRegistry([
+      makeComponent({
+        component_id: 'comp-designed-only',
+        component_name: 'Designed Only',
+        lifecycle_status: 'designed',
+      }),
+    ])
+    renderPage()
+
+    expect(screen.queryByLabelText(/Deprecate Designed Only/)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Restore Designed Only/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/ui/src/pages/ComponentRegistryPage.tsx
+++ b/frontend/ui/src/pages/ComponentRegistryPage.tsx
@@ -1,9 +1,11 @@
 /**
  * ComponentRegistryPage — ENC-FTR-041 Component Registry UI
+ * ENC-FTR-076 v2 / ENC-TSK-F44 — 8-status lifecycle UI + io-only modals.
  *
  * Lists all registered components with filters for project, category, and status.
- * Authenticated users (Cognito session) can create, edit, and delete components.
- * transition_type edits are enforced server-side as Cognito-only.
+ * Authenticated users (Cognito session) can create, edit, delete, and manage
+ * lifecycle (approve/revert/deprecate/restore/advance) components.
+ * transition_type edits and lifecycle actions are enforced server-side as Cognito-only.
  */
 
 import { useState, useMemo, useCallback } from 'react'
@@ -14,7 +16,9 @@ import {
   useUpdateComponent,
   useDeleteComponent,
   useApproveComponent,
-  useRejectComponent,
+  useRevertComponent,
+  useDeprecateComponent,
+  useRestoreComponent,
 } from '../hooks/useComponentRegistry'
 import { LoadingState } from '../components/shared/LoadingState'
 import { ErrorState } from '../components/shared/ErrorState'
@@ -29,6 +33,8 @@ import {
   COMPONENT_TRANSITION_TYPE_LABELS,
   COMPONENT_TRANSITION_TYPE_COLORS,
   COMPONENT_STATUSES,
+  COMPONENT_LIFECYCLE_STATUS_COLORS,
+  COMPONENT_LIFECYCLE_STATUS_LABELS,
   STATUS_COLORS,
   STATUS_LABELS,
 } from '../lib/constants'
@@ -67,9 +73,18 @@ interface ComponentCardProps {
   canEdit: boolean
   onEdit: (c: RegistryComponent) => void
   onDelete: (c: RegistryComponent) => void
+  onDeprecate: (c: RegistryComponent) => void
+  onRestore: (c: RegistryComponent) => void
 }
 
-function ComponentCard({ component, canEdit, onEdit, onDelete }: ComponentCardProps) {
+function ComponentCard({
+  component,
+  canEdit,
+  onEdit,
+  onDelete,
+  onDeprecate,
+  onRestore,
+}: ComponentCardProps) {
   const categoryColor =
     COMPONENT_CATEGORY_COLORS[component.category] ?? 'bg-slate-500/20 text-slate-400'
   const transitionColor =
@@ -78,8 +93,23 @@ function ComponentCard({ component, canEdit, onEdit, onDelete }: ComponentCardPr
   const statusColor =
     STATUS_COLORS[component.status] ?? 'bg-slate-500/20 text-slate-400'
 
+  // ENC-FTR-076 v2: render lifecycle_status badge when present
+  const lifecycleStatus = component.lifecycle_status
+  const lifecycleColor = lifecycleStatus
+    ? COMPONENT_LIFECYCLE_STATUS_COLORS[lifecycleStatus] ?? 'bg-slate-500/20 text-slate-400'
+    : null
+
+  // Only show Deprecate when lifecycle_status is production (io-only). Restore only
+  // when deprecated. Both paths are gated server-side — UI shows the button only
+  // when the action is contextually meaningful.
+  const canDeprecate = canEdit && lifecycleStatus === 'production'
+  const canRestore = canEdit && lifecycleStatus === 'deprecated'
+
   return (
-    <div className="bg-slate-800/60 border border-slate-700/60 rounded-lg p-4 space-y-3 hover:border-slate-600/80 transition-colors">
+    <div
+      className="bg-slate-800/60 border border-slate-700/60 rounded-lg p-4 space-y-3 hover:border-slate-600/80 transition-colors"
+      data-testid={`component-card-${component.component_id}`}
+    >
       {/* Header row */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
@@ -88,6 +118,30 @@ function ComponentCard({ component, canEdit, onEdit, onDelete }: ComponentCardPr
         </div>
         {canEdit && (
           <div className="flex items-center gap-1 shrink-0">
+            {canDeprecate && (
+              <button
+                onClick={() => onDeprecate(component)}
+                aria-label={`Deprecate ${component.component_name}`}
+                title="Deprecate"
+                className="p-1.5 text-slate-500 hover:text-amber-400 hover:bg-amber-500/10 rounded transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </button>
+            )}
+            {canRestore && (
+              <button
+                onClick={() => onRestore(component)}
+                aria-label={`Restore ${component.component_name}`}
+                title="Restore to production"
+                className="p-1.5 text-slate-500 hover:text-emerald-400 hover:bg-emerald-500/10 rounded transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </button>
+            )}
             <button
               onClick={() => onEdit(component)}
               aria-label={`Edit ${component.component_name}`}
@@ -118,6 +172,16 @@ function ComponentCard({ component, canEdit, onEdit, onDelete }: ComponentCardPr
         <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${transitionColor}`}>
           {COMPONENT_TRANSITION_TYPE_LABELS[component.transition_type] ?? component.transition_type}
         </span>
+        {/* ENC-FTR-076 v2: 8-status lifecycle badge (AC[3]-b) */}
+        {lifecycleStatus && lifecycleColor && (
+          <span
+            data-testid="lifecycle-status-badge"
+            data-lifecycle-status={lifecycleStatus}
+            className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${lifecycleColor}`}
+          >
+            {COMPONENT_LIFECYCLE_STATUS_LABELS[lifecycleStatus] ?? lifecycleStatus}
+          </span>
+        )}
         <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${statusColor}`}>
           {STATUS_LABELS[component.status] ?? component.status}
         </span>
@@ -478,64 +542,102 @@ function ProposalCard({
   proposal,
   canAct,
   onApprove,
-  onReject,
+  onRevert,
 }: {
   proposal: ComponentProposal
   canAct: boolean
   onApprove: (p: ComponentProposal) => void
-  onReject: (p: ComponentProposal) => void
+  onRevert: (p: ComponentProposal) => void
 }) {
   return (
-    <div className="bg-amber-900/20 border border-amber-500/30 rounded-lg p-4 space-y-3">
+    <div
+      className="bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-500/30 rounded-lg p-4 space-y-3"
+      data-testid={`proposal-card-${proposal.component_id}`}
+    >
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-amber-200 truncate">{proposal.component_id}</h3>
-          <p className="text-xs text-amber-300/60 mt-0.5 truncate">
-            proposed by <span className="font-mono">{proposal.proposing_agent_session_id}</span>
+          <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200 truncate">
+            {proposal.component_id}
+          </h3>
+          <p className="text-xs text-amber-800/70 dark:text-amber-300/60 mt-0.5 truncate">
+            proposed by{' '}
+            <span className="font-mono" data-testid="proposing-agent-session-id">
+              {proposal.proposing_agent_session_id}
+            </span>
           </p>
         </div>
         {canAct && (
           <div className="flex items-center gap-1.5 shrink-0">
             <button
               onClick={() => onApprove(proposal)}
+              data-testid={`approve-button-${proposal.component_id}`}
               className="px-2.5 py-1 text-xs font-medium text-white bg-emerald-700 hover:bg-emerald-600 rounded transition-colors"
             >
               Approve
             </button>
             <button
-              onClick={() => onReject(proposal)}
+              onClick={() => onRevert(proposal)}
+              data-testid={`revert-button-${proposal.component_id}`}
               className="px-2.5 py-1 text-xs font-medium text-white bg-rose-700 hover:bg-rose-600 rounded transition-colors"
             >
-              Reject
+              Revert
             </button>
           </div>
         )}
       </div>
 
       {proposal.description && (
-        <p className="text-xs text-amber-200/70 line-clamp-2">{proposal.description}</p>
+        <p className="text-xs text-amber-900/80 dark:text-amber-200/70 line-clamp-2">
+          {proposal.description}
+        </p>
       )}
 
       <div className="flex flex-wrap gap-1.5">
-        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-800/40 text-amber-300">
-          {COMPONENT_TRANSITION_TYPE_LABELS[proposal.requested_minimum_transition_type] ?? proposal.requested_minimum_transition_type}
+        <span
+          className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-200 dark:bg-amber-800/40 text-amber-900 dark:text-amber-300"
+          data-testid="requested-minimum-transition-type"
+        >
+          min:{' '}
+          {COMPONENT_TRANSITION_TYPE_LABELS[proposal.requested_minimum_transition_type] ??
+            proposal.requested_minimum_transition_type}
         </span>
-        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-800/40 text-amber-300/80 font-mono">
+        {proposal.requested_required_transition_type && (
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-200 dark:bg-amber-800/40 text-amber-900 dark:text-amber-300"
+            data-testid="requested-required-transition-type"
+          >
+            required:{' '}
+            {COMPONENT_TRANSITION_TYPE_LABELS[proposal.requested_required_transition_type] ??
+              proposal.requested_required_transition_type}
+          </span>
+        )}
+        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-200 dark:bg-amber-800/40 text-amber-900 dark:text-amber-300/80 font-mono">
           {proposal.project_id}
         </span>
       </div>
 
       {proposal.source_paths && proposal.source_paths.length > 0 && (
-        <div className="text-xs text-amber-200/50 font-mono truncate">
+        <div className="text-xs text-amber-800/60 dark:text-amber-200/50 font-mono truncate">
           {proposal.source_paths.join(', ')}
         </div>
       )}
 
-      <div className="text-xs text-amber-200/40">
-        {new Date(proposal.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+      <div className="text-xs text-amber-800/50 dark:text-amber-200/40">
+        {new Date(proposal.created_at).toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })}
       </div>
     </div>
   )
+}
+
+// ENC-FTR-076 v2 / AC[3]-c — Approve modal with required_transition_type + alarm_arn overrides.
+interface ApproveConfirmPayload {
+  minimum_transition_type: ComponentTransitionType
+  required_transition_type: ComponentTransitionType
+  alarm_arn: string
 }
 
 function ApproveModal({
@@ -545,26 +647,63 @@ function ApproveModal({
   isSubmitting,
 }: {
   proposal: ComponentProposal
-  onConfirm: (transitionType: ComponentTransitionType) => void
+  onConfirm: (payload: ApproveConfirmPayload) => void
   onCancel: () => void
   isSubmitting: boolean
 }) {
-  const [transitionType, setTransitionType] = useState<ComponentTransitionType>(
+  const [minimumType, setMinimumType] = useState<ComponentTransitionType>(
     proposal.requested_minimum_transition_type,
   )
+  // Default required_transition_type: proposal's requested value, else mirror minimum.
+  const [requiredType, setRequiredType] = useState<ComponentTransitionType>(
+    proposal.requested_required_transition_type ?? proposal.requested_minimum_transition_type,
+  )
+  const [alarmArn, setAlarmArn] = useState('')
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal
+      aria-label="Approve Component"
+      data-testid="approve-modal"
+    >
       <div className="relative z-10 w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl p-5 shadow-2xl">
         <h2 className="text-sm font-semibold text-slate-100 mb-2">Approve Component</h2>
         <p className="text-xs text-slate-400 mb-3">
-          Approve <span className="text-slate-200 font-medium font-mono">{proposal.component_id}</span> and set its minimum transition type.
+          Approve <span className="text-slate-200 font-medium font-mono">{proposal.component_id}</span>.
         </p>
+
+        <div className="bg-slate-800/40 border border-slate-700/60 rounded px-3 py-2 mb-4 space-y-1">
+          <p className="text-xs text-slate-500">
+            Proposing session:{' '}
+            <span className="text-slate-300 font-mono">{proposal.proposing_agent_session_id}</span>
+          </p>
+          <p className="text-xs text-slate-500">
+            Requested minimum:{' '}
+            <span className="text-slate-300">
+              {COMPONENT_TRANSITION_TYPE_LABELS[proposal.requested_minimum_transition_type] ??
+                proposal.requested_minimum_transition_type}
+            </span>
+          </p>
+          {proposal.requested_required_transition_type && (
+            <p className="text-xs text-slate-500">
+              Requested required:{' '}
+              <span className="text-slate-300">
+                {COMPONENT_TRANSITION_TYPE_LABELS[proposal.requested_required_transition_type] ??
+                  proposal.requested_required_transition_type}
+              </span>
+            </p>
+          )}
+        </div>
+
         <label className="block text-xs text-slate-500 mb-1">Minimum Transition Type</label>
         <select
-          value={transitionType}
-          onChange={(e) => setTransitionType(e.target.value as ComponentTransitionType)}
-          className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-slate-500 mb-4"
+          value={minimumType}
+          onChange={(e) => setMinimumType(e.target.value as ComponentTransitionType)}
+          data-testid="approve-minimum-transition-type"
+          aria-label="Minimum Transition Type"
+          className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-slate-500 mb-3"
         >
           {COMPONENT_TRANSITION_TYPES.map((tt) => (
             <option key={tt} value={tt}>
@@ -572,6 +711,35 @@ function ApproveModal({
             </option>
           ))}
         </select>
+
+        <label className="block text-xs text-slate-500 mb-1">Required Transition Type</label>
+        <select
+          value={requiredType}
+          onChange={(e) => setRequiredType(e.target.value as ComponentTransitionType)}
+          data-testid="approve-required-transition-type"
+          aria-label="Required Transition Type"
+          className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-slate-500 mb-3"
+        >
+          {COMPONENT_TRANSITION_TYPES.map((tt) => (
+            <option key={tt} value={tt}>
+              {COMPONENT_TRANSITION_TYPE_LABELS[tt] ?? tt}
+            </option>
+          ))}
+        </select>
+
+        <label className="block text-xs text-slate-500 mb-1">
+          Alarm ARN <span className="text-slate-600">(optional — v5 CloudWatch hook)</span>
+        </label>
+        <input
+          type="text"
+          value={alarmArn}
+          onChange={(e) => setAlarmArn(e.target.value)}
+          placeholder="arn:aws:cloudwatch:..."
+          data-testid="approve-alarm-arn"
+          aria-label="Alarm ARN"
+          className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 font-mono focus:outline-none focus:border-slate-500 mb-4"
+        />
+
         <div className="flex justify-end gap-2">
           <button
             type="button"
@@ -582,8 +750,15 @@ function ApproveModal({
           </button>
           <button
             type="button"
-            onClick={() => onConfirm(transitionType)}
+            onClick={() =>
+              onConfirm({
+                minimum_transition_type: minimumType,
+                required_transition_type: requiredType,
+                alarm_arn: alarmArn,
+              })
+            }
             disabled={isSubmitting}
+            data-testid="approve-confirm"
             className="px-4 py-2 text-sm font-medium text-white bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 rounded-lg transition-colors"
           >
             {isSubmitting ? 'Approving...' : 'Approve'}
@@ -595,7 +770,9 @@ function ApproveModal({
   )
 }
 
-function RejectModal({
+// ENC-FTR-076 v2 / AC[3]-d — Revert is terminal (archives component).
+// Requires reverted_reason (min 10 chars). Displays terminal warning.
+function RevertModal({
   proposal,
   onConfirm,
   onCancel,
@@ -609,20 +786,42 @@ function RejectModal({
   const [reason, setReason] = useState('')
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal
+      aria-label="Revert Component"
+      data-testid="revert-modal"
+    >
       <div className="relative z-10 w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl p-5 shadow-2xl">
-        <h2 className="text-sm font-semibold text-slate-100 mb-2">Reject Component</h2>
+        <h2 className="text-sm font-semibold text-slate-100 mb-2">Revert Component</h2>
         <p className="text-xs text-slate-400 mb-3">
-          Reject <span className="text-slate-200 font-medium font-mono">{proposal.component_id}</span>. Please provide a reason (min 10 characters).
+          Revert{' '}
+          <span className="text-slate-200 font-medium font-mono">{proposal.component_id}</span>.
         </p>
+        <div
+          className="bg-rose-900/30 border border-rose-500/40 rounded px-3 py-2 mb-3"
+          role="alert"
+        >
+          <p className="text-xs font-semibold text-rose-300 mb-0.5">Warning: terminal action</p>
+          <p className="text-xs text-rose-200/80">
+            Revert archives the component (lifecycle_status=archived) atomically. This cannot be
+            undone — a new proposal must be filed to re-register this component_id.
+          </p>
+        </div>
+        <label className="block text-xs text-slate-500 mb-1">Reverted Reason</label>
         <textarea
           value={reason}
           onChange={(e) => setReason(e.target.value)}
-          placeholder="Reason for rejection..."
+          placeholder="Reason for revert (min 10 chars)..."
           rows={3}
+          data-testid="revert-reason"
+          aria-label="Reverted Reason"
           className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-slate-500 mb-1 resize-none"
         />
-        <p className="text-xs text-slate-600 mb-4">{reason.length}/10 characters minimum</p>
+        <p className="text-xs text-slate-600 mb-4" data-testid="revert-reason-count">
+          {reason.length}/10 characters minimum
+        </p>
         <div className="flex justify-end gap-2">
           <button
             type="button"
@@ -635,9 +834,148 @@ function RejectModal({
             type="button"
             onClick={() => onConfirm(reason)}
             disabled={isSubmitting || reason.length < 10}
-            className="px-4 py-2 text-sm font-medium text-white bg-rose-700 hover:bg-rose-600 disabled:opacity-50 rounded-lg transition-colors"
+            data-testid="revert-confirm"
+            className="px-4 py-2 text-sm font-medium text-white bg-rose-700 hover:bg-rose-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
           >
-            {isSubmitting ? 'Rejecting...' : 'Reject'}
+            {isSubmitting ? 'Reverting...' : 'Revert (archive)'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// ENC-FTR-076 v2 / AC[3]-e — Deprecate modal.
+// io-only action; backend is Cognito-gated. UI surfaces the -v2/-v3 fork guidance.
+function DeprecateModal({
+  component,
+  onConfirm,
+  onCancel,
+  isSubmitting,
+}: {
+  component: RegistryComponent
+  onConfirm: (reason: string) => void
+  onCancel: () => void
+  isSubmitting: boolean
+}) {
+  const [reason, setReason] = useState('')
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal
+      aria-label="Deprecate Component"
+      data-testid="deprecate-modal"
+    >
+      <div className="relative z-10 w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl p-5 shadow-2xl">
+        <h2 className="text-sm font-semibold text-slate-100 mb-2">Deprecate Component</h2>
+        <p className="text-xs text-slate-400 mb-3">
+          Deprecate{' '}
+          <span className="text-slate-200 font-medium font-mono">{component.component_id}</span>.
+        </p>
+        <div
+          className="bg-amber-900/30 border border-amber-500/40 rounded px-3 py-2 mb-3"
+          role="alert"
+        >
+          <p className="text-xs font-semibold text-amber-300 mb-0.5">io-only action</p>
+          <p className="text-xs text-amber-200/80">
+            Deprecation is Cognito-gated (io humans only). Future development on this component
+            requires a version fork (e.g.{' '}
+            <span className="font-mono">{component.component_id}-v2</span>). Restore returns the
+            component to production (lifecycle_status=production).
+          </p>
+        </div>
+        <label className="block text-xs text-slate-500 mb-1">
+          Reason <span className="text-slate-600">(optional)</span>
+        </label>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Why is this component being deprecated?"
+          rows={3}
+          data-testid="deprecate-reason"
+          aria-label="Deprecation Reason"
+          className="w-full bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-slate-500 mb-4 resize-none"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(reason)}
+            disabled={isSubmitting}
+            data-testid="deprecate-confirm"
+            className="px-4 py-2 text-sm font-medium text-white bg-amber-700 hover:bg-amber-600 disabled:opacity-50 rounded-lg transition-colors"
+          >
+            {isSubmitting ? 'Deprecating...' : 'Deprecate'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// ENC-FTR-076 v2 / AC[3]-e — Restore modal.
+// Only available when lifecycle_status === 'deprecated'. Target is production.
+function RestoreModal({
+  component,
+  onConfirm,
+  onCancel,
+  isSubmitting,
+}: {
+  component: RegistryComponent
+  onConfirm: () => void
+  onCancel: () => void
+  isSubmitting: boolean
+}) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal
+      aria-label="Restore Component"
+      data-testid="restore-modal"
+    >
+      <div className="relative z-10 w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl p-5 shadow-2xl">
+        <h2 className="text-sm font-semibold text-slate-100 mb-2">Restore Component</h2>
+        <p className="text-xs text-slate-400 mb-3">
+          Restore{' '}
+          <span className="text-slate-200 font-medium font-mono">{component.component_id}</span> to
+          production?
+        </p>
+        <div
+          className="bg-emerald-900/30 border border-emerald-500/40 rounded px-3 py-2 mb-4"
+          role="alert"
+        >
+          <p className="text-xs text-emerald-200/90">
+            Restore moves the component from <span className="font-mono">deprecated</span> to{' '}
+            <span className="font-mono">production</span>. Only deprecated components may be
+            restored.
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            data-testid="restore-confirm"
+            className="px-4 py-2 text-sm font-medium text-white bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 rounded-lg transition-colors"
+          >
+            {isSubmitting ? 'Restoring...' : 'Restore to Production'}
           </button>
         </div>
       </div>
@@ -659,7 +997,9 @@ export function ComponentRegistryPage() {
   const [editingComponent, setEditingComponent] = useState<RegistryComponent | null>(null)
   const [deletingComponent, setDeletingComponent] = useState<RegistryComponent | null>(null)
   const [approvingProposal, setApprovingProposal] = useState<ComponentProposal | null>(null)
-  const [rejectingProposal, setRejectingProposal] = useState<ComponentProposal | null>(null)
+  const [revertingProposal, setRevertingProposal] = useState<ComponentProposal | null>(null)
+  const [deprecatingComponent, setDeprecatingComponent] = useState<RegistryComponent | null>(null)
+  const [restoringComponent, setRestoringComponent] = useState<RegistryComponent | null>(null)
   const [projectSearch, setProjectSearch] = useState('')
 
   const { components, isPending, isError, dataUpdatedAt } = useComponentRegistry({
@@ -672,7 +1012,9 @@ export function ComponentRegistryPage() {
   const updateMutation = useUpdateComponent()
   const deleteMutation = useDeleteComponent()
   const approveMutation = useApproveComponent()
-  const rejectMutation = useRejectComponent()
+  const revertMutation = useRevertComponent()
+  const deprecateMutation = useDeprecateComponent()
+  const restoreMutation = useRestoreComponent()
 
   // Derive unique project IDs from the full (unfiltered) list for the filter dropdown
   const { components: allComponents } = useComponentRegistry()
@@ -682,38 +1024,60 @@ export function ComponentRegistryPage() {
     [allComponents],
   )
 
-  // ENC-FTR-076: Pending proposals (lifecycle_status === 'proposed')
-  const pendingProposals = useMemo(
-    () =>
-      allComponents.filter(
-        (c) => (c as unknown as ComponentProposal).lifecycle_status === 'proposed',
-      ) as unknown as ComponentProposal[],
-    [allComponents],
-  )
+  // ENC-FTR-076 v2 / AC[3]-a: Pending proposals (lifecycle_status === 'proposed').
+  // Sorted oldest-first so long-pending proposals surface at the top.
+  const pendingProposals = useMemo(() => {
+    const proposals = allComponents.filter(
+      (c) => (c as unknown as ComponentProposal).lifecycle_status === 'proposed',
+    ) as unknown as ComponentProposal[]
+    return [...proposals].sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    )
+  }, [allComponents])
 
   const handleApproveConfirm = useCallback(
-    async (transitionType: ComponentTransitionType) => {
+    async (payload: ApproveConfirmPayload) => {
       if (!approvingProposal) return
       await approveMutation.mutateAsync({
         id: approvingProposal.component_id,
-        minimum_transition_type: transitionType,
+        minimum_transition_type: payload.minimum_transition_type,
+        required_transition_type: payload.required_transition_type,
+        alarm_arn: payload.alarm_arn || undefined,
       })
       setApprovingProposal(null)
     },
     [approvingProposal, approveMutation],
   )
 
-  const handleRejectConfirm = useCallback(
+  const handleRevertConfirm = useCallback(
     async (reason: string) => {
-      if (!rejectingProposal) return
-      await rejectMutation.mutateAsync({
-        id: rejectingProposal.component_id,
-        rejection_reason: reason,
+      if (!revertingProposal) return
+      await revertMutation.mutateAsync({
+        id: revertingProposal.component_id,
+        reverted_reason: reason,
       })
-      setRejectingProposal(null)
+      setRevertingProposal(null)
     },
-    [rejectingProposal, rejectMutation],
+    [revertingProposal, revertMutation],
   )
+
+  const handleDeprecateConfirm = useCallback(
+    async (reason: string) => {
+      if (!deprecatingComponent) return
+      await deprecateMutation.mutateAsync({
+        id: deprecatingComponent.component_id,
+        deprecated_reason: reason || undefined,
+      })
+      setDeprecatingComponent(null)
+    },
+    [deprecatingComponent, deprecateMutation],
+  )
+
+  const handleRestoreConfirm = useCallback(async () => {
+    if (!restoringComponent) return
+    await restoreMutation.mutateAsync({ id: restoringComponent.component_id })
+    setRestoringComponent(null)
+  }, [restoringComponent, restoreMutation])
 
   const handleOpenCreate = useCallback(() => {
     setEditingComponent(null)
@@ -752,11 +1116,14 @@ export function ComponentRegistryPage() {
 
   const generatedAt = dataUpdatedAt ? new Date(dataUpdatedAt).toISOString() : null
 
-  // Filter by project search input (local filter on top of server filters)
+  // Filter by project search input (local filter on top of server filters).
+  // ENC-FTR-076 v2: also strip lifecycle_status='proposed' from the main grid
+  // so proposals only render in the Pending Approval section (AC[3]-a).
   const filteredByProject = useMemo(() => {
-    if (!projectSearch.trim()) return components
+    const withoutProposed = components.filter((c) => c.lifecycle_status !== 'proposed')
+    if (!projectSearch.trim()) return withoutProposed
     const q = projectSearch.toLowerCase()
-    return components.filter(
+    return withoutProposed.filter(
       (c) =>
         c.project_id.includes(q) ||
         c.component_name.toLowerCase().includes(q) ||
@@ -766,6 +1133,33 @@ export function ComponentRegistryPage() {
 
   return (
     <div className="p-4 space-y-4">
+      {/* ENC-FTR-076 v2 / AC[3]-a: Pending Approval section pinned at the top
+          of the page. Amber-styled, oldest-first. */}
+      {pendingProposals.length > 0 && (
+        <section
+          data-testid="pending-approval-section"
+          className="bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-500/30 rounded-lg p-3 space-y-2"
+        >
+          <h2
+            className="text-xs font-semibold text-amber-900 dark:text-amber-200 uppercase tracking-wider"
+            data-testid="pending-approval-header"
+          >
+            Pending Approval ({pendingProposals.length})
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {pendingProposals.map((p) => (
+              <ProposalCard
+                key={p.component_id}
+                proposal={p}
+                canAct={canEdit}
+                onApprove={setApprovingProposal}
+                onRevert={setRevertingProposal}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Top bar */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex items-center gap-2">
@@ -852,26 +1246,6 @@ export function ComponentRegistryPage() {
         </div>
       </div>
 
-      {/* Pending Approval — ENC-FTR-076 Phase 6 */}
-      {pendingProposals.length > 0 && (
-        <section className="space-y-2">
-          <h2 className="text-xs font-semibold text-amber-200 uppercase tracking-wider">
-            Pending Approval ({pendingProposals.length})
-          </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {pendingProposals.map((p) => (
-              <ProposalCard
-                key={p.component_id}
-                proposal={p}
-                canAct={canEdit}
-                onApprove={setApprovingProposal}
-                onReject={setRejectingProposal}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
       {/* Results */}
       {isPending ? (
         <LoadingState />
@@ -888,6 +1262,8 @@ export function ComponentRegistryPage() {
               canEdit={canEdit}
               onEdit={handleOpenEdit}
               onDelete={setDeletingComponent}
+              onDeprecate={setDeprecatingComponent}
+              onRestore={setRestoringComponent}
             />
           ))}
         </div>
@@ -914,7 +1290,7 @@ export function ComponentRegistryPage() {
         />
       )}
 
-      {/* Approve modal — ENC-FTR-076 Phase 6 */}
+      {/* Approve modal — ENC-FTR-076 v2 / AC[3]-c */}
       {approvingProposal && (
         <ApproveModal
           proposal={approvingProposal}
@@ -924,13 +1300,33 @@ export function ComponentRegistryPage() {
         />
       )}
 
-      {/* Reject modal — ENC-FTR-076 Phase 6 */}
-      {rejectingProposal && (
-        <RejectModal
-          proposal={rejectingProposal}
-          onConfirm={handleRejectConfirm}
-          onCancel={() => setRejectingProposal(null)}
-          isSubmitting={rejectMutation.isPending}
+      {/* Revert modal — ENC-FTR-076 v2 / AC[3]-d (terminal-archive) */}
+      {revertingProposal && (
+        <RevertModal
+          proposal={revertingProposal}
+          onConfirm={handleRevertConfirm}
+          onCancel={() => setRevertingProposal(null)}
+          isSubmitting={revertMutation.isPending}
+        />
+      )}
+
+      {/* Deprecate modal — ENC-FTR-076 v2 / AC[3]-e (io only) */}
+      {deprecatingComponent && (
+        <DeprecateModal
+          component={deprecatingComponent}
+          onConfirm={handleDeprecateConfirm}
+          onCancel={() => setDeprecatingComponent(null)}
+          isSubmitting={deprecateMutation.isPending}
+        />
+      )}
+
+      {/* Restore modal — ENC-FTR-076 v2 / AC[3]-e (deprecated → production) */}
+      {restoringComponent && (
+        <RestoreModal
+          component={restoringComponent}
+          onConfirm={handleRestoreConfirm}
+          onCancel={() => setRestoringComponent(null)}
+          isSubmitting={restoreMutation.isPending}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Pending Approval amber section pinned at the top of `/components`, sorted oldest-first
- 8-status lifecycle badges per DOC-546B896390EA §3 (proposed/approved gray, designed blue, development indigo, production emerald, code-red rose, deprecated amber, archived slate)
- Four io-only modals — approve (minimum_transition_type + required_transition_type + optional alarm_arn overrides), revert (reverted_reason min 10 chars, terminal-archive warning), deprecate (io-only, -v2/-v3 fork guidance), restore (deprecated → production)
- Extended `api/components.ts` types + `useComponentRegistry` hooks against dict v2026-04-19.04
- Proposed components stripped from the main grid so they only render in Pending Approval
- Vitest smoke covers all AC[3] evidence points

## Tracker
- Task: ENC-TSK-F44 (web_deploy)
- Plan: ENC-PLN-040
- Feature: ENC-FTR-076 v2
- Spec: DOC-546B896390EA AC[3]
- Dict contract: v2026-04-19.04

## Commit Complete ID
CCI-2b102536823c4be0a40b384d592a9b8d

## Test plan
- [x] Vite build passes (`npm run build` green, ComponentRegistryPage chunk emitted)
- [x] Vitest smoke covers Pending Approval render + 4 modals + revert min-10 gating + deprecate/restore button surfacing (`src/pages/ComponentRegistryPage.test.tsx`, 7/7 pass)
- [x] ESLint clean on all touched files
- [ ] PR Commit Gate validates CCI
- [ ] UI Backend Deploy workflow publishes to https://jreese.net/enceladus

Note: backend handlers for advance/revert/deprecate/restore land in F40 (currently blocked on deploy-intake 401). Live round-trip testing deferred — smoke scope is render + form-validation + click-through per F44 dispatch context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)