### PR TITLE
ENC-TSK-H16: codify env_drift_registry.json as the single classified required-env source

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-21.02",
-  "updated_at": "2026-06-21T10:40:00Z",
-  "last_change_summary": "ENC-TSK-G45 + ENC-TSK-G12 (PR #483, ENC-FTR-077): rewrote the top-20 code-mode search/execute tool descriptions in tools/enceladus-mcp-server/server.py to pure Diataxis Reference (DOC-E88C197AE0F3 RULE-06) and added the canonical typed handoff mandate schema (goal/constraints/prior_findings/tools_allowed/output_schema/budget_tokens; tools/enceladus-mcp-server/handoff_mandate.py) wired strict:true into the dispatch-plan generator. No tracker/field schema changes; version bump satisfies the path-triggered Governance Dictionary Guard for the server.py tool-surface change.",
+  "version": "2026-06-21.03",
+  "updated_at": "2026-06-21T12:33:34Z",
+  "last_change_summary": "ENC-TSK-H16 (PR #510, ENC-PLN-048 Obj 1 / ENC-FTR-102): made backend/lambda/env_drift_auditor/env_drift_registry.json the single canonical required-env + deploy-critical/advisory classification source consumed by both the pre-deploy env-parity gate and the post-deploy env_drift_auditor (removed the advisory_vars second copy from tools/env_parity_waivers.json). Touched backend/lambda/env_drift_auditor/lambda_function.py (advisory-aware scan). No tracker/field/governed-entity schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob).",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/env_drift_auditor/env_drift_registry.json
+++ b/backend/lambda/env_drift_auditor/env_drift_registry.json
@@ -1,5 +1,22 @@
 {
-  "_doc": "ENC-ISS-283 REQUIRED_ENV registry. Maps Lambda function name to the list of env vars that MUST be set and non-empty at runtime. Derived from three prod incidents in Apr 2026 where env vars silently went missing across deploys. Extend by adding entries — the auditor will pick them up on next scheduled run.",
+  "_doc": "ENC-ISS-283 REQUIRED_ENV registry. Maps each Lambda function name to the env vars that MUST be set and non-empty at runtime, each with a deploy-critical/advisory classification. Derived from three prod incidents in Apr 2026 (and the 2026-06 ENC-ISS-369 SQS_QUEUE_URL recurrence) where env vars silently went missing across full-env CFN deploys. ENC-TSK-H16 (ENC-PLN-048 Obj 1): this file is the SINGLE canonical required-env + classification source — consumed by the pre-deploy env-parity gate (tools/cfn_env_resolver.py + tools/env_parity_gate.py + tools/live_template_strip_detector.py, ENC-FTR-102) AND the post-deploy env_drift_auditor (backend/lambda/env_drift_auditor/lambda_function.py). No second copy: classification lives here, not in tools/env_parity_waivers.json. Extend by adding entries — both the gate and the auditor pick them up. Entry-shape interpretation lives in backend/lambda/env_drift_auditor/env_parity_core.py.",
+  "_schema": {
+    "version": "2026-06-21-h16",
+    "format": "lambdas.<function_name> maps to an object {ENV_VAR: classification}. classification is one of: 'deploy-critical' or 'advisory'.",
+    "classifications": {
+      "deploy-critical": "The CFN template MUST set this var. Pre-deploy gate FAILS CLOSED if the template-resolved env would not set it (the var would be stripped on the next full-env deploy — the ENC-LSN-053 / ENC-ISS-369 class). Post-deploy auditor files a P0 drift issue if it is missing or placeholder on the live function.",
+      "advisory": "Pre-deploy gate WARNS (does not fail) if the template would not set it; post-deploy auditor reports it without filing a P0. Use for conditionally-set vars the template may legitimately leave unset for a given parameter set — e.g. APPCONFIG_* gated by HasAppConfigLayer (!If -> AWS::NoValue), where the appconfig extension degrades to env fallback when absent."
+    },
+    "default_classification": "deploy-critical",
+    "legacy_form": "A function may still map to a flat list [\"VAR\", ...]; every var in a list entry is treated as deploy-critical (the fail-closed default). New entries should use the {VAR: classification} object form.",
+    "example": {
+      "EXAMPLE-some-function": {
+        "REQUIRED_TABLE": "deploy-critical",
+        "APPCONFIG_APPLICATION": "advisory"
+      }
+    },
+    "provenance": "Deploy-critical vars and coverage gaps surfaced by the ENC-TSK-H15 coverage matrix (DOC-0C7E8AEF512E, ENC-PLN-048 Obj 1 child 1.1): COORDINATION_INTERNAL_API_KEY is deploy-critical on all 10 of its compute-stack consumers (it was the 2026-06-18 Sev-1 strip casualty, ENC-TSK-H04/H05); SQS_QUEUE_URL is deploy-critical on devops-deploy-intake (ENC-ISS-369, templated by ENC-TSK-H26). Out-of-band functions with no FunctionName in any CFN template (checkout_service, deploy_capability_auditor) are NOT added — they are not subject to the compute-stack strip (H15 waiver)."
+  },
   "_policy": {
     "scan_interval": "hourly",
     "on_drift_action": "create_tracker_issue",
@@ -8,72 +25,85 @@
     "issue_project_id": "enceladus"
   },
   "lambdas": {
-    "devops-deploy-intake": [
-      "COORDINATION_INTERNAL_API_KEY",
-      "DEPLOY_TABLE",
-      "PROJECTS_TABLE",
-      "SQS_QUEUE_URL"
-    ],
-    "devops-graph-query-api": [
-      "COORDINATION_INTERNAL_API_KEY",
-      "NEO4J_SECRET_NAME",
-      "COGNITO_USER_POOL_ID",
-      "COGNITO_CLIENT_ID"
-    ],
-    "devops-github-integration": [
-      "COORDINATION_INTERNAL_API_KEY",
-      "DEPLOY_TABLE",
-      "ALLOWED_REPOS",
-      "GITHUB_APP_ID",
-      "GITHUB_INSTALLATION_ID"
-    ],
-    "devops-document-api": [
-      "DOCUMENTS_TABLE",
-      "COGNITO_USER_POOL_ID",
-      "COGNITO_CLIENT_ID"
-    ],
-    "devops-coordination-api": [
-      "COORDINATION_INTERNAL_API_KEY",
-      "TRACKER_TABLE",
-      "PROJECTS_TABLE",
-      "COGNITO_USER_POOL_ID",
-      "COGNITO_CLIENT_ID"
-    ],
-    "devops-deploy-decide": [
-      "COGNITO_USER_POOL_ID",
-      "COGNITO_CLIENT_ID",
-      "DEPLOY_TABLE",
-      "ALLOWED_REPOS",
-      "GITHUB_APP_ID",
-      "GITHUB_INSTALLATION_ID"
-    ],
-    "devops-deploy-finalize": [
-      "DEPLOY_TABLE",
-      "PROJECTS_TABLE",
-      "TRACKER_TABLE",
-      "CONFIG_BUCKET"
-    ],
-    "devops-tracker-mutation-api": [
-      "DYNAMODB_TABLE",
-      "PROJECTS_TABLE",
-      "COORDINATION_INTERNAL_API_KEY"
-    ],
-    "enceladus-mcp-code": [
-      "TRACKER_TABLE",
-      "PROJECTS_TABLE",
-      "DOCUMENTS_TABLE",
-      "COORDINATION_INTERNAL_API_KEY",
-      "ENCELADUS_COGNITO_USER_POOL_ID",
-      "ENCELADUS_COGNITO_CLIENT_ID"
-    ],
-    "enceladus-mcp-code-gamma": [
-      "TRACKER_TABLE",
-      "PROJECTS_TABLE",
-      "DOCUMENTS_TABLE",
-      "COORDINATION_INTERNAL_API_KEY",
-      "ENCELADUS_COGNITO_USER_POOL_ID",
-      "ENCELADUS_COGNITO_CLIENT_ID",
-      "ENCELADUS_COGNITO_CLIENT_SECRET"
-    ]
+    "devops-deploy-intake": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "DEPLOY_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "SQS_QUEUE_URL": "deploy-critical"
+    },
+    "devops-graph-query-api": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "NEO4J_SECRET_NAME": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical"
+    },
+    "devops-github-integration": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "DEPLOY_TABLE": "deploy-critical",
+      "ALLOWED_REPOS": "deploy-critical",
+      "GITHUB_APP_ID": "deploy-critical",
+      "GITHUB_INSTALLATION_ID": "deploy-critical"
+    },
+    "devops-document-api": {
+      "DOCUMENTS_TABLE": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-coordination-api": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "TRACKER_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical"
+    },
+    "devops-changelog-api": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-deploy-decide": {
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical",
+      "DEPLOY_TABLE": "deploy-critical",
+      "ALLOWED_REPOS": "deploy-critical",
+      "GITHUB_APP_ID": "deploy-critical",
+      "GITHUB_INSTALLATION_ID": "deploy-critical"
+    },
+    "devops-deploy-finalize": {
+      "DEPLOY_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "TRACKER_TABLE": "deploy-critical",
+      "CONFIG_BUCKET": "deploy-critical"
+    },
+    "devops-deploy-parity-validator": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-env-drift-auditor": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-project-service": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-tracker-mutation-api": {
+      "DYNAMODB_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "enceladus-mcp-code": {
+      "TRACKER_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "DOCUMENTS_TABLE": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "ENCELADUS_COGNITO_USER_POOL_ID": "deploy-critical",
+      "ENCELADUS_COGNITO_CLIENT_ID": "deploy-critical"
+    },
+    "enceladus-mcp-code-gamma": {
+      "TRACKER_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "DOCUMENTS_TABLE": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "ENCELADUS_COGNITO_USER_POOL_ID": "deploy-critical",
+      "ENCELADUS_COGNITO_CLIENT_ID": "deploy-critical",
+      "ENCELADUS_COGNITO_CLIENT_SECRET": "deploy-critical"
+    }
   }
 }

--- a/backend/lambda/env_drift_auditor/env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/env_parity_core.py
@@ -16,6 +16,19 @@ now live here, so the pre-deploy detector reuses exactly the same primitives
 rather than re-deriving them. Post-deploy and pre-deploy stay consistent by
 construction.
 
+ENC-TSK-H16 (ENC-PLN-048 Objective 1, parent ENC-TSK-H11): this module is also
+the SINGLE interpreter of the env_drift_registry.json ``lambdas`` entry shape and
+its per-var deploy-critical/advisory classification. Every consumer — the H17
+resolver/diff, the H18 pre-deploy gate, the H19 strip detector, and the
+post-deploy auditor — reads the registry through ``required_vars`` /
+``classification_of`` here instead of re-deriving the shape, so the classification
+has exactly one source of truth (AC2: "single source, no second copy"). Two entry
+shapes are accepted per function:
+
+  * dict (canonical, H16): ``{"VAR": "deploy-critical" | "advisory", ...}``
+  * list (legacy):         ``["VAR", ...]`` — every var treated as deploy-critical
+    (the fail-closed default).
+
 Pure module: no environment reads, no AWS calls, no side effects at import time
 (unlike lambda_function.py, which reads os.environ at import) — so it is safe to
 import from CLI tools and unit tests.
@@ -78,3 +91,66 @@ def live_only_vars(live_env: Dict[str, str], template_env: Dict[str, str]) -> Li
     -unset var is not mistaken for a live-only var.
     """
     return sorted(set(live_env or {}) - set(template_env or {}))
+
+
+# ---------------------------------------------------------------------------
+# Registry entry shape + per-var classification (ENC-TSK-H16)
+# ---------------------------------------------------------------------------
+# A function's env_drift_registry.json "lambdas" entry declares its required env
+# vars. H16 adds a per-var classification while keeping the legacy flat-list form
+# working. These helpers are the ONLY place that interprets the entry shape, so
+# the resolver, gate, strip detector, and auditor never re-derive it (AC2).
+
+DEPLOY_CRITICAL = "deploy-critical"
+ADVISORY = "advisory"
+VALID_CLASSIFICATIONS = (DEPLOY_CRITICAL, ADVISORY)
+# Anything not explicitly classified (legacy list entry, unknown value) is
+# treated as deploy-critical: the gate fails closed and the auditor files a P0.
+DEFAULT_CLASSIFICATION = DEPLOY_CRITICAL
+
+
+def required_vars(entry: Any) -> List[str]:
+    """All required env-var names for a function's registry entry.
+
+    Accepts the canonical dict form ``{"VAR": classification}`` (returns its keys)
+    or the legacy list form ``["VAR", ...]``. ``None`` (no entry) yields ``[]``.
+    """
+    if entry is None:
+        return []
+    if isinstance(entry, dict):
+        return list(entry.keys())
+    if isinstance(entry, (list, tuple)):
+        return list(entry)
+    raise TypeError(f"unsupported registry entry type: {type(entry).__name__}")
+
+
+def classification_of(entry: Any, var: str) -> str:
+    """Classification of a single var: ``deploy-critical`` or ``advisory``.
+
+    Legacy list entries, unknown classification strings, and vars absent from a
+    dict entry all resolve to ``deploy-critical`` (the fail-closed default).
+    """
+    if isinstance(entry, dict):
+        value = entry.get(var, DEFAULT_CLASSIFICATION)
+        return value if value in VALID_CLASSIFICATIONS else DEFAULT_CLASSIFICATION
+    return DEFAULT_CLASSIFICATION
+
+
+def is_deploy_critical(entry: Any, var: str) -> bool:
+    """True if ``var`` is deploy-critical for this entry (gate fails closed)."""
+    return classification_of(entry, var) == DEPLOY_CRITICAL
+
+
+def critical_vars(entry: Any) -> List[str]:
+    """Required vars classified deploy-critical (gate FAIL / auditor P0 set)."""
+    return [v for v in required_vars(entry) if is_deploy_critical(entry, v)]
+
+
+def advisory_vars(entry: Any) -> List[str]:
+    """Required vars classified advisory (gate WARN / auditor report-only set)."""
+    return [v for v in required_vars(entry) if not is_deploy_critical(entry, v)]
+
+
+def classification_map(entry: Any) -> Dict[str, str]:
+    """``{var: classification}`` for every required var in the entry."""
+    return {v: classification_of(entry, v) for v in required_vars(entry)}

--- a/backend/lambda/env_drift_auditor/lambda_function.py
+++ b/backend/lambda/env_drift_auditor/lambda_function.py
@@ -25,7 +25,10 @@ from typing import Any, Dict, List, Tuple
 import boto3
 
 # ENC-TSK-H19: shared comparison core — single source for pre- and post-deploy.
-from env_parity_core import build_placeholders, classify_required
+# ENC-TSK-H16: critical_vars/advisory_vars read the per-var deploy-critical vs
+# advisory classification from the same core, so the auditor and the pre-deploy
+# gate split the registry the same way (no second copy).
+from env_parity_core import build_placeholders, classify_required, critical_vars, advisory_vars
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -138,8 +141,15 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     results: List[Dict[str, Any]] = []
     drift_count = 0
     ok_count = 0
+    advisory_drift_count = 0
 
-    for fn_name, required in REGISTRY.get("lambdas", {}).items():
+    for fn_name, spec in REGISTRY.get("lambdas", {}).items():
+        # ENC-TSK-H16: P0 drift issues fire only for deploy-critical vars. Advisory
+        # vars are reported but never file a P0 — the pre-deploy gate WARNs on them
+        # too, so the post-deploy auditor and the gate classify the registry the
+        # same way. critical_vars/advisory_vars also accept legacy flat-list entries
+        # (every var deploy-critical), so pre-H16 registries behave unchanged.
+        required = critical_vars(spec)
         status, drift = _audit_lambda(lambda_client, fn_name, required)
         entry: Dict[str, Any] = {"lambda": fn_name, "status": status}
         if drift:
@@ -151,6 +161,14 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             drift_count += 1
         else:
             ok_count += 1
+
+        advisory = advisory_vars(spec)
+        if advisory:
+            # Report-only: surface advisory misses without filing a P0 issue.
+            _, adv_drift = _audit_lambda(lambda_client, fn_name, advisory)
+            if adv_drift:
+                entry["advisory_drift"] = adv_drift
+                advisory_drift_count += 1
         results.append(entry)
 
     summary = {
@@ -158,8 +176,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "ok": ok_count,
         "drift": drift_count,
+        "advisory_drift": advisory_drift_count,
         "total": ok_count + drift_count,
         "results": results,
     }
-    logger.info("env_drift_auditor run complete: ok=%d drift=%d", ok_count, drift_count)
+    logger.info(
+        "env_drift_auditor run complete: ok=%d drift=%d advisory_drift=%d",
+        ok_count, drift_count, advisory_drift_count,
+    )
     return summary

--- a/backend/lambda/env_drift_auditor/test_env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/test_env_parity_core.py
@@ -52,6 +52,56 @@ def test_live_only_vars():
     assert core.live_only_vars({}, {"A": "1"}) == []
 
 
+# --- ENC-TSK-H16: registry entry shape + classification --------------------
+def test_required_vars_dict_and_list_and_none():
+    assert core.required_vars({"A": "deploy-critical", "B": "advisory"}) == ["A", "B"]
+    assert core.required_vars(["A", "B"]) == ["A", "B"]  # legacy flat list
+    assert core.required_vars(None) == []
+
+
+def test_required_vars_rejects_bad_type():
+    try:
+        core.required_vars(42)
+    except TypeError:
+        return
+    raise AssertionError("expected TypeError for non-dict/list entry")
+
+
+def test_classification_of_dict_list_and_default():
+    entry = {"A": "deploy-critical", "B": "advisory"}
+    assert core.classification_of(entry, "A") == core.DEPLOY_CRITICAL
+    assert core.classification_of(entry, "B") == core.ADVISORY
+    # var absent from a dict entry -> fail-closed default (deploy-critical)
+    assert core.classification_of(entry, "Z") == core.DEPLOY_CRITICAL
+    # unknown classification string -> fail-closed default
+    assert core.classification_of({"A": "wat"}, "A") == core.DEPLOY_CRITICAL
+    # legacy list entry -> every var deploy-critical
+    assert core.classification_of(["A"], "A") == core.DEPLOY_CRITICAL
+
+
+def test_is_deploy_critical():
+    entry = {"A": "deploy-critical", "B": "advisory"}
+    assert core.is_deploy_critical(entry, "A") is True
+    assert core.is_deploy_critical(entry, "B") is False
+    assert core.is_deploy_critical(["A"], "A") is True  # legacy = critical
+
+
+def test_critical_and_advisory_partition():
+    entry = {"A": "deploy-critical", "B": "advisory", "C": "deploy-critical"}
+    assert core.critical_vars(entry) == ["A", "C"]
+    assert core.advisory_vars(entry) == ["B"]
+    # legacy list: all critical, none advisory
+    assert core.critical_vars(["A", "B"]) == ["A", "B"]
+    assert core.advisory_vars(["A", "B"]) == []
+
+
+def test_classification_map():
+    entry = {"A": "deploy-critical", "B": "advisory"}
+    assert core.classification_map(entry) == {"A": "deploy-critical", "B": "advisory"}
+    assert core.classification_map(["A"]) == {"A": "deploy-critical"}
+    assert core.classification_map(None) == {}
+
+
 # --- AC2: env_drift_auditor delegates to the shared core --------------------
 class _StubExceptions:
     class ResourceNotFoundException(Exception):

--- a/tools/cfn_env_resolver.py
+++ b/tools/cfn_env_resolver.py
@@ -41,6 +41,15 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+# ENC-TSK-H16: env_parity_core is the single interpreter of the registry entry
+# shape + per-var deploy-critical/advisory classification. Add its dir to
+# sys.path so this resolver (and the gate/detector that import it) reads the
+# classification from one place instead of re-deriving it (AC2: no second copy).
+_CORE_DIR = str(Path(__file__).resolve().parents[1] / "backend" / "lambda" / "env_drift_auditor")
+if _CORE_DIR not in sys.path:
+    sys.path.insert(0, _CORE_DIR)
+import env_parity_core as core  # noqa: E402
+
 
 # --- AWS::NoValue sentinel -------------------------------------------------
 # A node that resolves to this is treated as "not set" and dropped from its
@@ -320,7 +329,14 @@ def resolve_function_envs(template: Dict[str, Any], ctx: ResolveContext) -> Dict
     return result
 
 
-def load_required_env(registry_path: Path) -> Dict[str, List[str]]:
+def load_required_env(registry_path: Path) -> Dict[str, Any]:
+    """Load the registry's per-function required-env map.
+
+    Values are either the canonical ENC-TSK-H16 ``{VAR: classification}`` object or
+    a legacy ``[VAR, ...]`` list. Callers must interpret the shape via
+    env_parity_core (``required_vars`` / ``classification_of``) rather than assuming
+    a list — that keeps shape interpretation in one place (AC2).
+    """
     with open(registry_path) as fh:
         registry = json.load(fh)
     return registry.get("lambdas", {})
@@ -328,23 +344,30 @@ def load_required_env(registry_path: Path) -> Dict[str, List[str]]:
 
 def diff_required(
     resolved: Dict[str, Dict[str, Any]],
-    required_map: Dict[str, List[str]],
+    required_map: Dict[str, Any],
 ) -> Dict[str, Dict[str, Any]]:
     """Per-function diff of resolved template env keys vs the required-env registry.
 
-    missing  = required vars not present in the template-resolved env (would fail
-               the parity gate — the deploy would not set a var the handler needs).
+    missing         = required vars not present in the template-resolved env (the
+                      deploy would not set a var the handler needs).
+    classification  = {var: 'deploy-critical'|'advisory'} for every required var,
+                      read from the registry via env_parity_core (ENC-TSK-H16). The
+                      H18 gate uses this to decide FAIL (deploy-critical) vs WARN
+                      (advisory) — no separate advisory list (AC2: single source).
     """
     report: Dict[str, Dict[str, Any]] = {}
     for fn_name, info in resolved.items():
         keys = set(info["resolved_env"])
-        required = required_map.get(fn_name, [])
+        has_entry = fn_name in required_map
+        entry = required_map.get(fn_name)
+        required = core.required_vars(entry) if has_entry else []
         report[fn_name] = {
             "logical_id": info["logical_id"],
-            "has_registry_entry": fn_name in required_map,
+            "has_registry_entry": has_entry,
             "required": sorted(required),
             "resolved_keys": sorted(keys),
             "missing": sorted(set(required) - keys),
+            "classification": core.classification_map(entry) if has_entry else {},
         }
     return report
 

--- a/tools/env_parity_gate.py
+++ b/tools/env_parity_gate.py
@@ -7,14 +7,18 @@ H17 resolver/diff engine (tools/cfn_env_resolver.py) with fail-closed behavior:
   * Exits NON-ZERO if any deploy-critical required var would be unset by the
     template-resolved env (the H05/H09 "deploy would strip <var>" class).
   * Prints function + var + remediation for every finding.
-  * Advisory vars WARN without failing (configurable per-function or via "*").
+  * Advisory vars WARN without failing. The deploy-critical/advisory split is
+    read from the env_drift_registry.json per-var classification (ENC-TSK-H16),
+    NOT a separate advisory list in the waivers file (AC2: single source).
   * A documented, auditable waiver suppresses a specific (function, var) FAILURE
     — but the waiver is still RECORDED in the report. Waivers are never silent,
     so the gate cannot be quietly bypassed.
 
 Single diff implementation: this gate does NOT re-diff. It consumes
 cfn_env_resolver.diff_required so pre-deploy and the resolver stay consistent
-(ENC-TSK-H17/H19 AC2 — no divergent second implementation).
+(ENC-TSK-H17/H19 AC2 — no divergent second implementation). The classification
+likewise comes from cfn_env_resolver's diff output (registry-sourced), so the
+gate never re-derives whether a var is deploy-critical (ENC-TSK-H16 AC2).
 
 Usage:
   python3 tools/env_parity_gate.py \
@@ -35,6 +39,7 @@ from typing import Any, Dict, List, Optional, Tuple
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import cfn_env_resolver as resolver  # noqa: E402
+import env_parity_core as core  # noqa: E402  (single source of registry classification — ENC-TSK-H16)
 
 CRITICAL = "critical"
 ADVISORY = "advisory"
@@ -45,9 +50,14 @@ _DEFAULT_WAIVERS = _REPO_ROOT / "tools" / "env_parity_waivers.json"
 
 
 def load_waivers(path: Optional[Path]) -> Dict[str, Any]:
-    """Load the waiver/advisory config. Missing file -> empty (fail-closed)."""
+    """Load the waiver config: documented (function, var) failure suppressions.
+
+    Missing file -> empty (fail-closed). ENC-TSK-H16: the deploy-critical/advisory
+    classification is NOT loaded here anymore — it lives in env_drift_registry.json
+    (single source). The waivers file carries only risk-accepted suppressions.
+    """
     if path is None or not Path(path).exists():
-        return {"waivers": {}, "advisory": {}}
+        return {"waivers": {}}
     data = json.loads(Path(path).read_text())
     waivers: Dict[Tuple[str, str], Dict[str, Any]] = {}
     for entry in data.get("waivers", []) or []:
@@ -55,16 +65,7 @@ def load_waivers(path: Optional[Path]) -> Dict[str, Any]:
         var = entry.get("var")
         if fn and var and not str(fn).startswith("EXAMPLE"):
             waivers[(fn, var)] = entry
-    advisory: Dict[str, set] = {}
-    for fn, vars_ in (data.get("advisory_vars", {}) or {}).items():
-        if fn.startswith("_"):
-            continue
-        advisory[fn] = set(vars_ or [])
-    return {"waivers": waivers, "advisory": advisory}
-
-
-def _is_advisory(fn: str, var: str, advisory: Dict[str, set]) -> bool:
-    return var in advisory.get(fn, set()) or var in advisory.get("*", set())
+    return {"waivers": waivers}
 
 
 def _remediation(fn: str, var: str) -> str:
@@ -83,10 +84,16 @@ def run_gate(
     waivers_cfg: Dict[str, Any],
     region: str = resolver.DEFAULT_REGION,
 ) -> Dict[str, Any]:
-    """Resolve template env, diff vs required-env, classify each missing var."""
+    """Resolve template env, diff vs required-env, classify each missing var.
+
+    Classification precedence per missing var: a documented waiver wins (WAIVED,
+    recorded not silent); otherwise the registry's per-var classification decides
+    advisory (WARN) vs deploy-critical (FAIL). The advisory signal is read from the
+    resolver diff's ``classification`` map (registry-sourced, ENC-TSK-H16) — the
+    gate keeps no advisory list of its own.
+    """
     report = resolver.resolve_and_diff(template_path, overrides, registry_path, region=region)
     waivers = waivers_cfg["waivers"]
-    advisory = waivers_cfg["advisory"]
 
     findings: List[Dict[str, Any]] = []
     counts = {CRITICAL: 0, ADVISORY: 0, WAIVED: 0}
@@ -94,11 +101,12 @@ def run_gate(
         d = report["diff"][fn_name]
         if not d["has_registry_entry"]:
             continue  # only registry-governed functions are gated
+        classification = d.get("classification", {})
         for var in d["missing"]:
             if (fn_name, var) in waivers:
                 klass = WAIVED
                 detail = waivers[(fn_name, var)]
-            elif _is_advisory(fn_name, var, advisory):
+            elif classification.get(var) == core.ADVISORY:
                 klass = ADVISORY
                 detail = None
             else:

--- a/tools/env_parity_waivers.json
+++ b/tools/env_parity_waivers.json
@@ -1,5 +1,6 @@
 {
   "_doc": "Documented, auditable waivers for the pre-deploy env parity gate (ENC-TSK-H18, ENC-PLN-048, ENC-FTR-102). A waiver suppresses a specific (function, var) FAILURE so an intentional, justified out-of-band variable does not block a deploy. Waivers are NEVER silent: every waived finding is still printed and recorded in the gate report. To accept a risk, add an entry with a real reason, owner, and review_by date; remove the entry to re-arm the gate for that var. Entries whose function name starts with 'EXAMPLE' are ignored by the loader (documentation only).",
+  "_classification_moved": "ENC-TSK-H16: the deploy-critical vs advisory classification is NO LONGER configured here. It lives in backend/lambda/env_drift_auditor/env_drift_registry.json as a per-var classification field (single source, consumed by both the gate and the post-deploy auditor). To make a required var advisory (gate WARN instead of FAIL), set its classification to 'advisory' in the registry. This file now carries only risk-accepted (function, var) FAILURE suppressions.",
   "_remediation_preferred": "The preferred fix is NOT a waiver but template remediation: add the missing var to the function's Environment.Variables in infrastructure/cloudformation/02-compute.yaml (referencing the deploy parameter that supplies it) so CloudFormation sets it and the next deploy cannot strip the live value.",
   "waivers": [
     {
@@ -9,9 +10,5 @@
       "owner": "io",
       "review_by": "2026-12-31"
     }
-  ],
-  "advisory_vars": {
-    "_comment": "Map a function name (or '*' for all functions) to a list of vars that should WARN instead of FAIL when missing from the template-resolved env. Use sparingly — advisory means 'not deploy-critical'.",
-    "*": []
-  }
+  ]
 }

--- a/tools/live_template_strip_detector.py
+++ b/tools/live_template_strip_detector.py
@@ -12,11 +12,12 @@ template-resolved env is flagged:
 
 — the exact H05/H09 failure signature — BEFORE merge/deploy.
 
-Classification:
-  * critical : the live-only var is a REQUIRED var (env_drift_registry.json).
-    A deploy that strips it reproduces the incident class -> gate FAILS.
-  * warning  : the live-only var is not in the registry (extra / out-of-band but
-    not declared deploy-critical) -> reported, does not fail the gate.
+Classification (ENC-TSK-H16 — registry-sourced, same split as the H18 gate):
+  * critical : the live-only var is a DEPLOY-CRITICAL required var
+    (env_drift_registry.json). A deploy that strips it reproduces the incident
+    class -> detector FAILS.
+  * warning  : the live-only var is classified advisory in the registry, or is
+    not in the registry at all (extra / out-of-band) -> reported, does not fail.
 
 AC2 (no divergent second implementation): the live-vs-template comparison uses
 backend/lambda/env_drift_auditor/env_parity_core.live_only_vars — the same module
@@ -52,14 +53,16 @@ WARNING = "warning"
 def detect(
     template_envs: Dict[str, Dict[str, Any]],
     live_envs: Dict[str, Dict[str, str]],
-    required_map: Dict[str, List[str]],
+    required_map: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Pure comparison: for each function present in BOTH the template and live,
     flag vars that are live-only (the deploy would strip them).
 
     template_envs: {fn: {"resolved_env": {...}}} (H17 output) or {fn: {...env...}}.
     live_envs:     {fn: {var: value}} live Environment.Variables.
-    required_map:  {fn: [required vars]} from env_drift_registry.json.
+    required_map:  {fn: entry} from env_drift_registry.json — entry is the
+                   {VAR: classification} dict (H16) or a legacy [VAR, ...] list;
+                   both are read via env_parity_core (no shape re-derivation).
     """
     findings: List[Dict[str, Any]] = []
     counts = {CRITICAL: 0, WARNING: 0}
@@ -70,16 +73,24 @@ def detect(
         if fn_name not in live_envs:
             skipped.append(fn_name)  # not deployed live (nothing to strip)
             continue
-        required = set(required_map.get(fn_name, []))
+        entry = required_map.get(fn_name)
+        required = set(env_parity_core.required_vars(entry))
         for var in env_parity_core.live_only_vars(live_envs[fn_name], template_env):
-            klass = CRITICAL if var in required else WARNING
+            is_req = var in required
+            # ENC-TSK-H16: stripping a DEPLOY-CRITICAL required var reproduces the
+            # incident class (FAIL). Advisory required vars and out-of-band/
+            # non-registry vars only WARN — same split the H18 gate applies.
+            if is_req and env_parity_core.is_deploy_critical(entry, var):
+                klass = CRITICAL
+            else:
+                klass = WARNING
             counts[klass] += 1
             findings.append(
                 {
                     "function": fn_name,
                     "var": var,
                     "classification": klass,
-                    "required": var in required,
+                    "required": is_req,
                     "message": f"deploy would strip {var} from {fn_name}",
                 }
             )

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -187,9 +187,10 @@ fi
 # --- Check 6: Validate environment-variable parity (ENC-PLN-048 / ENC-FTR-102) ---
 # Resolves the template's per-function Environment.Variables (evaluating
 # !Ref/--parameter-overrides, !Sub, !If/AWS::NoValue) and fails closed if any
-# deploy-critical required var (env_drift_registry.json) would be unset — the
-# exact H05/H09 "deploy would strip <var>" class. Waivers/advisory live in
-# tools/env_parity_waivers.json.
+# deploy-critical required var would be unset — the exact H05/H09 "deploy would
+# strip <var>" class. ENC-TSK-H16: the required vars AND their deploy-critical/
+# advisory classification are the single source in env_drift_registry.json;
+# tools/env_parity_waivers.json carries only risk-accepted failure suppressions.
 echo ""
 echo "[CHECK 6/6] Validating env-var parity (no out-of-band vars the deploy would strip)..."
 

--- a/tools/test_cfn_env_resolver.py
+++ b/tools/test_cfn_env_resolver.py
@@ -149,6 +149,33 @@ def test_diff_required_surfaces_missing_keys():
     diff = r.diff_required(resolved, {"fn-x": ["A", "B"]})
     assert diff["fn-x"]["missing"] == ["B"]
     assert diff["fn-x"]["has_registry_entry"] is True
+    # ENC-TSK-H16: legacy flat-list entry -> every var classified deploy-critical.
+    assert diff["fn-x"]["classification"] == {"A": "deploy-critical", "B": "deploy-critical"}
+
+
+def test_diff_required_surfaces_classification_dict_form():
+    # ENC-TSK-H16: a dict-form registry entry surfaces per-var classification in
+    # the diff so the H18 gate can split FAIL (deploy-critical) vs WARN (advisory)
+    # without re-deriving it.
+    resolved = {"fn-x": {"logical_id": "X", "resolved_env": {"A": "1"}}}
+    diff = r.diff_required(
+        resolved, {"fn-x": {"A": "deploy-critical", "B": "advisory", "C": "deploy-critical"}}
+    )
+    assert diff["fn-x"]["missing"] == ["B", "C"]
+    assert diff["fn-x"]["classification"] == {
+        "A": "deploy-critical",
+        "B": "advisory",
+        "C": "deploy-critical",
+    }
+    assert diff["fn-x"]["has_registry_entry"] is True
+
+
+def test_diff_required_no_entry_has_empty_classification():
+    resolved = {"fn-y": {"logical_id": "Y", "resolved_env": {"A": "1"}}}
+    diff = r.diff_required(resolved, {})  # fn-y not in registry
+    assert diff["fn-y"]["has_registry_entry"] is False
+    assert diff["fn-y"]["missing"] == []
+    assert diff["fn-y"]["classification"] == {}
 
 
 def test_secret_params_redacted_in_report():

--- a/tools/test_env_parity_gate.py
+++ b/tools/test_env_parity_gate.py
@@ -55,7 +55,7 @@ def test_critical_missing_fails():
         tmp = Path(d)
         tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
         reg = _registry(tmp, {"fn-a": ["PRESENT", "NEEDED"], "fn-b": ["PRESENT"]})
-        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}})
         assert result["failed"] is True
         crit = [f for f in result["findings"] if f["classification"] == gate.CRITICAL]
         assert len(crit) == 1
@@ -70,7 +70,6 @@ def test_waiver_suppresses_but_records():
         reg = _registry(tmp, {"fn-a": ["PRESENT", "NEEDED"]})
         cfg = {
             "waivers": {("fn-a", "NEEDED"): {"reason": "intentional", "owner": "io", "review_by": "2026-12-31"}},
-            "advisory": {},
         }
         result = gate.run_gate(tpl, {}, reg, cfg)
         assert result["failed"] is False  # waived -> no critical
@@ -80,26 +79,34 @@ def test_waiver_suppresses_but_records():
 
 
 def test_advisory_warns_without_failing():
+    # ENC-TSK-H16: advisory is read from the registry per-var classification, not
+    # a cfg advisory list. A missing advisory var WARNs; the gate does not fail.
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
         tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
-        reg = _registry(tmp, {"fn-a": ["PRESENT", "OPTIONAL"]})
-        cfg = {"waivers": {}, "advisory": {"fn-a": {"OPTIONAL"}}}
-        result = gate.run_gate(tpl, {}, reg, cfg)
+        reg = _registry(tmp, {"fn-a": {"PRESENT": "deploy-critical", "OPTIONAL": "advisory"}})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}})
         assert result["failed"] is False
         adv = [f for f in result["findings"] if f["classification"] == gate.ADVISORY]
         assert len(adv) == 1 and adv[0]["var"] == "OPTIONAL"
 
 
-def test_advisory_wildcard():
+def test_mixed_entry_critical_fails_advisory_warns():
+    # ENC-TSK-H16: in one dict entry, a missing deploy-critical var FAILS while a
+    # missing advisory var only WARNs — both surfaced, single registry source.
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
         tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
-        reg = _registry(tmp, {"fn-a": ["PRESENT", "OPTIONAL"]})
-        cfg = {"waivers": {}, "advisory": {"*": {"OPTIONAL"}}}
-        result = gate.run_gate(tpl, {}, reg, cfg)
-        assert result["failed"] is False
+        reg = _registry(
+            tmp,
+            {"fn-a": {"PRESENT": "deploy-critical", "NEEDED": "deploy-critical", "OPTIONAL": "advisory"}},
+        )
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}})
+        assert result["failed"] is True
+        assert result["counts"][gate.CRITICAL] == 1
         assert result["counts"][gate.ADVISORY] == 1
+        crit = [f for f in result["findings"] if f["classification"] == gate.CRITICAL]
+        assert crit[0]["var"] == "NEEDED"
 
 
 def test_all_present_passes():
@@ -107,7 +114,7 @@ def test_all_present_passes():
         tmp = Path(d)
         tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
         reg = _registry(tmp, {"fn-a": ["PRESENT"], "fn-b": ["PRESENT", "ALSO"]})
-        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}})
         assert result["failed"] is False
         assert result["findings"] == []
 
@@ -118,7 +125,7 @@ def test_untracked_function_not_gated():
         tpl = _write(tmp, "t.yaml", SYNTH_TEMPLATE)
         # fn-b not in registry -> not gated even though it has extra var.
         reg = _registry(tmp, {"fn-a": ["PRESENT"]})
-        result = gate.run_gate(tpl, {}, reg, {"waivers": {}, "advisory": {}})
+        result = gate.run_gate(tpl, {}, reg, {"waivers": {}})
         assert all(f["function"] != "fn-b" for f in result["findings"])
 
 
@@ -134,6 +141,9 @@ def test_load_waivers_filters_example_entries():
                         {"function": "EXAMPLE-x", "var": "Y", "reason": "doc"},
                         {"function": "fn-a", "var": "NEEDED", "reason": "real", "owner": "io"},
                     ],
+                    # ENC-TSK-H16: advisory_vars is no longer read from this file
+                    # (classification lives in the registry). A stale key here must
+                    # be ignored, not crash the loader.
                     "advisory_vars": {"_comment": "x", "fn-a": ["OPT"]},
                 }
             ),
@@ -141,7 +151,7 @@ def test_load_waivers_filters_example_entries():
         cfg = gate.load_waivers(wf)
         assert ("fn-a", "NEEDED") in cfg["waivers"]
         assert ("EXAMPLE-x", "Y") not in cfg["waivers"]
-        assert cfg["advisory"]["fn-a"] == {"OPT"}
+        assert "advisory" not in cfg  # classification no longer sourced here
 
 
 def test_main_exit_code_nonzero_on_critical():

--- a/tools/test_live_template_strip_detector.py
+++ b/tools/test_live_template_strip_detector.py
@@ -52,6 +52,20 @@ def test_live_only_nonrequired_is_warning():
     assert len(warn) == 1 and warn[0]["var"] == "MANUAL_DEBUG_FLAG"
 
 
+def test_advisory_required_live_only_is_warning():
+    # ENC-TSK-H16: a live-only var that is REQUIRED but classified advisory WARNs
+    # (not FAIL) — the same split the H18 gate applies. A deploy-critical live-only
+    # var still FAILs, so the detector fails overall.
+    template = {"fn": {"resolved_env": {"A": "1"}}}
+    live = {"fn": {"A": "1", "OPT": "x", "KEY": "y"}}
+    required_map = {"fn": {"A": "deploy-critical", "OPT": "advisory", "KEY": "deploy-critical"}}
+    result = det.detect(template, live, required_map)
+    assert result["failed"] is True  # KEY (deploy-critical) is live-only
+    by_var = {f["var"]: f["classification"] for f in result["findings"]}
+    assert by_var["OPT"] == det.WARNING
+    assert by_var["KEY"] == det.CRITICAL
+
+
 def test_function_not_live_is_skipped():
     template = {"fn-a": {"resolved_env": {"A": "1"}}, "fn-b": {"resolved_env": {"B": "1"}}}
     live = {"fn-a": {"A": "1"}}  # fn-b not deployed


### PR DESCRIPTION
## ENC-TSK-H16 — single classified required-env source for the env-parity gate + auditor

**Plan:** ENC-PLN-048 Obj 1 (child 1.2) · **Parent:** ENC-TSK-H11 · **Feature:** ENC-FTR-102 · **1.1 findings:** DOC-0C7E8AEF512E (H15 coverage matrix)

CCI-ca6060a511714eeeb644725042bf0bed

### What & why
Makes `backend/lambda/env_drift_auditor/env_drift_registry.json` the single canonical required-env **+ deploy-critical/advisory classification** source consumed by **both** the pre-deploy env-parity gate (ENC-FTR-102) and the post-deploy env_drift_auditor. Eliminates the "second copy" — the `advisory_vars` map previously in `tools/env_parity_waivers.json`. Satisfies the AC2 "single source, no second copy" requirement.

### Changes (12 files, +395/−126)
- **Registry**: each function → `{VAR: "deploy-critical"|"advisory"}` (legacy flat list still accepted = all deploy-critical, fail-closed). `COORDINATION_INTERNAL_API_KEY` now registry-guarded on **all 10** compute-stack consumers (matrix §4.1/§6c gap closed: added changelog-api, deploy-parity-validator, env-drift-auditor, project-service + key on document-api); `SQS_QUEUE_URL` deploy-critical on deploy-intake (templated by H26). Added `_schema` doc block. 7→14 entries.
- **`env_parity_core.py`**: `required_vars`/`classification_of`/`is_deploy_critical`/`critical_vars`/`advisory_vars`/`classification_map` — the single entry-shape interpreter.
- **Gate/resolver/strip-detector**: read classification from the registry; **auditor** files P0 only for deploy-critical, reports advisory misses; **waivers file** stripped of `advisory_vars` (now only risk-accepted suppressions).

### Verification
- ✅ 43/43 unit tests pass across the 4 suites (env_parity_core, cfn_env_resolver, env_parity_gate, live_template_strip_detector)
- ✅ Real gate vs `02-compute.yaml` @ prod defaults: **PASSED** (critical=0 / advisory=0 / waived=0)
- ✅ Negative proof on the real template: deploy-critical strip → **FAIL rc=2**; advisory miss → **WARN** only

### Governance notes
- **Governance-dict gate N/A**: the CI dict guard (`component-registry-guard.yml` / `ci.yml`) is scoped to `coordination_api/lambda_function.py`; this PR touches `env_drift_auditor/lambda_function.py` only and introduces no governed-schema change.
- **OGTM N/A** — no new record types, relational fields, or edge types.
- Deployable artifact = the **env_drift_auditor Lambda** (bundles registry + core); the `tools/*` gate scripts run in CI/local and take effect on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
