### PR TITLE
feat: token-optimized 4-call init + lazy-load triggers + skills index in AGENTS.md (ENC-TSK-G01)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,18 +6,47 @@ MCP server `enceladus` is configured via remote HTTP gateway.
 - Gateway URL: `https://jreese.net/api/v1/coordination/mcp`
 - Source: `tools/enceladus-mcp-server/server.py` (deployed as Lambda)
 
-## Initialization (REQUIRED — run in order every session)
+## Initialization (REQUIRED — 4 calls, in order)
 
-1. `mcp: connection_health` — verify DynamoDB/S3/API connectivity, get governance hash
-2. `mcp: governance_get("agents.md")` — **load full governance rules and execute all steps**
-3. `mcp: governance_dictionary` — load compact enum/constraint index
-4. `mcp: governance_get("agents/bootstrap-template.md")` — load session init protocol
-5. `mcp: governance_get("agents/lifecycle-primer.md")` — load lifecycle gates before any PR work
-6. `mcp: tracker_list(project_id="enceladus", record_type="task", status="open")` — open tasks
-7. `mcp: tracker_pending_updates(project_id="enceladus")` — pending updates
+Token-optimized init derived from `DOC-89D35679FE91` (enceladus-agent-webui-alpha skill). Saves ~15–20k tokens vs. the former 7-call sequence by deferring heavy governance fetches until actually needed.
 
-All operating rules, tool reference, and task policies are in `governance://agents.md`.
-Do not proceed with any work until steps 1-5 are complete.
+1. `mcp: connection_health` — verify DynamoDB/S3/API connectivity, capture `governance_hash`
+2. `mcp: tracker_list(project_id="enceladus", record_type="task", status="open", page_size=10)` — P0/P1 open tasks
+3. `mcp: tracker_list(project_id="enceladus", record_type="lesson", page_size=5)` — recent lessons
+4. `mcp: plan.objectives_status(record_id="ENC-PLN-006")` — active plan health
+
+After step 4, produce a 3–5 paragraph briefing: service status, priority tasks, active lessons, plan progress.
+
+## Lazy-Load Triggers (do NOT fetch at init)
+
+| Condition | Load |
+|---|---|
+| Task involves git / PR workflow | `governance.get("agents.md")` §7, §8 |
+| Task involves deploy / evidence schemas | `governance.get("agents.md")` §11 |
+| Task involves governance file edits | `governance.get("agents.md")` §13 |
+| Task involves OGTM compliance | `governance.get("agents.md")` §2a |
+| Creating or validating records | `governance.dictionary` |
+| Checking PWA state | `tracker.pending_updates` |
+| Full lifecycle arc / strictness rank table | `governance.get("agents/lifecycle-primer.md")` |
+
+Completed plans (e.g. ENC-PLN-012): static state — do not re-check.
+
+## Agent Skills (MCP docstore)
+
+Skills are stored as governed documents in the MCP docstore and loaded dynamically. Do not copy skill content into this file.
+
+```
+mcp: documents.search(project_id="enceladus", document_subtype="skill")
+```
+
+| Skill doc | Name | Use when |
+|---|---|---|
+| `DOC-89D35679FE91` | enceladus-agent-webui-alpha | Ad-hoc governed sessions, token-optimized init |
+| `DOC-D340B31BDDE9` | enceladus-skill-manual-sync | Export skill to claude.ai skill manager |
+| `DOC-84F23F2C80DC` | enc-cognito-auth | Authenticated curl/Playwright against PWA |
+| `DOC-654BB71C4420` | enceladus-doc-export-alpha | Canonicalize chat payload as docstore document |
+
+Load a skill: `mcp: documents.get(document_id="DOC-...")` — use `full_description` field as instructions.
 
 ## Git Lifecycle Quick Reference
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Installs the `enceladus-agent-webui-alpha` skill into `AGENTS.md` by wiring its 4-call token-optimized init sequence directly, rather than copying skill content into the repo. The skill itself lives in the MCP docstore at `DOC-89D35679FE91` and is loaded dynamically.

**Tracker task:** ENC-TSK-G01
**CCI token:** CCI-401ffb65ca494a72a4b8931c8487d438

## What Changed

### `AGENTS.md`

**Initialization section** — replaces the former 7-call sequence with the 4-call token-optimized init from `DOC-89D35679FE91`. Saves ~15–20k tokens per session startup by deferring heavy governance document fetches until actually needed:

1. `connection_health` — governance hash + service verify
2. `tracker.list` tasks (open, page 10) — P0/P1 priority queue
3. `tracker.list` lessons (recent 5) — active lesson awareness
4. `plan.objectives_status(ENC-PLN-006)` — active plan health

Followed by a required 3–5 paragraph briefing.

**Lazy-Load Triggers table** — documents exactly which conditions trigger each deferred fetch (`governance.get(agents.md)` §7/8/11/13, `governance.dictionary`, `lifecycle-primer`, `tracker.pending_updates`). Agents no longer eagerly load these at startup.

**Agent Skills section** — documents the MCP docstore as the canonical skill store with a `documents.search` query and per-skill index table. No skill content is copied into the repo; skills load dynamically via `documents.get`.

| Doc ID | Skill | Use when |
|---|---|---|
| `DOC-89D35679FE91` | enceladus-agent-webui-alpha | Ad-hoc governed sessions |
| `DOC-D340B31BDDE9` | enceladus-skill-manual-sync | Export skill to claude.ai manager |
| `DOC-84F23F2C80DC` | enc-cognito-auth | Authenticated curl/Playwright vs PWA |
| `DOC-654BB71C4420` | enceladus-doc-export-alpha | Canonicalize payload as docstore doc |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86c66328-cff2-4bed-9234-ae36fae74a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86c66328-cff2-4bed-9234-ae36fae74a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

