### PR TITLE
ENC-TSK-H06: wire provisioned AppConfig IDs into compute deploy

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -109,7 +109,9 @@ jobs:
             --s3-prefix 02-compute/ \
             --parameter-overrides \
               DataStackName="${{ steps.params.outputs.data_stack_name }}" \
-              CoordinationInternalApiKey="${{ secrets.COORDINATION_INTERNAL_API_KEY }}"
+              CoordinationInternalApiKey="${{ secrets.COORDINATION_INTERNAL_API_KEY }}" \
+              AppConfigApplicationId="5t3sqte" \
+              AppConfigEnvironmentId="bnwj3lj"
 
       - name: Report stack events on failure
         if: failure() && steps.deploy.conclusion == 'failure'


### PR DESCRIPTION
Provisioned prod AppConfig (app `5t3sqte`=enceladus, env `bnwj3lj`=production, profile feature-flags v1) holding the F63 flags (enable_lesson_primitive=true, enable_claude_headless=true, enable_mcp_governance_prompt=true, enable_component_proposal=false). Passes AppConfigApplicationId + AppConfigEnvironmentId via --parameter-overrides so the deploy sets APPCONFIG_APPLICATION/ENVIRONMENT on the consumer Lambdas (same pattern as the ENC-TSK-H05 key fix). Restores the appconfig_flags.flag()-gated primitives durably, superseding the out-of-band env-fallback stopgap.

CCI-35801c3a5cf946c1a6eb85ddbe53998b

Refs: ENC-TSK-H06, ENC-TSK-F63, ENC-TSK-H05, ENC-LSN-053

🤖 Generated with [Claude Code](https://claude.com/claude-code)