### PR TITLE
chore(deploy): bump deploy job timeout-minutes 60→90 (ENC-TSK-G20)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -224,7 +224,7 @@ jobs:
     if: always() && needs.resolve.result == 'success'
     environment: ${{ needs.resolve.outputs.environment }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `_deploy.yml` Deploy job `timeout-minutes` raised from 60 → 90

30-Lambda cold prod deploys (sequential update loop + Canary10Percent5Minutes CodeDeploy poll) reliably breach the 60-minute ceiling. Three consecutive cancellations observed on 2026-04-22/23. 90 min gives ~30 min headroom above the measured worst-case.

## Test plan

- [ ] CI passes
- [ ] Next prod deploy completes within 90 min without cancellation

## Linked task

ENC-TSK-G20

CCI-f8ab0258212e465d9b67662b7cb0c629

🤖 Generated with [Claude Code](https://claude.com/claude-code)