### PR TITLE
[DO-NOT-MERGE] ENC-TSK-H57: codify graphsearch ingress routes (03-api.yaml)

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -187,6 +187,38 @@ Resources:
       PayloadFormatVersion: '2.0'
 
   # ---------------------------------------------------------------------------
+  # Graph Query API — graphsearch ingress (ENC-TSK-H57 / ENC-PLN-050)
+  # Codifies the graphsearch routes that exist live-but-uncodified on prod
+  # (API 8nkzqkmxqc, out-of-band drift) so that (a) gamma gets a governed HTTP
+  # path to its OWN graph — closing gap #1, where gamma graphsearch 404s and the
+  # graph is reachable only via direct Lambda invoke — and (b) the eventual prod
+  # promotion is a no-op delta against prod's real contract rather than a
+  # behaviour change. EnvironmentSuffix routes to the per-env Lambda
+  # (devops-graph-query-api / devops-graph-query-api-gamma), each of which holds
+  # its own NEO4J_SECRET_NAME and therefore reaches the correct graph.
+  # Mirrors the prod integration exactly: AWS_PROXY POST, payload 2.0.
+  # ---------------------------------------------------------------------------
+  GraphQueryIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  # Grants the HTTP API permission to invoke the graph-query Lambda for the
+  # graphsearch path only. Mirrors the prod live resource policy statement
+  # (Sid allow-apigw-8nkzqkmxqc-graphsearch); CFN assigns its own statement id.
+  GraphQueryApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*/api/v1/tracker/graphsearch*"
+
+  # ---------------------------------------------------------------------------
   # Routes — Coordination API
   # ---------------------------------------------------------------------------
 
@@ -346,6 +378,32 @@ Resources:
       ApiId: !Ref HttpApi
       RouteKey: PATCH /api/v1/tracker/{projectId}/{recordType}/{recordId}
       Target: !Sub integrations/${TrackerMutationIntegration}
+
+  # graphsearch ingress routes (ENC-TSK-H57) — mirror prod API 8nkzqkmxqc
+  # exactly: GET + OPTIONS on /graphsearch and GET on /graphsearch/health, all
+  # AuthorizationType NONE, all targeting GraphQueryIntegration. /graphsearch
+  # serves neighbors/keyword/path/hybrid queries; /graphsearch/health is the
+  # governed graph_index + graph_projection health probe (closes AC3.2).
+  RouteGraphSearch:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchHealth:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch/health
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchOptions:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
 
   # ---------------------------------------------------------------------------
   # Routes — Document API


### PR DESCRIPTION
> **STATUS UPDATE (2026-06-23, ENC-TSK-H64):** The gamma blocker is now CLEARED — `enceladus-api-gamma` was reconciled (resource-import of the 6 out-of-band resources) and the graphsearch routes from this PR's diff are **already LIVE on gamma** (deployed gamma-first by ENC-TSK-H64, not via this merge). The **only remaining blocker is prod promotion (ENC-ISS-394)**: merging this to `main` would fire the prod `enceladus-api` deploy and hit `ResourceAlreadyExists` on prod's out-of-band routes. Converted to **Draft** — this PR is the staged prod-promotion artifact and must merge only as part of the gated prod resource-import (ENC-ISS-394), NOT before. See report DOC-AF44C9F96A56.

---

## ⛔ DO NOT MERGE TO main — evidence/codification PR for ENC-TSK-H57 (no_code)

Merging to `main` auto-triggers the **prod** `enceladus-api` deploy (`EnvironmentSuffix=''`), which would attempt to CREATE prod's **already-live** graphsearch routes → `ResourceAlreadyExists` → prod api-stack rollback. Prod promotion is a deliberate, **gated resource-import** step tracked by **ENC-ISS-394**.

## What this does
Codifies the graphsearch ingress into the API-layer template (`infrastructure/cloudformation/03-api.yaml`):
- `GraphQueryIntegration` — AWS_PROXY POST → `devops-graph-query-api${EnvironmentSuffix}`
- `GraphQueryApiInvokePermission` — apigw invoke scoped to `.../api/v1/tracker/graphsearch*`
- `RouteGraphSearch`, `RouteGraphSearchHealth`, `RouteGraphSearchOptions`

Mirrors prod API `8nkzqkmxqc`'s exact live contract (payload 2.0, `AuthorizationType: NONE`). `EnvironmentSuffix` routes each env to its own graph-query Lambda (each holds its own `NEO4J_SECRET_NAME`).

## Why
- **Gamma gap #1 (ENC-TSK-H57):** gamma graphsearch 404s; the graph is reachable only via direct Lambda invoke. These routes give gamma a governed HTTP path to its own graph (AC3.1) + a graph health probe (`.../graphsearch/health`, AC3.2).
- **Prod drift (ENC-ISS-394):** prod's graphsearch routes are live-but-uncodified out-of-band drift; codifying them makes the prod promotion a no-op delta instead of a behaviour change.

## Blocked on (not merged here)
- **Gamma go-live:** `ENC-TSK-H64` — the gamma `enceladus-api-gamma` stack is `UPDATE_ROLLBACK_COMPLETE` with ~6 live out-of-band resources; needs a resource-import reconciliation before any gamma api deploy can land.
- **Prod go-live:** `ENC-ISS-394` — gated resource-import promotion.

Plan: **ENC-PLN-050**. Related: ENC-TSK-H57, ENC-TSK-H64, ENC-TSK-H58, ENC-ISS-394.
