### PR TITLE
fix(pwa): remove stale VITE_GITHUB_READ_TOKEN reference from DM error message

### DIFF
--- a/frontend/ui/src/pages/DeploymentManagerPage.tsx
+++ b/frontend/ui/src/pages/DeploymentManagerPage.tsx
@@ -233,7 +233,7 @@ export function DeploymentManagerPage() {
         </div>
       ) : isError ? (
         <div className="dm-error">
-          GitHub API unavailable — check VITE_GITHUB_READ_TOKEN or rate limits.
+          GitHub API unavailable — authentication error or rate limit exceeded.
         </div>
       ) : items.length === 0 ? (
         <div className="dm-empty">No deployments found.</div>


### PR DESCRIPTION
## Summary
- Removes stale reference to `VITE_GITHUB_READ_TOKEN` in the Deployment Manager error message
- Error text now reads: "GitHub API unavailable — authentication error or rate limit exceeded."
- Runtime token vending via `GET /api/v1/auth/github-token` (ENC-TSK-F62) replaced the build-time env var

## Test plan
- [ ] Verify error state displays updated message (trigger by unauthenticated or GitHub API error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)