### PR TITLE
test(component-registry): FTR-076v2 lifecycle test coverage (ENC-TSK-F46)

### DIFF
--- a/backend/lambda/checkout_service/test_component_lifecycle_gate.py
+++ b/backend/lambda/checkout_service/test_component_lifecycle_gate.py
@@ -1,0 +1,253 @@
+"""Tests for ENC-TSK-F46 AC[4]: checkout response for each of 8 lifecycle statuses.
+
+Covers the FTR-076 v2 / ENC-ISS-172 component lifecycle gate in checkout_service:
+
+The 8 lifecycle statuses and their expected checkout responses:
+  OPAQUE statuses (checkout -> 404):
+    - archived
+
+  BLOCKED statuses (checkout -> 400):
+    - proposed
+    - deprecated
+
+  PERMITTED statuses (checkout -> proceeds normally):
+    - approved
+    - designed
+    - development
+    - production
+    - code-red
+
+Per DOC-546B896390EA §6 / ENC-ISS-172: the checkout_service validates
+task.transition_type against the component registry BEFORE writing any
+checkout lock, status mutation, or CAI token. If a component is in an
+OPAQUE or BLOCKED lifecycle status, checkout fails fast.
+
+Related: ENC-ISS-172, ENC-TSK-C15, ENC-FTR-076 v2
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_lambda",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = checkout_lambda
+_SPEC.loader.exec_module(checkout_lambda)
+
+
+def _make_task(components, transition_type="github_pr_deploy"):
+    return {
+        "task_id": "ENC-TSK-TEST",
+        "status": "open",
+        "transition_type": transition_type,
+        "components": components,
+    }
+
+
+def _ddb_lifecycle_side_effect(component_lifecycle_map):
+    """Return a ddb.get_item side_effect answering with lifecycle + required_transition_type."""
+    def _side(TableName, Key):
+        cid = Key["component_id"]["S"]
+        ls = component_lifecycle_map.get(cid)
+        if ls is None:
+            return {}
+        return {
+            "Item": {
+                "component_id": {"S": cid},
+                "lifecycle_status": {"S": ls},
+                "required_transition_type": {"S": "github_pr_deploy"},
+            }
+        }
+    return _side
+
+
+class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
+    """Checkout response for each of the 8 lifecycle statuses (ENC-TSK-F46 AC[4])."""
+
+    def _call_checkout(self, lifecycle_status):
+        cid = f"comp-{lifecycle_status.replace('-', '_')}"
+        task = _make_task([cid])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+             mock.patch.object(checkout_lambda._ddb, "get_item",
+                               side_effect=_ddb_lifecycle_side_effect({cid: lifecycle_status})):
+            return checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+
+    # ---- OPAQUE status: archived -> 404 ----
+
+    def test_archived_component_returns_404(self):
+        """archived: checkout returns 404 (opaque — indistinguishable from non-existent)."""
+        resp = self._call_checkout("archived")
+        self.assertEqual(resp["statusCode"], 404)
+        body = json.loads(resp["body"])
+        self.assertNotEqual(body.get("success"), True)
+        self.assertIn("not found", body.get("error", "").lower())
+
+    def test_archived_checkout_body_says_not_found(self):
+        """archived 404 body contains 'not found' error — identical pattern to non-existent."""
+        resp = self._call_checkout("archived")
+        body = json.loads(resp["body"])
+        self.assertIn("not found", body.get("error", "").lower())
+
+    # ---- BLOCKED statuses: proposed, deprecated -> 400 ----
+
+    def test_proposed_component_returns_400(self):
+        """proposed: checkout returns 400 (blocked — component not yet approved)."""
+        resp = self._call_checkout("proposed")
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertNotEqual(body.get("success"), True)
+
+    def test_proposed_checkout_body_contains_component_id(self):
+        """proposed 400 body must contain the component_id for operator diagnosis."""
+        cid = "comp-proposed"
+        task = _make_task([cid])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+             mock.patch.object(checkout_lambda._ddb, "get_item",
+                               side_effect=_ddb_lifecycle_side_effect({cid: "proposed"})):
+            resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+        self.assertEqual(resp["statusCode"], 400)
+        self.assertIn(cid, json.dumps(json.loads(resp["body"])))
+
+    def test_deprecated_component_returns_400(self):
+        """deprecated: checkout returns 400 (blocked — end-of-life component)."""
+        resp = self._call_checkout("deprecated")
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertNotEqual(body.get("success"), True)
+
+    def test_deprecated_checkout_body_contains_component_id(self):
+        """deprecated 400 body must contain the component_id for operator diagnosis."""
+        cid = "comp-deprecated"
+        task = _make_task([cid])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+             mock.patch.object(checkout_lambda._ddb, "get_item",
+                               side_effect=_ddb_lifecycle_side_effect({cid: "deprecated"})):
+            resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+        self.assertEqual(resp["statusCode"], 400)
+        self.assertIn(cid, json.dumps(json.loads(resp["body"])))
+
+    # ---- PERMITTED statuses: approved, designed, development, production, code-red -> not blocked ----
+
+    def _assert_permitted_status_not_blocked(self, lifecycle_status):
+        """Helper: permitted status must not return 400 or 404 from the lifecycle gate."""
+        resp = self._call_checkout(lifecycle_status)
+        body = json.loads(resp["body"])
+        body_str = json.dumps(body)
+        # Must not be blocked by the opacity or lifecycle gate.
+        self.assertNotEqual(
+            resp["statusCode"], 404,
+            f"lifecycle_status={lifecycle_status!r} returned 404 — must not be OPAQUE",
+        )
+        # Must not be blocked by the lifecycle gate (may still fail for other
+        # downstream reasons, e.g. transition_type mismatch — that is acceptable).
+        self.assertNotIn(
+            "component_lifecycle_blocked", body_str,
+            f"lifecycle_status={lifecycle_status!r} was blocked by lifecycle gate",
+        )
+
+    def test_approved_component_is_permitted(self):
+        """approved: PERMITTED — checkout is not blocked by the lifecycle gate."""
+        self._assert_permitted_status_not_blocked("approved")
+
+    def test_designed_component_is_permitted(self):
+        """designed: PERMITTED — checkout is not blocked by the lifecycle gate."""
+        self._assert_permitted_status_not_blocked("designed")
+
+    def test_development_component_is_permitted(self):
+        """development: PERMITTED — checkout is not blocked by the lifecycle gate."""
+        self._assert_permitted_status_not_blocked("development")
+
+    def test_production_component_is_permitted(self):
+        """production: PERMITTED — checkout is not blocked by the lifecycle gate."""
+        self._assert_permitted_status_not_blocked("production")
+
+    def test_code_red_component_is_permitted(self):
+        """code-red: PERMITTED — checkout is not blocked by the lifecycle gate."""
+        self._assert_permitted_status_not_blocked("code-red")
+
+    # ---- All 8 statuses covered in a parametric sweep ----
+
+    def test_all_8_statuses_are_classified(self):
+        """Verify all 8 lifecycle statuses are classified as OPAQUE, BLOCKED, or PERMITTED."""
+        opaque = frozenset({"archived"})
+        blocked = frozenset({"proposed", "deprecated"})
+        permitted = frozenset({"approved", "designed", "development", "production", "code-red"})
+        all_statuses = opaque | blocked | permitted
+
+        # All 8 statuses are present.
+        self.assertEqual(len(all_statuses), 8)
+
+        # Verify the gate constants on the module under test.
+        self.assertEqual(checkout_lambda._OPAQUE_LIFECYCLE_STATUSES, opaque)
+        self.assertEqual(checkout_lambda._BLOCKED_LIFECYCLE_STATUSES, blocked)
+
+    # ---- Opacity: archived 404 body matches non-existent shape ----
+
+    def test_archived_404_body_key_set_matches_not_found_pattern(self):
+        """Archived 404 body keys must not differ from a genuine missing-component pattern."""
+        archived_resp = self._call_checkout("archived")
+        self.assertEqual(archived_resp["statusCode"], 404)
+        archived_body = json.loads(archived_resp["body"])
+
+        # Must have 'error' key.
+        self.assertIn("error", archived_body)
+        # Must NOT have 'success': True.
+        self.assertNotEqual(archived_body.get("success"), True)
+        # Must NOT have a 'lifecycle_status' key revealing the actual status.
+        self.assertNotIn("lifecycle_status", archived_body)
+        # Must NOT have a 'component' key revealing registry details.
+        self.assertNotIn("component", archived_body)
+
+    # ---- Mixed components: one blocked, one permitted -> blocked wins ----
+
+    def test_mixed_proposed_and_approved_blocks(self):
+        """If any component is proposed (BLOCKED), checkout is blocked even if others are permitted."""
+        task = _make_task(["comp-approved", "comp-proposed"])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+             mock.patch.object(checkout_lambda._ddb, "get_item",
+                               side_effect=_ddb_lifecycle_side_effect({
+                                   "comp-approved": "approved",
+                                   "comp-proposed": "proposed",
+                               })):
+            resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_mixed_archived_and_approved_returns_404(self):
+        """If any component is archived (OPAQUE), checkout returns 404."""
+        task = _make_task(["comp-approved", "comp-archived"])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+             mock.patch.object(checkout_lambda._ddb, "get_item",
+                               side_effect=_ddb_lifecycle_side_effect({
+                                   "comp-approved": "approved",
+                                   "comp-archived": "archived",
+                               })):
+            resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_task_without_components_not_blocked(self):
+        """Task with no components in the registry is not blocked by the lifecycle gate."""
+        task = _make_task([])
+        body = {"active_agent_session_id": "test-agent-session"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)):
+            resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
+        # Should not be blocked by the lifecycle gate (may fail for other reasons).
+        body_str = json.dumps(json.loads(resp["body"]))
+        self.assertNotIn("component_lifecycle_blocked", body_str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_component_advance.py
+++ b/backend/lambda/coordination_api/test_component_advance.py
@@ -1,12 +1,29 @@
-"""Tests for coordination_api._handle_components_advance (ENC-TSK-F40 AC[1g]).
+"""Tests for coordination_api._handle_components_advance (ENC-TSK-F46 AC[0]).
 
-Exercises:
-- Authority matrix (agent-permitted targets only).
-- Evidence gate evaluation (DESIGNS/IMPLEMENTS counter thresholds + deploy-success).
-- Happy path with DDB UpdateItem invocation.
-- Hard-block (archived source, deprecated->development) rejection.
-- Feature flag gate.
-- io bypass of gates.
+Covers all 15 transitions in the FTR-076 v2 state machine including:
+- All valid table-permitted transitions (13 valid + 2 hard blocks = 15 total)
+- Hard-block assertions: deprecated->development, archived->any
+- Authority matrix (agent-permitted targets only)
+- Evidence gate evaluation (DESIGNS/IMPLEMENTS counter thresholds + deploy-success)
+- Happy path with DDB UpdateItem invocation
+- Feature flag gate
+- io bypass of gates
+
+The 8 lifecycle statuses per DOC-546B896390EA §3.1:
+  proposed, approved, designed, development, production, code-red, deprecated, archived
+
+The 13 valid transitions per §3.2:
+  proposed -> approved, proposed -> archived
+  approved -> designed
+  designed -> development, designed -> approved
+  development -> production, development -> designed
+  production -> code-red, production -> deprecated, production -> development
+  code-red -> production, code-red -> deprecated
+  deprecated -> production
+
+Hard blocks (rejected even though both statuses are valid):
+  deprecated -> development  (forbidden per §3.2 / DD-3: version-fork required)
+  archived -> any            (archived has empty transition list)
 """
 
 import importlib.util
@@ -51,6 +68,26 @@ def _fake_ddb_update_success(attrs):
     return fake
 
 
+def _component_at(status):
+    return {"component_id": "comp-x", "lifecycle_status": status}
+
+
+def _task_at(status, closed_count=0, checkout_count=0):
+    return {
+        "item_id": "ENC-TSK-X01",
+        "status": status,
+        "closed_count": closed_count,
+        "checkout_count": checkout_count,
+    }
+
+
+def _fake_ddb(target_status):
+    return _fake_ddb_update_success({
+        "component_id": {"S": "comp-x"},
+        "lifecycle_status": {"S": target_status},
+    })
+
+
 class ComponentAdvanceTests(unittest.TestCase):
 
     def setUp(self):
@@ -62,6 +99,8 @@ class ComponentAdvanceTests(unittest.TestCase):
 
     def tearDown(self):
         self._flag.stop()
+
+    # ------------------------------------------------------------------ guards
 
     def test_feature_flag_off_returns_503(self):
         with mock.patch.object(
@@ -78,6 +117,12 @@ class ComponentAdvanceTests(unittest.TestCase):
         )
         self.assertEqual(resp["statusCode"], 400)
 
+    def test_invalid_target_status_returns_400(self):
+        resp = coordination_lambda._handle_components_advance(
+            "comp-x", _event({"target_status": "nonexistent_status"}), AGENT_CLAIMS
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
     def test_unknown_component_returns_404(self):
         with mock.patch.object(
             coordination_lambda, "_get_component_record", return_value=None
@@ -87,23 +132,61 @@ class ComponentAdvanceTests(unittest.TestCase):
             )
         self.assertEqual(resp["statusCode"], 404)
 
-    def test_archived_source_returns_404_opacity(self):
+    # ------------------------------------------- hard block: archived->any (opacity)
+
+    def test_archived_source_to_production_returns_404_opacity(self):
+        """Hard block: archived -> any. Opacity: indistinguishable from 404."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "archived"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("archived"),
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "production"}), AGENT_CLAIMS
             )
         self.assertEqual(resp["statusCode"], 404)
 
-    def test_deprecated_to_development_hard_block(self):
-        """Hard block per §3.2 / DD-3."""
+    def test_archived_source_to_deprecated_returns_404_opacity(self):
+        """Hard block: archived -> any even when io-callers try."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "deprecated"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("archived"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "deprecated"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_archived_source_to_code_red_returns_404_opacity(self):
+        """Hard block: archived -> any, no valid targets for archived status."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("archived"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "code-red"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 404)
+
+    # --------------------------------- hard block: deprecated->development
+
+    def test_deprecated_to_development_hard_block_agent(self):
+        """Hard block per §3.2 / DD-3: version-fork required for deprecated->development."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("deprecated"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "LIFECYCLE_TRANSITION_UNMET")
+
+    def test_deprecated_to_development_hard_block_io(self):
+        """Hard block also applies to io — Cognito auth does not bypass hard blocks."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("deprecated"),
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "development"}), IO_CLAIMS
@@ -112,12 +195,13 @@ class ComponentAdvanceTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["error_envelope"]["code"], "LIFECYCLE_TRANSITION_UNMET")
 
-    def test_agent_denied_for_io_only_target(self):
-        """Agents may not target 'approved' etc. — only §3.3 agent-permitted set."""
+    # ---------------------------------------- authority matrix (agent restricted)
+
+    def test_agent_denied_for_approved_target(self):
+        """Agents may not target 'approved' — io only per §3.3."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "designed"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "approved"}), AGENT_CLAIMS
@@ -126,13 +210,59 @@ class ComponentAdvanceTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["error_envelope"]["code"], "AUTHORITY_MATRIX_DENIED")
 
-    def test_approved_to_designed_gate_missing_edge(self):
-        """Agent advance approved->designed requires a DESIGNS edge; with
-        no edge registered, expect GATE_CONDITION_UNMET."""
+    def test_agent_denied_for_deprecated_target(self):
+        """Agents may not target 'deprecated' — io only."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("production"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "deprecated"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 403)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "AUTHORITY_MATRIX_DENIED")
+
+    # ----------- transition 1: proposed -> approved (io only)
+
+    def test_proposed_to_approved_io_path(self):
+        """Transition 1/13: proposed -> approved (io path, table-permitted)."""
+        fake = _fake_ddb("approved")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("proposed"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "approved"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "approved")
+        self.assertEqual(body["advanced_by"], "io")
+
+    # ----------- transition 2: proposed -> archived (io only)
+
+    def test_proposed_to_archived_io_path(self):
+        """Transition 2/13: proposed -> archived (io path, table-permitted)."""
+        fake = _fake_ddb("archived")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("proposed"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "archived"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "archived")
+
+    # ----------- transition 3: approved -> designed (agent, gate: DESIGNS + closed_count>=1)
+
+    def test_approved_to_designed_gate_missing_edge(self):
+        """Transition 3 gate: approved->designed requires a DESIGNS edge."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("approved"),
         ), mock.patch.object(
             coordination_lambda, "_query_component_edges", return_value=[]
         ):
@@ -146,19 +276,16 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertTrue(body.get("missing_edge"))
 
     def test_approved_to_designed_gate_task_not_closed(self):
-        """DESIGNS edge exists but task closed_count=0 -> GATE_CONDITION_UNMET."""
+        """Transition 3 gate: DESIGNS edge exists but closed_count=0."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("approved"),
         ), mock.patch.object(
-            coordination_lambda,
-            "_query_component_edges",
+            coordination_lambda, "_query_component_edges",
             return_value=[{"target_id": "ENC-TSK-X01", "relationship_type": "designs"}],
         ), mock.patch.object(
-            coordination_lambda,
-            "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X01", "closed_count": 0},
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("closed", closed_count=0),
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "designed"}), AGENT_CLAIMS
@@ -169,26 +296,18 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertEqual(body["observed_value"], 0)
 
     def test_approved_to_designed_gate_passes(self):
-        """DESIGNS edge with closed_count=1 passes; DDB update fires."""
-        fake = _fake_ddb_update_success({
-            "component_id": {"S": "comp-x"},
-            "lifecycle_status": {"S": "designed"},
-        })
+        """Transition 3/13 happy path: DESIGNS edge with closed_count=1 passes."""
+        fake = _fake_ddb("designed")
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("approved"),
         ), mock.patch.object(
-            coordination_lambda,
-            "_query_component_edges",
+            coordination_lambda, "_query_component_edges",
             return_value=[{"target_id": "ENC-TSK-X01", "relationship_type": "designs"}],
         ), mock.patch.object(
-            coordination_lambda,
-            "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X01", "closed_count": 1},
-        ), mock.patch.object(
-            coordination_lambda, "_get_ddb", return_value=fake
-        ):
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("closed", closed_count=1),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "designed"}), AGENT_CLAIMS
             )
@@ -198,19 +317,15 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertEqual(body["previous_lifecycle_status"], "approved")
         self.assertEqual(body["advanced_by"], "agent")
 
-    def test_designed_to_development_gate_fails_checkout_count_zero(self):
+    # ----------- transition 4: designed -> development (agent, gate: IMPLEMENTS + checkout_count>=1)
+
+    def test_designed_to_development_gate_no_edge(self):
+        """Transition 4 gate: designed->development requires IMPLEMENTS edge."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "designed"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
         ), mock.patch.object(
-            coordination_lambda,
-            "_query_component_edges",
-            return_value=[{"target_id": "ENC-TSK-X02", "relationship_type": "implements"}],
-        ), mock.patch.object(
-            coordination_lambda,
-            "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X02", "checkout_count": 0},
+            coordination_lambda, "_query_component_edges", return_value=[]
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "development"}), AGENT_CLAIMS
@@ -220,20 +335,76 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
         self.assertEqual(body["required_edge"], "IMPLEMENTS")
 
-    def test_development_to_production_requires_deploy_success(self):
-        """Task must have status=deploy-success to gate development->production."""
+    def test_designed_to_development_gate_checkout_count_zero(self):
+        """Transition 4 gate: IMPLEMENTS edge but checkout_count=0 still fails."""
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "development"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
         ), mock.patch.object(
-            coordination_lambda,
-            "_query_component_edges",
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X02", "relationship_type": "implements"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("in-progress", checkout_count=0),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
+        self.assertEqual(body["required_edge"], "IMPLEMENTS")
+
+    def test_designed_to_development_gate_passes(self):
+        """Transition 4/13 happy path: IMPLEMENTS edge with checkout_count=1."""
+        fake = _fake_ddb("development")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X02", "relationship_type": "implements"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("in-progress", checkout_count=1),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "development")
+
+    # ----------- transition 5: designed -> approved (io only, backstep)
+
+    def test_designed_to_approved_io_path(self):
+        """Transition 5/13: designed -> approved (io backstep, table-permitted)."""
+        fake = _fake_ddb("approved")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "approved"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "approved")
+        self.assertEqual(body["advanced_by"], "io")
+
+    # ----------- transition 6: development -> production (agent, gate: IMPLEMENTS + deploy-success)
+
+    def test_development_to_production_requires_deploy_success(self):
+        """Transition 6 gate: IMPLEMENTS edge task must have status=deploy-success."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("development"),
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges",
             return_value=[{"target_id": "ENC-TSK-X02"}],
         ), mock.patch.object(
-            coordination_lambda,
-            "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X02", "status": "merged-main"},
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("merged-main"),
         ):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "production"}), AGENT_CLAIMS
@@ -243,18 +414,52 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
         self.assertEqual(body["observed_task_status"], "merged-main")
 
-    def test_production_to_code_red_no_gate(self):
-        fake = _fake_ddb_update_success({
-            "component_id": {"S": "comp-x"},
-            "lifecycle_status": {"S": "code-red"},
-        })
+    def test_development_to_production_passes_on_deploy_success(self):
+        """Transition 6/13 happy path: IMPLEMENTS edge task=deploy-success."""
+        fake = _fake_ddb("production")
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "production"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("development"),
         ), mock.patch.object(
-            coordination_lambda, "_get_ddb", return_value=fake
-        ):
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X02"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value=_task_at("deploy-success"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "production"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "production")
+
+    # ----------- transition 7: development -> designed (io only, regression)
+
+    def test_development_to_designed_io_path(self):
+        """Transition 7/13: development -> designed (io regression step)."""
+        fake = _fake_ddb("designed")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("development"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "designed"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "designed")
+        self.assertEqual(body["advanced_by"], "io")
+
+    # ----------- transition 8: production -> code-red (agent, no gate)
+
+    def test_production_to_code_red_no_gate(self):
+        """Transition 8/13: production -> code-red (agent-permitted, no evidence gate)."""
+        fake = _fake_ddb("code-red")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("production"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "code-red"}), AGENT_CLAIMS
             )
@@ -262,21 +467,95 @@ class ComponentAdvanceTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["lifecycle_status"], "code-red")
 
-    def test_io_bypasses_agent_target_restrictions(self):
-        """io may target any table-permitted status (even ones outside the
-        agent-permitted set) without triggering AUTHORITY_MATRIX_DENIED.
-        Here: designed->approved (backstep) is io-only."""
-        fake = _fake_ddb_update_success({
-            "component_id": {"S": "comp-x"},
-            "lifecycle_status": {"S": "approved"},
-        })
+    # ----------- transition 9: production -> deprecated (io only)
+
+    def test_production_to_deprecated_io_path(self):
+        """Transition 9/13: production -> deprecated (io only)."""
+        fake = _fake_ddb("deprecated")
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "designed"},
-        ), mock.patch.object(
-            coordination_lambda, "_get_ddb", return_value=fake
-        ):
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("production"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "deprecated"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "deprecated")
+
+    # ----------- transition 10: production -> development (io only)
+
+    def test_production_to_development_io_path(self):
+        """Transition 10/13: production -> development (io regression)."""
+        fake = _fake_ddb("development")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("production"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "development")
+
+    # ----------- transition 11: code-red -> production (agent, no gate)
+
+    def test_code_red_to_production_no_gate(self):
+        """Transition 11/13: code-red -> production (no evidence gate)."""
+        fake = _fake_ddb("production")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("code-red"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "production"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "production")
+
+    # ----------- transition 12: code-red -> deprecated (io only)
+
+    def test_code_red_to_deprecated_io_path(self):
+        """Transition 12/13: code-red -> deprecated (io only)."""
+        fake = _fake_ddb("deprecated")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("code-red"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "deprecated"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "deprecated")
+
+    # ----------- transition 13: deprecated -> production (io only)
+
+    def test_deprecated_to_production_io_path(self):
+        """Transition 13/13: deprecated -> production (io only)."""
+        fake = _fake_ddb("production")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("deprecated"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "production"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "production")
+
+    # -------------------------------- io bypasses gates
+
+    def test_io_bypasses_agent_target_restrictions(self):
+        """io may target any table-permitted status including io-only ones (backstep)."""
+        fake = _fake_ddb("approved")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "approved"}), IO_CLAIMS
             )
@@ -285,26 +564,62 @@ class ComponentAdvanceTests(unittest.TestCase):
         self.assertEqual(body["advanced_by"], "io")
 
     def test_io_bypasses_evidence_gates(self):
-        """io may advance approved->designed without a DESIGNS edge (no gate)."""
-        fake = _fake_ddb_update_success({
-            "component_id": {"S": "comp-x"},
-            "lifecycle_status": {"S": "designed"},
-        })
+        """io may advance approved->designed without a DESIGNS edge (no gate applied)."""
+        fake = _fake_ddb("designed")
         with mock.patch.object(
-            coordination_lambda,
-            "_get_component_record",
-            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("approved"),
         ), mock.patch.object(
             coordination_lambda, "_query_component_edges", return_value=[]
-        ), mock.patch.object(
-            coordination_lambda, "_get_ddb", return_value=fake
-        ):
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_advance(
                 "comp-x", _event({"target_status": "designed"}), IO_CLAIMS
             )
         self.assertEqual(resp["statusCode"], 200)
         body = json.loads(resp["body"])
         self.assertEqual(body["advanced_by"], "io")
+
+    def test_io_bypasses_implements_gate(self):
+        """io may advance designed->development without an IMPLEMENTS edge."""
+        fake = _fake_ddb("development")
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("designed"),
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges", return_value=[]
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["advanced_by"], "io")
+
+    # -------------------------------- non-permitted transitions (table-blocked)
+
+    def test_proposed_to_development_not_table_permitted(self):
+        """proposed -> development is not in the transition table — blocked."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("proposed"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "LIFECYCLE_TRANSITION_UNMET")
+
+    def test_approved_to_production_not_table_permitted(self):
+        """approved -> production is not in the transition table — blocked."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value=_component_at("approved"),
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "production"}), IO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
 
 
 if __name__ == "__main__":

--- a/backend/lambda/coordination_api/test_component_counters.py
+++ b/backend/lambda/coordination_api/test_component_counters.py
@@ -1,0 +1,392 @@
+"""Tests for ENC-TSK-F46 AC[3]: FTR-076 v2 component registry counter enforcement.
+
+Covers how the component registry consumes the FTR-076 v2 server-side counter
+fields (closed_count, checkout_count) from task records:
+
+  1. closed_count increment on task->closed: The DESIGNS edge advance gate
+     (approved->designed) passes when closed_count >= 1, confirming that the
+     counter is correctly incremented by tracker_mutation on close.
+
+  2. checkout_count increment on checkout.task success: The IMPLEMENTS edge
+     advance gate (designed->development) passes when checkout_count >= 1,
+     confirming that the counter is correctly incremented by checkout_service.
+
+  3. 400 rejection on direct write attempts to counter fields: The tracker_mutation
+     reserved-field guard rejects agent writes to closed_count and checkout_count
+     with HTTP 400 and error_envelope.code=RESERVED_FIELD.
+
+  4. Gate behavior at boundary values: gate fails at count=0, passes at count=1.
+
+These tests exercise the coordination_api advance gate at the boundary between
+the counter fields and the component lifecycle state machine. The atomic-ADD
+mechanics live in tracker_mutation (test_counter_fields.py) — here we verify
+the coordination_api gate correctly reads and interprets the counter values.
+
+Related: DOC-546B896390EA §3.4, §5; ENC-TSK-F41
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+# ---- Load coordination_api lambda ------------------------------------------
+
+sys.path.insert(0, os.path.dirname(__file__))
+_COORD_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_COORD_SPEC)
+assert _COORD_SPEC and _COORD_SPEC.loader
+sys.modules[_COORD_SPEC.name] = coordination_lambda
+_COORD_SPEC.loader.exec_module(coordination_lambda)
+
+# ---- Load tracker_mutation lambda ------------------------------------------
+
+_TRACKER_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "tracker_mutation"
+)
+sys.path.insert(0, _TRACKER_DIR)
+_TRACKER_SPEC = importlib.util.spec_from_file_location(
+    "tracker_mutation",
+    os.path.join(_TRACKER_DIR, "lambda_function.py"),
+)
+tracker_mutation = importlib.util.module_from_spec(_TRACKER_SPEC)
+assert _TRACKER_SPEC and _TRACKER_SPEC.loader
+sys.modules[_TRACKER_SPEC.name] = tracker_mutation
+_TRACKER_SPEC.loader.exec_module(tracker_mutation)
+
+
+AGENT_CLAIMS = {"auth_mode": "internal-key", "sub": "agent-session"}
+
+
+def _event(body):
+    return {"httpMethod": "POST", "body": json.dumps(body or {})}
+
+
+class _TCE(Exception):
+    """Stand-in for ddb.exceptions.ConditionalCheckFailedException."""
+
+
+def _fake_ddb(target_status):
+    fake = mock.MagicMock()
+    fake.exceptions.ConditionalCheckFailedException = _TCE
+    fake.update_item.return_value = {
+        "Attributes": {
+            "component_id": {"S": "comp-x"},
+            "lifecycle_status": {"S": target_status},
+        }
+    }
+    return fake
+
+
+class ClosedCountGateTests(unittest.TestCase):
+    """DESIGNS edge advance gate (approved->designed) reads task.closed_count."""
+
+    def setUp(self):
+        coordination_lambda._COMPONENT_TRANSITION_TABLE_CACHE = None
+        self._flag = mock.patch.object(
+            coordination_lambda, "ENABLE_COMPONENT_PROPOSAL", True
+        )
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _advance_with_closed_count(self, closed_count):
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X01", "relationship_type": "designs"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={
+                "item_id": "ENC-TSK-X01",
+                "status": "closed",
+                "closed_count": closed_count,
+            },
+        ), mock.patch.object(
+            coordination_lambda, "_get_ddb", return_value=_fake_ddb("designed")
+        ):
+            return coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "designed"}), AGENT_CLAIMS
+            )
+
+    def test_gate_fails_when_closed_count_is_zero(self):
+        """approved->designed gate: closed_count=0 fails with GATE_CONDITION_UNMET."""
+        resp = self._advance_with_closed_count(0)
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
+        self.assertEqual(body["observed_value"], 0)
+
+    def test_gate_passes_when_closed_count_is_one(self):
+        """approved->designed gate: closed_count=1 passes (task->closed incremented it)."""
+        resp = self._advance_with_closed_count(1)
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "designed")
+
+    def test_gate_passes_when_closed_count_is_greater_than_one(self):
+        """closed_count=3 (multiple close cycles) also passes the gate."""
+        resp = self._advance_with_closed_count(3)
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_gate_fails_when_task_not_closed_despite_count(self):
+        """closed_count is the gate criterion — not task status."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-x", "lifecycle_status": "approved"},
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X01", "relationship_type": "designs"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={
+                "item_id": "ENC-TSK-X01",
+                "status": "in-progress",
+                "closed_count": 0,  # the counter is what matters
+            },
+        ):
+            resp = coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "designed"}), AGENT_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
+
+
+class CheckoutCountGateTests(unittest.TestCase):
+    """IMPLEMENTS edge advance gate (designed->development) reads task.checkout_count."""
+
+    def setUp(self):
+        coordination_lambda._COMPONENT_TRANSITION_TABLE_CACHE = None
+        self._flag = mock.patch.object(
+            coordination_lambda, "ENABLE_COMPONENT_PROPOSAL", True
+        )
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _advance_with_checkout_count(self, checkout_count):
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-x", "lifecycle_status": "designed"},
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-X02", "relationship_type": "implements"}],
+        ), mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={
+                "item_id": "ENC-TSK-X02",
+                "status": "in-progress",
+                "checkout_count": checkout_count,
+            },
+        ), mock.patch.object(
+            coordination_lambda, "_get_ddb", return_value=_fake_ddb("development")
+        ):
+            return coordination_lambda._handle_components_advance(
+                "comp-x", _event({"target_status": "development"}), AGENT_CLAIMS
+            )
+
+    def test_gate_fails_when_checkout_count_is_zero(self):
+        """designed->development gate: checkout_count=0 fails with GATE_CONDITION_UNMET."""
+        resp = self._advance_with_checkout_count(0)
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "GATE_CONDITION_UNMET")
+
+    def test_gate_passes_when_checkout_count_is_one(self):
+        """designed->development gate: checkout_count=1 passes (checkout.task incremented it)."""
+        resp = self._advance_with_checkout_count(1)
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lifecycle_status"], "development")
+
+    def test_gate_passes_when_checkout_count_is_greater_than_one(self):
+        """checkout_count=5 (multiple checkout cycles) also passes the gate."""
+        resp = self._advance_with_checkout_count(5)
+        self.assertEqual(resp["statusCode"], 200)
+
+
+class EdgeLockCounterTests(unittest.TestCase):
+    """Counter thresholds control edge mutability after creation."""
+
+    def setUp(self):
+        coordination_lambda._COMPONENT_TRANSITION_TABLE_CACHE = None
+        self._flag = mock.patch.object(
+            coordination_lambda, "ENABLE_COMPONENT_PROPOSAL", True
+        )
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def test_designs_edge_unlocked_at_closed_count_zero(self):
+        """DESIGNS edge: closed_count=0 means edge is NOT locked (remove succeeds)."""
+        class _TXE(Exception):
+            pass
+        fake = mock.MagicMock()
+        fake.exceptions.TransactionCanceledException = _TXE
+        fake.transact_write_items.return_value = {}
+        with mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={
+                "item_id": "ENC-TSK-X01",
+                "closed_count": 0,
+                "project_id": "enceladus",
+            },
+        ), mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-x", "project_id": "enceladus"},
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-X01"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertTrue(json.loads(resp["body"])["removed"])
+
+    def test_designs_edge_locked_at_closed_count_one(self):
+        """DESIGNS edge: closed_count=1 (task was closed) locks the edge."""
+        with mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={"item_id": "ENC-TSK-X01", "closed_count": 1},
+        ):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-X01"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 423)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "EDGE_LOCKED")
+        self.assertEqual(body["lock_trigger"], "closed_count_ge_1")
+
+    def test_implements_edge_unlocked_at_checkout_count_zero(self):
+        """IMPLEMENTS edge: checkout_count=0 means edge is NOT locked."""
+        class _TXE(Exception):
+            pass
+        fake = mock.MagicMock()
+        fake.exceptions.TransactionCanceledException = _TXE
+        fake.transact_write_items.return_value = {}
+        with mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={
+                "item_id": "ENC-TSK-X02",
+                "checkout_count": 0,
+                "project_id": "enceladus",
+            },
+        ), mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-x", "project_id": "enceladus"},
+        ), mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "IMPLEMENTS", "task_id": "ENC-TSK-X02"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_implements_edge_locked_at_checkout_count_one(self):
+        """IMPLEMENTS edge: checkout_count=1 (task was checked out) locks the edge."""
+        with mock.patch.object(
+            coordination_lambda, "_get_task_record",
+            return_value={"item_id": "ENC-TSK-X02", "checkout_count": 1},
+        ):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "IMPLEMENTS", "task_id": "ENC-TSK-X02"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 423)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "EDGE_LOCKED")
+        self.assertEqual(body["lock_trigger"], "checkout_count_ge_1")
+
+
+class ReservedFieldGuardTests(unittest.TestCase):
+    """tracker_mutation must reject direct writes to counter fields (400 RESERVED_FIELD)."""
+
+    def test_direct_write_to_closed_count_returns_400(self):
+        """tracker.set closed_count directly: 400 RESERVED_FIELD."""
+        body = {"field": "closed_count", "value": 7, "provider": "agent-x"}
+        result = tracker_mutation._handle_update_field(
+            "enceladus", "task", "ENC-TSK-001", body
+        )
+        self.assertEqual(result.get("statusCode"), 400)
+        body_dict = json.loads(result.get("body", "{}"))
+        envelope = body_dict.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "RESERVED_FIELD")
+        self.assertEqual(envelope.get("details", {}).get("field"), "closed_count")
+
+    def test_direct_write_to_checkout_count_returns_400(self):
+        """tracker.set checkout_count directly: 400 RESERVED_FIELD."""
+        body = {"field": "checkout_count", "value": 42, "provider": "agent-y"}
+        result = tracker_mutation._handle_update_field(
+            "enceladus", "task", "ENC-TSK-001", body
+        )
+        self.assertEqual(result.get("statusCode"), 400)
+        body_dict = json.loads(result.get("body", "{}"))
+        envelope = body_dict.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "RESERVED_FIELD")
+        self.assertEqual(envelope.get("details", {}).get("field"), "checkout_count")
+
+    def test_reserved_field_guard_fires_before_ddb_access(self):
+        """The guard must fire before any DDB read — no DB round-trip for rejected fields."""
+        mock_ddb = mock.MagicMock()
+        with mock.patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = tracker_mutation._handle_update_field(
+                "enceladus", "task", "ENC-TSK-001",
+                {"field": "closed_count", "value": 5, "provider": "x"},
+            )
+        self.assertEqual(result.get("statusCode"), 400)
+        mock_ddb.update_item.assert_not_called()
+        mock_ddb.get_item.assert_not_called()
+
+    def test_reserved_field_guard_on_create_closed_count(self):
+        """tracker.create with closed_count in body: 400 RESERVED_FIELD."""
+        result = tracker_mutation._handle_create_record(
+            "enceladus", "task",
+            {
+                "title": "Test",
+                "acceptance_criteria": [{"description": "x"}],
+                "closed_count": 99,
+            },
+        )
+        self.assertEqual(result.get("statusCode"), 400)
+        body_dict = json.loads(result.get("body", "{}"))
+        envelope = body_dict.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "RESERVED_FIELD")
+
+    def test_reserved_field_guard_on_create_checkout_count(self):
+        """tracker.create with checkout_count in body: 400 RESERVED_FIELD."""
+        result = tracker_mutation._handle_create_record(
+            "enceladus", "task",
+            {
+                "title": "Test",
+                "acceptance_criteria": [{"description": "x"}],
+                "checkout_count": 12,
+            },
+        )
+        self.assertEqual(result.get("statusCode"), 400)
+        body_dict = json.loads(result.get("body", "{}"))
+        envelope = body_dict.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "RESERVED_FIELD")
+
+    def test_reserved_field_constant_contains_both_fields(self):
+        """_F41_RESERVED_COUNTER_FIELDS frozenset must contain both counter names."""
+        self.assertIn("closed_count", tracker_mutation._F41_RESERVED_COUNTER_FIELDS)
+        self.assertIn("checkout_count", tracker_mutation._F41_RESERVED_COUNTER_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_component_edges.py
+++ b/backend/lambda/coordination_api/test_component_edges.py
@@ -1,12 +1,18 @@
-"""Tests for coordination_api component edge handlers (ENC-TSK-F40 AC[1b..1d]).
+"""Tests for coordination_api component edge handlers (ENC-TSK-F46 AC[1]).
 
-Exercises:
-- DESIGNS/IMPLEMENTS strict 1:1 cardinality (409 at both endpoints).
-- DEPLOYS append-ok cardinality.
-- 423 Locked on immutable-edge mutation attempts.
-- Unknown edge_type validation.
-- Missing task / missing component rejection.
-- Component lifecycle_status PERMITTED gate for edge write.
+Covers:
+- DESIGNS/IMPLEMENTS strict 1:1 cardinality:
+  * 2 components refused the same task (task already has a DESIGNED_BY edge)
+  * 2 tasks refused the same component (component already has a DESIGNS edge)
+- DEPLOYS append-ok cardinality (allowed even when existing edges exist)
+- 423 Locked on mutation after immutability threshold:
+  * DESIGNS: locked when task closed_count >= 1
+  * IMPLEMENTS: locked when task checkout_count >= 1
+  * DEPLOYS: locked when linked task reached deploy-success status
+- 409 on duplicate DESIGNS/IMPLEMENTS edge add
+- Unknown edge_type validation
+- Missing task / missing component rejection
+- Component lifecycle_status PERMITTED gate for edge write
 """
 
 import importlib.util
@@ -43,7 +49,27 @@ class _TXE(Exception):
     """Stand-in for ddb.exceptions.TransactionCanceledException."""
 
 
-class ComponentAddEdgeTests(unittest.TestCase):
+def _approved_component(component_id="comp-x"):
+    return {
+        "component_id": component_id,
+        "lifecycle_status": "approved",
+        "project_id": "enceladus",
+    }
+
+
+def _open_task(task_id="ENC-TSK-X01"):
+    return {"item_id": task_id, "status": "open"}
+
+
+def _fake_transact_ddb():
+    fake = mock.MagicMock()
+    fake.exceptions.TransactionCanceledException = _TXE
+    fake.transact_write_items.return_value = {}
+    return fake
+
+
+class ComponentAddEdgeCardinalityTests(unittest.TestCase):
+    """Strict 1:1 cardinality enforcement for DESIGNS and IMPLEMENTS edges."""
 
     def setUp(self):
         coordination_lambda._COMPONENT_TRANSITION_TABLE_CACHE = None
@@ -54,6 +80,8 @@ class ComponentAddEdgeTests(unittest.TestCase):
 
     def tearDown(self):
         self._flag.stop()
+
+    # -------------------------------- basic guards
 
     def test_feature_flag_off_returns_503(self):
         with mock.patch.object(
@@ -82,9 +110,8 @@ class ComponentAddEdgeTests(unittest.TestCase):
         )
         self.assertEqual(resp["statusCode"], 400)
 
-    def test_component_in_blocked_status_rejected(self):
-        """lifecycle_status=proposed is BLOCKED — edges may only attach to
-        components in PERMITTED_STATUSES."""
+    def test_component_in_proposed_status_rejected(self):
+        """lifecycle_status=proposed is BLOCKED — edges may only attach to PERMITTED statuses."""
         with mock.patch.object(
             coordination_lambda,
             "_get_component_record",
@@ -99,26 +126,25 @@ class ComponentAddEdgeTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["error_envelope"]["code"], "EDGE_TARGET_BLOCKED")
 
+    # -------------------------------- DESIGNS 1:1: component-side uniqueness
+
     def test_designs_edge_component_already_has_one_returns_409(self):
-        """DESIGNS is strict 1:1 — 409 when the component already has an edge."""
+        """DESIGNS is strict 1:1 — 409 when component already has a DESIGNS edge."""
         with mock.patch.object(
             coordination_lambda,
             "_get_component_record",
-            return_value={
-                "component_id": "comp-x", "lifecycle_status": "approved",
-                "project_id": "enceladus",
-            },
+            return_value=_approved_component("comp-first"),
         ), mock.patch.object(
             coordination_lambda,
             "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X02", "status": "open"},
+            return_value=_open_task("ENC-TSK-X02"),
         ), mock.patch.object(
             coordination_lambda,
             "_query_component_edges",
             return_value=[{"target_id": "ENC-TSK-OTHER"}],
         ):
             resp = coordination_lambda._handle_components_add_edge(
-                "comp-x",
+                "comp-first",
                 _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-X02"}),
                 AGENT_CLAIMS,
             )
@@ -127,19 +153,42 @@ class ComponentAddEdgeTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "EDGE_UNIQUENESS_VIOLATION")
         self.assertEqual(body["existing_task_id"], "ENC-TSK-OTHER")
 
+    def test_designs_edge_second_component_also_refused_when_has_edge(self):
+        """A different component that already has its own DESIGNS edge is also refused."""
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_component_record",
+            return_value=_approved_component("comp-second"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value=_open_task("ENC-TSK-X03"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-PRIOR"}],
+        ):
+            resp = coordination_lambda._handle_components_add_edge(
+                "comp-second",
+                _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-X03"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 409)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "EDGE_UNIQUENESS_VIOLATION")
+
+    # -------------------------------- DESIGNS 1:1: task-side uniqueness
+
     def test_designs_edge_task_already_has_one_returns_409(self):
         """Task-side uniqueness: task already DESIGNED_BY another component."""
         with mock.patch.object(
             coordination_lambda,
             "_get_component_record",
-            return_value={
-                "component_id": "comp-x", "lifecycle_status": "approved",
-                "project_id": "enceladus",
-            },
+            return_value=_approved_component("comp-x"),
         ), mock.patch.object(
             coordination_lambda,
             "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X02", "status": "open"},
+            return_value=_open_task("ENC-TSK-X02"),
         ), mock.patch.object(
             coordination_lambda, "_query_component_edges", return_value=[]
         ), mock.patch.object(
@@ -156,21 +205,93 @@ class ComponentAddEdgeTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["error_envelope"]["code"], "EDGE_UNIQUENESS_VIOLATION")
 
-    def test_designs_edge_happy_path_writes_forward_and_inverse(self):
-        fake = mock.MagicMock()
-        fake.exceptions.TransactionCanceledException = _TXE
-        fake.transact_write_items.return_value = {}
+    def test_designs_edge_second_task_also_refused_when_has_designer(self):
+        """Task-side 1:1: a second task that already has DESIGNED_BY is refused too."""
         with mock.patch.object(
             coordination_lambda,
             "_get_component_record",
-            return_value={
-                "component_id": "comp-x", "lifecycle_status": "approved",
-                "project_id": "enceladus",
-            },
+            return_value=_approved_component("comp-y"),
         ), mock.patch.object(
             coordination_lambda,
             "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X02", "status": "open"},
+            return_value=_open_task("ENC-TSK-Y01"),
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges", return_value=[]
+        ), mock.patch.object(
+            coordination_lambda,
+            "_query_task_inverse_edges",
+            return_value=[{"target_id": "comp-existing-designer"}],
+        ):
+            resp = coordination_lambda._handle_components_add_edge(
+                "comp-y",
+                _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-Y01"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 409)
+
+    # -------------------------------- IMPLEMENTS 1:1 cardinality
+
+    def test_implements_edge_component_already_has_one_returns_409(self):
+        """IMPLEMENTS is strict 1:1 — 409 when component already has an IMPLEMENTS edge."""
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_component_record",
+            return_value=_approved_component("comp-impl"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value=_open_task("ENC-TSK-NEW"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_query_component_edges",
+            return_value=[{"target_id": "ENC-TSK-PRIOR"}],
+        ):
+            resp = coordination_lambda._handle_components_add_edge(
+                "comp-impl",
+                _event({"edge_type": "IMPLEMENTS", "task_id": "ENC-TSK-NEW"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 409)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "EDGE_UNIQUENESS_VIOLATION")
+
+    def test_implements_edge_task_already_has_one_returns_409(self):
+        """Task-side uniqueness for IMPLEMENTS: task already IMPLEMENTED_BY another component."""
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_component_record",
+            return_value=_approved_component("comp-x"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value=_open_task("ENC-TSK-IMPL"),
+        ), mock.patch.object(
+            coordination_lambda, "_query_component_edges", return_value=[]
+        ), mock.patch.object(
+            coordination_lambda,
+            "_query_task_inverse_edges",
+            return_value=[{"target_id": "comp-other-impl"}],
+        ):
+            resp = coordination_lambda._handle_components_add_edge(
+                "comp-x",
+                _event({"edge_type": "IMPLEMENTS", "task_id": "ENC-TSK-IMPL"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 409)
+
+    # -------------------------------- DESIGNS happy path writes forward+inverse
+
+    def test_designs_edge_happy_path_writes_forward_and_inverse(self):
+        """DESIGNS edge write: both forward and inverse rows created atomically."""
+        fake = _fake_transact_ddb()
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_component_record",
+            return_value=_approved_component("comp-x"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value=_open_task("ENC-TSK-X02"),
         ), mock.patch.object(
             coordination_lambda, "_query_component_edges", return_value=[]
         ), mock.patch.object(
@@ -190,17 +311,14 @@ class ComponentAddEdgeTests(unittest.TestCase):
         self.assertEqual(
             body["inverse_edge_id"], "rel#ENC-TSK-X02#designed-by#comp-x"
         )
-        # transact_write_items called with 2 Put items.
         call = fake.transact_write_items.call_args
         self.assertEqual(len(call.kwargs["TransactItems"]), 2)
 
+    # -------------------------------- DEPLOYS append-ok
+
     def test_deploys_edge_append_ok_even_with_existing(self):
-        """DEPLOYS is append-ok: uniqueness check is NOT performed."""
-        fake = mock.MagicMock()
-        fake.exceptions.TransactionCanceledException = _TXE
-        fake.transact_write_items.return_value = {}
-        # The uniqueness-check mocks don't matter for DEPLOYS — we don't
-        # call them. Sanity-check that the write path is reached anyway.
+        """DEPLOYS is append-ok: uniqueness check NOT performed, write proceeds."""
+        fake = _fake_transact_ddb()
         with mock.patch.object(
             coordination_lambda,
             "_get_component_record",
@@ -211,7 +329,7 @@ class ComponentAddEdgeTests(unittest.TestCase):
         ), mock.patch.object(
             coordination_lambda,
             "_get_task_record",
-            return_value={"item_id": "ENC-TSK-X03", "status": "open"},
+            return_value=_open_task("ENC-TSK-X03"),
         ), mock.patch.object(
             coordination_lambda,
             "_query_component_edges",
@@ -228,8 +346,40 @@ class ComponentAddEdgeTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["cardinality"], "append_ok")
 
+    def test_deploys_edge_third_add_also_succeeds(self):
+        """DEPLOYS append-ok: adding a third DEPLOYS edge to the same component succeeds."""
+        fake = _fake_transact_ddb()
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_component_record",
+            return_value={
+                "component_id": "comp-x", "lifecycle_status": "production",
+                "project_id": "enceladus",
+            },
+        ), mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value=_open_task("ENC-TSK-X04"),
+        ), mock.patch.object(
+            coordination_lambda,
+            "_query_component_edges",
+            return_value=[
+                {"target_id": "ENC-TSK-DEPLOY-1"},
+                {"target_id": "ENC-TSK-DEPLOY-2"},
+            ],
+        ), mock.patch.object(
+            coordination_lambda, "_get_ddb", return_value=fake
+        ):
+            resp = coordination_lambda._handle_components_add_edge(
+                "comp-x",
+                _event({"edge_type": "DEPLOYS", "task_id": "ENC-TSK-X04"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 201)
 
-class ComponentRemoveEdgeTests(unittest.TestCase):
+
+class ComponentRemoveEdgeLockTests(unittest.TestCase):
+    """423 Locked on edge removal attempts after immutability threshold is crossed."""
 
     def setUp(self):
         coordination_lambda._COMPONENT_TRANSITION_TABLE_CACHE = None
@@ -241,8 +391,8 @@ class ComponentRemoveEdgeTests(unittest.TestCase):
     def tearDown(self):
         self._flag.stop()
 
-    def test_designs_edge_locked_by_closed_count_returns_423(self):
-        """DESIGNS locks when linked task closed_count >= 1."""
+    def test_designs_edge_locked_when_closed_count_ge_1(self):
+        """DESIGNS locks when linked task closed_count >= 1 (§4.1)."""
         with mock.patch.object(
             coordination_lambda,
             "_get_task_record",
@@ -258,7 +408,22 @@ class ComponentRemoveEdgeTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "EDGE_LOCKED")
         self.assertEqual(body["lock_trigger"], "closed_count_ge_1")
 
-    def test_implements_edge_locked_by_checkout_count_returns_423(self):
+    def test_designs_edge_locked_at_closed_count_3(self):
+        """DESIGNS remains locked at closed_count=3 (threshold is >=1)."""
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value={"item_id": "ENC-TSK-X01", "closed_count": 3},
+        ):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "DESIGNS", "task_id": "ENC-TSK-X01"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 423)
+
+    def test_implements_edge_locked_when_checkout_count_ge_1(self):
+        """IMPLEMENTS locks when linked task checkout_count >= 1 (§4.2)."""
         with mock.patch.object(
             coordination_lambda,
             "_get_task_record",
@@ -274,7 +439,22 @@ class ComponentRemoveEdgeTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "EDGE_LOCKED")
         self.assertEqual(body["lock_trigger"], "checkout_count_ge_1")
 
-    def test_deploys_edge_locked_by_deploy_success_returns_423(self):
+    def test_implements_edge_locked_at_checkout_count_1(self):
+        """IMPLEMENTS locks immediately at checkout_count=1."""
+        with mock.patch.object(
+            coordination_lambda,
+            "_get_task_record",
+            return_value={"item_id": "ENC-TSK-X02", "checkout_count": 1},
+        ):
+            resp = coordination_lambda._handle_components_remove_edge(
+                "comp-x",
+                _event({"edge_type": "IMPLEMENTS", "task_id": "ENC-TSK-X02"}),
+                AGENT_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 423)
+
+    def test_deploys_edge_locked_when_task_reached_deploy_success(self):
+        """DEPLOYS per-edge lock: task status=deploy-success prevents removal (§4.3)."""
         with mock.patch.object(
             coordination_lambda,
             "_get_task_record",
@@ -290,8 +470,8 @@ class ComponentRemoveEdgeTests(unittest.TestCase):
         self.assertEqual(body["error_envelope"]["code"], "EDGE_LOCKED")
         self.assertEqual(body["lock_trigger"], "task_status_deploy_success")
 
-    def test_unlocked_edge_removed_atomically(self):
-        """DESIGNS task closed_count=0 -> unlocked; transact_write_items fires."""
+    def test_unlocked_designs_edge_removed_atomically(self):
+        """DESIGNS task closed_count=0 -> unlocked; transact_write_items fires for both rows."""
         fake = mock.MagicMock()
         fake.exceptions.TransactionCanceledException = _TXE
         fake.transact_write_items.return_value = {}

--- a/backend/lambda/coordination_api/test_component_opacity.py
+++ b/backend/lambda/coordination_api/test_component_opacity.py
@@ -1,10 +1,17 @@
-"""Tests for ENC-TSK-F42 opacity model in coordination_api.
+"""Tests for ENC-TSK-F46 AC[2]: opacity model in coordination_api.
 
-Validates AC[1h]-a + AC[1h]-b:
-- GET archived → 404 with body byte-identical to genuinely non-existent component
-- GET proposed → 200 full record
-- GET deprecated → 200 full record
-- GET approved → 200 full record
+Validates that the archived-component response is byte-identical to a
+genuine non-existent component response:
+- GET archived component -> 404 with response bytes == GET nonexistent component
+- No dynamic fields (request IDs, timestamps) leak the distinction
+- GET proposed -> 200 full record (not opaque)
+- GET deprecated -> 200 full record (not opaque)
+- GET approved -> 200 full record (not opaque)
+- All 8 lifecycle statuses correctly classified
+
+Opacity design per DOC-546B896390EA §5: archived components must be
+indistinguishable from non-existent components at the HTTP response layer.
+This prevents existence enumeration attacks against the component registry.
 """
 
 import importlib.util
@@ -39,31 +46,99 @@ def _ddb_item(component_id: str, lifecycle_status: str) -> dict:
 
 class ComponentGetOpacityTests(unittest.TestCase):
 
-    def test_archived_returns_404_identical_to_nonexistent(self):
-        """AC[1h]-a: archived component returns the same 404 as a non-existent one."""
-        nonexistent_resp = coordination_lambda._handle_components_get("comp-does-not-exist")
-        assert nonexistent_resp["statusCode"] == 404
+    def _get_nonexistent_response(self):
+        """Capture the baseline 404 for a genuinely non-existent component."""
+        resp = coordination_lambda._handle_components_get("comp-definitely-does-not-exist-xyz")
+        self.assertEqual(resp["statusCode"], 404, "baseline 404 must come back for non-existent")
+        return resp
 
+    def test_archived_returns_404_identical_to_nonexistent(self):
+        """AC[2]: archived -> 404, response body keys match non-existent pattern."""
+        nonexistent_resp = self._get_nonexistent_response()
+
+        ddb = coordination_lambda._get_ddb()
         with mock.patch.object(
-            coordination_lambda._get_ddb(),
-            "get_item",
+            ddb, "get_item",
             return_value=_ddb_item("comp-archived", "archived"),
         ):
             archived_resp = coordination_lambda._handle_components_get("comp-archived")
 
         self.assertEqual(archived_resp["statusCode"], 404)
+
         nonexistent_body = json.loads(nonexistent_resp["body"])
         archived_body = json.loads(archived_resp["body"])
-        # Error field must be present and identical pattern
-        self.assertIn("error", archived_body)
-        self.assertIn("not found", archived_body["error"].lower())
-        # success must not be True (existence not disclosed)
+
+        # Key sets must be identical — no extra fields leaking status.
+        self.assertEqual(
+            set(nonexistent_body.keys()),
+            set(archived_body.keys()),
+            "Key sets differ: archived response leaks existence information",
+        )
+        self.assertIn("not found", archived_body.get("error", "").lower())
         self.assertNotEqual(archived_body.get("success"), True)
-        # The response shape must match the non-existent path exactly
-        self.assertEqual(nonexistent_body.keys(), archived_body.keys())
+
+    def test_archived_response_bytes_identical_to_nonexistent_normalized(self):
+        """Normalized response bytes: only component_id differs — no dynamic fields."""
+        nonexistent_resp = self._get_nonexistent_response()
+
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(
+            ddb, "get_item",
+            return_value=_ddb_item("comp-archived-byte-check", "archived"),
+        ):
+            archived_resp = coordination_lambda._handle_components_get(
+                "comp-archived-byte-check"
+            )
+
+        self.assertEqual(archived_resp["statusCode"], 404)
+
+        # Normalize component IDs, then compare bodies byte-for-byte.
+        normalized_nonexistent = nonexistent_resp["body"].replace(
+            "comp-definitely-does-not-exist-xyz", "<COMP_ID>"
+        )
+        normalized_archived = archived_resp["body"].replace(
+            "comp-archived-byte-check", "<COMP_ID>"
+        )
+        self.assertEqual(
+            normalized_nonexistent,
+            normalized_archived,
+            (
+                "Normalized response bodies differ — archived response may be leaking "
+                "existence information via dynamic fields (timestamps, request IDs, etc.)"
+            ),
+        )
+
+    def test_archived_body_does_not_disclose_lifecycle_status(self):
+        """Archived 404 body must NOT include lifecycle_status or component details."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(
+            ddb, "get_item",
+            return_value=_ddb_item("comp-archived", "archived"),
+        ):
+            resp = coordination_lambda._handle_components_get("comp-archived")
+        body = json.loads(resp["body"])
+        body_str = json.dumps(body)
+        # Must not reveal 'archived' status (beyond the comp ID in the error message).
+        body_without_id = body_str.replace("comp-archived", "")
+        self.assertNotIn("archived", body_without_id.lower())
+        # Must not have a 'component' key revealing registry details.
+        self.assertNotIn("component", body)
+        self.assertNotEqual(body.get("success"), True)
+
+    def test_archived_body_contains_not_found_error(self):
+        """Archived 404 body has a 'not found' error — same pattern as non-existent."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(
+            ddb, "get_item",
+            return_value=_ddb_item("comp-archived-2", "archived"),
+        ):
+            resp = coordination_lambda._handle_components_get("comp-archived-2")
+        body = json.loads(resp["body"])
+        self.assertIn("error", body)
+        self.assertIn("not found", body["error"].lower())
 
     def test_proposed_returns_200_full_record(self):
-        """AC[1h]-b: proposed component returns full record (io management visibility)."""
+        """proposed: not opaque — returns full record (io management visibility)."""
         ddb = coordination_lambda._get_ddb()
         with mock.patch.object(ddb, "get_item",
                                return_value=_ddb_item("comp-proposed", "proposed")):
@@ -74,7 +149,7 @@ class ComponentGetOpacityTests(unittest.TestCase):
         self.assertEqual(body["component"]["lifecycle_status"], "proposed")
 
     def test_deprecated_returns_200_full_record(self):
-        """AC[1h]-b: deprecated component returns full record."""
+        """deprecated: not opaque — returns full record."""
         ddb = coordination_lambda._get_ddb()
         with mock.patch.object(ddb, "get_item",
                                return_value=_ddb_item("comp-deprecated", "deprecated")):
@@ -85,7 +160,7 @@ class ComponentGetOpacityTests(unittest.TestCase):
         self.assertEqual(body["component"]["lifecycle_status"], "deprecated")
 
     def test_approved_returns_200_full_record(self):
-        """Permitted status — returns full record unchanged."""
+        """approved: permitted status — returns full record unchanged."""
         ddb = coordination_lambda._get_ddb()
         with mock.patch.object(ddb, "get_item",
                                return_value=_ddb_item("comp-approved", "approved")):
@@ -94,6 +169,50 @@ class ComponentGetOpacityTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertTrue(body.get("success"))
         self.assertEqual(body["component"]["lifecycle_status"], "approved")
+
+    def test_designed_returns_200_full_record(self):
+        """designed: permitted status — returns full record."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(ddb, "get_item",
+                               return_value=_ddb_item("comp-designed", "designed")):
+            resp = coordination_lambda._handle_components_get("comp-designed")
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_development_returns_200_full_record(self):
+        """development: permitted status — returns full record."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(ddb, "get_item",
+                               return_value=_ddb_item("comp-dev", "development")):
+            resp = coordination_lambda._handle_components_get("comp-dev")
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_production_returns_200_full_record(self):
+        """production: permitted status — returns full record."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(ddb, "get_item",
+                               return_value=_ddb_item("comp-prod", "production")):
+            resp = coordination_lambda._handle_components_get("comp-prod")
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_code_red_returns_200_full_record(self):
+        """code-red: permitted status — returns full record."""
+        ddb = coordination_lambda._get_ddb()
+        with mock.patch.object(ddb, "get_item",
+                               return_value=_ddb_item("comp-cr", "code-red")):
+            resp = coordination_lambda._handle_components_get("comp-cr")
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_archived_advance_also_opaque(self):
+        """Opacity extends to advance calls: archived -> 404 on advance attempt."""
+        with mock.patch.object(
+            coordination_lambda, "_get_component_record",
+            return_value={"component_id": "comp-archived", "lifecycle_status": "archived"},
+        ), mock.patch.object(coordination_lambda, "ENABLE_COMPONENT_PROPOSAL", True):
+            event = {"httpMethod": "POST", "body": json.dumps({"target_status": "production"})}
+            resp = coordination_lambda._handle_components_advance(
+                "comp-archived", event, {"auth_mode": "internal-key", "sub": "agent"}
+            )
+        self.assertEqual(resp["statusCode"], 404)
 
 
 if __name__ == "__main__":

--- a/backend/lambda/coordination_api/test_component_sns_lifecycle_events.py
+++ b/backend/lambda/coordination_api/test_component_sns_lifecycle_events.py
@@ -1,4 +1,21 @@
-"""Tests for ENC-TSK-F45: SNS lifecycle events on component approve/revert/deprecate/restore."""
+"""Tests for ENC-TSK-F46 / ENC-TSK-F45: SNS lifecycle event emission.
+
+Validates that the coordination_api emits SNS events on all component
+lifecycle transitions, including events from the v2 state machine:
+
+  - component.approved (proposed -> approved)
+  - component.reverted (active -> archived via revert)
+  - component.deprecated (production/code-red -> deprecated)
+  - component.restored (deprecated -> production)
+  - component.advanced (advance transitions that emit events)
+  - Error handling: SNS failure must not raise (fire-and-forget semantics)
+  - Topic ARN guard: events skipped silently when no topic ARN configured
+
+Per DOC-546B896390EA §7: all lifecycle transitions emit SNS events for
+downstream consumers (e.g. the coordination monitor). The publish is
+best-effort — Lambda continues even if SNS publish fails.
+"""
+
 import importlib.util
 import json
 import os
@@ -18,6 +35,9 @@ sys.modules[_SPEC.name] = coordination_lambda
 _SPEC.loader.exec_module(coordination_lambda)
 
 
+TOPIC_ARN = "arn:aws:sns:us-west-2:123456789012:enceladus-component-events"
+
+
 class TestPublishComponentLifecycleEvent(unittest.TestCase):
     """Unit tests for _publish_component_lifecycle_event."""
 
@@ -25,7 +45,7 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
         self._topic = mock.patch.object(
             coordination_lambda,
             "COMPONENT_EVENTS_TOPIC_ARN",
-            "arn:aws:sns:us-west-2:123:topic",
+            TOPIC_ARN,
         )
         self._topic.start()
 
@@ -33,6 +53,7 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
         self._topic.stop()
 
     def test_approved_event_published(self):
+        """component.approved event: correct TopicArn, event_type, component_id."""
         mock_sns = mock.MagicMock()
         with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
             coordination_lambda._publish_component_lifecycle_event(
@@ -42,13 +63,12 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
                     "component_id": "comp-test-alpha",
                     "project_id": "enceladus",
                     "approved_by_session_id": "session-abc",
-                    "approved_at": "2026-04-20T19:00:00Z",
+                    "approved_at": "2026-04-21T00:00:00Z",
                 },
             )
-
         mock_sns.publish.assert_called_once()
         call_kwargs = mock_sns.publish.call_args[1]
-        self.assertEqual(call_kwargs["TopicArn"], "arn:aws:sns:us-west-2:123:topic")
+        self.assertEqual(call_kwargs["TopicArn"], TOPIC_ARN)
         payload = json.loads(call_kwargs["Message"])
         self.assertEqual(payload["event_type"], "component.approved")
         self.assertEqual(payload["component_id"], "comp-test-alpha")
@@ -56,6 +76,7 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
         self.assertEqual(payload["approved_by_session_id"], "session-abc")
 
     def test_reverted_event_published(self):
+        """component.reverted event: contains reverted_reason and archived_at."""
         mock_sns = mock.MagicMock()
         with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
             coordination_lambda._publish_component_lifecycle_event(
@@ -64,17 +85,17 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
                     "event_type": "component.reverted",
                     "component_id": "comp-test-beta",
                     "reverted_reason": "design change required",
-                    "reverted_at": "2026-04-20T19:01:00Z",
-                    "archived_at": "2026-04-20T19:01:00Z",
+                    "reverted_at": "2026-04-21T00:01:00Z",
+                    "archived_at": "2026-04-21T00:01:00Z",
                 },
             )
-
         payload = json.loads(mock_sns.publish.call_args[1]["Message"])
         self.assertEqual(payload["event_type"], "component.reverted")
         self.assertEqual(payload["reverted_reason"], "design change required")
         self.assertIn("archived_at", payload)
 
     def test_deprecated_event_published(self):
+        """component.deprecated event: contains deprecated_at timestamp."""
         mock_sns = mock.MagicMock()
         with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
             coordination_lambda._publish_component_lifecycle_event(
@@ -82,15 +103,15 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
                 {
                     "event_type": "component.deprecated",
                     "component_id": "comp-test-gamma",
-                    "deprecated_at": "2026-04-20T19:02:00Z",
+                    "deprecated_at": "2026-04-21T00:02:00Z",
                 },
             )
-
         payload = json.loads(mock_sns.publish.call_args[1]["Message"])
         self.assertEqual(payload["event_type"], "component.deprecated")
         self.assertEqual(payload["component_id"], "comp-test-gamma")
 
     def test_restored_event_published(self):
+        """component.restored event: contains restored_at timestamp."""
         mock_sns = mock.MagicMock()
         with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
             coordination_lambda._publish_component_lifecycle_event(
@@ -98,14 +119,33 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
                 {
                     "event_type": "component.restored",
                     "component_id": "comp-test-delta",
-                    "restored_at": "2026-04-20T19:03:00Z",
+                    "restored_at": "2026-04-21T00:03:00Z",
                 },
             )
-
         payload = json.loads(mock_sns.publish.call_args[1]["Message"])
         self.assertEqual(payload["event_type"], "component.restored")
+        self.assertEqual(payload["component_id"], "comp-test-delta")
+
+    def test_event_payload_is_valid_json_string(self):
+        """Published Message must be a JSON-serialized string, not a dict."""
+        mock_sns = mock.MagicMock()
+        with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
+            coordination_lambda._publish_component_lifecycle_event(
+                "component.approved",
+                {
+                    "event_type": "component.approved",
+                    "component_id": "comp-json-test",
+                    "project_id": "enceladus",
+                },
+            )
+        call_kwargs = mock_sns.publish.call_args[1]
+        message = call_kwargs["Message"]
+        self.assertIsInstance(message, str)
+        parsed = json.loads(message)
+        self.assertIsInstance(parsed, dict)
 
     def test_skips_when_topic_arn_empty(self):
+        """No SNS call when COMPONENT_EVENTS_TOPIC_ARN is empty string."""
         self._topic.stop()
         with mock.patch.object(coordination_lambda, "COMPONENT_EVENTS_TOPIC_ARN", ""):
             with mock.patch.object(coordination_lambda.boto3, "client") as mock_boto:
@@ -117,14 +157,60 @@ class TestPublishComponentLifecycleEvent(unittest.TestCase):
         self._topic.start()
 
     def test_sns_failure_does_not_raise(self):
+        """SNS publish failure must not propagate — fire-and-forget semantics."""
         mock_sns = mock.MagicMock()
         mock_sns.publish.side_effect = Exception("SNS unreachable")
         with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
-            # Should not raise
+            # Must not raise.
             coordination_lambda._publish_component_lifecycle_event(
                 "component.approved",
                 {"event_type": "component.approved", "component_id": "comp-x"},
             )
+
+    def test_sns_subject_attribute_set_on_publish(self):
+        """SNS publish call must include a Subject or MessageAttributes for routing."""
+        mock_sns = mock.MagicMock()
+        with mock.patch.object(coordination_lambda.boto3, "client", return_value=mock_sns):
+            coordination_lambda._publish_component_lifecycle_event(
+                "component.approved",
+                {"event_type": "component.approved", "component_id": "comp-y",
+                 "project_id": "enceladus"},
+            )
+        call_kwargs = mock_sns.publish.call_args[1]
+        # Must have either Subject or MessageAttributes for event routing.
+        has_routing = (
+            "Subject" in call_kwargs
+            or "MessageAttributes" in call_kwargs
+        )
+        self.assertTrue(
+            has_routing,
+            "SNS publish must include Subject or MessageAttributes for event routing",
+        )
+
+    def test_all_v2_event_types_can_be_published(self):
+        """All FTR-076 v2 event types can be published without error."""
+        event_types = [
+            "component.approved",
+            "component.reverted",
+            "component.deprecated",
+            "component.restored",
+            "component.advanced",
+        ]
+        for event_type in event_types:
+            with self.subTest(event_type=event_type):
+                mock_sns = mock.MagicMock()
+                with mock.patch.object(
+                    coordination_lambda.boto3, "client", return_value=mock_sns
+                ):
+                    # Should not raise.
+                    coordination_lambda._publish_component_lifecycle_event(
+                        event_type,
+                        {
+                            "event_type": event_type,
+                            "component_id": "comp-event-test",
+                            "project_id": "enceladus",
+                        },
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## FTR-076v2 Phase 10 — Test Coverage

Adds 6 pytest test files for the component registry lifecycle hardening (ENC-FTR-076 v2 / ENC-PLN-040 Phase 10).

### Tests added

- **test_component_advance.py** (34 tests): All 15 v2 state machine transitions including hard-block assertions (deprecated→development, archived→any), authority matrix enforcement, evidence gates for DESIGNS/IMPLEMENTS/deploy-success, io bypass of gates.

- **test_component_edges.py** (19 tests): DESIGNS/IMPLEMENTS strict 1:1 cardinality (2 components refused same task; 2 tasks refused same component), DEPLOYS append-ok with multiple existing edges, 423 Locked on mutation after closed_count/checkout_count/deploy-success threshold.

- **test_component_opacity.py** (12 tests): byte-identical normalized response comparison for archived vs genuine-nonexistent components, all 8 lifecycle statuses correctly classified.

- **test_component_counters.py** (17 tests): closed_count gate at approved→designed boundary, checkout_count gate at designed→development boundary, edge lock at exact threshold, 400 RESERVED_FIELD rejection on direct writes.

- **test_component_lifecycle_gate.py** (16 tests): checkout response for all 8 lifecycle statuses (archived→404, proposed/deprecated→400, approved/designed/development/production/code-red→permitted), mixed component sets.

- **test_component_sns_lifecycle_events.py** (9 tests): SNS event emission for all v2 event types, fire-and-forget semantics, topic ARN guard.

**107 tests total pass locally.**

CCI-bbc1a900e6d2454798f872627c02b737