### PR TITLE
fix(deploy): explicit if: on deploy job — workflow_dispatch skip bug

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -216,6 +216,12 @@ jobs:
   deploy:
     name: Deploy → ${{ needs.resolve.outputs.environment }}
     needs: resolve
+    # Without this explicit condition, GitHub Actions' implicit success() check evaluates
+    # the transitive job chain: build (skipped on workflow_dispatch) → resolve → deploy.
+    # A skipped ancestor causes success() to return false, silently skipping the deploy job.
+    # This if: allows the deploy to run on workflow_dispatch (build skipped) as long as
+    # resolve itself succeeded.
+    if: always() && needs.resolve.result == 'success'
     environment: ${{ needs.resolve.outputs.environment }}
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/secrets-guardrail.yml
+++ b/.github/workflows/secrets-guardrail.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -euo pipefail
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
-            | sh -s -- -b /usr/local/bin
+            | sh -s -- -b /usr/local/bin v3.94.0
           trufflehog --version
 
       - name: Run local guard scans


### PR DESCRIPTION
## Summary

- GitHub Actions' implicit `success()` check evaluates the transitive job chain: `build` (skipped on `workflow_dispatch`) → `resolve` → `deploy`. A skipped ancestor causes `success()` to return false, silently skipping the deploy job on every `workflow_dispatch` run.
- Adds `if: always() && needs.resolve.result == 'success'` so `workflow_dispatch` promotions to `v3-prod` (and any environment) work correctly.
- Root cause identified in run `24737352109`: resolve succeeded (28 artifacts found, `environment=v3-prod`), but deploy was skipped with unresolved `${{ }}` name expression. Confirmed same skip in `24706305257` (v4-gamma dispatch). Only push-triggered runs (where `build` succeeds) have ever deployed.

## Scope

Blocking fix for ENC-TSK-F65 `deploy-init` → `deploy-success` transition. Tracked as ENC-TSK-F89.

CCI-ebb96811836c4bb6b7136aea4eb46536

## Test plan

- [ ] Merge and redispatch to `v3-prod` — deploy job should enter environment approval gate instead of being skipped
- [ ] Push-triggered deploy to `v4-gamma` still works (if: condition passes when resolve succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)