### PR TITLE
Add PolyForm Noncommercial 1.0.0 LICENSE + README licensing section [v4/main] (ENC-TSK-H72)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,131 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ must not bypass APIs with direct DynamoDB reads/writes.
 - Policy doc: `docs/mcp-api-boundary-governance.md`
 - CI guard: `.github/workflows/mcp-api-boundary-guard.yml`
 - Guard script: `tools/check_mcp_api_boundary.py`
+
+## License
+
+Enceladus is source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+- **Noncommercial use is permitted** — education, academic and nonprofit research, personal study, experimentation, and other noncommercial purposes as defined by the license.
+- **Commercial use requires a separate license** — production deployment, integration into a paid product or service, SaaS offerings, or use as revenue-generating infrastructure all require a negotiated commercial agreement.
+
+For commercial licensing inquiries, contact **me@jreese.net**.


### PR DESCRIPTION
Adds the verbatim **PolyForm Noncommercial License 1.0.0** at the repository root and a README licensing section (clear noncommercial-vs-commercial terms + commercial-licensing contact me@jreese.net).

Minimum protective licensing set for the already-public repository. **License activation only** — dependency audit and NOTICE/ATTRIBUTION are deferred (fast-follow). No deploy (documentation / `code_only`).

Governed task: **ENC-TSK-H72** — carries the in-scope slice of ENC-TSK-B68 under io's explicit deferral override.

CCI-e21982b9d6bf46c0b51984d64c255f28