### PR TITLE
feat(deploy): G70 v4/main cutover prereqs — push trigger split + CI guards

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,9 +1,13 @@
 name: Deploy Lambda Artifacts (Gen2)
 
 # ENC-FTR-090 / ENC-PLN-041 Phase 2 / ENC-TSK-F60
+# ENC-TSK-G70: branch-based env routing. push to main → no-op (v3-prod is
+# workflow_dispatch-only). push to v4/main → build + deploy v4-gamma.
 #
 # AC-1: Sole prod-IAM-assumer. GitHubActions-V*-DeployRole is assumed ONLY here.
-#       push to main  → build (via _build.yml) then deploy to v4-gamma.
+#       push to v4/main → build (via _build.yml) then deploy to v4-gamma.
+#       push to main → skipped (deploy chain rebuilt in ENC-TSK-G71 fires v3-prod via
+#         post-gamma promotion + required-reviewer gate).
 #       workflow_dispatch → deploy a pre-built SHA to the specified target_environment.
 #       workflow_call → reusable entry point for programmatic callers.
 #       Concurrency group keyed per-environment with cancel-in-progress=false.
@@ -17,7 +21,7 @@ name: Deploy Lambda Artifacts (Gen2)
 
 on:
   push:
-    branches: [main]
+    branches: [main, v4/main]
   workflow_dispatch:
     inputs:
       target_environment:
@@ -55,11 +59,14 @@ env:
 jobs:
 
   # ---------------------------------------------------------------------------
-  # BUILD — runs only on push-to-main (gamma path).
+  # BUILD — runs only on push-to-v4/main (gamma path).
+  # push-to-main is intentionally a no-op: v3-prod is workflow_dispatch-only,
+  # and v4/main is forward-synced from main by the sync-main-to-v4main workflow
+  # (ENC-TSK-G71) which then triggers this workflow on the v4/main push.
   # workflow_dispatch / workflow_call callers provide a pre-built SHA.
   # ---------------------------------------------------------------------------
   build:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_name == 'v4/main'
     uses: ./.github/workflows/_build.yml
     with:
       commit_sha: ${{ github.sha }}
@@ -71,7 +78,15 @@ jobs:
   resolve:
     name: Resolve artifacts (${{ inputs.target_environment || 'v4-gamma' }})
     needs: [build]
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    # On push events, only proceed when the build job actually ran (v4/main).
+    # On workflow_dispatch / workflow_call, build is skipped — proceed with the
+    # caller-supplied commit_sha + target_environment.
+    if: |
+      always() &&
+      (
+        (github.event_name == 'push' && needs.build.result == 'success') ||
+        (github.event_name != 'push' && needs.build.result == 'skipped')
+      )
     runs-on: ubuntu-latest
     outputs:
       commit_sha:            ${{ steps.sha.outputs.commit_sha }}

--- a/.github/workflows/lambda-workflow-coverage-guard.yml
+++ b/.github/workflows/lambda-workflow-coverage-guard.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*/main'
     paths:
       - "backend/lambda/**"
       - "infrastructure/cloudformation/02-compute.yaml"

--- a/.github/workflows/mcp-api-boundary-guard.yml
+++ b/.github/workflows/mcp-api-boundary-guard.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*/main'
     paths:
       - "tools/enceladus-mcp-server/server.py"
       - "tools/check_mcp_api_boundary.py"

--- a/.github/workflows/secrets-guardrail.yml
+++ b/.github/workflows/secrets-guardrail.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'v[0-9]*/main'
   schedule:
     - cron: "17 8 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

ENC-TSK-G70 — Stages prerequisites so v4/main can become source-of-truth for v4-gamma deploys without v4 work bleeding into v3-prod. Sev1 deploy-pipeline restoration, paired with the forthcoming ENC-TSK-G71 work.

- **AC2** `.github/workflows/_deploy.yml`: push trigger now `[main, v4/main]`; build/resolve/deploy gated to v4/main on push events. Push to main is no-op (v3-prod stays workflow_dispatch-only). v4/main push fires v4-gamma deploy.
- **AC4** Extended push triggers to `v[0-9]*/main` on `mcp-api-boundary-guard`, `lambda-workflow-coverage-guard`, `secrets-guardrail`. `governance-dictionary-guard` and `component-registry-guard` already covered.
- **AC3** Already satisfied: ruleset `git-governance` (id 13297478) actively covers both `refs/heads/main` and `refs/heads/v[0-9]*/main` with identical PR / non_fast_forward / required_status_checks rules.
- **AC6** Topology + cutover toggle captured in **DOC-2F8C5207B2A1**.

## Out-of-band for AC1 (forward-sync)

origin/v4/main has 8 commits not in main — obsolete pre-Gen2 D59 mcp-streamable-gamma scaffolding superseded by ENC-TSK-F60 (commit `b6d4d7d`). Force-push blocked by the ruleset's non_fast_forward rule. Will land via a follow-up PR (base=v4/main, head=main, `-s ours` to absorb the 8 obsolete commits) immediately after this PR merges.

Backup tag: `v4-main-pre-G70-sync-20260426`.

## Test plan

- [ ] CI guards green on this PR (CI, Secrets Scan, Governance Dictionary Guard, PR Commit Gate).
- [ ] After merge: open the v4/main forward-sync PR, get it merged.
- [ ] AC5 validation: synthetic push to v4/main → v4-gamma deploy <10 min, no v3-prod activity. Capture run links + LastModified deltas.

CCI-15303776076b4d3e91d2375897a26b3a

🤖 Generated with [Claude Code](https://claude.com/claude-code)