### PR TITLE
ENC-TSK-H22: synthetic-strip proof that env_parity_gate catches a template strip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,17 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m unittest tools.test_verify_lambda_package_arch -v
+
+      # ENC-TSK-H22 (ENC-PLN-048 Obj 4.1): prove the env-parity gate catches a
+      # template strip. Needs PyYAML (the gate's resolver parses CFN); no current
+      # CI step imports yaml, so provision Python+PyYAML scoped to this step only.
+      - name: Set up Python for env-parity strip proof
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Env-parity gate synthetic-strip proof (ENC-TSK-H22)
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet pyyaml
+          python3 tools/test_synthetic_strip_proof.py

--- a/tools/test_synthetic_strip_proof.py
+++ b/tools/test_synthetic_strip_proof.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Synthetic-strip proof for the pre-deploy env-parity gate — ENC-TSK-H22.
+
+ENC-PLN-048 Objective 4.1 (parent ENC-TSK-H14, feature ENC-FTR-102). This is
+the recorded "prove, not assert" evidence that ENC-TSK-H05 AC-8 lacked
+(correctness was previously asserted only by code inspection): that
+tools/env_parity_gate.py actually FAILS (non-zero exit) when a deploy-critical
+required var is stripped from the real CloudFormation template, and PASSES
+(exit 0) against the current good 02-compute.yaml.
+
+It generalizes the single-var synthetic strip baked into
+tools/verify_internal_key_coverage.py (which exits non-zero when a consumer
+loses COORDINATION_INTERNAL_API_KEY) into a gate-driven proof over the two
+deploy-critical vars from the 2026-06-18 Sev-1 (ENC-LSN-053):
+COORDINATION_INTERNAL_API_KEY and SQS_QUEUE_URL.
+
+The strip is applied to the REAL infrastructure/cloudformation/02-compute.yaml
+rather than a hand-written synthetic template, so the proof tracks the live
+template as it evolves. The historical pre-#493 template (commit a258b40, with
+SQS_QUEUE_URL absent on devops-deploy-intake) is the real-world instance of this
+exact strip; here we reproduce it deterministically by removing the var — incl.
+its multi-line `!ImportValue` value — from a temp copy and running the gate.
+
+No AWS calls; pure template-side resolution (the gate consumes
+cfn_env_resolver). Run standalone or in CI:
+
+    python3 tools/test_synthetic_strip_proof.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import env_parity_gate as gate  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO_ROOT / "infrastructure" / "cloudformation" / "02-compute.yaml"
+REGISTRY = REPO_ROOT / "backend" / "lambda" / "env_drift_auditor" / "env_drift_registry.json"
+WAIVERS = REPO_ROOT / "tools" / "env_parity_waivers.json"
+
+# The two deploy-critical vars from the ENC-LSN-053 Sev-1 the gate must catch.
+TARGET_VARS = ["COORDINATION_INTERNAL_API_KEY", "SQS_QUEUE_URL"]
+
+# Canonical deploy parameter-override sets (prod uses the "" default; gamma uses
+# -gamma). The gate must pass under each, proving the good template is correct
+# for every sanctioned deploy target.
+OVERRIDE_SETS = [[], ["EnvironmentSuffix="], ["EnvironmentSuffix=-gamma"]]
+
+
+def _strip_var(text: str, var: str):
+    """Remove every ``<var>:`` mapping (including multi-line intrinsic values)
+    from a CFN template's text. Returns ``(new_text, removed_count)``.
+
+    Indent-aware so it correctly drops a multi-line value such as
+    ``SQS_QUEUE_URL: !ImportValue`` followed by an indented ``Fn::Sub:`` line
+    without orphaning the continuation, and the trailing ``:`` boundary keeps it
+    from matching longer keys that share the prefix (e.g.
+    ``COORDINATION_INTERNAL_API_KEY_PREVIOUS``).
+    """
+    lines = text.split("\n")
+    key_re = re.compile(rf"^(\s*){re.escape(var)}:(?:\s|$)")
+    out = []
+    removed = 0
+    i = 0
+    while i < len(lines):
+        m = key_re.match(lines[i])
+        if not m:
+            out.append(lines[i])
+            i += 1
+            continue
+        indent = len(m.group(1))
+        removed += 1
+        i += 1
+        # Drop the (optional) more-indented continuation lines of a block value.
+        while i < len(lines):
+            nxt = lines[i]
+            if nxt.strip() and (len(nxt) - len(nxt.lstrip(" "))) <= indent:
+                break
+            i += 1
+    return "\n".join(out), removed
+
+
+def _write(tmpdir: Path, name: str, text: str) -> Path:
+    p = tmpdir / name
+    p.write_text(text)
+    return p
+
+
+def _empty_waivers(tmpdir: Path) -> Path:
+    # Hermetic: a known-empty waiver file so the strip proof is unaffected by any
+    # waiver later added to the shipped tools/env_parity_waivers.json.
+    return _write(tmpdir, "waivers.json", json.dumps({"waivers": [], "advisory_vars": {}}))
+
+
+def _run_main(template: Path, waivers: Path, overrides=None) -> int:
+    argv = ["--template", str(template), "--registry", str(REGISTRY),
+            "--waivers", str(waivers), "--format", "json"]
+    for kv in overrides or []:
+        argv += ["--parameter", kv]
+    return gate.main(argv)
+
+
+def test_good_template_passes():
+    """AC2: the gate exits 0 against the current good 02-compute.yaml under the
+    default and each canonical deploy parameter-override set."""
+    for overrides in OVERRIDE_SETS:
+        rc = _run_main(TEMPLATE, WAIVERS, overrides)
+        assert rc == 0, f"gate failed on the good template with overrides={overrides} (rc={rc})"
+    result = gate.run_gate(TEMPLATE, {}, REGISTRY, gate.load_waivers(WAIVERS))
+    assert result["failed"] is False
+    assert result["counts"][gate.CRITICAL] == 0
+
+
+def test_strip_each_required_var_fails():
+    """AC1: stripping COORDINATION_INTERNAL_API_KEY, and separately
+    SQS_QUEUE_URL, from the real template makes the gate fail closed (rc=2), and
+    the stripped var is reported as a deploy-critical finding."""
+    real = TEMPLATE.read_text()
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        waivers = _empty_waivers(tmp)
+        for var in TARGET_VARS:
+            stripped, removed = _strip_var(real, var)
+            assert removed > 0, f"strip of {var} was a no-op — has the template format changed?"
+            tpl = _write(tmp, f"stripped_{var}.yaml", stripped)
+
+            rc = _run_main(tpl, waivers, overrides=[])
+            assert rc != 0, f"gate did NOT fail when {var} was stripped (rc={rc})"
+            assert rc == 2, f"expected fail-closed rc=2 for stripped {var}, got rc={rc}"
+
+            result = gate.run_gate(tpl, {}, REGISTRY, gate.load_waivers(None))
+            crit_vars = {f["var"] for f in result["findings"] if f["classification"] == gate.CRITICAL}
+            assert var in crit_vars, f"{var} not flagged critical after strip; got {sorted(crit_vars)}"
+
+
+def test_sqs_strip_attributes_the_right_function():
+    """The SQS_QUEUE_URL strip is attributed to devops-deploy-intake (its sole
+    registry consumer) — proving per-function attribution, not just a global
+    fail. This is the deterministic reproduction of the pre-#493 / ENC-TSK-H09
+    real-world strip."""
+    real = TEMPLATE.read_text()
+    stripped, removed = _strip_var(real, "SQS_QUEUE_URL")
+    assert removed == 1, f"expected exactly one SQS_QUEUE_URL occurrence; removed {removed}"
+    with tempfile.TemporaryDirectory() as d:
+        tpl = _write(Path(d), "stripped_sqs.yaml", stripped)
+        result = gate.run_gate(tpl, {}, REGISTRY, gate.load_waivers(None))
+        hits = [f for f in result["findings"]
+                if f["classification"] == gate.CRITICAL and f["var"] == "SQS_QUEUE_URL"]
+        assert len(hits) == 1, f"expected one SQS_QUEUE_URL critical finding; got {hits}"
+        assert hits[0]["function"] == "devops-deploy-intake", hits[0]["function"]
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"  FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_all())


### PR DESCRIPTION
## ENC-TSK-H22 — synthetic-strip proof for the env-parity gate

ENC-PLN-048 Objective 4.1 (parent ENC-TSK-H14, feature ENC-FTR-102). The recorded "prove, not assert" evidence ENC-TSK-H05 AC-8 lacked (correctness was previously asserted only by code inspection).

Adds `tools/test_synthetic_strip_proof.py`, which drives `tools/env_parity_gate.py` against the **real** `infrastructure/cloudformation/02-compute.yaml`:

- **AC1 — gate fails closed on a stripped required var:** strips `COORDINATION_INTERNAL_API_KEY`, and separately `SQS_QUEUE_URL`, from a temp copy of the live template (indent-aware strip handles the multi-line `SQS_QUEUE_URL: !ImportValue / Fn::Sub` block; the trailing-`:` boundary protects `COORDINATION_INTERNAL_API_KEY_PREVIOUS`) → `gate.main()` returns **rc=2** with the var reported deploy-critical. The `SQS_QUEUE_URL` finding is attributed to `devops-deploy-intake` — the deterministic reproduction of the pre-#493 / ENC-TSK-H09 real-world strip.
- **AC2 — gate passes on the good template; runs in CI:** asserts `gate.main()` **rc=0** against the current template under the default, prod (`EnvironmentSuffix=`), and gamma (`EnvironmentSuffix=-gamma`) override sets. Wired into `.github/workflows/ci.yml` with `actions/setup-python` + `pip install pyyaml` (no existing CI step imports `yaml`, which the gate's resolver requires).

Generalizes the single-var strip self-test in `tools/verify_internal_key_coverage.py` per the PLN-048 refinement.

### Local verification
- New proof `tools/test_synthetic_strip_proof.py`: **3/3 PASS**
- Existing `tools/test_env_parity_gate.py`: **9/9** still green
- `ci.yml` validates as YAML

### Terminal-close note
Tools-only change (test + CI wiring; no deployable Lambda/web artifact) on the `github_pr_deploy` arc (`code_only` is sealed). Per the ENC-TSK-H18 precedent, the deploy-success agent gate cannot be satisfied — terminal close is code-on-main via io's `user_initiated` Cognito override, or by riding the next compute deploy.

CCI-b63dbe67d4354d20bd84cc2c457d1a5a

🤖 Generated with [Claude Code](https://claude.com/claude-code)