### PR TITLE
fix(deploy): download artifact via runner to avoid cross-region S3 redirect

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -277,7 +277,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import json, os, subprocess, sys
+          import json, os, subprocess, sys, tempfile
 
           version_ids = json.loads(os.environ['VERSION_IDS_JSON'])
           fn_map      = json.loads(os.environ.get('FUNCTION_NAME_MAP_JSON') or '{}')
@@ -298,15 +298,35 @@ jobs:
                   continue
               s3_key = f"{prefix}/{fn}-{sha}.zip"
               print(f"[deploy] {fn} -> {mapped_name}  s3://{bucket}/{s3_key}@{version_id}")
+
+              # Download artifact to runner then push via --zip-file.
+              # Lambda UpdateFunctionCode requires S3 bucket in same region as function
+              # (us-west-2); jreese-net is in us-east-1 → PermanentRedirect on S3-side fetch.
+              tmp = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+              tmp.close()
+              dl = subprocess.run([
+                  'aws', 's3api', 'get-object',
+                  '--bucket', bucket,
+                  '--key', s3_key,
+                  '--version-id', version_id,
+                  '--region', 'us-east-1',
+                  tmp.name,
+              ], capture_output=True, text=True)
+              if dl.returncode != 0:
+                  print(f'::error::s3 download failed for {fn}: {dl.stderr.strip()}',
+                        file=sys.stderr)
+                  errors.append(fn)
+                  os.unlink(tmp.name)
+                  continue
+
               r = subprocess.run([
                   'aws', 'lambda', 'update-function-code',
                   '--region', region,
                   '--function-name', mapped_name,
-                  '--s3-bucket', bucket,
-                  '--s3-key', s3_key,
-                  '--s3-object-version', version_id,
+                  '--zip-file', f'fileb://{tmp.name}',
                   '--publish',
               ], capture_output=True, text=True)
+              os.unlink(tmp.name)
               if r.returncode != 0:
                   print(f'::error::update-function-code failed for {mapped_name}: {r.stderr.strip()}',
                         file=sys.stderr)


### PR DESCRIPTION
## Summary

- `jreese-net` S3 bucket is in `us-east-1`; Lambda functions are in `us-west-2`
- `UpdateFunctionCode --s3-bucket` triggers a Lambda service-side S3 fetch that rejects cross-region refs with `PermanentRedirect`
- Fix: `s3api get-object` (us-east-1) to runner temp file → `update-function-code --zip-file` — bypasses service-side S3 entirely
- VersionId still captured in logs for audit provenance

## Test plan

- [ ] Trigger `_deploy.yml` via `workflow_dispatch` targeting `v4-gamma` with a pre-built SHA
- [ ] Verify all 26 Lambda functions update without `PermanentRedirect` error
- [ ] Confirm deploy step completes with `Deployed N Lambda functions` summary

CCI-eb62b628a95248718d390ea867f12c33

🤖 Generated with [Claude Code](https://claude.com/claude-code)