### PR TITLE
ENC-PLN-042 Stage 3 / ISS-284: PWA filter widens to awaiting_prod_approval

### DIFF
--- a/frontend/ui/src/pages/DeploymentManagerPage.tsx
+++ b/frontend/ui/src/pages/DeploymentManagerPage.tsx
@@ -30,6 +30,7 @@ function sanitizeDecision(d: DeploymentDecision): DeploymentDecision {
 
 const STATUS_COLORS: Record<string, string> = {
   pending_approval: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+  awaiting_prod_approval: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
   approved: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
   diverted: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
   reverted: 'bg-red-500/20 text-red-400 border-red-500/30',
@@ -88,7 +89,8 @@ function DecisionCard({
   const [showRevertDialog, setShowRevertDialog] = useState(false)
   const [revertReason, setRevertReason] = useState('')
 
-  const isPending = decision.status === 'pending_approval'
+  const isPending =
+    decision.status === 'pending_approval' || decision.status === 'awaiting_prod_approval'
   const queue_time = timeInQueue(decision.created_at)
 
   return (
@@ -273,7 +275,12 @@ export function DeploymentManagerPage() {
   const [actionError, setActionError] = useState<string | null>(null)
 
   const pendingDecisions = useMemo(
-    () => decisions.filter((d) => d.status === 'pending_approval').map(sanitizeDecision),
+    () =>
+      decisions
+        .filter(
+          (d) => d.status === 'pending_approval' || d.status === 'awaiting_prod_approval',
+        )
+        .map(sanitizeDecision),
     [decisions],
   )
 

--- a/frontend/ui/src/types/deployments.ts
+++ b/frontend/ui/src/types/deployments.ts
@@ -30,6 +30,7 @@ export interface DeploymentDecision {
 
 export type DeploymentStatus =
   | 'pending_approval'
+  | 'awaiting_prod_approval'
   | 'approved'
   | 'diverted'
   | 'reverted'


### PR DESCRIPTION
## Summary

Frontend half of ENC-TSK-F54 gamma-success two-stage governance intent. Shipped bundle (DeploymentManagerPage-BgN9i3bf.js) filters strictly on `d.status === 'pending_approval'`; backfilled DPL rows in the new `awaiting_prod_approval` state produced a non-zero badge but zero rendered cards, blocking all PR-approval flow through the Deployment Manager PWA.

- `types/deployments.ts` — DeploymentStatus union extends with `awaiting_prod_approval`
- `DeploymentManagerPage.tsx` — STATUS_COLORS, isPending, and useMemo filter widened

CCI-1deb159eca874611b20b077af17ed0f7

## Follow-ups (NOT in this PR)

- PWA bundle rebuild + `aws s3 sync` to `s3://jreese-net/enceladus/` + CloudFront invalidation (`/enceladus/*`) — supersede delivery since the frontend-deploy workflow may not trigger for every merge
- Revert 3 DDB workaround rows (PR 394/395/396) from `pending_approval` back to `awaiting_prod_approval` after the new bundle is live

## Governance

- Plan: ENC-PLN-042 (remediation plan)
- Task: ENC-TSK-F72 (Stage 3; status=pr)
- Wave: DOC-AA6D4AAEB8FA
- Closes: ENC-ISS-284 (pending merge + live deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)