### PR TITLE
ENC-TSK-G06: repair graph projection parity cleanup

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-22.02",
-  "updated_at": "2026-04-22T06:58:00Z",
-  "last_change_summary": "ENC-TSK-G02 (ENC-ISS-301): no schema changes — behavioral fix only. _query_component_edges() and _query_task_inverse_edges() now paginate DynamoDB scan to exhaustion via LastEvaluatedKey. Version bump required by CI governance-dictionary guard.",
+  "version": "2026-04-23.01",
+  "updated_at": "2026-04-23T11:29:00Z",
+  "last_change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan is_placeholder nodes after MODIFY/REMOVE and archived relationship edge removal; backfill_graph replay follows the canonical tracker+documents projection contract.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4295,6 +4295,10 @@
         "race_fix_invariant": {
           "type": "string",
           "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+        },
+        "orphan_purge_on_edge_removal": {
+          "type": "string",
+          "definition": "ENC-TSK-G06: graph_sync now collects the label-qualified placeholder candidates implied by plan/lesson/document/relationship edges and, after MODIFY/REMOVE or archived relationship deletion, runs `MATCH (n:{Label} {record_id: $rid}) WHERE coalesce(n.is_placeholder, false) = true AND NOT (n)--() DETACH DELETE n`. This removes phantom placeholder stubs once their final incident edge disappears while preserving real projected nodes and placeholders still anchored by any remaining relationship."
         }
       }
     },
@@ -4446,6 +4450,11 @@
           "definition": "Structured agent-session output in docstore .md documents MUST use comment-free YAML code blocks (```yaml ... ```) instead of GFM pipe tables. Pipe tables are permitted only for purely presentational content where renderer-dependence is explicitly acknowledged. YAML hash-comments (# ...) must be omitted inside fenced blocks to avoid compliance checker heading false positives. MCP server injects format_guidance in document.put/patch responses when pipe-table warnings are detected.",
           "governing_lesson": "ENC-LSN-026",
           "enforcement": "Advisory via MCP format_guidance response field. Compliance checker fence-awareness prevents false positives on conforming documents."
+        },
+        "graph_remove_identity": {
+          "type": "rule",
+          "definition": "ENC-TSK-G06: graph_sync normalizes document stream images so INSERT/MODIFY and REMOVE project by the same bare document identity. REMOVE resolves Keys.record_id, Keys.document_id, then Keys.item_id, and falls back to OldImage fields before deleting the Neo4j node. This prevents DOC-* nodes from surviving a documents-table delete solely because the stream key lacked record_id.",
+          "write_authority": "graph_sync Lambda (derived index behavior)."
         }
       }
     },
@@ -5052,8 +5061,13 @@
       }
     }
   },
-  "change_summary": "ENC-TSK-F45 / ENC-FTR-076 v2 Phase 9: SNS lifecycle events on component.approve/revert/deprecate/restore; 6 new typed relationship types (designs/designed-by/implements/implemented-by/deploys/deployed-by) in tracker_mutation; RELATIONSHIP_TYPE_TO_EDGE_LABEL + _upsert_relationship_edge placeholder support in graph_sync; 5 new OGTM edge labels (DESIGNS/DESIGNED_BY/IMPLEMENTED_BY/DEPLOYS/DEPLOYED_BY) in graph_query_api _ALLOWED_EDGE_TYPES. | ENC-FTR-091/F87: Added deploy.parity_validator entity.",
+  "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
   "change_log": [
+    {
+      "version": "2026-04-23.01",
+      "date": "2026-04-23",
+      "summary": "ENC-TSK-G06: documented graph_sync document DELETE identity normalization and orphan placeholder purge semantics; version bump required by CI governance-dictionary guard."
+    },
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # ENC-TSK-B94: Incremental Titan V2 embedding helpers. build_embedding_text,
 # hash_embedding_text, compute_embedding_for_record, and the model/property
@@ -124,6 +124,44 @@ def _deser_image(image: Dict) -> Dict[str, Any]:
     return {k: _deser_value(v) for k, v in image.items()}
 
 
+def _normalize_record_for_graph(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize cross-table record identity before graph projection.
+
+    Tracker rows key on ``record_id`` while document rows key on
+    ``document_id``. The graph projection code expects ``record_id``.
+    """
+    normalized = dict(record or {})
+    if not normalized:
+        return normalized
+
+    record_type = str(normalized.get("record_type") or "").strip()
+    if not record_type and normalized.get("document_id"):
+        record_type = "document"
+        normalized["record_type"] = record_type
+
+    if record_type == "document" and not normalized.get("record_id"):
+        normalized["record_id"] = normalized.get("document_id", "")
+
+    return normalized
+
+
+def _extract_remove_record_id(keys: Dict[str, Any], old_record: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the primary ID for REMOVE events across tracker + document tables."""
+    for key_name in ("record_id", "document_id", "item_id"):
+        typed = keys.get(key_name) or {}
+        value = str(typed.get("S") or "").strip()
+        if value:
+            return value
+
+    if old_record:
+        for key_name in ("record_id", "document_id", "item_id"):
+            value = str(old_record.get(key_name) or "").strip()
+            if value:
+                return value
+
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Graph schema constants
 # ---------------------------------------------------------------------------
@@ -195,6 +233,94 @@ NODE_PROPERTIES = [
     "record_id", "project_id", "title", "status", "priority",
     "category", "updated_at", "created_at",
 ]
+
+
+PlaceholderRef = Tuple[str, str]
+
+
+def _add_placeholder_ref(refs: Set[PlaceholderRef], label: str, raw_id: Any) -> None:
+    """Add a label-qualified placeholder candidate if the id is non-empty."""
+    record_id = _bare_id(str(raw_id).strip()) if raw_id is not None else ""
+    if label and record_id:
+        refs.add((label, record_id))
+
+
+def _collect_placeholder_target_refs(record: Dict[str, Any]) -> Set[PlaceholderRef]:
+    """Collect label-qualified placeholder nodes that a record may create.
+
+    Only graph_sync branches that use placeholder MERGE participate here.
+    This lets MODIFY/REMOVE flows prune stale placeholders after edges are
+    removed without touching real projected nodes.
+    """
+    refs: Set[PlaceholderRef] = set()
+    record_type = str(record.get("record_type") or "").strip()
+
+    if record_type == "plan":
+        for objective_id in record.get("objectives_set", []) or []:
+            obj_id = _bare_id(str(objective_id).strip()) if objective_id else ""
+            _add_placeholder_ref(refs, _infer_label_from_id(obj_id), obj_id)
+        for document_id in record.get("attached_documents", []) or []:
+            _add_placeholder_ref(refs, "Document", document_id)
+        _add_placeholder_ref(refs, "Feature", record.get("related_feature_id", ""))
+
+    elif record_type == "lesson":
+        for evidence_id in record.get("evidence_chain", []) or []:
+            ev_id = _bare_id(str(evidence_id).strip()) if evidence_id else ""
+            _add_placeholder_ref(refs, _infer_label_from_id(ev_id), ev_id)
+        for ext in record.get("extensions", []) or []:
+            if not isinstance(ext, dict):
+                continue
+            for evidence_id in ext.get("evidence_ids", []) or []:
+                ev_id = _bare_id(str(evidence_id).strip()) if evidence_id else ""
+                _add_placeholder_ref(refs, _infer_label_from_id(ev_id), ev_id)
+
+    elif record_type == "document":
+        for related_id in record.get("related_items", []) or []:
+            rid = _bare_id(str(related_id).strip()) if related_id else ""
+            _add_placeholder_ref(refs, _infer_label_from_id(rid), rid)
+        for source_id in record.get("informed_by", []) or []:
+            _add_placeholder_ref(refs, "Document", source_id)
+
+        doc_subtype = str(record.get("document_subtype") or "").strip()
+        if doc_subtype == "coe":
+            src = _bare_id(str(record.get("source_incident_id") or "").strip())
+            _add_placeholder_ref(refs, _infer_label_from_id(src), src)
+        elif doc_subtype == "wave":
+            _add_placeholder_ref(refs, "Plan", record.get("plan_anchor_id", ""))
+        elif doc_subtype == "handoff":
+            src = _bare_id(str(record.get("source_record_id") or "").strip())
+            _add_placeholder_ref(refs, _infer_label_from_id(src), src)
+
+    elif record_type == "relationship":
+        for endpoint in (record.get("source_id", ""), record.get("target_id", "")):
+            endpoint_id = _bare_id(str(endpoint).strip()) if endpoint else ""
+            _add_placeholder_ref(refs, _infer_label_from_id(endpoint_id), endpoint_id)
+
+    return refs
+
+
+def _relationship_placeholder_refs_from_sk(record_id_sk: str) -> Set[PlaceholderRef]:
+    """Infer placeholder endpoints from a rel# sort key when OldImage is absent."""
+    refs: Set[PlaceholderRef] = set()
+    parts = str(record_id_sk or "").split("#")
+    if len(parts) < 4 or parts[0] != "rel":
+        return refs
+    for endpoint in (parts[1], parts[3]):
+        endpoint_id = _bare_id(endpoint)
+        _add_placeholder_ref(refs, _infer_label_from_id(endpoint_id), endpoint_id)
+    return refs
+
+
+def _purge_orphan_placeholders(tx, refs: Set[PlaceholderRef]) -> None:
+    """Delete placeholder nodes that no longer participate in any edge."""
+    for label, record_id in refs:
+        tx.run(
+            f"MATCH (n:{label} {{record_id: $rid}}) "
+            "WHERE coalesce(n.is_placeholder, false) = true "
+            "AND NOT (n)--() "
+            "DETACH DELETE n",
+            rid=record_id,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -874,27 +1000,27 @@ def _process_record(driver, stream_record: Dict) -> None:
         if not new_image:
             return
 
-        record = _deser_image(new_image)
+        record = _normalize_record_for_graph(_deser_image(new_image))
         record_type = record.get("record_type", "")
-
-        # ENC-TSK-C49: Documents use 'document_id' as their DynamoDB primary
-        # key, not 'record_id'. Normalize here so downstream _upsert_node and
-        # _reconcile_edges (which both extract via record.get("record_id"))
-        # project Document nodes and edges correctly. Without this fix every
-        # document stream event silently bails out at `if not record_id: return`
-        # in _upsert_node, leaving Neo4j with zero Document nodes even though
-        # the DocumentsToGraphPipe is delivering events.
-        if record_type == "document" and not record.get("record_id"):
-            record["record_id"] = record.get("document_id", "")
+        old_image = dynamodb.get("OldImage", {})
+        old_record = _normalize_record_for_graph(_deser_image(old_image)) if old_image else {}
+        stale_placeholder_refs = _collect_placeholder_target_refs(old_record) - _collect_placeholder_target_refs(record)
 
         # ENC-FTR-049: Handle typed relationship records
         if record_type == "relationship":
             rel_status = record.get("status", "")
             record_id_sk = record.get("record_id", "")
+            relationship_refs = (
+                _collect_placeholder_target_refs(record)
+                if rel_status == "archived"
+                else set()
+            )
             with driver.session() as session:
                 if rel_status == "archived":
                     # Soft-deleted: remove edge from Neo4j projection
                     session.execute_write(lambda tx: _delete_relationship_edge(tx, record_id_sk))
+                    if relationship_refs:
+                        session.execute_write(lambda tx: _purge_orphan_placeholders(tx, relationship_refs))
                     logger.info(
                         "[INFO] Archived relationship edge removed from graph: %s",
                         record_id_sk,
@@ -925,6 +1051,8 @@ def _process_record(driver, stream_record: Dict) -> None:
 
             session.execute_write(lambda tx: _upsert_node(tx, record))
             session.execute_write(lambda tx: _reconcile_edges(tx, record))
+            if stale_placeholder_refs:
+                session.execute_write(lambda tx: _purge_orphan_placeholders(tx, stale_placeholder_refs))
 
             # ENC-TSK-B94: Incremental Titan V2 embedding. Runs inline on the
             # already-async SQS consumer so the user-visible mutation path is
@@ -970,24 +1098,34 @@ def _process_record(driver, stream_record: Dict) -> None:
         )
 
     elif event_name == "REMOVE":
+        old_image = dynamodb.get("OldImage", {})
+        old_record = _normalize_record_for_graph(_deser_image(old_image)) if old_image else {}
         keys = dynamodb.get("Keys", {})
-        record_id_val = keys.get("record_id", {}).get("S", "")
+        record_id_val = _extract_remove_record_id(keys, old_record)
         if not record_id_val:
             return
 
         # ENC-FTR-049: Handle relationship record removal
         if record_id_val.startswith("rel#"):
+            relationship_refs = _collect_placeholder_target_refs(old_record)
+            if not relationship_refs:
+                relationship_refs = _relationship_placeholder_refs_from_sk(record_id_val)
             with driver.session() as session:
                 session.execute_write(lambda tx: _delete_relationship_edge(tx, record_id_val))
+                if relationship_refs:
+                    session.execute_write(lambda tx: _purge_orphan_placeholders(tx, relationship_refs))
             logger.info("[INFO] Deleted relationship edge %s (event=REMOVE)", record_id_val)
             return
 
         # Extract the actual item_id from the record_id key
         # DynamoDB record_id format: "task#ENC-TSK-123" or bare "ENC-TSK-123"
         item_id = record_id_val.split("#", 1)[-1] if "#" in record_id_val else record_id_val
+        stale_placeholder_refs = _collect_placeholder_target_refs(old_record)
 
         with driver.session() as session:
             session.execute_write(lambda tx: _delete_node(tx, item_id))
+            if stale_placeholder_refs:
+                session.execute_write(lambda tx: _purge_orphan_placeholders(tx, stale_placeholder_refs))
 
         logger.info("[INFO] Deleted node %s (event=REMOVE)", item_id)
 

--- a/backend/lambda/graph_sync/test_document_record_id_normalization.py
+++ b/backend/lambda/graph_sync/test_document_record_id_normalization.py
@@ -176,6 +176,78 @@ class TestDocumentRecordIdNormalization(unittest.TestCase):
         self.assertIn("Document", cypher)
         self.assertIn("MERGE", cypher)
 
+    def test_process_remove_uses_document_id_key_for_document_delete(self):
+        """REMOVE events from the documents table must resolve document_id."""
+        captured: dict = {}
+
+        def fake_delete_node(tx, record_id):
+            captured["deleted_record_id"] = record_id
+
+        def fake_purge(tx, refs):
+            captured["purge_refs"] = set(refs)
+
+        GS._delete_node = fake_delete_node  # type: ignore[assignment]
+        GS._purge_orphan_placeholders = fake_purge  # type: ignore[assignment]
+
+        driver = MagicMock()
+        session_cm = MagicMock()
+        driver.session.return_value = session_cm
+        session_cm.__enter__.return_value = session_cm
+        session_cm.__exit__.return_value = False
+        session_cm.execute_write.side_effect = lambda fn: fn(MagicMock())
+
+        stream_record = {
+            "eventName": "REMOVE",
+            "dynamodb": {
+                "Keys": {"document_id": {"S": "DOC-REMOVE-123"}},
+                "OldImage": _dynamodb_image_for_document("DOC-REMOVE-123"),
+            },
+        }
+
+        GS._process_record(driver, stream_record)
+
+        self.assertEqual(captured.get("deleted_record_id"), "DOC-REMOVE-123")
+        self.assertNotIn("purge_refs", captured)
+
+    def test_process_remove_purges_orphan_placeholders_from_old_document_edges(self):
+        """REMOVE should purge placeholder stubs that only existed for old doc edges."""
+        captured: dict = {}
+
+        def fake_delete_node(tx, record_id):
+            captured["deleted_record_id"] = record_id
+
+        def fake_purge(tx, refs):
+            captured["purge_refs"] = set(refs)
+
+        GS._delete_node = fake_delete_node  # type: ignore[assignment]
+        GS._purge_orphan_placeholders = fake_purge  # type: ignore[assignment]
+
+        driver = MagicMock()
+        session_cm = MagicMock()
+        driver.session.return_value = session_cm
+        session_cm.__enter__.return_value = session_cm
+        session_cm.__exit__.return_value = False
+        session_cm.execute_write.side_effect = lambda fn: fn(MagicMock())
+
+        image = _dynamodb_image_for_document("DOC-REMOVE-EDGE")
+        image["related_items"] = {"L": [{"S": "ENC-TSK-999"}]}
+        stream_record = {
+            "eventName": "REMOVE",
+            "dynamodb": {
+                "Keys": {"document_id": {"S": "DOC-REMOVE-EDGE"}},
+                "OldImage": image,
+            },
+        }
+
+        GS._process_record(driver, stream_record)
+
+        self.assertEqual(captured.get("deleted_record_id"), "DOC-REMOVE-EDGE")
+        self.assertEqual(
+            captured.get("purge_refs"),
+            {("Task", "ENC-TSK-999")},
+            "document REMOVE should surface old placeholder targets for cleanup",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/backfill_graph.py
+++ b/tools/backfill_graph.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
-"""Backfill Neo4j graph index from DynamoDB tracker table.
+"""Backfill Neo4j graph index from DynamoDB tracker + document tables.
 
-Scans devops-project-tracker, creates nodes and edges in Neo4j AuraDB.
-Uses MERGE for idempotent upserts. Filters out COUNTER-* records.
+Replays the current ``graph_sync`` node and edge projection logic against the
+authoritative DynamoDB corpus so parity repairs do not fork the live contract.
+Supports optional graph wipe before replay to remove historical phantom nodes.
 
 Usage:
     NEO4J_SECRET_NAME=enceladus/neo4j/auradb-credentials \
     python3 tools/backfill_graph.py --region us-west-2
 """
 import argparse
+import importlib.util
 import json
 import logging
 import os
+import pathlib
 import sys
 import time
 from typing import Any, Dict, List, Optional
@@ -24,21 +27,25 @@ logger = logging.getLogger(__name__)
 FREE_TIER_NODE_LIMIT = 50_000
 FREE_TIER_RELATIONSHIP_LIMIT = 175_000
 
-RECORD_TYPE_TO_LABEL = {
-    "task": "Task",
-    "issue": "Issue",
-    "feature": "Feature",
-    "project": "Project",
-}
+
+def _load_graph_sync_module():
+    """Load the canonical graph_sync implementation for parity replays."""
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    graph_sync_dir = repo_root / "backend" / "lambda" / "graph_sync"
+    if str(graph_sync_dir) not in sys.path:
+        sys.path.insert(0, str(graph_sync_dir))
+    spec = importlib.util.spec_from_file_location(
+        "enceladus_graph_sync_backfill_module",
+        graph_sync_dir / "lambda_function.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
 
 
-def _bare_id(record_id: str) -> str:
-    """Strip the 'type#' prefix from a composite DynamoDB record_id.
-
-    DynamoDB stores record_ids as 'task#ENC-TSK-890' but related fields
-    and user queries use bare IDs like 'ENC-TSK-890'.
-    """
-    return record_id.split("#", 1)[-1] if "#" in record_id else record_id
+GS = _load_graph_sync_module()
+RECORD_TYPE_TO_LABEL = GS.RECORD_TYPE_TO_LABEL
 
 
 def get_neo4j_credentials(secret_name: str, region: str) -> Dict[str, str]:
@@ -55,7 +62,7 @@ def get_neo4j_driver(creds: Dict[str, str]):
     )
 
 
-def scan_tracker_table(region: str, table_name: str = "devops-project-tracker"):
+def scan_table(region: str, table_name: str):
     dynamodb = boto3.resource("dynamodb", region_name=region)
     table = dynamodb.Table(table_name)
     kwargs: Dict[str, Any] = {}
@@ -75,135 +82,48 @@ def scan_tracker_table(region: str, table_name: str = "devops-project-tracker"):
         if not last_key:
             break
         kwargs["ExclusiveStartKey"] = last_key
-    logger.info("[INFO] Total records scanned: %d", total)
+    logger.info("[INFO] Total records scanned from %s: %d", table_name, total)
 
 
-def determine_label(record: Dict[str, Any]) -> Optional[str]:
-    record_id = record.get("record_id", "")
-    record_type = record.get("record_type", "")
-    if record_type in RECORD_TYPE_TO_LABEL:
-        return RECORD_TYPE_TO_LABEL[record_type]
-    parts = record_id.split("-")
-    if len(parts) >= 3:
-        type_part = parts[1].lower()
-        if type_part == "tsk":
-            return "Task"
-        elif type_part == "iss":
-            return "Issue"
-        elif type_part == "ftr":
-            return "Feature"
-        elif type_part == "prj":
-            return "Project"
-    return "Task"
+def _normalize_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply graph_sync's identity normalization to scanned DynamoDB rows."""
+    normalized = GS._normalize_record_for_graph(dict(record))
+    if normalized.get("document_id") and not normalized.get("record_type"):
+        normalized["record_type"] = "document"
+    return normalized
 
 
-def merge_node(tx, record: Dict[str, Any], label: str):
-    record_id = _bare_id(record.get("record_id", ""))
-    project_id = record.get("project_id", "")
-    props = {
-        "record_id": record_id,
-        "project_id": project_id,
-        "title": record.get("title", ""),
-        "status": record.get("status", ""),
-        "priority": record.get("priority", ""),
-        "record_type": record.get("record_type", ""),
-        "updated_at": record.get("updated_at", ""),
-    }
-    query = f"""
-    MERGE (n:{label} {{record_id: $record_id}})
-    SET n.project_id = $project_id,
-        n.title = $title,
-        n.status = $status,
-        n.priority = $priority,
-        n.record_type = $record_type,
-        n.updated_at = $updated_at
-    """
-    tx.run(query, **props)
+def _load_projection_records(
+    region: str,
+    tracker_table: str,
+    documents_table: str,
+) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for item in scan_table(region, tracker_table):
+        records.append(_normalize_record(item))
+    for item in scan_table(region, documents_table):
+        records.append(_normalize_record(item))
+    return records
 
 
-def reconcile_edges(tx, record: Dict[str, Any]):
-    record_id = _bare_id(record.get("record_id", ""))
-    project_id = record.get("project_id", "")
+def _is_entity_record(record: Dict[str, Any]) -> bool:
+    return str(record.get("record_type") or "").strip() in RECORD_TYPE_TO_LABEL
 
-    # CHILD_OF: child -> parent
-    parent = _bare_id(record.get("parent", ""))
-    if parent:
-        tx.run(
-            "MATCH (child), (parent) "
-            "WHERE child.record_id = $child_id AND child.project_id = $project_id "
-            "AND parent.record_id = $parent_id AND parent.project_id = $project_id "
-            "MERGE (child)-[:CHILD_OF]->(parent)",
-            child_id=record_id, parent_id=parent, project_id=project_id,
-        )
 
-    # BELONGS_TO: record -> project node (if project node exists)
-    if project_id:
-        tx.run(
-            "MATCH (n), (p:Project) "
-            "WHERE n.record_id = $record_id AND n.project_id = $project_id "
-            "AND p.project_id = $project_id "
-            "MERGE (n)-[:BELONGS_TO]->(p)",
-            record_id=record_id, project_id=project_id,
-        )
+def _is_relationship_record(record: Dict[str, Any]) -> bool:
+    return str(record.get("record_type") or "").strip() == "relationship"
 
-    # RELATED_TO: from related_task_ids
-    related_task_ids = record.get("related_task_ids", []) or []
-    if isinstance(related_task_ids, str):
-        related_task_ids = [related_task_ids]
-    for rid in related_task_ids:
-        rid = _bare_id(rid) if rid else ""
-        if rid:
-            tx.run(
-                "MATCH (a), (b) "
-                "WHERE a.record_id = $a_id AND a.project_id = $project_id "
-                "AND b.record_id = $b_id AND b.project_id = $project_id "
-                "MERGE (a)-[:RELATED_TO]->(b)",
-                a_id=record_id, b_id=rid, project_id=project_id,
-            )
 
-    # RELATED_TO + ADDRESSES: from related_issue_ids
-    related_issue_ids = record.get("related_issue_ids", []) or []
-    if isinstance(related_issue_ids, str):
-        related_issue_ids = [related_issue_ids]
-    for iid in related_issue_ids:
-        iid = _bare_id(iid) if iid else ""
-        if iid:
-            tx.run(
-                "MATCH (a), (b) "
-                "WHERE a.record_id = $a_id AND a.project_id = $project_id "
-                "AND b.record_id = $b_id AND b.project_id = $project_id "
-                "MERGE (a)-[:RELATED_TO]->(b)",
-                a_id=record_id, b_id=iid, project_id=project_id,
-            )
-            tx.run(
-                "MATCH (t), (i) "
-                "WHERE t.record_id = $task_id AND t.project_id = $project_id "
-                "AND i.record_id = $issue_id AND i.project_id = $project_id "
-                "MERGE (t)-[:ADDRESSES]->(i)",
-                task_id=record_id, issue_id=iid, project_id=project_id,
-            )
-
-    # RELATED_TO + IMPLEMENTS: from related_feature_ids
-    related_feature_ids = record.get("related_feature_ids", []) or []
-    if isinstance(related_feature_ids, str):
-        related_feature_ids = [related_feature_ids]
-    for fid in related_feature_ids:
-        fid = _bare_id(fid) if fid else ""
-        if fid:
-            tx.run(
-                "MATCH (a), (b) "
-                "WHERE a.record_id = $a_id AND a.project_id = $project_id "
-                "AND b.record_id = $b_id AND b.project_id = $project_id "
-                "MERGE (a)-[:RELATED_TO]->(b)",
-                a_id=record_id, b_id=fid, project_id=project_id,
-            )
-            tx.run(
-                "MATCH (t), (f) "
-                "WHERE t.record_id = $task_id AND t.project_id = $project_id "
-                "AND f.record_id = $feature_id AND f.project_id = $project_id "
-                "MERGE (t)-[:IMPLEMENTS]->(f)",
-                task_id=record_id, feature_id=fid, project_id=project_id,
-            )
+def _wipe_graph(driver) -> None:
+    """Clear the existing graph before replaying projection state."""
+    with driver.session() as session:
+        summary = session.run("MATCH (n) DETACH DELETE n").consume()
+    counters = summary.counters
+    logger.info(
+        "[INFO] Cleared graph: nodes_deleted=%s relationships_deleted=%s",
+        counters.nodes_deleted,
+        counters.relationships_deleted,
+    )
 
 
 def report_counts(driver):
@@ -291,12 +211,15 @@ def show_vector_indexes(driver) -> List[Dict[str, Any]]:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Backfill Neo4j graph from DynamoDB tracker table")
+    parser = argparse.ArgumentParser(description="Backfill Neo4j graph from governed DynamoDB tables")
     parser.add_argument("--region", default="us-west-2")
-    parser.add_argument("--table", default="devops-project-tracker")
+    parser.add_argument("--tracker-table", default="devops-project-tracker")
+    parser.add_argument("--documents-table", default="documents")
     parser.add_argument("--secret-name", default=None,
                         help="Secrets Manager secret name (default: env NEO4J_SECRET_NAME)")
     parser.add_argument("--dry-run", action="store_true", help="Scan only, no graph writes")
+    parser.add_argument("--wipe-existing", action="store_true",
+                        help="DETACH DELETE the current graph before replaying projection state")
     parser.add_argument("--run-migration", default=None,
                         help="Path to a .cypher migration file; when set, runs only the migration "
                              "and exits (no DynamoDB scan, no backfill). See "
@@ -327,38 +250,69 @@ def main():
             driver.close()
         return
 
-    logger.info("[START] Backfill graph from %s (region=%s)", args.table, args.region)
+    logger.info(
+        "[START] Backfill graph from %s + %s (region=%s)",
+        args.tracker_table,
+        args.documents_table,
+        args.region,
+    )
 
-    records = list(scan_tracker_table(args.region, args.table))
-    logger.info("[INFO] Loaded %d records (excluding COUNTER-*)", len(records))
+    records = _load_projection_records(args.region, args.tracker_table, args.documents_table)
+    entity_records = [record for record in records if _is_entity_record(record)]
+    relationship_records = [record for record in records if _is_relationship_record(record)]
+    logger.info(
+        "[INFO] Loaded %d entity records and %d relationship records",
+        len(entity_records),
+        len(relationship_records),
+    )
 
     if args.dry_run:
-        logger.info("[END] Dry run complete — %d records would be backfilled", len(records))
+        logger.info(
+            "[END] Dry run complete — %d entity rows and %d relationship rows would be replayed",
+            len(entity_records),
+            len(relationship_records),
+        )
         return
 
     logger.info("[INFO] Connecting to Neo4j...")
     creds = get_neo4j_credentials(secret_name, args.region)
     driver = get_neo4j_driver(creds)
 
+    if args.wipe_existing:
+        _wipe_graph(driver)
+
     # Phase 1: Create all nodes
     logger.info("[START] Creating nodes...")
     start = time.time()
     with driver.session() as session:
-        for i, record in enumerate(records, 1):
-            label = determine_label(record)
-            session.execute_write(merge_node, record, label)
+        for i, record in enumerate(entity_records, 1):
+            project_id = str(record.get("project_id") or "").strip()
+            if project_id:
+                session.execute_write(GS._upsert_project_node, project_id)
+            session.execute_write(GS._upsert_node, record)
             if i % 100 == 0:
-                logger.info("[INFO] Nodes created: %d / %d", i, len(records))
+                logger.info("[INFO] Nodes created: %d / %d", i, len(entity_records))
     logger.info("[END] Nodes created in %.1fs", time.time() - start)
 
     # Phase 2: Reconcile all edges
     logger.info("[START] Reconciling edges...")
     start = time.time()
     with driver.session() as session:
-        for i, record in enumerate(records, 1):
-            session.execute_write(reconcile_edges, record)
+        for i, record in enumerate(entity_records, 1):
+            session.execute_write(GS._reconcile_edges, record)
             if i % 100 == 0:
-                logger.info("[INFO] Edges reconciled: %d / %d", i, len(records))
+                logger.info("[INFO] Entity edges reconciled: %d / %d", i, len(entity_records))
+        for i, record in enumerate(relationship_records, 1):
+            if str(record.get("status") or "").strip() == "archived":
+                session.execute_write(GS._delete_relationship_edge, record.get("record_id", ""))
+            else:
+                session.execute_write(GS._upsert_relationship_edge, record)
+            if i % 100 == 0:
+                logger.info(
+                    "[INFO] Relationship edges reconciled: %d / %d",
+                    i,
+                    len(relationship_records),
+                )
     logger.info("[END] Edges reconciled in %.1fs", time.time() - start)
 
     node_count, edge_count = report_counts(driver)

--- a/tools/test_backfill_graph.py
+++ b/tools/test_backfill_graph.py
@@ -1,0 +1,34 @@
+"""Unit tests for tools/backfill_graph.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("backfill_graph.py")
+SPEC = importlib.util.spec_from_file_location("enceladus_backfill_graph_under_test", MODULE_PATH)
+backfill_graph = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = backfill_graph
+SPEC.loader.exec_module(backfill_graph)
+
+
+def test_normalize_record_promotes_document_identity():
+    normalized = backfill_graph._normalize_record({"document_id": "DOC-UNIT-123"})
+
+    assert normalized["record_type"] == "document"
+    assert normalized["record_id"] == "DOC-UNIT-123"
+
+
+def test_entity_record_detection_includes_plan_lesson_and_document():
+    assert backfill_graph._is_entity_record({"record_type": "plan"}) is True
+    assert backfill_graph._is_entity_record({"record_type": "lesson"}) is True
+    assert backfill_graph._is_entity_record({"record_type": "document"}) is True
+    assert backfill_graph._is_entity_record({"record_type": "relationship"}) is False
+
+
+def test_relationship_record_detection_is_explicit():
+    assert backfill_graph._is_relationship_record({"record_type": "relationship"}) is True
+    assert backfill_graph._is_relationship_record({"record_type": "task"}) is False


### PR DESCRIPTION
## Summary
- fix graph_sync REMOVE handling so document deletes resolve document_id and purge stale placeholder-only nodes
- purge orphan placeholders for modify/remove and archived relationship flows to remove phantom graph nodes
- rework backfill_graph to replay canonical tracker + document projection logic and add focused parity tests

## Verification
- python3 -m pytest backend/lambda/graph_sync/test_document_record_id_normalization.py backend/lambda/graph_sync/test_edge_projection_f45.py tools/test_backfill_graph.py
- python3 -m py_compile backend/lambda/graph_sync/lambda_function.py tools/backfill_graph.py tools/test_backfill_graph.py

## Governance
- CCI-458b7ec5593d4f7a87f82751604fdbe9