### PR TITLE
fix(_deploy.yml): export SHA/ENV as step env vars for Python os.environ

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -200,10 +200,10 @@ jobs:
         id: create_deployment
         env:
           GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.resolve.outputs.commit_sha }}
+          ENV: ${{ needs.resolve.outputs.environment }}
         run: |
           set -euo pipefail
-          SHA="${{ needs.resolve.outputs.commit_sha }}"
-          ENV="${{ needs.resolve.outputs.environment }}"
 
           PAYLOAD=$(python3 - <<'PY'
           import json, os


### PR DESCRIPTION
## Summary

- `SHA` and `ENV` were set as shell variables in the `Create GitHub Deployment` step but Python's `os.environ` reads from process environment, not shell scope
- Every `Deploy → v4-gamma` run failed with `KeyError: 'SHA'` at this step (confirmed in runs 24697693400 and 24699807022)
- Fix: move both variables from shell assignments into the step-level `env:` block; they remain accessible to both Python and the subsequent `echo` shell command

## Test plan

- [ ] After merge, re-run `Deploy Lambda Artifacts (Gen2)` workflow — `Deploy → v4-gamma` job should reach `Create GitHub Deployment` without KeyError
- [ ] Confirm GitHub Deployment object created for `v4-gamma` environment

CCI-c0bfaca9a86845f587cfa1aefb481955

🤖 Generated with [Claude Code](https://claude.com/claude-code)