### PR TITLE
feat(infra): DM Gen2 Phase 5 — AppConfig, SnapStart, CodeDeploy canary across all prod Lambdas (ENC-TSK-F63)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -82,6 +82,8 @@ jobs:
       canary_preference:     ${{ steps.manifest.outputs.canary_preference }}
       version_ids_json:      ${{ steps.probe.outputs.version_ids_json }}
       function_name_map_json: ${{ steps.manifest.outputs.function_name_map_json }}
+      environment_suffix:    ${{ steps.manifest.outputs.environment_suffix }}
+      codedeploy_app_name:   ${{ steps.manifest.outputs.codedeploy_app_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -109,6 +111,9 @@ jobs:
           RUNTIME=$(_parse runtime)
           PY="${RUNTIME#python}"
           CANARY=$(_parse canary_preference)
+          # ENC-TSK-F63 AC-2/AC-3: SnapStart and CodeDeploy fields
+          ENV_SUFFIX=$(_parse environment_suffix)
+          CODEDEPLOY_APP=$(_parse codedeploy_app_name)
 
           [[ -n "$ROLE" ]] || { echo "::error::deploy_role_arn missing in $MANIFEST"; exit 1; }
 
@@ -138,6 +143,8 @@ jobs:
             echo "py_version=$PY"
             echo "canary_preference=$CANARY"
             echo "function_name_map_json=$FNMAP_JSON"
+            echo "environment_suffix=${ENV_SUFFIX}"
+            echo "codedeploy_app_name=${CODEDEPLOY_APP}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Target=$TARGET  Arch=$ARCH  Runtime=$RUNTIME  Role=$ROLE"
@@ -274,22 +281,43 @@ jobs:
           SHA: ${{ needs.resolve.outputs.commit_sha }}
           ARCH: ${{ needs.resolve.outputs.arch }}
           PY_VERSION: ${{ needs.resolve.outputs.py_version }}
+          # ENC-TSK-F63 AC-3: CodeDeploy canary preference from env manifest.
+          # Empty string → direct alias update (AllAtOnce). Non-empty → CodeDeploy traffic shift.
+          CANARY_PREFERENCE: ${{ needs.resolve.outputs.canary_preference }}
+          ENVIRONMENT_SUFFIX: ${{ needs.resolve.outputs.environment_suffix }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import json, os, subprocess, sys, tempfile
+          import json, os, subprocess, sys, tempfile, time
 
-          version_ids = json.loads(os.environ['VERSION_IDS_JSON'])
-          fn_map      = json.loads(os.environ.get('FUNCTION_NAME_MAP_JSON') or '{}')
+          version_ids     = json.loads(os.environ['VERSION_IDS_JSON'])
+          fn_map          = json.loads(os.environ.get('FUNCTION_NAME_MAP_JSON') or '{}')
+          canary_pref     = os.environ.get('CANARY_PREFERENCE', '').strip()
           bucket = 'jreese-net'
           arch   = os.environ['ARCH']
           py     = os.environ['PY_VERSION']
           sha    = os.environ['SHA']
           prefix = f"lambda-artifacts/{arch}-py{py}"
           region = 'us-west-2'
+          # CodeDeploy application name mirrors the CFN resource in 07-codedeploy.yaml.
+          # EnvironmentSuffix embedded in the app name; v3-prod uses "" suffix.
+          env_suffix = os.environ.get('ENVIRONMENT_SUFFIX', '')
+          codedeploy_app = f"enceladus-lambda{env_suffix}"
+
+          # Map manifest canary_preference to CodeDeploy built-in config name.
+          CODEDEPLOY_CONFIG_MAP = {
+              'Canary10Percent5Minutes':        'CodeDeployDefault.LambdaCanary10Percent5Minutes',
+              'Canary10Percent10Minutes':       'CodeDeployDefault.LambdaCanary10Percent10Minutes',
+              'Linear10PercentEvery1Minute':    'CodeDeployDefault.LambdaLinear10PercentEvery1Minute',
+              'Linear10PercentEvery10Minutes':  'CodeDeployDefault.LambdaLinear10PercentEvery10Minutes',
+              'AllAtOnce':                      'CodeDeployDefault.LambdaAllAtOnce',
+          }
+          use_codedeploy = canary_pref and canary_pref != 'AllAtOnce' and canary_pref in CODEDEPLOY_CONFIG_MAP
 
           errors  = []
           skipped = []
+          deployments = []  # (fn, mapped_name, deployment_id) for CodeDeploy wait
+
           for fn, version_id in sorted(version_ids.items()):
               mapped_name = fn_map.get(fn)
               if not mapped_name:
@@ -332,11 +360,167 @@ jobs:
                         file=sys.stderr)
                   errors.append(fn)
                   continue
+
+              # ENC-TSK-F63 AC-2/AC-3: capture published version for alias + CodeDeploy.
+              try:
+                  fn_info = json.loads(r.stdout)
+                  new_version = fn_info.get('Version', '')
+              except (json.JSONDecodeError, KeyError):
+                  new_version = ''
+
               subprocess.run([
                   'aws', 'lambda', 'wait', 'function-updated-v2',
                   '--region', region, '--function-name', mapped_name,
               ], check=False)
-              print(f'  + {mapped_name}')
+
+              # ENC-TSK-F63 AC-3: Canary traffic shift via CodeDeploy.
+              # Get current alias version (CurrentVersion for CodeDeploy AppSpec).
+              if new_version and use_codedeploy:
+                  try:
+                      alias_r = subprocess.run([
+                          'aws', 'lambda', 'get-alias',
+                          '--function-name', mapped_name,
+                          '--name', 'live',
+                          '--region', region,
+                      ], capture_output=True, text=True)
+                      if alias_r.returncode == 0:
+                          alias_info = json.loads(alias_r.stdout)
+                          current_version = alias_info.get('FunctionVersion', '$LATEST')
+                      else:
+                          current_version = '$LATEST'
+
+                      account_id = subprocess.check_output(
+                          ['aws', 'sts', 'get-caller-identity', '--query', 'Account', '--output', 'text'],
+                          text=True
+                      ).strip()
+                      fn_arn_base = f"arn:aws:lambda:{region}:{account_id}:function:{mapped_name}"
+
+                      # Build AppSpec for CodeDeploy Lambda deployment.
+                      appspec = {
+                          "version": "0.0",
+                          "Resources": [{
+                              mapped_name: {
+                                  "Type": "AWS::Lambda::Function",
+                                  "Properties": {
+                                      "Name": mapped_name,
+                                      "Alias": "live",
+                                      "CurrentVersion": f"{fn_arn_base}:{current_version}" if current_version != '$LATEST' else f"{fn_arn_base}",
+                                      "TargetVersion": f"{fn_arn_base}:{new_version}",
+                                  }
+                              }
+                          }]
+                      }
+                      appspec_json = json.dumps(appspec)
+
+                      # Derive deployment group name from function name (strip env suffix).
+                      # Mapping mirrors 07-codedeploy.yaml DeploymentGroup names.
+                      dg_name_map = {
+                          'devops-coordination-api':        'coordination-api',
+                          'devops-tracker-mutation-api':    'tracker-mutation',
+                          'devops-document-api':            'document-api',
+                          'devops-graph-query-api':         'graph-query-api',
+                          'devops-project-service':         'project-service',
+                          'devops-feed-query-api':          'feed-query',
+                          'devops-coordination-monitor-api': 'coordination-monitor',
+                          'devops-deploy-intake':           'deploy-intake',
+                          'devops-reference-search':        'reference-search',
+                          'auth-refresh':                   'auth-refresh',
+                          'devops-deploy-orchestrator':     'deploy-orchestrator',
+                          'devops-deploy-finalize':         'deploy-finalize',
+                          'devops-deploy-decide':           'deploy-decide',
+                          'devops-feed-publisher':          'feed-publisher',
+                          'enceladus-governance-audit':     'governance-audit',
+                          'devops-doc-prep':                'doc-prep',
+                          'enceladus-bedrock-agent-actions': 'bedrock-agent-actions',
+                          'devops-changelog-api':           'changelog-api',
+                          'devops-graph-sync':              'graph-sync',
+                          'enceladus-neo4j-backup':         'neo4j-backup',
+                          'enceladus-graph-health-metrics': 'graph-health-metrics',
+                          'devops-env-drift-auditor':       'env-drift-auditor',
+                          'devops-deploy-parity-validator': 'deploy-parity-validator',
+                      }
+                      # Strip env suffix from mapped_name to look up base name.
+                      base_name = mapped_name
+                      if env_suffix and mapped_name.endswith(env_suffix):
+                          base_name = mapped_name[:-len(env_suffix)]
+                      dg_name = dg_name_map.get(base_name, base_name)
+                      if env_suffix:
+                          dg_name = f"{dg_name}{env_suffix}"
+
+                      cd_r = subprocess.run([
+                          'aws', 'deploy', 'create-deployment',
+                          '--application-name', codedeploy_app,
+                          '--deployment-group-name', dg_name,
+                          '--revision',
+                          f'revisionType=AppSpecContent,appSpecContent={{content={appspec_json}}}',
+                          '--region', region,
+                          '--output', 'json',
+                      ], capture_output=True, text=True)
+                      if cd_r.returncode == 0:
+                          cd_info = json.loads(cd_r.stdout)
+                          dep_id = cd_info.get('deploymentId', '')
+                          print(f'  + {mapped_name} → CodeDeploy deployment {dep_id} ({canary_pref})')
+                          if dep_id:
+                              deployments.append((fn, mapped_name, dep_id))
+                      else:
+                          print(f'  [warn] CodeDeploy create-deployment failed for {mapped_name}: {cd_r.stderr.strip()}')
+                          print(f'  [warn] Falling back to direct alias update for {mapped_name}')
+                          # Fall through to direct alias update below.
+                          new_version = new_version  # keep for direct update
+                  except Exception as e:
+                      print(f'  [warn] CodeDeploy error for {mapped_name}: {e}', file=sys.stderr)
+
+              # Direct alias update: used when canary is disabled, AllAtOnce, or CodeDeploy unavailable.
+              if new_version and not use_codedeploy:
+                  alias_r = subprocess.run([
+                      'aws', 'lambda', 'update-alias',
+                      '--function-name', mapped_name,
+                      '--name', 'live',
+                      '--function-version', new_version,
+                      '--region', region,
+                  ], capture_output=True, text=True)
+                  if alias_r.returncode != 0:
+                      # Alias may not exist yet (first deploy) — create it.
+                      subprocess.run([
+                          'aws', 'lambda', 'create-alias',
+                          '--function-name', mapped_name,
+                          '--name', 'live',
+                          '--function-version', new_version,
+                          '--region', region,
+                      ], capture_output=True, text=True, check=False)
+                  print(f'  + {mapped_name} → live:{new_version} (direct)')
+
+          # Wait for all CodeDeploy deployments to complete.
+          if deployments:
+              print(f'Waiting for {len(deployments)} CodeDeploy deployment(s)...')
+              timeout_at = time.time() + 3600
+              pending = list(deployments)
+              while pending and time.time() < timeout_at:
+                  time.sleep(30)
+                  still_pending = []
+                  for fn, mapped_name, dep_id in pending:
+                      status_r = subprocess.run([
+                          'aws', 'deploy', 'get-deployment',
+                          '--deployment-id', dep_id,
+                          '--region', region,
+                          '--query', 'deploymentInfo.status',
+                          '--output', 'text',
+                      ], capture_output=True, text=True)
+                      status = status_r.stdout.strip()
+                      if status in ('Succeeded', 'Failed', 'Stopped'):
+                          if status != 'Succeeded':
+                              print(f'::error::CodeDeploy {dep_id} for {mapped_name}: {status}',
+                                    file=sys.stderr)
+                              errors.append(fn)
+                          else:
+                              print(f'  ✓ {mapped_name} CodeDeploy {dep_id}: {status}')
+                      else:
+                          still_pending.append((fn, mapped_name, dep_id))
+                  pending = still_pending
+              if pending:
+                  for fn, mapped_name, dep_id in pending:
+                      print(f'::error::CodeDeploy {dep_id} for {mapped_name} timed out', file=sys.stderr)
+                      errors.append(fn)
 
           deployed = len(version_ids) - len(skipped) - len(errors)
           if skipped:

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-21.47",
-  "updated_at": "2026-04-21T16:00:00Z",
-  "last_change_summary": "Added auth.github_installation_token entity for GET /api/v1/auth/github-token (ENC-TSK-F62).",
+  "version": "2026-04-21.48",
+  "updated_at": "2026-04-21T17:30:00Z",
+  "last_change_summary": "Added appconfig.feature_flags entity for AppConfig extension-based feature flag resolution (ENC-TSK-F63 AC-1). Migrated coordination_api and mcp-server ENABLE_* env var reads to AppConfig flag() helper with env fallback.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4975,6 +4975,32 @@
         "expires_in": {
           "type": "integer",
           "usage_guidance": "Nominal expiry in seconds (3600). Use as a hint only; the GitHub-issued token may expire sooner if the installation is revoked."
+        }
+      }
+    },
+    "appconfig.feature_flags": {
+      "description": "AppConfig-based boolean feature flag contract (ENC-TSK-F63 AC-1). The enceladus_shared.appconfig_flags.flag() helper resolves flags via the AppConfig Lambda extension (localhost:2772, TTL 45 s) with env-var fallback for local dev. Replaces direct ENABLE_* env var reads in coordination_api and mcp-server. Extension layer ARN is arch-specific (x86 / arm64) and attached to all 24 prod Lambdas via HasAppConfigLayer CFN condition.",
+      "fields": {
+        "flag_name": {
+          "type": "string",
+          "usage_guidance": "Snake_case key in the AppConfig JSON configuration profile (e.g. 'enable_lesson_primitive'). Must match an entry in the 06-feature-flags.yaml JSON Schema to pass pre-deployment validation."
+        },
+        "env_fallback": {
+          "type": "string",
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
+        },
+        "default": {
+          "type": "boolean",
+          "usage_guidance": "Hardcoded fallback returned when both AppConfig and env_fallback are absent or unreachable. Defaults to False for all flags unless explicitly overridden (e.g. enable_mcp_governance_prompt defaults to True)."
+        },
+        "resolution_order": {
+          "type": "enum",
+          "enum": [
+            "appconfig_extension",
+            "env_fallback",
+            "default"
+          ],
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
         }
       }
     }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -47,6 +47,7 @@ import boto3
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
+from enceladus_shared.appconfig_flags import flag as _appconfig_flag
 
 try:
     from mcp_client import CoordinationMcpClient
@@ -308,7 +309,7 @@ ENCELADUS_MCP_SERVER_PATH = os.environ.get(
     "tools/enceladus-mcp-server/server.py",
 )
 
-ENABLE_CLAUDE_HEADLESS = os.environ.get("ENABLE_CLAUDE_HEADLESS", "false").lower() == "true"
+ENABLE_CLAUDE_HEADLESS = _appconfig_flag("enable_claude_headless", env_fallback="ENABLE_CLAUDE_HEADLESS")
 
 # v0.3 callback infrastructure
 CALLBACK_EVENTBRIDGE_BUS = os.environ.get("CALLBACK_EVENTBRIDGE_BUS", "default")
@@ -325,14 +326,12 @@ MCP_SERVER_LOG_GROUP = os.environ.get("MCP_SERVER_LOG_GROUP", "/enceladus/mcp/se
 MCP_AUDIT_CALLER_IDENTITY = os.environ.get("MCP_AUDIT_CALLER_IDENTITY", "devops-coordination-api")
 COORDINATION_PUBLIC_BASE_URL = os.environ.get("COORDINATION_PUBLIC_BASE_URL", "https://jreese.net")
 COORDINATION_MCP_HTTP_PATH = os.environ.get("COORDINATION_MCP_HTTP_PATH", "/api/v1/coordination/mcp")
-ENABLE_MCP_GOVERNANCE_PROMPT = os.environ.get("ENABLE_MCP_GOVERNANCE_PROMPT", "true").lower() == "true"
+ENABLE_MCP_GOVERNANCE_PROMPT = _appconfig_flag("enable_mcp_governance_prompt", env_fallback="ENABLE_MCP_GOVERNANCE_PROMPT", default=True)
 # ENC-FTR-052: Governed Lesson Primitive
-ENABLE_LESSON_PRIMITIVE = os.environ.get("ENABLE_LESSON_PRIMITIVE", "false").lower() == "true"
-# ENC-FTR-076 / ENC-TSK-E08: Agent-proposable component registry. Default off
-# in prod; enabled in gamma via env var on the deploy. Gates POST
-# /api/v1/coordination/components/propose + the MCP component.propose action
-# + checkout-service lifecycle_status gate (delivered by E10).
-ENABLE_COMPONENT_PROPOSAL = os.environ.get("ENABLE_COMPONENT_PROPOSAL", "false").lower() == "true"
+ENABLE_LESSON_PRIMITIVE = _appconfig_flag("enable_lesson_primitive", env_fallback="ENABLE_LESSON_PRIMITIVE")
+# ENC-FTR-076 / ENC-TSK-E08: Agent-proposable component registry.
+# Gates POST /api/v1/coordination/components/propose + component.propose MCP action.
+ENABLE_COMPONENT_PROPOSAL = _appconfig_flag("enable_component_proposal", env_fallback="ENABLE_COMPONENT_PROPOSAL")
 GOVERNANCE_PROMPT_MAX_CHARS = int(os.environ.get("GOVERNANCE_PROMPT_MAX_CHARS", "120000"))
 GOVERNANCE_PROMPT_RESOURCE_URIS_FALLBACK = (
     "governance://agents.md",

--- a/backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py
@@ -1,0 +1,67 @@
+"""
+AppConfig feature flag reader — ENC-TSK-F63 AC-1.
+
+Replaces ENABLE_* env var reads with AppConfig extension HTTP polling.
+The AppConfig Lambda extension (layer AWS-AppConfig-Extension) runs on
+localhost:2772 and serves cached config; calls are sub-millisecond after
+the first warm fetch. Falls back to env var values for local dev / test
+environments where the extension is not running.
+"""
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+_APPCONFIG_PORT = int(os.environ.get("AWS_APPCONFIG_EXTENSION_HTTP_PORT", "2772"))
+_CACHE: dict = {}
+_CACHE_AT: float = 0.0
+_CACHE_TTL: float = float(os.environ.get("AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS", "45"))
+
+
+def _fetch() -> dict:
+    app = os.environ.get("APPCONFIG_APPLICATION", "enceladus")
+    env = os.environ.get("APPCONFIG_ENVIRONMENT", "production")
+    cfg = os.environ.get("APPCONFIG_CONFIGURATION", "feature-flags")
+    url = f"http://localhost:{_APPCONFIG_PORT}/applications/{app}/environments/{env}/configurations/{cfg}"
+    try:
+        with urllib.request.urlopen(url, timeout=1) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, OSError):
+        return {}
+
+
+def get_flags() -> dict:
+    """Return the current feature flag dict; serves from cache within TTL."""
+    global _CACHE, _CACHE_AT
+    now = time.monotonic()
+    if not _CACHE or now - _CACHE_AT >= _CACHE_TTL:
+        fresh = _fetch()
+        if fresh:
+            _CACHE = fresh
+            _CACHE_AT = now
+    return _CACHE
+
+
+def flag(name: str, *, env_fallback: str | None = None, default: bool = False) -> bool:
+    """
+    Read a boolean feature flag by name.
+
+    Resolution order:
+      1. AppConfig (if extension is reachable)
+      2. env_fallback env var (for local dev / legacy compat)
+      3. default
+
+    name        — key in AppConfig JSON, e.g. "enable_lesson_primitive"
+    env_fallback — optional ENABLE_* env var name to try when AppConfig is unreachable
+    default     — hardcoded fallback when neither source is available
+    """
+    flags = get_flags()
+    if name in flags:
+        val = flags[name]
+        return bool(val) if not isinstance(val, bool) else val
+    if env_fallback:
+        raw = os.environ.get(env_fallback, "").strip().lower()
+        if raw:
+            return raw == "true"
+    return default

--- a/envs/v3-prod.yaml
+++ b/envs/v3-prod.yaml
@@ -40,9 +40,18 @@ runner_label: ubuntu-latest
 # landed in PR #407) scopes sub=environment:v3-prod.
 environment: v3-prod
 
-# Optional: AppConfig application ID for runtime feature flag control (F63).
+# ENC-TSK-F63 AC-1: AppConfig IDs for runtime feature flag control.
+# Populated after the 06-feature-flags stack is deployed to prod.
+# Deploy workflow passes these to --parameter-overrides for AppConfigApplicationId
+# and AppConfigEnvironmentId in the 02-compute stack update.
 appconfig_application_id: ""
 appconfig_environment_id: ""
+
+# ENC-TSK-F63 AC-2/AC-3: SnapStart and CodeDeploy settings.
+# v3-prod uses x86_64/py3.11 — SnapStart NOT supported. Canary via CodeDeploy.
+enable_snapstart: "false"
+environment_suffix: ""
+codedeploy_app_name: "enceladus-lambda"
 
 # ENC-FTR-090 / ENC-TSK-F59 Phase 1 \u2014 artifact promotion fields.
 # Populated by F60 Phase 2 _deploy.yml on each promotion. Empty here means

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -27,10 +27,14 @@ runner_label: ubuntu-24.04-arm
 # human approval gate; the OIDC trust policy scopes sub=environment:v4-gamma.
 environment: v4-gamma
 
-# Optional: AppConfig application ID for runtime feature flag control (F63).
-# Empty until F63 lands; the deploy workflow treats empty-string as "no AppConfig".
+# ENC-TSK-F63 AC-1: AppConfig IDs. Populated after 06-feature-flags stack deploys.
 appconfig_application_id: ""
 appconfig_environment_id: ""
+
+# ENC-TSK-F63 AC-2/AC-3: SnapStart (arm64/py3.12 — supported) and CodeDeploy.
+enable_snapstart: "true"
+environment_suffix: "-gamma"
+codedeploy_app_name: "enceladus-lambda-gamma"
 
 # ENC-FTR-090 / ENC-TSK-F59 Phase 1 \u2014 artifact promotion fields.
 # artifact_commit_sha + artifact_version_ids are populated by F60 Phase 2

--- a/envs/v4-prod.yaml
+++ b/envs/v4-prod.yaml
@@ -34,3 +34,8 @@ environment: v4-prod
 
 appconfig_application_id: ""
 appconfig_environment_id: ""
+
+# ENC-TSK-F63 AC-2/AC-3: SnapStart (arm64/py3.12 — supported) and CodeDeploy.
+enable_snapstart: "true"
+environment_suffix: ""
+codedeploy_app_name: "enceladus-lambda"

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -88,9 +88,45 @@ Parameters:
       enceladus-mcp-code-gamma Lambda OAuth-direct path. Kept out of the repo; injected
       at deploy/IMPORT via --parameters.
 
+  # ENC-TSK-F63 AC-1: AppConfig extension layer ARNs.
+  # Arch-specific; separate params because AWS publishes distinct layer versions.
+  # See: https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html
+  AppConfigExtensionLayerArnX86:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension:147"
+    Description: AppConfig Lambda extension layer ARN for x86_64 (us-west-2). Pin to latest per AWS docs.
+  AppConfigExtensionLayerArnArm64:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension-Arm64:147"
+    Description: AppConfig Lambda extension layer ARN for arm64 (us-west-2). Pin to latest per AWS docs.
+
+  # ENC-TSK-F63 AC-1: AppConfig IDs — populated after 06-feature-flags.yaml stack deploy.
+  # Empty defaults disable AppConfig polling; appconfig_flags.flag() falls back to env_fallback.
+  AppConfigApplicationId:
+    Type: String
+    Default: ""
+    Description: AppConfig Application ID from 06-feature-flags stack. Pass via --parameter-overrides.
+  AppConfigEnvironmentId:
+    Type: String
+    Default: ""
+    Description: AppConfig Environment ID from 06-feature-flags stack. Pass via --parameter-overrides.
+
+  # ENC-TSK-F63 AC-2: SnapStart.ApplyOn=PublishedVersions. Only arm64/py3.12 supports it.
+  # v3-prod (x86_64/py3.11): false. v4-gamma/v4-prod (arm64/py3.12): true.
+  EnableSnapStart:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Enable SnapStart on all Lambdas. Set true only for arm64/python3.12 stacks.
+
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
   IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+  # ENC-TSK-F63 AC-2: SnapStart enabled only when EnableSnapStart=true (arm64/py3.12 targets).
+  # Replaces the old IsProduction-negation pattern (was: !If [IsProduction, NoValue, SnapStart]).
+  SnapStartEnabled: !Equals [!Ref EnableSnapStart, "true"]
+  # ENC-TSK-F63 AC-1: AppConfig layer conditional — only attach when an ARN is provided.
+  HasAppConfigLayer: !Not [!Equals [!Ref AppConfigExtensionLayerArnX86, ""]]
 
 Resources:
   # ---------------------------------------------------------------------------
@@ -111,12 +147,17 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt CoordinationApiRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        # ENC-TSK-F63 AC-1: AppConfig extension layer (arch-conditional)
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -131,6 +172,11 @@ Resources:
           ENCELADUS_MCP_INTERFACE_MODE: code
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -151,12 +197,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt TrackerMutationRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -164,6 +214,10 @@ Resources:
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -184,12 +238,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DocumentApiRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -202,6 +260,10 @@ Resources:
           S3_PREFIX: !Sub "${S3EnvPrefix}agent-documents"
           S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
           S3_GOVERNANCE_PREFIX: !Sub "${S3EnvPrefix}governance/live"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -222,12 +284,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt ProjectServiceRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -237,6 +303,10 @@ Resources:
           DYNAMODB_REGION: !Ref AWS::Region
           S3_BUCKET: !Ref S3Bucket
           S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -257,12 +327,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt FeedQueryRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -271,6 +345,10 @@ Resources:
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           FEED_PUBLISHER_FUNCTION: !Sub "devops-feed-publisher${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -291,18 +369,26 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt CoordinationMonitorRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -323,12 +409,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DeployIntakeRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -339,6 +429,10 @@ Resources:
           CONFIG_BUCKET: !Ref S3Bucket
           CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
           CORS_ORIGIN: !Ref CorsOrigin
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -359,18 +453,26 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt ReferenceSearchRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           S3_BUCKET: !Ref S3Bucket
           S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -391,10 +493,15 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt AuthRefreshRole.Arn
+      Layers:
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -403,6 +510,10 @@ Resources:
           GITHUB_APP_ID: !Ref GitHubAppId
           GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
           GITHUB_PRIVATE_KEY_SECRET: devops/github-app/private-key
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -427,10 +538,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DeployOrchestratorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
@@ -439,6 +556,10 @@ Resources:
           CONFIG_BUCKET: !Ref S3Bucket
           CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
           CODEBUILD_PROJECT: devops-ui-deploy-builder
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -459,10 +580,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DeployFinalizeRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
@@ -471,6 +598,10 @@ Resources:
           TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           CONFIG_BUCKET: !Ref S3Bucket
           CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -492,9 +623,17 @@ Resources:
       Timeout: 30
       Architectures:
         - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DeployDecideRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -507,6 +646,10 @@ Resources:
           GITHUB_PRIVATE_KEY_SECRET: devops/github-app/private-key
           ALLOWED_REPOS: NX-2021-L/enceladus
           GAMMA_INTEGRATION_BRANCH: v4/main
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -527,9 +670,17 @@ Resources:
       Timeout: 120
       Architectures:
         - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DeployParityValidatorRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
@@ -538,6 +689,10 @@ Resources:
           GITHUB_TOKEN_SECRET: devops/github-app/private-key
           DOCUMENT_API_URL: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1
           TRACKER_API_URL: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -558,11 +713,17 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt FeedPublisherRole.Arn
       Description: Event-driven mobile feed publisher triggered by DynamoDB Streams via SQS FIFO
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
@@ -573,6 +734,10 @@ Resources:
           FEED_PREFIX: !Sub "${S3EnvPrefix}mobile/v1"
           EVENT_BUS: default
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -593,10 +758,22 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt GovernanceAuditRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -617,10 +794,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt DocPrepRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
@@ -628,6 +811,10 @@ Resources:
           TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           S3_BUCKET: !Ref S3Bucket
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -648,10 +835,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt BedrockActionsRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
@@ -662,6 +855,10 @@ Resources:
           S3_BUCKET: !Ref S3Bucket
           GOVERNANCE_POLICIES_TABLE: !Sub "governance-policies${EnvironmentSuffix}"
           AGENT_COMPLIANCE_TABLE: !Sub "agent-compliance-violations${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -682,12 +879,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt ChangelogApiRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
@@ -697,6 +898,10 @@ Resources:
           CONFIG_BUCKET: !Ref S3Bucket
           CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
           CORS_ORIGIN: !Ref CorsOrigin
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -717,14 +922,24 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt GraphSyncRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           SECRETS_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -750,10 +965,16 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt GraphQueryApiRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
@@ -768,6 +989,10 @@ Resources:
           # both values via --parameter-overrides.
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
           COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -792,16 +1017,26 @@ Resources:
       Architectures:
         - !If [IsGamma, arm64, x86_64]
       SnapStart: !If
-        - IsProduction
-        - !Ref AWS::NoValue
+        - SnapStartEnabled
         - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt Neo4jBackupRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           S3_BUCKET: !Ref S3Bucket
           S3_PREFIX: !Sub "${S3EnvPrefix}neo4j-backups/"
           SECRETS_REGION: !Ref "AWS::Region"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -828,7 +1063,17 @@ Resources:
       Timeout: 60
       Architectures:
         - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt EnvDriftAuditorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           TRACKER_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker
@@ -836,6 +1081,10 @@ Resources:
           ISSUE_PROJECT_ID: enceladus
           DRIFT_SEVERITY: P0
           DRY_RUN: "false"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -859,13 +1108,27 @@ Resources:
       Timeout: 120
       Architectures:
         - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
       Role: !GetAtt GraphHealthMetricsRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
           PROJECT_ID: enceladus
           SECRETS_REGION: !Ref "AWS::Region"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus
@@ -1148,6 +1411,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1164,6 +1439,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   DocumentApiRole:
     Type: AWS::IAM::Role
@@ -1177,6 +1464,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   ProjectServiceRole:
     Type: AWS::IAM::Role
@@ -1190,6 +1489,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   FeedQueryRole:
     Type: AWS::IAM::Role
@@ -1214,6 +1525,17 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-feed-publisher${EnvironmentSuffix}"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-feed-publisher${EnvironmentSuffix}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   CoordinationMonitorRole:
     Type: AWS::IAM::Role
@@ -1227,6 +1549,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   DeployIntakeRole:
     Type: AWS::IAM::Role
@@ -1240,6 +1574,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   DeployOrchestratorRole:
     Type: AWS::IAM::Role
@@ -1277,6 +1623,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   DeployFinalizeRole:
     Type: AWS::IAM::Role
@@ -1290,6 +1647,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   # GMF: Deploy Decide IAM Role (DOC-63420302EF65)
   DeployDecideRole:
@@ -1331,6 +1700,17 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
+                Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
                 Resource: "*"
 
   # ENC-FTR-091 / ENC-TSK-F87 — Deploy Parity Validator IAM role
@@ -1390,6 +1770,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   ReferenceSearchRole:
     Type: AWS::IAM::Role
@@ -1403,6 +1794,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   FeedPublisherRole:
     Type: AWS::IAM::Role
@@ -1440,6 +1843,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   GovernanceAuditRole:
     Type: AWS::IAM::Role
@@ -1478,6 +1892,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   DocPrepRole:
     Type: AWS::IAM::Role
@@ -1491,6 +1916,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   BedrockActionsRole:
     Type: AWS::IAM::Role
@@ -1504,6 +1941,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   ChangelogApiRole:
     Type: AWS::IAM::Role
@@ -1517,6 +1966,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1542,6 +2003,17 @@ Resources:
                 Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/github-app/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   FeedPipeRole:
     Type: AWS::IAM::Role
@@ -1620,6 +2092,17 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1636,6 +2119,18 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1674,6 +2169,17 @@ Resources:
                 Action:
                   - s3:PutObject
                 Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}neo4j-backups/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1713,6 +2219,17 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1801,6 +2318,17 @@ Resources:
                   - lambda:GetFunctionConfiguration
                   - lambda:ListFunctions
                 Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1829,7 +2357,17 @@ Resources:
       Timeout: 30
       Architectures:
         - arm64
+      # ENC-TSK-F63 AC-2: SnapStart enabled (arm64/py3.12)
+      SnapStart:
+        ApplyOn: PublishedVersions
       Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/devops-coordination-api-lambda-role-gamma"
+      Layers:
+        - !Ref SharedLayerArn
+        # ENC-TSK-F63 AC-1: AppConfig extension layer (arm64)
+        - !If
+          - HasAppConfigLayer
+          - !Ref AppConfigExtensionLayerArnArm64
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
@@ -1860,12 +2398,12 @@ Resources:
           ENCELADUS_COGNITO_DOMAIN: https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com
           MCP_AUDIT_CALLER_IDENTITY: devops-coordination-api-gamma
           MCP_SERVER_LOG_GROUP: /enceladus/mcp/server
-          ENABLE_CLAUDE_HEADLESS: "true"
-          ENABLE_COMPONENT_PROPOSAL: "true"
-          ENABLE_CONTEXT_NODES: "true"
-          ENABLE_HANDOFF_PRIMITIVE: "true"
-          ENABLE_LESSON_PRIMITIVE: "true"
-          ENABLE_TYPED_RELATIONSHIPS: "true"
+          # ENC-TSK-F63 AC-1: ENABLE_* env vars removed — feature flags now served by AppConfig.
+          # enceladus_shared.appconfig_flags.flag() polls localhost:2772 via the extension layer.
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project
           Value: enceladus

--- a/infrastructure/cloudformation/06-feature-flags.yaml
+++ b/infrastructure/cloudformation/06-feature-flags.yaml
@@ -1,0 +1,173 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus Feature Flags — AppConfig hosted configuration.
+  ENC-TSK-F63 AC-1: AppConfig application, environment, configuration profile,
+  JSON Schema validator, and initial hosted configuration version replacing
+  all ENABLE_* Lambda env vars with a governed, hot-reloadable config surface.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues: [production, gamma]
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+
+Conditions:
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # AppConfig Application
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsApplication:
+    Type: AWS::AppConfig::Application
+    Properties:
+      Name: !Sub "enceladus${EnvironmentSuffix}"
+      Description: Enceladus runtime feature flags (replaces ENABLE_* env vars)
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: feature-flags
+
+  # ---------------------------------------------------------------------------
+  # AppConfig Environment
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsEnvironment:
+    Type: AWS::AppConfig::Environment
+    Properties:
+      ApplicationId: !Ref FeatureFlagsApplication
+      Name: !If [IsGamma, gamma, production]
+      Description: !If [IsGamma, Gamma stack feature flags, Production feature flags]
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ---------------------------------------------------------------------------
+  # Configuration Profile + JSON Schema Validator
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref FeatureFlagsApplication
+      Name: feature-flags
+      LocationUri: hosted
+      Description: Runtime feature flag configuration for all Enceladus Lambdas
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "type": "object",
+              "properties": {
+                "enable_claude_headless":     { "type": "boolean" },
+                "enable_component_proposal":  { "type": "boolean" },
+                "enable_context_nodes":       { "type": "boolean" },
+                "enable_handoff_primitive":   { "type": "boolean" },
+                "enable_lesson_primitive":    { "type": "boolean" },
+                "enable_typed_relationships": { "type": "boolean" },
+                "enable_mcp_governance_prompt": { "type": "boolean" }
+              },
+              "additionalProperties": false,
+              "required": [
+                "enable_claude_headless",
+                "enable_component_proposal",
+                "enable_context_nodes",
+                "enable_handoff_primitive",
+                "enable_lesson_primitive",
+                "enable_typed_relationships",
+                "enable_mcp_governance_prompt"
+              ]
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ---------------------------------------------------------------------------
+  # Initial Hosted Configuration Version
+  # All flags enabled — matches the live values previously set via ENABLE_* env vars
+  # on enceladus-mcp-code-gamma. Production defaults to all-enabled (identical
+  # to what gamma had hardcoded).
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref FeatureFlagsApplication
+      ConfigurationProfileId: !Ref FeatureFlagsProfile
+      ContentType: application/json
+      Description: "Initial version — all flags enabled (migrated from ENABLE_* env vars)"
+      Content: |
+        {
+          "enable_claude_headless": true,
+          "enable_component_proposal": true,
+          "enable_context_nodes": true,
+          "enable_handoff_primitive": true,
+          "enable_lesson_primitive": true,
+          "enable_typed_relationships": true,
+          "enable_mcp_governance_prompt": true
+        }
+
+  # ---------------------------------------------------------------------------
+  # Deployment Strategy — immediate (no bake time, instant activation)
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsDeploymentStrategy:
+    Type: AWS::AppConfig::DeploymentStrategy
+    Properties:
+      Name: !Sub "enceladus-immediate${EnvironmentSuffix}"
+      Description: Immediate activation, no bake time — safe for boolean feature flags
+      ReplicateTo: NONE
+      DeploymentDurationInMinutes: 0
+      FinalBakeTimeInMinutes: 0
+      GrowthFactor: 100
+      GrowthType: LINEAR
+
+  # ---------------------------------------------------------------------------
+  # Initial Deployment — activates the hosted config version
+  # ---------------------------------------------------------------------------
+
+  FeatureFlagsInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref FeatureFlagsApplication
+      EnvironmentId: !Ref FeatureFlagsEnvironment
+      ConfigurationProfileId: !Ref FeatureFlagsProfile
+      ConfigurationVersion: !Ref FeatureFlagsInitialVersion
+      DeploymentStrategyId: !Ref FeatureFlagsDeploymentStrategy
+      Description: "Initial activation — migrated from ENABLE_* env vars (ENC-TSK-F63)"
+
+Outputs:
+  ApplicationId:
+    Value: !Ref FeatureFlagsApplication
+    Export:
+      Name: !Sub "${AWS::StackName}-AppConfigApplicationId"
+    Description: AppConfig Application ID — set as APPCONFIG_APPLICATION env var on all Lambdas
+
+  EnvironmentId:
+    Value: !Ref FeatureFlagsEnvironment
+    Export:
+      Name: !Sub "${AWS::StackName}-AppConfigEnvironmentId"
+    Description: AppConfig Environment ID — set as APPCONFIG_ENVIRONMENT env var on all Lambdas
+
+  ConfigurationProfileId:
+    Value: !Ref FeatureFlagsProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-AppConfigConfigProfileId"
+    Description: AppConfig Configuration Profile ID
+
+  ApplicationName:
+    Value: !Sub "enceladus${EnvironmentSuffix}"
+    Export:
+      Name: !Sub "${AWS::StackName}-AppConfigApplicationName"
+
+  EnvironmentName:
+    Value: !If [IsGamma, gamma, production]
+    Export:
+      Name: !Sub "${AWS::StackName}-AppConfigEnvironmentName"

--- a/infrastructure/cloudformation/07-codedeploy.yaml
+++ b/infrastructure/cloudformation/07-codedeploy.yaml
@@ -1,0 +1,1492 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus CodeDeploy Canary Infrastructure — ENC-TSK-F63 AC-3.
+  CodeDeploy application, IAM role, Lambda aliases (live), per-function
+  DeploymentGroups, and per-function CloudWatch error/latency alarms wired
+  for automatic rollback. Imported into the enceladus-compute stack family.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues: [production, gamma]
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+  ComputeStackName:
+    Type: String
+    Default: enceladus-compute
+    Description: Name of the 02-compute stack; used for cross-stack Lambda ARN imports.
+  CanaryPreference:
+    Type: String
+    Default: Linear10PercentEvery10Minutes
+    AllowedValues:
+      - Canary10Percent5Minutes
+      - Canary10Percent10Minutes
+      - Linear10PercentEvery1Minute
+      - Linear10PercentEvery10Minutes
+      - AllAtOnce
+    Description: >
+      CodeDeploy deployment config suffix. Mapped to
+      CodeDeployDefault.Lambda<CanaryPreference>. Set per-environment in
+      envs/<target>.yaml and passed via --parameter-overrides at deploy time.
+
+Conditions:
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # CodeDeploy Application (Lambda compute platform)
+  # ---------------------------------------------------------------------------
+
+  CodeDeployApplication:
+    Type: AWS::CodeDeploy::Application
+    Properties:
+      ApplicationName: !Sub "enceladus-lambda${EnvironmentSuffix}"
+      ComputePlatform: Lambda
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ---------------------------------------------------------------------------
+  # IAM Role for CodeDeploy
+  # ---------------------------------------------------------------------------
+
+  CodeDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "enceladus-codedeploy-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codedeploy.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Alarms — per-function error + latency alarms for rollback trigger.
+  # CodeDeploy AutoRollbackConfiguration references these alarm names.
+  # EvaluationPeriods=1, 5-minute window: any error burst or p99 latency spike
+  # during the canary window triggers automatic rollback.
+  # ---------------------------------------------------------------------------
+
+  # --- coordination-api ---
+  CoordinationApiErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-coordination-api-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-coordination-api${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  CoordinationApiLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-coordination-api-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-coordination-api${EnvironmentSuffix}"
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- tracker-mutation ---
+  TrackerMutationErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-tracker-mutation-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  TrackerMutationLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-tracker-mutation-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 9000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- document-api ---
+  DocumentApiErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-document-api-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-document-api${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DocumentApiLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-document-api-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-document-api${EnvironmentSuffix}"
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 29000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- graph-query-api (highest latency SLO — 180s timeout) ---
+  GraphQueryApiErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-query-api-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  GraphQueryApiLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-query-api-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 175000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Metric Filters — REPORT Init Duration (SnapStart cold-start telemetry)
+  # ENC-TSK-F63 AC-2: captures before/after cold-start measurements.
+  # ---------------------------------------------------------------------------
+
+  CoordinationApiInitDurationFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/devops-coordination-api${EnvironmentSuffix}"
+      FilterName: !Sub "SnapStartInitDuration-coordination-api${EnvironmentSuffix}"
+      FilterPattern: "[report=REPORT, requestId=RequestId:, reqId, duration=Duration:, dur, durUnit=ms, billedDuration=Billed, billedDur, billedDurUnit=ms, memSize=Memory, memSizeUnit=Size:, memSizeVal, memSizeUnit2=MB, maxMem=Max, memUsed=Memory, memUsedUnit=Used:, memUsedVal, memUsedUnit2=MB, initDuration=Init, initDur=Duration:, initDurVal, initDurUnit=ms]"
+      MetricTransformations:
+        - MetricNamespace: Enceladus/SnapStart
+          MetricName: !Sub "InitDuration-coordination-api${EnvironmentSuffix}"
+          MetricValue: "$initDurVal"
+          Unit: Milliseconds
+
+  GraphQueryApiInitDurationFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/devops-graph-query-api${EnvironmentSuffix}"
+      FilterName: !Sub "SnapStartInitDuration-graph-query-api${EnvironmentSuffix}"
+      FilterPattern: "[report=REPORT, requestId=RequestId:, reqId, duration=Duration:, dur, durUnit=ms, billedDuration=Billed, billedDur, billedDurUnit=ms, memSize=Memory, memSizeUnit=Size:, memSizeVal, memSizeUnit2=MB, maxMem=Max, memUsed=Memory, memUsedUnit=Used:, memUsedVal, memUsedUnit2=MB, initDuration=Init, initDur=Duration:, initDurVal, initDurUnit=ms]"
+      MetricTransformations:
+        - MetricNamespace: Enceladus/SnapStart
+          MetricName: !Sub "InitDuration-graph-query-api${EnvironmentSuffix}"
+          MetricValue: "$initDurVal"
+          Unit: Milliseconds
+
+  TrackerMutationInitDurationFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/devops-tracker-mutation-api${EnvironmentSuffix}"
+      FilterName: !Sub "SnapStartInitDuration-tracker-mutation${EnvironmentSuffix}"
+      FilterPattern: "[report=REPORT, requestId=RequestId:, reqId, duration=Duration:, dur, durUnit=ms, billedDuration=Billed, billedDur, billedDurUnit=ms, memSize=Memory, memSizeUnit=Size:, memSizeVal, memSizeUnit2=MB, maxMem=Max, memUsed=Memory, memUsedUnit=Used:, memUsedVal, memUsedUnit2=MB, initDuration=Init, initDur=Duration:, initDurVal, initDurUnit=ms]"
+      MetricTransformations:
+        - MetricNamespace: Enceladus/SnapStart
+          MetricName: !Sub "InitDuration-tracker-mutation${EnvironmentSuffix}"
+          MetricValue: "$initDurVal"
+          Unit: Milliseconds
+
+  # ---------------------------------------------------------------------------
+  # Lambda live Aliases — initial bootstrap pointing to $LATEST.
+  # The _deploy.yml canary step updates these to a specific published version
+  # after each update-function-code --publish invocation, then creates a
+  # CodeDeploy deployment for traffic shifting.
+  # ---------------------------------------------------------------------------
+
+  CoordinationApiAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-coordination-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  TrackerMutationAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DocumentApiAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-document-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  ProjectServiceAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-project-service${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  FeedQueryAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-feed-query-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  CoordinationMonitorAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-coordination-monitor-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DeployIntakeAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-deploy-intake${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  ReferenceSearchAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-reference-search${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  AuthRefreshAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "auth-refresh${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DeployOrchestratorAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-deploy-orchestrator${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DeployFinalizeAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-deploy-finalize${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DeployDecideAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-deploy-decide${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  FeedPublisherAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-feed-publisher${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  GovernanceAuditAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "enceladus-governance-audit${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DocPrepAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-doc-prep${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  BedrockAgentActionsAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "enceladus-bedrock-agent-actions${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  ChangelogApiAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-changelog-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  GraphSyncAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-graph-sync${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  GraphQueryApiAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  Neo4jBackupAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "enceladus-neo4j-backup${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  GraphHealthMetricsAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  # ---------------------------------------------------------------------------
+  # CodeDeploy Deployment Groups — one per prod Lambda.
+  # DeploymentConfigName mapped from CanaryPreference parameter.
+  # AutoRollback on DEPLOYMENT_FAILURE + DEPLOYMENT_STOP_ON_ALARM.
+  # ---------------------------------------------------------------------------
+
+  CoordinationApiDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: CoordinationApiAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "coordination-api${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref CoordinationApiErrorAlarm
+          - Name: !Ref CoordinationApiLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events:
+          - DEPLOYMENT_FAILURE
+          - DEPLOYMENT_STOP_ON_ALARM
+
+  TrackerMutationDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: TrackerMutationAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "tracker-mutation${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref TrackerMutationErrorAlarm
+          - Name: !Ref TrackerMutationLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events:
+          - DEPLOYMENT_FAILURE
+          - DEPLOYMENT_STOP_ON_ALARM
+
+  DocumentApiDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DocumentApiAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "document-api${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DocumentApiErrorAlarm
+          - Name: !Ref DocumentApiLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events:
+          - DEPLOYMENT_FAILURE
+          - DEPLOYMENT_STOP_ON_ALARM
+
+  GraphQueryApiDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: GraphQueryApiAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "graph-query-api${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref GraphQueryApiErrorAlarm
+          - Name: !Ref GraphQueryApiLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events:
+          - DEPLOYMENT_FAILURE
+          - DEPLOYMENT_STOP_ON_ALARM
+
+  # ---------------------------------------------------------------------------
+  # Missing live aliases — DeployParityValidator and DevopsEnvDriftAuditor
+  # ---------------------------------------------------------------------------
+
+  DeployParityValidatorAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-deploy-parity-validator${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  DevopsEnvDriftAuditorAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Sub "devops-env-drift-auditor${EnvironmentSuffix}"
+      FunctionVersion: $LATEST
+      Name: live
+      Description: Live traffic alias — managed by _deploy.yml canary step
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Alarms — remaining prod Lambdas (error + latency, rollback triggers)
+  # Thresholds: error=3 in 5min; duration=p99 at 95% of function timeout.
+  # ---------------------------------------------------------------------------
+
+  # --- project-service ---
+  ProjectServiceErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-project-service-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-project-service${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  ProjectServiceLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-project-service-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-project-service${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- feed-query ---
+  FeedQueryErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-feed-query-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-feed-query-api${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  FeedQueryLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-feed-query-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-feed-query-api${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 58000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- coordination-monitor ---
+  CoordinationMonitorErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-coordination-monitor-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-coordination-monitor-api${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  CoordinationMonitorLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-coordination-monitor-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-coordination-monitor-api${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- deploy-intake ---
+  DeployIntakeErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-intake-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-intake${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployIntakeLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-intake-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-intake${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- reference-search ---
+  ReferenceSearchErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-reference-search-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-reference-search${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  ReferenceSearchLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-reference-search-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-reference-search${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 9000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- auth-refresh ---
+  AuthRefreshErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-auth-refresh-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "auth-refresh${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  AuthRefreshLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-auth-refresh-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "auth-refresh${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 9000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- deploy-orchestrator ---
+  DeployOrchestratorErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-orchestrator-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-orchestrator${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployOrchestratorLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-orchestrator-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-orchestrator${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- deploy-finalize ---
+  DeployFinalizeErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-finalize-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-finalize${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployFinalizeLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-finalize-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-finalize${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- deploy-decide ---
+  DeployDecideErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-decide-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-decide${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployDecideLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-decide-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-decide${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- deploy-parity-validator ---
+  DeployParityValidatorErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-parity-validator-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-parity-validator${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployParityValidatorLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-deploy-parity-validator-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-deploy-parity-validator${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- feed-publisher ---
+  FeedPublisherErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-feed-publisher-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-feed-publisher${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  FeedPublisherLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-feed-publisher-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-feed-publisher${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 580000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- governance-audit ---
+  GovernanceAuditErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-governance-audit-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-governance-audit${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  GovernanceAuditLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-governance-audit-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-governance-audit${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- doc-prep ---
+  DocPrepErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-doc-prep-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-doc-prep${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DocPrepLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-doc-prep-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-doc-prep${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- bedrock-agent-actions ---
+  BedrockAgentActionsErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-bedrock-agent-actions-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-bedrock-agent-actions${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  BedrockAgentActionsLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-bedrock-agent-actions-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-bedrock-agent-actions${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- changelog-api ---
+  ChangelogApiErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-changelog-api-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-changelog-api${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  ChangelogApiLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-changelog-api-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-changelog-api${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 28000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- graph-sync ---
+  GraphSyncErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-sync-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-graph-sync${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  GraphSyncLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-sync-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-graph-sync${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 58000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- neo4j-backup ---
+  Neo4jBackupErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-neo4j-backup-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-neo4j-backup${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  Neo4jBackupLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-neo4j-backup-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-neo4j-backup${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 290000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- env-drift-auditor ---
+  EnvDriftAuditorErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-env-drift-auditor-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-env-drift-auditor${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  EnvDriftAuditorLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-env-drift-auditor-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "devops-env-drift-auditor${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 58000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # --- graph-health-metrics ---
+  GraphHealthMetricsErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-health-metrics-errors${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"}]
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  GraphHealthMetricsLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enc-codedeploy-graph-health-metrics-duration${EnvironmentSuffix}"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions: [{Name: FunctionName, Value: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"}]
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 115000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # ---------------------------------------------------------------------------
+  # CodeDeploy Deployment Groups — remaining prod Lambdas
+  # ---------------------------------------------------------------------------
+
+  ProjectServiceDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: ProjectServiceAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "project-service${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref ProjectServiceErrorAlarm
+          - Name: !Ref ProjectServiceLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  FeedQueryDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: FeedQueryAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "feed-query${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref FeedQueryErrorAlarm
+          - Name: !Ref FeedQueryLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  CoordinationMonitorDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: CoordinationMonitorAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "coordination-monitor${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref CoordinationMonitorErrorAlarm
+          - Name: !Ref CoordinationMonitorLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DeployIntakeDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DeployIntakeAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "deploy-intake${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DeployIntakeErrorAlarm
+          - Name: !Ref DeployIntakeLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  ReferenceSearchDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: ReferenceSearchAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "reference-search${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref ReferenceSearchErrorAlarm
+          - Name: !Ref ReferenceSearchLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  AuthRefreshDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: AuthRefreshAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "auth-refresh${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref AuthRefreshErrorAlarm
+          - Name: !Ref AuthRefreshLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DeployOrchestratorDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DeployOrchestratorAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "deploy-orchestrator${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DeployOrchestratorErrorAlarm
+          - Name: !Ref DeployOrchestratorLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DeployFinalizeDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DeployFinalizeAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "deploy-finalize${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DeployFinalizeErrorAlarm
+          - Name: !Ref DeployFinalizeLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DeployDecideDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DeployDecideAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "deploy-decide${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DeployDecideErrorAlarm
+          - Name: !Ref DeployDecideLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DeployParityValidatorDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DeployParityValidatorAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "deploy-parity-validator${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DeployParityValidatorErrorAlarm
+          - Name: !Ref DeployParityValidatorLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  FeedPublisherDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: FeedPublisherAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "feed-publisher${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref FeedPublisherErrorAlarm
+          - Name: !Ref FeedPublisherLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  GovernanceAuditDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: GovernanceAuditAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "governance-audit${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref GovernanceAuditErrorAlarm
+          - Name: !Ref GovernanceAuditLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  DocPrepDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DocPrepAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "doc-prep${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref DocPrepErrorAlarm
+          - Name: !Ref DocPrepLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  BedrockAgentActionsDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: BedrockAgentActionsAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "bedrock-agent-actions${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref BedrockAgentActionsErrorAlarm
+          - Name: !Ref BedrockAgentActionsLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  ChangelogApiDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: ChangelogApiAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "changelog-api${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref ChangelogApiErrorAlarm
+          - Name: !Ref ChangelogApiLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  GraphSyncDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: GraphSyncAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "graph-sync${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref GraphSyncErrorAlarm
+          - Name: !Ref GraphSyncLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  Neo4jBackupDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: Neo4jBackupAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "neo4j-backup${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref Neo4jBackupErrorAlarm
+          - Name: !Ref Neo4jBackupLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  EnvDriftAuditorDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: DevopsEnvDriftAuditorAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "env-drift-auditor${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref EnvDriftAuditorErrorAlarm
+          - Name: !Ref EnvDriftAuditorLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+  GraphHealthMetricsDeploymentGroup:
+    Type: AWS::CodeDeploy::DeploymentGroup
+    DependsOn: GraphHealthMetricsAlias
+    Properties:
+      ApplicationName: !Ref CodeDeployApplication
+      DeploymentGroupName: !Sub "graph-health-metrics${EnvironmentSuffix}"
+      ServiceRoleArn: !GetAtt CodeDeployRole.Arn
+      DeploymentConfigName: !Sub "CodeDeployDefault.Lambda${CanaryPreference}"
+      DeploymentStyle:
+        DeploymentType: BLUE_GREEN
+        DeploymentOption: WITH_TRAFFIC_CONTROL
+      AlarmConfiguration:
+        Enabled: true
+        Alarms:
+          - Name: !Ref GraphHealthMetricsErrorAlarm
+          - Name: !Ref GraphHealthMetricsLatencyAlarm
+      AutoRollbackConfiguration:
+        Enabled: true
+        Events: [DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM]
+
+Outputs:
+  CodeDeployApplicationName:
+    Value: !Ref CodeDeployApplication
+    Export:
+      Name: !Sub "${AWS::StackName}-CodeDeployApplicationName"
+    Description: Pass to _deploy.yml as CODEDEPLOY_APP_NAME
+
+  CodeDeployRoleArn:
+    Value: !GetAtt CodeDeployRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CodeDeployRoleArn"

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -48,6 +48,10 @@ from mcp.types import (
     TextResourceContents,
     Tool,
 )
+try:
+    from enceladus_shared.appconfig_flags import flag as _appconfig_flag
+except ImportError:
+    from appconfig_flags import flag as _appconfig_flag  # local fallback for testing
 
 # ---------------------------------------------------------------------------
 # Lazy boto3 import (provider sessions may need pip install)
@@ -214,26 +218,19 @@ CHECKOUT_SERVICE_API_BASE = os.environ.get(
     "CHECKOUT_SERVICE_API_BASE",
     "https://jreese.net/api/v1/checkout",
 )
-# ENC-FTR-049: Typed relationship edge feature flag
-ENABLE_TYPED_RELATIONSHIPS = os.environ.get(
-    "ENABLE_TYPED_RELATIONSHIPS", "false"
-).lower() == "true"
-# ENC-FTR-050: Context Node feature flag (default off — all new code paths gated)
-ENABLE_CONTEXT_NODES = os.environ.get(
-    "ENABLE_CONTEXT_NODES", "false"
-).lower() == "true"
-# ENC-FTR-052: Governed Lesson Primitive feature flag
-ENABLE_LESSON_PRIMITIVE = os.environ.get(
-    "ENABLE_LESSON_PRIMITIVE", "false"
-).lower() == "true"
-# ENC-FTR-061: Governed Handoff Primitive feature flag
-ENABLE_HANDOFF_PRIMITIVE = os.environ.get(
-    "ENABLE_HANDOFF_PRIMITIVE", "false"
-).lower() == "true"
-# ENC-FTR-076 / ENC-TSK-E08: Agent-proposable component registry feature flag
-ENABLE_COMPONENT_PROPOSAL = os.environ.get(
-    "ENABLE_COMPONENT_PROPOSAL", "false"
-).lower() == "true"
+# ENC-TSK-F63: Feature flags migrated from ENABLE_* env vars to AppConfig.
+# appconfig_flags.flag() reads from AppConfig extension (localhost:2772) with
+# env_fallback for local dev / environments without the extension layer.
+# ENC-FTR-049
+ENABLE_TYPED_RELATIONSHIPS = _appconfig_flag("enable_typed_relationships", env_fallback="ENABLE_TYPED_RELATIONSHIPS")
+# ENC-FTR-050
+ENABLE_CONTEXT_NODES = _appconfig_flag("enable_context_nodes", env_fallback="ENABLE_CONTEXT_NODES")
+# ENC-FTR-052
+ENABLE_LESSON_PRIMITIVE = _appconfig_flag("enable_lesson_primitive", env_fallback="ENABLE_LESSON_PRIMITIVE")
+# ENC-FTR-061
+ENABLE_HANDOFF_PRIMITIVE = _appconfig_flag("enable_handoff_primitive", env_fallback="ENABLE_HANDOFF_PRIMITIVE")
+# ENC-FTR-076 / ENC-TSK-E08
+ENABLE_COMPONENT_PROPOSAL = _appconfig_flag("enable_component_proposal", env_fallback="ENABLE_COMPONENT_PROPOSAL")
 
 TRACKER_API_INTERNAL_API_KEY = os.environ.get(
     "ENCELADUS_TRACKER_API_INTERNAL_API_KEY",


### PR DESCRIPTION
## Summary

- **AC-1 — AppConfig feature flags**: New `06-feature-flags.yaml` CFN stack provisions AppConfig application/environment/profile with JSON Schema validator for 7 boolean feature flags. AppConfig Lambda extension layer (arch-specific ARNs: x86 and arm64) attached to all 24 Lambdas via `HasAppConfigLayer` condition. New `appconfig_flags.py` shared module in `enceladus_shared` layer; `coordination_api` and `enceladus-mcp-server` migrated from ENABLE_* env vars. `AppConfigAccess` IAM inline policy (GetConfiguration/StartConfigurationSession) added to all Lambda execution roles. Zero ENABLE_* env vars remain in any Lambda Environment.Variables.

- **AC-2 — SnapStart**: `EnableSnapStart` CFN parameter + `SnapStartEnabled` condition replaces old `IsProduction`-negation pattern. `SnapStart: ApplyOn: PublishedVersions` now correctly gated on arm64/py3.12 targets (`v4-gamma`, `v4-prod`). CloudWatch Metric Filters capture REPORT InitDuration into `Enceladus/SnapStart` namespace for 3 key Lambdas (coordination-api, graph-query-api, tracker-mutation).

- **AC-3 — CodeDeploy canary**: New `07-codedeploy.yaml` provisions CodeDeploy application, IAM role, `live` alias (bootstrapped to $LATEST), per-function ErrorAlarm + p99 LatencyAlarm, and DeploymentGroup for all 23 parametric Lambdas. AutoRollback on `DEPLOYMENT_FAILURE` + `DEPLOYMENT_STOP_ON_ALARM`. `_deploy.yml` canary step calls `update-function-code --publish`, builds AppSpec, calls `create-deployment`, polls for completion.

## Changed files

| File | Change |
|------|--------|
| `infrastructure/cloudformation/06-feature-flags.yaml` | **New** — AppConfig app/env/profile/deployment |
| `infrastructure/cloudformation/07-codedeploy.yaml` | **New** — CodeDeploy app, 23 aliases, 23 DeploymentGroups, 38 CW alarms, 3 Metric Filters |
| `infrastructure/cloudformation/02-compute.yaml` | AppConfig layer + env vars on all 24 Lambdas; AppConfigAccess IAM on all roles; SnapStart via EnableSnapStart param |
| `backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py` | **New** — flag() helper with AppConfig→env_fallback→default resolution |
| `backend/lambda/coordination_api/lambda_function.py` | Migrated 4 ENABLE_* reads to appconfig_flags.flag() |
| `tools/enceladus-mcp-server/server.py` | Migrated 5 ENABLE_* reads to appconfig_flags.flag() |
| `.github/workflows/_deploy.yml` | CodeDeploy canary integration + 23-entry dg_name_map |
| `envs/v3-prod.yaml` | enable_snapstart=false, environment_suffix, codedeploy_app_name |
| `envs/v4-gamma.yaml` | enable_snapstart=true, environment_suffix=-gamma, codedeploy_app_name |
| `envs/v4-prod.yaml` | enable_snapstart=true, environment_suffix, codedeploy_app_name |

## Governance

**CCI-71bb89b1c0dc4394bdf08823e0063df2**

Commit: `9ef783cd06704d2048fbf907dcf2cf23628dfc42`
Task: ENC-TSK-F63 (status: committed)
Plan: ENC-PLN-041 Phase 5 / ENC-FTR-090

## Test plan

- [ ] Deploy `06-feature-flags.yaml` to gamma; capture ApplicationId + EnvironmentId → populate `envs/v4-gamma.yaml` appconfig_* fields
- [ ] Deploy `07-codedeploy.yaml` to gamma; verify 23 DeploymentGroups + 23 aliases created
- [ ] Deploy `02-compute.yaml` to gamma with `EnableSnapStart=true`; verify extension layer attached on coordination-api
- [ ] Invoke coordination-api; confirm AppConfig HTTP poll succeeds (check CW logs for no URLError)
- [ ] Deploy a Lambda via Gen2 workflow; verify CodeDeploy deployment created and traffic shifted
- [ ] Simulate bad deploy (force error threshold); verify AutoRollback fires within 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)