### PR TITLE
fix(deploy): skip ResourceNotFoundException on update-function-code (ENC-FTR-090)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -362,9 +362,17 @@ jobs:
               ], capture_output=True, text=True)
               os.unlink(tmp.name)
               if r.returncode != 0:
-                  print(f'::error::update-function-code failed for {mapped_name}: {r.stderr.strip()}',
-                        file=sys.stderr)
-                  errors.append(fn)
+                  stderr = r.stderr.strip()
+                  if 'ResourceNotFoundException' in stderr or 'Function not found' in stderr:
+                      # Function not yet provisioned in this environment (CFN ZipFile stub
+                      # not deployed). Skip gracefully — it will be deployed in a future
+                      # run once the CFN stack update provisions the function.
+                      print(f'  [skip] {mapped_name}: not provisioned in this environment yet')
+                      skipped.append(fn)
+                  else:
+                      print(f'::error::update-function-code failed for {mapped_name}: {stderr}',
+                            file=sys.stderr)
+                      errors.append(fn)
                   continue
 
               # ENC-TSK-F63 AC-2/AC-3: capture published version for alias + CodeDeploy.


### PR DESCRIPTION
## Summary

- When a Lambda function doesn't exist in the target environment yet (CFN ZipFile stub not deployed), `update-function-code` returns `ResourceNotFoundException`. The prior code treated this as a hard error, failing the entire deploy job even when 30/31 other functions deployed successfully.
- Adds detection for `ResourceNotFoundException`/`Function not found` in `update-function-code` stderr: function is skipped with a `[skip]` log line instead of added to the `errors` list.
- This unblocks ENC-TSK-F65 `deploy-init → deploy-success`: run `24738319316` deployed all 30 existing prod functions; only `devops-deploy-parity-validator` was skipped (not yet provisioned via CFN stack update).

## Governance

CCI-e3017f5f4e5d443ab98f0fda7d256db9 (ENC-TSK-F90)

## Test plan

- [ ] Re-dispatch to v3-prod after merge — deploy job succeeds with `[skip] devops-deploy-parity-validator: not provisioned in this environment yet`
- [ ] All other 30 functions deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)