### PR TITLE
ENC-TSK-F43: v5 CloudWatch alarm_arn stub (FTR-076v2 Phase 7)

### DIFF
--- a/backend/lambda/coordination_api/deploy.sh
+++ b/backend/lambda/coordination_api/deploy.sh
@@ -1019,6 +1019,7 @@ ensure_api_integration_and_routes() {
     "POST /api/v1/coordination/components/{componentId}/deprecate"
     "POST /api/v1/coordination/components/{componentId}/restore"
     "POST /api/v1/coordination/components/{componentId}/revert"
+    "POST /api/v1/coordination/components/{componentId}/cloudwatch_event"
   )
 
   local existing_route_keys

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-20.44",
-  "updated_at": "2026-04-20T20:00:00Z",
-  "last_change_summary": "ENC-TSK-F42 / ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: Opacity model enforcement landed. coordination_api._handle_components_get returns 404 identical to non-existent for OPAQUE_STATUSES={archived}; BLOCKED_STATUSES={proposed,deprecated} return full record. checkout_service._handle_checkout opacity gate added before strictness matrix: OPAQUE \u2192 identical 404, BLOCKED \u2192 400 with component_id + status. Constants mirrored in checkout_service as _OPAQUE_LIFECYCLE_STATUSES / _BLOCKED_LIFECYCLE_STATUSES. component_registry.opacity_model enforcement_surfaces already listed both surfaces (F53 encoded, F42 enforces). Tests: test_component_opacity.py (coordination_api, 4 cases) + test_component_opacity_gate.py (checkout_service, 6 cases).",
+  "version": "2026-04-20.45",
+  "updated_at": "2026-04-20T20:30:00Z",
+  "last_change_summary": "ENC-TSK-F43 / ENC-FTR-076 v2 / DOC-546B896390EA §8: CloudWatch alarm_arn stub landed. coordination_api._handle_components_approve already persisted alarm_arn (optional ARN string) to component DDB record when provided at approval time. New handler _handle_components_cloudwatch_event added: POST /components/{id}/cloudwatch_event returns HTTP 501 with \"CloudWatch automation not available until v5\" + component_id. Route registered in deploy.sh (ENC-LSN-002). component_registry.component.fields.alarm_arn confirmed present (F53/PR#393). No EventBridge rule. No component-alarm-poller Lambda. Tests: test_component_alarm_stub.py (4 cases).",
   "owners": [
     "enceladus-platform"
   ],
@@ -25,8 +25,8 @@
             "closed",
             "deployed"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -76,8 +76,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -86,7 +86,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -112,14 +112,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -210,7 +210,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -220,12 +220,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -239,7 +239,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -253,7 +253,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -261,8 +261,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -307,7 +307,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -319,9 +319,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         }
       }
@@ -401,7 +401,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -549,7 +549,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
         }
       }
     },
@@ -585,7 +585,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -705,7 +705,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -730,7 +730,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -838,7 +838,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -945,7 +945,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -974,7 +974,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1082,7 +1082,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1214,7 +1214,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1240,7 +1240,7 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
           "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
@@ -2061,7 +2061,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2088,7 +2088,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2159,7 +2159,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2316,7 +2316,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2342,7 +2342,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2398,7 +2398,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2459,7 +2459,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2501,14 +2501,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -2537,7 +2537,7 @@
       }
     },
     "component_registry.component": {
-      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement — the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict — see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
       "fields": {
         "component_id": {
           "type": "string",
@@ -2576,7 +2576,7 @@
             "code_only",
             "no_code"
           ],
-          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement \u2014 see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
+          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement — see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
         },
         "required_transition_type": {
           "type": "string",
@@ -2595,9 +2595,9 @@
             "code_only": 2,
             "no_code": 3
           },
-          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field \u2014 not the legacy transition_type \u2014 and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
-          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent \u2014 same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
-          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) \u2014 raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
+          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field — not the legacy transition_type — and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
+          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent — same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
+          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) — raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
         },
         "description": {
           "type": "string",
@@ -2640,9 +2640,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -2675,11 +2675,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -2696,18 +2696,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -2809,7 +2809,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -2863,17 +2863,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -2891,7 +2891,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -2904,12 +2904,12 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
       "description": "Five-surface defense-in-depth contract for required_transition_type on component_registry.component (ENC-TSK-F50 / ENC-ISS-270). Mirrors the governance.ogtm pattern (ENC-FTR-066): every component record must carry required_transition_type, and every write path into the component registry validates its presence and type. Governance-intent source: DOC-240A67973B13 (AC-1 per-component review document).",
@@ -3045,12 +3045,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3073,7 +3073,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3521,7 +3521,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -3549,7 +3549,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -3562,7 +3562,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -3593,9 +3593,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -3703,7 +3703,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -3718,7 +3718,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -3981,7 +3981,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4011,7 +4011,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4028,12 +4028,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4060,23 +4060,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
+          "definition": "Plan → document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -4257,11 +4257,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -4294,7 +4294,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         }
       }
     },
@@ -4345,7 +4345,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -4364,12 +4364,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md \u00a713 Governance File Authority"
+          "reference": "agents.md §13 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -4381,7 +4381,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -4408,7 +4408,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -4421,7 +4421,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -4450,7 +4450,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -4581,7 +4581,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -4630,7 +4630,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -4651,7 +4651,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -4746,7 +4746,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -4779,7 +4779,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -4846,12 +4846,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match \u2014 fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match — fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -4861,28 +4861,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -8737,6 +8737,28 @@ def _handle_components_reject(
     )
 
 
+def _handle_components_cloudwatch_event(
+    component_id: str, event: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/components/{id}/cloudwatch_event — v5 stub.
+
+    ENC-TSK-F43 / DOC-546B896390EA §8. CloudWatch alarm automation is deferred
+    to v5. Any non-empty JSON body is accepted; malformed bodies are treated
+    gracefully. Always returns HTTP 501.
+    """
+    try:
+        json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        pass  # treat malformed body as empty — still 501, no 500
+    return _response(
+        501,
+        {
+            "error": "CloudWatch automation not available until v5",
+            "component_id": component_id,
+        },
+    )
+
+
 # ============================================================================
 # ENC-FTR-076 v2 / ENC-TSK-F40 — state machine + edge + advance/revert/deprecate/
 # restore handlers. Spec: DOC-546B896390EA §3 (state machine), §4 (edge types),
@@ -13642,7 +13664,7 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     # (enforced inside the handlers via _is_cognito_session checks).
     match_comp_f40 = re.fullmatch(
         r"/api/v1/coordination/components/([A-Za-z0-9_\-]+)/"
-        r"(advance|add_edge|remove_edge|deprecate|restore|revert)",
+        r"(advance|add_edge|remove_edge|deprecate|restore|revert|cloudwatch_event)",
         path,
     )
     if method == "POST" and match_comp_f40:
@@ -13660,6 +13682,8 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
             return _handle_components_restore(comp_id, event, claims or {})
         if action == "revert":
             return _handle_components_revert(comp_id, event, claims or {})
+        if action == "cloudwatch_event":
+            return _handle_components_cloudwatch_event(comp_id, event)
 
     # GET /api/v1/coordination/components/{componentId}
     match_comp = re.fullmatch(r"/api/v1/coordination/components/([A-Za-z0-9_\-]+)", path)

--- a/backend/lambda/coordination_api/test_component_alarm_stub.py
+++ b/backend/lambda/coordination_api/test_component_alarm_stub.py
@@ -1,0 +1,139 @@
+"""Tests for ENC-TSK-F43 alarm_arn persist + cloudwatch_event 501 stub.
+
+Validates AC[1i]-a through AC[1i]-d:
+- component.approve with alarm_arn → field persisted in DDB update
+- component.approve without alarm_arn → alarm_arn absent from update expression
+- POST /cloudwatch_event with valid JSON body → 501 with correct body shape
+- POST /cloudwatch_event with malformed body → graceful 501 (no 500)
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = coordination_lambda
+_SPEC.loader.exec_module(coordination_lambda)
+
+_ARN = "arn:aws:cloudwatch:us-west-2:123456789012:alarm:MyAlarm"
+
+
+def _cognito_claims():
+    return {"sub": "io-lead-cognito-user", "cognito:username": "io-lead", "iss": "cognito"}
+
+
+def _approve_event(body: dict) -> dict:
+    return {
+        "httpMethod": "POST",
+        "path": "/api/v1/coordination/components/comp-test/approve",
+        "body": json.dumps(body),
+    }
+
+
+def _cloudwatch_event(body_str: str) -> dict:
+    return {
+        "httpMethod": "POST",
+        "path": "/api/v1/coordination/components/comp-test/cloudwatch_event",
+        "body": body_str,
+    }
+
+
+class AlarmArnApproveTests(unittest.TestCase):
+
+    def setUp(self):
+        self._flag_patcher = mock.patch.object(
+            coordination_lambda, "ENABLE_COMPONENT_PROPOSAL", True
+        )
+        self._flag_patcher.start()
+
+    def tearDown(self):
+        self._flag_patcher.stop()
+
+    def test_approve_with_alarm_arn_persists_field(self):
+        """AC[1i]-a: alarm_arn is written to DDB when provided at approve time."""
+        fake_ddb = mock.MagicMock()
+        fake_ddb.update_item.return_value = {
+            "Attributes": {
+                "component_id": {"S": "comp-test"},
+                "lifecycle_status": {"S": "approved"},
+                "alarm_arn": {"S": _ARN},
+            }
+        }
+        with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake_ddb), \
+             mock.patch.object(coordination_lambda, "_is_cognito_session", return_value=True), \
+             mock.patch.object(coordination_lambda, "_publish_component_lifecycle_event"):
+            resp = coordination_lambda._handle_components_approve(
+                "comp-test",
+                _approve_event({"alarm_arn": _ARN}),
+                _cognito_claims(),
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        # The UpdateExpression must include alarm_arn
+        call_kwargs = fake_ddb.update_item.call_args.kwargs
+        update_expr = call_kwargs.get("UpdateExpression", "")
+        attr_vals = call_kwargs.get("ExpressionAttributeValues", {})
+        self.assertIn("alarm_arn", update_expr)
+        self.assertEqual(attr_vals[":alarm"]["S"], _ARN)
+
+    def test_approve_without_alarm_arn_omits_field(self):
+        """AC[1i]-a: alarm_arn absent from DDB update when not provided."""
+        fake_ddb = mock.MagicMock()
+        fake_ddb.update_item.return_value = {
+            "Attributes": {
+                "component_id": {"S": "comp-test"},
+                "lifecycle_status": {"S": "approved"},
+            }
+        }
+        with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake_ddb), \
+             mock.patch.object(coordination_lambda, "_is_cognito_session", return_value=True), \
+             mock.patch.object(coordination_lambda, "_publish_component_lifecycle_event"):
+            resp = coordination_lambda._handle_components_approve(
+                "comp-test",
+                _approve_event({}),
+                _cognito_claims(),
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        call_kwargs = fake_ddb.update_item.call_args.kwargs
+        update_expr = call_kwargs.get("UpdateExpression", "")
+        attr_vals = call_kwargs.get("ExpressionAttributeValues", {})
+        self.assertNotIn(":alarm", attr_vals)
+        self.assertNotIn("alarm_arn", update_expr)
+
+
+class CloudwatchEventStubTests(unittest.TestCase):
+
+    def test_valid_json_body_returns_501(self):
+        """AC[1i]-b: POST /cloudwatch_event with valid JSON returns 501 with v5-deferral."""
+        body = {"AlarmName": "MyAlarm", "NewStateValue": "ALARM"}
+        resp = coordination_lambda._handle_components_cloudwatch_event(
+            "comp-test",
+            _cloudwatch_event(json.dumps(body)),
+        )
+        self.assertEqual(resp["statusCode"], 501)
+        resp_body = json.loads(resp["body"])
+        self.assertIn("v5", resp_body.get("error", "").lower())
+        self.assertEqual(resp_body.get("component_id"), "comp-test")
+
+    def test_malformed_body_returns_graceful_501(self):
+        """AC[1i]-b: malformed JSON body returns 501, not 500."""
+        resp = coordination_lambda._handle_components_cloudwatch_event(
+            "comp-test",
+            _cloudwatch_event("not-valid-json{{"),
+        )
+        self.assertEqual(resp["statusCode"], 501)
+        resp_body = json.loads(resp["body"])
+        self.assertEqual(resp_body.get("component_id"), "comp-test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ENC-TSK-F43 / ENC-FTR-076 v2 / DOC-546B896390EA §8 — v5 CloudWatch alarm_arn stub.

- **`_handle_components_cloudwatch_event`** (new): `POST /api/v1/coordination/components/{id}/cloudwatch_event` returns HTTP 501 `{"error": "CloudWatch automation not available until v5", "component_id": "<id>"}`. Accepts any JSON body; malformed bodies handled gracefully (no 500).
- **`alarm_arn` persist** (pre-existing, confirmed): `_handle_components_approve` already accepts optional `alarm_arn` string, validates it as an AWS ARN, and persists it to the component DDB record at approval time. No null written if absent.
- **Router + `deploy.sh`** (ENC-LSN-002): `cloudwatch_event` added to F40 action regex and route list.
- **Dict bump**: `governance_data_dictionary.json` → `2026-04-20.45`. `component_registry.component.fields.alarm_arn` confirmed present (F53/PR#393). No new entity required.
- **No EventBridge rule. No `ComponentAlarmPoller` Lambda. No CFN change** (AC[1i]-c).
- **Tests**: `test_component_alarm_stub.py` — 4 cases. 15 total passing in coordination_api.

## Acceptance Criteria

- [x] AC[1i]-a: `alarm_arn` persisted via `component.approve` when provided; absent when not
- [x] AC[1i]-b: `POST /cloudwatch_event` → 501 with v5-deferral message + `component_id`
- [x] AC[1i]-c: No EventBridge rule / ComponentAlarmPollerSchedule in CFN
- [x] AC[1i]-d: `governance_data_dictionary.json` `component_registry.component` documents `alarm_arn`

## Commit

`CCI-5064e54b8db64c6b9c61f834ddc62e45`

---
🤖 Agent session: `claude-code-f42-f43-opacity-alarm-2026-04-20T20-00Z`
Plan: ENC-PLN-040 | Feature: ENC-FTR-076