### PR TITLE
ENC-TSK-H63: disable main → v4/main auto-sync for PLN-006 fork-mode

### DIFF
--- a/.github/workflows/sync-main-to-v4main.yml
+++ b/.github/workflows/sync-main-to-v4main.yml
@@ -1,5 +1,15 @@
 name: Sync main to v4/main
 
+# ============================================================================
+# DISABLED — ENC-TSK-H63 (ENC-PLN-006 fork-mode).
+# v4/main has diverged from main and is now ahead with v4-only work, so
+# auto-syncing main -> v4/main is a collision risk (it would -s ours clobber
+# v4/main's tree, or fail-loud on every main push). The single `sync` job is
+# gated off via `if: ${{ false }}` below. Do NOT re-enable without io approval.
+# promote-gamma-to-prod-request.yml stays active — the approval gate there is
+# the cutover toggle. Re-enable only when v4 is cut over to main.
+# ============================================================================
+#
 # ENC-TSK-G71: Auto-sync main -> v4/main on every main push.
 # v4/main rulesets reject direct push from non-bypass actors, so the sync
 # runs as a transient PR with auto-merge enabled. The PR base is v4/main and
@@ -28,6 +38,10 @@ concurrency:
 
 jobs:
   sync:
+    # ENC-TSK-H63: hard-disabled for the duration of ENC-PLN-006 fork-mode.
+    # See the DISABLED banner at the top of this file. Removing this guard
+    # re-enables the main -> v4/main auto-sync and requires io approval.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## ENC-TSK-H63 — Disable `sync-main-to-v4main.yml` for PLN-006 fork-mode

`v4/main` has diverged from `main` and is now strictly ahead with v4-only
work, so the `main → v4/main` auto-sync is a collision risk: it would
`-s ours` clobber v4/main's tree, or fail-loud on every main push.

This PR gates the single `sync` job off with `if: ${{ false }}` and adds a
DISABLED banner. The file/history are preserved so re-enabling is a one-line
revert (which must **not** happen without io approval).

`promote-gamma-to-prod-request.yml` is intentionally **left active** — the
v3-prod approval gate remains the cutover toggle (ENC-TSK-G71).

### Self-disabling on merge
The sync workflow triggers on `push: [main]` and GitHub evaluates the workflow
at the pushed commit. The merge commit here carries `if: ${{ false }}`, so the
sync job is skipped on its own arrival — no clobber risk during cutover.

CCI-eaabd2decd38497c8f1d9dbf4cf81fb1

🤖 Generated with [Claude Code](https://claude.com/claude-code)