### PR TITLE
feat(monitoring): DM Gen2 Phase 6 — daily parity+drift audit via deploy-parity-validator (ENC-TSK-F64)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-21.48",
-  "updated_at": "2026-04-21T17:30:00Z",
-  "last_change_summary": "Added appconfig.feature_flags entity for AppConfig extension-based feature flag resolution (ENC-TSK-F63 AC-1). Migrated coordination_api and mcp-server ENABLE_* env var reads to AppConfig flag() helper with env fallback.",
+  "version": "2026-04-21.49",
+  "updated_at": "2026-04-21T17:21:00Z",
+  "last_change_summary": "Extended deploy.parity_validator entity: added daily_drift_audit action (ENC-TSK-F64 / ENC-FTR-090 AC-20). Added monitoring.continuous_drift_audit entity documenting the devops-parity-drift-daily EventBridge schedule, CFN stack drift detection, CodeSize anomaly, and SnapStart version audit.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4947,7 +4947,7 @@
         },
         "event_schema": {
           "type": "object",
-          "definition": "{action: pre_merge_check|deploy_watch|parity_check, pr_number: int, commit_sha: str, repo: str, function_name_map?: dict, lambda_dirs?: list}."
+          "definition": "{action: pre_merge_check|deploy_watch|parity_check|daily_drift_audit, pr_number: int, commit_sha: str, repo: str, function_name_map?: dict, lambda_dirs?: list}. daily_drift_audit requires no additional fields; triggered by EventBridge Scheduler via devops-parity-drift-daily rule."
         },
         "detection_rules": {
           "type": "array",
@@ -4957,7 +4957,7 @@
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -5001,6 +5001,32 @@
             "default"
           ],
           "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
+        }
+      }
+    },
+    "monitoring.continuous_drift_audit": {
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "fields": {
+        "trigger": {
+          "type": "string",
+          "definition": "EventBridge Scheduler rule devops-parity-drift-daily, cron(0 10 * * ? *). Input payload: {\"action\": \"daily_drift_audit\"}. Targets devops-deploy-parity-validator function ARN."
+        },
+        "cfn_drift_stacks": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "CFN stacks checked via detect_stack_drift: enceladus-data, enceladus-api, enceladus-github-roles, enceladus-monitoring. Configurable via CFN_DRIFT_STACKS env var."
+        },
+        "code_size_check": {
+          "type": "object",
+          "definition": "Flags any Lambda with CodeSize < 1024 bytes as a CFN ZipFile stub overwrite (ENC-FTR-068 AC-5). Covers all functions with devops-/enceladus- prefix via list_functions pagination."
+        },
+        "snapstart_check": {
+          "type": "object",
+          "definition": "Flags any Lambda with >SNAPSTART_MAX_STALE_VERSIONS (default 5) published versions as a potential SnapStart storage cost trap. Uses list_versions_by_function."
+        },
+        "alert_channel": {
+          "type": "string",
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
         }
       }
     }

--- a/backend/lambda/deploy_parity_validator/lambda_function.py
+++ b/backend/lambda/deploy_parity_validator/lambda_function.py
@@ -45,6 +45,20 @@ INTERNAL_API_KEY     = os.environ.get("COORDINATION_INTERNAL_API_KEY", "")
 ENVIRONMENT_SUFFIX   = os.environ.get("ENVIRONMENT_SUFFIX", "")  # "" = prod, "-gamma" = gamma
 AWS_REGION           = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 
+# ENC-TSK-F64 / ENC-FTR-090 AC-20 — daily drift audit config
+SNS_TOPIC_ARN        = os.environ.get("SNS_TOPIC_ARN", "")
+CFN_DRIFT_STACKS     = [
+    s.strip()
+    for s in os.environ.get(
+        "CFN_DRIFT_STACKS",
+        "enceladus-data,enceladus-api,enceladus-github-roles,enceladus-monitoring",
+    ).split(",")
+    if s.strip()
+]
+SNAPSTART_MAX_STALE  = int(os.environ.get("SNAPSTART_MAX_STALE_VERSIONS", "5"))
+DRIFT_POLL_TIMEOUT   = int(os.environ.get("DRIFT_POLL_TIMEOUT", "240"))
+_LAMBDA_FN_PREFIXES  = ("devops-", "enceladus-")
+
 # Deployment Manager pipeline Lambdas — env health checked before every merge.
 _DM_BASE_NAMES = [
     "devops-deploy-intake",
@@ -100,6 +114,24 @@ def _get_secrets():
     if _secrets is None:
         _secrets = boto3.client("secretsmanager", region_name=DEPLOY_REGION)
     return _secrets
+
+
+_cfn  = None
+_sns  = None
+
+
+def _get_cfn():
+    global _cfn
+    if _cfn is None:
+        _cfn = boto3.client("cloudformation", region_name=DEPLOY_REGION)
+    return _cfn
+
+
+def _get_sns():
+    global _sns
+    if _sns is None:
+        _sns = boto3.client("sns", region_name=DEPLOY_REGION)
+    return _sns
 
 
 # ---------------------------------------------------------------------------
@@ -469,6 +501,159 @@ def _patch_readiness_doc(doc_id: str, outcome: Dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit
+# ---------------------------------------------------------------------------
+
+def _detect_and_poll_stack_drift(stack_name: str) -> Dict:
+    """Trigger CFN detect_stack_drift, poll until complete or DRIFT_POLL_TIMEOUT."""
+    cfn = _get_cfn()
+    try:
+        resp = cfn.detect_stack_drift(StackName=stack_name)
+        detection_id = resp["StackDriftDetectionId"]
+    except Exception as exc:
+        return {"stack": stack_name, "status": "detection_error", "error": str(exc)}
+
+    deadline = time.monotonic() + DRIFT_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        sr = cfn.describe_stack_drift_detection_status(StackDriftDetectionId=detection_id)
+        ds = sr.get("DetectionStatus")
+        if ds == "DETECTION_COMPLETE":
+            drift_status = sr.get("StackDriftStatus", "UNKNOWN")
+            return {
+                "stack": stack_name,
+                "drift_status": drift_status,
+                "drifted_resource_count": sr.get("DriftedStackResourceCount", 0),
+                "drifted": drift_status == "DRIFTED",
+            }
+        if ds == "DETECTION_FAILED":
+            return {"stack": stack_name, "status": "detection_failed",
+                    "reason": sr.get("DetectionStatusReason", "")}
+        time.sleep(15)
+
+    return {"stack": stack_name, "status": "detection_timeout", "detection_id": detection_id}
+
+
+def _list_prod_lambda_names() -> List[str]:
+    """Return all Lambda function names matching the devops-/enceladus- prefixes."""
+    lc = _get_lambda()
+    names: List[str] = []
+    paginator = lc.get_paginator("list_functions")
+    for page in paginator.paginate():
+        for fn in page.get("Functions", []):
+            name = fn.get("FunctionName", "")
+            if any(name.startswith(p) for p in _LAMBDA_FN_PREFIXES):
+                names.append(name)
+    return names
+
+
+def _audit_code_size(fn_names: List[str]) -> List[Dict]:
+    """CodeSize < 1024 bytes = CFN ZipFile stub overwrite (ENC-FTR-068 AC-5)."""
+    lc = _get_lambda()
+    anomalies: List[Dict] = []
+    for name in fn_names:
+        try:
+            cfg = lc.get_function_configuration(FunctionName=name)
+            size = cfg.get("CodeSize", 0)
+            if size < 1024:
+                anomalies.append({"lambda": name, "code_size": size,
+                                  "reason": "CFN ZipFile stub overwrite (ENC-FTR-068 AC-5)"})
+        except Exception as exc:
+            logger.warning("code_size check failed for %s: %s", name, exc)
+    return anomalies
+
+
+def _audit_snapstart_versions(fn_names: List[str]) -> List[Dict]:
+    """Flag Lambdas with >SNAPSTART_MAX_STALE published versions (SnapStart cost trap)."""
+    lc = _get_lambda()
+    anomalies: List[Dict] = []
+    for name in fn_names:
+        try:
+            resp = lc.list_versions_by_function(FunctionName=name, MaxItems=50)
+            versions = [v for v in resp.get("Versions", []) if v.get("Version") != "$LATEST"]
+            if len(versions) > SNAPSTART_MAX_STALE:
+                anomalies.append({"lambda": name, "published_versions": len(versions),
+                                  "reason": f"{len(versions)} published versions exceeds {SNAPSTART_MAX_STALE} — potential SnapStart storage cost trap"})
+        except Exception as exc:
+            logger.warning("snapstart version check failed for %s: %s", name, exc)
+    return anomalies
+
+
+def _publish_drift_alert(subject: str, lines: List[str]) -> None:
+    if not SNS_TOPIC_ARN:
+        logger.warning("SNS_TOPIC_ARN not set; skipping drift alert")
+        return
+    try:
+        _get_sns().publish(
+            TopicArn=SNS_TOPIC_ARN,
+            Subject=subject[:100],
+            Message="\n".join(lines)[:262144],
+        )
+        logger.info("drift alert published: %s", subject)
+    except Exception as exc:
+        logger.error("SNS publish failed: %s", exc)
+
+
+def _run_daily_drift_audit() -> Dict:
+    """
+    ENC-FTR-090 AC-20 daily drift audit: CFN stack drift, CodeSize anomaly,
+    SnapStart published-version count. Publishes SNS alert if any anomaly found.
+    """
+    run_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    logger.info("[START] daily_drift_audit run_at=%s stacks=%s", run_at, CFN_DRIFT_STACKS)
+
+    # 1. CFN stack drift
+    cfn_results = [_detect_and_poll_stack_drift(s) for s in CFN_DRIFT_STACKS]
+    cfn_anomalies = [r for r in cfn_results
+                     if r.get("drifted") or r.get("status") in
+                     ("detection_error", "detection_failed", "detection_timeout")]
+
+    # 2 & 3. Lambda CodeSize + SnapStart version count
+    fn_names = _list_prod_lambda_names()
+    size_anomalies = _audit_code_size(fn_names)
+    snap_anomalies = _audit_snapstart_versions(fn_names)
+
+    total = len(cfn_anomalies) + len(size_anomalies) + len(snap_anomalies)
+
+    if total > 0:
+        lines = [f"deploy-parity-validator daily drift audit: {total} anomaly(ies) at {run_at}", ""]
+        if cfn_anomalies:
+            lines.append("=== CFN Stack Drift ===")
+            for r in cfn_anomalies:
+                detail = r.get("drift_status", r.get("status", ""))
+                count = r.get("drifted_resource_count", "")
+                lines.append(f"  {r['stack']}: {detail}" + (f" ({count} resources)" if count else ""))
+        if size_anomalies:
+            lines.append("=== CodeSize Anomaly (<1024 bytes — CFN stomp) ===")
+            for a in size_anomalies:
+                lines.append(f"  {a['lambda']}: {a['code_size']} bytes")
+        if snap_anomalies:
+            lines.append(f"=== SnapStart Version Count (>{SNAPSTART_MAX_STALE} stale) ===")
+            for a in snap_anomalies:
+                lines.append(f"  {a['lambda']}: {a['published_versions']} versions")
+        _publish_drift_alert(
+            subject=f"[drift-audit] {total} anomaly(ies) — {run_at}",
+            lines=lines,
+        )
+
+    result = {
+        "action": "daily_drift_audit",
+        "run_at": run_at,
+        "cfn_stacks_checked": len(cfn_results),
+        "cfn_anomalies": len(cfn_anomalies),
+        "lambdas_checked": len(fn_names),
+        "code_size_anomalies": len(size_anomalies),
+        "snapstart_anomalies": len(snap_anomalies),
+        "total_anomalies": total,
+        "alert_published": total > 0 and bool(SNS_TOPIC_ARN),
+        "cfn_detail": cfn_results,
+        "code_size_detail": size_anomalies,
+        "snapstart_detail": snap_anomalies,
+    }
+    logger.info("[END] daily_drift_audit total_anomalies=%d", total)
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Pre-merge analysis + fix pass
 # ---------------------------------------------------------------------------
 def _run_pre_merge(event: Dict) -> Dict:
@@ -586,6 +771,9 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
             result = _run_pre_merge(event)
         elif action in ("deploy_watch", "pr_merged"):
             result = _run_deploy_watch(event)
+        elif action == "daily_drift_audit":
+            # ENC-TSK-F64 / ENC-FTR-090 AC-20 — triggered by devops-parity-drift-daily schedule
+            result = _run_daily_drift_audit()
         else:
             return {
                 "statusCode": 400,

--- a/frontend/ui/src/pages/DeploymentManagerPage.tsx
+++ b/frontend/ui/src/pages/DeploymentManagerPage.tsx
@@ -233,7 +233,7 @@ export function DeploymentManagerPage() {
         </div>
       ) : isError ? (
         <div className="dm-error">
-          GitHub API unavailable — check VITE_GITHUB_READ_TOKEN or rate limits.
+          GitHub API unavailable — authentication error or rate limit exceeded.
         </div>
       ) : items.length === 0 ? (
         <div className="dm-empty">No deployments found.</div>

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -693,6 +693,10 @@ Resources:
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
           APPCONFIG_CONFIGURATION: feature-flags
+          SNS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-deploy-alerts"
+          CFN_DRIFT_STACKS: "enceladus-data,enceladus-api,enceladus-github-roles,enceladus-monitoring"
+          SNAPSTART_MAX_STALE_VERSIONS: "5"
+          DRIFT_POLL_TIMEOUT: "240"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1770,6 +1774,24 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: "*"
+              - Sid: DriftAuditCfn
+                Effect: Allow
+                Action:
+                  - cloudformation:DetectStackDrift
+                  - cloudformation:DescribeStackDriftDetectionStatus
+                Resource: "*"
+              - Sid: DriftAuditLambdaRead
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:ListFunctions
+                  - lambda:ListVersionsByFunction
+                Resource: "*"
+              - Sid: DriftAuditSns
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-deploy-alerts"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -98,31 +98,36 @@ Resources:
           Arn: !GetAtt ProdHealthMonitorFunction.Arn
 
   # ---------------------------------------------------------------------------
-  # ENC-TSK-E69 / ENC-PLN-031 Phase 4 — Deploy Capability Auditor schedule
+  # ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily parity + drift schedule
   # ---------------------------------------------------------------------------
-  # The Lambda function itself is created by backend/lambda/deploy_capability_auditor/deploy.sh
-  # (self-managed IAM + zip update). This block owns only the EventBridge rule
-  # so the schedule is IaC-managed and visible to the CFN drift audit
-  # (ENC-TSK-E67).
+  # Extends devops-deploy-parity-validator (ENC-TSK-F87) via EventBridge to run
+  # daily at 10:00 UTC with action=daily_drift_audit. Adds to its scope:
+  #   (a) CFN detect_stack_drift across enceladus-data/api/github-roles/monitoring
+  #   (b) CodeSize < 1024 bytes anomaly detection (CFN stomp — ENC-FTR-068 AC-5)
+  #   (c) SnapStart published-version count audit (>5 stale triggers SNS alert)
+  # No new Lambda created; all logic consolidated in deploy-parity-validator per
+  # ENC-LSN-027 (minimise blast-radius surface).
 
-  DeployCapabilityAuditorScheduleRule:
+  ParityDriftDailyScheduleRule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub "enceladus-deploy-capability-auditor-schedule${EnvironmentSuffix}"
-      Description: Triggers deploy capability auditor Lambda daily at 10:00 UTC
+      Name: !Sub "devops-parity-drift-daily${EnvironmentSuffix}"
+      Description: >
+        Triggers deploy-parity-validator daily_drift_audit at 10:00 UTC (ENC-TSK-F64 / AC-20)
       ScheduleExpression: "cron(0 10 * * ? *)"
       State: ENABLED
       Targets:
-        - Id: DeployCapabilityAuditorTarget
-          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-deploy-capability-auditor${EnvironmentSuffix}"
+        - Id: ParityDriftDailyTarget
+          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-deploy-parity-validator${EnvironmentSuffix}"
+          Input: '{"action": "daily_drift_audit"}'
 
-  DeployCapabilityAuditorInvokePermission:
+  ParityDriftDailyInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub "enceladus-deploy-capability-auditor${EnvironmentSuffix}"
+      FunctionName: !Sub "devops-deploy-parity-validator${EnvironmentSuffix}"
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt DeployCapabilityAuditorScheduleRule.Arn
+      SourceArn: !GetAtt ParityDriftDailyScheduleRule.Arn
 
   # ---------------------------------------------------------------------------
   # ENC-ISS-283 / ENC-LSN-027 — Env Drift Auditor schedule
@@ -211,3 +216,7 @@ Outputs:
   HealthProbeScheduleRuleArn:
     Description: ARN of the EventBridge health probe schedule
     Value: !GetAtt HealthProbeScheduleRule.Arn
+
+  ParityDriftDailyScheduleRuleArn:
+    Description: ARN of the daily parity+drift EventBridge schedule (ENC-TSK-F64 / AC-20)
+    Value: !GetAtt ParityDriftDailyScheduleRule.Arn


### PR DESCRIPTION
## Summary

- Extends `devops-deploy-parity-validator` (ENC-TSK-F87 scaffold) with a `daily_drift_audit` action per **ENC-FTR-090 AC-20** — no new Lambda created; all drift logic consolidated in one governed Lambda with one IAM role (ENC-LSN-027).
- Replaces `DeployCapabilityAuditorScheduleRule` (ENC-TSK-E69, retired) with new `devops-parity-drift-daily` EventBridge rule targeting the parity validator.
- Addresses **ENC-FTR-090 AC-12** (daily drift auditor) + **AC-20** (scope extension via parity validator).

## Changes

**`backend/lambda/deploy_parity_validator/lambda_function.py`**
- New `_run_daily_drift_audit()`: (a) `detect_stack_drift` across `enceladus-data/api/github-roles/monitoring`, (b) CodeSize < 1024 bytes anomaly (CFN ZipFile stomp — ENC-FTR-068 AC-5), (c) SnapStart published-version count audit (>5 stale → SNS alert)
- New helpers: `_detect_and_poll_stack_drift()`, `_list_prod_lambda_names()`, `_audit_code_size()`, `_audit_snapstart_versions()`, `_publish_drift_alert()`
- `lambda_handler` wires `action=daily_drift_audit` → `_run_daily_drift_audit()`

**`infrastructure/cloudformation/02-compute.yaml`**
- `DeployParityValidatorRole`: add `DriftAuditCfn`, `DriftAuditLambdaRead`, `DriftAuditSns` IAM sids
- `DeployParityValidatorFunction`: add `SNS_TOPIC_ARN`, `CFN_DRIFT_STACKS`, `SNAPSTART_MAX_STALE_VERSIONS`, `DRIFT_POLL_TIMEOUT` env vars

**`infrastructure/cloudformation/05-monitoring.yaml`**
- Remove `DeployCapabilityAuditorScheduleRule` + `DeployCapabilityAuditorInvokePermission` (ENC-TSK-E69 retired)
- Add `ParityDriftDailyScheduleRule` (`devops-parity-drift-daily`, `cron(0 10 * * ? *)`) + `ParityDriftDailyInvokePermission`

**`backend/lambda/coordination_api/governance_data_dictionary.json`**
- Bumped to v2026-04-21.49
- Extended `deploy.parity_validator` event_schema + IAM contract
- Added `monitoring.continuous_drift_audit` entity

## Linked

ENC-TSK-F64 | ENC-FTR-090 AC-12, AC-20 | ENC-PLN-041

CCI-0ec9269c38df4d2aa1a8825a3c90f06e

🤖 Generated with [Claude Code](https://claude.com/claude-code)