### PR TITLE
ENC-TSK-H76 / ENC-ISS-398: backport deploy-both pipeline fix to the prod line

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -381,12 +381,13 @@ jobs:
               with _print_lock:
                   print(msg, file=(sys.stderr if err else sys.stdout), flush=True)
 
-          def deploy_one(fn, version_id):
-              """Per-function pipeline: download artifact, update code, publish version,
+          def deploy_one(fn, mapped_name, version_id):
+              """Per-target pipeline: download artifact, update code, publish version,
               kick off CodeDeploy canary (or fall back to direct alias). Returns:
                 {'fn', 'mapped_name', 'status', 'dep_id'?, 'error'?}
-              status in {'codedeploy', 'direct', 'skip', 'error'}."""
-              mapped_name = fn_map.get(fn)
+              status in {'codedeploy', 'direct', 'skip', 'error'}.
+              ENC-ISS-398: mapped_name is passed explicitly so one shared build artifact
+              (fn) can fan out to multiple target functions from a comma-list map value."""
               if not mapped_name:
                   log(f'[skip] {fn}  (not in function_name_map)')
                   return {'fn': fn, 'status': 'skip'}
@@ -525,20 +526,34 @@ jobs:
           # ============================================================
           # PARALLEL KICKOFF — 8-worker pool
           # ============================================================
-          targets = sorted(version_ids.items())
-          log(f'Kicking off {len(targets)} Lambda updates with 8-worker pool...')
-          t_kickoff = time.time()
+          # ENC-ISS-398: expand each built artifact (fn) into one deploy unit per target
+          # function. A function_name_map value may be a comma-separated list (e.g.
+          # checkout_service -> 'enceladus-checkout-service-gamma,...-auto-gamma') so one
+          # shared artifact updates several Lambda functions. Single-name values produce
+          # exactly one unit and behave identically to the prior 1:1 mapping.
           deployments = []  # list of (fn, mapped_name, dep_id)
           errors = []
           skipped = []
+          deploy_units = []  # list of (fn, mapped_name, version_id)
+          for fn, vid in sorted(version_ids.items()):
+              names = [n.strip() for n in (fn_map.get(fn) or '').split(',') if n.strip()]
+              if not names:
+                  log(f'[skip] {fn}  (not in function_name_map)')
+                  skipped.append(fn)
+                  continue
+              for mapped_name in names:
+                  deploy_units.append((fn, mapped_name, vid))
+          log(f'Kicking off {len(deploy_units)} Lambda updates with 8-worker pool...')
+          t_kickoff = time.time()
           with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-              futures = {pool.submit(deploy_one, fn, vid): fn for fn, vid in targets}
+              futures = {pool.submit(deploy_one, fn, mapped_name, vid): (fn, mapped_name)
+                         for fn, mapped_name, vid in deploy_units}
               for fut in concurrent.futures.as_completed(futures):
                   try:
                       result = fut.result()
                   except Exception as e:
-                      fn = futures[fut]
-                      log(f'::error::worker exception on {fn}: {e}', err=True)
+                      fn, mapped_name = futures[fut]
+                      log(f'::error::worker exception on {fn} -> {mapped_name}: {e}', err=True)
                       errors.append(fn)
                       continue
                   fn = result['fn']

--- a/envs/v3-prod.yaml
+++ b/envs/v3-prod.yaml
@@ -66,7 +66,7 @@ function_name_map:
   auth_refresh: auth-refresh
   bedrock_agent_actions: enceladus-bedrock-agent-actions
   changelog_api: devops-changelog-api
-  checkout_service: enceladus-checkout-service-auto
+  checkout_service: enceladus-checkout-service,enceladus-checkout-service-auto
   coordination_api: devops-coordination-api
   coordination_monitor_api: devops-coordination-monitor-api
   deploy_decide: devops-deploy-decide


### PR DESCRIPTION
## Summary
Durable prod-line fix for **ENC-ISS-398** so a future Gen2 `v3-prod` deploy reaches the **served** checkout function (`enceladus-checkout-service`, non-auto) instead of only `-auto`.

- **`_deploy.yml`**: backport the ENC-ISS-398 comma-expansion (one built artifact fans out to a comma-separated list of target functions). Single-name map values behave identically to the prior 1:1 mapping — no change for any other function.
- **`envs/v3-prod.yaml`**: `checkout_service` → `enceladus-checkout-service,enceladus-checkout-service-auto` (deploy-both), mirroring `envs/v4-gamma.yaml`.

## Context
Part of the io-authorized **ENC-TSK-H76** prod-frozen exception. The H49 failure-classification code was promoted to the served prod fn **out of band** in the same task (surgical `update-function-code`, scope-limited to `checkout_service` — the full Gen2 pipeline deploys all ~29 env functions and cannot scope to one Lambda). This PR is the *durable config* so the eventual full cutover targets the served fn.

Scope guard (AC#6): diff touches **only** `_deploy.yml` + `envs/v3-prod.yaml`.

CCI-9862144452f44cbeb88730bc586ca605

🤖 Generated with [Claude Code](https://claude.com/claude-code)