### PR TITLE
ENC-TSK-H09: codify SQS_QUEUE_URL on devops-deploy-intake (restore CFN-stripped var)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -440,6 +440,11 @@ Resources:
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
           DEPLOY_REGION: !Ref AWS::Region
+          # ENC-TSK-H09: restore SQS_QUEUE_URL — stripped by a post-2026-02-24 CFN full-env replace
+          # (same drift class as the PLN-047 COORDINATION_INTERNAL_API_KEY Sev-1). !Sub construction
+          # mirrors the deploy-queue ARN idiom elsewhere in this file; gamma-correct via
+          # ${EnvironmentSuffix}, no hardcoded account/region. Resolves to the canonical manifest value.
+          SQS_QUEUE_URL: !Sub "https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/devops-deploy-queue${EnvironmentSuffix}.fifo"
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           CONFIG_BUCKET: !Ref S3Bucket
           CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"


### PR DESCRIPTION
## Summary
Restores `SQS_QUEUE_URL` to the `devops-deploy-intake` `Environment.Variables` in `infrastructure/cloudformation/02-compute.yaml`. The variable was present in the canonical manifest (`infrastructure/lambda-manifests/devops-deploy-intake.json`) and the 2026-02-24 live inventory but was stripped by a post-Feb-24 CFN full-environment replace — the **same drift class as the PLN-047 `COORDINATION_INTERNAL_API_KEY` Sev-1**. Without it, `POST /api/v1/deploy/trigger/{projectId}` returns HTTP 500 "Deploy trigger queue is not configured" (`deploy_intake/lambda_function.py:1176`), and `env_drift_auditor` re-flags it hourly (ENC-ISS-369).

## Change
One additive line (+ explanatory comment):
```yaml
SQS_QUEUE_URL: !Sub "https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/devops-deploy-queue${EnvironmentSuffix}.fifo"
```
Constructed via `!Sub` to mirror the deploy-queue ARN idiom already in this file — no hardcoded account/region, gamma-correct via `${EnvironmentSuffix}`. Resolves to the canonical manifest value for prod: `https://sqs.us-west-2.amazonaws.com/356364570033/devops-deploy-queue.fifo`.

- Additive-only change-set (1 file, +5 / -0); verified `SQS_QUEUE_URL` lands on `devops-deploy-intake` **only**.
- Structural YAML parse OK; resolved value byte-matches the canonical manifest.

## Deploy safety (please read before merging)
Merging triggers the compute-stack deploy. A pre-merge live reconciliation (2026-06-21) confirmed **`live ⊆ template` across all 23 compute functions** — a deploy strips nothing currently set, and this PR makes the template *more* complete (it restores the missing var). The one delta a deploy introduces is the additive `enceladus-shared :7→:10` layer heal (safe — `:10` is the version `coordination-api` already runs on). **Recommended before deploy:** run `tools/pre-deploy-health-gate.sh` (per AC-2).

> ⚠️ This PR is the **durable codification (AC-2)**. The immediate **live hotfix (AC-1)** — restoring the var on the running Lambda via `update-function-configuration` — needs product-lead IAM (agent IAM denies Lambda writes) and is a separate product-lead-terminal step. Alternatively, merging + deploying this PR restores it directly via CFN.

## Governance
- Task: **ENC-TSK-H09** (canonical issue **ENC-ISS-369**)
- Durable fix (generalizes this whole class): **ENC-FTR-102** — pre-deploy env-parity gate
- CCI-d1147a8bc2244b58a978ee0ee0726c13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
