### PR TITLE
ENC-TSK-H10: make env_drift_auditor idempotent (signature dedup)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-21.03",
-  "updated_at": "2026-06-21T12:33:34Z",
-  "last_change_summary": "ENC-TSK-H16 (PR #510, ENC-PLN-048 Obj 1 / ENC-FTR-102): made backend/lambda/env_drift_auditor/env_drift_registry.json the single canonical required-env + deploy-critical/advisory classification source consumed by both the pre-deploy env-parity gate and the post-deploy env_drift_auditor (removed the advisory_vars second copy from tools/env_parity_waivers.json). Touched backend/lambda/env_drift_auditor/lambda_function.py (advisory-aware scan). No tracker/field/governed-entity schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob).",
+  "version": "2026-06-21.04",
+  "updated_at": "2026-06-21T15:13:24Z",
+  "last_change_summary": "ENC-TSK-H10 (ENC-PLN-048 / ENC-FTR-102): made backend/lambda/env_drift_auditor idempotent. It now computes a (lambda, missing-var-set) content-hash signature (env_parity_core.drift_signature), queries open issues for that signature before filing, and bumps the existing P0 via a worklog instead of POSTing a duplicate. Stops the hourly byte-identical P0 storm (ENC-ISS-369..379) the old code caused by assuming a tracker-side dedup guard that does not exist. Touched backend/lambda/env_drift_auditor/lambda_function.py. No tracker/field/governed-entity schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/env_drift_auditor/env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/env_parity_core.py
@@ -36,6 +36,7 @@ import from CLI tools and unit tests.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Dict, List, Optional, Sequence
 
 # Values that count as "not really set" (drift), independent of any registry.
@@ -154,3 +155,62 @@ def advisory_vars(entry: Any) -> List[str]:
 def classification_map(entry: Any) -> Dict[str, str]:
     """``{var: classification}`` for every required var in the entry."""
     return {v: classification_of(entry, v) for v in required_vars(entry)}
+
+
+# ---------------------------------------------------------------------------
+# Drift-issue dedup signature (ENC-TSK-H10)
+# ---------------------------------------------------------------------------
+# env_drift_auditor runs hourly. Before H10 it POSTed a NEW P0 issue every run
+# for the SAME unresolved drift — ENC-ISS-369..379 were 11 byte-identical P0s,
+# one per hour, for ONE finding — because it assumed a tracker-side dedup guard
+# that does not exist. These helpers give each finding a stable identity so the
+# auditor can recognize an already-open issue and bump it instead of re-filing.
+# The signature is the dedup key AC-1 requires; it travels in the issue TITLE via
+# sig_token() because the tracker create API persists only a fixed field
+# whitelist (an arbitrary top-level field would be silently dropped) and the
+# title round-trips through the create -> list path the auditor queries.
+
+
+def drift_signature(fn_name: str, missing_vars: Sequence[str]) -> str:
+    """Stable content hash identifying a drift finding by (lambda, missing-var set).
+
+    Order- and duplicate-independent: built from the sorted unique var set, so the
+    same persistent drift always hashes to the same value regardless of the order
+    ``classify_required`` happened to emit the rows in (the ``frozenset(missing_vars)``
+    dedup key from the ENC-TSK-H10 design). 12 hex chars (48 bits) is ample to keep
+    the handful of live (function, missing-var-set) findings distinct without
+    bloating the issue title.
+    """
+    canonical = fn_name + "\n" + "\n".join(sorted(set(missing_vars)))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+
+
+def sig_token(signature: str) -> str:
+    """The machine-matchable marker embedded in a drift issue's title.
+
+    Carried in the title (a whitelisted, always-returned field) so a later auditor
+    run can recognize its own prior issue from a plain ``type=issue&status=open``
+    listing without depending on any custom-field round-trip.
+    """
+    return f"[sig:{signature}]"
+
+
+def find_signature_match(open_issues: Sequence[Dict[str, Any]], signature: str) -> Optional[str]:
+    """Return the bare id of the first OPEN issue carrying ``signature``, else None.
+
+    Pure decision half of the auditor's idempotency (ENC-TSK-H10 AC-2): given the
+    records a ``type=issue&status=open`` query returned, find one whose title carries
+    ``sig_token(signature)``. The auditor bumps that issue rather than filing a new
+    one. Prefers ``item_id`` (the bare ENC-ISS-NNN the ``/log`` route path wants) and
+    falls back to the segment after ``#`` in ``record_id``.
+    """
+    token = sig_token(signature)
+    for issue in open_issues:
+        if token in str(issue.get("title", "")):
+            bare = issue.get("item_id") or issue.get("id")
+            if not bare:
+                rid = str(issue.get("record_id", ""))
+                bare = rid.split("#", 1)[1] if "#" in rid else rid
+            if bare:
+                return bare
+    return None

--- a/backend/lambda/env_drift_auditor/lambda_function.py
+++ b/backend/lambda/env_drift_auditor/lambda_function.py
@@ -1,8 +1,9 @@
 """env_drift_auditor — ENC-ISS-283.
 
 Hourly scanner that checks each Lambda in env_drift_registry.json for
-missing or placeholder values in its REQUIRED_ENV list. On drift, files a
-P0 tracker issue via the internal-key tracker API.
+missing or placeholder values in its REQUIRED_ENV list. On drift it files a
+P0 tracker issue via the internal-key tracker API — idempotently: a finding
+already tracked by an open issue is bumped, not re-filed (ENC-TSK-H10).
 
 Trigger: EventBridge rule on cron(0 * * * ? *)  — every hour on the hour.
 Also handles ad-hoc invokes (empty event) for on-demand scans.
@@ -17,10 +18,11 @@ from __future__ import annotations
 import json
 import logging
 import os
-import urllib.request
 import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 
@@ -28,7 +30,17 @@ import boto3
 # ENC-TSK-H16: critical_vars/advisory_vars read the per-var deploy-critical vs
 # advisory classification from the same core, so the auditor and the pre-deploy
 # gate split the registry the same way (no second copy).
-from env_parity_core import build_placeholders, classify_required, critical_vars, advisory_vars
+# ENC-TSK-H10: drift_signature/sig_token/find_signature_match give a finding a
+# stable identity so the auditor dedups against an already-open issue (below).
+from env_parity_core import (
+    advisory_vars,
+    build_placeholders,
+    classify_required,
+    critical_vars,
+    drift_signature,
+    find_signature_match,
+    sig_token,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -42,6 +54,10 @@ COORDINATION_INTERNAL_API_KEY = os.environ["COORDINATION_INTERNAL_API_KEY"]
 PROJECT_ID = os.environ.get("ISSUE_PROJECT_ID", "enceladus")
 SEVERITY = os.environ.get("DRIFT_SEVERITY", "P0")
 DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
+# ENC-TSK-H10: cap the open-issue dedup scan. 200/page * 10 pages = 2000 open
+# issues, far above any real backlog; bounds the hourly query if the listing ever
+# balloons.
+_MAX_ISSUE_PAGES = 10
 
 # Load registry bundled with the Lambda package
 _REGISTRY_PATH = os.path.join(os.path.dirname(__file__), "env_drift_registry.json")
@@ -71,15 +87,23 @@ def _audit_lambda(lambda_client: Any, fn_name: str, required: List[str]) -> Tupl
     return "ok", []
 
 
-def _file_drift_issue(fn_name: str, drift: List[Dict[str, Any]], run_id: str) -> Dict[str, Any]:
-    if DRY_RUN:
-        logger.info("DRY_RUN: would file drift issue for %s — %s", fn_name, drift)
-        return {"dry_run": True}
+def _file_drift_issue(
+    fn_name: str, drift: List[Dict[str, Any]], run_id: str, signature: str
+) -> Dict[str, Any]:
+    """File a NEW P0 drift issue (ENC-TSK-H10).
 
+    The title carries ``sig_token(signature)`` and the evidence carries the structured
+    ``drift_signature`` so a later run can find and bump this record instead of
+    re-filing. ``_handle_drift_finding`` only reaches here when no open issue already
+    carries this signature, so DRY_RUN and the dedup decision live in the caller.
+    """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     missing_vars = ", ".join(d["var"] for d in drift if d.get("var"))
     body = {
-        "title": f"[auto-drift] {fn_name} missing required env vars: {missing_vars}",
+        "title": (
+            f"[auto-drift] {fn_name} missing required env vars: {missing_vars} "
+            f"{sig_token(signature)}"
+        ),
         "priority": SEVERITY,
         "status": "open",
         "severity": "high",
@@ -102,6 +126,7 @@ def _file_drift_issue(fn_name: str, drift: List[Dict[str, Any]], run_id: str) ->
                     f"Compare against REQUIRED_ENV registry: {missing_vars}",
                 ],
                 "drift_detail": drift,
+                "drift_signature": signature,
                 "auditor_run_id": run_id,
             }
         ],
@@ -126,12 +151,118 @@ def _file_drift_issue(fn_name: str, drift: List[Dict[str, Any]], run_id: str) ->
     )
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
-            return {"status": resp.status, "body": json.loads(resp.read())}
+            return {"status": resp.status, "filed": True, "signature": signature,
+                    "body": json.loads(resp.read())}
     except urllib.error.HTTPError as exc:
-        return {"status": exc.code, "error": exc.read().decode("utf-8", errors="replace")}
+        return {"status": exc.code, "filed": True, "signature": signature,
+                "error": exc.read().decode("utf-8", errors="replace")}
     except Exception as exc:
         logger.exception("tracker.create failed")
-        return {"status": 0, "error": str(exc)}
+        return {"status": 0, "filed": True, "signature": signature, "error": str(exc)}
+
+
+def _fetch_open_issues() -> List[Dict[str, Any]]:
+    """GET every OPEN issue record (paginated) via the internal-key tracker API.
+
+    Used to dedup a drift finding against an issue the auditor already filed
+    (ENC-TSK-H10). Raises on transport/HTTP error so the caller can decide whether to
+    fail open to filing.
+    """
+    issues: List[Dict[str, Any]] = []
+    cursor = ""
+    for _ in range(_MAX_ISSUE_PAGES):
+        url = f"{TRACKER_API_BASE}/{PROJECT_ID}?type=issue&status=open&page_size=200"
+        if cursor:
+            url += "&next_cursor=" + urllib.parse.quote(cursor, safe="")
+        req = urllib.request.Request(
+            url,
+            method="GET",
+            headers={"X-Coordination-Internal-Key": COORDINATION_INTERNAL_API_KEY},
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            payload = json.loads(resp.read())
+        issues.extend(payload.get("records", []))
+        cursor = payload.get("next_cursor", "")
+        if not cursor:
+            break
+    return issues
+
+
+def _find_existing_drift_issue(signature: str) -> Tuple[Optional[str], bool]:
+    """Return (matched_issue_id, query_ok) for an OPEN issue carrying ``signature``.
+
+    query_ok=False means the lookup itself failed; the caller fails OPEN to filing so a
+    transient query error never silently drops a real finding (ENC-TSK-H10).
+    """
+    try:
+        issues = _fetch_open_issues()
+    except Exception:
+        logger.exception("open-issue dedup query failed")
+        return None, False
+    return find_signature_match(issues, signature), True
+
+
+def _bump_drift_issue(issue_id: str, fn_name: str, run_id: str, now: str) -> Dict[str, Any]:
+    """Append a worklog to an already-open drift issue instead of filing a duplicate
+    (ENC-TSK-H10 AC-1). Records that the drift is STILL present at this run, so a
+    persistent finding leaves a recurrence trail rather than an hourly P0 storm."""
+    body = {
+        "description": (
+            f"[auto-drift] still present on {fn_name} at {now} (auditor run_id={run_id}). "
+            f"Drift unresolved since this issue was filed; bumping instead of filing a "
+            f"duplicate P0 (ENC-TSK-H10 signature dedup)."
+        ),
+        "write_source": {"provider": "env-drift-auditor"},
+    }
+    req = urllib.request.Request(
+        f"{TRACKER_API_BASE}/{PROJECT_ID}/issue/{issue_id}/log",
+        method="POST",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Coordination-Internal-Key": COORDINATION_INTERNAL_API_KEY,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return {"status": resp.status, "deduped": True, "issue_id": issue_id}
+    except urllib.error.HTTPError as exc:
+        return {"status": exc.code, "deduped": True, "issue_id": issue_id,
+                "error": exc.read().decode("utf-8", errors="replace")}
+    except Exception as exc:
+        logger.exception("drift issue bump failed for %s", issue_id)
+        return {"status": 0, "deduped": True, "issue_id": issue_id, "error": str(exc)}
+
+
+def _handle_drift_finding(fn_name: str, drift: List[Dict[str, Any]], run_id: str) -> Dict[str, Any]:
+    """Idempotent drift emission (ENC-TSK-H10).
+
+    Computes the (lambda, missing-var) signature and, unless an OPEN issue already
+    carries it, files a single P0. On a signature match it BUMPS the existing issue
+    instead — so one persistent finding yields one record plus hourly worklog bumps,
+    not the hourly P0 storm that produced ENC-ISS-369..379.
+    """
+    missing_var_names = [d["var"] for d in drift if d.get("var")]
+    signature = drift_signature(fn_name, missing_var_names)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if DRY_RUN:
+        logger.info("DRY_RUN: would emit drift for %s (sig=%s) — %s", fn_name, signature, drift)
+        return {"dry_run": True, "signature": signature}
+
+    existing_id, query_ok = _find_existing_drift_issue(signature)
+    if existing_id:
+        logger.info(
+            "drift on %s already tracked by %s (sig=%s) — bumping, not re-filing",
+            fn_name, existing_id, signature,
+        )
+        return _bump_drift_issue(existing_id, fn_name, run_id, now)
+    if not query_ok:
+        logger.warning(
+            "open-issue dedup query failed for %s (sig=%s) — filing without dedup to "
+            "avoid missing drift (ENC-TSK-H10 fail-open)", fn_name, signature,
+        )
+    return _file_drift_issue(fn_name, drift, run_id, signature)
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -154,10 +285,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         entry: Dict[str, Any] = {"lambda": fn_name, "status": status}
         if drift:
             entry["drift"] = drift
-            # File an issue — one per Lambda per drift event. Idempotency is
-            # best-effort here; the tracker dedup guard may collapse repeated
-            # identical titles into the same record.
-            entry["issue_filed"] = _file_drift_issue(fn_name, drift, run_id)
+            # ENC-TSK-H10: emit idempotently. A persistent finding is filed ONCE,
+            # then bumped each hour — never re-filed. The old code filed
+            # unconditionally on the assumption that a tracker-side dedup guard
+            # collapsed identical titles; no such guard exists, so one finding
+            # produced 11 byte-identical P0s (ENC-ISS-369..379).
+            entry["issue_filed"] = _handle_drift_finding(fn_name, drift, run_id)
             drift_count += 1
         else:
             ok_count += 1

--- a/backend/lambda/env_drift_auditor/test_env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/test_env_parity_core.py
@@ -134,6 +134,107 @@ def test_env_drift_auditor_uses_shared_core():
     assert {d["var"] for d in drift} == {"MISSING_ONE"}
 
 
+# --- ENC-TSK-H10: drift-issue dedup signature -------------------------------
+def test_drift_signature_stable_and_order_independent():
+    # Same (lambda, missing-var SET) -> same signature regardless of var order
+    # or duplicates (the frozenset(missing_vars) dedup key).
+    a = core.drift_signature("devops-fn", ["B", "A"])
+    b = core.drift_signature("devops-fn", ["A", "B"])
+    c = core.drift_signature("devops-fn", ["A", "B", "B", "A"])
+    assert a == b == c
+    # Different missing-var set -> different signature.
+    assert core.drift_signature("devops-fn", ["A"]) != a
+    # Different lambda -> different signature.
+    assert core.drift_signature("devops-other", ["A", "B"]) != a
+    # 12 hex chars.
+    assert len(a) == 12 and all(ch in "0123456789abcdef" for ch in a)
+
+
+def test_sig_token_format():
+    assert core.sig_token("abc123") == "[sig:abc123]"
+
+
+def test_find_signature_match_by_title_token():
+    sig = core.drift_signature("devops-fn", ["A", "B"])
+    issues = [
+        {"item_id": "ENC-ISS-001", "title": "[auto-drift] other thing [sig:deadbeef0000]"},
+        {"item_id": "ENC-ISS-002", "title": f"[auto-drift] devops-fn missing X {core.sig_token(sig)}"},
+    ]
+    assert core.find_signature_match(issues, sig) == "ENC-ISS-002"
+    # No carrier -> no match.
+    assert core.find_signature_match([{"item_id": "ENC-ISS-003", "title": "unrelated"}], sig) is None
+    # record_id fallback when item_id is absent.
+    rid_only = [{"record_id": "issue#ENC-ISS-004", "title": f"x {core.sig_token(sig)}"}]
+    assert core.find_signature_match(rid_only, sig) == "ENC-ISS-004"
+
+
+def test_find_signature_match_idempotency_core():
+    """Pure AC-2 core (no boto3/network): once an issue carrying the signature is
+    open, a repeat finding matches it, so the auditor bumps instead of filing."""
+    sig = core.drift_signature("devops-fn", ["A", "B"])
+    open_issues: list = []
+    # First run: nothing open yet -> no match -> auditor would FILE.
+    assert core.find_signature_match(open_issues, sig) is None
+    # Simulate the filed issue now being open (title carries the token).
+    open_issues.append({
+        "item_id": "ENC-ISS-T1",
+        "title": f"[auto-drift] devops-fn missing required env vars: A, B {core.sig_token(sig)}",
+        "status": "open",
+    })
+    # Second run, same finding (even with vars discovered in a different order) ->
+    # matches the open issue -> auditor BUMPS, files nothing new.
+    assert core.find_signature_match(open_issues, core.drift_signature("devops-fn", ["B", "A"])) == "ENC-ISS-T1"
+
+
+def test_auditor_idempotent_dedup_bumps_not_refiles():
+    """AC-2 (ENC-TSK-H10) at the orchestrator level: a repeat run against unresolved
+    drift creates ZERO new issues — it bumps the existing one. Only the network I/O
+    is stubbed; the real _handle_drift_finding + drift_signature + find_signature_match
+    make the decision."""
+    os.environ.setdefault("COORDINATION_INTERNAL_API_KEY", "test-key")
+    try:
+        import lambda_function as lf  # noqa: E402
+    except Exception as exc:  # boto3 missing locally etc. — pure test above still proves AC-2
+        print(f"  SKIP test_auditor_idempotent_dedup_bumps_not_refiles ({exc})")
+        return
+
+    open_issues: list = []  # simulated tracker OPEN-issue store
+    counters = {"filed": 0, "bumped": 0}
+
+    def fake_fetch_open_issues():
+        return list(open_issues)
+
+    def fake_file(fn_name, drift, run_id, signature):
+        counters["filed"] += 1
+        open_issues.append({
+            "item_id": f"ENC-ISS-T{counters['filed']}",
+            "title": f"[auto-drift] {fn_name} missing required env vars: X {core.sig_token(signature)}",
+            "status": "open",
+        })
+        return {"status": 201, "filed": True, "signature": signature}
+
+    def fake_bump(issue_id, fn_name, run_id, now):
+        counters["bumped"] += 1
+        return {"status": 200, "deduped": True, "issue_id": issue_id}
+
+    saved = (lf._fetch_open_issues, lf._file_drift_issue, lf._bump_drift_issue, lf.DRY_RUN)
+    lf._fetch_open_issues = fake_fetch_open_issues
+    lf._file_drift_issue = fake_file
+    lf._bump_drift_issue = fake_bump
+    lf.DRY_RUN = False
+    try:
+        drift = [{"var": "COORDINATION_INTERNAL_API_KEY", "reason": "missing"}]
+        lf._handle_drift_finding("devops-some-fn", drift, "run-1")
+        r2 = lf._handle_drift_finding("devops-some-fn", drift, "run-2")
+    finally:
+        (lf._fetch_open_issues, lf._file_drift_issue, lf._bump_drift_issue, lf.DRY_RUN) = saved
+
+    assert counters["filed"] == 1, f"expected exactly 1 file, got {counters['filed']}"
+    assert counters["bumped"] == 1, f"expected exactly 1 bump, got {counters['bumped']}"
+    assert len(open_issues) == 1, "repeat run must not create a new issue record"
+    assert r2.get("deduped") is True
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failures = 0


### PR DESCRIPTION
## ENC-TSK-H10 — stop the hourly P0 duplicate storm

`env_drift_auditor` filed a brand-new P0 every hour for the same unresolved drift (ENC-ISS-369..379 were 11 byte-identical P0s) because the code assumed a tracker-side dedup guard that does not exist.

### Change
- **`env_parity_core.py`** — pure, unit-testable dedup primitives: `drift_signature(fn, vars)` (sha256[:12] over the sorted-unique `(lambda, missing-var)` set = order/dup-independent `frozenset` key), `sig_token()`, `find_signature_match()`.
- **`lambda_function.py`** — `_handle_drift_finding` queries open issues by signature and **bumps** the existing P0 (`POST /{project}/issue/{id}/log`) instead of re-filing. The signature rides in the issue title (the create API persists only whitelisted fields). **Fail-open** to filing if the dedup query errors — the auditor must never silently miss drift.
- **`test_env_parity_core.py`** — AC-2 idempotency proven pure + orchestrator-level (repeat run = 1 file + 1 bump + **0 new records**).
- **`governance_data_dictionary.json`** — version bump to satisfy the Governance Dictionary Guard (no schema change; live S3 sync is a post-merge product-lead handoff).

### Verification
48/48 tests green across 4 suites (`env_parity_core`, `cfn_env_resolver`, `env_parity_gate`, `live_template_strip_detector`). Additive change to the shared core — no consumer breakage.

### Acceptance criteria
- **AC-1** ✅ signature query + worklog bump (content-hash dedup key)
- **AC-2** ✅ idempotency unit test — zero new records on repeat run
- **AC-3** ✅ CFN infra via ENC-TSK-F56 + component `comp-enceladus-infrastructure`

Related: ENC-TSK-F56, ENC-ISS-369

CCI-b9c252f9791f421c8d3a0f447823fb7b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
