### PR TITLE
ENC-PLN-042 Stage 4 / F73: env_drift_auditor CFN adoption (F57 AC-3/4/5/7)

### DIFF
--- a/.github/workflows/lambda-env-drift-auditor-deploy.yml
+++ b/.github/workflows/lambda-env-drift-auditor-deploy.yml
@@ -1,0 +1,35 @@
+name: Lambda Deploy - devops-env-drift-auditor
+
+# ENC-TSK-F73 / ENC-PLN-042 Stage 4 (F57 AC-7).
+
+on:
+  push:
+    branches:
+      - main
+      - 'v4/**'
+    paths:
+      - "backend/lambda/env_drift_auditor/**"
+      - ".github/workflows/lambda-env-drift-auditor-deploy.yml"
+      - ".github/workflows/deploy-orchestration.yml"
+      - ".github/workflows/lambda-deploy-reusable.yml"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual deploy"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-orchestration.yml
+    with:
+      function_name: "devops-env-drift-auditor"
+      lambda_dir: "backend/lambda/env_drift_auditor"
+      deploy_script: "backend/lambda/env_drift_auditor/deploy.sh"
+      deploy_mode: "per-lambda"
+    secrets: inherit

--- a/backend/lambda/env_drift_auditor/deploy.sh
+++ b/backend/lambda/env_drift_auditor/deploy.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# ENC-TSK-F73 / ENC-PLN-042 Stage 4 — env_drift_auditor Lambda (F57 AC-5).
+#
+# Pattern mirrors backend/lambda/deploy_capability_auditor/deploy.sh: self-
+# managed IAM role created via deploy.sh ensure_role (so that the live role
+# matches the inline policy stamped in 02-compute.yaml EnvDriftAuditorRole),
+# code-only package bundling lambda_function.py + env_drift_registry.json,
+# EventBridge schedule maintained out-of-band (devops-env-drift-auditor-hourly).
+
+set -euo pipefail
+
+ENVIRONMENT_SUFFIX="${ENVIRONMENT_SUFFIX:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+source "${REPO_ROOT}/tools/lambda_artifact_helper.sh"
+REGION="${REGION:-us-west-2}"
+ACCOUNT_ID="${ACCOUNT_ID:-356364570033}"
+FUNCTION_NAME="${FUNCTION_NAME:-devops-env-drift-auditor${ENVIRONMENT_SUFFIX}}"
+ROLE_NAME="${ROLE_NAME:-devops-env-drift-auditor-role${ENVIRONMENT_SUFFIX}}"
+ZIP_FILE="/tmp/${FUNCTION_NAME}.zip"
+
+log() { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+ensure_role() {
+  if aws iam get-role --role-name "${ROLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+    log "[INFO] Role ${ROLE_NAME} exists"
+    return
+  fi
+  log "[INFO] Creating role ${ROLE_NAME}"
+  aws iam create-role \
+    --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document '{
+      "Version":"2012-10-17",
+      "Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]
+    }' \
+    --region "${REGION}" >/dev/null
+
+  aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name env-drift-auditor-inline \
+    --policy-document '{
+      "Version":"2012-10-17",
+      "Statement":[
+        {"Sid":"CloudWatchLogs","Effect":"Allow","Action":[
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],"Resource":"arn:aws:logs:*:*:*"},
+        {"Sid":"LambdaConfigRead","Effect":"Allow","Action":[
+          "lambda:GetFunctionConfiguration",
+          "lambda:ListFunctions"
+        ],"Resource":"*"}
+      ]
+    }' \
+    --region "${REGION}" >/dev/null
+
+  log "[INFO] Waiting 10s for IAM propagation"
+  sleep 10
+}
+
+package_lambda() {
+  local resolved_zip
+  if resolved_zip="$(resolve_artifact "${FUNCTION_NAME}" "${ZIP_FILE}")"; then
+    echo "${resolved_zip}"
+    return 0
+  fi
+  local build_dir
+  build_dir="$(mktemp -d /tmp/build-${FUNCTION_NAME}-XXXXXX)"
+  cp "${SCRIPT_DIR}/lambda_function.py" "${build_dir}/"
+  cp "${SCRIPT_DIR}/env_drift_registry.json" "${build_dir}/"
+  (
+    cd "${build_dir}"
+    zip -qr "${ZIP_FILE}" .
+  )
+  rm -rf "${build_dir}"
+}
+
+deploy_lambda() {
+  local role_arn
+  role_arn="$(aws iam get-role --role-name "${ROLE_NAME}" --region "${REGION}" --query 'Role.Arn' --output text)"
+
+  local arch_flag="x86_64" runtime_flag="python3.11"
+  if [ -n "${ENVIRONMENT_SUFFIX}" ]; then
+    arch_flag="arm64"
+    runtime_flag="python3.12"
+  fi
+
+  local env_vars
+  env_vars=$(jq -n --arg key "${COORDINATION_INTERNAL_API_KEY:-}" \
+    --arg tracker "${TRACKER_API_BASE:-https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker}" \
+    --arg project "${ISSUE_PROJECT_ID:-enceladus}" \
+    --arg severity "${DRIFT_SEVERITY:-P0}" \
+    --arg dry "${DRY_RUN:-false}" \
+    '{Variables: {
+      TRACKER_API_BASE: $tracker,
+      COORDINATION_INTERNAL_API_KEY: $key,
+      ISSUE_PROJECT_ID: $project,
+      DRIFT_SEVERITY: $severity,
+      DRY_RUN: $dry
+    }}')
+
+  if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+    log "[INFO] Updating ${FUNCTION_NAME}"
+    aws lambda update-function-code \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}" \
+      --zip-file "fileb://${ZIP_FILE}" \
+      --architectures "${arch_flag}" >/dev/null
+    aws lambda wait function-updated-v2 \
+      --function-name "${FUNCTION_NAME}" --region "${REGION}"
+    aws lambda update-function-configuration \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}" \
+      --role "${role_arn}" \
+      --handler "lambda_function.lambda_handler" \
+      --runtime "${runtime_flag}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${env_vars}" >/dev/null
+  else
+    log "[INFO] Creating ${FUNCTION_NAME}"
+    aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --region "${REGION}" \
+      --runtime "${runtime_flag}" \
+      --architectures "${arch_flag}" \
+      --role "${role_arn}" \
+      --handler "lambda_function.lambda_handler" \
+      --zip-file "fileb://${ZIP_FILE}" \
+      --timeout 60 \
+      --memory-size 256 \
+      --environment "${env_vars}" >/dev/null
+  fi
+
+  aws lambda wait function-active-v2 --function-name "${FUNCTION_NAME}" --region "${REGION}"
+}
+
+main() {
+  log "[START] Deploy env drift auditor → ${FUNCTION_NAME}"
+  ensure_role
+  package_lambda
+  deploy_lambda
+  rm -f "${ZIP_FILE}"
+  log "[SUCCESS] ${FUNCTION_NAME} deployed"
+}
+
+main "$@"

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -764,6 +764,40 @@ Resources:
           Value: neo4j-backup
 
   # ---------------------------------------------------------------------------
+  # ENC-TSK-F73 / ENC-ISS-283: Env Drift Auditor Lambda (F57 AC-3/4 CFN adoption)
+  # Live resource created out-of-band for ENC-ISS-283; imported under this stack
+  # via create-change-set --change-set-type=IMPORT. EventBridge schedule
+  # (devops-env-drift-auditor-hourly) remains unmanaged and is not in scope here.
+  # ---------------------------------------------------------------------------
+
+  DevopsEnvDriftAuditorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-env-drift-auditor${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      Role: !GetAtt EnvDriftAuditorRole.Arn
+      Environment:
+        Variables:
+          TRACKER_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          ISSUE_PROJECT_ID: enceladus
+          DRIFT_SEVERITY: P0
+          DRY_RUN: "false"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: env-drift-auditor
+
+  # ---------------------------------------------------------------------------
   # ENC-TSK-C10: Graph Health Metrics Lambda (CloudWatch proxy path)
   # ---------------------------------------------------------------------------
 
@@ -1621,6 +1655,45 @@ Resources:
       Tags:
         - Key: Project
           Value: enceladus
+
+  # ENC-TSK-F73 / ENC-ISS-283: EnvDriftAuditor IAM role (F57 AC-4 CFN adoption).
+  # Inline policy `env-drift-auditor-inline` is stamped to match live exactly so
+  # the CFN IMPORT change set reports no drift on the imported role.
+  EnvDriftAuditorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-env-drift-auditor-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: env-drift-auditor-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Sid: LambdaConfigRead
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:ListFunctions
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: env-drift-auditor
 
 Outputs:
   CoordinationApiFunctionArn:

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -186,6 +186,12 @@
       "workflow_file": ".github/workflows/lambda-deploy-capability-auditor-deploy.yml",
       "deploy_script": "backend/lambda/deploy_capability_auditor/deploy.sh",
       "cfn_managed": false
+    },
+    {
+      "function_name": "devops-env-drift-auditor",
+      "lambda_dir": "backend/lambda/env_drift_auditor",
+      "workflow_file": ".github/workflows/lambda-env-drift-auditor-deploy.yml",
+      "deploy_script": "backend/lambda/env_drift_auditor/deploy.sh"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Stage 4 of ENC-PLN-042 remediation wave (DOC-AA6D4AAEB8FA) — brings the out-of-band live `devops-env-drift-auditor` Lambda + IAM role under CloudFormation management by adding the resources to `enceladus-compute` and running a resource-import change set (executed post-merge by this session against the product-lead AWS profile).

- `infrastructure/cloudformation/02-compute.yaml`: adds `DevopsEnvDriftAuditorFunction` (python3.11/x86_64 for prod, gamma-aware via `IsGamma`, 256 MB / 60 s, `DeletionPolicy: Retain`, env vars `TRACKER_API_BASE` + `COORDINATION_INTERNAL_API_KEY` (!Ref Parameter) + `ISSUE_PROJECT_ID=enceladus` + `DRIFT_SEVERITY=P0` + `DRY_RUN=false`) and `EnvDriftAuditorRole` (inline `env-drift-auditor-inline` policy matching live exactly: CloudWatch Logs + `lambda:GetFunctionConfiguration`/`ListFunctions`). EventBridge schedule `devops-env-drift-auditor-hourly` intentionally out of scope.
- `backend/lambda/env_drift_auditor/deploy.sh`: mirrors `deploy_capability_auditor` pattern — self-managed IAM role (ensure_role), code-only package bundling `lambda_function.py` + `env_drift_registry.json`. Hits F57 AC-5.
- `.github/workflows/lambda-env-drift-auditor-deploy.yml`: follows `lambda-deploy-capability-auditor-deploy.yml` contract, `per-lambda` deploy_mode. Hits F57 AC-7.

## Why

Closes F57 AC-3 (CFN Lambda), AC-4 (CFN Role), AC-5 (deploy.sh), AC-7 (GHA workflow). Remaining F57 ACs (6 + 8) addressed by Stage 5 (F74).

## Commit Complete ID

CCI-41517406062744878b9d377d339825ff

## Test plan

- [x] CFN YAML parses (62 resources, `DevopsEnvDriftAuditorFunction` + `EnvDriftAuditorRole` present)
- [x] deploy.sh passes `bash -n`
- [x] GHA workflow YAML parses
- [ ] Post-merge: `aws cloudformation create-change-set --change-set-type=IMPORT` against `enceladus-compute` for the two new resources — reviewed + executed by this session (CONFIRMED INLINE)
- [ ] Post-merge: `aws cloudformation describe-stack-resources --stack-name enceladus-compute` confirms both are CFN-managed
- [ ] Post-merge: GHA workflow run for `devops-env-drift-auditor` deploy-success evidence (touching backend/lambda/env_drift_auditor/** triggers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)