### PR TITLE
fix(deploy): use bare integer version strings in CodeDeploy Lambda AppSpec

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -421,16 +421,17 @@ jobs:
                           fn_arn_base = f"arn:aws:lambda:{region}:{account_id}:function:{mapped_name}"
 
                           # Build AppSpec for CodeDeploy Lambda deployment.
+                          # CurrentVersion/TargetVersion must be bare integer strings, not qualified ARNs.
                           appspec = {
-                              "version": "0.0",
+                              "version": 0.0,
                               "Resources": [{
                                   mapped_name: {
                                       "Type": "AWS::Lambda::Function",
                                       "Properties": {
                                           "Name": mapped_name,
                                           "Alias": "live",
-                                          "CurrentVersion": f"{fn_arn_base}:{current_version}",
-                                          "TargetVersion": f"{fn_arn_base}:{new_version}",
+                                          "CurrentVersion": current_version,
+                                          "TargetVersion": new_version,
                                       }
                                   }
                               }]


### PR DESCRIPTION
## Summary

- Fix `_deploy.yml` lines 432-433: `CurrentVersion`/`TargetVersion` in the CodeDeploy Lambda AppSpec were being built as full qualified ARNs (`arn:aws:lambda:...:function:auth-refresh:5`) instead of bare integer version strings (`5`, `8`) as required by the CodeDeploy Lambda API
- Fix line 425: AppSpec `version` field changed from string `"0.0"` to float `0.0`
- Root cause of all 22 CodeDeploy deployment group failures (`INVALID_LAMBDA_CONFIGURATION`) since FTR-090 Gen2 went live — `lastSuccessful:{}` confirmed on all groups
- Diagnostic test `d-QUF83S3AI` confirmed fix: integer-string AppSpec entered `InProgress`; ARN-based AppSpec failed in <1s

## Test plan

- [ ] PR CI passes
- [ ] After merge, next `_deploy.yml` run shows CodeDeploy deployments entering `InProgress` and completing for all 22 groups
- [ ] No regressions in bootstrap function deploys (checkout-service-auto, github-integration, prod-health-monitor, titan-embedding-backfill)

## References

- Fixes: ENC-ISS-302
- Lesson: ENC-LSN-047
- Investigation doc: DOC-EB61ED951DD6
- Task: ENC-TSK-G03
- CCI: CCI-59f295ee945a46c6baf18da22e87d1df

🤖 Generated with [Claude Code](https://claude.com/claude-code)