### PR TITLE
ENC-TSK-G47: 5-surface MCP client parity — shared tool surface + DRIFT-1/3/4 fixes + DRIFT-2 auth (all-internal-key)

### DIFF
--- a/tools/enceladus-mcp-server/briefings/native-desktop-mcp-briefing-extras/TERMINAL_MCP_BOOTSTRAP_CONTRACT.md
+++ b/tools/enceladus-mcp-server/briefings/native-desktop-mcp-briefing-extras/TERMINAL_MCP_BOOTSTRAP_CONTRACT.md
@@ -75,3 +75,15 @@ Define one idempotent startup contract for terminal sessions that may begin with
 - `COORDINATION_PREFLIGHT_ERROR={"stage":"mcp",...}` on failure paths
 
 These markers provide deterministic evidence during validation matrix runs.
+
+## Required Environment Variables (stdio mode only)
+
+HTTP gateway surfaces (Claude Code, Codex, Cursor desktop, Cursor cloud, claude.ai web) are unaffected — the coordination_api gateway enforces code mode independently of env vars.
+
+For sessions running `tools/enceladus-mcp-server/server.py` directly via stdio (local development, test harness, future stdio-transport surfaces):
+
+| Variable | Required value | Effect if absent |
+|----------|---------------|-----------------|
+| `ENCELADUS_MCP_INTERFACE_MODE` | `code` | server.py defaults to raw mode (50+ tools instead of the governed 4-tool code-mode surface) |
+
+Set this in your shell or in the session launcher before invoking `server.py`. The `install_profile.sh` installer documents this requirement in the managed codex startup comment block.

--- a/tools/enceladus-mcp-server/install_profile.sh
+++ b/tools/enceladus-mcp-server/install_profile.sh
@@ -159,8 +159,12 @@ import os
 import pathlib
 import re
 
+import sys
 cfg = pathlib.Path(os.environ["CODEX_CONFIG_FILE"])
 text = cfg.read_text() if cfg.exists() else ""
+
+if "mcp.jreese.net" in text:
+    print("[WARNING] Existing codex config contains legacy URL (mcp.jreese.net) — overwriting with canonical URL.", file=sys.stderr)
 
 # Remove prior managed blocks to avoid duplicate TOML keys.
 text = re.sub(r"(?ms)^# BEGIN ENCELADUS CODEX STARTUP \(managed\)\n.*?# END ENCELADUS CODEX STARTUP \(managed\)\n?", "", text)
@@ -212,6 +216,7 @@ text += (
     "# - During init, load governance://agents/bootstrap-template.md and governance://agents/lifecycle-primer.md.\n"
     "# - Use MCP checkout_task / advance_task_status for the CAI -> CCI lifecycle; put CCI-... in the PR body.\n"
     "# - Prefer non-interactive git flows and operate from the task worktree CWD, not the shared main checkout.\n"
+    "# - For stdio-mode sessions (server.py direct): set ENCELADUS_MCP_INTERFACE_MODE=code to surface the governed 4-tool interface.\n"
     "# END ENCELADUS CODEX STARTUP (managed)\n\n"
 )
 
@@ -231,6 +236,11 @@ if auth_key:
     lines.append("")
     lines.append(f"[mcp_servers.{alias}.headers]")
     lines.append(f"X-Coordination-Internal-Key = {_toml_str(auth_key)}")
+
+for tool in ("search", "coordination", "get_compact_context", "execute"):
+    lines.append("")
+    lines.append(f"[mcp_servers.{alias}.tools.{tool}]")
+    lines.append(f"approval_mode = {_toml_str('approve')}")
 
 server_block = "\n".join(lines)
 managed = "# BEGIN ENCELADUS MCP PROFILE (managed)\n" + server_block + "\n# END ENCELADUS MCP PROFILE (managed)\n"

--- a/tools/enceladus-mcp-server/install_profile.sh
+++ b/tools/enceladus-mcp-server/install_profile.sh
@@ -171,7 +171,7 @@ text = re.sub(r"(?ms)^# BEGIN ENCELADUS CODEX STARTUP \(managed\)\n.*?# END ENCE
 text = re.sub(r"(?ms)^# BEGIN ENCELADUS MCP PROFILE \(managed\)\n.*?# END ENCELADUS MCP PROFILE \(managed\)\n?", "", text)
 alias = os.environ["MCP_PRIMARY_ALIAS"]
 # Remove any prior stdio or HTTP server sections for this alias.
-for section_suffix in ("", ".env", ".headers"):
+for section_suffix in ("", ".env", ".headers", ".http_headers"):
     text = re.sub(
         rf"(?ms)^\[mcp_servers\.{re.escape(alias)}{re.escape(section_suffix)}\]\n.*?(?=^\[|\Z)",
         "",
@@ -234,7 +234,7 @@ lines = [
 ]
 if auth_key:
     lines.append("")
-    lines.append(f"[mcp_servers.{alias}.headers]")
+    lines.append(f"[mcp_servers.{alias}.http_headers]")
     lines.append(f"X-Coordination-Internal-Key = {_toml_str(auth_key)}")
 
 for tool in ("search", "coordination", "get_compact_context", "execute"):


### PR DESCRIPTION
## Summary

Implements the parity remediations identified by ENC-TSK-G46 (PR #471, matrix doc at 48061a9). Fixes all 4 drift findings across the 5 MCP client surfaces.

**CCI-94e2bcc723824755a156a6194df6fbb1**

## Drift Fixes

| Drift | Finding | Fix |
|-------|---------|-----|
| DRIFT-1 | `~/.codex/config.toml` had legacy URL `https://mcp.jreese.net` | Added migration warning in installer; canonical URL `https://jreese.net/api/v1/coordination/mcp` already written by default — re-running installer corrects live config |
| DRIFT-2 | Codex used Cognito JWT Bearer (~60 min TTL) vs persistent internal key on surfaces 1/4/5. Also: installer wrote `[mcp_servers.enceladus.headers]` but codex reads `[mcp_servers.enceladus.http_headers]` (TOML key mismatch) | Standardized codex to `X-Coordination-Internal-Key` under `http_headers`; added `http_headers` to cleanup loop for idempotent re-runs. io decision: all-internal-key via wave DOC-1487FA9B03A5 |
| DRIFT-3 | `coordination` tool absent from codex `approval_mode` entries | Installer now writes all 4 code-mode tools (`search`, `coordination`, `get_compact_context`, `execute`) with `approval_mode = "approve"` |
| DRIFT-4 | `server.py` defaults to raw mode (50+ tools) when `ENCELADUS_MCP_INTERFACE_MODE` unset | Documented requirement in managed codex startup block (`install_profile.sh`) and `TERMINAL_MCP_BOOTSTRAP_CONTRACT.md` required-env section |

## AC Verification

- **AC1** (single tool inventory): Confirmed by inspection — `_ENCELADUS_CODE_MODE_TOOLS` in `coordination_api/lambda_function.py:398-403` and `CODE_MODE_TOOL_NAMES` in `server.py:425-426` are consistent; no surface-specific tool registration remains. No code change required.
- **AC2** (auth adapters isolated): `_authenticate()` at `lambda_function.py:13634` is the single branching point. No change required. DRIFT-2 fix is entirely in the installer boundary.
- **AC3** (G15 defer_loading propagation): Out of scope for G47 — G15 is the follow-on task. Shared backend handles this uniformly across all 5 surfaces.

## Commits

- `4e175fd` — DRIFT-1/3/4: codex URL migration warning, all-4-tool approval policy, stdio env doc
- `a2db51c` — DRIFT-2: codex auth → internal-key + http_headers TOML key fix

## Test Results

379 tests passed (coordination_api + mcp-server suites). 1 pre-existing failure (`test_deploy_adapter_contract`) confirmed on `48061a9` before G47.

## References

- Predecessor: PR #471 (ENC-TSK-G46 audit + parity matrix)
- Wave: DOC-1487FA9B03A5
- Handoff: DOC-2685BDEB122B
- Lesson: ENC-LSN-050 (doc-only tasks need `transition_type=code_only` at create time)

Do NOT self-merge. Coord-lead merges after review.