### PR TITLE
fix(coordination_api): replace scan(Limit=2) with get_item in _get_task_record (ENC-ISS-300)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-04-21.51",
-  "updated_at": "2026-04-21T23:20:00Z",
+  "version": "2026-04-22.01",
+  "updated_at": "2026-04-22T06:08:00Z",
   "last_change_summary": "ENC-TSK-F93: added feed_publisher.s3_lessons_plans entity documenting lessons.json and plans.json S3 outputs added to feed_publisher generate_mobile_feeds(). ENC-ISS-299 follow-on.",
   "owners": [
     "enceladus-platform"
@@ -5052,5 +5052,12 @@
       }
     }
   },
-  "change_summary": "ENC-TSK-F45 / ENC-FTR-076 v2 Phase 9: SNS lifecycle events on component.approve/revert/deprecate/restore; 6 new typed relationship types (designs/designed-by/implements/implemented-by/deploys/deployed-by) in tracker_mutation; RELATIONSHIP_TYPE_TO_EDGE_LABEL + _upsert_relationship_edge placeholder support in graph_sync; 5 new OGTM edge labels (DESIGNS/DESIGNED_BY/IMPLEMENTED_BY/DEPLOYS/DEPLOYED_BY) in graph_query_api _ALLOWED_EDGE_TYPES. | ENC-FTR-091/F87: Added deploy.parity_validator entity."
+  "change_summary": "ENC-TSK-F45 / ENC-FTR-076 v2 Phase 9: SNS lifecycle events on component.approve/revert/deprecate/restore; 6 new typed relationship types (designs/designed-by/implements/implemented-by/deploys/deployed-by) in tracker_mutation; RELATIONSHIP_TYPE_TO_EDGE_LABEL + _upsert_relationship_edge placeholder support in graph_sync; 5 new OGTM edge labels (DESIGNS/DESIGNED_BY/IMPLEMENTED_BY/DEPLOYS/DEPLOYED_BY) in graph_query_api _ALLOWED_EDGE_TYPES. | ENC-FTR-091/F87: Added deploy.parity_validator entity.",
+  "change_log": [
+    {
+      "version": "2026-04-22.01",
+      "date": "2026-04-22",
+      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+    }
+  ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -8998,24 +8998,32 @@ def _get_component_record(component_id: str) -> Optional[Dict[str, Any]]:
 
 
 def _get_task_record(task_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch a task record from DynamoDB tracker table by scanning on item_id.
+    """Fetch a task record from DynamoDB tracker table by item_id.
 
     Returns the full record as a plain dict, or None if not found.
-    Tracker keys are rel#/task#/... so we use a scan with a filter — the
-    tracker_mutation API does this with a GSI in prod; this helper is a
-    defensive direct-read variant used for gate evaluation. The table is
-    small enough to scan when callers already know the exact item_id.
+    Primary path: direct get_item using the known composite key (project_id=enceladus,
+    record_id=task#<item_id>). Fallback: full-table scan for cross-project tasks.
+    The previous scan(Limit=2) evaluated at most 2 items before filtering and was
+    statistically unable to locate any specific task in a large table (ENC-ISS-300).
     """
     ddb = _get_ddb()
-    # Tracker items are stored with record_id='task#ENC-TSK-F40' pattern.
-    # We also try 'item_id=ENC-TSK-F40' as a filter since older records may
-    # lack the record_id composite key.
     normalized = task_id.strip()
     record_key = normalized if normalized.startswith("task#") else f"task#{normalized}"
     item_id = normalized if not normalized.startswith("task#") else normalized[len("task#"):]
 
-    # Most tracker rows are keyed by project_id + record_id. We don't know
-    # project_id here, so scan with item_id filter.
+    # Primary path: direct key lookup for the common single-project case.
+    try:
+        resp = ddb.get_item(
+            TableName=TRACKER_TABLE,
+            Key={"project_id": {"S": "enceladus"}, "record_id": {"S": record_key}},
+        )
+        item = resp.get("Item")
+        if item:
+            return _ddb_to_py(item)
+    except Exception as exc:
+        logger.warning("get_item for task %s failed, falling back to scan: %s", item_id, exc)
+
+    # Fallback: full scan for cross-project tasks not keyed under 'enceladus'.
     try:
         resp = ddb.scan(
             TableName=TRACKER_TABLE,
@@ -9024,7 +9032,6 @@ def _get_task_record(task_id: str) -> Optional[Dict[str, Any]]:
                 ":iid": {"S": item_id},
                 ":rt": {"S": "task"},
             },
-            Limit=2,
         )
     except Exception as exc:
         logger.warning("Unable to scan tracker for task %s: %s", item_id, exc)


### PR DESCRIPTION
## Summary

- `_get_task_record()` in `coordination_api/lambda_function.py` used `ddb.scan(Limit=2)` which evaluates at most 2 DynamoDB items before applying FilterExpression — statistically unable to find any specific task on a large table
- Primary lookup replaced with `ddb.get_item()` keyed on `(project_id=enceladus, record_id=task#<item_id>)`
- Full scan (no Limit) retained as fallback for cross-project tasks
- Unblocks `component.add_edge` DESIGNS edge creation and the `approved→designed` gate for all components

Resolves: ENC-ISS-300
Task: ENC-TSK-F99

CCI-88f34a8ddddd44f6a38167c44e9fe932

## Test plan

- [ ] CI passes
- [ ] Secrets Scan passes
- [ ] PR Commit Gate passes (CCI token present)
- [ ] Post-deploy: `component.add_edge` succeeds for ENC-TSK-F96 without NOT_FOUND error