### PR TITLE
feat(deploy-chain): G71 rebuild auto-promote main->gamma->prod-request

### DIFF
--- a/.github/workflows/pr-commit-gate.yml
+++ b/.github/workflows/pr-commit-gate.yml
@@ -25,8 +25,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # ENC-TSK-G71: sync-main-to-v4main.yml opens transient PRs base=v4/main
+      # head=auto/sync-main-to-v4main-* to forward-sync v4/main without bypass
+      # actors. These PRs are not task-bound and have no CCI. Recognize the
+      # pattern + base and short-circuit the gate as a pass.
+      - name: Detect auto sync PR (CCI-exempt)
+        id: classify
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [[ "$HEAD_REF" == auto/sync-main-to-v4main-* && "$BASE_REF" == "v4/main" ]]; then
+            echo "Auto-sync PR detected (head=$HEAD_REF base=$BASE_REF) — CCI requirement waived."
+            echo "auto_sync=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "auto_sync=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract commit-complete-id from PR body
         id: extract_cci
+        if: steps.classify.outputs.auto_sync != 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -45,6 +63,7 @@ jobs:
           echo "cci_id=$CCI_ID" >> "$GITHUB_OUTPUT"
 
       - name: Validate commit-complete-id with checkout service
+        if: steps.classify.outputs.auto_sync != 'true'
         env:
           CCI_ID: ${{ steps.extract_cci.outputs.cci_id }}
           CHECKOUT_SERVICE_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/checkout
@@ -87,6 +106,7 @@ jobs:
 
       # ENC-TSK-E57 AC1: Reject PRs with undeclared deploy target
       - name: Validate deploy target declaration
+        if: steps.classify.outputs.auto_sync != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           DEPLOY_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/deploy

--- a/.github/workflows/promote-gamma-to-prod-request.yml
+++ b/.github/workflows/promote-gamma-to-prod-request.yml
@@ -1,0 +1,45 @@
+name: Promote v4-gamma success to v3-prod request
+
+# ENC-TSK-G71: Listens for successful v4-gamma deploys (push events on v4/main)
+# and dispatches _deploy.yml with target_environment=v3-prod. The dispatch hits
+# the v3-prod GitHub Environment's required-reviewer rule and pauses until
+# io approves. The approval click is the cutover toggle: stop approving =>
+# v4 work stays in gamma without any workflow rewiring.
+
+on:
+  workflow_run:
+    workflows: ["Deploy Lambda Artifacts (Gen2)"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: promote-gamma-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'v4/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch v3-prod deploy request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          GAMMA_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          echo "Gamma success run=$GAMMA_RUN_ID sha=$SHA — dispatching v3-prod request"
+
+          gh workflow run "_deploy.yml" \
+            --ref main \
+            -f target_environment=v3-prod \
+            -f commit_sha="$SHA"
+
+          echo "v3-prod deploy request dispatched. Awaiting reviewer approval on the GitHub Environment."

--- a/.github/workflows/sync-main-to-v4main.yml
+++ b/.github/workflows/sync-main-to-v4main.yml
@@ -1,0 +1,106 @@
+name: Sync main to v4/main
+
+# ENC-TSK-G71: Auto-sync main -> v4/main on every main push.
+# v4/main rulesets reject direct push from non-bypass actors, so the sync
+# runs as a transient PR with auto-merge enabled. The PR base is v4/main and
+# its head is auto/sync-main-to-v4main-<sha>. pr-commit-gate.yml exempts this
+# head_ref pattern from the CCI requirement (these PRs are not task-bound).
+#
+# Pre-fork mode: each main push fast-forward-merges into v4/main.
+# Post-fork mode: when v4/main has commits not in main, the PR will be a
+# non-fast-forward merge (or conflict). Conflicts FAIL the workflow loudly,
+# which is the cutover signal.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: sync-main-to-v4main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Decide sync action
+        id: decide
+        env:
+          MAIN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin main v4/main
+          MAIN_SHA="$(git rev-parse origin/main)"
+          V4_SHA="$(git rev-parse origin/v4/main)"
+          echo "main_sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
+          echo "v4_sha=$V4_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$MAIN_SHA" = "$V4_SHA" ]; then
+            echo "v4/main already at main HEAD ($MAIN_SHA) — no-op"
+            echo "action=noop" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "$MAIN_SHA" "$V4_SHA"; then
+            echo "v4/main already strictly ahead of main (post-fork mode) — no-op"
+            echo "action=noop" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "$V4_SHA" "$MAIN_SHA"; then
+            echo "Pre-fork fast-forward: main is ahead, v4/main is ancestor."
+            echo "action=ff_pr" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::v4/main has diverged from main (post-fork mode). Manual coordination required."
+          echo "main:    $MAIN_SHA"
+          echo "v4/main: $V4_SHA"
+          echo "merge-base: $(git merge-base "$MAIN_SHA" "$V4_SHA")"
+          exit 1
+
+      - name: Open + auto-merge sync PR
+        if: steps.decide.outputs.action == 'ff_pr'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN_SHA: ${{ steps.decide.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          BRANCH="auto/sync-main-to-v4main-${MAIN_SHA:0:12}"
+
+          if gh api -X GET "/repos/$GITHUB_REPOSITORY/branches/$BRANCH" >/dev/null 2>&1; then
+            echo "Sync branch $BRANCH already exists — assuming a previous run is in flight; exiting OK"
+            exit 0
+          fi
+
+          git push origin "$MAIN_SHA:refs/heads/$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base v4/main \
+            --head "$BRANCH" \
+            --title "chore(sync): main -> v4/main @ ${MAIN_SHA:0:12} (auto)" \
+            --body "Automated forward-sync of main into v4/main (ENC-TSK-G71). \
+Source SHA: \`$MAIN_SHA\`. \
+This PR is exempt from the PR Commit Gate via head_ref pattern \`auto/sync-main-to-v4main-*\`. \
+Will auto-merge once required status checks pass.")
+          echo "Opened sync PR: $PR_URL"
+
+          gh pr merge "$PR_URL" --auto --merge --delete-branch
+          echo "Auto-merge enabled on $PR_URL"


### PR DESCRIPTION
## Summary

ENC-TSK-G71 — Restores the auto-promote deploy chain that ENC-TSK-F60 (Gen2 _deploy.yml consolidation, commit b6d4d7d, 2026-04-20) accidentally deleted with deploy-orchestration.yml. Sev1 deploy-pipeline restoration following PR #457 (G70 prereqs).

Built on the Gen2 substrate (single _deploy.yml, GitHub Deployments API state) using GitHub-native primitives — workflow_run listeners + transient PR auto-merge — instead of the legacy workflow_call chain.

### New workflows

- **`.github/workflows/sync-main-to-v4main.yml`** — on main push, opens transient PR base=v4/main head=auto/sync-main-to-v4main-<sha> with auto-merge enabled. Idempotent in pre-fork mode (fast-forward); fails loudly on non-fast-forward (cutover signal). Uses PR-and-auto-merge instead of direct push because ruleset 'git-governance' (id=13297478) blocks force-push and requires PRs on v4/main.
- **`.github/workflows/promote-gamma-to-prod-request.yml`** — workflow_run listener filtered to (Deploy Lambda Artifacts (Gen2)) + conclusion=success + event=push + head_branch=v4/main. Dispatches _deploy.yml with target_environment=v3-prod and commit_sha=<gamma sha>, hitting the v3-prod GH Environment's required-reviewer rule (io). The approval click is the cutover toggle.

### Modified

- **`.github/workflows/pr-commit-gate.yml`** — exempt CCI requirement for transient sync PRs matching head=auto/sync-main-to-v4main-* base=v4/main. These are not task-bound and have no commit-complete-id.

### Why the deploy-key path was rejected

The handoff suggested `git push origin main:v4/main` with an SSH deploy key. v4/main's ruleset enforces non_fast_forward + pull_request with no bypass actors configured. A deploy key alone would still be rejected. Adding bypass actors needs separate org/admin coordination. The PR-with-auto-merge approach honors existing governance and matches the §10 escalation: "Branch protection blocks deploy key → use GitHub App token instead, document choice." — chose the auto-merge variant since it requires no new credentials.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: this very merge to main fires sync-main-to-v4main.yml → opens an auto-sync PR → auto-merges → v4/main updates → fires v4-gamma deploy → v4-gamma success → fires promote-gamma-to-prod-request.yml → creates v3-prod deploy request awaiting reviewer approval. Validates ACs 1, 2, 3.
- [ ] User approves the v3-prod request → AC4 (prod deploy <10 min, success).
- [ ] AC5 post-fork simulation: deferred — requires synthetic v4-only commit on v4/main and io withholding approval.

CCI-8c1931cf1ec848c6ad83b341a1b1497d

🤖 Generated with [Claude Code](https://claude.com/claude-code)