### PR TITLE
fix(deploy): function_name_map for v4-gamma Lambda name resolution

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -74,13 +74,14 @@ jobs:
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
-      commit_sha:        ${{ steps.sha.outputs.commit_sha }}
-      deploy_role_arn:   ${{ steps.manifest.outputs.deploy_role_arn }}
-      environment:       ${{ steps.manifest.outputs.environment }}
-      arch:              ${{ steps.manifest.outputs.arch }}
-      py_version:        ${{ steps.manifest.outputs.py_version }}
-      canary_preference: ${{ steps.manifest.outputs.canary_preference }}
-      version_ids_json:  ${{ steps.probe.outputs.version_ids_json }}
+      commit_sha:            ${{ steps.sha.outputs.commit_sha }}
+      deploy_role_arn:       ${{ steps.manifest.outputs.deploy_role_arn }}
+      environment:           ${{ steps.manifest.outputs.environment }}
+      arch:                  ${{ steps.manifest.outputs.arch }}
+      py_version:            ${{ steps.manifest.outputs.py_version }}
+      canary_preference:     ${{ steps.manifest.outputs.canary_preference }}
+      version_ids_json:      ${{ steps.probe.outputs.version_ids_json }}
+      function_name_map_json: ${{ steps.manifest.outputs.function_name_map_json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -111,15 +112,36 @@ jobs:
 
           [[ -n "$ROLE" ]] || { echo "::error::deploy_role_arn missing in $MANIFEST"; exit 1; }
 
+          FNMAP_JSON=$(python3 - "$MANIFEST" <<'PY'
+          import json, re, sys
+          content = open(sys.argv[1]).read()
+          result = {}
+          in_map = False
+          for line in content.splitlines():
+              if line.rstrip() == 'function_name_map:':
+                  in_map = True
+                  continue
+              if in_map:
+                  m = re.match(r'^  (\w+):\s+(\S+)', line)
+                  if m:
+                      result[m.group(1)] = m.group(2)
+                  elif line and not line.startswith(' ') and not line.startswith('#'):
+                      break
+          print(json.dumps(result))
+          PY
+          )
+
           {
             echo "deploy_role_arn=$ROLE"
             echo "environment=$ENV"
             echo "arch=$ARCH"
             echo "py_version=$PY"
             echo "canary_preference=$CANARY"
+            echo "function_name_map_json=$FNMAP_JSON"
           } >> "$GITHUB_OUTPUT"
 
           echo "Target=$TARGET  Arch=$ARCH  Runtime=$RUNTIME  Role=$ROLE"
+          echo "function_name_map: $(echo "$FNMAP_JSON" | python3 -c 'import json,sys; m=json.load(sys.stdin); print(f"{len(m)} entries")')"
 
       - name: Configure AWS credentials (build role — S3 artifact probe)
         uses: aws-actions/configure-aws-credentials@v4
@@ -248,6 +270,7 @@ jobs:
         id: lambda_deploy
         env:
           VERSION_IDS_JSON: ${{ needs.resolve.outputs.version_ids_json }}
+          FUNCTION_NAME_MAP_JSON: ${{ needs.resolve.outputs.function_name_map_json }}
           SHA: ${{ needs.resolve.outputs.commit_sha }}
           ARCH: ${{ needs.resolve.outputs.arch }}
           PY_VERSION: ${{ needs.resolve.outputs.py_version }}
@@ -257,6 +280,7 @@ jobs:
           import json, os, subprocess, sys
 
           version_ids = json.loads(os.environ['VERSION_IDS_JSON'])
+          fn_map      = json.loads(os.environ.get('FUNCTION_NAME_MAP_JSON') or '{}')
           bucket = 'jreese-net'
           arch   = os.environ['ARCH']
           py     = os.environ['PY_VERSION']
@@ -264,35 +288,44 @@ jobs:
           prefix = f"lambda-artifacts/{arch}-py{py}"
           region = 'us-west-2'
 
-          errors = []
+          errors  = []
+          skipped = []
           for fn, version_id in sorted(version_ids.items()):
+              mapped_name = fn_map.get(fn)
+              if not mapped_name:
+                  print(f'[skip] {fn}  (not in function_name_map)')
+                  skipped.append(fn)
+                  continue
               s3_key = f"{prefix}/{fn}-{sha}.zip"
-              print(f"[deploy] {fn}  s3://{bucket}/{s3_key}@{version_id}")
+              print(f"[deploy] {fn} -> {mapped_name}  s3://{bucket}/{s3_key}@{version_id}")
               r = subprocess.run([
                   'aws', 'lambda', 'update-function-code',
                   '--region', region,
-                  '--function-name', fn,
+                  '--function-name', mapped_name,
                   '--s3-bucket', bucket,
                   '--s3-key', s3_key,
                   '--s3-object-version', version_id,
                   '--publish',
               ], capture_output=True, text=True)
               if r.returncode != 0:
-                  print(f'::error::update-function-code failed for {fn}: {r.stderr.strip()}',
+                  print(f'::error::update-function-code failed for {mapped_name}: {r.stderr.strip()}',
                         file=sys.stderr)
                   errors.append(fn)
                   continue
               subprocess.run([
                   'aws', 'lambda', 'wait', 'function-updated-v2',
-                  '--region', region, '--function-name', fn,
+                  '--region', region, '--function-name', mapped_name,
               ], check=False)
-              print(f'  + {fn}')
+              print(f'  + {mapped_name}')
 
+          deployed = len(version_ids) - len(skipped) - len(errors)
+          if skipped:
+              print(f'Skipped {len(skipped)} functions with no env mapping: {", ".join(skipped)}')
           if errors:
               print(f'::error::Deploy failed for: {", ".join(errors)}', file=sys.stderr)
               sys.exit(1)
 
-          print(f'Deployed {len(version_ids)} Lambda functions  {arch}-py{py} @ {sha[:7]}')
+          print(f'Deployed {deployed} Lambda functions  {arch}-py{py} @ {sha[:7]}')
           PY
 
       - name: Set deployment status → success

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -40,3 +40,37 @@ appconfig_environment_id: ""
 # (rules: manifest_artifact_version_ids_shape + manifest_artifact_commit_sha_pinned).
 artifact_commit_sha: ""
 artifact_version_ids: {}
+
+# ENC-TSK-F60 Phase 2 — directory-name → deployed Lambda function name mapping.
+# _deploy.yml resolve step outputs this as function_name_map_json; deploy step uses
+# the mapped name in `aws lambda update-function-code --function-name`.
+# Gamma uses prefixed/hyphenated conventions that differ from backend/lambda/<dir> names.
+# Functions absent from this map are silently skipped by the deploy step.
+# deploy_capability_auditor intentionally excluded — not provisioned in v4-gamma.
+function_name_map:
+  auth_refresh: auth-refresh-gamma
+  bedrock_agent_actions: enceladus-bedrock-agent-actions-gamma
+  changelog_api: devops-changelog-api-gamma
+  checkout_service: enceladus-checkout-service-auto-gamma
+  coordination_api: devops-coordination-api-gamma
+  coordination_monitor_api: devops-coordination-monitor-api-gamma
+  deploy_decide: devops-deploy-decide-gamma
+  deploy_finalize: devops-deploy-finalize-gamma
+  deploy_intake: devops-deploy-intake-gamma
+  deploy_orchestrator: devops-deploy-orchestrator-gamma
+  doc_prep: devops-doc-prep-gamma
+  document_api: devops-document-api-gamma
+  env_drift_auditor: devops-env-drift-auditor-gamma
+  feed_publisher: devops-feed-publisher-gamma
+  feed_query: devops-feed-query-api-gamma
+  github_integration: devops-github-integration-gamma
+  governance_audit: enceladus-governance-audit-gamma
+  graph_health_metrics: enceladus-graph-health-metrics-gamma
+  graph_query_api: devops-graph-query-api-gamma
+  graph_sync: devops-graph-sync-gamma
+  neo4j_backup: enceladus-neo4j-backup-gamma
+  prod_health_monitor: enceladus-prod-health-monitor-gamma
+  project_service: devops-project-service-gamma
+  reference_search: devops-reference-search-gamma
+  titan_embedding_backfill: devops-titan-embedding-backfill-gamma
+  tracker_mutation: devops-tracker-mutation-api-gamma


### PR DESCRIPTION
## Root cause

All five previous fix PRs (#418–#422) missed the real failure: `_deploy.yml` called `aws lambda update-function-code --function-name auth_refresh` (bare directory name), but gamma Lambda functions use prefixed/hyphenated names (`devops-tracker-mutation-api-gamma`, `auth-refresh-gamma`, etc.). Every function returned `ResourceNotFoundException`.

## Changes

**`envs/v4-gamma.yaml`** — adds `function_name_map` block: 26 entries mapping each `backend/lambda/<dir>` name to the actual deployed Lambda function name in v4-gamma. `deploy_capability_auditor` is intentionally excluded — it is not provisioned in v4-gamma per the D60 inventory (ENC-TSK-D60).

**`.github/workflows/_deploy.yml`** — resolve step parses `function_name_map` from the manifest and outputs `function_name_map_json`. Deploy step looks up the mapped name per function, logs `[skip]` for unmapped functions (currently only `deploy_capability_auditor`), and passes `mapped_name` to `update-function-code` and `function-updated-v2` wait.

## Verification

- YAML validity confirmed locally
- Python parser smoke-tested against `envs/v4-gamma.yaml`: 26 entries parsed correctly
- `deploy_capability_auditor` (1 directory, no gamma Lambda) → silently skipped

ENC-TSK-F60 / ENC-PLN-041 Phase 2 / ENC-FTR-090

CCI-eb62b628a95248718d390ea867f12c33