### PR TITLE
ENC-PLN-048 Obj 2: env-parity gate engine (H17 resolver + H18 fail-closed gate + H19 strip detector)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-17.01",
-  "updated_at": "2026-06-17T00:55:00Z",
-  "last_change_summary": "ENC-PLN-046 (ENC-TSK-G97/G98/G99): graph_query_api hybrid-retrieval remediation. Keyword signal now tokenizes the query and scores per-token field-weighted CONTAINS so multi-word queries match (ENC-ISS-310); the anchored graph signal runs under a hard wall-clock deadline and degrades to graph_algorithm='timeout' instead of hanging the whole response (ENC-ISS-311); the graphsearch /health endpoint adds a functional per-signal readiness probe (vector/graph/keyword) surfaced through connection_health.graph_index.signals (ENC-ISS-312).",
+  "version": "2026-06-21.01",
+  "updated_at": "2026-06-21T09:31:58Z",
+  "last_change_summary": "ENC-PLN-048 Objective 2 (ENC-FTR-102, ENC-TSK-H17/H18/H19): added the deploy.env_parity_gate entity documenting the pre-deploy environment-variable parity gate — tools/cfn_env_resolver.py (CFN intrinsic env resolver), tools/env_parity_gate.py (fail-closed gate + waivers, wired as CHECK 6 in pre-deploy-health-gate.sh), tools/live_template_strip_detector.py, and the shared backend/lambda/env_drift_auditor/env_parity_core.py comparison core. Version bump also satisfies the path-triggered Governance Dictionary Guard on the env_drift_auditor lambda_function.py AC2 refactor (ENC-ISS-179).",
   "owners": [
     "enceladus-platform"
   ],
@@ -5143,6 +5143,31 @@
         "historical_precedent": {
           "type": "string",
           "definition": "ENC-ISS-213 (2026-04-12): devops-coordination-api-gamma Lambda shipped x86_64 pydantic_core wheels on an arm64 runtime despite the deploy.sh arch bifurcation from ENC-FTR-072 / ENC-ISS-224. Entire gamma MCP surface failed with 'No module named pydantic_core._pydantic_core'. Hot-fixed by ENC-TSK-D57; this guard is the structural prevention of recurrence."
+        }
+      }
+    },
+    "deploy.env_parity_gate": {
+      "description": "Pre-deploy environment-variable parity gate (ENC-PLN-048 Objective 2 / ENC-FTR-102). Resolves each CloudFormation Lambda's template Environment.Variables and fails closed if a deploy-critical required var (env_drift_auditor/env_drift_registry.json) would be unset, or if a var present live would be stripped by the deploy (the H05/H09 'deploy would strip <var>' class). The pre-deploy gate and the post-deploy env_drift_auditor share a single comparison core (env_parity_core) so they cannot diverge (ENC-TSK-H19 AC2).",
+      "fields": {
+        "cfn_env_resolver": {
+          "type": "string",
+          "definition": "tools/cfn_env_resolver.py (ENC-TSK-H17): a real CloudFormation intrinsic-function evaluator (Ref, Fn::Sub, Fn::If, Fn::Equals/Not/And/Or, Fn::Join/Select/GetAtt/ImportValue/FindInMap, plus the Conditions block) that resolves per-function Environment.Variables for infrastructure/cloudformation/02-compute.yaml given a parameter-overrides set, dropping any var that resolves to AWS::NoValue (the !If-unset case). Diffs resolved keys against the required-env registry. Replaces naive !Ref substitution, which false-flagged AppConfig !If vars as 'would be stripped'."
+        },
+        "fail_closed_gate": {
+          "type": "string",
+          "definition": "tools/env_parity_gate.py (ENC-TSK-H18): wraps the H17 resolver diff and exits non-zero with function+var+remediation for any missing deploy-critical var; exits zero when all are present. Invoked as CHECK 6 in tools/pre-deploy-health-gate.sh."
+        },
+        "waiver_mechanism": {
+          "type": "string",
+          "definition": "tools/env_parity_waivers.json (ENC-TSK-H18): documented, auditable per-(function,var) waivers that suppress a FAILURE but are still RECORDED in the report (never silent), plus an advisory_vars map (function name or '*' -> vars that WARN instead of FAIL). The committed file ships with zero active waivers so the gate stays honest."
+        },
+        "live_template_strip_detector": {
+          "type": "string",
+          "definition": "tools/live_template_strip_detector.py (ENC-TSK-H19): diffs live Lambda Environment.Variables (aws lambda get-function-configuration) against the H17 template-resolved env and flags any live-only var as 'deploy would strip <var> from <function>', classified critical (var is in the required-env registry) vs warning. Live fetch is pluggable (--live-env-file) for offline/CI/test runs."
+        },
+        "shared_comparison_core": {
+          "type": "string",
+          "definition": "backend/lambda/env_drift_auditor/env_parity_core.py (ENC-TSK-H19 AC2): the single source of env-comparison primitives (build_placeholders, classify_required, live_only_vars) imported by BOTH the env_drift_auditor Lambda (post-deploy required-var scan) and the pre-deploy strip detector, so pre- and post-deploy checks stay consistent by construction. Pure module with no import-time side effects."
         }
       }
     },

--- a/backend/lambda/env_drift_auditor/env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/env_parity_core.py
@@ -1,0 +1,80 @@
+"""env_parity_core — shared environment-variable comparison primitives.
+
+ENC-TSK-H19 (ENC-PLN-048 Objective 2, parent ENC-TSK-H12, feature ENC-FTR-102).
+
+This is the SINGLE source of env-comparison logic, imported by BOTH:
+
+  * env_drift_auditor/lambda_function.py   — post-deploy scan: required vars
+    that are missing or placeholder on a LIVE Lambda.
+  * tools/live_template_strip_detector.py  — pre-deploy scan: vars present LIVE
+    but NOT set by the template-resolved env (the deploy would strip them — the
+    H05/H09 incident signature).
+
+ENC-TSK-H19 AC2 (no divergent second implementation): the placeholder set and
+the missing/placeholder comparison that used to be inline in env_drift_auditor
+now live here, so the pre-deploy detector reuses exactly the same primitives
+rather than re-deriving them. Post-deploy and pre-deploy stay consistent by
+construction.
+
+Pure module: no environment reads, no AWS calls, no side effects at import time
+(unlike lambda_function.py, which reads os.environ at import) — so it is safe to
+import from CLI tools and unit tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+# Values that count as "not really set" (drift), independent of any registry.
+# Mirrors the historical env_drift_auditor list so behavior is unchanged.
+DEFAULT_PLACEHOLDERS: List[str] = ["", "CHANGE_ME", "TODO", "REPLACE_", "REPLACE_WITH_", "null", "None"]
+
+
+def build_placeholders(policy: Optional[Dict[str, Any]] = None) -> set:
+    """Build the placeholder set: registry ``_policy`` extras + module defaults.
+
+    ``policy`` is the env_drift_registry.json ``_policy`` block (or None).
+    """
+    extra = list((policy or {}).get("placeholder_values_that_count_as_drift", []))
+    return set(extra + DEFAULT_PLACEHOLDERS)
+
+
+def is_placeholder(value: Optional[str], placeholders: set) -> bool:
+    """True if ``value`` is a placeholder (drift). None is 'missing', not placeholder."""
+    if value is None:
+        return False
+    return value in placeholders or value.startswith("REPLACE_")
+
+
+def classify_required(
+    required: Sequence[str],
+    env: Dict[str, str],
+    placeholders: set,
+) -> List[Dict[str, Any]]:
+    """Post-deploy comparison (env_drift_auditor): for each required var, flag it
+    if missing or set to a placeholder value.
+
+    Returns a list of drift rows ``[{"var": str, "reason": str}]`` — identical in
+    shape and semantics to the pre-refactor env_drift_auditor inline logic.
+    """
+    drift: List[Dict[str, Any]] = []
+    for var in required:
+        val = env.get(var)
+        if val is None:
+            drift.append({"var": var, "reason": "missing"})
+        elif is_placeholder(val, placeholders):
+            drift.append({"var": var, "reason": f"placeholder value: {val!r}"})
+    return drift
+
+
+def live_only_vars(live_env: Dict[str, str], template_env: Dict[str, str]) -> List[str]:
+    """Pre-deploy comparison (H19): variable names present in the LIVE env but NOT
+    set by the template-resolved env.
+
+    These are exactly the vars a CloudFormation deploy of the template would strip
+    from the live function (because the template does not set them). Returned
+    sorted for stable reporting. The template side must already have AWS::NoValue
+    /!If resolution applied (see tools/cfn_env_resolver.py) so a conditionally
+    -unset var is not mistaken for a live-only var.
+    """
+    return sorted(set(live_env or {}) - set(template_env or {}))

--- a/backend/lambda/env_drift_auditor/lambda_function.py
+++ b/backend/lambda/env_drift_auditor/lambda_function.py
@@ -24,6 +24,9 @@ from typing import Any, Dict, List, Tuple
 
 import boto3
 
+# ENC-TSK-H19: shared comparison core — single source for pre- and post-deploy.
+from env_parity_core import build_placeholders, classify_required
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -42,10 +45,9 @@ _REGISTRY_PATH = os.path.join(os.path.dirname(__file__), "env_drift_registry.jso
 with open(_REGISTRY_PATH) as _f:
     REGISTRY = json.load(_f)
 
-PLACEHOLDER_VALUES = set(
-    REGISTRY.get("_policy", {}).get("placeholder_values_that_count_as_drift", [])
-    + ["", "CHANGE_ME", "TODO", "REPLACE_", "REPLACE_WITH_", "null", "None"]
-)
+# ENC-TSK-H19 AC2: placeholder set now built by the shared env_parity_core so the
+# pre-deploy strip detector and this post-deploy auditor cannot diverge.
+PLACEHOLDER_VALUES = build_placeholders(REGISTRY.get("_policy", {}))
 
 
 def _audit_lambda(lambda_client: Any, fn_name: str, required: List[str]) -> Tuple[str, List[Dict[str, Any]]]:
@@ -59,13 +61,8 @@ def _audit_lambda(lambda_client: Any, fn_name: str, required: List[str]) -> Tupl
         return "error", [{"var": None, "reason": f"aws error: {exc!s}"}]
 
     env_vars: Dict[str, str] = (cfg.get("Environment") or {}).get("Variables", {}) or {}
-    drift: List[Dict[str, Any]] = []
-    for var in required:
-        val = env_vars.get(var)
-        if val is None:
-            drift.append({"var": var, "reason": "missing"})
-        elif val in PLACEHOLDER_VALUES or val.startswith("REPLACE_"):
-            drift.append({"var": var, "reason": f"placeholder value: {val!r}"})
+    # ENC-TSK-H19 AC2: delegate to the shared comparison core (no divergent impl).
+    drift = classify_required(required, env_vars, PLACEHOLDER_VALUES)
     if drift:
         return "drift", drift
     return "ok", []

--- a/backend/lambda/env_drift_auditor/test_env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/test_env_parity_core.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for env_parity_core + AC2 (env_drift_auditor uses the shared core).
+
+ENC-TSK-H19 (ENC-PLN-048 Objective 2). Run:
+    python3 backend/lambda/env_drift_auditor/test_env_parity_core.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import env_parity_core as core  # noqa: E402
+
+
+def test_build_placeholders_merges_policy_and_defaults():
+    ph = core.build_placeholders({"placeholder_values_that_count_as_drift": ["XX"]})
+    assert "XX" in ph
+    assert "" in ph and "CHANGE_ME" in ph and "None" in ph
+
+
+def test_build_placeholders_handles_none_policy():
+    ph = core.build_placeholders(None)
+    assert "TODO" in ph
+
+
+def test_is_placeholder():
+    ph = core.build_placeholders(None)
+    assert core.is_placeholder("", ph) is True
+    assert core.is_placeholder("REPLACE_ME", ph) is True  # REPLACE_ prefix
+    assert core.is_placeholder("real-value", ph) is False
+    assert core.is_placeholder(None, ph) is False  # None is 'missing', not placeholder
+
+
+def test_classify_required_missing_and_placeholder_and_ok():
+    ph = core.build_placeholders(None)
+    env = {"A": "ok", "B": "", "C": "REPLACE_X"}
+    drift = core.classify_required(["A", "B", "C", "D"], env, ph)
+    by_var = {d["var"]: d["reason"] for d in drift}
+    assert "A" not in by_var  # present and real
+    assert by_var["B"].startswith("placeholder")
+    assert by_var["C"].startswith("placeholder")
+    assert by_var["D"] == "missing"
+
+
+def test_live_only_vars():
+    assert core.live_only_vars({"A": "1", "B": "2"}, {"A": "1"}) == ["B"]
+    assert core.live_only_vars({"A": "1"}, {"A": "1", "B": "2"}) == []  # live subset
+    assert core.live_only_vars({}, {"A": "1"}) == []
+
+
+# --- AC2: env_drift_auditor delegates to the shared core --------------------
+class _StubExceptions:
+    class ResourceNotFoundException(Exception):
+        pass
+
+
+class _StubLambdaClient:
+    def __init__(self, variables):
+        self._variables = variables
+        self.exceptions = _StubExceptions
+
+    def get_function_configuration(self, FunctionName):  # noqa: N803 (boto3 casing)
+        return {"Environment": {"Variables": self._variables}}
+
+
+def test_env_drift_auditor_uses_shared_core():
+    os.environ.setdefault("COORDINATION_INTERNAL_API_KEY", "test-key")
+    try:
+        import lambda_function as lf  # noqa: E402
+    except Exception as exc:  # boto3 missing etc. — don't fail the whole suite
+        print(f"  SKIP test_env_drift_auditor_uses_shared_core ({exc})")
+        return
+    # The auditor must import the very same functions from the core (no copy).
+    assert lf.classify_required is core.classify_required
+    assert lf.build_placeholders is core.build_placeholders
+    # Behavior: a missing required var surfaces as drift via the shared core.
+    client = _StubLambdaClient({"PRESENT": "ok"})
+    status, drift = lf._audit_lambda(client, "fn", ["PRESENT", "MISSING_ONE"])
+    assert status == "drift"
+    assert {d["var"] for d in drift} == {"MISSING_ONE"}
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"  FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_all())

--- a/tools/cfn_env_resolver.py
+++ b/tools/cfn_env_resolver.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""CFN template environment resolver + required-env diff — ENC-TSK-H17.
+
+ENC-PLN-048 Objective 2 (parity gate core), parent ENC-TSK-H12, feature ENC-FTR-102.
+
+Parses infrastructure/cloudformation/02-compute.yaml, resolves each
+``AWS::Lambda::Function``'s ``Environment.Variables`` to their fully-evaluated
+values for a given parameter set, and diffs the resolved key set against the
+canonical required-env registry
+(backend/lambda/env_drift_auditor/env_drift_registry.json — codified as the
+single source by ENC-TSK-H16).
+
+Why a real intrinsic-function evaluator instead of naive ``!Ref`` substitution
+(PLN-048 refinement, CRITICAL): the prototype's ``!Ref``-only resolver
+FALSE-FLAGGED the AppConfig vars as "would be stripped" purely because it did
+not evaluate ``!If``. A variable whose value resolves to ``AWS::NoValue`` is NOT
+SET (absent) — not present-empty. To match what CloudFormation will actually
+apply, this module evaluates ``Ref``, ``Fn::Sub``, ``Fn::If``, ``Fn::Equals``,
+``Fn::Not``, ``Fn::And``, ``Fn::Or``, ``Fn::Join``, ``Fn::Select``,
+``Fn::GetAtt``, ``Fn::ImportValue`` and the template ``Conditions`` block, and
+drops any property/variable that resolves to ``AWS::NoValue``.
+
+Consumed by:
+  - tools/env_parity_gate.py            (ENC-TSK-H18 fail-closed gate + waivers)
+  - tools/live_template_strip_detector.py (ENC-TSK-H19 live-vs-template detector)
+  - tools/pre-deploy-health-gate.sh     (direct-deploy safety gate)
+
+Pure template-side resolution — performs no AWS calls. ``--parameters`` /
+``--parameters-file`` supply the deploy's actual ``--parameter-overrides`` so
+``!Ref`` resolution matches the real deploy (no false "missing" for params).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+
+# --- AWS::NoValue sentinel -------------------------------------------------
+# A node that resolves to this is treated as "not set" and dropped from its
+# containing mapping/list, exactly as CloudFormation removes a property set to
+# AWS::NoValue.
+class _NoValue:
+    _instance: Optional["_NoValue"] = None
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "<AWS::NoValue>"
+
+
+NOVALUE = _NoValue()
+
+# Pseudo-parameter defaults. AWS::Region is the one that actually appears in
+# 02-compute.yaml env vars (DYNAMODB_REGION, SSM_REGION, SECRETS_REGION, and the
+# H09 SQS_QUEUE_URL !Sub). The rest are provided for completeness.
+DEFAULT_REGION = "us-west-2"
+DEFAULT_ACCOUNT_ID = "356364570033"  # enceladus prod/gamma account
+
+
+def _pseudo_params(region: str, account_id: str, stack_name: str) -> Dict[str, Any]:
+    return {
+        "AWS::Region": region,
+        "AWS::AccountId": account_id,
+        "AWS::StackName": stack_name,
+        "AWS::Partition": "aws",
+        "AWS::URLSuffix": "amazonaws.com",
+        "AWS::NoValue": NOVALUE,
+        "AWS::NotificationARNs": [],
+    }
+
+
+# --- CFN-aware YAML loader -------------------------------------------------
+# Normalizes short-form tags (!Ref, !Sub, !If, ...) to the long JSON form
+# ({"Ref": ...}, {"Fn::Sub": ...}, {"Fn::If": ...}) so resolution logic can be
+# written against a single representation.
+class _CfnLoader(yaml.SafeLoader):
+    pass
+
+
+def _cfn_multi_constructor(loader: "_CfnLoader", tag_suffix: str, node: yaml.Node) -> Any:
+    if isinstance(node, yaml.ScalarNode):
+        value: Any = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    else:
+        value = loader.construct_mapping(node, deep=True)
+
+    if tag_suffix == "Ref":
+        return {"Ref": value}
+    key = f"Fn::{tag_suffix}"
+    if key == "Fn::GetAtt" and isinstance(value, str):
+        # "Resource.Attr.Sub" -> ["Resource", "Attr.Sub"]
+        head, _, tail = value.partition(".")
+        value = [head, tail]
+    return {key: value}
+
+
+_CfnLoader.add_multi_constructor("!", _cfn_multi_constructor)
+
+
+def load_template(template_path: Path) -> Dict[str, Any]:
+    """Load a CloudFormation YAML template with intrinsic tags normalized."""
+    with open(template_path) as fh:
+        return yaml.load(fh, Loader=_CfnLoader) or {}
+
+
+# --- Resolution context ----------------------------------------------------
+class ResolveContext:
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        region: str = DEFAULT_REGION,
+        account_id: str = DEFAULT_ACCOUNT_ID,
+        stack_name: str = "enceladus-compute",
+        imports: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.params = dict(params)
+        self.region = region
+        self.account_id = account_id
+        self.stack_name = stack_name
+        self.imports = imports or {}
+        self.pseudo = _pseudo_params(region, account_id, stack_name)
+        self.conditions: Dict[str, bool] = {}
+        self._raw_conditions: Dict[str, Any] = {}
+
+    def ref(self, name: str) -> Any:
+        if name in self.pseudo:
+            return self.pseudo[name]
+        if name in self.params:
+            return self.params[name]
+        # Ref to a resource logical id (rare in env vars) — opaque but present.
+        return f"<Ref:{name}>"
+
+
+def build_params(template: Dict[str, Any], overrides: Dict[str, str]) -> Dict[str, Any]:
+    """Merge template Parameter defaults with explicit overrides.
+
+    Overrides win. A parameter with no default and no override is left absent so
+    that a Ref to it surfaces as unresolved rather than silently empty.
+    """
+    params: Dict[str, Any] = {}
+    for name, spec in (template.get("Parameters") or {}).items():
+        if isinstance(spec, dict) and "Default" in spec:
+            params[name] = spec["Default"]
+    for name, value in overrides.items():
+        params[name] = value
+    return params
+
+
+# --- Condition evaluation --------------------------------------------------
+def evaluate_conditions(template: Dict[str, Any], ctx: ResolveContext) -> Dict[str, bool]:
+    ctx._raw_conditions = dict(template.get("Conditions") or {})
+    ctx.conditions = {}
+    for name in ctx._raw_conditions:
+        _eval_named_condition(name, ctx, set())
+    return ctx.conditions
+
+
+def _eval_named_condition(name: str, ctx: ResolveContext, seen: set) -> bool:
+    if name in ctx.conditions:
+        return ctx.conditions[name]
+    if name in seen:
+        raise ValueError(f"circular condition reference: {name}")
+    seen.add(name)
+    result = _eval_condition_expr(ctx._raw_conditions[name], ctx, seen)
+    ctx.conditions[name] = result
+    return result
+
+
+def _eval_condition_expr(expr: Any, ctx: ResolveContext, seen: set) -> bool:
+    if isinstance(expr, dict) and len(expr) == 1:
+        key, val = next(iter(expr.items()))
+        if key == "Fn::Equals":
+            return _as_scalar(resolve(val[0], ctx)) == _as_scalar(resolve(val[1], ctx))
+        if key == "Fn::Not":
+            return not _eval_condition_expr(val[0], ctx, seen)
+        if key == "Fn::And":
+            return all(_eval_condition_expr(v, ctx, seen) for v in val)
+        if key == "Fn::Or":
+            return any(_eval_condition_expr(v, ctx, seen) for v in val)
+        if key == "Condition":
+            return _eval_named_condition(val, ctx, seen)
+    raise ValueError(f"unsupported condition expression: {expr!r}")
+
+
+# --- Value resolution ------------------------------------------------------
+_SUB_VAR = re.compile(r"\$\{([^}]+)\}")
+
+
+def resolve(node: Any, ctx: ResolveContext) -> Any:
+    """Recursively resolve an intrinsic node to a concrete value.
+
+    Mappings and lists drop entries that resolve to AWS::NoValue (matching CFN).
+    """
+    if isinstance(node, dict):
+        if len(node) == 1:
+            key = next(iter(node))
+            if key in _INTRINSIC_HANDLERS:
+                return _INTRINSIC_HANDLERS[key](node[key], ctx)
+        out: Dict[str, Any] = {}
+        for k, v in node.items():
+            rv = resolve(v, ctx)
+            if rv is NOVALUE:
+                continue
+            out[k] = rv
+        return out
+    if isinstance(node, list):
+        resolved = [resolve(x, ctx) for x in node]
+        return [x for x in resolved if x is not NOVALUE]
+    return node
+
+
+def _r_ref(value: Any, ctx: ResolveContext) -> Any:
+    return ctx.ref(value)
+
+
+def _r_sub(value: Any, ctx: ResolveContext) -> Any:
+    if isinstance(value, list):
+        template_str, var_map = value[0], (value[1] if len(value) > 1 else {})
+        local = {k: _as_scalar(resolve(v, ctx)) for k, v in (var_map or {}).items()}
+    else:
+        template_str, local = value, {}
+
+    def _replace(match: "re.Match[str]") -> str:
+        name = match.group(1)
+        if name in local:
+            return local[name]
+        if "." in name:  # ${Resource.Attr} GetAtt-style — opaque but present
+            return f"<{name}>"
+        resolved = ctx.ref(name)
+        if resolved is NOVALUE:
+            return ""
+        return _as_scalar(resolved)
+
+    return _SUB_VAR.sub(_replace, str(template_str))
+
+
+def _r_if(value: Any, ctx: ResolveContext) -> Any:
+    cond_name, true_val, false_val = value[0], value[1], value[2]
+    chosen = true_val if _eval_named_condition(cond_name, ctx, set()) else false_val
+    return resolve(chosen, ctx)
+
+
+def _r_join(value: Any, ctx: ResolveContext) -> Any:
+    delim, items = value[0], value[1]
+    resolved = resolve(items, ctx)  # list resolution drops NoValue
+    return str(delim).join(_as_scalar(x) for x in resolved)
+
+
+def _r_select(value: Any, ctx: ResolveContext) -> Any:
+    index, items = int(value[0]), resolve(value[1], ctx)
+    return items[index]
+
+
+def _r_getatt(value: Any, ctx: ResolveContext) -> Any:
+    parts = value if isinstance(value, list) else [value]
+    return f"<GetAtt:{'.'.join(str(p) for p in parts)}>"
+
+
+def _r_importvalue(value: Any, ctx: ResolveContext) -> Any:
+    name = _as_scalar(resolve(value, ctx))
+    if name in ctx.imports:
+        return ctx.imports[name]
+    return f"<ImportValue:{name}>"
+
+
+def _r_findinmap(value: Any, ctx: ResolveContext) -> Any:
+    return f"<FindInMap:{'.'.join(_as_scalar(resolve(v, ctx)) for v in value)}>"
+
+
+_INTRINSIC_HANDLERS = {
+    "Ref": _r_ref,
+    "Fn::Sub": _r_sub,
+    "Fn::If": _r_if,
+    "Fn::Join": _r_join,
+    "Fn::Select": _r_select,
+    "Fn::GetAtt": _r_getatt,
+    "Fn::ImportValue": _r_importvalue,
+    "Fn::FindInMap": _r_findinmap,
+}
+
+
+def _as_scalar(value: Any) -> str:
+    """Coerce a resolved value to the string form CFN would apply to an env var."""
+    if value is NOVALUE or value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+# --- Per-function resolution + diff ---------------------------------------
+def resolve_function_envs(template: Dict[str, Any], ctx: ResolveContext) -> Dict[str, Dict[str, Any]]:
+    """Return {resolved_function_name: {"logical_id", "resolved_env"}} for every
+    AWS::Lambda::Function in the template.
+
+    A variable whose value resolves to AWS::NoValue is omitted from resolved_env
+    (it is NOT set on the deployed function).
+    """
+    evaluate_conditions(template, ctx)
+    result: Dict[str, Dict[str, Any]] = {}
+    for logical_id, resource in (template.get("Resources") or {}).items():
+        if not isinstance(resource, dict) or resource.get("Type") != "AWS::Lambda::Function":
+            continue
+        props = resource.get("Properties") or {}
+        fn_name = _as_scalar(resolve(props.get("FunctionName"), ctx))
+        environment = resolve(props.get("Environment"), ctx)
+        variables = {}
+        if isinstance(environment, dict):
+            for k, v in (environment.get("Variables") or {}).items():
+                variables[k] = _as_scalar(v)
+        result[fn_name] = {"logical_id": logical_id, "resolved_env": variables}
+    return result
+
+
+def load_required_env(registry_path: Path) -> Dict[str, List[str]]:
+    with open(registry_path) as fh:
+        registry = json.load(fh)
+    return registry.get("lambdas", {})
+
+
+def diff_required(
+    resolved: Dict[str, Dict[str, Any]],
+    required_map: Dict[str, List[str]],
+) -> Dict[str, Dict[str, Any]]:
+    """Per-function diff of resolved template env keys vs the required-env registry.
+
+    missing  = required vars not present in the template-resolved env (would fail
+               the parity gate — the deploy would not set a var the handler needs).
+    """
+    report: Dict[str, Dict[str, Any]] = {}
+    for fn_name, info in resolved.items():
+        keys = set(info["resolved_env"])
+        required = required_map.get(fn_name, [])
+        report[fn_name] = {
+            "logical_id": info["logical_id"],
+            "has_registry_entry": fn_name in required_map,
+            "required": sorted(required),
+            "resolved_keys": sorted(keys),
+            "missing": sorted(set(required) - keys),
+        }
+    return report
+
+
+def resolve_and_diff(
+    template_path: Path,
+    overrides: Dict[str, str],
+    registry_path: Path,
+    region: str = DEFAULT_REGION,
+    imports: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Top-level helper used by the H18 gate and H19 detector."""
+    template = load_template(template_path)
+    ctx = ResolveContext(build_params(template, overrides), region=region, imports=imports)
+    resolved = resolve_function_envs(template, ctx)
+    required_map = load_required_env(registry_path)
+    return {
+        "template": str(template_path),
+        "region": region,
+        "parameters": {k: ("<redacted>" if _is_secret(k) else v) for k, v in ctx.params.items()},
+        "functions": resolved,
+        "diff": diff_required(resolved, required_map),
+    }
+
+
+def _is_secret(param_name: str) -> bool:
+    lowered = param_name.lower()
+    return any(tok in lowered for tok in ("secret", "apikey", "api_key", "password", "token"))
+
+
+# --- CLI -------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_TEMPLATE = _REPO_ROOT / "infrastructure" / "cloudformation" / "02-compute.yaml"
+_DEFAULT_REGISTRY = _REPO_ROOT / "backend" / "lambda" / "env_drift_auditor" / "env_drift_registry.json"
+
+
+def _parse_overrides(pairs: List[str], file_path: Optional[str]) -> Dict[str, str]:
+    overrides: Dict[str, str] = {}
+    if file_path:
+        data = json.loads(Path(file_path).read_text())
+        # Accept either {"Key": "Value"} or CFN [{"ParameterKey","ParameterValue"}]
+        if isinstance(data, list):
+            for item in data:
+                overrides[item["ParameterKey"]] = item["ParameterValue"]
+        else:
+            overrides.update({str(k): str(v) for k, v in data.items()})
+    for pair in pairs or []:
+        if "=" not in pair:
+            raise SystemExit(f"[ERROR] --parameter expects Key=Value, got: {pair!r}")
+        key, _, value = pair.partition("=")
+        overrides[key.strip()] = value
+    return overrides
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Resolve CFN Lambda env vars and diff vs required-env registry.")
+    parser.add_argument("--template", default=str(_DEFAULT_TEMPLATE))
+    parser.add_argument("--registry", default=str(_DEFAULT_REGISTRY))
+    parser.add_argument("--region", default=DEFAULT_REGION)
+    parser.add_argument(
+        "--parameter",
+        action="append",
+        default=[],
+        metavar="Key=Value",
+        help="Parameter override (repeatable). Mirrors --parameter-overrides.",
+    )
+    parser.add_argument("--parameters-file", help="JSON file of parameter overrides.")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    overrides = _parse_overrides(args.parameter, args.parameters_file)
+    report = resolve_and_diff(
+        Path(args.template),
+        overrides,
+        Path(args.registry),
+        region=args.region,
+    )
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print(f"# CFN env resolution: {report['template']} (region={report['region']})")
+    for fn_name in sorted(report["diff"]):
+        d = report["diff"][fn_name]
+        flag = "registry" if d["has_registry_entry"] else "no-registry-entry"
+        print(f"\n{fn_name} [{d['logical_id']}] ({flag})")
+        print(f"  resolved keys ({len(d['resolved_keys'])}): {', '.join(d['resolved_keys'])}")
+        if d["missing"]:
+            print(f"  MISSING required: {', '.join(d['missing'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/env_parity_gate.py
+++ b/tools/env_parity_gate.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Pre-deploy environment-parity gate — ENC-TSK-H18.
+
+ENC-PLN-048 Objective 2 (parent ENC-TSK-H12, feature ENC-FTR-102). Wraps the
+H17 resolver/diff engine (tools/cfn_env_resolver.py) with fail-closed behavior:
+
+  * Exits NON-ZERO if any deploy-critical required var would be unset by the
+    template-resolved env (the H05/H09 "deploy would strip <var>" class).
+  * Prints function + var + remediation for every finding.
+  * Advisory vars WARN without failing (configurable per-function or via "*").
+  * A documented, auditable waiver suppresses a specific (function, var) FAILURE
+    — but the waiver is still RECORDED in the report. Waivers are never silent,
+    so the gate cannot be quietly bypassed.
+
+Single diff implementation: this gate does NOT re-diff. It consumes
+cfn_env_resolver.diff_required so pre-deploy and the resolver stay consistent
+(ENC-TSK-H17/H19 AC2 — no divergent second implementation).
+
+Usage:
+  python3 tools/env_parity_gate.py \
+      --template infrastructure/cloudformation/02-compute.yaml \
+      --parameter EnvironmentSuffix=-gamma \
+      --waivers tools/env_parity_waivers.json
+Exit codes: 0 = pass (no un-waived critical gaps), 2 = fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cfn_env_resolver as resolver  # noqa: E402
+
+CRITICAL = "critical"
+ADVISORY = "advisory"
+WAIVED = "waived"
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_WAIVERS = _REPO_ROOT / "tools" / "env_parity_waivers.json"
+
+
+def load_waivers(path: Optional[Path]) -> Dict[str, Any]:
+    """Load the waiver/advisory config. Missing file -> empty (fail-closed)."""
+    if path is None or not Path(path).exists():
+        return {"waivers": {}, "advisory": {}}
+    data = json.loads(Path(path).read_text())
+    waivers: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for entry in data.get("waivers", []) or []:
+        fn = entry.get("function")
+        var = entry.get("var")
+        if fn and var and not str(fn).startswith("EXAMPLE"):
+            waivers[(fn, var)] = entry
+    advisory: Dict[str, set] = {}
+    for fn, vars_ in (data.get("advisory_vars", {}) or {}).items():
+        if fn.startswith("_"):
+            continue
+        advisory[fn] = set(vars_ or [])
+    return {"waivers": waivers, "advisory": advisory}
+
+
+def _is_advisory(fn: str, var: str, advisory: Dict[str, set]) -> bool:
+    return var in advisory.get(fn, set()) or var in advisory.get("*", set())
+
+
+def _remediation(fn: str, var: str) -> str:
+    return (
+        f"add '{var}' to {fn}'s Environment.Variables in "
+        f"infrastructure/cloudformation/02-compute.yaml (reference the deploy "
+        f"parameter that supplies it so the next deploy does not strip the live "
+        f"value), or add a documented waiver to tools/env_parity_waivers.json"
+    )
+
+
+def run_gate(
+    template_path: Path,
+    overrides: Dict[str, str],
+    registry_path: Path,
+    waivers_cfg: Dict[str, Any],
+    region: str = resolver.DEFAULT_REGION,
+) -> Dict[str, Any]:
+    """Resolve template env, diff vs required-env, classify each missing var."""
+    report = resolver.resolve_and_diff(template_path, overrides, registry_path, region=region)
+    waivers = waivers_cfg["waivers"]
+    advisory = waivers_cfg["advisory"]
+
+    findings: List[Dict[str, Any]] = []
+    counts = {CRITICAL: 0, ADVISORY: 0, WAIVED: 0}
+    for fn_name in sorted(report["diff"]):
+        d = report["diff"][fn_name]
+        if not d["has_registry_entry"]:
+            continue  # only registry-governed functions are gated
+        for var in d["missing"]:
+            if (fn_name, var) in waivers:
+                klass = WAIVED
+                detail = waivers[(fn_name, var)]
+            elif _is_advisory(fn_name, var, advisory):
+                klass = ADVISORY
+                detail = None
+            else:
+                klass = CRITICAL
+                detail = None
+            counts[klass] += 1
+            findings.append(
+                {
+                    "function": fn_name,
+                    "var": var,
+                    "classification": klass,
+                    "waiver": detail,
+                    "remediation": _remediation(fn_name, var),
+                }
+            )
+
+    return {
+        "template": str(template_path),
+        "region": region,
+        "findings": findings,
+        "counts": counts,
+        "failed": counts[CRITICAL] > 0,
+    }
+
+
+def format_report(result: Dict[str, Any]) -> str:
+    lines = [
+        "============================================================",
+        "  PRE-DEPLOY ENV PARITY GATE (ENC-PLN-048 / ENC-FTR-102)",
+        "============================================================",
+        f"  Template: {result['template']}  Region: {result['region']}",
+        f"  critical={result['counts'][CRITICAL]} "
+        f"advisory={result['counts'][ADVISORY]} waived={result['counts'][WAIVED]}",
+        "",
+    ]
+    if not result["findings"]:
+        lines.append("  All registry-required vars are present in the template-resolved env.")
+    for f in result["findings"]:
+        tag = {CRITICAL: "[FAIL]", ADVISORY: "[WARN]", WAIVED: "[WAIVED]"}[f["classification"]]
+        lines.append(f"  {tag} {f['function']} :: {f['var']}")
+        if f["classification"] == WAIVED and f["waiver"]:
+            w = f["waiver"]
+            lines.append(f"          waiver: {w.get('reason', '')} (owner={w.get('owner', '?')}, review_by={w.get('review_by', '?')})")
+        elif f["classification"] == CRITICAL:
+            lines.append(f"          fix: {f['remediation']}")
+    lines.append("")
+    if result["failed"]:
+        lines.append(f"  GATE: FAILED — {result['counts'][CRITICAL]} deploy-critical var(s) would be stripped.")
+    else:
+        lines.append("  GATE: PASSED")
+    lines.append("============================================================")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fail-closed pre-deploy env parity gate (ENC-TSK-H18).")
+    parser.add_argument("--template", default=str(resolver._DEFAULT_TEMPLATE))
+    parser.add_argument("--registry", default=str(resolver._DEFAULT_REGISTRY))
+    parser.add_argument("--waivers", default=str(_DEFAULT_WAIVERS))
+    parser.add_argument("--region", default=resolver.DEFAULT_REGION)
+    parser.add_argument("--parameter", action="append", default=[], metavar="Key=Value")
+    parser.add_argument("--parameters-file")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    overrides = resolver._parse_overrides(args.parameter, args.parameters_file)
+    waivers_cfg = load_waivers(Path(args.waivers))
+    result = run_gate(
+        Path(args.template), overrides, Path(args.registry), waivers_cfg, region=args.region
+    )
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+    else:
+        print(format_report(result))
+    return 2 if result["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/env_parity_waivers.json
+++ b/tools/env_parity_waivers.json
@@ -1,0 +1,17 @@
+{
+  "_doc": "Documented, auditable waivers for the pre-deploy env parity gate (ENC-TSK-H18, ENC-PLN-048, ENC-FTR-102). A waiver suppresses a specific (function, var) FAILURE so an intentional, justified out-of-band variable does not block a deploy. Waivers are NEVER silent: every waived finding is still printed and recorded in the gate report. To accept a risk, add an entry with a real reason, owner, and review_by date; remove the entry to re-arm the gate for that var. Entries whose function name starts with 'EXAMPLE' are ignored by the loader (documentation only).",
+  "_remediation_preferred": "The preferred fix is NOT a waiver but template remediation: add the missing var to the function's Environment.Variables in infrastructure/cloudformation/02-compute.yaml (referencing the deploy parameter that supplies it) so CloudFormation sets it and the next deploy cannot strip the live value.",
+  "waivers": [
+    {
+      "function": "EXAMPLE-devops-some-lambda",
+      "var": "EXAMPLE_OPTIONAL_VAR",
+      "reason": "Documentation-only example. Replace with a real, justified waiver. Set intentionally out-of-band; template remediation tracked on ENC-ISS-XXX.",
+      "owner": "io",
+      "review_by": "2026-12-31"
+    }
+  ],
+  "advisory_vars": {
+    "_comment": "Map a function name (or '*' for all functions) to a list of vars that should WARN instead of FAIL when missing from the template-resolved env. Use sparingly — advisory means 'not deploy-critical'.",
+    "*": []
+  }
+}

--- a/tools/live_template_strip_detector.py
+++ b/tools/live_template_strip_detector.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Live-vs-template env strip detector — ENC-TSK-H19.
+
+ENC-PLN-048 Objective 2 (child 2.3), parent ENC-TSK-H12, feature ENC-FTR-102.
+
+For each in-scope function, dump the LIVE Environment.Variables
+(aws lambda get-function-configuration) and diff them against the H17
+template-resolved env. Any variable present LIVE but NOT set by the
+template-resolved env is flagged:
+
+    deploy would strip <var> from <function>
+
+— the exact H05/H09 failure signature — BEFORE merge/deploy.
+
+Classification:
+  * critical : the live-only var is a REQUIRED var (env_drift_registry.json).
+    A deploy that strips it reproduces the incident class -> gate FAILS.
+  * warning  : the live-only var is not in the registry (extra / out-of-band but
+    not declared deploy-critical) -> reported, does not fail the gate.
+
+AC2 (no divergent second implementation): the live-vs-template comparison uses
+backend/lambda/env_drift_auditor/env_parity_core.live_only_vars — the same module
+the env_drift_auditor Lambda uses for its post-deploy scan. The template side is
+tools/cfn_env_resolver.py (H17), which correctly evaluates !If/AWS::NoValue/!Sub
+so a conditionally-unset template var is NOT mistaken for a live-only var (the
+prototype's AppConfig false-positive).
+
+Live env is pluggable: --live-env-file <json> ({fn: {var: val}}) for offline/CI
+or unit tests; otherwise boto3 lambda.get_function_configuration is used. No AWS
+writes — read-only get-function-configuration only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "tools"))
+sys.path.insert(0, str(_REPO_ROOT / "backend" / "lambda" / "env_drift_auditor"))
+
+import cfn_env_resolver as resolver  # noqa: E402
+import env_parity_core  # noqa: E402  (shared comparison core — AC2)
+
+CRITICAL = "critical"
+WARNING = "warning"
+
+
+def detect(
+    template_envs: Dict[str, Dict[str, Any]],
+    live_envs: Dict[str, Dict[str, str]],
+    required_map: Dict[str, List[str]],
+) -> Dict[str, Any]:
+    """Pure comparison: for each function present in BOTH the template and live,
+    flag vars that are live-only (the deploy would strip them).
+
+    template_envs: {fn: {"resolved_env": {...}}} (H17 output) or {fn: {...env...}}.
+    live_envs:     {fn: {var: value}} live Environment.Variables.
+    required_map:  {fn: [required vars]} from env_drift_registry.json.
+    """
+    findings: List[Dict[str, Any]] = []
+    counts = {CRITICAL: 0, WARNING: 0}
+    skipped: List[str] = []
+
+    for fn_name in sorted(template_envs):
+        template_env = _extract_env(template_envs[fn_name])
+        if fn_name not in live_envs:
+            skipped.append(fn_name)  # not deployed live (nothing to strip)
+            continue
+        required = set(required_map.get(fn_name, []))
+        for var in env_parity_core.live_only_vars(live_envs[fn_name], template_env):
+            klass = CRITICAL if var in required else WARNING
+            counts[klass] += 1
+            findings.append(
+                {
+                    "function": fn_name,
+                    "var": var,
+                    "classification": klass,
+                    "required": var in required,
+                    "message": f"deploy would strip {var} from {fn_name}",
+                }
+            )
+
+    return {
+        "findings": findings,
+        "counts": counts,
+        "skipped_not_live": sorted(skipped),
+        "failed": counts[CRITICAL] > 0,
+    }
+
+
+def _extract_env(value: Any) -> Dict[str, str]:
+    if isinstance(value, dict) and "resolved_env" in value:
+        return value["resolved_env"]
+    return value if isinstance(value, dict) else {}
+
+
+def fetch_live_envs_boto3(function_names: List[str], region: str) -> Dict[str, Dict[str, str]]:
+    """Read-only live env fetch via boto3 (get-function-configuration)."""
+    import boto3  # local import so offline/file mode needs no boto3
+
+    client = boto3.client("lambda", region_name=region)
+    out: Dict[str, Dict[str, str]] = {}
+    for fn in function_names:
+        try:
+            cfg = client.get_function_configuration(FunctionName=fn)
+        except client.exceptions.ResourceNotFoundException:
+            continue  # not deployed -> nothing to strip
+        out[fn] = (cfg.get("Environment") or {}).get("Variables", {}) or {}
+    return out
+
+
+def run(
+    template_path: Path,
+    overrides: Dict[str, str],
+    registry_path: Path,
+    region: str = resolver.DEFAULT_REGION,
+    live_env_provider: Optional[Callable[[List[str], str], Dict[str, Dict[str, str]]]] = None,
+) -> Dict[str, Any]:
+    template = resolver.load_template(template_path)
+    ctx = resolver.ResolveContext(resolver.build_params(template, overrides), region=region)
+    template_envs = resolver.resolve_function_envs(template, ctx)
+    required_map = resolver.load_required_env(registry_path)
+
+    provider = live_env_provider or fetch_live_envs_boto3
+    live_envs = provider(sorted(template_envs), region)
+
+    result = detect(template_envs, live_envs, required_map)
+    result["template"] = str(template_path)
+    result["region"] = region
+    return result
+
+
+def format_report(result: Dict[str, Any]) -> str:
+    lines = [
+        "============================================================",
+        "  LIVE-vs-TEMPLATE STRIP DETECTOR (ENC-TSK-H19 / ENC-FTR-102)",
+        "============================================================",
+        f"  Template: {result.get('template')}  Region: {result.get('region')}",
+        f"  critical={result['counts'][CRITICAL]} warning={result['counts'][WARNING]} "
+        f"not-live={len(result['skipped_not_live'])}",
+        "",
+    ]
+    if not result["findings"]:
+        lines.append("  No live-only vars — live env is a SUBSET of the template-resolved env.")
+        lines.append("  (Zero pre-deploy strip risk.)")
+    for f in result["findings"]:
+        tag = "[FAIL]" if f["classification"] == CRITICAL else "[WARN]"
+        lines.append(f"  {tag} {f['message']}" + (" (required)" if f["required"] else " (not in registry)"))
+    lines.append("")
+    if result["failed"]:
+        lines.append(
+            f"  DETECTOR: FAILED — {result['counts'][CRITICAL]} required var(s) are live-only "
+            f"and would be stripped by the deploy. Add them to the template or remove them live."
+        )
+    else:
+        lines.append("  DETECTOR: PASSED")
+    lines.append("============================================================")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Live-vs-template env strip detector (ENC-TSK-H19).")
+    parser.add_argument("--template", default=str(resolver._DEFAULT_TEMPLATE))
+    parser.add_argument("--registry", default=str(resolver._DEFAULT_REGISTRY))
+    parser.add_argument("--region", default=resolver.DEFAULT_REGION)
+    parser.add_argument("--parameter", action="append", default=[], metavar="Key=Value")
+    parser.add_argument("--parameters-file")
+    parser.add_argument(
+        "--live-env-file",
+        help="JSON {function: {var: value}} of live env (offline/CI/test). "
+        "Omit to read live via boto3 get-function-configuration.",
+    )
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    overrides = resolver._parse_overrides(args.parameter, args.parameters_file)
+
+    provider: Optional[Callable[[List[str], str], Dict[str, Dict[str, str]]]] = None
+    if args.live_env_file:
+        live_data = json.loads(Path(args.live_env_file).read_text())
+        provider = lambda names, region: {k: v for k, v in live_data.items() if k in set(names)}  # noqa: E731
+
+    result = run(
+        Path(args.template),
+        overrides,
+        Path(args.registry),
+        region=args.region,
+        live_env_provider=provider,
+    )
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(format_report(result))
+    return 2 if result["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -16,10 +16,12 @@
 #   3. Validates EnvironmentSuffix parameter presence in template
 #   4. Validates deploy scripts have no hardcoded runtime defaults
 #   5. Validates enceladus-shared layer is pinned to canonical (verify_shared_layer_version.py)
+#   6. Validates env-var parity — no out-of-band vars the deploy would strip (env_parity_gate.py)
 #   ...and warns operator about direct deploy risks
 #
 # Part of ENC-PLN-020 (Production Deploy Hardening) / ENC-FTR-068.
 # ENC-TSK-H24: Check 5 added — the enceladus-shared :7-vs-:10 layer-version parity gate.
+# ENC-PLN-048 / ENC-FTR-102: Check 6 added — env-var parity gate (H17 resolver + H18 fail-closed).
 
 set -euo pipefail
 
@@ -81,7 +83,7 @@ ERRORS=0
 SNAPSHOT_FILE="/tmp/pre-deploy-snapshot-${TIMESTAMP}.json"
 
 # --- Check 1: Capture Lambda snapshot ---
-echo "[CHECK 1/5] Capturing current Lambda state snapshot..."
+echo "[CHECK 1/6] Capturing current Lambda state snapshot..."
 
 if [[ ! -f "${MANIFEST}" ]]; then
     echo "[ERROR] Lambda workflow manifest not found: ${MANIFEST}"
@@ -126,7 +128,7 @@ fi
 
 # --- Check 2: Validate IsGamma conditionals ---
 echo ""
-echo "[CHECK 2/5] Validating CFN template architecture parity..."
+echo "[CHECK 2/6] Validating CFN template architecture parity..."
 
 if python3 "${REPO_ROOT}/tools/verify_lambda_arch_parity.py"; then
     echo "[PASS] CFN template uses IsGamma conditionals correctly"
@@ -137,7 +139,7 @@ fi
 
 # --- Check 3: Validate EnvironmentSuffix parameter ---
 echo ""
-echo "[CHECK 3/5] Validating EnvironmentSuffix parameter in template..."
+echo "[CHECK 3/6] Validating EnvironmentSuffix parameter in template..."
 
 if grep -q "EnvironmentSuffix" "${TEMPLATE_FILE}"; then
     echo "[PASS] Template contains EnvironmentSuffix parameter"
@@ -148,7 +150,7 @@ fi
 
 # --- Check 4: Validate deploy scripts ---
 echo ""
-echo "[CHECK 4/5] Validating deploy scripts via manifest..."
+echo "[CHECK 4/6] Validating deploy scripts via manifest..."
 
 # This is already done by verify_lambda_arch_parity.py, but we add a specific
 # check for hardcoded RUNTIME/ARCHITECTURE defaults without conditionals
@@ -163,7 +165,7 @@ fi
 
 # --- Check 5: Validate enceladus-shared layer-version parity (ENC-TSK-H24) ---
 echo ""
-echo "[CHECK 5/5] Validating enceladus-shared layer-version pin (:7-vs-:10 gate)..."
+echo "[CHECK 5/6] Validating enceladus-shared layer-version pin (:7-vs-:10 gate)..."
 
 # Template-mode is fail-closed (no AWS creds needed). Add --live opportunistically:
 # it diffs against live get-function-configuration and fails only on a regression
@@ -172,6 +174,30 @@ if python3 "${REPO_ROOT}/tools/verify_shared_layer_version.py" "${TEMPLATE_FILE}
     echo "[PASS] enceladus-shared pinned to canonical version; no live regression"
 else
     echo "[FAIL] enceladus-shared layer-version parity violation (would re-introduce the :7-class incident, ENC-LSN-053)"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# --- Check 6: Validate environment-variable parity (ENC-PLN-048 / ENC-FTR-102) ---
+# Resolves the template's per-function Environment.Variables (evaluating
+# !Ref/--parameter-overrides, !Sub, !If/AWS::NoValue) and fails closed if any
+# deploy-critical required var (env_drift_registry.json) would be unset — the
+# exact H05/H09 "deploy would strip <var>" class. Waivers/advisory live in
+# tools/env_parity_waivers.json.
+echo ""
+echo "[CHECK 6/6] Validating env-var parity (no out-of-band vars the deploy would strip)..."
+
+# Infer EnvironmentSuffix from the stack name so gamma stacks resolve their -gamma env.
+PARITY_PARAMS=()
+case "${STACK_NAME}" in
+    *gamma*) PARITY_PARAMS+=(--parameter "EnvironmentSuffix=-gamma") ;;
+esac
+
+if python3 "${REPO_ROOT}/tools/env_parity_gate.py" \
+        --template "${TEMPLATE_FILE}" \
+        ${PARITY_PARAMS[@]+"${PARITY_PARAMS[@]}"}; then
+    echo "[PASS] All deploy-critical env vars are present in the template-resolved env"
+else
+    echo "[FAIL] Env parity gate found deploy-critical vars the deploy would strip (see above)"
     ERRORS=$((ERRORS + 1))
 fi
 

--- a/tools/test_cfn_env_resolver.py
+++ b/tools/test_cfn_env_resolver.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tests for tools/cfn_env_resolver.py — ENC-TSK-H17 (ENC-PLN-048 Objective 2).
+
+Covers the intrinsic-function evaluation that the PLN-048 prototype got wrong
+(!If / AWS::NoValue), plus !Ref/--parameter-overrides, !Sub, gamma suffixing,
+and the required-env diff. Runs under pytest OR directly:
+
+    python3 tools/test_cfn_env_resolver.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cfn_env_resolver as r  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "infrastructure" / "cloudformation" / "02-compute.yaml"
+REGISTRY = REPO_ROOT / "backend" / "lambda" / "env_drift_auditor" / "env_drift_registry.json"
+
+
+# --- Synthetic template exercising every intrinsic deterministically --------
+SYNTHETIC = """
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+  LayerArn:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:1:layer:x:1"
+  SuppliedKey:
+    Type: String
+    Default: ""
+Conditions:
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+  HasLayer: !Not [!Equals [!Ref LayerArn, ""]]
+Resources:
+  Fn:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "widget${EnvironmentSuffix}"
+      Environment:
+        Variables:
+          PLAIN: hello
+          TABLE: !Sub "tbl${EnvironmentSuffix}"
+          REGION_VAR: !Ref AWS::Region
+          SUPPLIED: !Ref SuppliedKey
+          APPCONFIG: !If [HasLayer, !Ref SuppliedKey, !Ref "AWS::NoValue"]
+          ROLE_ATTR: !GetAtt SomeRole.Arn
+          JOINED: !Join ["-", ["a", !Ref EnvironmentSuffix, "b"]]
+  NotALambda:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: ignored
+"""
+
+
+def _resolve_synthetic(overrides=None, region="us-west-2"):
+    template = r.yaml.load(io.StringIO(SYNTHETIC), Loader=r._CfnLoader)
+    ctx = r.ResolveContext(r.build_params(template, overrides or {}), region=region)
+    return r.resolve_function_envs(template, ctx)
+
+
+def test_plain_and_sub_and_region():
+    env = _resolve_synthetic()["widget"]["resolved_env"]
+    assert env["PLAIN"] == "hello"
+    assert env["TABLE"] == "tbl"  # suffix "" -> no suffix
+    assert env["REGION_VAR"] == "us-west-2"  # AWS::Region pseudo-param
+    assert env["JOINED"] == "a--b"  # empty suffix joins to a--b
+
+
+def test_novalue_dropped_when_condition_false():
+    # LayerArn="" -> HasLayer False -> APPCONFIG = !Ref AWS::NoValue -> ABSENT.
+    env = _resolve_synthetic({"LayerArn": ""})["widget"]["resolved_env"]
+    assert "APPCONFIG" not in env, "AWS::NoValue var must be dropped, not present-empty"
+
+
+def test_novalue_present_when_condition_true():
+    # Default LayerArn non-empty -> HasLayer True -> APPCONFIG present (== SuppliedKey).
+    env = _resolve_synthetic()["widget"]["resolved_env"]
+    assert "APPCONFIG" in env
+    assert env["APPCONFIG"] == ""  # SuppliedKey default ""
+
+
+def test_param_override_resolves():
+    env = _resolve_synthetic({"SuppliedKey": "s3cr3t"})["widget"]["resolved_env"]
+    assert env["SUPPLIED"] == "s3cr3t"
+    assert env["APPCONFIG"] == "s3cr3t"  # HasLayer True branch picks SuppliedKey
+
+
+def test_gamma_suffix_applies_to_name_and_vars():
+    funcs = _resolve_synthetic({"EnvironmentSuffix": "-gamma"})
+    assert "widget-gamma" in funcs
+    env = funcs["widget-gamma"]["resolved_env"]
+    assert env["TABLE"] == "tbl-gamma"
+    assert env["JOINED"] == "a--gamma-b"
+
+
+def test_getatt_present_but_opaque():
+    env = _resolve_synthetic()["widget"]["resolved_env"]
+    assert env["ROLE_ATTR"].startswith("<GetAtt:SomeRole.Arn")
+
+
+def test_only_lambda_resources_returned():
+    funcs = _resolve_synthetic()
+    assert set(funcs) == {"widget"}  # S3 bucket excluded
+
+
+# --- Real-template smoke tests (the documented prototype failure) -----------
+def test_real_template_appconfig_present_under_defaults():
+    template = r.load_template(TEMPLATE)
+    ctx = r.ResolveContext(r.build_params(template, {}))
+    funcs = r.resolve_function_envs(template, ctx)
+    env = funcs["devops-coordination-api"]["resolved_env"]
+    # HasAppConfigLayer True under defaults -> these are SET (the prototype's bug
+    # was reporting them as "would be stripped").
+    assert "APPCONFIG_APPLICATION" in env
+    assert "APPCONFIG_ENVIRONMENT" in env
+
+
+def test_real_template_appconfig_dropped_when_layer_absent():
+    template = r.load_template(TEMPLATE)
+    ctx = r.ResolveContext(r.build_params(template, {"AppConfigExtensionLayerArnX86": ""}))
+    funcs = r.resolve_function_envs(template, ctx)
+    env = funcs["devops-coordination-api"]["resolved_env"]
+    assert "APPCONFIG_APPLICATION" not in env
+    assert "APPCONFIG_ENVIRONMENT" not in env
+
+
+def test_real_template_gamma_names():
+    template = r.load_template(TEMPLATE)
+    ctx = r.ResolveContext(r.build_params(template, {"EnvironmentSuffix": "-gamma"}))
+    funcs = r.resolve_function_envs(template, ctx)
+    assert "devops-coordination-api-gamma" in funcs
+
+
+def test_diff_required_surfaces_missing_keys():
+    # Deterministic: the diff must surface a required var absent from the resolved
+    # env. (Previously asserted a specific real-template gap, but the live template
+    # is remediated over time — ENC-TSK-H05 codified COORDINATION_INTERNAL_API_KEY
+    # on main — so this is synthetic to stay stable across template changes.)
+    resolved = {"fn-x": {"logical_id": "X", "resolved_env": {"A": "1"}}}
+    diff = r.diff_required(resolved, {"fn-x": ["A", "B"]})
+    assert diff["fn-x"]["missing"] == ["B"]
+    assert diff["fn-x"]["has_registry_entry"] is True
+
+
+def test_secret_params_redacted_in_report():
+    report = r.resolve_and_diff(TEMPLATE, {"CoordinationInternalApiKey": "abc"}, REGISTRY)
+    assert report["parameters"]["CoordinationInternalApiKey"] == "<redacted>"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"  FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_all())

--- a/tools/test_env_parity_gate.py
+++ b/tools/test_env_parity_gate.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for tools/env_parity_gate.py — ENC-TSK-H18 (ENC-PLN-048 Objective 2).
+
+Proves fail-closed exit, the documented-waiver suppression (recorded, not
+silent), and advisory warn-without-fail. Uses synthetic templates so the tests
+stay stable when the real 02-compute.yaml is later remediated.
+
+    python3 tools/test_env_parity_gate.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import env_parity_gate as gate  # noqa: E402
+
+SYNTH_TEMPLATE = """
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  A:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: fn-a
+      Environment:
+        Variables:
+          PRESENT: ok
+  B:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: fn-b
+      Environment:
+        Variables:
+          PRESENT: ok
+          ALSO: ok
+"""
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content)
+    return p
+
+
+def _registry(tmp: Path, mapping: dict) -> Path:
+    return _write(tmp, "registry.json", json.dumps({"lambdas": mapping}))
+
+
+def test_critical_missing_fails():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT", "NEEDED"], "fn-b": ["PRESENT"]})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        assert result["failed"] is True
+        crit = [f for f in result["findings"] if f["classification"] == gate.CRITICAL]
+        assert len(crit) == 1
+        assert crit[0]["function"] == "fn-a" and crit[0]["var"] == "NEEDED"
+        assert "02-compute.yaml" in crit[0]["remediation"]
+
+
+def test_waiver_suppresses_but_records():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT", "NEEDED"]})
+        cfg = {
+            "waivers": {("fn-a", "NEEDED"): {"reason": "intentional", "owner": "io", "review_by": "2026-12-31"}},
+            "advisory": {},
+        }
+        result = gate.run_gate(tpl, {}, reg, cfg)
+        assert result["failed"] is False  # waived -> no critical
+        waived = [f for f in result["findings"] if f["classification"] == gate.WAIVED]
+        assert len(waived) == 1  # still RECORDED (not silent)
+        assert waived[0]["waiver"]["reason"] == "intentional"
+
+
+def test_advisory_warns_without_failing():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT", "OPTIONAL"]})
+        cfg = {"waivers": {}, "advisory": {"fn-a": {"OPTIONAL"}}}
+        result = gate.run_gate(tpl, {}, reg, cfg)
+        assert result["failed"] is False
+        adv = [f for f in result["findings"] if f["classification"] == gate.ADVISORY]
+        assert len(adv) == 1 and adv[0]["var"] == "OPTIONAL"
+
+
+def test_advisory_wildcard():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT", "OPTIONAL"]})
+        cfg = {"waivers": {}, "advisory": {"*": {"OPTIONAL"}}}
+        result = gate.run_gate(tpl, {}, reg, cfg)
+        assert result["failed"] is False
+        assert result["counts"][gate.ADVISORY] == 1
+
+
+def test_all_present_passes():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT"], "fn-b": ["PRESENT", "ALSO"]})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        assert result["failed"] is False
+        assert result["findings"] == []
+
+
+def test_untracked_function_not_gated():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        # fn-b not in registry -> not gated even though it has extra var.
+        reg = _registry(tmp, {"fn-a": ["PRESENT"]})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        assert all(f["function"] != "fn-b" for f in result["findings"])
+
+
+def test_load_waivers_filters_example_entries():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wf = _write(
+            tmp,
+            "w.json",
+            json.dumps(
+                {
+                    "waivers": [
+                        {"function": "EXAMPLE-x", "var": "Y", "reason": "doc"},
+                        {"function": "fn-a", "var": "NEEDED", "reason": "real", "owner": "io"},
+                    ],
+                    "advisory_vars": {"_comment": "x", "fn-a": ["OPT"]},
+                }
+            ),
+        )
+        cfg = gate.load_waivers(wf)
+        assert ("fn-a", "NEEDED") in cfg["waivers"]
+        assert ("EXAMPLE-x", "Y") not in cfg["waivers"]
+        assert cfg["advisory"]["fn-a"] == {"OPT"}
+
+
+def test_main_exit_code_nonzero_on_critical():
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
+        reg = _registry(tmp, {"fn-a": ["PRESENT", "NEEDED"]})
+        wf = _write(tmp, "w.json", json.dumps({"waivers": [], "advisory_vars": {}}))
+        rc = gate.main(["--template", str(tpl), "--registry", str(reg), "--waivers", str(wf), "--format", "json"])
+        assert rc == 2
+
+
+def test_shipped_waiver_file_has_no_active_waivers():
+    """The committed waiver file must not pre-waive real findings (stays honest)."""
+    cfg = gate.load_waivers(gate._DEFAULT_WAIVERS)
+    assert cfg["waivers"] == {}, "shipped waivers file should have zero active waivers"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"  FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_all())

--- a/tools/test_live_template_strip_detector.py
+++ b/tools/test_live_template_strip_detector.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Tests for tools/live_template_strip_detector.py — ENC-TSK-H19.
+
+Covers the live-vs-template comparison + classification, the baseline
+(live subset of template -> zero strip risk), and the end-to-end proof that
+template vars correctly resolved by H17 (incl. AppConfig !If vars) are NOT
+false-flagged as live-only.
+
+    python3 tools/test_live_template_strip_detector.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cfn_env_resolver as resolver  # noqa: E402
+import live_template_strip_detector as det  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "infrastructure" / "cloudformation" / "02-compute.yaml"
+REGISTRY = REPO_ROOT / "backend" / "lambda" / "env_drift_auditor" / "env_drift_registry.json"
+
+
+def test_baseline_live_subset_no_findings():
+    template = {"fn": {"resolved_env": {"A": "1", "B": "2"}}}
+    live = {"fn": {"A": "1"}}  # subset
+    result = det.detect(template, live, {"fn": ["A", "B"]})
+    assert result["failed"] is False
+    assert result["findings"] == []
+
+
+def test_live_only_required_is_critical():
+    template = {"fn": {"resolved_env": {"A": "1"}}}
+    live = {"fn": {"A": "1", "COORDINATION_INTERNAL_API_KEY": "live-secret"}}
+    result = det.detect(template, live, {"fn": ["A", "COORDINATION_INTERNAL_API_KEY"]})
+    assert result["failed"] is True
+    crit = [f for f in result["findings"] if f["classification"] == det.CRITICAL]
+    assert len(crit) == 1
+    assert crit[0]["var"] == "COORDINATION_INTERNAL_API_KEY"
+    assert crit[0]["message"] == "deploy would strip COORDINATION_INTERNAL_API_KEY from fn"
+
+
+def test_live_only_nonrequired_is_warning():
+    template = {"fn": {"resolved_env": {"A": "1"}}}
+    live = {"fn": {"A": "1", "MANUAL_DEBUG_FLAG": "on"}}
+    result = det.detect(template, live, {"fn": ["A"]})  # MANUAL_DEBUG_FLAG not required
+    assert result["failed"] is False
+    warn = [f for f in result["findings"] if f["classification"] == det.WARNING]
+    assert len(warn) == 1 and warn[0]["var"] == "MANUAL_DEBUG_FLAG"
+
+
+def test_function_not_live_is_skipped():
+    template = {"fn-a": {"resolved_env": {"A": "1"}}, "fn-b": {"resolved_env": {"B": "1"}}}
+    live = {"fn-a": {"A": "1"}}  # fn-b not deployed
+    result = det.detect(template, live, {})
+    assert "fn-b" in result["skipped_not_live"]
+
+
+def test_accepts_flat_env_shape():
+    # detect() should also accept {fn: {var: val}} without the resolved_env wrapper.
+    result = det.detect({"fn": {"A": "1"}}, {"fn": {"A": "1", "X": "2"}}, {"fn": ["A"]})
+    assert result["counts"][det.WARNING] == 1
+
+
+def test_end_to_end_appconfig_not_false_flagged():
+    """The prototype flagged APPCONFIG_* as 'would strip'. With H17 resolving !If
+    correctly, APPCONFIG_APPLICATION is present in the template-resolved env, so a
+    live env that also has it is NOT flagged — only the genuine out-of-band var is.
+    """
+    template = resolver.load_template(TEMPLATE)
+    ctx = resolver.ResolveContext(resolver.build_params(template, {}))
+    template_envs = resolver.resolve_function_envs(template, ctx)
+    fn = "devops-coordination-api"
+    resolved = template_envs[fn]["resolved_env"]
+    assert "APPCONFIG_APPLICATION" in resolved  # H17 resolved the !If branch
+
+    # Live = exactly the template-resolved env PLUS one genuine out-of-band var.
+    live = {fn: dict(resolved, OUT_OF_BAND_ONLY="x")}
+    result = det.detect(template_envs, live, resolver.load_required_env(REGISTRY))
+    flagged_vars = {f["var"] for f in result["findings"]}
+    assert flagged_vars == {"OUT_OF_BAND_ONLY"}  # APPCONFIG_* NOT flagged
+    assert "APPCONFIG_APPLICATION" not in flagged_vars
+
+
+def test_run_with_injected_provider():
+    # Full run() path with a synthetic live provider (no AWS).
+    def provider(names, region):
+        return {"devops-coordination-api": {"BOGUS_LIVE_ONLY": "1"}}
+
+    result = det.run(TEMPLATE, {}, REGISTRY, live_env_provider=provider)
+    msgs = [f["message"] for f in result["findings"]]
+    assert "deploy would strip BOGUS_LIVE_ONLY from devops-coordination-api" in msgs
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"  FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_all())


### PR DESCRIPTION
## ENC-PLN-048 Objective 2 — Environment-parity gate engine

Feature **ENC-FTR-102** · Plan **ENC-PLN-048** · Parent **ENC-TSK-H12**

Implements the generalized env-parity gate as one coupled unit:

- **ENC-TSK-H17** — `tools/cfn_env_resolver.py`: a real CFN intrinsic evaluator (Ref/Sub/If/AWS::NoValue/Equals/Not/And/Or/Join/Select/GetAtt/ImportValue + Conditions) resolving per-function `Environment.Variables` for `02-compute.yaml`, with a required-env diff vs `env_drift_registry.json`. Fixes the prototype's AppConfig `!If`/NoValue false-positive.
- **ENC-TSK-H18** — `tools/env_parity_gate.py` + `tools/env_parity_waivers.json`: fail-closed gate (prints function+var+remediation), documented/auditable waivers (recorded, never silent) and an advisory class; wired as CHECK 6 in `tools/pre-deploy-health-gate.sh`.
- **ENC-TSK-H19** — `tools/live_template_strip_detector.py` + shared core `backend/lambda/env_drift_auditor/env_parity_core.py`; `env_drift_auditor` refactored to consume the core (single comparison implementation — AC2). Flags live-only vars as `deploy would strip <var> from <fn>`.

### Verification
34 unit tests pass (resolver / gate / detector / core). Run against the current `02-compute.yaml`, the gate catches **1 real deploy-critical gap**: `devops-deploy-intake :: SQS_QUEUE_URL` (the COORDINATION_INTERNAL_API_KEY gaps were already remediated on main by ENC-TSK-H05). Template remediation tracked in **ENC-TSK-H26**.

### Notes
- `env_drift_auditor` Lambda has a behavior-preserving refactor → needs a redeploy.
- H17/H18 are tools-only (no deploy artifact); H19 redeploys the env_drift_auditor Lambda.

### Commit Complete IDs (PR Commit Gate)
- ENC-TSK-H17: CCI-2504eb28b4434db2937ec47d9d0dcef3
- ENC-TSK-H18: CCI-d0722eb2fe124a0c8bb0d2e6d44b4489
- ENC-TSK-H19: CCI-283024b3070b47b78fe97484da51144e

🤖 Generated with [Claude Code](https://claude.com/claude-code)