### PR TITLE
ENC-TSK-H29: unblock gamma 02-compute deploy (ENC-ISS-386)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -83,6 +83,58 @@ jobs:
             echo "data_stack_name=${data_stack_name}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Guard against unadopted out-of-band Lambdas (ENC-TSK-H29 / ENC-ISS-386)
+        run: |
+          set -euo pipefail
+          # ENC-TSK-H29 / ENC-ISS-386: Lambda code+config for the template's functions is created
+          # out-of-band by the matrix-build (_deploy.yml), NOT by this CFN workflow (see the CodeSize
+          # step below). When such a function is created live but never adopted into the target stack,
+          # `aws cloudformation deploy` plans it as an Add, and AWS::EarlyValidation::ResourceExistenceCheck
+          # rejects the ENTIRE change set ("resource already exists") at change-set creation — silently
+          # wedging every deploy to this stack (gamma sat broken ~2 months this way). The failure mode is
+          # opaque (it names no resource), so detect it here and fail closed with the exact remediation.
+          # Precise signal: a template-managed function that exists live but carries NO
+          # aws:cloudformation:stack-name tag is owned by no stack => it will collide. Functions owned by
+          # ANY stack (incl. the intentionally prod-owned enceladus-mcp-code-gamma) are tagged and skipped.
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          suffix="${ENVIRONMENT_SUFFIX}"
+          # Derive the function names THIS template actually declares — literal FunctionNames plus
+          # !Sub "...${EnvironmentSuffix}" rendered with the active suffix. Deliberately NOT the
+          # matrix-build manifest (lambda_workflow_manifest.json), which is a superset that also lists
+          # functions owned by other stacks (checkout-service, mcp-streamable, …) and would false-positive.
+          # The grep drops !Ref/!GetAtt-style FunctionName references (Permissions, EventSourceMappings).
+          template_fns=$(grep -E '^[[:space:]]*FunctionName:' "${TEMPLATE_FILE}" \
+            | sed -E 's/.*FunctionName:[[:space:]]*//; s/!Sub[[:space:]]*//; s/"//g' \
+            | sed -E "s/\\\$\{EnvironmentSuffix\}/${suffix}/g" \
+            | grep -E '^[A-Za-z0-9._-]+$' | sort -u)
+          orphans=()
+          while IFS= read -r fn; do
+            [ -z "${fn}" ] && continue
+            arn=$(aws lambda get-function --function-name "${fn}" --region "${AWS_REGION}" \
+              --query 'Configuration.FunctionArn' --output text 2>/dev/null || echo "")
+            [ -z "${arn}" ] && continue   # not live => CFN will create it fresh; no collision
+            owner=$(aws lambda list-tags --resource "${arn}" --region "${AWS_REGION}" \
+              --query 'Tags."aws:cloudformation:stack-name"' --output text 2>/dev/null || echo "None")
+            # A template-declared function that is live but owned by no stack will collide on Add.
+            # Functions owned by ANY stack (incl. the intentionally prod-owned enceladus-mcp-code-gamma)
+            # are tagged and correctly skipped.
+            if [ "${owner}" = "None" ] || [ -z "${owner}" ]; then
+              orphans+=("${fn}")
+            fi
+          done <<< "${template_fns}"
+          if [ "${#orphans[@]}" -gt 0 ]; then
+            echo "::error::Unadopted out-of-band Lambda(s) detected — live but owned by no CloudFormation stack."
+            echo "::error::This deploy to ${stack_name} would fail AWS::EarlyValidation::ResourceExistenceCheck. Offending function(s):"
+            printf '::error::  - %s\n' "${orphans[@]}"
+            echo "::error::Remediate by IMPORTING them into ${stack_name} before re-running:"
+            echo "::error::  1) aws cloudformation create-change-set --change-set-type IMPORT --stack-name ${stack_name} \\"
+            echo "::error::       --resources-to-import <manifest> --template-url <s3 template> --parameters <UsePreviousValue + new> --capabilities CAPABILITY_NAMED_IAM"
+            echo "::error::  2) aws cloudformation execute-change-set --stack-name ${stack_name} --change-set-name <name>"
+            echo "::error::Full procedure: ENC-TSK-H29 / ENC-ISS-386 worklog."
+            exit 1
+          fi
+          echo "✓ No unadopted out-of-band Lambdas — all live template functions are stack-owned (or will be created fresh)."
+
       - name: Deploy Compute stack (02-compute)
         id: deploy
         run: |

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3269,6 +3269,15 @@ Resources:
 
   EnceladusMcpCodeGammaFunction:
     Type: AWS::Lambda::Function
+    # ENC-TSK-H29 / ENC-ISS-386: FunctionName is a hardcoded literal (no ${EnvironmentSuffix}),
+    # so this resource maps to the SAME physical function in every stack that renders it. The
+    # prod stack (enceladus-compute, Environment=production) already owns enceladus-mcp-code-gamma;
+    # without this condition the gamma stack (enceladus-compute-gamma) also tries to CREATE it and
+    # AWS::EarlyValidation::ResourceExistenceCheck rejects the cross-stack name collision, blocking
+    # every gamma compute deploy. Gating on IsProduction keeps the function prod-owned (zero prod
+    # change) and stops gamma from contending for the name. The live gamma environment continues to
+    # use this function unchanged.
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       FunctionName: enceladus-mcp-code-gamma


### PR DESCRIPTION
## Summary
Remediates **ENC-ISS-386** — the gamma (v4) *CloudFormation Compute Stack Deploy* has failed at change-set creation with `AWS::EarlyValidation::ResourceExistenceCheck` for ~2 months, while the identical commit deploys cleanly to v3/prod.

Live AWS telemetry (io-dev-admin) pinned **two distinct create-vs-already-exists collisions** on `enceladus-compute-gamma`:

1. **`enceladus-mcp-code-gamma`** — `EnceladusMcpCodeGammaFunction` hardcodes its `FunctionName` (no `${EnvironmentSuffix}`, no `Condition`), so the **prod** stack already owns that exact physical function. The gamma stack can never create it. → **Fix: gate the resource on `IsProduction`** (keeps it prod-owned, zero prod change; gamma stops contending for the name).
2. **`devops-deploy-parity-validator-gamma`, `devops-env-drift-auditor-gamma` + their 2 IAM roles** — env-suffixed functions created out-of-band by the matrix-build but never adopted into the gamma stack. → **Remediated operationally** via a CloudFormation resource **IMPORT** (stack now `IMPORT_COMPLETE`; live functions untouched). This PR adds a **deploy-workflow guard** that detects this recurrence class and fails closed with the import remediation, instead of the opaque EarlyValidation error.

## Changes
- `infrastructure/cloudformation/02-compute.yaml` — add `Condition: IsProduction` to `EnceladusMcpCodeGammaFunction`.
- `.github/workflows/cloudformation-compute-stack-deploy.yml` — pre-deploy guard: any template-declared Lambda that is live but owned by no CloudFormation stack fails the deploy closed with the import procedure.

## Verification
- No-execute UPDATE change set on `enceladus-compute-gamma` with the gated template → `CREATE_COMPLETE`, **no** EarlyValidation failure, MCP function correctly absent (56 in-place Modify, no Remove/Replacement).
- Prod unchanged: `Environment=production` → `IsProduction` true → MCP function stays prod-owned. Guard simulated against prod **and** gamma: **0** false positives.

Refs ENC-ISS-386, ENC-ISS-197 (closed prod analog), ENC-TSK-1291/1292.

CCI-b61d32fa60924e8099f82e98c0aa0371

🤖 Generated with [Claude Code](https://claude.com/claude-code)