### PR TITLE
ENC-TSK-H49: classify checkout-service blocked transitions + recommended_next_actions (ENC-ISS-142)

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -331,6 +331,71 @@ def _response(status: int, body: Any, extra_headers: Optional[dict] = None) -> d
     }
 
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-H49 / ENC-ISS-142: machine-readable failure classification.
+# Every blocked-transition envelope carries a `failure_classification` and a
+# `recommended_next_actions` array so agents can escalate with concrete operator
+# actions instead of guessing. Consumed by the agents.md "Escalation Protocol".
+# ---------------------------------------------------------------------------
+FAILURE_CLASSIFICATIONS = (
+    "transient",
+    "deterministic-governance",
+    "external-dependency",
+    "human-override-required",
+)
+
+# Map known error codes to a canonical classification. Codes not listed fall
+# back by HTTP status family (see _failure_classification).
+_CLASSIFICATION_BY_CODE = {
+    "INVALID_INPUT": "deterministic-governance",
+    "CONFLICT": "deterministic-governance",
+    "NOT_FOUND": "deterministic-governance",
+    "RESERVED_FIELD": "deterministic-governance",
+    "component_lifecycle_blocked": "deterministic-governance",
+    "GATE_CONDITION_UNMET": "deterministic-governance",
+    "PERMISSION_DENIED": "human-override-required",
+    "component_not_approved": "human-override-required",
+    "component_rejected": "human-override-required",
+    "COMPONENT_MISCONFIGURED": "human-override-required",
+    "INTERNAL_ERROR": "transient",
+}
+
+_RECOMMENDED_NEXT_ACTIONS = {
+    "deterministic-governance": [
+        "Re-run tracker.validation_rules(record_id, target_status, provider) for the exact required evidence and allowed next statuses.",
+        "Correct the governed inputs (set components/transition_type before checkout; supply the missing transition_evidence; satisfy the subtask gate), then retry once.",
+        "If the block persists, escalate per the agents.md Escalation Protocol (L2) -- never reshape governed state to bypass the gate.",
+    ],
+    "human-override-required": [
+        "This action is outside agent authority. Surface to io: use the PWA user_initiated (Cognito) path, or have io approve/remediate the component.",
+        "Do not retry against the Cognito/authority guard.",
+        "Escalate per the agents.md Escalation Protocol (L2/L3) with the exact failing operation and a proposed operator action.",
+    ],
+    "external-dependency": [
+        "The failure originates from an external dependency (e.g. GitHub API, Cognito). Check the upstream service status.",
+        "Retry after recovery within the bounded retry budget (3 attempts; 1s/4s/16s backoff).",
+        "If it persists, escalate per the agents.md Escalation Protocol (L2).",
+    ],
+    "transient": [
+        "Transient/internal error. Retry with exponential backoff (3 attempts; 1s/4s/16s).",
+        "If it persists after the retry budget, escalate per the agents.md Escalation Protocol.",
+    ],
+}
+
+
+def _failure_classification(
+    code: Optional[str], status: int, override: Optional[str]
+) -> str:
+    """Classify a blocked-transition failure (ENC-TSK-H49). An explicit override
+    wins (e.g. call sites that know a failure is an external dependency); else map
+    by error code; else fall back by HTTP status family."""
+    if override in FAILURE_CLASSIFICATIONS:
+        return override
+    if code in _CLASSIFICATION_BY_CODE:
+        return _CLASSIFICATION_BY_CODE[code]
+    return "transient" if status >= 500 else "deterministic-governance"
+
+
 def _error(
     status: int,
     message: str,
@@ -338,6 +403,7 @@ def _error(
     code: Optional[str] = None,
     retryable: Optional[bool] = None,
     details: Optional[Dict[str, Any]] = None,
+    failure_classification: Optional[str] = None,
 ) -> dict:
     details = dict(details or {})
     if not code:
@@ -357,6 +423,8 @@ def _error(
             code = "INTERNAL_ERROR"
     if retryable is None:
         retryable = status >= 500
+    classification = _failure_classification(code, status, failure_classification)
+    recommended_next_actions = _RECOMMENDED_NEXT_ACTIONS.get(classification, [])
     body: Dict[str, Any] = {
         "success": False,
         "error": message,
@@ -364,6 +432,8 @@ def _error(
             "code": code,
             "message": message,
             "retryable": retryable,
+            "failure_classification": classification,
+            "recommended_next_actions": recommended_next_actions,
             "details": details,
         },
     }

--- a/backend/lambda/checkout_service/test_checkout_error_context.py
+++ b/backend/lambda/checkout_service/test_checkout_error_context.py
@@ -289,5 +289,71 @@ class TestCodeOnMainEvidenceValidator(unittest.TestCase):
         self.assertIn("40-char hex", reason)
 
 
+class FailureClassificationTests(unittest.TestCase):
+    """ENC-TSK-H49 / ENC-ISS-142: every blocked-transition envelope carries a
+    machine-readable failure_classification + a recommended_next_actions array."""
+
+    def _envelope(self, status, **kw):
+        resp = checkout_service._error(status, "boom", **kw)
+        return json.loads(resp["body"])["error_envelope"]
+
+    def test_invalid_input_is_deterministic_governance(self):
+        env = self._envelope(400)
+        self.assertEqual(env["failure_classification"], "deterministic-governance")
+        self.assertTrue(env["recommended_next_actions"])
+        self.assertIn("validation_rules", " ".join(env["recommended_next_actions"]))
+
+    def test_conflict_is_deterministic_governance(self):
+        self.assertEqual(
+            self._envelope(409)["failure_classification"], "deterministic-governance"
+        )
+
+    def test_permission_denied_is_human_override(self):
+        env = self._envelope(403)
+        self.assertEqual(env["failure_classification"], "human-override-required")
+        self.assertTrue(env["recommended_next_actions"])
+
+    def test_internal_error_is_transient(self):
+        self.assertEqual(self._envelope(500)["failure_classification"], "transient")
+
+    def test_explicit_override_wins(self):
+        env = self._envelope(400, failure_classification="external-dependency")
+        self.assertEqual(env["failure_classification"], "external-dependency")
+        self.assertTrue(env["recommended_next_actions"])
+
+    def test_unknown_override_is_ignored(self):
+        # An override outside the canonical set falls back to code/status mapping.
+        env = self._envelope(400, failure_classification="bogus")
+        self.assertEqual(env["failure_classification"], "deterministic-governance")
+
+    def test_domain_code_classified(self):
+        env = self._envelope(400, code="COMPONENT_MISCONFIGURED")
+        self.assertEqual(env["failure_classification"], "human-override-required")
+
+    def test_classification_always_in_canonical_set(self):
+        for status in (400, 401, 403, 404, 409, 500):
+            self.assertIn(
+                self._envelope(status)["failure_classification"],
+                checkout_service.FAILURE_CLASSIFICATIONS,
+            )
+
+    def test_backward_compatible_details_preserved(self):
+        # New fields coexist with existing details (AC#3 backward-compat).
+        env = self._envelope(
+            400, details={"required_fields": ["x"], "valid_next_statuses": ["y"]}
+        )
+        self.assertEqual(env["details"]["required_fields"], ["x"])
+        self.assertEqual(env["details"]["valid_next_statuses"], ["y"])
+        self.assertIn("failure_classification", env)
+        self.assertIn("recommended_next_actions", env)
+
+    def test_real_checkout_block_carries_classification(self):
+        # Integration: a real blocked checkout (missing session id) is classified.
+        resp = checkout_service._handle_checkout("enceladus", "ENC-TSK-840", {})
+        env = json.loads(resp["body"])["error_envelope"]
+        self.assertEqual(env["failure_classification"], "deterministic-governance")
+        self.assertTrue(env["recommended_next_actions"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -516,6 +516,15 @@
           "type": "boolean",
           "definition": "Whether the caller can retry unchanged input or must first correct the request."
         },
+        "failure_classification": {
+          "type": "enum",
+          "enum": ["transient", "deterministic-governance", "external-dependency", "human-override-required"],
+          "definition": "ENC-TSK-H49 / ENC-ISS-142: machine-readable category of a blocked-transition failure so agents route to the correct Escalation Protocol response instead of guessing. Derived in checkout_service._failure_classification from the error code (with an HTTP status-family fallback) or an explicit per-call override. transient = retry with backoff; deterministic-governance = correct governed inputs then escalate L2; external-dependency = upstream (GitHub/Cognito) retry; human-override-required = needs io / Cognito / PWA action. Present on every checkout_service error envelope; other emitters may adopt it incrementally."
+        },
+        "recommended_next_actions": {
+          "type": "array",
+          "definition": "ENC-TSK-H49 / ENC-ISS-142: ordered operator-facing next actions keyed to failure_classification, consumed by the agents.md Escalation Protocol. checkout_service supplies a default action list per classification (checkout_service._RECOMMENDED_NEXT_ACTIONS)."
+        },
         "details": {
           "type": "object",
           "definition": "Self-correcting context for the next attempt. Standard keys: required_fields (list), allowed_values (dict), evidence_schema (dict), strictness_rank (list), example_fix (dict with tool+arguments). Post-D56 additions: allowed_plan_transitions (dict), plan_terminal_statuses (list), token_type/token_purpose/prerequisite_call (CAI/CCI), lesson_gate_requirements (dict), ogtm_compliance_template (dict with 4 requirements + evidence template), dpl_record_id_format/dpl_ddb_key_schema/dpl_label_conventions (GMF/DPL), governed_rules (list of rule strings)."


### PR DESCRIPTION
## ENC-TSK-H49 — Checkout-service failure classification (ENC-ISS-142, gate #2)

Enriches the checkout-service error envelope (`_error()`) so every blocked `checkout.task` / `advance` / `append_worklog` response carries:
- **`failure_classification`** in {transient, deterministic-governance, external-dependency, human-override-required}
- **`recommended_next_actions`** — operator-facing actions that route blocked agents into the agents.md **Escalation Protocol** (ENC-TSK-H48) instead of guessing.

Centralized + additive (backward compatible): a `_CLASSIFICATION_BY_CODE` map with an HTTP status-family fallback and an optional per-call override for sites that know a failure is external-dependency.

### Acceptance criteria
- AC#1 classification enum on every blocked response ✅
- AC#2 `recommended_next_actions` array ✅
- AC#3 backward compatible + regression tests ✅ (+9 tests; full `checkout_service` suite 73/73 green)

### Governance
- `governance_data_dictionary.json` `api.error_envelope` documents the two new fields (Dict Guard).
- Component: `comp-checkout-service`. Arc: `github_pr_deploy`. Diff: +136 / -0.

CCI-35831b29b0f5481784899ca7dd120f18

🤖 Generated with [Claude Code](https://claude.com/claude-code)