### PR TITLE
feat(sync-workflow): wire SYNC_PAT for true auto-merge (ENC-TSK-G81)

### DIFF
--- a/.github/workflows/sync-main-to-v4main.yml
+++ b/.github/workflows/sync-main-to-v4main.yml
@@ -99,7 +99,15 @@ jobs:
       - name: Open + auto-merge sync PR
         if: steps.decide.outputs.action == 'ff_pr' || steps.decide.outputs.action == 'ours_pr'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ENC-TSK-G81 / ENC-ISS-307: prefer SYNC_PAT (a fine-grained PAT or
+          # GitHub App installation token) so PR creation fires required
+          # pull_request workflows on the auto-sync PR. GITHUB_TOKEN-created
+          # PRs are blocked from firing recursive workflows by GitHub design,
+          # which leaves the auto-merge armed but never triggered. If
+          # SYNC_PAT is not yet provisioned, fall back to GITHUB_TOKEN —
+          # the chain still works but requires a manual empty-commit nudge
+          # on the auto-sync PR to fire required checks.
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
           MAIN_SHA: ${{ steps.decide.outputs.main_sha }}
           V4_SHA: ${{ steps.decide.outputs.v4_sha }}
           ACTION: ${{ steps.decide.outputs.action }}


### PR DESCRIPTION
## Summary

ENC-TSK-G81 — closes the GITHUB_TOKEN recursion gap surfaced during ENC-TSK-G74 validation.

The sync-main-to-v4main.yml "Open + auto-merge sync PR" step now uses:

\`\`\`yaml
GH_TOKEN: \${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

Once io adds **SYNC_PAT** to repo secrets (fine-grained PAT, repo-scoped to NX-2021-L/enceladus, scopes: Contents RW + Pull Requests RW + Workflows RW + Metadata R), auto-PRs are created under that identity → required pull_request workflows fire → auto-merge fires → chain proceeds with zero human nudge.

If SYNC_PAT is not yet provisioned, the expression falls back to GITHUB_TOKEN (current behavior, requires manual empty-commit push to fire required checks). Safe to merge before the PAT is minted.

Closes-after-merge: ENC-ISS-307.

## Test plan

- [ ] CI green on this PR (no functional change to workflow behavior in fallback mode).
- [ ] After merge: io mints SYNC_PAT (separately) and stores as repo secret.
- [ ] First main push after secret creation: auto-PR fires required checks automatically; auto-merge fires without nudge. AC2 closes ENC-TSK-G81.

CCI-9d8af9f658a340e889928d986a85fcb3

🤖 Generated with [Claude Code](https://claude.com/claude-code)