### PR TITLE
ENC-TSK-H71 / ENC-ISS-398: deploy checkout_service to served + -auto companion (gamma)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -381,12 +381,13 @@ jobs:
               with _print_lock:
                   print(msg, file=(sys.stderr if err else sys.stdout), flush=True)
 
-          def deploy_one(fn, version_id):
-              """Per-function pipeline: download artifact, update code, publish version,
+          def deploy_one(fn, mapped_name, version_id):
+              """Per-target pipeline: download artifact, update code, publish version,
               kick off CodeDeploy canary (or fall back to direct alias). Returns:
                 {'fn', 'mapped_name', 'status', 'dep_id'?, 'error'?}
-              status in {'codedeploy', 'direct', 'skip', 'error'}."""
-              mapped_name = fn_map.get(fn)
+              status in {'codedeploy', 'direct', 'skip', 'error'}.
+              ENC-ISS-398: mapped_name is passed explicitly so one shared build artifact
+              (fn) can fan out to multiple target functions from a comma-list map value."""
               if not mapped_name:
                   log(f'[skip] {fn}  (not in function_name_map)')
                   return {'fn': fn, 'status': 'skip'}
@@ -525,20 +526,34 @@ jobs:
           # ============================================================
           # PARALLEL KICKOFF — 8-worker pool
           # ============================================================
-          targets = sorted(version_ids.items())
-          log(f'Kicking off {len(targets)} Lambda updates with 8-worker pool...')
-          t_kickoff = time.time()
+          # ENC-ISS-398: expand each built artifact (fn) into one deploy unit per target
+          # function. A function_name_map value may be a comma-separated list (e.g.
+          # checkout_service -> 'enceladus-checkout-service-gamma,...-auto-gamma') so one
+          # shared artifact updates several Lambda functions. Single-name values produce
+          # exactly one unit and behave identically to the prior 1:1 mapping.
           deployments = []  # list of (fn, mapped_name, dep_id)
           errors = []
           skipped = []
+          deploy_units = []  # list of (fn, mapped_name, version_id)
+          for fn, vid in sorted(version_ids.items()):
+              names = [n.strip() for n in (fn_map.get(fn) or '').split(',') if n.strip()]
+              if not names:
+                  log(f'[skip] {fn}  (not in function_name_map)')
+                  skipped.append(fn)
+                  continue
+              for mapped_name in names:
+                  deploy_units.append((fn, mapped_name, vid))
+          log(f'Kicking off {len(deploy_units)} Lambda updates with 8-worker pool...')
+          t_kickoff = time.time()
           with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-              futures = {pool.submit(deploy_one, fn, vid): fn for fn, vid in targets}
+              futures = {pool.submit(deploy_one, fn, mapped_name, vid): (fn, mapped_name)
+                         for fn, mapped_name, vid in deploy_units}
               for fut in concurrent.futures.as_completed(futures):
                   try:
                       result = fut.result()
                   except Exception as e:
-                      fn = futures[fut]
-                      log(f'::error::worker exception on {fn}: {e}', err=True)
+                      fn, mapped_name = futures[fut]
+                      log(f'::error::worker exception on {fn} -> {mapped_name}: {e}', err=True)
                       errors.append(fn)
                       continue
                   fn = result['fn']

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -58,7 +58,7 @@ function_name_map:
   auth_refresh: auth-refresh-gamma
   bedrock_agent_actions: enceladus-bedrock-agent-actions-gamma
   changelog_api: devops-changelog-api-gamma
-  checkout_service: enceladus-checkout-service-auto-gamma
+  checkout_service: enceladus-checkout-service-gamma,enceladus-checkout-service-auto-gamma
   coordination_api: devops-coordination-api-gamma
   coordination_monitor_api: devops-coordination-monitor-api-gamma
   deploy_decide: devops-deploy-decide-gamma


### PR DESCRIPTION
## Summary
Fixes **ENC-ISS-398** (P1): the Gen2 deploy pipeline never updated the API-served checkout function on gamma — it deployed only the `-auto` EventBridge companion — so `enceladus-checkout-service-gamma` has been frozen since 2026-04-20 and every checkout-service change since (incl. ENC-TSK-H49's failure-classification) is green-deployed but not live.

## Root cause
The Gen2 deploy probe keys artifacts by lambda dir name (`backend/lambda/checkout_service` → `checkout_service`); `_deploy.yml` resolves that key via `envs/v4-gamma.yaml` `function_name_map`, which pointed `checkout_service` only at `enceladus-checkout-service-auto-gamma`. The served (non-auto) function was absent from the map → never updated by the generic pipeline. `-auto` is a *live* EventBridge companion (`handler_auto_checkout`, rate(5 min)) that shares the checkout_service code module; the dedicated workflow that used to deploy both was retired ~Apr 21.

## Change (io-approved "deploy both"; GAMMA ONLY)
- `envs/v4-gamma.yaml`: `checkout_service` → comma-list `enceladus-checkout-service-gamma,enceladus-checkout-service-auto-gamma` (served first, then companion).
- `.github/workflows/_deploy.yml`: the deploy step expands a comma-separated `function_name_map` value into one Lambda update per target from the single shared artifact. `deploy_one()` now takes `mapped_name` explicitly. Single-name map values produce exactly one unit → byte-identical for the other 27 functions.

`envs/v3-prod.yaml` is intentionally untouched per the PLN-006 gamma-only deploy-target invariant (v3-prod frozen until the io-approved cutover).

## Validation
- All embedded Python heredocs in `_deploy.yml` `py_compile` clean.
- Both YAML files parse.
- Expansion logic unit-simulated: checkout fans to 2 targets; single-name maps unchanged; unmapped dirs skipped.

## Records
- Task: ENC-TSK-H71 · Fixes: ENC-ISS-398 · Unblocks: ENC-TSK-H49 (deploy-success) → ENC-ISS-142 gate #2

CCI-2fd23d0cd9854a6ea98f2ec4a4cc0bcd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
