### PR TITLE
feat(graph_query_api): allowlist MENTIONS edge type (ENC-TSK-G36, Unit 4)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-04-25.02",
-  "updated_at": "2026-04-25T19:47:38Z",
-  "last_change_summary": "ENC-FTR-098 / ENC-TSK-G33: add graph_sync.mentions_extraction entity (prose-field allowlist, ID-prefix alphabet, code-fence skip, provenance schema); register MENTIONS in document.graph_edges, gmf.graph_edges, and tracker.graphsearch.edge_types.",
+  "version": "2026-04-25.03",
+  "updated_at": "2026-04-26T00:36:46Z",
+  "last_change_summary": "ENC-FTR-098 / ENC-TSK-G36: graph_query_api._ALLOWED_EDGE_TYPES += MENTIONS (Unit 4 of MENTIONS Edge MVP). Documents the API-gate uplift; the dictionary entity graph_sync.mentions_extraction (added in 2026-04-25.02) already declared the contract.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3091,7 +3091,7 @@
       }
     },
     "tracker.graphsearch": {
-      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges.",
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate.",
       "fields": {
         "search_type": {
           "type": "enum",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -339,6 +339,11 @@ _ALLOWED_EDGE_TYPES = frozenset({
     "IMPLEMENTED_BY",         # Task -> Component
     "DEPLOYS",                # Component -> Task
     "DEPLOYED_BY",            # Task -> Component
+    # ENC-FTR-098 / ENC-TSK-G35: MENTIONS edge auto-extracted from prose by
+    # graph_sync._reconcile_mentions_edges(). Properties: source ('auto_mention'
+    # | 'backfill' | 'audit_recompute'), extracted_from_field. See dictionary
+    # entity graph_sync.mentions_extraction for the full extraction contract.
+    "MENTIONS",
 })
 
 


### PR DESCRIPTION
## Summary

**ENC-TSK-G36** (Unit 4 of [ENC-FTR-098](https://) MENTIONS Edge MVP). One-line addition to `graph_query_api._ALLOWED_EDGE_TYPES` plus a 4-line provenance comment. Unblocks `tracker.graphsearch` calls with `edge_types=['MENTIONS']` so the auto-extracted edges that landed in PR #454 (ENC-TSK-G35) become queryable through the public API.

MENTIONS edges are already live in Neo4j carrying `source='auto_mention'` + `extracted_from_field=<prose_field>` provenance — this patch just removes the API gate.

## Tracker linkage

- Parent: ENC-TSK-G28 · Source feature: ENC-FTR-098 · Spec: DOC-59D2295AA7FD §7.2.4

CCI-21c04eb18cee4ed58dcbf8b592a9b02e

## Test plan

- [x] Local import smoke (with neo4j stub): `MENTIONS in _ALLOWED_EDGE_TYPES = True`, total 55 types, no regression on RELATED_TO/CHILD_OF/LEARNED_FROM/PLAN_CONTAINS
- [ ] Post-deploy: `tracker.graphsearch(record_id=…, search_type=neighbors, edge_types=['MENTIONS'])` succeeds (no `Invalid edge_types` error)