### PR TITLE
fix(coordination-api): paginate edge scan functions to fix GATE_CONDITION_UNMET (ENC-ISS-301)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-22.01",
-  "updated_at": "2026-04-22T06:08:00Z",
-  "last_change_summary": "ENC-TSK-F93: added feed_publisher.s3_lessons_plans entity documenting lessons.json and plans.json S3 outputs added to feed_publisher generate_mobile_feeds(). ENC-ISS-299 follow-on.",
+  "version": "2026-04-22.02",
+  "updated_at": "2026-04-22T06:58:00Z",
+  "last_change_summary": "ENC-TSK-G02 (ENC-ISS-301): no schema changes — behavioral fix only. _query_component_edges() and _query_task_inverse_edges() now paginate DynamoDB scan to exhaustion via LastEvaluatedKey. Version bump required by CI governance-dictionary guard.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -9053,27 +9053,35 @@ def _query_component_edges(
     is_inverse=false (forward edges only).
     """
     ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "FilterExpression": (
+            "source_id = :sid AND relationship_type = :rt "
+            "AND record_type = :rec AND is_inverse = :false"
+        ),
+        "ExpressionAttributeValues": {
+            ":sid": {"S": component_id},
+            ":rt": {"S": rel_type},
+            ":rec": {"S": "relationship"},
+            ":false": {"BOOL": False},
+        },
+    }
+    items: List[Dict[str, Any]] = []
     try:
-        resp = ddb.scan(
-            TableName=TRACKER_TABLE,
-            FilterExpression=(
-                "source_id = :sid AND relationship_type = :rt "
-                "AND record_type = :rec AND is_inverse = :false"
-            ),
-            ExpressionAttributeValues={
-                ":sid": {"S": component_id},
-                ":rt": {"S": rel_type},
-                ":rec": {"S": "relationship"},
-                ":false": {"BOOL": False},
-            },
-        )
+        while True:
+            resp = ddb.scan(**scan_kwargs)
+            items.extend(resp.get("Items", []))
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_key
     except Exception as exc:
         logger.warning(
             "Unable to scan for %s edges from %s: %s",
             rel_type, component_id, exc,
         )
         return []
-    return [_ddb_to_py(i) for i in resp.get("Items", [])]
+    return [_ddb_to_py(i) for i in items]
 
 
 def _query_task_inverse_edges(
@@ -9087,27 +9095,35 @@ def _query_task_inverse_edges(
     another component).
     """
     ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "FilterExpression": (
+            "source_id = :sid AND relationship_type = :rt "
+            "AND record_type = :rec AND is_inverse = :true"
+        ),
+        "ExpressionAttributeValues": {
+            ":sid": {"S": task_id},
+            ":rt": {"S": inverse_rel_type},
+            ":rec": {"S": "relationship"},
+            ":true": {"BOOL": True},
+        },
+    }
+    items: List[Dict[str, Any]] = []
     try:
-        resp = ddb.scan(
-            TableName=TRACKER_TABLE,
-            FilterExpression=(
-                "source_id = :sid AND relationship_type = :rt "
-                "AND record_type = :rec AND is_inverse = :true"
-            ),
-            ExpressionAttributeValues={
-                ":sid": {"S": task_id},
-                ":rt": {"S": inverse_rel_type},
-                ":rec": {"S": "relationship"},
-                ":true": {"BOOL": True},
-            },
-        )
+        while True:
+            resp = ddb.scan(**scan_kwargs)
+            items.extend(resp.get("Items", []))
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_key
     except Exception as exc:
         logger.warning(
             "Unable to scan for inverse %s edges on %s: %s",
             inverse_rel_type, task_id, exc,
         )
         return []
-    return [_ddb_to_py(i) for i in resp.get("Items", [])]
+    return [_ddb_to_py(i) for i in items]
 
 
 def _edge_is_locked(


### PR DESCRIPTION
## Summary

- `_query_component_edges()` and `_query_task_inverse_edges()` in `backend/lambda/coordination_api/lambda_function.py` called `ddb.scan()` with no `LastEvaluatedKey` follow-through — silently dropping relationship rows beyond the first 1MB DynamoDB page
- Both functions now loop to exhaustion following `LastEvaluatedKey`, collecting all pages before returning
- Fixes `component.advance` gate returning `GATE_CONDITION_UNMET` when the required DESIGNS/IMPLEMENTS edge exists in DynamoDB but falls outside the first scan page

## Test plan

- [x] `test_component_advance.py` — 34 tests pass (all 15 transitions + authority matrix + gate failures)
- [x] `test_component_edges.py` — 19 tests pass (DESIGNS/IMPLEMENTS 1:1 cardinality, DEPLOYS append-ok, 423 lock, 409 duplicate, missing task/component)
- [x] Deploy coordination_api Lambda to production and confirm `component.advance` gate succeeds for `comp-ftr076-e2e-test-v1`

## Governance

Resolves: ENC-ISS-301  
Task: ENC-TSK-G02  
CCI-fb28626084b5462d9ad56a07fefe5790

🤖 Generated with [Claude Code](https://claude.com/claude-code)