### PR TITLE
fix(_deploy.yml): indent heredoc Python inside YAML block scalar

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -205,16 +205,17 @@ jobs:
           SHA="${{ needs.resolve.outputs.commit_sha }}"
           ENV="${{ needs.resolve.outputs.environment }}"
 
-          PAYLOAD=$(python3 -c "
-import json, os
-print(json.dumps({
-    'ref': os.environ['SHA'],
-    'environment': os.environ['ENV'],
-    'description': 'Gen2 deploy — ENC-FTR-090',
-    'auto_merge': False,
-    'required_contexts': [],
-}))
-")
+          PAYLOAD=$(python3 - <<'PY'
+          import json, os
+          print(json.dumps({
+              'ref': os.environ['SHA'],
+              'environment': os.environ['ENV'],
+              'description': 'Gen2 deploy — ENC-FTR-090',
+              'auto_merge': False,
+              'required_contexts': [],
+          }))
+          PY
+          )
           DEPLOYMENT_ID=$(echo "$PAYLOAD" | gh api \
             --method POST \
             "/repos/$GITHUB_REPOSITORY/deployments" \


### PR DESCRIPTION
## Summary

Fixes YAML parse error introduced in PR #418 (`python3 -c` → `python3 - <<'PY'`).

The heredoc Python content at column 0 breaks YAML block scalar parsing: `run: |` establishes indentation from the first content line (`set -euo pipefail` at 10 spaces); lines at column 0 fall outside the scalar. Fix: indent the Python heredoc lines to 10 spaces — YAML strips the block's base indentation, shell/Python receive unindented content. This is the same pattern used by the existing `Deploy Lambda functions` step.

CCI-091f8a2a58ee4fc48b0395f068a5c3ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)