### PR TITLE
fix(graph-query-api): restore hybrid vector signal — package embedding.py + Bedrock IAM (ENC-ISS-304)

### DIFF
--- a/backend/lambda/graph_query_api/.build_extras
+++ b/backend/lambda/graph_query_api/.build_extras
@@ -1,0 +1,13 @@
+# ENC-TSK-G43: cross-Lambda module sharing manifest.
+# Each non-comment line is a repo-relative path to a single file; the build
+# step copies it to the function root so the Lambda can `import` it normally.
+# Honored by .github/workflows/_build.yml.
+#
+# ENC-ISS-304 / ENC-TSK-G94: graph_query_api's hybrid retrieval computes the
+# query-side embedding via `import embedding` (the canonical graph_sync helper,
+# ENC-TSK-B94). The tombstoned per-Lambda deploy.sh used to copy this file in;
+# the matrix-build migration dropped that step, so `import embedding` began
+# failing at runtime and the vector signal went dead (signal_availability.vector
+# = false on every query, despite the corpus being fully embedded). Declaring it
+# here restores packaging.
+backend/lambda/graph_sync/embedding.py

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2181,6 +2181,21 @@ Resources:
                   - appconfig:GetLatestConfiguration
                   - appconfig:StartConfigurationSession
                 Resource: "*"
+        # ENC-ISS-304 / ENC-TSK-G94: re-grant the Bedrock Titan V2 invoke that the
+        # tombstoned per-Lambda deploy.sh ensure_role() used to apply. Required by
+        # backend/lambda/graph_sync/embedding.py invoke_titan_v2 for the
+        # hybrid-retrieval query-side embedding (the vector signal). Foundation-model
+        # ARNs are region-scoped and account-less.
+        - PolicyName: BedrockTitanInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: BedrockTitanV2InvokeModel
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.titan-embed-text-v2:0"
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary
Remediates **ENC-ISS-304** (Defect A): the hybrid-retrieval **vector signal** is dead because graph_query_api's deferred `import embedding` fails — `backend/lambda/graph_sync/embedding.py` stopped being packaged when the per-Lambda `deploy.sh` was tombstoned for the matrix build (that script also applied the Bedrock grant via `ensure_role()`). Neither step was migrated to `.build_extras`/CFN.

## Changes
- **`backend/lambda/graph_query_api/.build_extras`** (new) — declares `backend/lambda/graph_sync/embedding.py` so `_build.yml` copies it into the function package (ENC-TSK-G43 cross-Lambda mechanism). Fixes the `import embedding` ImportError that zeroed the vector signal.
- **`infrastructure/cloudformation/02-compute.yaml`** — adds `Sid BedrockTitanV2InvokeModel` (`bedrock:InvokeModel` on `amazon.titan-embed-text-v2:0`) to `GraphQueryApiRole`, restoring the grant the tombstoned `deploy.sh ensure_role()` applied.

No `lambda_function.py` change → governance dictionary gate not triggered.

## Validation
- Reproduced live (prod): `signal_availability.vector=false` on every query; CloudWatch shows only the `import embedding` ImportError path (never the Titan-invoke path). Corpus is fully embedded (`embedding_coverage 25/25`) — only the *query* embedding fails.
- CFN parses with both policies; `.build_extras` path resolves; `embedding.py` needs only boto3 (Lambda-provided).
- Post-deploy AC: `get_compact_context` topic query returns `vector=true` with non-zero `embedding_coverage_sample.covered`.

## Governance
Task: **ENC-TSK-G94** (P1, `comp-graph-query-api`, `github_pr_deploy`) · Issue: **ENC-ISS-304**
Sibling defects split out: ENC-ISS-310 (keyword), ENC-ISS-311 (graph AGA timeout), ENC-ISS-312 (health), ENC-ISS-313 (CFN IAM drift)

CCI-d451ab328e1245fdb23789117e6c1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)