### PR TITLE
fix(_deploy.yml): pass required_contexts as JSON array — HTTP 422 on gamma deploy

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -205,14 +205,20 @@ jobs:
           SHA="${{ needs.resolve.outputs.commit_sha }}"
           ENV="${{ needs.resolve.outputs.environment }}"
 
-          DEPLOYMENT_ID=$(gh api \
+          PAYLOAD=$(python3 -c "
+import json, os
+print(json.dumps({
+    'ref': os.environ['SHA'],
+    'environment': os.environ['ENV'],
+    'description': 'Gen2 deploy — ENC-FTR-090',
+    'auto_merge': False,
+    'required_contexts': [],
+}))
+")
+          DEPLOYMENT_ID=$(echo "$PAYLOAD" | gh api \
             --method POST \
             "/repos/$GITHUB_REPOSITORY/deployments" \
-            -f ref="$SHA" \
-            -f environment="$ENV" \
-            -f description="Gen2 deploy — ENC-FTR-090" \
-            -F auto_merge=false \
-            -F required_contexts='[]' \
+            --input - \
             --jq '.id')
 
           echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes the first gamma deploy attempt post-F60 merge (run #24696437433).

`gh api -F required_contexts='[]'` passes a string literal `"[]"`, not a JSON array,
causing `HTTP 422: "[]" is not an array or null`. Switch to a python3-constructed JSON
body piped via `--input -` so `required_contexts` is typed as `[]`.

No structural changes to deploy logic — single step fix.

CCI-e91bcd0ce59a442b80c5b19c3674a9b3

🤖 Generated with [Claude Code](https://claude.com/claude-code)