### PR TITLE
ENC-TSK-H36: disambiguate prod vs gamma API in CFN drift auditor

### DIFF
--- a/.github/workflows/cfn-drift-audit.yml
+++ b/.github/workflows/cfn-drift-audit.yml
@@ -54,6 +54,15 @@ jobs:
               || true
           fi
           echo "=== Drift Report ==="
+          # The audit invocations above are guarded with `|| true` so that a
+          # detected-drift exit code does not abort the step. But a hard crash
+          # (e.g. resolve_api_id ambiguity) leaves no report behind. Surface
+          # that explicitly instead of letting `cat` fail with an opaque
+          # "No such file or directory" under `set -e` (ENC-TSK-H36).
+          if [[ ! -s /tmp/cfn-drift-report.json ]]; then
+            echo "::error::audit_cfn_drift.py produced no drift report — the audit script failed (see traceback above)."
+            exit 1
+          fi
           cat /tmp/cfn-drift-report.json
 
           any_drift=$(python3 -c "

--- a/tests/tools/test_audit_cfn_drift.py
+++ b/tests/tools/test_audit_cfn_drift.py
@@ -106,6 +106,39 @@ def test_audit_report_has_expected_shape(tmp_path, monkeypatch, mod):
     assert report["eventbridge_rules"]["cfn_only"] == []
 
 
+def test_resolve_api_id_drops_gamma_sibling(monkeypatch, mod):
+    """prod + gamma siblings both match the prefix filter; resolver must
+    deterministically return the production ApiId (ENC-TSK-H36)."""
+    apis = {
+        "Items": [
+            {"Name": "devops-tracker-api", "ApiId": "prod123"},
+            {"Name": "devops-tracker-api-gamma", "ApiId": "gamma456"},
+        ]
+    }
+    monkeypatch.setattr(mod, "_aws_json", lambda cmd: apis)
+    assert mod.resolve_api_id("enceladus-") == "prod123"
+
+
+def test_resolve_api_id_still_raises_on_genuine_ambiguity(monkeypatch, mod):
+    """Two genuine (non-env-suffixed) prod candidates remain ambiguous and
+    must still raise so the operator passes --api-id explicitly."""
+    apis = {
+        "Items": [
+            {"Name": "devops-tracker-api", "ApiId": "a1"},
+            {"Name": "devops-checkout-api", "ApiId": "a2"},
+        ]
+    }
+    monkeypatch.setattr(mod, "_aws_json", lambda cmd: apis)
+    with pytest.raises(RuntimeError, match="Multiple API Gateway v2 APIs match"):
+        mod.resolve_api_id("enceladus-")
+
+
+def test_resolve_api_id_single_match(monkeypatch, mod):
+    apis = {"Items": [{"Name": "devops-tracker-api", "ApiId": "only1"}]}
+    monkeypatch.setattr(mod, "_aws_json", lambda cmd: apis)
+    assert mod.resolve_api_id("enceladus-") == "only1"
+
+
 def test_audit_no_drift(tmp_path, monkeypatch, mod):
     _write_cfn_template(
         tmp_path,

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -59,6 +59,19 @@ def live_apigw_routes(api_id: str) -> Set[str]:
     return {item["RouteKey"] for item in (data or {}).get("Items", [])}
 
 
+# Non-production environment siblings (e.g. devops-tracker-api-gamma) share
+# the production name prefix but are NOT the audit target. The audit compares
+# live routes against the CFN templates that declare the *production* stack, so
+# these env-suffixed APIs are dropped when disambiguating. Without this, the
+# creation of a gamma sibling makes resolve_api_id ambiguous and the daily
+# CFN Drift Audit workflow fails (ENC-TSK-H36).
+_ENV_SUFFIXES = ("-gamma", "-beta", "-staging", "-dev", "-test")
+
+
+def _is_env_sibling(name: str) -> bool:
+    return any(name.endswith(suffix) for suffix in _ENV_SUFFIXES)
+
+
 def resolve_api_id(stack_prefix: str) -> str:
     data = _aws_json([
         "aws", "apigatewayv2", "get-apis",
@@ -76,7 +89,12 @@ def resolve_api_id(stack_prefix: str) -> str:
             f"pass --api-id explicitly."
         )
     if len(candidates) > 1:
-        names = [c["Name"] for c in candidates]
+        # Prefer production APIs by dropping env-suffixed siblings. If exactly
+        # one production candidate remains the ambiguity is resolved.
+        prod = [c for c in candidates if not _is_env_sibling(c.get("Name", ""))]
+        if len(prod) == 1:
+            return prod[0]["ApiId"]
+        names = [c["Name"] for c in (prod or candidates)]
         raise RuntimeError(
             f"Multiple API Gateway v2 APIs match: {names}. "
             f"Pass --api-id explicitly."


### PR DESCRIPTION
## Summary
The scheduled **CFN Drift Audit** workflow has been failing on every daily run (e.g. [run 27947966208](https://github.com/NX-2021-L/enceladus/actions/runs/27947966208), 2026-06-22 09:00 UTC).

**Root cause:** `tools/audit_cfn_drift.py:resolve_api_id()` resolves the target API Gateway v2 API by name prefix (`devops-`, `enceladus`). A gamma sibling, `devops-tracker-api-gamma`, now exists alongside production `devops-tracker-api`. Both match the prefix filter → 2 candidates → `RuntimeError: Multiple API Gateway v2 APIs match: [...]. Pass --api-id explicitly.` The script exits 1 before writing its report.

**Secondary defect:** the workflow `Run audit` step guards the python call with `|| true`, but the following `cat /tmp/cfn-drift-report.json` runs under `set -euo pipefail`. On a crash no report exists, so `cat` fails with an opaque `No such file or directory`, masking the real traceback.

## Changes
- **`resolve_api_id`**: when >1 candidate matches, drop env-suffixed siblings (`-gamma`/`-beta`/`-staging`/`-dev`/`-test`) and return the single remaining production API; only raise if >1 genuine prod candidate remains.
- **`cfn-drift-audit.yml`**: the `Run audit` step now fails with a clear `::error::` message when no report is produced, instead of a misleading `cat` error.
- **tests**: cover prod+gamma → prod ApiId, genuine ambiguity → raise, single match.

## Testing
`python3 -m pytest tests/tools/test_audit_cfn_drift.py -q` → 7 passed. The new `test_resolve_api_id_drops_gamma_sibling` reproduces the exact failure scenario and confirms the fix.

## Scope
- No file in the governance-dictionary gate list is touched (no dictionary bump needed).
- `code_only` arc — no deploy; effective on merge to main.

Task: ENC-TSK-H36

CCI-edc8cbeeb692468eaa1f7f7b55e620ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)
