### PR TITLE
ENC-TSK-H64: gamma api-stack reconcile artifacts (deploy-role TagResource + gamma import manifest)

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -94,6 +94,12 @@ Resources:
                   - apigateway:PUT
                   - apigateway:PATCH
                   - apigateway:DELETE
+                  # ENC-TSK-H64: CFn tags stages with stack tags on create; the
+                  # 2026-04-28 ApiDefaultStage CREATE_FAILED was an apigateway:TagResource
+                  # AccessDenied (not CreateStage). Required for the deploy role to
+                  # manage the gamma $default stage going forward.
+                  - apigateway:TagResource
+                  - apigateway:UntagResource
                 Resource:
                   - !Sub "arn:aws:apigateway:us-west-2::/*"
 

--- a/infrastructure/cloudformation/resource-import-api-gamma.json
+++ b/infrastructure/cloudformation/resource-import-api-gamma.json
@@ -1,0 +1,8 @@
+[
+  {"ResourceType":"AWS::ApiGatewayV2::Stage","LogicalResourceId":"ApiDefaultStage","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","StageName":"$default"}},
+  {"ResourceType":"AWS::ApiGatewayV2::Route","LogicalResourceId":"RouteComponentsAddEdge","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","RouteId":"sj35b5h"}},
+  {"ResourceType":"AWS::ApiGatewayV2::Route","LogicalResourceId":"RouteComponentsRemoveEdge","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","RouteId":"l4firt2"}},
+  {"ResourceType":"AWS::ApiGatewayV2::Route","LogicalResourceId":"RouteComponentsDeprecate","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","RouteId":"irvhawj"}},
+  {"ResourceType":"AWS::ApiGatewayV2::Route","LogicalResourceId":"RouteComponentsRestore","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","RouteId":"ek3cpd0"}},
+  {"ResourceType":"AWS::ApiGatewayV2::Route","LogicalResourceId":"RouteComponentsRevert","ResourceIdentifier":{"ApiId":"hi0dzmvqrc","RouteId":"ugv0wfl"}}
+]


### PR DESCRIPTION
## Summary

Durability artifacts from the **ENC-TSK-H64** gamma `enceladus-api-gamma` reconciliation (a `no_code` task, already **closed** — the live AWS operations were applied via CLI under `io-dev-admin` this session). This PR codifies what was done live so it survives future stack deploys.

- **`04-github-roles.yaml`** — add `apigateway:TagResource` + `apigateway:UntagResource` to the `ApiGatewayOps` statement. The 2026-04-28 `ApiDefaultStage` CREATE_FAILED was an `apigateway:TagResource` AccessDenied (**not** `CreateStage` — the role already had `apigateway:POST`). The live grant is already applied; this prevents the next github-roles stack deploy from stripping it (ENC-LSN-053 strip class).
- **`resource-import-api-gamma.json`** — the gamma CFN resource-import manifest for the 6 live out-of-band resources (`$default` stage + the 5 component edge routes). The prior `resource-import-api.json` was prod-only.

## Context
- Report: **DOC-AF44C9F96A56**
- Plan: ENC-PLN-050 · related: ENC-TSK-H57 (graphsearch codification, PR #535 DO-NOT-MERGE), ENC-TSK-H58 (next)

## ⚠️ Merge notes
- H64 is `no_code` and already closed, so **no CCI token** was issued — the PR Commit Gate has nothing to validate. Merge will need the admin/`user_initiated` path or a follow-up governed task; this PR is for review + durability, not a gated deploy.
- The `04-github-roles.yaml` change only takes effect when the **github-roles stack** is deployed; until then the live grant (already applied) is what's authoritative.
- Does **not** touch `03-api.yaml` or prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Governance — PR Commit Gate
Governed under **ENC-TSK-H66** (`code_only`) — the codification home for the ENC-TSK-H64 (`no_code`) artifacts.

CCI-ba61bc13a9a346d5b97d36abd318282d

(commit_sha cfdac7b2d9558acde624c5e80b9a76a6cf7955c4 advanced to `committed`; merging is deploy-inert — neither file is in any CFN push-trigger path.)
