### PR TITLE
ENC-PLN-052 Wave-1: H89 governed vector-read path + H91 correlation analysis

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-23.01",
-  "updated_at": "2026-06-23T01:45:00Z",
-  "last_change_summary": "ENC-FTR-082 Phase A (ENC-PLN-049): registered the PATHWAY_TRAVERSED/TRAVERSED_BY edge type (AC-6 OGTM) across graph_query_api _ALLOWED_EDGE_TYPES, graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL, and the four tracker_mutation relationship registries (_RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS, _DOMAIN_RANGE_CONSTRAINTS); added raw pathway telemetry (AC-1; one JSONL object per hybrid call to an S3 append-log partitioned by wave_id, degrading to a CloudWatch log line until the Wave-2 IAM/env CFN change) and the per-edge edge_participation output (AC-10; the ENC-FTR-108 AC-4 input contract) to graph_query_api hybrid retrieval, plus optional wave_id/intent_signature graphsearch params; added the tracker.pathway_traversed and graph_query_api.pathway_telemetry dictionary entities. Touched backend/lambda/graph_query_api/lambda_function.py, backend/lambda/graph_sync/lambda_function.py, backend/lambda/tracker_mutation/lambda_function.py. Live S3 governance store sync is a post-merge product-lead handoff. Prior change — ENC-TSK-H35 (ENC-FTR-101 / ENC-PLN-006, Option B): pre-materialized standing Neo4j Aura Graph Analytics projection for hybrid-retrieval Personalized PageRank. graph_query_api gains an env-gated (GDS_STANDING_PROJECTION_PREFIX) warm read path that runs gds.pageRank.stream against a standing named projection refreshed out-of-band by a single-writer action=refresh_projection invoke, with a hard fallback to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S (no regression when unset); the standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot) and /health gains a graph_projection staleness block. Updated the tracker.graphsearch entity description accordingly. Touched backend/lambda/graph_query_api/lambda_function.py. No tracker/field schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff. Reconciliation context: DOC-6EFD5DB32CD8 Rev 14 (F36 closed ENC-ISS-268 via Bolt-pool resilience, not session reuse; session reuse is ENC-ISS-271, open).",
+  "version": "2026-06-24.01",
+  "updated_at": "2026-06-24T01:15:00Z",
+  "last_change_summary": "ENC-TSK-H89 (ENC-FTR-082 AC-12 / ENC-PLN-052): added a governed bulk vector-read path (search_type=vector_read) over the n.embedding corpus in backend/lambda/graph_query_api/lambda_function.py — strip-EXEMPT (the hybrid path keeps stripping at :1785-1788), latency-bounded (_VECTOR_READ_DEADLINE_S) + server-side SKIP/LIMIT pagination; wired the MCP code-mode action graph_query.vector_read plus a tracker.graphsearch offset/limit passthrough in tools/enceladus-mcp-server/server.py; added the graph_query_api.vector_read dictionary entity and the vector_read (and hybrid) search_type enum values. No new edge type (OGTM N/A). Touched backend/lambda/graph_query_api/lambda_function.py and tools/enceladus-mcp-server/server.py. Live S3 governance store sync is a post-merge product-lead handoff. Prior change — ENC-FTR-082 Phase A (ENC-PLN-049): registered the PATHWAY_TRAVERSED/TRAVERSED_BY edge type (AC-6 OGTM) across graph_query_api _ALLOWED_EDGE_TYPES, graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL, and the four tracker_mutation relationship registries (_RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS, _DOMAIN_RANGE_CONSTRAINTS); added raw pathway telemetry (AC-1; one JSONL object per hybrid call to an S3 append-log partitioned by wave_id, degrading to a CloudWatch log line until the Wave-2 IAM/env CFN change) and the per-edge edge_participation output (AC-10; the ENC-FTR-108 AC-4 input contract) to graph_query_api hybrid retrieval, plus optional wave_id/intent_signature graphsearch params; added the tracker.pathway_traversed and graph_query_api.pathway_telemetry dictionary entities. Touched backend/lambda/graph_query_api/lambda_function.py, backend/lambda/graph_sync/lambda_function.py, backend/lambda/tracker_mutation/lambda_function.py. Live S3 governance store sync is a post-merge product-lead handoff. Prior change — ENC-TSK-H35 (ENC-FTR-101 / ENC-PLN-006, Option B): pre-materialized standing Neo4j Aura Graph Analytics projection for hybrid-retrieval Personalized PageRank. graph_query_api gains an env-gated (GDS_STANDING_PROJECTION_PREFIX) warm read path that runs gds.pageRank.stream against a standing named projection refreshed out-of-band by a single-writer action=refresh_projection invoke, with a hard fallback to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S (no regression when unset); the standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot) and /health gains a graph_projection staleness block. Updated the tracker.graphsearch entity description accordingly. Touched backend/lambda/graph_query_api/lambda_function.py. No tracker/field schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff. Reconciliation context: DOC-6EFD5DB32CD8 Rev 14 (F36 closed ENC-ISS-268 via Bolt-pool resilience, not session reuse; session reuse is ENC-ISS-271, open).",
   "owners": [
     "enceladus-platform"
   ],
@@ -3108,9 +3108,11 @@
             "traversal",
             "neighbors",
             "path",
-            "keyword"
+            "keyword",
+            "hybrid",
+            "vector_read"
           ],
-          "definition": "Graph search mode. traversal: walk PARENT_OF hierarchy from record_id. neighbors: all nodes within N hops via any edge type. path: shortest path between two record_ids. keyword: full-text title match + immediate neighbors."
+          "definition": "Graph search mode. traversal: walk PARENT_OF hierarchy from record_id. neighbors: all nodes within N hops via any edge type. path: shortest path between two record_ids. keyword: full-text title match + immediate neighbors. hybrid: three-signal RRF retrieval (vector+graph+keyword). vector_read (ENC-TSK-H89 / ENC-FTR-082 AC-12): governed bulk strip-EXEMPT SKIP/LIMIT pagination over the n.embedding corpus for correlation analysis; see entity graph_query_api.vector_read."
         },
         "project_id": {
           "type": "string",
@@ -4563,6 +4565,29 @@
         "ogtm_compliance": {
           "type": "object",
           "definition": "Four-criteria OGTM evidence: graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL entry; tracker_mutation four-registry registration; graph_query_api _ALLOWED_EDGE_TYPES entry; live tracker.graphsearch E2E traversal. Governing feature ENC-FTR-082."
+        }
+      }
+    },
+    "graph_query_api.vector_read": {
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "fields": {
+        "offset": {
+          "type": "integer",
+          "definition": "Pagination cursor (rows to SKIP). Default 0.",
+          "constraints": {"min": 0, "default": 0}
+        },
+        "limit": {
+          "type": "integer",
+          "definition": "Page size (rows to return). Clamped server-side to [1, 1000].",
+          "constraints": {"min": 1, "max": 1000, "default": 200}
+        },
+        "record_type": {
+          "type": "string",
+          "definition": "Optional label scope (task/issue/feature/plan/lesson/document). Omit to read across the whole embedded corpus."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "{nodes: [{record_id, record_type, embedding:[float,...]}], edges: [], paths: [], pagination: {offset, limit, returned, next_offset|null, has_more}, embedding_property: 'embedding', embedding_dim: int|null, summary: string, query_cypher: 'vector_read/paginated'}."
         }
       }
     },

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -54,7 +54,7 @@ MAX_DEPTH = 5
 MAX_RESULTS = 100
 QUERY_TIMEOUT_SECONDS = 10
 
-VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword", "hybrid"}
+VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword", "hybrid", "vector_read"}
 
 # ---------------------------------------------------------------------------
 # ENC-TSK-B92 Phase 1 hybrid retrieval constants
@@ -181,6 +181,19 @@ try:
     _PATHWAY_EDGE_DEADLINE_S = float(os.environ.get("PATHWAY_EDGE_DEADLINE_S", "2.0"))
 except (TypeError, ValueError):
     _PATHWAY_EDGE_DEADLINE_S = 2.0
+
+# ENC-TSK-H89 (ENC-FTR-082 AC-12): governed bulk vector-read path config. A
+# dedicated, strip-EXEMPT pagination over the n.embedding corpus for downstream
+# correlation analysis (ENC-TSK-H34 AC-1). Latency-bounded by its own wall-clock
+# deadline + server-side SKIP/LIMIT so a large page can never extend or perturb
+# the hybrid retrieval request path. The hybrid path keeps stripping embeddings
+# (_query_hybrid); ONLY this path returns the raw vector.
+try:
+    _VECTOR_READ_DEADLINE_S = float(os.environ.get("VECTOR_READ_DEADLINE_S", "10.0"))
+except (TypeError, ValueError):
+    _VECTOR_READ_DEADLINE_S = 10.0
+_VECTOR_READ_DEFAULT_LIMIT = 200
+_VECTOR_READ_MAX_LIMIT = 1000
 
 _s3 = None
 
@@ -1861,12 +1874,153 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
 _EMBEDDING_PROPERTY = "embedding"
 
 
+def _query_vector_read(driver, project_id: str, params: Dict) -> Dict:
+    """ENC-TSK-H89 / ENC-FTR-082 AC-12 — governed bulk vector-read over the
+    n.embedding corpus.
+
+    A dedicated, strip-EXEMPT, paginated read of node embeddings for downstream
+    correlation analysis (ENC-TSK-H34 AC-1). This is the ONLY graphsearch path
+    that returns the raw n.embedding vector; the hybrid retrieval path
+    (_query_hybrid) keeps stripping it (lambda_function.py:1785-1788). The read is
+    latency-bounded by a dedicated wall-clock deadline and server-side SKIP/LIMIT
+    pagination so a large page can never extend or perturb the hybrid request
+    path. Backward compatible: this handler is only reached for
+    search_type=vector_read, so the hybrid/other paths are unchanged.
+
+    Query parameters:
+      project_id    (required; validated by _handle_search)
+      offset        Pagination cursor; default 0.
+      limit         Page size; default 200, clamped to [1, 1000].
+      record_type   Optional label filter (task/issue/feature/plan/lesson/document).
+
+    Response contract:
+      {
+        "nodes":   [{record_id, record_type, embedding:[...float]}],
+        "edges":   [], "paths": [],
+        "pagination": {offset, limit, returned, next_offset|null, has_more},
+        "embedding_property": "embedding",
+        "embedding_dim": <int|null>,
+        "summary": "...",
+        "query_cypher": "vector_read/paginated",
+      }
+    """
+    # ---- Parse + clamp pagination -----------------------------------------
+    try:
+        offset = int(params.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    offset = max(0, offset)
+    try:
+        limit = int(params.get("limit", _VECTOR_READ_DEFAULT_LIMIT))
+    except (TypeError, ValueError):
+        limit = _VECTOR_READ_DEFAULT_LIMIT
+    limit = max(1, min(limit, _VECTOR_READ_MAX_LIMIT))
+
+    record_type_filter = params.get("record_type") or None
+
+    # Reuse the live-pool guard so a frozen container's half-open Bolt socket
+    # cannot stall this read (mirrors _query_hybrid).
+    driver = _ensure_live_driver(driver)
+    if driver is None:
+        return {"error": "neo4j driver unavailable after rebuild attempt"}
+
+    # Optional single-label scope; otherwise read across the embedded corpus.
+    label_clause = ""
+    if record_type_filter:
+        label = str(record_type_filter).capitalize()
+        if label not in LABEL_VECTOR_INDEXES:
+            valid = ", ".join(sorted(k.lower() for k in LABEL_VECTOR_INDEXES))
+            return {"error": f"record_type must be one of: {valid}"}
+        label_clause = f":{label}"
+
+    # Stable record_id ordering => deterministic SKIP/LIMIT pages across calls.
+    # Fetch limit+1 to detect has_more without a second round-trip.
+    cypher = (
+        f"MATCH (n{label_clause}) "
+        f"WHERE n.project_id = $project_id AND n.{_EMBEDDING_PROPERTY} IS NOT NULL "
+        f"RETURN n.record_id AS record_id, labels(n) AS labels, "
+        f"n.{_EMBEDDING_PROPERTY} AS embedding "
+        "ORDER BY n.record_id "
+        "SKIP $offset LIMIT $limit"
+    )
+
+    def _read():
+        rows: List[Dict[str, Any]] = []
+        with driver.session() as session:
+            result = session.run(
+                cypher,
+                project_id=project_id,
+                offset=offset,
+                limit=limit + 1,
+            )
+            for rec in result:
+                rid = rec.get("record_id")
+                if not rid:
+                    continue
+                labels = rec.get("labels") or []
+                embedding = rec.get("embedding")
+                rows.append({
+                    "record_id": rid,
+                    "record_type": labels[0].lower() if labels else "",
+                    _EMBEDDING_PROPERTY: list(embedding) if embedding is not None else None,
+                })
+        return rows
+
+    # Latency-bound the read on a worker thread; abandon on timeout so a slow
+    # page can never hang the handler (mirrors the hybrid graph-signal pattern).
+    _vex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        rows = _vex.submit(_read).result(timeout=_VECTOR_READ_DEADLINE_S)
+    except concurrent.futures.TimeoutError:
+        logger.warning(
+            "[WARNING] vector_read exceeded %.1fs deadline (offset=%s limit=%s) — reduce limit",
+            _VECTOR_READ_DEADLINE_S, offset, limit,
+        )
+        return {"error": f"vector_read exceeded {_VECTOR_READ_DEADLINE_S:.0f}s deadline; reduce limit"}
+    except Exception:
+        logger.exception("[ERROR] vector_read query failed (offset=%s limit=%s)", offset, limit)
+        return {"error": "vector_read query failed"}
+    finally:
+        _vex.shutdown(wait=False)
+
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_offset = offset + limit if has_more else None
+    embedding_dim = (
+        len(page[0][_EMBEDDING_PROPERTY])
+        if page and page[0].get(_EMBEDDING_PROPERTY) is not None
+        else None
+    )
+
+    return {
+        "nodes": page,
+        "edges": [],
+        "paths": [],
+        "pagination": {
+            "offset": offset,
+            "limit": limit,
+            "returned": len(page),
+            "next_offset": next_offset,
+            "has_more": has_more,
+        },
+        "embedding_property": _EMBEDDING_PROPERTY,
+        "embedding_dim": embedding_dim,
+        "summary": (
+            f"Vector-read: {len(page)} nodes "
+            f"(offset={offset}, limit={limit}, has_more={str(has_more).lower()}; "
+            f"dim={embedding_dim}; record_type={record_type_filter or 'all'})"
+        ),
+        "query_cypher": "vector_read/paginated",
+    }
+
+
 SEARCH_HANDLERS = {
     "traversal": _query_traversal,
     "neighbors": _query_neighbors,
     "path": _query_path,
     "keyword": _query_keyword,
     "hybrid": _query_hybrid,
+    "vector_read": _query_vector_read,
 }
 
 

--- a/backend/lambda/graph_query_api/test_vector_read_h89.py
+++ b/backend/lambda/graph_query_api/test_vector_read_h89.py
@@ -1,0 +1,156 @@
+"""Unit tests for ENC-TSK-H89 / ENC-FTR-082 AC-12 — governed bulk vector-read.
+
+Exercises the dedicated, strip-EXEMPT, paginated _query_vector_read handler:
+  - response shape {record_id, record_type, embedding}
+  - pagination cursor (offset / limit / next_offset / has_more)
+  - strip-exemption scope (vector_read returns embeddings; the hybrid wiring is
+    untouched and still strips at lambda_function.py:1785-1788)
+  - limit clamping, record_type scoping, driver-unavailable handling
+
+Pure-Python: no Neo4j or Bedrock. The Bolt driver/session is faked and
+_ensure_live_driver is patched to a pass-through so the fake driver flows through.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Ensure the Lambda module directory is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lambda_function as lf  # noqa: E402
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, cypher, **kwargs):
+        # Emulate the DB honoring SKIP/LIMIT: the test preloads exactly the rows
+        # the query would return for its (offset, limit+1) window.
+        return _FakeResult(self._rows)
+
+
+class _FakeDriver:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def session(self):
+        return _FakeSession(self._rows)
+
+
+def _row(rid, label):
+    return {"record_id": rid, "labels": [label], "embedding": [0.1, 0.2, 0.3]}
+
+
+class VectorReadTest(unittest.TestCase):
+    def setUp(self):
+        # _ensure_live_driver pings the pool; bypass it so the fake driver flows through.
+        self._patch = mock.patch.object(lf, "_ensure_live_driver", side_effect=lambda d: d)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_registered_in_search_surface(self):
+        self.assertIn("vector_read", lf.VALID_SEARCH_TYPES)
+        self.assertIn("vector_read", lf.SEARCH_HANDLERS)
+        self.assertIs(lf.SEARCH_HANDLERS["vector_read"], lf._query_vector_read)
+
+    def test_strip_exemption_scope(self):
+        # vector_read is the ONLY handler that returns embeddings; the hybrid
+        # handler wiring is untouched and the strip property name is unchanged.
+        self.assertIs(lf.SEARCH_HANDLERS["hybrid"], lf._query_hybrid)
+        self.assertEqual(lf._EMBEDDING_PROPERTY, "embedding")
+        driver = _FakeDriver([_row("ENC-TSK-001", "Task")])
+        out = lf._query_vector_read(driver, "enceladus", {"limit": 10})
+        self.assertEqual(len(out["nodes"]), 1)
+        # Strip-EXEMPT: the raw embedding survives in the response.
+        self.assertIn("embedding", out["nodes"][0])
+        self.assertEqual(out["nodes"][0]["embedding"], [0.1, 0.2, 0.3])
+
+    def test_response_shape(self):
+        driver = _FakeDriver([_row("ENC-TSK-001", "Task"), _row("ENC-ISS-002", "Issue")])
+        out = lf._query_vector_read(driver, "enceladus", {"limit": 10})
+        self.assertEqual(out["query_cypher"], "vector_read/paginated")
+        self.assertEqual(out["edges"], [])
+        self.assertEqual(out["paths"], [])
+        self.assertEqual(out["embedding_property"], "embedding")
+        self.assertEqual(out["embedding_dim"], 3)
+        node = out["nodes"][0]
+        self.assertEqual(set(node.keys()), {"record_id", "record_type", "embedding"})
+        self.assertEqual(node["record_id"], "ENC-TSK-001")
+        self.assertEqual(node["record_type"], "task")
+        self.assertEqual(out["nodes"][1]["record_type"], "issue")
+
+    def test_pagination_has_more(self):
+        # limit=2, DB returns limit+1=3 rows => has_more, page trimmed to 2.
+        driver = _FakeDriver([
+            _row("ENC-TSK-001", "Task"),
+            _row("ENC-TSK-002", "Task"),
+            _row("ENC-TSK-003", "Task"),
+        ])
+        out = lf._query_vector_read(driver, "enceladus", {"offset": 0, "limit": 2})
+        self.assertEqual(out["pagination"]["returned"], 2)
+        self.assertTrue(out["pagination"]["has_more"])
+        self.assertEqual(out["pagination"]["next_offset"], 2)
+        self.assertEqual(len(out["nodes"]), 2)
+
+    def test_pagination_last_page(self):
+        # limit=5, DB returns 3 (< limit+1) => no more pages.
+        driver = _FakeDriver([
+            _row("ENC-TSK-001", "Task"),
+            _row("ENC-TSK-002", "Task"),
+            _row("ENC-TSK-003", "Task"),
+        ])
+        out = lf._query_vector_read(driver, "enceladus", {"offset": 10, "limit": 5})
+        self.assertEqual(out["pagination"]["returned"], 3)
+        self.assertFalse(out["pagination"]["has_more"])
+        self.assertIsNone(out["pagination"]["next_offset"])
+
+    def test_limit_clamping(self):
+        driver = _FakeDriver([])
+        hi = lf._query_vector_read(driver, "enceladus", {"limit": 999999})
+        self.assertEqual(hi["pagination"]["limit"], lf._VECTOR_READ_MAX_LIMIT)
+        lo = lf._query_vector_read(driver, "enceladus", {"limit": -4})
+        self.assertEqual(lo["pagination"]["limit"], 1)
+        bad = lf._query_vector_read(driver, "enceladus", {"limit": "abc"})
+        self.assertEqual(bad["pagination"]["limit"], lf._VECTOR_READ_DEFAULT_LIMIT)
+
+    def test_record_type_filter_invalid(self):
+        driver = _FakeDriver([])
+        out = lf._query_vector_read(driver, "enceladus", {"record_type": "bogus"})
+        self.assertIn("error", out)
+        self.assertIn("record_type must be one of", out["error"])
+
+    def test_record_type_filter_valid(self):
+        driver = _FakeDriver([_row("ENC-PLN-001", "Plan")])
+        out = lf._query_vector_read(driver, "enceladus", {"record_type": "plan"})
+        self.assertNotIn("error", out)
+        self.assertEqual(out["nodes"][0]["record_type"], "plan")
+
+    def test_driver_unavailable(self):
+        with mock.patch.object(lf, "_ensure_live_driver", side_effect=lambda d: None):
+            out = lf._query_vector_read(object(), "enceladus", {})
+        self.assertIn("error", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/correlation_analysis_h91.py
+++ b/tools/correlation_analysis_h91.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""ENC-TSK-H91 — Cosine-similarity correlation analysis over the Enceladus
+``n.embedding`` corpus.
+
+Delivers ENC-TSK-H34 AC-1 and consumes the ENC-TSK-H89 / ENC-FTR-082 AC-12
+governed bulk vector-read contract (graph_query_api ``search_type=vector_read``).
+The emitted ``pairs.jsonl`` is the input contract for the downstream pseudoinverse
+encoding (ENC-TSK-H92).
+
+Pipeline (READ -> COMPUTE -> SINK):
+
+  READ  ``load_corpus(args)`` returns a flat ``list[node]`` where each node is
+        ``{"record_id", "record_type", "embedding": [float, ...]}``. Three
+        sources:
+          * ``file``  — load + concatenate nodes from a local JSON file
+                        (either ``{"nodes": [...]}`` or a bare list of node
+                        dicts). The only source exercised by the unit tests.
+          * ``gamma`` — boto3 ``lambda.invoke`` against the gamma graph-query
+                        function with a synthetic API Gateway v2 GET event for
+                        ``/api/v1/tracker/graphsearch`` and
+                        ``queryStringParameters={search_type:"vector_read", ...}``.
+                        The ``x-coordination-internal-key`` header is sourced
+                        from the invoked function's OWN env via
+                        ``lambda.get_function_configuration`` (ENC-LSN-039).
+                        Paginates by following ``pagination.next_offset`` until
+                        ``has_more`` is false.
+          * ``mcp``   — ``search(action="graph_query.vector_read",
+                        arguments={project_id, offset, limit})`` with the same
+                        pagination loop. Requires an injected ``search``
+                        callable (the MCP code-mode surface) or an importable
+                        shim; otherwise degrades with a clear error.
+
+        NOTE: the LIVE gamma/mcp run happens later in a product-lead terminal
+        against gamma. Those paths are intentionally defensive (wrapped in
+        try/except, clear diagnostics) and are NOT unit-tested against a live
+        service — only the ``file`` source and the pure compute/sink layers are.
+
+  COMPUTE ``cosine_pairs(nodes, threshold)`` -> ``(pairs, stats)``. Each
+        embedding is L2-normalized; pairwise cosine is computed for the upper
+        triangle (i < j); pairs with cosine strictly greater than ``threshold``
+        are flagged. Uses numpy (``sims = X @ X.T``) when importable for speed
+        on a ~5000-node corpus, with a pure-Python (``math`` only) fallback.
+        Zero-norm vectors are skipped safely.
+
+  SINK  ``write_results(pairs, stats, args)`` mirrors the graph_query_api S3
+        sink (lambda_function.py:165-176 + 1563-1590): if env
+        ``CORRELATION_RESULTS_BUCKET`` is set, lazily build a tight-timeout
+        boto3 S3 client and PUT ``pairs.jsonl`` + ``summary.json`` under
+        ``s3://{bucket}/{prefix}/...``; ALWAYS also write both files to the
+        local ``--out`` dir; and ALWAYS emit one structured stdout line
+        ``CORRELATION_RESULTS {json-summary}`` (the CloudWatch-degraded mirror).
+        An S3 failure is caught and never aborts the local write.
+
+pairs.jsonl schema (one JSON object per line, sorted by cosine desc) — the
+ENC-TSK-H92 input contract:
+
+    {"a": <record_id>, "b": <record_id>,
+     "a_type": <record_type>, "b_type": <record_type>,
+     "cosine": <float>}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Optional numpy. Imported once at module load; the unit tests monkeypatch this
+# module attribute to None to force-exercise the pure-Python path.
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - exercised indirectly
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - numpy absent is a supported config
+    np = None  # type: ignore
+
+# Mirror graph_query_api: the read path returns the raw vector under this key.
+EMBEDDING_PROPERTY = "embedding"
+
+# Defaults that mirror the vector_read contract / governance config.
+DEFAULT_PROJECT_ID = "enceladus"
+DEFAULT_THRESHOLD = 0.95
+DEFAULT_PAGE_LIMIT = 200
+DEFAULT_OUT_DIR = "./h91_results"
+DEFAULT_GAMMA_FUNCTION = "devops-graph-query-api-gamma"
+
+# S3 sink env contract (mirrors PATHWAY_TELEMETRY_BUCKET/_PREFIX).
+RESULTS_BUCKET_ENV = "CORRELATION_RESULTS_BUCKET"
+RESULTS_PREFIX_ENV = "CORRELATION_RESULTS_PREFIX"
+DEFAULT_RESULTS_PREFIX = "correlation-analysis-h91"
+
+PAIRS_FILENAME = "pairs.jsonl"
+SUMMARY_FILENAME = "summary.json"
+
+_GRAPHSEARCH_PATH = "/api/v1/tracker/graphsearch"
+# A high upper bound on pagination iterations so a misbehaving surface that never
+# clears has_more cannot loop forever.
+_MAX_PAGES = 100_000
+
+
+# ===========================================================================
+# READ layer
+# ===========================================================================
+def _coerce_nodes(payload: Any) -> List[Dict[str, Any]]:
+    """Normalize a vector-read payload fragment into a list of node dicts.
+
+    Accepts either ``{"nodes": [...]}`` or a bare ``[...]`` list. Non-dict
+    members are dropped defensively.
+    """
+    if isinstance(payload, dict):
+        nodes = payload.get("nodes", [])
+    elif isinstance(payload, list):
+        nodes = payload
+    else:
+        nodes = []
+    return [n for n in nodes if isinstance(n, dict)]
+
+
+def load_corpus_from_file(path: str) -> List[Dict[str, Any]]:
+    """Load + concatenate nodes from a local JSON file.
+
+    The file is either a single vector-read page ``{"nodes": [...]}``, a bare
+    list of node dicts, or a list of such pages. This is the source the unit
+    tests exercise.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    # A list of pages (each a dict with "nodes") vs. a bare list of nodes.
+    if isinstance(data, list) and data and all(
+        isinstance(item, dict) and "nodes" in item for item in data
+    ):
+        out: List[Dict[str, Any]] = []
+        for page in data:
+            out.extend(_coerce_nodes(page))
+        return out
+    return _coerce_nodes(data)
+
+
+def _build_vector_read_event(project_id: str, offset: int, limit: int,
+                             internal_key: str) -> Dict[str, Any]:
+    """Construct a synthetic API Gateway v2 (HTTP API) proxy GET event for the
+    graph_query_api ``vector_read`` route.
+
+    Matches what ``lambda_handler`` expects (lambda_function.py:2182-2214):
+    ``requestContext.http.method == GET``, ``rawPath`` ending in
+    ``/graphsearch`` (not ``/health``), ``queryStringParameters`` carrying the
+    vector_read contract, and the lowercase ``x-coordination-internal-key``
+    header consumed by ``_authenticate`` (lambda_function.py:358).
+    """
+    return {
+        "version": "2.0",
+        "routeKey": "GET /api/v1/tracker/graphsearch",
+        "rawPath": _GRAPHSEARCH_PATH,
+        "rawQueryString": (
+            f"search_type=vector_read&project_id={project_id}"
+            f"&offset={offset}&limit={limit}"
+        ),
+        "headers": {
+            "x-coordination-internal-key": internal_key,
+            "content-type": "application/json",
+        },
+        "queryStringParameters": {
+            "search_type": "vector_read",
+            "project_id": project_id,
+            "offset": str(offset),
+            "limit": str(limit),
+        },
+        "requestContext": {
+            "http": {
+                "method": "GET",
+                "path": _GRAPHSEARCH_PATH,
+                "sourceIp": "127.0.0.1",
+            },
+        },
+        "isBase64Encoded": False,
+    }
+
+
+def _gamma_internal_key(lambda_client: Any, function_name: str) -> str:
+    """Source the coordination internal key from the gamma function's OWN env
+    (ENC-LSN-039) via ``get_function_configuration``.
+
+    Returns an empty string when unavailable; the caller surfaces a clear error
+    rather than silently sending an unauthenticated invoke.
+    """
+    try:
+        cfg = lambda_client.get_function_configuration(FunctionName=function_name)
+        env = (cfg.get("Environment") or {}).get("Variables") or {}
+        return (
+            env.get("COORDINATION_INTERNAL_API_KEY")
+            or env.get("COORDINATION_INTERNAL_API_KEY_PREVIOUS")
+            or ""
+        )
+    except Exception as exc:  # pragma: no cover - live AWS only
+        print(
+            f"[WARNING] could not read internal key from {function_name} env: {exc}",
+            file=sys.stderr,
+        )
+        return ""
+
+
+def _parse_invoke_payload(raw: Any) -> Dict[str, Any]:
+    """Decode a Lambda invoke response Payload into the vector-read result dict.
+
+    The function returns an API Gateway proxy envelope ``{"statusCode", "body"}``
+    where ``body`` is a JSON string (lambda_function.py:318-323). Tolerates an
+    already-decoded dict for robustness.
+    """
+    if hasattr(raw, "read"):
+        raw = raw.read()
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+        raw = json.loads(raw) if raw.strip() else {}
+    if not isinstance(raw, dict):
+        return {}
+
+    # Unwrap the proxy envelope when present.
+    if "body" in raw and "nodes" not in raw:
+        status = raw.get("statusCode")
+        body = raw.get("body")
+        if isinstance(body, str):
+            body = json.loads(body) if body.strip() else {}
+        if isinstance(status, int) and status >= 400:
+            msg = body.get("error") if isinstance(body, dict) else body
+            raise RuntimeError(f"gamma vector_read returned HTTP {status}: {msg}")
+        return body if isinstance(body, dict) else {}
+    return raw
+
+
+def load_corpus_from_gamma(project_id: str, page_limit: int,
+                           function_name: str,
+                           lambda_client: Any = None) -> List[Dict[str, Any]]:
+    """Paginate the gamma graph-query Lambda's ``vector_read`` path via direct
+    ``lambda.invoke`` (RequestResponse).
+
+    DEFENSIVE / NOT unit-tested against live AWS: the live run is a product-lead
+    terminal job. boto3 is imported lazily; the internal key is sourced from the
+    invoked function's env (ENC-LSN-039); pagination follows
+    ``pagination.next_offset`` until ``has_more`` is false.
+    """
+    if lambda_client is None:
+        try:
+            import boto3  # lazy: keeps the file importable without boto3
+            from botocore.config import Config
+            lambda_client = boto3.client(
+                "lambda",
+                config=Config(
+                    connect_timeout=5,
+                    read_timeout=60,
+                    retries={"max_attempts": 2, "mode": "standard"},
+                ),
+            )
+        except Exception as exc:  # pragma: no cover - live AWS only
+            raise RuntimeError(
+                f"boto3 lambda client unavailable for gamma source: {exc}"
+            ) from exc
+
+    internal_key = _gamma_internal_key(lambda_client, function_name)
+    if not internal_key:
+        raise RuntimeError(
+            "missing coordination internal key for gamma invoke; "
+            "cannot source from function env (ENC-LSN-039)"
+        )
+
+    nodes: List[Dict[str, Any]] = []
+    offset = 0
+    for _ in range(_MAX_PAGES):
+        event = _build_vector_read_event(project_id, offset, page_limit, internal_key)
+        resp = lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(event).encode("utf-8"),
+        )
+        if resp.get("FunctionError"):
+            payload = resp.get("Payload")
+            detail = payload.read().decode("utf-8") if hasattr(payload, "read") else payload
+            raise RuntimeError(f"gamma invoke FunctionError: {detail}")
+
+        body = _parse_invoke_payload(resp.get("Payload"))
+        nodes.extend(_coerce_nodes(body))
+
+        pagination = body.get("pagination") if isinstance(body, dict) else None
+        if not isinstance(pagination, dict) or not pagination.get("has_more"):
+            break
+        next_offset = pagination.get("next_offset")
+        if next_offset is None:
+            break
+        offset = int(next_offset)
+
+    return nodes
+
+
+def load_corpus_from_mcp(project_id: str, page_limit: int,
+                         search_fn: Optional[Callable] = None) -> List[Dict[str, Any]]:
+    """Paginate the MCP ``graph_query.vector_read`` action.
+
+    DEFENSIVE / NOT unit-tested against live MCP. ``search_fn`` is the MCP
+    code-mode ``search(action, arguments)`` callable; when omitted this attempts
+    a best-effort import shim and otherwise raises with a clear message. The MCP
+    ``search`` result mirrors the vector_read body (``nodes`` + ``pagination``).
+    """
+    if search_fn is None:
+        try:  # pragma: no cover - environment-specific shim
+            from enceladus_mcp import search as search_fn  # type: ignore
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError(
+                "no MCP `search` callable available; pass search_fn= or run the "
+                "live read from a session where the MCP code-mode surface is bound"
+            ) from exc
+
+    nodes: List[Dict[str, Any]] = []
+    offset = 0
+    for _ in range(_MAX_PAGES):
+        result = search_fn(
+            action="graph_query.vector_read",
+            arguments={"project_id": project_id, "offset": offset, "limit": page_limit},
+        )
+        if isinstance(result, str):
+            result = json.loads(result)
+        body = result if isinstance(result, dict) else {}
+        # Some MCP surfaces wrap the handler payload under "result"/"data".
+        if "nodes" not in body:
+            for key in ("result", "data", "body"):
+                inner = body.get(key)
+                if isinstance(inner, str):
+                    inner = json.loads(inner)
+                if isinstance(inner, dict) and "nodes" in inner:
+                    body = inner
+                    break
+
+        nodes.extend(_coerce_nodes(body))
+        pagination = body.get("pagination") if isinstance(body, dict) else None
+        if not isinstance(pagination, dict) or not pagination.get("has_more"):
+            break
+        next_offset = pagination.get("next_offset")
+        if next_offset is None:
+            break
+        offset = int(next_offset)
+
+    return nodes
+
+
+def load_corpus(args: argparse.Namespace) -> List[Dict[str, Any]]:
+    """Dispatch the READ layer by ``--source``. Returns a flat list of node
+    dicts ``{"record_id", "record_type", "embedding": [...]}``.
+    """
+    source = getattr(args, "source", "gamma")
+    if source == "file":
+        if not getattr(args, "input", None):
+            raise ValueError("--input PATH is required for --source file")
+        return load_corpus_from_file(args.input)
+    if source == "gamma":
+        return load_corpus_from_gamma(
+            args.project_id, args.page_limit, args.gamma_function,
+        )
+    if source == "mcp":
+        return load_corpus_from_mcp(args.project_id, args.page_limit)
+    raise ValueError(f"unknown source: {source!r}")
+
+
+# ===========================================================================
+# COMPUTE layer
+# ===========================================================================
+def _valid_vectors(nodes: Sequence[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[List[float]]]:
+    """Filter to nodes carrying a non-empty numeric embedding, returning the
+    parallel (kept-node, vector) lists. Embeddings that are missing, empty, or
+    non-numeric are dropped.
+    """
+    kept_nodes: List[Dict[str, Any]] = []
+    vectors: List[List[float]] = []
+    for n in nodes:
+        emb = n.get(EMBEDDING_PROPERTY)
+        if not emb or not isinstance(emb, (list, tuple)):
+            continue
+        try:
+            vec = [float(x) for x in emb]
+        except (TypeError, ValueError):
+            continue
+        if not vec:
+            continue
+        kept_nodes.append(n)
+        vectors.append(vec)
+    return kept_nodes, vectors
+
+
+def _percentile(sorted_vals: Sequence[float], pct: float) -> Optional[float]:
+    """Linear-interpolated percentile over an already-sorted ascending list.
+    ``pct`` in [0, 100]. Returns None for an empty list.
+    """
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return float(sorted_vals[lo])
+    frac = rank - lo
+    return float(sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac)
+
+
+def _cosine_pairs_numpy(nodes: List[Dict[str, Any]], vectors: List[List[float]],
+                        threshold: float) -> List[Dict[str, Any]]:
+    """Vectorized upper-triangle cosine via numpy: normalize rows, ``X @ X.T``,
+    flag entries above ``threshold``. Zero-norm rows are normalized to 0 so they
+    contribute cosine 0 (never flagged). Used for the ~5000-node corpus.
+    """
+    X = np.asarray(vectors, dtype=np.float64)  # type: ignore[union-attr]
+    norms = np.linalg.norm(X, axis=1, keepdims=True)  # type: ignore[union-attr]
+    safe = np.where(norms == 0.0, 1.0, norms)  # type: ignore[union-attr]
+    Xn = X / safe
+    Xn[(norms == 0.0).ravel()] = 0.0  # zero-norm rows -> all-zero unit vector
+    sims = Xn @ Xn.T
+
+    iu, ju = np.triu_indices(len(vectors), k=1)  # type: ignore[union-attr]
+    if iu.size == 0:
+        return []
+    sims_pairs = sims[iu, ju]
+    mask = sims_pairs > threshold
+    pairs: List[Dict[str, Any]] = []
+    for i, j, c in zip(iu[mask].tolist(), ju[mask].tolist(), sims_pairs[mask].tolist()):
+        pairs.append(_pair_record(nodes[i], nodes[j], float(c)))
+    return pairs
+
+
+def _cosine_pairs_python(nodes: List[Dict[str, Any]], vectors: List[List[float]],
+                         threshold: float) -> List[Dict[str, Any]]:
+    """Pure-Python (``math`` only) upper-triangle cosine fallback for when numpy
+    is unavailable. Pre-normalizes each vector to unit L2 norm once; zero-norm
+    vectors are recorded as None and skipped.
+    """
+    unit: List[Optional[List[float]]] = []
+    for vec in vectors:
+        norm = math.sqrt(sum(x * x for x in vec))
+        if norm == 0.0:
+            unit.append(None)
+        else:
+            unit.append([x / norm for x in vec])
+
+    pairs: List[Dict[str, Any]] = []
+    n = len(unit)
+    for i in range(n):
+        ui = unit[i]
+        if ui is None:
+            continue
+        for j in range(i + 1, n):
+            uj = unit[j]
+            if uj is None:
+                continue
+            cos = sum(a * b for a, b in zip(ui, uj))
+            if cos > threshold:
+                pairs.append(_pair_record(nodes[i], nodes[j], float(cos)))
+    return pairs
+
+
+def _pair_record(a: Dict[str, Any], b: Dict[str, Any], cosine: float) -> Dict[str, Any]:
+    """One flagged pair in the ENC-TSK-H92 input-contract shape."""
+    return {
+        "a": a.get("record_id"),
+        "b": b.get("record_id"),
+        "a_type": a.get("record_type"),
+        "b_type": b.get("record_type"),
+        "cosine": cosine,
+    }
+
+
+def cosine_pairs(nodes: Sequence[Dict[str, Any]], threshold: float,
+                 generated_at: Optional[str] = None) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """COMPUTE entrypoint. Normalize embeddings, compute upper-triangle cosine,
+    flag pairs with cosine strictly greater than ``threshold``, and assemble
+    stats.
+
+    Returns ``(pairs, stats)`` where ``pairs`` is sorted by cosine desc. Uses
+    numpy when importable, else the pure-Python fallback. ``generated_at`` is
+    passed through into stats verbatim (the caller owns the clock; this function
+    never calls ``datetime.now()``).
+    """
+    kept_nodes, vectors = _valid_vectors(nodes)
+
+    embedding_dim = len(vectors[0]) if vectors else None
+    # Defensive: drop any ragged vectors that disagree with the modal dimension
+    # so the numpy matrix build cannot raise on a jagged corpus.
+    if embedding_dim is not None:
+        filtered = [(nd, v) for nd, v in zip(kept_nodes, vectors) if len(v) == embedding_dim]
+        kept_nodes = [nd for nd, _ in filtered]
+        vectors = [v for _, v in filtered]
+
+    if len(vectors) < 2:
+        pairs: List[Dict[str, Any]] = []
+    elif np is not None:
+        pairs = _cosine_pairs_numpy(kept_nodes, vectors, threshold)
+    else:
+        pairs = _cosine_pairs_python(kept_nodes, vectors, threshold)
+
+    pairs.sort(key=lambda p: p["cosine"], reverse=True)
+
+    flagged_cos = [p["cosine"] for p in pairs]
+    involved = set()
+    for p in pairs:
+        involved.add(p["a"])
+        involved.add(p["b"])
+
+    sorted_flagged = sorted(flagged_cos)
+    stats: Dict[str, Any] = {
+        "corpus_size": len(kept_nodes),
+        "embedding_dim": embedding_dim,
+        "threshold": threshold,
+        "num_pairs": len(pairs),
+        "num_nodes_involved": len(involved),
+        "max_cosine": max(flagged_cos) if flagged_cos else None,
+        "mean_flagged_cosine": (sum(flagged_cos) / len(flagged_cos)) if flagged_cos else None,
+        "cosine_percentiles": {
+            "p50": _percentile(sorted_flagged, 50.0),
+            "p90": _percentile(sorted_flagged, 90.0),
+            "p99": _percentile(sorted_flagged, 99.0),
+        },
+        "generated_at": generated_at,
+    }
+    return pairs, stats
+
+
+# ===========================================================================
+# SINK layer
+# ===========================================================================
+_s3 = None
+
+
+def _get_s3():
+    """Lazy S3 client with tight timeouts + a single retry, mirroring
+    graph_query_api ``_get_s3`` (lambda_function.py:214-231). A slow/unavailable
+    S3 cannot abort the local write because the caller suppresses all errors.
+    """
+    global _s3
+    if _s3 is None:
+        import boto3
+        from botocore.config import Config
+        _s3 = boto3.client(
+            "s3",
+            config=Config(
+                connect_timeout=2,
+                read_timeout=5,
+                retries={"max_attempts": 1, "mode": "standard"},
+            ),
+        )
+    return _s3
+
+
+def _pairs_to_jsonl(pairs: Sequence[Dict[str, Any]]) -> str:
+    """Serialize pairs to newline-delimited JSON (the H92 input contract)."""
+    return "".join(json.dumps(p, default=str) + "\n" for p in pairs)
+
+
+def write_results(pairs: Sequence[Dict[str, Any]], stats: Dict[str, Any],
+                  args: argparse.Namespace) -> Dict[str, Any]:
+    """SINK entrypoint. ALWAYS writes ``pairs.jsonl`` + ``summary.json`` to the
+    local ``--out`` dir and emits one structured ``CORRELATION_RESULTS {json}``
+    stdout line. When ``CORRELATION_RESULTS_BUCKET`` is set, ALSO PUTs both files
+    to S3 under ``{prefix}/`` — an S3 failure is caught and never aborts the
+    local write.
+
+    Returns the summary dict (the same object emitted on the stdout line),
+    augmented with the artifact locations.
+    """
+    out_dir = getattr(args, "out", DEFAULT_OUT_DIR)
+    os.makedirs(out_dir, exist_ok=True)
+
+    pairs_path = os.path.join(out_dir, PAIRS_FILENAME)
+    summary_path = os.path.join(out_dir, SUMMARY_FILENAME)
+
+    pairs_body = _pairs_to_jsonl(pairs)
+    summary_obj = dict(stats)
+
+    # ---- Local write (always) ---------------------------------------------
+    with open(pairs_path, "w", encoding="utf-8") as fh:
+        fh.write(pairs_body)
+
+    # ---- Optional S3 mirror (best-effort) ---------------------------------
+    bucket = os.environ.get(RESULTS_BUCKET_ENV, "").strip()
+    prefix = (os.environ.get(RESULTS_PREFIX_ENV, DEFAULT_RESULTS_PREFIX).strip()
+              or DEFAULT_RESULTS_PREFIX).rstrip("/")
+    s3_uris: Dict[str, str] = {}
+    if bucket:
+        try:
+            client = _get_s3()
+            pairs_key = f"{prefix}/{PAIRS_FILENAME}"
+            summary_key = f"{prefix}/{SUMMARY_FILENAME}"
+            client.put_object(
+                Bucket=bucket, Key=pairs_key,
+                Body=pairs_body.encode("utf-8"),
+                ContentType="application/x-ndjson",
+            )
+            s3_uris = {
+                "pairs": f"s3://{bucket}/{pairs_key}",
+                "summary": f"s3://{bucket}/{summary_key}",
+            }
+            # Summary written below once s3_uris is folded in, to S3 too.
+        except Exception as exc:
+            print(
+                f"[WARNING] correlation results S3 put failed ({exc}); "
+                "local write retained",
+                file=sys.stderr,
+            )
+            s3_uris = {}
+
+    summary_obj["artifacts"] = {
+        "pairs_local": pairs_path,
+        "summary_local": summary_path,
+        **({"pairs_s3": s3_uris["pairs"], "summary_s3": s3_uris["summary"]} if s3_uris else {}),
+    }
+
+    # Write the (now artifact-annotated) summary locally — always.
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary_obj, fh, indent=2, default=str)
+
+    # Mirror the annotated summary to S3 when the pairs PUT succeeded.
+    if bucket and s3_uris:
+        try:
+            client = _get_s3()
+            client.put_object(
+                Bucket=bucket, Key=f"{prefix}/{SUMMARY_FILENAME}",
+                Body=json.dumps(summary_obj, default=str).encode("utf-8"),
+                ContentType="application/json",
+            )
+        except Exception as exc:
+            print(
+                f"[WARNING] correlation summary S3 put failed ({exc}); "
+                "local summary retained",
+                file=sys.stderr,
+            )
+
+    # ---- Structured stdout line (always; CloudWatch-degraded mirror) -------
+    print("CORRELATION_RESULTS " + json.dumps(summary_obj, default=str))
+    return summary_obj
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="correlation_analysis_h91",
+        description=(
+            "ENC-TSK-H91 cosine-similarity correlation analysis over the "
+            "Enceladus n.embedding corpus (ENC-TSK-H34 AC-1; consumes the "
+            "ENC-TSK-H89 vector_read contract; emits the ENC-TSK-H92 pairs.jsonl)."
+        ),
+    )
+    p.add_argument("--source", choices=["gamma", "mcp", "file"], default="gamma",
+                   help="Corpus read surface (default: gamma).")
+    p.add_argument("--input", default=None,
+                   help="JSON file of {'nodes':[...]} or a bare node list (--source file).")
+    p.add_argument("--project-id", dest="project_id", default=DEFAULT_PROJECT_ID,
+                   help="Project id to read (default: enceladus).")
+    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                   help="Flag pairs with cosine strictly above this (default: 0.95).")
+    p.add_argument("--page-limit", dest="page_limit", type=int, default=DEFAULT_PAGE_LIMIT,
+                   help="vector_read page size (default: 200).")
+    p.add_argument("--out", default=DEFAULT_OUT_DIR,
+                   help="Local output directory (default: ./h91_results).")
+    p.add_argument("--gamma-function", dest="gamma_function", default=DEFAULT_GAMMA_FUNCTION,
+                   help="Gamma graph-query Lambda name (default: devops-graph-query-api-gamma).")
+    p.add_argument("--generated-at", dest="generated_at", default=None,
+                   help="Optional ISO timestamp stamped into stats.generated_at.")
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        nodes = load_corpus(args)
+    except Exception as exc:
+        print(f"[ERROR] corpus read failed (source={args.source}): {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"[INFO] loaded {len(nodes)} nodes from source={args.source}; "
+        f"threshold={args.threshold}",
+        file=sys.stderr,
+    )
+
+    pairs, stats = cosine_pairs(nodes, args.threshold, generated_at=args.generated_at)
+    write_results(pairs, stats, args)
+
+    print(
+        f"[SUCCESS] {stats['num_pairs']} flagged pairs over "
+        f"{stats['corpus_size']} embedded nodes (dim={stats['embedding_dim']})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -7537,6 +7537,8 @@ if ENABLE_COMPONENT_PROPOSAL:
 
 # ENC-FTR-058 / ENC-TSK-A97 / ENC-TSK-C09: Plan action aliases in code-mode surface
 _SEARCH_ACTIONS["plan.objectives_status"] = {"tool": "plan_objectives_status"}
+# ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read action
+_SEARCH_ACTIONS["graph_query.vector_read"] = {"tool": "graph_query_vector_read"}
 _EXECUTE_ACTIONS["plan.create"] = {"tool": "tracker_create", "requires_governance_hash": True}
 _EXECUTE_ACTIONS["plan.checkout"] = {"tool": "plan_checkout", "requires_governance_hash": True}
 _EXECUTE_ACTIONS["plan.advance"] = {"tool": "plan_advance", "requires_governance_hash": True}
@@ -8885,10 +8887,37 @@ async def _tracker_graphsearch(args: dict) -> list[TextContent]:
     for key in ("anchor_record_id", "top_n", "include_below_threshold"):
         if args.get(key) is not None:
             query_params[key] = args[key]
+    # ENC-TSK-H89 (ENC-FTR-082 AC-12): bulk vector-read pagination passthrough
+    # (search_type=vector_read). offset/limit reach the dedicated strip-exempt
+    # corpus read in graph_query_api; no effect on the other search types.
+    for key in ("offset", "limit"):
+        if args.get(key) is not None:
+            query_params[key] = args[key]
 
     resp = _graph_query_api_request(query=query_params)
     if resp.get("error"):
         return _result_text(resp)
+    return _result_text(resp)
+
+
+async def _graph_query_vector_read(args: dict) -> list[TextContent]:
+    """ENC-TSK-H89 / ENC-FTR-082 AC-12 — governed bulk vector-read over the
+    n.embedding corpus. Self-describing alias for the graph_query_api
+    search_type=vector_read path: returns paginated {record_id, record_type,
+    embedding} for downstream correlation analysis (ENC-TSK-H34 AC-1). The hybrid
+    retrieval path keeps stripping embeddings; ONLY this dedicated read returns
+    the raw vector."""
+    project_id = args.get("project_id")
+    if not project_id:
+        return _result_text({"error": "project_id is required"})
+    query_params: Dict[str, Any] = {
+        "search_type": "vector_read",
+        "project_id": project_id,
+    }
+    for key in ("offset", "limit", "record_type"):
+        if args.get(key) is not None:
+            query_params[key] = args[key]
+    resp = _graph_query_api_request(query=query_params)
     return _result_text(resp)
 
 
@@ -10101,6 +10130,8 @@ _TOOL_HANDLERS = {
     "github_projects_list": _github_projects_list,
     # ENC-FTR-047: Graph search
     "tracker_graphsearch": _tracker_graphsearch,
+    # ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read
+    "graph_query_vector_read": _graph_query_vector_read,
     # ENC-FTR-097 / ENC-TSK-G27: Manifest Primitive v1 read actions
     "tracker_manifest": _tracker_manifest,
     "tracker_get_acs": _tracker_get_acs,

--- a/tools/requirements-analysis.txt
+++ b/tools/requirements-analysis.txt
@@ -1,0 +1,8 @@
+# ENC-TSK-H91 correlation analysis (tools/correlation_analysis_h91.py).
+# numpy is OPTIONAL: it vectorizes the upper-triangle cosine (X @ X.T) for the
+# ~5000-node corpus. The script and its unit tests fall back to a pure-Python
+# (stdlib math) path when numpy is absent, so this is the only third-party dep.
+# boto3/botocore are imported lazily for the live gamma/S3 paths and are expected
+# to already be present in the product-lead terminal / Lambda runtime; they are
+# intentionally NOT pinned here so `--source file` and the unit tests need no AWS.
+numpy>=1.21

--- a/tools/test_correlation_analysis_h91.py
+++ b/tools/test_correlation_analysis_h91.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Unit tests for ENC-TSK-H91 correlation analysis (tools/correlation_analysis_h91.py).
+
+stdlib unittest (NOT pytest). Synthetic in-memory data only — no network, no S3,
+no live corpus. Exercises cosine correctness, threshold filtering, the pair-set
++ stats shape, and the pure-Python compute path explicitly (so the suite passes
+where numpy is unavailable).
+"""
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import correlation_analysis_h91 as ca  # noqa: E402
+
+
+def _node(rid, vec, rtype="task"):
+    return {"record_id": rid, "record_type": rtype, ca.EMBEDDING_PROPERTY: list(vec)}
+
+
+class CosineCorrectnessTest(unittest.TestCase):
+    """Hand-built vectors: identical -> 1.0, orthogonal -> 0.0, known angle."""
+
+    def test_identical_vectors_cosine_one(self):
+        nodes = [_node("A", [1.0, 2.0, 3.0]), _node("B", [1.0, 2.0, 3.0])]
+        pairs, stats = ca.cosine_pairs(nodes, threshold=0.5)
+        self.assertEqual(stats["num_pairs"], 1)
+        self.assertAlmostEqual(pairs[0]["cosine"], 1.0, places=9)
+
+    def test_orthogonal_vectors_cosine_zero(self):
+        # Orthogonal vectors -> cosine 0.0, below any positive threshold.
+        nodes = [_node("A", [1.0, 0.0]), _node("B", [0.0, 1.0])]
+        pairs, stats = ca.cosine_pairs(nodes, threshold=0.0001)
+        self.assertEqual(stats["num_pairs"], 0)
+        # Confirm the raw cosine via the pure-Python helper (always available).
+        py_pairs = ca._cosine_pairs_python(nodes, [[1.0, 0.0], [0.0, 1.0]], threshold=-1.0)
+        self.assertEqual(len(py_pairs), 1)
+        self.assertAlmostEqual(py_pairs[0]["cosine"], 0.0, places=9)
+
+    def test_known_angle_45_degrees(self):
+        # [1,0] vs [1,1] -> cos(45deg) = 1/sqrt(2) ~= 0.7071.
+        vecs = [[1.0, 0.0], [1.0, 1.0]]
+        nodes = [_node("A", vecs[0]), _node("B", vecs[1])]
+        py_pairs = ca._cosine_pairs_python(nodes, vecs, threshold=-1.0)
+        self.assertAlmostEqual(py_pairs[0]["cosine"], 1.0 / math.sqrt(2.0), places=9)
+
+    def test_negative_cosine_not_flagged_at_positive_threshold(self):
+        # Anti-parallel vectors -> cosine -1.0, never flagged for threshold>=0.
+        vecs = [[1.0, 0.0], [-1.0, 0.0]]
+        nodes = [_node("A", vecs[0]), _node("B", vecs[1])]
+        _, stats = ca.cosine_pairs(nodes, threshold=0.95)
+        self.assertEqual(stats["num_pairs"], 0)
+        py_pairs = ca._cosine_pairs_python(nodes, vecs, threshold=-2.0)
+        self.assertAlmostEqual(py_pairs[0]["cosine"], -1.0, places=9)
+
+
+class ThresholdFilteringTest(unittest.TestCase):
+    """A corpus where exactly one pair exceeds 0.95 and the others don't."""
+
+    def _corpus(self):
+        # A and B are near-identical (cosine ~1.0 > 0.95). C is orthogonal-ish to
+        # both, so neither (A,C) nor (B,C) crosses 0.95.
+        return [
+            _node("ENC-TSK-A", [1.0, 0.0, 0.0], "task"),
+            _node("ENC-TSK-B", [1.0, 0.001, 0.0], "task"),
+            _node("ENC-ISS-C", [0.0, 1.0, 0.0], "issue"),
+        ]
+
+    def test_exactly_one_pair_over_threshold(self):
+        pairs, stats = ca.cosine_pairs(self._corpus(), threshold=0.95)
+        self.assertEqual(stats["num_pairs"], 1)
+        self.assertEqual(len(pairs), 1)
+        flagged = {pairs[0]["a"], pairs[0]["b"]}
+        self.assertEqual(flagged, {"ENC-TSK-A", "ENC-TSK-B"})
+        self.assertGreater(pairs[0]["cosine"], 0.95)
+        self.assertEqual(stats["num_nodes_involved"], 2)
+
+    def test_pure_python_matches_default_path(self):
+        corpus = self._corpus()
+        _, vectors = ca._valid_vectors(corpus)
+        py_pairs = ca._cosine_pairs_python(corpus, vectors, threshold=0.95)
+        self.assertEqual(len(py_pairs), 1)
+        self.assertEqual({py_pairs[0]["a"], py_pairs[0]["b"]}, {"ENC-TSK-A", "ENC-TSK-B"})
+
+
+class PairAndStatsShapeTest(unittest.TestCase):
+    def test_pair_record_keys(self):
+        nodes = [_node("A", [1.0, 1.0], "feature"), _node("B", [1.0, 1.0], "plan")]
+        pairs, _ = ca.cosine_pairs(nodes, threshold=0.5)
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(set(pairs[0].keys()), {"a", "b", "a_type", "b_type", "cosine"})
+        self.assertEqual(pairs[0]["a_type"], "feature")
+        self.assertEqual(pairs[0]["b_type"], "plan")
+        self.assertIsInstance(pairs[0]["cosine"], float)
+
+    def test_stats_keys_present(self):
+        nodes = [_node("A", [1.0, 0.0]), _node("B", [1.0, 0.0]), _node("C", [0.0, 1.0])]
+        _, stats = ca.cosine_pairs(nodes, threshold=0.9, generated_at="2026-06-23T00:00:00Z")
+        for key in (
+            "corpus_size", "embedding_dim", "threshold", "num_pairs",
+            "num_nodes_involved", "max_cosine", "mean_flagged_cosine",
+            "cosine_percentiles", "generated_at",
+        ):
+            self.assertIn(key, stats)
+        self.assertEqual(stats["corpus_size"], 3)
+        self.assertEqual(stats["embedding_dim"], 2)
+        self.assertEqual(stats["threshold"], 0.9)
+        self.assertEqual(stats["generated_at"], "2026-06-23T00:00:00Z")
+        self.assertEqual(set(stats["cosine_percentiles"].keys()), {"p50", "p90", "p99"})
+
+    def test_generated_at_defaults_none(self):
+        nodes = [_node("A", [1.0, 0.0]), _node("B", [1.0, 0.0])]
+        _, stats = ca.cosine_pairs(nodes, threshold=0.5)
+        self.assertIsNone(stats["generated_at"])
+
+    def test_pairs_sorted_descending(self):
+        # Three mutually-high pairs with distinct cosines; assert desc order.
+        nodes = [
+            _node("A", [1.0, 0.0, 0.0]),
+            _node("B", [0.99, 0.14107, 0.0]),   # ~cos 0.99 with A
+            _node("C", [0.9, 0.43589, 0.0]),     # ~cos 0.90 with A
+        ]
+        pairs, _ = ca.cosine_pairs(nodes, threshold=0.0)
+        cosines = [p["cosine"] for p in pairs]
+        self.assertEqual(cosines, sorted(cosines, reverse=True))
+
+    def test_zero_norm_vector_skipped(self):
+        nodes = [
+            _node("ZERO", [0.0, 0.0, 0.0]),
+            _node("A", [1.0, 0.0, 0.0]),
+            _node("B", [1.0, 0.0, 0.0]),
+        ]
+        pairs, stats = ca.cosine_pairs(nodes, threshold=0.5)
+        # Only the A/B pair survives; the zero vector never flags.
+        self.assertEqual(stats["num_pairs"], 1)
+        involved = {pairs[0]["a"], pairs[0]["b"]}
+        self.assertNotIn("ZERO", involved)
+
+    def test_empty_and_singleton_corpus(self):
+        for corpus in ([], [_node("solo", [1.0, 2.0])]):
+            pairs, stats = ca.cosine_pairs(corpus, threshold=0.5)
+            self.assertEqual(pairs, [])
+            self.assertEqual(stats["num_pairs"], 0)
+            self.assertIsNone(stats["max_cosine"])
+            self.assertIsNone(stats["mean_flagged_cosine"])
+
+
+class PurePythonPathTest(unittest.TestCase):
+    """Force the numpy-absent configuration by monkeypatching ca.np to None so
+    cosine_pairs() routes through the stdlib fallback. Restored in tearDown so
+    test ordering is irrelevant."""
+
+    def setUp(self):
+        self._saved_np = ca.np
+        ca.np = None  # type: ignore[assignment]
+
+    def tearDown(self):
+        ca.np = self._saved_np  # type: ignore[assignment]
+
+    def test_cosine_pairs_without_numpy(self):
+        self.assertIsNone(ca.np)
+        nodes = [
+            _node("ENC-TSK-A", [1.0, 0.0, 0.0]),
+            _node("ENC-TSK-B", [1.0, 0.0001, 0.0]),
+            _node("ENC-ISS-C", [0.0, 1.0, 0.0]),
+        ]
+        pairs, stats = ca.cosine_pairs(nodes, threshold=0.95)
+        self.assertEqual(stats["num_pairs"], 1)
+        self.assertEqual({pairs[0]["a"], pairs[0]["b"]}, {"ENC-TSK-A", "ENC-TSK-B"})
+        self.assertAlmostEqual(pairs[0]["cosine"], 1.0, places=6)
+
+    def test_identical_cosine_one_without_numpy(self):
+        nodes = [_node("A", [3.0, 4.0]), _node("B", [3.0, 4.0])]
+        pairs, _ = ca.cosine_pairs(nodes, threshold=0.5)
+        self.assertAlmostEqual(pairs[0]["cosine"], 1.0, places=9)
+
+
+class HelperTest(unittest.TestCase):
+    def test_percentile_interpolation(self):
+        vals = [0.90, 0.92, 0.94, 0.96, 0.98]
+        self.assertAlmostEqual(ca._percentile(vals, 50.0), 0.94, places=9)
+        self.assertAlmostEqual(ca._percentile(vals, 0.0), 0.90, places=9)
+        self.assertAlmostEqual(ca._percentile(vals, 100.0), 0.98, places=9)
+        self.assertIsNone(ca._percentile([], 50.0))
+        self.assertAlmostEqual(ca._percentile([0.5], 90.0), 0.5, places=9)
+
+    def test_coerce_nodes_accepts_dict_and_list(self):
+        n = {"record_id": "A", "record_type": "task", "embedding": [1.0]}
+        self.assertEqual(ca._coerce_nodes({"nodes": [n]}), [n])
+        self.assertEqual(ca._coerce_nodes([n]), [n])
+        self.assertEqual(ca._coerce_nodes([n, "junk", 5]), [n])
+        self.assertEqual(ca._coerce_nodes(None), [])
+
+    def test_valid_vectors_filters_bad_embeddings(self):
+        nodes = [
+            _node("good", [1.0, 2.0]),
+            {"record_id": "no_emb", "record_type": "task"},
+            {"record_id": "empty", "record_type": "task", "embedding": []},
+            {"record_id": "nonnum", "record_type": "task", "embedding": ["x", "y"]},
+        ]
+        kept, vecs = ca._valid_vectors(nodes)
+        self.assertEqual([n["record_id"] for n in kept], ["good"])
+        self.assertEqual(vecs, [[1.0, 2.0]])
+
+    def test_pairs_to_jsonl_roundtrip(self):
+        pairs = [{"a": "A", "b": "B", "a_type": "task", "b_type": "task", "cosine": 0.99}]
+        text = ca._pairs_to_jsonl(pairs)
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        import json as _json
+        self.assertEqual(_json.loads(lines[0]), pairs[0])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## ENC-PLN-052 Wave-1 — governed vector-read path + correlation analysis

Lands the ENC-TSK-H89 governed bulk vector-read path over the `n.embedding` corpus
(FTR-082 AC-12) and the ENC-TSK-H91 cosine-similarity correlation analysis tool
(ENC-TSK-H34 AC-1). Ships as `code_only`; no deploy stage on these records.

### Commits
- `cb93c99` ENC-TSK-H89 — `graph_query_api._query_vector_read` (strip-exempt paginated corpus read) + MCP `graph_query.vector_read` action + `tracker.graphsearch` offset/limit passthrough + dict entity (v2026-06-24.01)
- `2cb93de` ENC-TSK-H91 — `tools/correlation_analysis_h91.py` (cosine > threshold, emits pairs.jsonl + summary.json)

### Commit gate
- CCI-73fa394f9a10432f817d31f7edbce0ef  (ENC-TSK-H89)
- CCI-6f417b6ff8074d658f368508fa76360d  (ENC-TSK-H91)

### Tests
- `test_vector_read_h89.py` 9/9; regression `test_hybrid_retrieval` + `test_edge_allowlist_f45` 23/23
- `test_correlation_analysis_h91.py` 18/18 (incl. pure-python cosine path)

### Governance
- `governance_data_dictionary.json` bumped to v2026-06-24.01 (dict-guard: `graph_query_api.vector_read` entity + enum)

Part of ENC-PLN-052 (Ship ENC-TSK-H34 correlation-aware encoding). Handoff DOC-0CA20D57DA66.
