### PR TITLE
ENC-TSK-H07: fix invalid compute deploy workflow (remove orphaned full-stack-restore job)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -163,16 +163,6 @@ jobs:
             fi
           done < <(jq -r '.functions[].function_name' infrastructure/lambda_workflow_manifest.json)
           if [ "${failed}" -eq 1 ]; then
-            echo "::warning::One or more Lambda functions have stub-sized code packages after CFN stack update. Full-stack deploy orchestration will restore all Lambdas."
+            echo "::warning::One or more Lambda functions have stub-sized code packages. Lambda code is managed out-of-band (matrix-build / _deploy.yml); this CFN workflow deploys config/IAM only and does not deploy or restore code."
           fi
-          echo "CodeSize validation complete. Full-stack orchestration follows."
-
-  # After CFN stack update, run full-stack deploy orchestration to restore
-  # any Lambdas that may have been overwritten with CFN ZipFile stubs.
-  # This closes the path-filter coverage gap from the Sev1 incident (ENC-TSK-1292).
-  full-stack-restore:
-    needs: deploy
-    uses: ./.github/workflows/deploy-orchestration.yml
-    with:
-      deploy_mode: "full-stack"
-    secrets: inherit
+          echo "CodeSize validation complete (informational only; Lambda code is deployed out-of-band via matrix-build / _deploy.yml, not by this CFN workflow)."


### PR DESCRIPTION
Removes the orphaned `full-stack-restore` job from `cloudformation-compute-stack-deploy.yml` that referenced `./.github/workflows/deploy-orchestration.yml` — deleted in the Gen2 migration (ENC-TSK-F60, 169c910). The dangling reference made the whole workflow invalid (0 jobs / 'workflow file issue' on every run since April), so the compute CFN deploy never ran.

Now matches its clean siblings (api/monitoring/codedeploy = single `deploy` job). Preserves the ENC-TSK-H05 `CoordinationInternalApiKey` param-override + fail-closed guard. No Lambda code stomp (placeholder ZipFile unchanged; code is managed out-of-band via matrix-build / _deploy.yml).

**Merging this re-triggers the now-valid workflow → CFN deploy to enceladus-compute** (sanctioned CI path under the privileged OIDC role), which finally applies the ENC-TSK-H05 codification.

CCI-3e2fe278d86d443ca89f5ea132ab068e

Refs: ENC-TSK-H07, ENC-TSK-H05, ENC-TSK-F60, ENC-PLN-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)