### PR TITLE
ENC-TSK-H58/H69: gamma deploy→validate→promote gate (smoke + graph-probe + env-parity)

### DIFF
--- a/.github/workflows/promote-gamma-to-prod-request.yml
+++ b/.github/workflows/promote-gamma-to-prod-request.yml
@@ -5,6 +5,17 @@ name: Promote v4-gamma success to v3-prod request
 # the v3-prod GitHub Environment's required-reviewer rule and pauses until
 # io approves. The approval click is the cutover toggle: stop approving =>
 # v4 work stays in gamma without any workflow rewiring.
+#
+# ENC-TSK-H58: a successful gamma DEPLOY is necessary but NOT sufficient to offer
+# promotion. Before dispatching the prod request we run the GAMMA VALIDATION GATE
+# (tools/gamma_validation_gate.sh) — a runtime probe of the live gamma environment:
+# smoke (ingress 200) + graph-probe (the full hybrid trio is live and PPR-ranked:
+# graph_algorithm=gds_pagerank after warming the on-demand standing projection) +
+# env-parity (no deploy-critical gamma var the next compute deploy would strip).
+# The gate is FAIL-CLOSED: a red gate fails this job, so the dispatch step never
+# runs and promotion is not offered. Promotion itself stays human-approved (the
+# v3-prod Environment required-reviewer gate) — the gate only makes it AVAILABLE.
+# Bound to ENC-LSN-039 (pre-probe gamma before prod handoffs).
 
 on:
   workflow_run:
@@ -14,10 +25,14 @@ on:
 permissions:
   actions: write
   contents: read
+  id-token: write   # ENC-TSK-H58: OIDC for the gamma validation gate's AWS calls
 
 concurrency:
   group: promote-gamma-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
 
 jobs:
   promote:
@@ -26,8 +41,30 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'v4/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15   # ENC-TSK-H58: +gate warm-projection latency budget
     steps:
+      # ENC-TSK-H58: check out so the validation gate (tools/) + the compute
+      # template (env-parity check) are available at the promoted SHA.
+      - name: Checkout (promoted gamma SHA)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ENC-TSK-H58: THE validation gate. Fail-closed — no continue-on-error, so a
+      # red gate fails the job and the dispatch step below never runs. The gate
+      # warms the on-demand gamma standing projection, then asserts smoke + the
+      # full hybrid trio (graph_algorithm=gds_pagerank) + env-parity.
+      - name: Gamma validation gate (smoke + graph-probe + env-parity)
+        env:
+          COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
+        run: bash tools/gamma_validation_gate.sh --region "${AWS_REGION}"
+
       - name: Dispatch v3-prod deploy request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,11 +73,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "Gamma success run=$GAMMA_RUN_ID sha=$SHA — dispatching v3-prod request"
+          echo "Gamma validation gate GREEN. Run=$GAMMA_RUN_ID sha=$SHA — dispatching v3-prod request"
 
-          # gh api is used here (not gh workflow run) because there's no
-          # checkout in this job and gh workflow run requires a local git
-          # context. Workflow ID 263796502 = Deploy Lambda Artifacts (Gen2).
+          # Workflow ID 263796502 = Deploy Lambda Artifacts (Gen2). The dispatch
+          # hits the v3-prod Environment's required-reviewer rule and pauses for io.
           gh api -X POST \
             "/repos/$REPO/actions/workflows/263796502/dispatches" \
             -f ref=main \

--- a/tools/gamma_validation_gate.sh
+++ b/tools/gamma_validation_gate.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Gamma deploy->validate->promote gate — ENC-TSK-H58 (code child ENC-TSK-H69).
+#
+# Fail-closed RUNTIME validation of the live gamma pre-prod environment, run AFTER
+# a gamma deploy and BEFORE prod promotion. A green run makes prod promotion
+# AVAILABLE (the caller dispatches promote-gamma-to-prod-request.yml, which then
+# pauses on the v3-prod required-reviewer gate for a HUMAN to approve). A red run
+# blocks promotion. This is the gamma analog of tools/pre-deploy-health-gate.sh,
+# but it probes the LIVE deployed environment instead of a template.
+#
+# Bound to ENC-LSN-039 (pre-probe gamma before prod handoffs) and
+# DOC-733D76F4849B L1 (observability precedes deployability). It is the validation
+# step the api-stack deploy path lacks (ENC-TSK-H64 finding).
+#
+# Checks (ALL must pass — fail-closed):
+#   1. WARM   — invoke the on-demand standing-projection refresh on
+#               devops-graph-query-api-gamma (gamma has no always-warm AGA session,
+#               per the ENC-PLN-050 cost model, so the gds_standing projection is
+#               cold between runs). BEST-EFFORT: the refresh response's `ok` flag is
+#               a known FALSE-NEGATIVE on a cold AGA session (gds.graph.drop raises
+#               "graph ... might exist on another database"), so we DO NOT gate on it
+#               — we gate on the actual hybrid query in check 3 (ENC-TSK-H58 finding).
+#   2. SMOKE  — gamma API ingress serves: capabilities == 200 AND graphsearch/health
+#               == 200 with graph_index status == healthy.
+#   3. GRAPH  — the full hybrid trio is live and PPR-ranked: a gamma hybrid
+#               graphsearch returns graph_algorithm == gds_pagerank AND
+#               signal_availability {vector, graph, keyword} all true.
+#   4. PARITY — tools/env_parity_gate.py is green on the gamma compute param set
+#               (no deploy-critical env var the next gamma compute deploy would strip).
+#
+# Usage:
+#   COORDINATION_INTERNAL_API_KEY=<key> bash tools/gamma_validation_gate.sh
+#
+# Options:
+#   --skip-warm        Skip check 1 (used to PROVE fail-closed: a cold projection
+#                      makes check 3 fall back off gds_pagerank -> gate RED).
+#   --api-id <id>      Gamma tracker API id          (default: hi0dzmvqrc)
+#   --graph-fn <name>  Gamma graph-query Lambda name (default: devops-graph-query-api-gamma)
+#   --template <path>  Compute template for env-parity (default: infrastructure/cloudformation/02-compute.yaml)
+#   --region <region>  AWS region                    (default: us-west-2 / AWS_DEFAULT_REGION)
+#
+# Exit codes: 0 = GREEN (promotion available), 1 = RED (promotion blocked).
+
+set -uo pipefail  # deliberately NOT -e: run all checks, then aggregate fail-closed.
+
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GAMMA_API_ID="hi0dzmvqrc"
+GAMMA_GRAPH_FN="devops-graph-query-api-gamma"
+TEMPLATE_FILE="infrastructure/cloudformation/02-compute.yaml"
+SKIP_WARM=false
+PROJECT="enceladus"
+ANCHOR="${GAMMA_GATE_ANCHOR:-ENC-FTR-062}"          # a stable gamma feature node to anchor PPR
+QUERY="${GAMMA_GATE_QUERY:-extended mind governance}"
+GRAPH_PROBE_TIMEOUT="${GRAPH_PROBE_TIMEOUT:-120}"   # AGA warm-projection build latency budget (s)
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-warm) SKIP_WARM=true; shift ;;
+        --api-id) GAMMA_API_ID="$2"; shift 2 ;;
+        --graph-fn) GAMMA_GRAPH_FN="$2"; shift 2 ;;
+        --template) TEMPLATE_FILE="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
+        *) echo "[ERROR] unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+[[ "$TEMPLATE_FILE" = /* ]] || TEMPLATE_FILE="${REPO_ROOT}/${TEMPLATE_FILE}"
+BASE="https://${GAMMA_API_ID}.execute-api.${REGION}.amazonaws.com"
+ERRORS=0
+PASSES=0
+
+note()  { echo "  $*"; }
+pass()  { echo "[PASS] $*"; PASSES=$((PASSES + 1)); }
+fail()  { echo "[FAIL] $*"; ERRORS=$((ERRORS + 1)); }
+
+echo "============================================================"
+echo "  GAMMA VALIDATION GATE — runtime pre-prod gate (ENC-TSK-H58)"
+echo "  api=${GAMMA_API_ID}  graph_fn=${GAMMA_GRAPH_FN}  region=${REGION}"
+echo "  skip_warm=${SKIP_WARM}  (a red gate BLOCKS prod promotion)"
+echo "============================================================"
+
+# --- Check 1: WARM the on-demand gamma standing projection (best-effort) -------
+echo ""
+echo "[CHECK 1/4] Warming the on-demand gamma standing projection..."
+if [[ "$SKIP_WARM" == "true" ]]; then
+    note "--skip-warm set: NOT warming (fail-closed demonstration mode)."
+else
+    # ASYNC (--invocation-type Event): the AGA projection build is slow (~30-90s) and
+    # synchronous invoke would block the gate. Fire-and-forget the refresh, then check 3
+    # polls the live hybrid query until the projection is warm (or the budget expires).
+    REFRESH_OUT="$(mktemp)"
+    if aws lambda invoke --function-name "$GAMMA_GRAPH_FN" --region "$REGION" \
+            --invocation-type Event \
+            --cli-binary-format raw-in-base64-out \
+            --payload "{\"action\":\"refresh_projection\",\"project_ids\":[\"${PROJECT}\"]}" \
+            "$REFRESH_OUT" >/dev/null 2>&1; then
+        note "refresh dispatched async (202) — projection warming in the background."
+        note "(refresh.ok is a known false-negative on cold AGA — check 3 is the real graph gate.)"
+    else
+        note "refresh dispatch errored (best-effort) — check 3 still governs the graph signal."
+    fi
+    rm -f "$REFRESH_OUT"
+fi
+
+# --- Check 2: SMOKE — ingress serves -------------------------------------------
+echo ""
+echo "[CHECK 2/4] Smoke — gamma ingress (capabilities + graphsearch/health)..."
+CAP_CODE="$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/api/v1/coordination/capabilities" 2>/dev/null || echo 000)"
+HEALTH_BODY="$(curl -s "${BASE}/api/v1/tracker/graphsearch/health" 2>/dev/null || echo '{}')"
+HEALTH_STATUS="$(echo "$HEALTH_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("status","?"))' 2>/dev/null || echo '?')"
+if [[ "$CAP_CODE" == "200" && "$HEALTH_STATUS" == "healthy" ]]; then
+    pass "smoke: capabilities=200, graphsearch/health status=healthy"
+else
+    fail "smoke: capabilities=${CAP_CODE} (want 200), graphsearch/health status=${HEALTH_STATUS} (want healthy)"
+fi
+
+# --- Check 3: GRAPH — full trio + gds_pagerank (the real graph gate) -----------
+echo ""
+echo "[CHECK 3/4] Graph-probe — gamma hybrid must return graph_algorithm=gds_pagerank + full trio..."
+if [[ -z "${COORDINATION_INTERNAL_API_KEY:-}" ]]; then
+    fail "graph-probe: COORDINATION_INTERNAL_API_KEY not set (required to authenticate the hybrid probe)"
+else
+    Q="$(python3 -c 'import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))' "$QUERY")"
+    URL="${BASE}/api/v1/tracker/graphsearch?project_id=${PROJECT}&search_type=hybrid&query=${Q}&anchor_record_id=${ANCHOR}&top_n=5"
+    DEADLINE=$(( $(date +%s) + GRAPH_PROBE_TIMEOUT ))
+    GRAPH_OK=false
+    LAST=""
+    while [[ $(date +%s) -lt $DEADLINE ]]; do
+        BODY="$(curl -s -H "x-coordination-internal-key: ${COORDINATION_INTERNAL_API_KEY}" "$URL" 2>/dev/null || echo '{}')"
+        # Single parse -> "ALGO|TRIO|SUCCESS" (no backslashes in f-strings — py<3.12 safe).
+        PARSED="$(printf '%s' "$BODY" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("PARSE_ERR|N|False"); sys.exit()
+sa = d.get("signal_availability") or {}
+trio = "Y" if (sa.get("vector") and sa.get("graph") and sa.get("keyword")) else "N"
+print("%s|%s|%s" % (d.get("graph_algorithm"), trio, d.get("success")))
+' 2>/dev/null || echo "PARSE_ERR|N|False")"
+        ALGO="${PARSED%%|*}"; _rest="${PARSED#*|}"; TRIO="${_rest%%|*}"; SUCCESS="${_rest##*|}"
+        LAST="algo=${ALGO} trio=${TRIO} success=${SUCCESS}"
+        if [[ "$ALGO" == "gds_pagerank" && "$TRIO" == "Y" ]]; then GRAPH_OK=true; break; fi
+        note "graph signal not yet warm (${LAST}) — retrying..."
+        sleep 10
+    done
+    if [[ "$GRAPH_OK" == "true" ]]; then
+        pass "graph-probe: $LAST"
+    else
+        fail "graph-probe: never reached gds_pagerank+full-trio within ${GRAPH_PROBE_TIMEOUT}s (last: $LAST)"
+    fi
+fi
+
+# --- Check 4: ENV-PARITY — gamma compute param set -----------------------------
+echo ""
+echo "[CHECK 4/4] Env-parity — no deploy-critical gamma var the next compute deploy would strip..."
+if python3 "${REPO_ROOT}/tools/env_parity_gate.py" \
+        --template "$TEMPLATE_FILE" \
+        --parameter "EnvironmentSuffix=-gamma" >/dev/null 2>&1; then
+    pass "env-parity: gamma compute env is template-codified (no strip-class gaps)"
+else
+    fail "env-parity: env_parity_gate.py found deploy-critical gamma var(s) the deploy would strip (run it directly for detail)"
+fi
+
+# --- Verdict -------------------------------------------------------------------
+echo ""
+echo "============================================================"
+if [[ "$ERRORS" -eq 0 ]]; then
+    echo "  GAMMA GATE: GREEN (${PASSES}/3 checks passed) — prod promotion AVAILABLE."
+    echo "  (Promotion still pauses on the v3-prod required-reviewer gate — human approves.)"
+    echo "============================================================"
+    exit 0
+else
+    echo "  GAMMA GATE: RED (${ERRORS} check(s) failed) — prod promotion BLOCKED."
+    echo "============================================================"
+    exit 1
+fi

--- a/tools/test_gamma_validation_gate.sh
+++ b/tools/test_gamma_validation_gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Hermetic tests for tools/gamma_validation_gate.sh — ENC-TSK-H58 (child ENC-TSK-H69).
+#
+# No live AWS/network: stubs `aws` + `curl` on PATH and runs the gate inside a temp
+# REPO_ROOT whose tools/env_parity_gate.py is a controllable fake. Asserts the
+# FAIL-CLOSED contract: GREEN only when every gating check passes; RED (exit 1)
+# whenever any one of smoke / graph (gds_pagerank+trio) / env-parity fails.
+set -uo pipefail
+
+SRC_GATE="$(cd "$(dirname "$0")" && pwd)/gamma_validation_gate.sh"
+FAILS=0
+
+make_sandbox() {
+    # $1=dir. Lays out tmp/{bin,tools,infrastructure/cloudformation} + stubs.
+    local d="$1"
+    mkdir -p "$d/bin" "$d/tools" "$d/infrastructure/cloudformation"
+    cp "$SRC_GATE" "$d/tools/gamma_validation_gate.sh"
+    : > "$d/infrastructure/cloudformation/02-compute.yaml"
+
+    cat > "$d/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+# warm-step stub: last arg is the output file; succeed silently.
+out="${@: -1}"; [[ "$out" == *.json || -e "$(dirname "$out")" ]] && : > "$out" 2>/dev/null
+exit 0
+EOF
+
+    cat > "$d/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${!#}"   # last arg is the URL
+case "$url" in
+  *"/coordination/capabilities"*) printf '%s' "${GATE_TEST_CAP_CODE:-200}" ;;   # -o /dev/null -w '%{http_code}'
+  *"/graphsearch/health"*)        printf '{"status":"%s","signals":{"vector":true,"graph":true,"keyword":true}}' "${GATE_TEST_HEALTH:-healthy}" ;;
+  *"search_type=hybrid"*)         printf '{"success":true,"graph_algorithm":"%s","signal_availability":{"vector":%s,"graph":%s,"keyword":%s}}' \
+                                    "${GATE_TEST_ALGO:-gds_pagerank}" "${GATE_TEST_V:-true}" "${GATE_TEST_G:-true}" "${GATE_TEST_K:-true}" ;;
+  *) printf '{}' ;;
+esac
+EOF
+
+    cat > "$d/tools/env_parity_gate.py" <<'EOF'
+import os, sys
+sys.exit(int(os.environ.get("GATE_TEST_PARITY_EXIT", "0")))
+EOF
+    chmod +x "$d/bin/aws" "$d/bin/curl"
+}
+
+run_case() {
+    # $1=name  $2=expected_exit  rest=env assignments
+    local name="$1" expect="$2"; shift 2
+    local d; d="$(mktemp -d)"; make_sandbox "$d"
+    local out rc
+    out="$(cd "$d" && env PATH="$d/bin:$PATH" COORDINATION_INTERNAL_API_KEY=testkey \
+        GRAPH_PROBE_TIMEOUT=2 "$@" bash "$d/tools/gamma_validation_gate.sh" 2>&1)"
+    rc=$?
+    rm -rf "$d"
+    if [[ "$rc" -eq "$expect" ]]; then
+        echo "[ok]   $name -> exit $rc (expected $expect)"
+    else
+        echo "[FAIL] $name -> exit $rc (expected $expect)"
+        echo "$out" | sed 's/^/       | /'
+        FAILS=$((FAILS + 1))
+    fi
+}
+
+echo "=== gamma_validation_gate.sh hermetic tests ==="
+# All signals healthy -> GREEN.
+run_case "all-green"             0
+# Graph signal not gds_pagerank (cold/fallback) -> RED (the core fail-closed case).
+run_case "graph-not-pagerank"    1  GATE_TEST_ALGO=timeout
+# Graph trio incomplete (graph signal down) -> RED.
+run_case "graph-trio-broken"     1  GATE_TEST_G=false
+# Smoke: capabilities non-200 -> RED.
+run_case "smoke-capabilities"    1  GATE_TEST_CAP_CODE=503
+# Smoke: health not healthy -> RED.
+run_case "smoke-health"          1  GATE_TEST_HEALTH=degraded
+# Env-parity gate fails (a deploy-critical var would be stripped) -> RED.
+run_case "env-parity-strip"      1  GATE_TEST_PARITY_EXIT=2
+# Missing internal key -> graph probe cannot authenticate -> RED.
+run_case "missing-key"           1  COORDINATION_INTERNAL_API_KEY=
+
+echo ""
+if [[ "$FAILS" -eq 0 ]]; then
+    echo "ALL TESTS PASSED"; exit 0
+else
+    echo "${FAILS} TEST(S) FAILED"; exit 1
+fi


### PR DESCRIPTION
## Summary
Inserts a **fail-closed gamma validation gate** between the v4/main gamma deploy and the (human-approved) v3-prod promotion. Turns gamma from "alive" into a TRUSTED pre-prod gate (ENC-TSK-H58, the ENC-PLN-050 payoff unit).

- **`tools/gamma_validation_gate.sh`** — runtime probe of the LIVE gamma env:
  1. **warm** the on-demand standing projection (async refresh; gamma has no always-warm AGA session per the cost model). Best-effort — the refresh `ok` is a known false-negative on cold AGA, so the gate asserts on the query, not the refresh.
  2. **smoke** — capabilities 200 + `graphsearch/health` healthy (ingress, ENC-TSK-H64).
  3. **graph** — gamma hybrid returns `graph_algorithm=gds_pagerank` + the full vector+graph+keyword trio (H56 PPR + H61 vector + keyword).
  4. **env-parity** — `tools/env_parity_gate.py` on the gamma compute params.
  Fail-closed (exit 1 → no promotion).
- **`tools/test_gamma_validation_gate.sh`** — hermetic stub tests: green + 6 red scenarios.
- **`promote-gamma-to-prod-request.yml`** — checkout + OIDC + run the gate as a fail-closed prerequisite. Promotion stays human-approved (v3-prod required-reviewer). Bound to ENC-LSN-039.

## Verification
- **GREEN** against live gamma: gate exits 0 (`graph_algorithm=gds_pagerank`, full trio).
- **RED / fail-closed** proven: `--skip-warm` (cold projection) → `graph_algorithm` stays `timeout` → exit 1; missing key → exit 1. Hermetic suite: 7/7.
- Prod-safe: CI/tooling only, **no resource deploy**, promotion unchanged (human-gated).

## Governance — PR Commit Gate
Governed under **ENC-TSK-H69** (`code_only`), child of **ENC-TSK-H58** (`no_code`).

CCI-d5cda6bf04ec41c18fa07d55393eb752

Handoff DOC-0F68A08668D2 · Plan ENC-PLN-050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)