### PR TITLE
ENC-TSK-I02 / ENC-ISS-401: codify gamma tracker-mutation role DynamoDB+projects+logs grants

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1863,12 +1863,53 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      # ENC-ISS-401: CloudWatch Logs (CreateLogGroup/CreateLogStream/PutLogEvents). The
+      # G95 codification below captured this role's INLINE policies from the live IAM dump
+      # but missed its ATTACHED managed policies (logs + DynamoDB + projects). On gamma the
+      # role is created fresh by this template, so those grants were absent and the Lambda
+      # failed every request with 500 'Database read failed' (and had no log group).
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
         # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
         # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
         # proven to resolve identically to prod-live (EnvironmentSuffix='') and
         # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        # ENC-ISS-401: the DynamoDB + projects grants below were ATTACHED managed
+        # policies on prod-live (devops-tracker-dynamodb-policy, projects-read-policy)
+        # which are scoped to PROD table ARNs — so they are codified inline here with
+        # EnvironmentSuffix instead, resolving to the correct per-env table on gamma too.
+        - PolicyName: tracker-dynamodb
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: TrackerTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+        - PolicyName: projects-read
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ProjectsRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
         - PolicyName: eventbridge-put-events
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
## Summary
Durable fix for **ENC-ISS-401** (blocker for the **ENC-TSK-H46** gamma soak).

`TrackerMutationRole` in `infrastructure/cloudformation/02-compute.yaml` was codified (ENC-TSK-G95) from the live **prod** IAM dump but only captured the role's **inline** policies — it missed its **attached managed policies**: `AWSLambdaBasicExecutionRole` (logs), `devops-tracker-dynamodb-policy`, and `projects-read-policy`.

- **Prod** kept working: those out-of-band attachments persisted on the pre-existing role.
- **Gamma**: the role is created fresh by this template, so the grants were absent → `devops-tracker-mutation-api-gamma` returned HTTP 500 `Database read failed` on every request and had **no CloudWatch log group**, blocking the H46 48h soak.

## Change
The prod DynamoDB/projects managed policies are scoped to **PROD table ARNs**, so attaching them would not cover gamma. This codifies the grants **inline with `EnvironmentSuffix`** (resolving to the correct per-env table) and attaches the AWS-managed `AWSLambdaBasicExecutionRole` for logs:
- `ManagedPolicyArns: [AWSLambdaBasicExecutionRole]`
- inline `tracker-dynamodb` → `devops-project-tracker${EnvironmentSuffix}` (+`/index/*`)
- inline `projects-read` → `projects${EnvironmentSuffix}` (+`/index/*`)

`EnvironmentSuffix=''` keeps prod-live grants identical; `'-gamma'` now grants the gamma tables.

## Deploy / coordination notes
- Requires the **io-gated compute-stack deploy** (not Gen2 `_deploy.yml`).
- The compute-stack deploy **resets the `ENABLE_LIFECYCLE_SERVICE` env flag** on `devops-tracker-mutation-api-gamma` — **re-apply the flag after deploy** to resume the H46 soak (the soak clock restarts from re-activation).
- This **supersedes the manual stopgap** inline policy `H46-gamma-tracker-access-stopgap-ISS401` currently on the gamma role (remove it after deploy).

## Validation
- YAML parses; role resolves to 5 inline policies + 1 managed; 73 resources intact.
- Manually verified the equivalent grants on the live gamma role unblock the Lambda (200 + lifecycle routing + log group created).

CCI-c69a0b2dff4945c1bf775f67a75a9eb3

🤖 Generated with [Claude Code](https://claude.com/claude-code)