### PR TITLE
ENC-TSK-H20: wire pre-deploy env-parity gate into compute-stack-deploy CI

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -133,6 +133,30 @@ jobs:
           fi
           echo "✓ No unadopted out-of-band Lambdas — every live env-suffixed template function is managed by ${stack_name}."
 
+      - name: Pre-deploy health gate (ENC-FTR-102 env parity + ENC-PLN-020 — ENC-TSK-H20)
+        # ENC-TSK-H20 / ENC-PLN-048 Obj 3: run the sanctioned pre-deploy health gate
+        # BEFORE `aws cloudformation deploy`, so a deploy that would strip a deploy-critical
+        # env var (the H05/H09/ENC-ISS-369 strip class) fails THIS job and the deploy step
+        # never runs. Check 6 of the script is the FTR-102 env-parity gate
+        # (tools/env_parity_gate.py), registry-driven via env_drift_registry.json (ENC-TSK-H16).
+        # Closes the ENC-TSK-H05 AC-9 residual: tools/pre-deploy-health-gate.sh existed but was
+        # only referenced in coordination handoff templates, never wired into this workflow.
+        #
+        # AC2 (resolved-env parity reflects the actual deploy): --stack passes the SAME resolved
+        # stack name the deploy step uses (steps.params.outputs.stack_name), so the gate resolves
+        # the template under the identical EnvironmentSuffix (prod="" / gamma="-gamma"). The
+        # deploy's other --parameter-overrides supply NoEcho *values* (CoordinationInternalApiKey,
+        # EnceladusCognitoClientSecret, SharedLayerArn, AppConfig*) — !Ref values that do not
+        # change which env-var KEYS the parity gate evaluates; the empty-value strip class they
+        # guard against is covered by the deploy step's own inline NoEcho guards + Check 5.
+        # No `continue-on-error`: a non-zero exit is fail-closed and blocks the deploy.
+        run: |
+          set -euo pipefail
+          bash tools/pre-deploy-health-gate.sh \
+            --stack "${{ steps.params.outputs.stack_name }}" \
+            --template "${TEMPLATE_FILE}" \
+            --region "${AWS_REGION}"
+
       - name: Deploy Compute stack (02-compute)
         id: deploy
         run: |


### PR DESCRIPTION
## ENC-TSK-H20 — wire the FTR-102 pre-deploy env-parity gate into the sanctioned compute deploy

Inserts a required, **fail-closed** `Pre-deploy health gate` step into
`.github/workflows/cloudformation-compute-stack-deploy.yml`, immediately **before** the
`aws cloudformation deploy` step. The step runs `tools/pre-deploy-health-gate.sh`, whose
Check 6 is the ENC-FTR-102 registry-driven env-parity gate (`tools/env_parity_gate.py`,
`rc=2` on a deploy-critical strip). No `continue-on-error`, so a non-zero exit fails the
job and the deploy step never runs.

Closes the **ENC-TSK-H05 AC-9 residual**: `pre-deploy-health-gate.sh` existed but was only
referenced in coordination handoff templates, never wired into this workflow.

### Acceptance criteria
- **AC1** (gate before deploy; job fails on non-zero → deploy skipped): the new step is
  ordered strictly before the deploy step (verified via `yaml.safe_load`: step index 6 vs 7)
  and carries no `continue-on-error`. Check 6 = `env_parity_gate.py` (`rc=2` on a
  deploy-critical strip).
- **AC2** (same parameter-overrides → resolved-env parity reflects the actual deploy):
  `--stack ${{ steps.params.outputs.stack_name }}` passes the same resolved stack name the
  deploy step uses, so the gate resolves the template under the identical `EnvironmentSuffix`
  (prod `''` / gamma `-gamma`). The deploy's other `--parameter-overrides` supply NoEcho
  *values* (`!Ref`) that don't change which env-var *keys* the parity gate evaluates; the
  empty-value strip class is covered by the deploy's inline NoEcho guards + Check 5.

### Validation
- `env_parity_gate.py` vs current prod `02-compute.yaml` → **GATE PASSED** (`critical=0`).
- Full `pre-deploy-health-gate.sh` vs prod stack `enceladus-compute` → **HEALTH GATE: PASSED** (all 6 checks).

ENC-PLN-048 Objective 3 (parent ENC-TSK-H13) / ENC-FTR-102.

CCI-2d2a75eda0374c649c891c8004d3c18b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
