### PR TITLE
SEV1: disable Lambda SnapStart on gamma+prod (cost incident)

### DIFF
--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -32,7 +32,10 @@ appconfig_application_id: ""
 appconfig_environment_id: ""
 
 # ENC-TSK-F63 AC-2/AC-3: SnapStart (arm64/py3.12 — supported) and CodeDeploy.
-enable_snapstart: "true"
+# Disabled in gamma: SnapStart cached snapshot storage bills per GB-second per
+# published version, and the canary pipeline publishes a version on every deploy.
+# Cold-start latency is a prod concern only. Re-enable with a version-prune step.
+enable_snapstart: "false"
 environment_suffix: "-gamma"
 codedeploy_app_name: "enceladus-lambda-gamma"
 

--- a/envs/v4-prod.yaml
+++ b/envs/v4-prod.yaml
@@ -36,6 +36,9 @@ appconfig_application_id: ""
 appconfig_environment_id: ""
 
 # ENC-TSK-F63 AC-2/AC-3: SnapStart (arm64/py3.12 — supported) and CodeDeploy.
-enable_snapstart: "true"
+# Disabled (Sev1 cost incident 2026-04-22): SnapStart cached snapshot storage
+# bills per GB-second per published version. Re-enable only with a paired
+# version-prune step in the deploy pipeline.
+enable_snapstart: "false"
 environment_suffix: ""
 codedeploy_app_name: "enceladus-lambda"


### PR DESCRIPTION
## Summary

- **SEV1 cost incident** — Lambda bill jumped from ~\$0.20/day to \$20-30/day starting 2026-04-22, driven entirely by `USW2-Lambda-SnapStart-Cached-GB-S` storage charges accruing 24/7 even with zero invocations.
- Root cause: `EnableSnapStart=true` in `envs/v4-gamma.yaml` and `envs/v4-prod.yaml` causes `infrastructure/cloudformation/02-compute.yaml` to apply `SnapStart: ApplyOn: PublishedVersions` on ~24 Lambda resources. The deploy pipeline publishes a new version on every push, and each version captures its own cached snapshot. Result: 19 gamma functions × ~40 versions each ≈ 800 cached snapshots billing GB-second storage continuously.
- This PR sets `enable_snapstart: "false"` in both gamma and prod manifests so the next CFN deploy does not re-enable SnapStart.

## Out-of-band remediation already applied

To stop bleeding immediately (before this PR can merge + deploy):

- SnapStart disabled on all 19 live gamma functions via `aws lambda update-function-configuration --snap-start ApplyOn=None`
- 817 stale published versions deleted across the 19 functions (frees cached storage immediately)
- Verified post-fix: all 19 functions report `SnapStart: None`

Without this PR, the next gamma CFN deploy will re-set `ApplyOn=PublishedVersions` from the IaC and the cost will resume.

## Why disable in prod too

`envs/v4-prod.yaml` had the same `enable_snapstart: "true"` flag. v4-prod stack does not appear deployed yet (no v4-prod functions in live inventory), but if it ships unchanged it will hit the identical cost pattern at prod scale. Cold-start latency on prod is a real concern, but it must be paired with a deploy-pipeline version-prune step before re-enabling. That work is out of scope here.

v3-prod is unaffected (x86_64/py3.11 — SnapStart not supported, already `enable_snapstart: "false"`).

## Affected commits (root cause)

- `7d85da3` (2026-04-03) — ENC-TSK-B88 enabled gamma SnapStart
- `9ef783c` (2026-04-21) — ENC-TSK-F63 enabled prod SnapStart and triggered the deploy flurry that multiplied versions on Apr 22

## Test plan

- [ ] CFN guard / cfn-lint passes on changed manifests
- [ ] Gamma CFN deploy after merge: confirm `SnapStart: ApplyOn=None` (or absent) on all functions in the stack
- [ ] Cost Explorer: `USW2-Lambda-SnapStart-Cached-GB-S` line item drops to \$0 within 24h of the snapshot deletions (already done out-of-band)
- [ ] Follow-up task: design version-prune step in deploy pipeline before re-enabling prod SnapStart

🤖 Generated with [Claude Code](https://claude.com/claude-code)