### PR TITLE
ENC-TSK-H28 / ENC-ISS-385: pass canonical SharedLayerArn=:10 in compute-deploy overrides + extend H24 gate to assert workflow override and live param

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -89,11 +89,14 @@ jobs:
           set -euo pipefail
 
           # ENC-TSK-H05: CoordinationInternalApiKey is a NoEcho param with Default "".
-          # `aws cloudformation deploy` has no UsePreviousValue, so any param NOT passed
-          # here resolves to its template default. If the internal key is not passed it
-          # becomes "" and the env is zeroed on every consumer Lambda, re-triggering the
-          # 2026-06-18 MCP-auth Sev-1 (ENC-LSN-053, DOC-ED50175387B8). Fail closed if the
-          # secret is missing rather than silently stripping the key.
+          # `aws cloudformation deploy` REUSES a parameter's current stack value for any param
+          # not in --parameter-overrides; the template Default applies only when the stack has
+          # no stored value (a fresh stack or a newly added param). An empty/unset internal key
+          # therefore resolves to "" and the env is zeroed on every consumer Lambda, re-triggering
+          # the 2026-06-18 MCP-auth Sev-1 (ENC-LSN-053, DOC-ED50175387B8). Pass it explicitly and
+          # fail closed if the secret is missing rather than silently stripping the key.
+          # (ENC-TSK-H28 corrected the prior "no UsePreviousValue -> resolves to default" wording:
+          # reuse-of-stored-value is also why the SharedLayerArn=:7 stale param persisted below.)
           if [ -z "${{ secrets.COORDINATION_INTERNAL_API_KEY }}" ]; then
             echo "::error::COORDINATION_INTERNAL_API_KEY secret is empty — refusing to deploy (would strip the internal key; ENC-TSK-H05)"
             exit 1
@@ -111,6 +114,18 @@ jobs:
             exit 1
           fi
 
+          # ENC-TSK-H28 / ENC-ISS-385: SharedLayerArn must be passed explicitly too -- for the
+          # INVERSE reason to the NoEcho guards above. enceladus-shared:10 (== :7 + appconfig_flags)
+          # is the canonical pin; 02-compute.yaml's SharedLayerArn Default is :10 and all 23 fns
+          # !Ref it. But `aws cloudformation deploy` reuses the stack's stored param value for any
+          # un-passed param, and the deployed enceladus-compute stack stored SharedLayerArn=:7
+          # (stale/out-of-band). So every deploy reused :7, the :10 template Default was inert
+          # ("No changes to deploy" for layers), and 21/23 fns stayed on enceladus-shared:7 --
+          # blocking appconfig_flags fleet-wide (ENC-FTR-103) and ENC-TSK-H24 AC-1/AC-2. AXIS-2 of
+          # ENC-LSN-053 / DOC-ED50175387B8: a template Default is NOT a deployed value. Passing the
+          # canonical :10 ARN here forces the param so the heal moves live; the H24 gate
+          # (tools/verify_shared_layer_version.py) asserts this override stays == the canonical pin.
+
           aws cloudformation deploy \
             --region "${AWS_REGION}" \
             --stack-name "${{ steps.params.outputs.stack_name }}" \
@@ -124,7 +139,8 @@ jobs:
               CoordinationInternalApiKey="${{ secrets.COORDINATION_INTERNAL_API_KEY }}" \
               AppConfigApplicationId="5t3sqte" \
               AppConfigEnvironmentId="bnwj3lj" \
-              EnceladusCognitoClientSecret="${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}"
+              EnceladusCognitoClientSecret="${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}" \
+              SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10"
 
       - name: Report stack events on failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -167,13 +167,20 @@ fi
 echo ""
 echo "[CHECK 5/6] Validating enceladus-shared layer-version pin (:7-vs-:10 gate)..."
 
-# Template-mode is fail-closed (no AWS creds needed). Add --live opportunistically:
-# it diffs against live get-function-configuration and fails only on a regression
-# (template would move a function to a LOWER version), skipping silently without creds.
-if python3 "${REPO_ROOT}/tools/verify_shared_layer_version.py" "${TEMPLATE_FILE}" --live; then
-    echo "[PASS] enceladus-shared pinned to canonical version; no live regression"
+# Static checks (template Default + workflow --parameter-overrides override) are
+# fail-closed (no AWS creds needed). ENC-TSK-H28 added the workflow-override check that
+# closes the ENC-ISS-385 blind spot: `aws cloudformation deploy` reuses the stale stored
+# SharedLayerArn (:7) unless the workflow passes the canonical override, so a green template
+# Default alone never moved live. --live --regress-only opportunistically diffs the deployed
+# stack param + live get-function-configuration and fails ONLY on a regression (a function/
+# stack ABOVE canonical), TOLERATING a stale :7 here because THIS deploy is what heals it
+# (skips silently without creds). Post-deploy, reconcile with bare --live (fails on ANY
+# != canonical) to PROVE the :7->:10 heal landed -- see the tool docstring.
+if python3 "${REPO_ROOT}/tools/verify_shared_layer_version.py" "${TEMPLATE_FILE}" \
+        --live --regress-only --stack-name "${STACK_NAME}"; then
+    echo "[PASS] enceladus-shared template+workflow pinned to canonical; no live regression"
 else
-    echo "[FAIL] enceladus-shared layer-version parity violation (would re-introduce the :7-class incident, ENC-LSN-053)"
+    echo "[FAIL] enceladus-shared layer-version parity violation (missing workflow override or live regression; would (re)introduce the :7-class incident, ENC-ISS-385 / ENC-LSN-053)"
     ERRORS=$((ERRORS + 1))
 fi
 

--- a/tools/verify_shared_layer_version.py
+++ b/tools/verify_shared_layer_version.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Pre-deploy guard: the enceladus-shared layer in 02-compute.yaml must be pinned to
-the canonical version, and a compute deploy must never REGRESS a live function's layer.
+the canonical version, the sanctioned compute-deploy workflow must PASS that version as
+a --parameter-override, and a compute deploy must never leave a live function on a
+non-canonical layer.
 
 WHY (ENC-TSK-H24, child of ENC-FTR-103) -- the :7-vs-:10 fix
 -----------------------------------------------------------------------------
@@ -13,41 +15,73 @@ ENC-TSK-H05 codified the template default to :10. This guard makes that pin
 ENFORCED so :7 (or any non-canonical version) can never silently return via the
 template default or a per-function hardcode.
 
+WHY (ENC-TSK-H28 / ENC-ISS-385) -- closing the template-Default-only blind spot
+-----------------------------------------------------------------------------
+H24 enforced template Default == :10, yet two successful compute deploys still left
+21/23 fns on :7. ROOT CAUSE: `aws cloudformation deploy` REUSES the stack's stored
+parameter value for any param NOT in --parameter-overrides (the template Default
+applies only when the stack has no stored value). The deployed enceladus-compute
+stack stored SharedLayerArn=:7 and the workflow never passed it, so every deploy
+reused :7 and the :10 Default was inert ("No changes to deploy" for layers). A gate
+that checks only the TEMPLATE stays green while the DEPLOYED param -- and live --
+stay :7. A template Default is NOT a deployed value. This guard now also asserts the
+workflow passes the canonical override, and (--live) reconciles the deployed stack
+param + live function layers against canonical.
+
 CANONICAL VERSION (AC-4 pin -- single source of truth)
 -----------------------------------------------------------------------------
 CANONICAL_SHARED_LAYER_ARN below is the pin. Build provenance (ENC-LSN-020,
 three-flag ABI): the layer is built for the consumers' full ABI -- it carries the
 enceladus_shared package INCLUDING the appconfig_flags submodule that :7 lacked.
 :10 is proven-working on coordination-api in prod. Raising the canonical version
-(e.g. after a vetted rebuild) is a ONE-LINE edit here + the template Default;
-this guard then enforces template == canonical fleet-wide. Supersedes the
-ENC-TSK-D22 layer-ABI parity-gate intent for the V3 lock.
+(e.g. after a vetted rebuild) is a ONE-LINE edit here + the template Default + the
+workflow override; this guard then enforces template == workflow == canonical
+fleet-wide. Supersedes the ENC-TSK-D22 layer-ABI parity-gate intent for the V3 lock.
 
 CHECKS
 -----------------------------------------------------------------------------
-Template mode (default; no AWS creds -- safe for CI, mirrors
+Static mode (default; no AWS creds -- safe for CI, mirrors
 verify_internal_key_coverage.py):
   1. The SharedLayerArn parameter Default == CANONICAL_SHARED_LAYER_ARN.
   2. No resource hardcodes a DIFFERENT enceladus-shared:N ARN literal (every
      consumer must inherit via !Ref SharedLayerArn, or pin the canonical version).
+  3. (ENC-TSK-H28 / ENC-ISS-385) The sanctioned compute-deploy workflow PASSES
+     SharedLayerArn=CANONICAL in `aws cloudformation deploy --parameter-overrides`.
+     Without it the deploy reuses the stale stored param (:7) and the :10 template
+     Default is inert -- the H24 gate stayed green while live stayed :7 on 21/23 fns.
 
-Live mode (--live; requires aws creds, defense-in-depth per ENC-FTR-102 AC-4):
-  3. For each managed function in lambda_workflow_manifest.json, the canonical
-     template version must not REGRESS the live attached enceladus-shared version
-     (template_version < live_version => the deploy would move a function DOWN).
+Live mode (--live; requires aws creds -- reconciliation / defense-in-depth per
+ENC-FTR-102 AC-4. Run to PROVE the heal post-deploy or to detect drift; NOT the
+pre-deploy blocker -- pre-deploy the live state legitimately sits at :7 until the
+deploy runs, which is exactly why checks 1-3 are the pre-deploy gate):
+  4. The DEPLOYED stack's SharedLayerArn parameter (describe-stacks) == canonical.
+  5. Every managed function in lambda_workflow_manifest.json has its live attached
+     enceladus-shared version == canonical -- FIRING on a STALE version (live <
+     canonical, the :7-stuck state) as well as a REGRESS (live > canonical).
+     --regress-only narrows checks 4-5 to fire ONLY on a REGRESS (live > canonical),
+     TOLERATING a stale live -- the pre-deploy regression guard used by
+     tools/pre-deploy-health-gate.sh, where a stale :7 is the state THIS deploy heals
+     (firing on it pre-deploy would deadlock the heal). Post-deploy, use bare --live.
 
 Exit 0 = all checks pass. Exit 1 = a violation that would (re)introduce the
 :7-class incident. Exit 2 = usage error.
 
 WIRING (coordinate with ENC-FTR-102 / ENC-TSK-H13)
 -----------------------------------------------------------------------------
-Run before `aws cloudformation deploy` in the sanctioned compute deploy path
+Pre-deploy (static, no creds) -- run in the sanctioned compute deploy path
 (.github/workflows/cloudformation-compute-stack-deploy.yml) and/or from
-tools/pre-deploy-health-gate.sh:
+tools/pre-deploy-health-gate.sh. The workflow path is auto-derived from the
+template's repo root; override with --workflow:
 
     python3 tools/verify_shared_layer_version.py infrastructure/cloudformation/02-compute.yaml
 
-Self-test (AC-3 'proven to fire on a synthetic version mismatch'):
+Post-deploy reconciliation (proves the :7->:10 heal moved live; ENC-ISS-385 AC):
+
+    python3 tools/verify_shared_layer_version.py infrastructure/cloudformation/02-compute.yaml \
+        --live --stack-name enceladus-compute   # or enceladus-compute-gamma
+
+Self-test (ENC-TSK-H24 AC-3 + ENC-TSK-H28 AC-2: fires on a synthetic version
+mismatch, a missing/non-canonical workflow override, and a stale :7 live param):
 
     python3 tools/verify_shared_layer_version.py --selftest
 """
@@ -63,6 +97,13 @@ import tempfile
 CANONICAL_SHARED_LAYER_ARN = (
     "arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10"
 )
+
+# ENC-TSK-H28 / ENC-ISS-385: the sanctioned compute-deploy workflow that MUST pass
+# SharedLayerArn in --parameter-overrides (path relative to repo root; auto-derived from
+# the template's location, overridable with --workflow), and the default stack whose
+# deployed SharedLayerArn parameter --live reconciles against.
+DEFAULT_WORKFLOW_PATH = ".github/workflows/cloudformation-compute-stack-deploy.yml"
+DEFAULT_STACK_NAME = "enceladus-compute"
 
 LAYER_NAME = "enceladus-shared"
 # arn:aws:lambda:<region>:<acct>:layer:enceladus-shared:<version>
@@ -146,6 +187,62 @@ def check_template(path):
     return failures
 
 
+def shared_layer_override(path):
+    """Return the enceladus-shared ARN passed as the SharedLayerArn override in the
+    compute-deploy workflow's `aws cloudformation deploy --parameter-overrides`, or None
+    if the workflow does not pass SharedLayerArn. Line scan (no YAML dep): each override is
+    its own line `SharedLayerArn="<arn>"` (the file's convention, mirroring the AppConfig*/
+    EnceladusCognitoClientSecret overrides). COMMENT lines are skipped so a prose mention of
+    `SharedLayerArn=:7` (e.g. the H05/H28 rationale comments) cannot masquerade as the real
+    override. A value that is not a recognizable enceladus-shared ARN is returned verbatim
+    so check_workflow can report it."""
+    if not os.path.isfile(path):
+        return None
+    for raw_line in open(path).read().split("\n"):
+        stripped = raw_line.strip()
+        if stripped.startswith("#"):
+            continue  # rationale comments may mention SharedLayerArn=:N in prose
+        candidate = stripped.rstrip("\\").strip()
+        if candidate.startswith("SharedLayerArn="):
+            val = candidate[len("SharedLayerArn="):].strip().strip("'\"")
+            m = _ARN_RE.search(val)
+            return m.group(0) if m else val
+    return None
+
+
+def check_workflow(path):
+    """Check 3 (ENC-TSK-H28 / ENC-ISS-385): the compute-deploy workflow must pass
+    SharedLayerArn=CANONICAL in --parameter-overrides. Closes the template-Default-only
+    blind spot -- `aws cloudformation deploy` reuses the stack's stored param value for
+    un-passed params, so the :10 template Default is inert while the deployed param sits
+    at :7. Returns failure strings (empty == pass)."""
+    canonical = _canonical_version()
+    if not os.path.isfile(path):
+        return [
+            f"compute-deploy workflow not found: {path} -- cannot confirm the deploy "
+            f"passes SharedLayerArn=:{canonical}. Without the override the deployed stack "
+            f"param (:7) is retained and the template Default is inert (ENC-ISS-385). "
+            f"Pass --workflow <path> if the workflow lives elsewhere."
+        ]
+    override = shared_layer_override(path)
+    if override is None:
+        return [
+            f"{path} does not pass SharedLayerArn in --parameter-overrides. "
+            f"`aws cloudformation deploy` retains the stale deployed param (:7) and the "
+            f"template :10 Default stays inert -> fns stuck on :7 (ENC-ISS-385). Add "
+            f'SharedLayerArn="{CANONICAL_SHARED_LAYER_ARN}" to the override block.'
+        ]
+    if override != CANONICAL_SHARED_LAYER_ARN:
+        ov = _ARN_RE.search(override)
+        ov = ov.group(1) if ov else "?"
+        return [
+            f"{path} passes SharedLayerArn={override} but canonical is "
+            f"{CANONICAL_SHARED_LAYER_ARN} (:{ov} != :{canonical}). The deploy would "
+            f"force the wrong enceladus-shared version fleet-wide."
+        ]
+    return []
+
+
 def _live_layer_version(function_name, region):
     """Return the live attached enceladus-shared layer version for a function, or None."""
     try:
@@ -169,27 +266,104 @@ def _live_layer_version(function_name, region):
     return None
 
 
-def check_live(repo_root, region):
-    """Check 3 (defense-in-depth): the canonical template version must not regress any
-    live function's attached enceladus-shared version. Returns failure strings."""
+def _live_stack_param(stack_name, region):
+    """Return the deployed stack's SharedLayerArn parameter version (int), or None if the
+    stack / param / creds are unavailable. This is the value `aws cloudformation deploy`
+    reuses for an un-passed param -- the exact quantity ENC-ISS-385 turned on."""
+    try:
+        out = subprocess.check_output(
+            [
+                "aws", "cloudformation", "describe-stacks",
+                "--stack-name", stack_name,
+                "--region", region,
+                "--query",
+                "Stacks[0].Parameters[?ParameterKey=='SharedLayerArn'].ParameterValue",
+                "--output", "json",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    vals = json.loads(out.decode() if isinstance(out, bytes) else out or "null")
+    for val in vals or []:
+        m = _ARN_RE.search(val or "")
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _classify_live_version(label, live_version, canonical, regress_only=False):
+    """Pure comparator (no AWS) for checks 4-5. Returns a failure string when the live
+    version != canonical (STALE if below, REGRESS if above), else None. Factored out so
+    the FIRE-on-:7 / PASS-on-:10 behavior (ENC-TSK-H28 AC-2) is unit-testable offline.
+    regress_only=True tolerates a STALE live (live < canonical) and fires only on a
+    REGRESS -- the pre-deploy regression guard (a stale :7 is the state THIS deploy heals,
+    so firing on it pre-deploy would deadlock the heal)."""
+    if live_version is None:
+        return None  # not found / no creds -> skip silently (caller counts checks)
+    if live_version == canonical:
+        return None
+    if live_version < canonical:
+        if regress_only:
+            return None  # stale tolerated pre-deploy; the deploy heals it
+        return (
+            f"{label}: live enceladus-shared:{live_version} < canonical :{canonical} "
+            f"-> STALE; the :{canonical} heal has NOT moved live here (ENC-ISS-385: the "
+            f"stale deployed SharedLayerArn was retained / the override is not deployed yet)."
+        )
+    return (
+        f"{label}: live enceladus-shared:{live_version} > canonical :{canonical} "
+        f"-> REGRESS; a deploy would move this function/stack DOWN."
+    )
+
+
+def check_live(repo_root, region, stack_name=DEFAULT_STACK_NAME, regress_only=False):
+    """Checks 4-5 (reconciliation / defense-in-depth): the DEPLOYED stack's SharedLayerArn
+    parameter and every managed function's live attached enceladus-shared version must
+    EQUAL canonical -- firing on a stale :7 (heal not applied) as well as a regress.
+    Returns failure strings. Run post-deploy to prove the heal. With regress_only=True it
+    becomes the PRE-deploy regression guard (tolerates stale :7 -- the deploy heals it --
+    and fires only on a function/stack ABOVE canonical), so it can run before the heal
+    without deadlocking it."""
     canonical = _canonical_version()
+    failures = []
+    mode = " (regress-only)" if regress_only else ""
+
+    # Check 4: the deployed stack parameter -- the value the deploy actually reuses.
+    stack_ver = _live_stack_param(stack_name, region)
+    if stack_ver is None:
+        print(
+            f"[INFO] --live{mode}: stack '{stack_name}' SharedLayerArn param not readable "
+            f"(missing stack / param / creds) -- skipped check 4."
+        )
+    else:
+        fail = _classify_live_version(
+            f"stack '{stack_name}' SharedLayerArn param", stack_ver, canonical, regress_only
+        )
+        if fail:
+            failures.append(fail)
+        else:
+            print(
+                f"[INFO] --live{mode}: stack '{stack_name}' SharedLayerArn param = :{stack_ver} "
+                f"(canonical :{canonical})."
+            )
+
+    # Check 5: every managed function's live attached layer version.
     manifest = os.path.join(repo_root, "infrastructure", "lambda_workflow_manifest.json")
     if not os.path.isfile(manifest):
-        return [f"--live: manifest not found: {manifest}"]
+        failures.append(f"--live: manifest not found: {manifest}")
+        return failures
     fns = [f["function_name"] for f in json.load(open(manifest)).get("functions", [])]
-    failures = []
     checked = 0
     for fn in fns:
         live = _live_layer_version(fn, region)
         if live is None:
             continue  # function not found / no shared layer / no creds -> skip silently
         checked += 1
-        if canonical < live:
-            failures.append(
-                f"{fn}: live enceladus-shared:{live} > canonical :{canonical} "
-                f"-> deploy would REGRESS this function's layer."
-            )
-    print(f"[INFO] --live: compared {checked} function(s) against canonical :{canonical}")
+        fail = _classify_live_version(fn, live, canonical, regress_only)
+        if fail:
+            failures.append(fail)
+    print(f"[INFO] --live{mode}: compared {checked} function(s) against canonical :{canonical}.")
     return failures
 
 
@@ -211,34 +385,101 @@ Resources:
         - !Ref SharedLayerArn
 """
 
+# Minimal compute-deploy workflow fragment. check_workflow line-scans for the override,
+# so this need not be valid YAML -- only the --parameter-overrides shape matters.
+_SELFTEST_WORKFLOW = """\
+      - name: Deploy Compute stack (02-compute)
+        run: |
+          aws cloudformation deploy \\
+            --stack-name enceladus-compute \\
+            --parameter-overrides \\
+              DataStackName="enceladus-data" \\
+              CoordinationInternalApiKey="$KEY"{override}
+"""
+
 
 def _selftest():
     canonical = _canonical_version()
     bad_arn = CANONICAL_SHARED_LAYER_ARN.rsplit(":", 1)[0] + ":7"
+    canonical_override_line = ' \\\n              SharedLayerArn="%s"' % CANONICAL_SHARED_LAYER_ARN
+    bad_override_line = ' \\\n              SharedLayerArn="%s"' % bad_arn
     cases = []
-    # case 1: canonical default -> PASS (no failures)
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
-        f.write(_SELFTEST_TEMPLATE.format(arn=CANONICAL_SHARED_LAYER_ARN))
-        good_path = f.name
-    # case 2: :7 default -> must FAIL
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
-        f.write(_SELFTEST_TEMPLATE.format(arn=bad_arn))
-        bad_path = f.name
-    # case 3: canonical default but a stray hardcoded :7 -> must FAIL
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
-        body = _SELFTEST_TEMPLATE.format(arn=CANONICAL_SHARED_LAYER_ARN)
-        body += "        - " + bad_arn + "\n"
+    tmp_paths = []
+
+    def _tmp(suffix, body):
+        f = tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False)
         f.write(body)
-        stray_path = f.name
+        f.close()
+        tmp_paths.append(f.name)
+        return f.name
+
+    # template checks (1-2)
+    good_path = _tmp(".yaml", _SELFTEST_TEMPLATE.format(arn=CANONICAL_SHARED_LAYER_ARN))
+    bad_path = _tmp(".yaml", _SELFTEST_TEMPLATE.format(arn=bad_arn))
+    stray_path = _tmp(
+        ".yaml",
+        _SELFTEST_TEMPLATE.format(arn=CANONICAL_SHARED_LAYER_ARN)
+        + "        - " + bad_arn + "\n",
+    )
+    # workflow check (3)
+    wf_ok = _tmp(".yml", _SELFTEST_WORKFLOW.format(override=canonical_override_line))
+    wf_missing = _tmp(".yml", _SELFTEST_WORKFLOW.format(override=""))
+    wf_bad = _tmp(".yml", _SELFTEST_WORKFLOW.format(override=bad_override_line))
+
+    bad = []
     try:
-        good = check_template(good_path)
         bad = check_template(bad_path)
-        stray = check_template(stray_path)
-        cases.append(("canonical default passes", good == []))
-        cases.append((f"synthetic :7 default fires (canonical :{canonical})", bad != []))
-        cases.append(("synthetic stray hardcoded :7 fires", stray != []))
+        cases.append(("canonical template default passes", check_template(good_path) == []))
+        cases.append(
+            (f"synthetic :7 template default fires (canonical :{canonical})", bad != [])
+        )
+        cases.append(("synthetic stray hardcoded :7 fires", check_template(stray_path) != []))
+        # check 3: workflow override
+        cases.append(
+            ("workflow with canonical SharedLayerArn override passes", check_workflow(wf_ok) == [])
+        )
+        cases.append(
+            (
+                "workflow MISSING SharedLayerArn override fires (ENC-ISS-385 blind spot)",
+                check_workflow(wf_missing) != [],
+            )
+        )
+        cases.append(
+            ("workflow with stale :7 SharedLayerArn override fires", check_workflow(wf_bad) != [])
+        )
+        # checks 4-5: live comparator (synthetic; no AWS)
+        cases.append(
+            (
+                "--live stale :7 stack param FIRES (ENC-TSK-H28 AC-2)",
+                _classify_live_version("stack 'enceladus-compute' param", 7, canonical) is not None,
+            )
+        )
+        cases.append(
+            (
+                f"--live reconciled :{canonical} PASSES",
+                _classify_live_version("stack 'enceladus-compute' param", canonical, canonical) is None,
+            )
+        )
+        cases.append(
+            (
+                "--live regress (> canonical) fires",
+                _classify_live_version("fn", canonical + 1, canonical) is not None,
+            )
+        )
+        cases.append(
+            (
+                "--live --regress-only TOLERATES stale :7 (no pre-deploy deadlock)",
+                _classify_live_version("stack param", 7, canonical, regress_only=True) is None,
+            )
+        )
+        cases.append(
+            (
+                "--live --regress-only still fires on a regress",
+                _classify_live_version("fn", canonical + 1, canonical, regress_only=True) is not None,
+            )
+        )
     finally:
-        for p in (good_path, bad_path, stray_path):
+        for p in tmp_paths:
             os.unlink(p)
 
     ok = True
@@ -246,9 +487,24 @@ def _selftest():
         print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
         ok = ok and passed
     if bad:
-        print("  sample failure message ->", bad[0])
+        print("  sample template failure ->", bad[0])
+    missing_msg = check_workflow_message_sample()
+    if missing_msg:
+        print("  sample workflow failure ->", missing_msg)
     print("SELFTEST:", "PASS" if ok else "FAIL")
     return 0 if ok else 1
+
+
+def check_workflow_message_sample():
+    """Return a representative 'missing override' failure message for selftest display."""
+    f = tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False)
+    try:
+        f.write(_SELFTEST_WORKFLOW.format(override=""))
+        f.close()
+        msgs = check_workflow(f.name)
+        return msgs[0] if msgs else ""
+    finally:
+        os.unlink(f.name)
 
 
 def main(argv):
@@ -256,11 +512,40 @@ def main(argv):
         return _selftest()
 
     region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
-    do_live = "--live" in argv
-    positional = [a for a in argv[1:] if not a.startswith("-")]
+    do_live = False
+    regress_only = False
+    workflow_opt = None
+    stack_name = DEFAULT_STACK_NAME
+    positional = []
+
+    i = 1
+    while i < len(argv):
+        a = argv[i]
+        if a == "--live":
+            do_live = True
+        elif a == "--regress-only":
+            regress_only = True
+        elif a == "--workflow":
+            i += 1
+            workflow_opt = argv[i] if i < len(argv) else None
+        elif a == "--stack-name":
+            i += 1
+            stack_name = argv[i] if i < len(argv) else stack_name
+        elif a.startswith("--workflow="):
+            workflow_opt = a.split("=", 1)[1]
+        elif a.startswith("--stack-name="):
+            stack_name = a.split("=", 1)[1]
+        elif a.startswith("-"):
+            pass  # unknown flag -- ignore
+        else:
+            positional.append(a)
+        i += 1
+
     if len(positional) != 1:
         print(
-            f"usage: {argv[0]} <path-to-02-compute.yaml> [--live] | --selftest",
+            f"usage: {argv[0]} <path-to-02-compute.yaml> "
+            f"[--workflow <deploy-workflow.yml>] "
+            f"[--live [--stack-name <name>] [--regress-only]] | --selftest",
             file=sys.stderr,
         )
         return 2
@@ -269,12 +554,14 @@ def main(argv):
         print(f"FAIL: template not found: {template}", file=sys.stderr)
         return 2
 
+    # template lives at infrastructure/cloudformation/ -> repo root is two up
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(template), "..", ".."))
+    workflow = workflow_opt or os.path.join(repo_root, DEFAULT_WORKFLOW_PATH)
+
     failures = check_template(template)
+    failures += check_workflow(workflow)
     if do_live:
-        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(template)))
-        # template lives at infrastructure/cloudformation/ -> repo root is two up
-        repo_root = os.path.abspath(os.path.join(os.path.dirname(template), "..", ".."))
-        failures += check_live(repo_root, region)
+        failures += check_live(repo_root, region, stack_name, regress_only)
 
     if failures:
         print(
@@ -287,7 +574,7 @@ def main(argv):
         return 1
     print(
         f"OK: enceladus-shared pinned to canonical :{_canonical_version()} "
-        f"(template{' + live' if do_live else ''} parity verified)."
+        f"(template + workflow{' + live' if do_live else ''} parity verified)."
     )
     return 0
 


### PR DESCRIPTION
## Summary

Remediates **ENC-ISS-385** (P1). Two successful compute deploys (runs 27901024599, 27901123885) still left **21/23** `SharedLayerArn`-managed fns on `enceladus-shared:7`. Root cause: `aws cloudformation deploy` **reuses the stored stack parameter value** for any param not in `--parameter-overrides`, so the deployed `enceladus-compute` stack's stale `SharedLayerArn=:7` was retained and the template's `:10` Default was **inert** ("No changes to deploy" for layers). H24's gate only checked the template Default, so it stayed green while live stayed `:7`. AXIS-2 of ENC-LSN-053 / DOC-ED50175387B8.

Commit-Complete: `CCI-80f89ac488cc4e29b33dd85c5d9f19a1`

## Changes
- **`.github/workflows/cloudformation-compute-stack-deploy.yml`** — pass `SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10"` in `--parameter-overrides`, co-landed in the same block as the ENC-TSK-H27 `EnceladusCognitoClientSecret` override. Forces the deployed param to `:10` so the heal moves live across all 23 fns. Also corrected the H05 comment's inaccurate "no UsePreviousValue → resolves to default" CFN-semantics note (AC-4 recurrence-prevention).
- **`tools/verify_shared_layer_version.py`** — extend the H24 gate:
  - `check_workflow()` (static, no creds): **FAILS** when the compute-deploy workflow omits / non-canonically sets the `SharedLayerArn` override — closes the template-Default-only blind spot.
  - `--live`: now reconciles the **deployed stack param** (`describe-stacks`) **and** every managed fn's live layer, firing on any `!= canonical` (stale `:7` or regress).
  - new `--regress-only`: stale-tolerant pre-deploy regression guard.
  - `--selftest` 11/11 PASS.
- **`tools/pre-deploy-health-gate.sh`** — Check 5 → `--live --regress-only --stack-name "${STACK_NAME}"` so it gains the workflow-override check **without deadlocking** the `:7→:10` heal (a strict `--live` would block the deploy because live is still `:7`).

## Acceptance criteria
- **AC-2** ✅ Done & proven: static gate FIRES on the pre-fix workflow (exit 1) and PASSES on the reconciled state (exit 0); `--live` FIRES on synthetic stale `:7` and PASSES on `:10` (selftest).
- **AC-4** ✅ Distinction recorded in code + worklog `[LESSON]`; cross-links applied on the task.
- **AC-1 / AC-3** ⏳ Deploy-gated — require the merge-triggered compute deploy + post-deploy live `23/23` reconciliation (see below).

## Handoff (io-gated / privileged — governed session has no direct AWS access)
1. **Merge** to `main` (branch protection).
2. **Gamma-first** (ENC-LSN-039): merge auto-syncs to `v4/main` → gamma compute deploy; confirm layer heal + `appconfig_flags` import on `enceladus-mcp-code-gamma` **before** prod.
3. **Prod** compute deploy.
4. **Reconcile** (ENC-LSN-053): `python3 tools/verify_shared_layer_version.py infrastructure/cloudformation/02-compute.yaml --live --stack-name enceladus-compute` must PASS (23/23 on `:10`, no `appconfig_flags` ImportError) = AC-1/AC-3 live evidence; also satisfies ENC-TSK-H24 AC-1/AC-2.
- ⚠️ Watch **ENC-ISS-197** (pre-existing `EarlyValidation::ResourceExistenceCheck`) if the deploy errors — separate from H28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)