### PR TITLE
ENC-TSK-H54: register gamma-required env vars in FTR-102 parity registry

### DIFF
--- a/backend/lambda/env_drift_auditor/env_drift_registry.json
+++ b/backend/lambda/env_drift_auditor/env_drift_registry.json
@@ -15,7 +15,8 @@
         "APPCONFIG_APPLICATION": "advisory"
       }
     },
-    "provenance": "Deploy-critical vars and coverage gaps surfaced by the ENC-TSK-H15 coverage matrix (DOC-0C7E8AEF512E, ENC-PLN-048 Obj 1 child 1.1): COORDINATION_INTERNAL_API_KEY is deploy-critical on all 10 of its compute-stack consumers (it was the 2026-06-18 Sev-1 strip casualty, ENC-TSK-H04/H05); SQS_QUEUE_URL is deploy-critical on devops-deploy-intake (ENC-ISS-369, templated by ENC-TSK-H26). Out-of-band functions with no FunctionName in any CFN template (checkout_service, deploy_capability_auditor) are NOT added — they are not subject to the compute-stack strip (H15 waiver)."
+    "provenance": "Deploy-critical vars and coverage gaps surfaced by the ENC-TSK-H15 coverage matrix (DOC-0C7E8AEF512E, ENC-PLN-048 Obj 1 child 1.1): COORDINATION_INTERNAL_API_KEY is deploy-critical on all 10 of its compute-stack consumers (it was the 2026-06-18 Sev-1 strip casualty, ENC-TSK-H04/H05); SQS_QUEUE_URL is deploy-critical on devops-deploy-intake (ENC-ISS-369, templated by ENC-TSK-H26). Out-of-band functions with no FunctionName in any CFN template (checkout_service, deploy_capability_auditor) are NOT added — they are not subject to the compute-stack strip (H15 waiver).",
+    "gamma_parity_provenance": "ENC-TSK-H54 (ENC-PLN-050 P0, feature ENC-FTR-062, gamma stack completion): the registry was keyed only by PROD function names, so a compute deploy rendered under EnvironmentSuffix=-gamma produced -gamma function names that matched NO registry entry — the pre-deploy gate (env_parity_gate.py L102 'has_registry_entry' skip) and the post-deploy auditor BOTH silently skipped every gamma function except the lone enceladus-mcp-code-gamma entry. That is exactly why gamma rotted unobserved for ~2.5 months (DOC-A07B553431FD). H54 mirrors each registry-governed prod function rendered in 02-compute.yaml to its <fn>-gamma twin so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy. Each gamma deploy-critical var was verified present+nonempty on the live gamma function before registration (no env_drift_auditor P0-storm risk; ENC-ISS-369 class). GDS_STANDING_PROJECTION_PREFIX is registered ADVISORY (not deploy-critical) on devops-graph-query-api-gamma because 02-compute.yaml L1047 gates it on IsProduction (!Ref Environment=production) → it resolves to AWS::NoValue on gamma BY DESIGN until ENC-TSK-H56 provisions on-demand AGA GDS-PPR for gamma; advisory makes the gap a persistent WARN (visible) without failing gamma deploys. PATHWAY_TELEMETRY_{BUCKET,PREFIX} mirror prod's advisory classification (owned by ENC-TSK-H44, unset on prod AND gamma). ENABLE_LESSON_PRIMITIVE drift (live-set on prod, unset on gamma) is intentionally NOT registered here: it is an out-of-band flag the template never sets, so it is not a template-parity/strip-class var — its codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig), not the FTR-102 template-side gate. devops-github-integration and prod enceladus-mcp-code are NOT rendered in 02-compute.yaml, so their gamma twins are out of this gate's scope."
   },
   "_policy": {
     "scan_interval": "hourly",
@@ -106,6 +107,65 @@
       "ENCELADUS_COGNITO_USER_POOL_ID": "deploy-critical",
       "ENCELADUS_COGNITO_CLIENT_ID": "deploy-critical",
       "ENCELADUS_COGNITO_CLIENT_SECRET": "deploy-critical"
+    },
+    "devops-changelog-api-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-coordination-api-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "TRACKER_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical"
+    },
+    "devops-deploy-decide-gamma": {
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical",
+      "DEPLOY_TABLE": "deploy-critical",
+      "ALLOWED_REPOS": "deploy-critical",
+      "GITHUB_APP_ID": "deploy-critical",
+      "GITHUB_INSTALLATION_ID": "deploy-critical"
+    },
+    "devops-deploy-finalize-gamma": {
+      "DEPLOY_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "TRACKER_TABLE": "deploy-critical",
+      "CONFIG_BUCKET": "deploy-critical"
+    },
+    "devops-deploy-intake-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "DEPLOY_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "SQS_QUEUE_URL": "deploy-critical"
+    },
+    "devops-deploy-parity-validator-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-document-api-gamma": {
+      "DOCUMENTS_TABLE": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-env-drift-auditor-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-graph-query-api-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
+      "NEO4J_SECRET_NAME": "deploy-critical",
+      "COGNITO_USER_POOL_ID": "deploy-critical",
+      "COGNITO_CLIENT_ID": "deploy-critical",
+      "PATHWAY_TELEMETRY_BUCKET": "advisory",
+      "PATHWAY_TELEMETRY_PREFIX": "advisory",
+      "GDS_STANDING_PROJECTION_PREFIX": "advisory"
+    },
+    "devops-project-service-gamma": {
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
+    },
+    "devops-tracker-mutation-api-gamma": {
+      "DYNAMODB_TABLE": "deploy-critical",
+      "PROJECTS_TABLE": "deploy-critical",
+      "COORDINATION_INTERNAL_API_KEY": "deploy-critical"
     }
   }
 }

--- a/tools/test_synthetic_strip_proof.py
+++ b/tools/test_synthetic_strip_proof.py
@@ -49,8 +49,23 @@ TARGET_VARS = ["COORDINATION_INTERNAL_API_KEY", "SQS_QUEUE_URL"]
 
 # Canonical deploy parameter-override sets (prod uses the "" default; gamma uses
 # -gamma). The gate must pass under each, proving the good template is correct
-# for every sanctioned deploy target.
-OVERRIDE_SETS = [[], ["EnvironmentSuffix="], ["EnvironmentSuffix=-gamma"]]
+# for every sanctioned deploy target. ENC-TSK-H54: the gamma set now also pins
+# Environment=gamma so IsProduction=false — the real gamma deploy's parameters
+# (the prior ["EnvironmentSuffix=-gamma"]-only set left Environment at its
+# "production" default, masking the IsProduction-gated GDS_STANDING_PROJECTION_PREFIX).
+GAMMA_OVERRIDES = ["Environment=gamma", "EnvironmentSuffix=-gamma"]
+OVERRIDE_SETS = [[], ["EnvironmentSuffix="], ["EnvironmentSuffix=-gamma"], GAMMA_OVERRIDES]
+
+# ENC-TSK-H54 (ENC-PLN-050 P0): gamma parity coverage. Before H54 the registry
+# was keyed only by prod function names, so a -gamma-rendered deploy matched no
+# entry and the gate skipped every gamma function. These prove the gate now
+# catches a strip on a gamma function. ENCELADUS_COGNITO_CLIENT_SECRET is a
+# genuinely gamma-only deploy-critical var (only enceladus-mcp-code-gamma
+# requires it; no prod twin does). devops-coordination-api-gamma is one of the
+# H54-added twins that had NO registry entry before this task.
+GAMMA_ONLY_VAR = "ENCELADUS_COGNITO_CLIENT_SECRET"
+GAMMA_TWIN_FN = "devops-coordination-api-gamma"
+GAMMA_TWIN_VAR = "COORDINATION_INTERNAL_API_KEY"
 
 
 def _strip_var(text: str, var: str):
@@ -154,6 +169,69 @@ def test_sqs_strip_attributes_the_right_function():
                 if f["classification"] == gate.CRITICAL and f["var"] == "SQS_QUEUE_URL"]
         assert len(hits) == 1, f"expected one SQS_QUEUE_URL critical finding; got {hits}"
         assert hits[0]["function"] == "devops-deploy-intake", hits[0]["function"]
+
+
+def test_gamma_only_var_strip_fails():
+    """ENC-TSK-H54 AC0.2 (gamma-only var coverage): stripping
+    ENCELADUS_COGNITO_CLIENT_SECRET — a deploy-critical var that ONLY a -gamma
+    registry entry (enceladus-mcp-code-gamma) requires — makes the gate fail
+    closed (rc=2) under the gamma parameter-override set, attributed to the gamma
+    function. The good template passes under the same overrides."""
+    real = TEMPLATE.read_text()
+    # good template passes under the real gamma params (sanity).
+    assert _run_main(TEMPLATE, WAIVERS, GAMMA_OVERRIDES) == 0
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        waivers = _empty_waivers(tmp)
+        stripped, removed = _strip_var(real, GAMMA_ONLY_VAR)
+        assert removed > 0, f"strip of {GAMMA_ONLY_VAR} was a no-op — template format changed?"
+        tpl = _write(tmp, "stripped_gamma_only.yaml", stripped)
+        rc = _run_main(tpl, waivers, overrides=GAMMA_OVERRIDES)
+        assert rc == 2, f"gate did NOT fail closed when gamma-only {GAMMA_ONLY_VAR} stripped (rc={rc})"
+        result = gate.run_gate(tpl, {"Environment": "gamma", "EnvironmentSuffix": "-gamma"},
+                               REGISTRY, gate.load_waivers(None))
+        hits = [f for f in result["findings"]
+                if f["classification"] == gate.CRITICAL and f["var"] == GAMMA_ONLY_VAR]
+        assert any(f["function"] == "enceladus-mcp-code-gamma" for f in hits), \
+            f"{GAMMA_ONLY_VAR} strip not attributed to enceladus-mcp-code-gamma; got {hits}"
+
+
+def test_gamma_twin_governance_catches_strip():
+    """ENC-TSK-H54 AC0.2: a deploy-critical strip on a gamma twin that had NO
+    registry entry before H54 is now caught under the gamma override set. Proves
+    the registry expansion closed the 'gamma silently rots' gap (DOC-A07B553431FD):
+    the same strip on devops-coordination-api-gamma produced ZERO findings before
+    this task because the function was unregistered."""
+    real = TEMPLATE.read_text()
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        stripped, _ = _strip_var(real, GAMMA_TWIN_VAR)
+        tpl = _write(tmp, "stripped_twin.yaml", stripped)
+        result = gate.run_gate(tpl, {"Environment": "gamma", "EnvironmentSuffix": "-gamma"},
+                               REGISTRY, gate.load_waivers(None))
+        crit = [f for f in result["findings"]
+                if f["classification"] == gate.CRITICAL and f["function"] == GAMMA_TWIN_FN
+                and f["var"] == GAMMA_TWIN_VAR]
+        assert len(crit) == 1, f"expected {GAMMA_TWIN_FN}::{GAMMA_TWIN_VAR} critical finding; got {result['findings']}"
+        # And at least one finding must be on a -gamma function (gamma governance).
+        assert any(f["function"].endswith("-gamma") for f in result["findings"])
+
+
+def test_gds_prefix_is_advisory_on_gamma_not_failing():
+    """ENC-TSK-H54 AC0.3 reconciliation: GDS_STANDING_PROJECTION_PREFIX is
+    IsProduction-gated (02-compute.yaml L1047 -> AWS::NoValue on gamma) and is
+    registered ADVISORY on devops-graph-query-api-gamma. On the GOOD template
+    under the gamma params it must surface as an advisory WARN (visible gap) but
+    NOT fail the gate — it becomes deploy-critical only after ENC-TSK-H56 sets it
+    on gamma."""
+    result = gate.run_gate(TEMPLATE, {"Environment": "gamma", "EnvironmentSuffix": "-gamma"},
+                           REGISTRY, gate.load_waivers(WAIVERS))
+    assert result["failed"] is False, "good gamma template must pass"
+    adv = [f for f in result["findings"]
+           if f["classification"] == gate.ADVISORY
+           and f["function"] == "devops-graph-query-api-gamma"
+           and f["var"] == "GDS_STANDING_PROJECTION_PREFIX"]
+    assert len(adv) == 1, f"expected GDS_STANDING_PROJECTION_PREFIX advisory on gamma; got {result['findings']}"
 
 
 def _run_all() -> int:


### PR DESCRIPTION
## ENC-TSK-H54 — Gamma P0 env-parity drift audit + register gamma-required vars

**Plan:** ENC-PLN-050 (Gamma Stack Completion) · **Feature:** ENC-FTR-062 · **Reuses:** ENC-FTR-102 · **Rationale:** DOC-A07B553431FD

### Problem
The FTR-102 `env_drift_registry.json` was keyed **only by prod function names**. A compute deploy rendered under `EnvironmentSuffix=-gamma` produces `-gamma` function names that matched **no** registry entry, so the pre-deploy gate (`env_parity_gate.py` `has_registry_entry` skip, L102) **and** the hourly post-deploy `env_drift_auditor` both silently skipped every gamma function except the lone `enceladus-mcp-code-gamma`. That is the structural reason gamma drifted unobserved for ~2.5 months.

### Change
- **Register 11 `-gamma` twins** mirroring each registry-governed prod function rendered in `02-compute.yaml`, so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy.
- Every gamma **deploy-critical** var was verified **present + non-empty on the live gamma function** before registration → no `env_drift_auditor` P0-storm (ENC-ISS-369 class).
- `GDS_STANDING_PROJECTION_PREFIX` → **advisory** on `devops-graph-query-api-gamma`: `02-compute.yaml` L1047 gates it on `IsProduction` (`!Ref Environment`), so it resolves to `AWS::NoValue` on gamma **by design** until ENC-TSK-H56 provisions on-demand AGA GDS-PPR. Advisory = persistent visible WARN without failing gamma deploys.
- `PATHWAY_TELEMETRY_{BUCKET,PREFIX}` mirror prod's advisory (owned by ENC-TSK-H44; unset on prod **and** gamma).
- `ENABLE_LESSON_PRIMITIVE` (live-set on prod, unset on gamma) intentionally **not** registered: it is an out-of-band flag the template never sets, so it is not a template-strip-class var — codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig).
- **CI synthetic-strip proof extended** (`test_synthetic_strip_proof.py`): proper gamma override set (`Environment=gamma` + `EnvironmentSuffix=-gamma`), a gamma-only var strip (`ENCELADUS_COGNITO_CLIENT_SECRET`), a gamma-twin governance proof, and the GDS advisory-on-gamma reconciliation.

### Verification
- `tools/test_synthetic_strip_proof.py` — 6/6 ✅
- `test_cfn_env_resolver` 14/14, `test_env_parity_gate` 9/9, `test_live_template_strip_detector` 10/10, `test_env_parity_core` 17/17 ✅
- Gate PASSES on the good template for prod and gamma renders (gamma: 3 by-design advisory WARNs, 0 critical).
- Out of scope: `devops-github-integration` and prod `enceladus-mcp-code` are not rendered in `02-compute.yaml`.

Transition type: `no_code` (registry/CI registration; no CFN/Lambda deploy in this unit).

---
**Commit Gate:** CCI-a70d368154ff4b95b23907d36636f838 (minted via ENC-TSK-H60, code_only, owning commit 97e14c12fb3808d56d63aaf21b839979ee0b7a1c).
