### PR TITLE
fix(sync-workflow): YAML scalar hotfix for ENC-TSK-G71 sync workflow

### DIFF
--- a/.github/workflows/sync-main-to-v4main.yml
+++ b/.github/workflows/sync-main-to-v4main.yml
@@ -92,14 +92,12 @@ jobs:
 
           git push origin "$MAIN_SHA:refs/heads/$BRANCH"
 
+          BODY="Automated forward-sync of main into v4/main (ENC-TSK-G71). Source SHA: $MAIN_SHA. This PR is exempt from the PR Commit Gate via head_ref pattern auto/sync-main-to-v4main-*. Will auto-merge once required status checks pass."
           PR_URL=$(gh pr create \
             --base v4/main \
             --head "$BRANCH" \
             --title "chore(sync): main -> v4/main @ ${MAIN_SHA:0:12} (auto)" \
-            --body "Automated forward-sync of main into v4/main (ENC-TSK-G71). \
-Source SHA: \`$MAIN_SHA\`. \
-This PR is exempt from the PR Commit Gate via head_ref pattern \`auto/sync-main-to-v4main-*\`. \
-Will auto-merge once required status checks pass.")
+            --body "$BODY")
           echo "Opened sync PR: $PR_URL"
 
           gh pr merge "$PR_URL" --auto --merge --delete-branch


### PR DESCRIPTION
## Summary

ENC-TSK-G72 — Hotfix for the broken sync-main-to-v4main.yml shipped in PR #459. The workflow file failed to parse on GitHub side ("This run likely failed because of a workflow file issue", run 24945722899).

Cause: `gh pr create --body "..."` was split across four lines via shell `\` continuations inside a YAML `run: |` block scalar. Lines 100-102 were at column 1, dropping below the block scalar's indent baseline and escaping the scalar — yaml.safe_load fails at line 102 col 1.

Fix: assign body to local `BODY` variable on one line, pass `"$BODY"` to `--body`. Validated locally with `yaml.safe_load`.

## Test plan

- [ ] CI green
- [ ] After merge: this main push fires the *fixed* sync-main-to-v4main.yml → opens auto-sync PR → auto-merges to v4/main → fires v4-gamma deploy → fires promote-gamma-to-prod-request.yml → creates v3-prod deploy request awaiting approval. End-to-end chain validation for G71.

CCI-5400af26938c4a218541504e49591a1e

🤖 Generated with [Claude Code](https://claude.com/claude-code)