### PR TITLE
docs(agents): note PLN-006 fork-mode in AGENTS.md (ENC-TSK-H68)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,11 @@ Tasks declare a `deploy_target` field:
 
 PR label convention: `target:prod`, `target:gamma`, `target:undeclared`.
 
+> **Fork-mode control (ENC-PLN-006 / ENC-TSK-H63):** the `main → v4/main` auto-sync
+> workflow (`sync-main-to-v4main.yml`) is **DISABLED** via job-level `if: ${{ false }}`.
+> v4/main has diverged ahead of main; do **not** re-enable without io approval.
+> `promote-gamma-to-prod-request.yml` stays active as the cutover toggle (ENC-TSK-G71).
+
 ### Evolution Chapter Contribution
 
 Agent sessions contribute to the active generation's evolution chapter document via


### PR DESCRIPTION
## Summary

Mirrors the **ENC-TSK-H63** fork-mode control note into the repo-side `AGENTS.md`
§ *Generation-Scoped Deploy Target Convention*. The `main → v4/main` auto-sync
workflow (`sync-main-to-v4main.yml`) is disabled via job-level `if: ${{ false }}`
for the duration of ENC-PLN-006; `promote-gamma-to-prod-request.yml` stays active
as the cutover toggle (ENC-TSK-G71).

The equivalent subsection is already live in governance
`agents/generation-conventions.md` §16 (applied via §13 S3 archive+put).

This completes the repo-surface portion of ENC-TSK-H63 AC#4.

Task: ENC-TSK-H68 (code_only)
Related: ENC-TSK-H63, ENC-PLN-006

CCI-f962594340b24423bf43e679843ffe09