### PR TITLE
ENC-PLN-042 Stage 6 / F75: remove RouteComponentsAdvance (ISS-278 Mitigation A)

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -281,12 +281,12 @@ Resources:
   # revert's prior sibling _handle_components_propose + _handle_components_approve
   # registered under existing CFN routes; these six are additive.
 
-  RouteComponentsAdvance:
-    Type: AWS::ApiGatewayV2::Route
-    Properties:
-      ApiId: !Ref HttpApi
-      RouteKey: POST /api/v1/coordination/components/{componentId}/advance
-      Target: !Sub integrations/${CoordinationApiIntegration}
+  # ENC-TSK-F75 / ENC-ISS-278 Mitigation A: RouteComponentsAdvance was provisioned
+  # out-of-band on API 8nkzqkmxqc (pre-F40 H-PREREQ) and exists as an orphan not
+  # managed by this stack. Leaving it unmanaged was chosen over deleting it (the
+  # route actively serves prod traffic) so the five sibling routes below can deploy
+  # without ConflictException blocking the whole batch. Follow-up: adopt the live
+  # orphan via create-change-set --change-set-type=IMPORT (deferred).
 
   RouteComponentsAddEdge:
     Type: AWS::ApiGatewayV2::Route


### PR DESCRIPTION
## Summary

Unblocks the F40 H-PREREQ route batch by removing `RouteComponentsAdvance` from `03-api.yaml`. The orphan APIGW route on API `8nkzqkmxqc` stays live (it actively serves prod traffic) and remains drift-managed pending a follow-up resource-import. The other five F40 routes (AddEdge/RemoveEdge/Deprecate/Restore/Revert) now deploy cleanly.

## Commit Complete ID

CCI-d387f886a97a48be8e879aa6995d98b9

## Test plan

- [x] YAML parses (67 resources, RouteComponentsAdvance absent)
- [ ] Post-merge: CFN API Stack Deploy workflow completes without ConflictException
- [ ] Post-merge: `aws apigatewayv2 get-routes --api-id 8nkzqkmxqc --query "Items[?contains(RouteKey, 'components/{componentId}')]"` returns all 6 routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)