### PR TITLE
ENC-TSK-I05: duplicate-cluster detection over the >=0.95 same-type cosine graph

### DIFF
--- a/tools/dedup_cluster_i05.py
+++ b/tools/dedup_cluster_i05.py
@@ -1,0 +1,908 @@
+#!/usr/bin/env python3
+"""ENC-TSK-I05 — Duplicate-cluster detection over the Enceladus ``n.embedding``
+corpus.
+
+Phase 2 of the PLN-052 dedup track. After on-retrieval correlation *encoding*
+(ENC-TSK-H92 query-side, ENC-TSK-I03 symmetric re-rank) failed to clear the +5%
+recall bar, the residual near-duplicate mass measured by ENC-TSK-H91 (2281
+issue/issue + 209 task/task pairs at mean cosine 0.9998) is better addressed by
+*deduplication* than by further encoding. This script turns that pairwise signal
+into actionable duplicate **clusters** with a single **canonical suggestion**
+per cluster.
+
+It is a strictly **mutation-free** analysis tool: it reads the governed corpus,
+computes, and writes local (+ optional S3) result artifacts. It performs NO
+tracker writes and proposes nothing to the governed store — a human or a later
+governed task decides what to do with the suggestions.
+
+Pipeline (READ -> GRAPH -> COMPONENTS -> CANONICAL -> SINK):
+
+  READ      The embedding corpus is read via the ENC-TSK-H89 / ENC-FTR-082 AC-12
+            ``vector_read`` contract, reusing the ENC-TSK-H91 loaders verbatim
+            (``correlation_analysis_h91.load_corpus``) so there is a single
+            governed read path. Each node is
+            ``{"record_id", "record_type", "embedding": [float, ...]}``; this
+            script additionally stamps ``project_id`` from the read scope so the
+            graph builder can enforce the same-project edge rule. As an
+            efficiency alternative, ``--source pairs`` ingests an H91
+            ``pairs.jsonl`` directly as the edge set (no corpus re-read / no
+            cosine recompute).
+
+  GRAPH     ``similarity_edges(nodes, threshold)`` groups nodes by
+            ``(project_id, record_type)`` and, within each group only, flags
+            pairs whose cosine is >= ``threshold`` (default 0.95). Same-type +
+            same-project is therefore structural, not a post-filter, and the
+            O(n^2) pairwise cost collapses to the sum of per-group squares.
+            numpy is used when importable (``Xn @ Xn.T``) with a pure-Python
+            (``math`` only) fallback. Note the H91 *pair* analysis used a strict
+            ``>`` flag; the I05 *graph* edge rule is ``>=`` to match the AC text
+            "the >=0.95 ... cosine graph".
+
+  COMPONENTS ``connected_components(edges)`` runs union-find (DSU) over the
+            flagged edges. Each connected component with >= 2 members is one
+            duplicate cluster. Singletons are not duplicates and are dropped.
+
+  CANONICAL ``select_canonical(members, metadata)`` picks one deterministic
+            canonical record per cluster by argmax over, in priority order,
+            ``(evidence, inbound-edges, lifecycle, age)`` — richest evidence
+            first, then most graph-referenced, then most lifecycle-settled, then
+            oldest (the original). ``record_id`` is the final lexicographic
+            tiebreak so the choice is fully deterministic even when every signal
+            ties. The four ranking signals are NOT carried by ``vector_read``
+            (it returns only record_id/type/embedding), so they come from an
+            optional per-record ``metadata`` map (``--metadata``); without it the
+            canonical degrades gracefully to the deterministic record_id tiebreak
+            and a ``metadata_coverage`` warning is surfaced in the summary.
+
+  SINK      ``write_results`` mirrors the H91 sink: ALWAYS writes
+            ``clusters.jsonl`` + ``summary.json`` to the local ``--out`` dir and
+            emits one structured ``DEDUP_RESULTS {json-summary}`` stdout line
+            (the CloudWatch-degraded mirror); when ``DEDUP_RESULTS_BUCKET`` is
+            set it ALSO best-effort PUTs both files to S3. An S3 failure never
+            aborts the local write.
+
+clusters.jsonl schema (one JSON object per line, sorted by size desc then
+max-cosine desc):
+
+    {"cluster_id": "i05-cluster-0001",
+     "record_type": <type>, "project_id": <project>,
+     "size": <int>, "members": [<record_id>, ...],
+     "canonical": <record_id>, "duplicates": [<record_id>, ...],
+     "canonical_rationale": {"evidence": <float>, "inbound_edges": <int>,
+                             "lifecycle_rank": <int>, "lifecycle_status": <str>,
+                             "created_at": <str|null>, "tiebreak": <str>,
+                             "has_metadata": <bool>},
+     "edges": [{"a": <record_id>, "b": <record_id>, "cosine": <float>}, ...],
+     "max_cosine": <float>, "min_cosine": <float>, "mean_cosine": <float>}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Reuse the ENC-TSK-H91 corpus read + cosine helpers verbatim so there is a
+# single governed vector_read path. The script lives in tools/ alongside it, so
+# the sibling import resolves both when run as ``python tools/dedup_cluster_i05``
+# (tools/ is sys.path[0]) and from the unit tests (which insert tools/ on path).
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import correlation_analysis_h91 as h91  # noqa: E402
+
+# numpy is re-exported from h91 so the unit tests can monkeypatch a single
+# module attribute (``dc.np = None``) to force the pure-Python graph path, the
+# same idiom test_correlation_analysis_h91 uses.
+np = h91.np
+
+EMBEDDING_PROPERTY = h91.EMBEDDING_PROPERTY
+
+DEFAULT_PROJECT_ID = h91.DEFAULT_PROJECT_ID
+DEFAULT_THRESHOLD = 0.95
+DEFAULT_PAGE_LIMIT = h91.DEFAULT_PAGE_LIMIT
+DEFAULT_OUT_DIR = "./i05_results"
+DEFAULT_GAMMA_FUNCTION = h91.DEFAULT_GAMMA_FUNCTION
+
+# S3 sink env contract (mirrors H91 / PATHWAY_TELEMETRY_BUCKET).
+RESULTS_BUCKET_ENV = "DEDUP_RESULTS_BUCKET"
+RESULTS_PREFIX_ENV = "DEDUP_RESULTS_PREFIX"
+DEFAULT_RESULTS_PREFIX = "dedup-clusters-i05"
+
+CLUSTERS_FILENAME = "clusters.jsonl"
+SUMMARY_FILENAME = "summary.json"
+
+_CLUSTER_ID_PREFIX = "i05-cluster-"
+
+
+# ===========================================================================
+# CANONICAL ranking signals
+# ===========================================================================
+# Lifecycle ordinal: a more lifecycle-settled record is the better canonical
+# anchor (tertiary signal, per the AC priority order). Covers task / issue /
+# feature / plan / lesson terminal + intermediate statuses. Unknown -> 0. The
+# absolute values are arbitrary; only their relative order matters.
+LIFECYCLE_RANK: Dict[str, int] = {
+    # terminal / settled
+    "closed": 100,
+    "deployed": 100,
+    "production": 100,
+    "complete": 100,
+    "accepted": 95,
+    "merged-main": 90,
+    "deploy-success": 85,
+    "deploy-init": 80,
+    "active": 70,
+    # mid-flight code arc
+    "pr": 60,
+    "pushed": 60,
+    "committed": 55,
+    "coding-complete": 50,
+    "coding-updates": 45,
+    # early
+    "in-progress": 30,
+    "started": 30,
+    "drafted": 20,
+    "open": 10,
+    "incomplete": 5,
+}
+
+
+def _lifecycle_rank(status: Optional[str]) -> int:
+    """Ordinal lifecycle rank for a status string (case-insensitive). Higher is
+    more settled; unknown / empty -> 0."""
+    if not status:
+        return 0
+    return LIFECYCLE_RANK.get(str(status).strip().lower(), 0)
+
+
+def _age_epoch(created_at: Optional[str]) -> float:
+    """Parse an ISO-8601 ``created_at`` into a UTC epoch (seconds). Returns
+    ``+inf`` when missing/unparseable so an unknown-age record is treated as the
+    *newest* — i.e. it never wins the "oldest is canonical" age signal on the
+    strength of a missing timestamp.
+    """
+    if not created_at or not isinstance(created_at, str):
+        return math.inf
+    text = created_at.strip()
+    if not text:
+        return math.inf
+    # Normalize a trailing 'Z' to an explicit UTC offset for fromisoformat.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        import datetime as _dt
+        dt = _dt.datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_dt.timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return math.inf
+
+
+def derive_evidence_score(record: Dict[str, Any]) -> float:
+    """Evidence-richness heuristic for a tracker record (loader helper).
+
+    Higher means a more evidence-backed record and thus a better canonical
+    anchor. Weighting (documented, deterministic):
+      * +3 per acceptance criterion with ``evidence_acceptance`` true,
+      * +1 per acceptance criterion carrying non-empty ``evidence`` text,
+      * +2 when a non-empty ``resolution`` is present (resolved issues),
+      * +0.5 when a non-empty ``intent``/``description`` is present.
+    A bare string criterion (legacy) contributes 0 — it gates nothing.
+    """
+    score = 0.0
+    for crit in record.get("acceptance_criteria") or []:
+        if isinstance(crit, dict):
+            if crit.get("evidence_acceptance"):
+                score += 3.0
+            elif str(crit.get("evidence") or "").strip():
+                score += 1.0
+    if str(record.get("resolution") or "").strip():
+        score += 2.0
+    if str(record.get("intent") or record.get("description") or "").strip():
+        score += 0.5
+    return score
+
+
+def inbound_edges_from_neighbors(payload: Any, record_id: str) -> int:
+    """Count inbound governed graph edges for ``record_id`` from a graphsearch
+    ``neighbors`` payload (loader helper).
+
+    Tolerates the edge-shape variants the graph_query_api emits: the destination
+    endpoint may be keyed ``target``/``to``/``dst``/``end`` and the source
+    ``source``/``from``/``src``/``start``. An edge counts as inbound when its
+    destination is ``record_id`` and its source is some other record.
+    """
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError):
+            return 0
+    if not isinstance(payload, dict):
+        return 0
+    edges = payload.get("edges")
+    if not isinstance(edges, list):
+        return 0
+
+    def _endpoint(edge: Dict[str, Any], keys: Sequence[str]) -> str:
+        for k in keys:
+            val = edge.get(k)
+            if isinstance(val, dict):  # node object rather than a bare id
+                val = val.get("record_id") or val.get("id")
+            if isinstance(val, str) and val:
+                return val
+        return ""
+
+    count = 0
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        dst = _endpoint(edge, ("target", "to", "dst", "end", "end_id"))
+        src = _endpoint(edge, ("source", "from", "src", "start", "start_id"))
+        if dst == record_id and src and src != record_id:
+            count += 1
+    return count
+
+
+def _record_meta(metadata: Optional[Dict[str, Any]], record_id: str) -> Dict[str, Any]:
+    """Normalize the per-record metadata entry into the ranking signal tuple
+    source. Missing entries degrade to zeros / unknown age."""
+    raw = (metadata or {}).get(record_id) or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    # evidence_score may be supplied precomputed by the loader, else derived from
+    # the embedded record fields, else 0.
+    if "evidence_score" in raw:
+        try:
+            evidence = float(raw.get("evidence_score") or 0.0)
+        except (TypeError, ValueError):
+            evidence = 0.0
+    else:
+        evidence = derive_evidence_score(raw)
+    try:
+        inbound = int(raw.get("inbound_edges") or 0)
+    except (TypeError, ValueError):
+        inbound = 0
+    status = raw.get("status")
+    created_at = raw.get("created_at")
+    return {
+        "evidence": evidence,
+        "inbound_edges": inbound,
+        "lifecycle_rank": _lifecycle_rank(status),
+        "lifecycle_status": (str(status).strip().lower() if status else None),
+        "created_at": created_at if isinstance(created_at, str) else None,
+        "age_epoch": _age_epoch(created_at),
+        "has_metadata": bool(raw),
+    }
+
+
+def select_canonical(member_ids: Sequence[str],
+                     metadata: Optional[Dict[str, Any]] = None
+                     ) -> Tuple[str, Dict[str, Any]]:
+    """Deterministically pick the canonical record for a cluster.
+
+    argmax priority (AC order): evidence > inbound-edges > lifecycle > age
+    (oldest wins). ``record_id`` ascending is the final tiebreak, so the result
+    is total and reproducible even when all four signals tie (e.g. no metadata).
+
+    Returns ``(canonical_id, rationale)`` where rationale carries the winning
+    record's signals plus a ``tiebreak`` note describing what decided it.
+    """
+    if not member_ids:
+        raise ValueError("select_canonical requires a non-empty member list")
+
+    scored: List[Tuple[Tuple[float, int, int, float, str], str, Dict[str, Any]]] = []
+    for rid in member_ids:
+        m = _record_meta(metadata, rid)
+        # Sort key ascending: negate the "higher wins" signals and use +age_epoch
+        # (smaller epoch = older = wins) and record_id ascending as final key.
+        key = (
+            -m["evidence"],
+            -m["inbound_edges"],
+            -m["lifecycle_rank"],
+            m["age_epoch"],
+            rid,
+        )
+        scored.append((key, rid, m))
+    scored.sort(key=lambda t: t[0])
+
+    _, canonical_id, winner = scored[0]
+    tiebreak = _explain_tiebreak(scored)
+    rationale = {
+        "evidence": winner["evidence"],
+        "inbound_edges": winner["inbound_edges"],
+        "lifecycle_rank": winner["lifecycle_rank"],
+        "lifecycle_status": winner["lifecycle_status"],
+        "created_at": winner["created_at"],
+        "has_metadata": winner["has_metadata"],
+        "tiebreak": tiebreak,
+    }
+    return canonical_id, rationale
+
+
+def _explain_tiebreak(scored: Sequence[Tuple[Tuple[float, int, int, float, str], str, Dict[str, Any]]]) -> str:
+    """Describe which signal separated the winner from the runner-up — useful
+    audit context in the emitted rationale."""
+    if len(scored) < 2:
+        return "sole_member"
+    win, run = scored[0][0], scored[1][0]
+    labels = ("evidence", "inbound_edges", "lifecycle", "age")
+    for idx, label in enumerate(labels):
+        if win[idx] != run[idx]:
+            return label
+    return "record_id"
+
+
+# ===========================================================================
+# GRAPH layer — same-type same-project cosine edges
+# ===========================================================================
+def _group_key(node: Dict[str, Any], default_project: str) -> Tuple[str, str]:
+    """Partition key enforcing the same-project + same-type edge rule. The
+    ``vector_read`` payload omits ``project_id`` (it is a query-scope param, not
+    a node field), so fall back to the read scope's project."""
+    project = node.get("project_id") or default_project or ""
+    rtype = node.get("record_type") or ""
+    return (str(project), str(rtype))
+
+
+def _edges_for_group_numpy(group_nodes: List[Dict[str, Any]],
+                           vectors: List[List[float]],
+                           threshold: float) -> List[Dict[str, Any]]:
+    """Vectorized within-group upper-triangle cosine, flagging entries >=
+    ``threshold``. Zero-norm rows normalize to the zero vector (cosine 0, never
+    flagged)."""
+    X = np.asarray(vectors, dtype=np.float64)
+    norms = np.linalg.norm(X, axis=1, keepdims=True)
+    safe = np.where(norms == 0.0, 1.0, norms)
+    Xn = X / safe
+    Xn[(norms == 0.0).ravel()] = 0.0
+    sims = Xn @ Xn.T
+
+    iu, ju = np.triu_indices(len(vectors), k=1)
+    if iu.size == 0:
+        return []
+    sims_pairs = sims[iu, ju]
+    mask = sims_pairs >= threshold
+    edges: List[Dict[str, Any]] = []
+    for i, j, c in zip(iu[mask].tolist(), ju[mask].tolist(), sims_pairs[mask].tolist()):
+        edges.append(_edge_record(group_nodes[i], group_nodes[j], float(c)))
+    return edges
+
+
+def _edges_for_group_python(group_nodes: List[Dict[str, Any]],
+                            vectors: List[List[float]],
+                            threshold: float) -> List[Dict[str, Any]]:
+    """Pure-Python within-group cosine fallback (numpy absent). Pre-normalizes
+    once; zero-norm vectors are skipped."""
+    unit: List[Optional[List[float]]] = []
+    for vec in vectors:
+        norm = math.sqrt(sum(x * x for x in vec))
+        unit.append(None if norm == 0.0 else [x / norm for x in vec])
+
+    edges: List[Dict[str, Any]] = []
+    n = len(unit)
+    for i in range(n):
+        ui = unit[i]
+        if ui is None:
+            continue
+        for j in range(i + 1, n):
+            uj = unit[j]
+            if uj is None:
+                continue
+            cos = sum(a * b for a, b in zip(ui, uj))
+            if cos >= threshold:
+                edges.append(_edge_record(group_nodes[i], group_nodes[j], float(cos)))
+    return edges
+
+
+def _edge_record(a: Dict[str, Any], b: Dict[str, Any], cosine: float) -> Dict[str, Any]:
+    """One flagged same-type same-project cosine edge. ``a`` is the
+    lexicographically smaller record_id so edges are orientation-stable."""
+    aid, bid = a.get("record_id"), b.get("record_id")
+    if aid is not None and bid is not None and str(bid) < str(aid):
+        a, b = b, a
+        aid, bid = bid, aid
+    return {
+        "a": aid,
+        "b": bid,
+        "record_type": a.get("record_type"),
+        "project_id": a.get("project_id"),
+        "cosine": cosine,
+    }
+
+
+def similarity_edges(nodes: Sequence[Dict[str, Any]], threshold: float,
+                     default_project: str = DEFAULT_PROJECT_ID) -> List[Dict[str, Any]]:
+    """Build the same-type same-project >= ``threshold`` cosine edge set.
+
+    Nodes are partitioned by ``(project_id, record_type)``; cosine is computed
+    only within a partition, so cross-type and cross-project pairs can never
+    produce an edge. numpy is used when importable, else the pure-Python path.
+    """
+    # Reuse H91's embedding validation (drops missing/empty/non-numeric vectors).
+    kept_nodes, vectors = h91._valid_vectors(nodes)
+
+    # Bucket parallel (node, vector) by partition key.
+    groups: Dict[Tuple[str, str], Tuple[List[Dict[str, Any]], List[List[float]]]] = {}
+    for node, vec in zip(kept_nodes, vectors):
+        gk = _group_key(node, default_project)
+        bucket = groups.setdefault(gk, ([], []))
+        bucket[0].append(node)
+        bucket[1].append(vec)
+
+    edges: List[Dict[str, Any]] = []
+    for (_proj, _rtype), (group_nodes, group_vectors) in groups.items():
+        if len(group_vectors) < 2:
+            continue
+        # Drop ragged vectors that disagree with the group's modal dim so the
+        # numpy matrix build cannot raise on a jagged corpus (mirrors H91).
+        dim = len(group_vectors[0])
+        filtered = [(nd, v) for nd, v in zip(group_nodes, group_vectors) if len(v) == dim]
+        group_nodes = [nd for nd, _ in filtered]
+        group_vectors = [v for _, v in filtered]
+        if len(group_vectors) < 2:
+            continue
+        if np is not None:
+            edges.extend(_edges_for_group_numpy(group_nodes, group_vectors, threshold))
+        else:
+            edges.extend(_edges_for_group_python(group_nodes, group_vectors, threshold))
+
+    edges.sort(key=lambda e: e["cosine"], reverse=True)
+    return edges
+
+
+def edges_from_pairs(pairs: Sequence[Dict[str, Any]], threshold: float) -> List[Dict[str, Any]]:
+    """Build the I05 edge set from an H91 ``pairs.jsonl`` record list: keep only
+    same-type pairs with cosine >= ``threshold``. This is the ``--source pairs``
+    reuse path (no corpus re-read / no cosine recompute)."""
+    edges: List[Dict[str, Any]] = []
+    for p in pairs:
+        if not isinstance(p, dict):
+            continue
+        a, b = p.get("a"), p.get("b")
+        if not a or not b:
+            continue
+        a_type, b_type = p.get("a_type"), p.get("b_type")
+        if a_type != b_type:
+            continue
+        try:
+            cosine = float(p.get("cosine"))
+        except (TypeError, ValueError):
+            continue
+        if cosine < threshold:
+            continue
+        # Reuse the orientation-stable edge builder.
+        edges.append(_edge_record(
+            {"record_id": a, "record_type": a_type, "project_id": p.get("project_id")},
+            {"record_id": b, "record_type": b_type, "project_id": p.get("project_id")},
+            cosine,
+        ))
+    edges.sort(key=lambda e: e["cosine"], reverse=True)
+    return edges
+
+
+# ===========================================================================
+# COMPONENTS layer — union-find over the flagged edges
+# ===========================================================================
+class _DSU:
+    """Minimal disjoint-set (union by rank + path compression)."""
+
+    def __init__(self) -> None:
+        self.parent: Dict[str, str] = {}
+        self.rank: Dict[str, int] = {}
+
+    def find(self, x: str) -> str:
+        self.parent.setdefault(x, x)
+        self.rank.setdefault(x, 0)
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        # Path compression.
+        while self.parent[x] != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        if self.rank[ra] < self.rank[rb]:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+        if self.rank[ra] == self.rank[rb]:
+            self.rank[ra] += 1
+
+
+def connected_components(edges: Sequence[Dict[str, Any]]) -> List[List[str]]:
+    """Connected components (size >= 2) over the flagged edge set, via union-find.
+
+    Returns a list of member-id lists, each sorted ascending; the outer list is
+    sorted by size desc then by smallest member id, for deterministic output.
+    Singletons (records with no >= threshold same-type neighbor) are excluded —
+    they are not duplicates.
+    """
+    dsu = _DSU()
+    for e in edges:
+        a, b = e.get("a"), e.get("b")
+        if a and b:
+            dsu.union(str(a), str(b))
+
+    comps: Dict[str, List[str]] = {}
+    for node in list(dsu.parent.keys()):
+        comps.setdefault(dsu.find(node), []).append(node)
+
+    clusters = [sorted(members) for members in comps.values() if len(members) >= 2]
+    clusters.sort(key=lambda members: (-len(members), members[0]))
+    return clusters
+
+
+# ===========================================================================
+# Assembly — clusters + summary
+# ===========================================================================
+def build_clusters(nodes: Optional[Sequence[Dict[str, Any]]],
+                   threshold: float,
+                   metadata: Optional[Dict[str, Any]] = None,
+                   default_project: str = DEFAULT_PROJECT_ID,
+                   precomputed_edges: Optional[Sequence[Dict[str, Any]]] = None,
+                   generated_at: Optional[str] = None) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """End-to-end COMPUTE: edges -> components -> per-cluster canonical + stats.
+
+    Pass either ``nodes`` (compute the cosine graph) or ``precomputed_edges``
+    (e.g. from an H91 pairs.jsonl). ``generated_at`` is threaded through into
+    stats verbatim; this function never reads the clock.
+    """
+    if precomputed_edges is not None:
+        edges = list(precomputed_edges)
+        corpus_size = None
+        embedding_dim = None
+    else:
+        edges = similarity_edges(nodes or [], threshold, default_project=default_project)
+        kept_nodes, vectors = h91._valid_vectors(nodes or [])
+        corpus_size = len(kept_nodes)
+        embedding_dim = len(vectors[0]) if vectors else None
+
+    # Index edges by the unordered member pair for fast intra-cluster lookup.
+    edges_by_member: Dict[str, List[Dict[str, Any]]] = {}
+    for e in edges:
+        for endpoint in (e.get("a"), e.get("b")):
+            if endpoint:
+                edges_by_member.setdefault(str(endpoint), []).append(e)
+
+    components = connected_components(edges)
+
+    clusters: List[Dict[str, Any]] = []
+    for idx, members in enumerate(components, start=1):
+        member_set = set(members)
+        # The edges fully inside this cluster (dedup by id-pair).
+        seen: set = set()
+        cluster_edges: List[Dict[str, Any]] = []
+        for member in members:
+            for e in edges_by_member.get(member, ()):
+                a, b = str(e.get("a")), str(e.get("b"))
+                if a in member_set and b in member_set:
+                    pair_key = (a, b) if a < b else (b, a)
+                    if pair_key in seen:
+                        continue
+                    seen.add(pair_key)
+                    cluster_edges.append({"a": e["a"], "b": e["b"], "cosine": e["cosine"]})
+        cluster_edges.sort(key=lambda e: e["cosine"], reverse=True)
+
+        canonical, rationale = select_canonical(members, metadata)
+
+        cosines = [e["cosine"] for e in cluster_edges]
+        # record_type/project for the cluster: derived from an edge (homogeneous
+        # by construction) or the node metadata.
+        rtype = cluster_edges[0].get("record_type") if cluster_edges else None
+        if rtype is None and edges:
+            for e in edges_by_member.get(members[0], ()):
+                rtype = e.get("record_type")
+                break
+        proj = None
+        for e in edges_by_member.get(members[0], ()):
+            proj = e.get("project_id")
+            break
+
+        clusters.append({
+            "cluster_id": f"{_CLUSTER_ID_PREFIX}{idx:04d}",
+            "record_type": rtype,
+            "project_id": proj or default_project,
+            "size": len(members),
+            "members": members,
+            "canonical": canonical,
+            "duplicates": [m for m in members if m != canonical],
+            "canonical_rationale": rationale,
+            "edges": cluster_edges,
+            "max_cosine": max(cosines) if cosines else None,
+            "min_cosine": min(cosines) if cosines else None,
+            "mean_cosine": (sum(cosines) / len(cosines)) if cosines else None,
+        })
+
+    stats = _summary_stats(
+        clusters, edges, threshold, corpus_size, embedding_dim,
+        metadata, generated_at,
+    )
+    return clusters, stats
+
+
+def _summary_stats(clusters: Sequence[Dict[str, Any]], edges: Sequence[Dict[str, Any]],
+                   threshold: float, corpus_size: Optional[int], embedding_dim: Optional[int],
+                   metadata: Optional[Dict[str, Any]], generated_at: Optional[str]) -> Dict[str, Any]:
+    records_in_clusters = sorted({m for c in clusters for m in c["members"]})
+    size_hist: Dict[str, int] = {}
+    by_type: Dict[str, Dict[str, int]] = {}
+    for c in clusters:
+        size_hist[str(c["size"])] = size_hist.get(str(c["size"]), 0) + 1
+        bt = by_type.setdefault(str(c["record_type"]), {"clusters": 0, "records": 0})
+        bt["clusters"] += 1
+        bt["records"] += c["size"]
+
+    with_meta = sum(1 for r in records_in_clusters if (metadata or {}).get(r)) if metadata else 0
+    return {
+        "corpus_size": corpus_size,
+        "embedding_dim": embedding_dim,
+        "threshold": threshold,
+        "num_edges": len(edges),
+        "num_clusters": len(clusters),
+        "num_records_in_clusters": len(records_in_clusters),
+        "largest_cluster_size": max((c["size"] for c in clusters), default=0),
+        "cluster_size_histogram": dict(sorted(size_hist.items(), key=lambda kv: int(kv[0]))),
+        "by_type": by_type,
+        "metadata_coverage": {
+            "metadata_supplied": bool(metadata),
+            "records_in_clusters": len(records_in_clusters),
+            "records_with_metadata": with_meta,
+        },
+        "generated_at": generated_at,
+    }
+
+
+# ===========================================================================
+# Metadata loaders (the canonical-ranking signals; vector_read omits them)
+# ===========================================================================
+def load_metadata_from_file(path: str) -> Dict[str, Any]:
+    """Load a per-record metadata map ``{record_id: {status, created_at,
+    evidence_score?|acceptance_criteria?, inbound_edges?}}`` from a local JSON
+    file. The source exercised by the unit tests."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("metadata file must be a JSON object keyed by record_id")
+    return data
+
+
+def load_metadata_from_mcp(record_ids: Sequence[str],
+                           search_fn: Optional[Callable] = None,
+                           project_id: str = DEFAULT_PROJECT_ID) -> Dict[str, Any]:
+    """Enrich the clustered record_ids with the four canonical-ranking signals
+    via the MCP code-mode ``search`` surface.
+
+    DEFENSIVE / NOT unit-tested against live MCP (mirrors H91's live loaders).
+    For each record it reads ``tracker.get`` (status, created_at, evidence) and
+    ``tracker.graphsearch`` neighbors (inbound edge count). ``search_fn`` is the
+    injected ``search(action, arguments)`` callable; without it an import shim is
+    attempted and otherwise a clear error is raised.
+    """
+    if search_fn is None:  # pragma: no cover - environment-specific shim
+        try:
+            from enceladus_mcp import search as search_fn  # type: ignore
+        except Exception as exc:
+            raise RuntimeError(
+                "no MCP `search` callable available; pass search_fn= or run the "
+                "enrichment from a session where the MCP code-mode surface is bound"
+            ) from exc
+
+    def _unwrap(result: Any) -> Dict[str, Any]:
+        if isinstance(result, str):
+            result = json.loads(result)
+        if not isinstance(result, dict):
+            return {}
+        # Peel the code-mode envelope ({success, result: {...}}).
+        for key in ("result", "record", "data", "body"):
+            inner = result.get(key)
+            if isinstance(inner, dict):
+                result = inner
+        return result
+
+    metadata: Dict[str, Any] = {}
+    for rid in record_ids:  # pragma: no cover - live MCP only
+        entry: Dict[str, Any] = {}
+        try:
+            rec = _unwrap(search_fn(action="tracker.get", arguments={"record_id": rid}))
+            entry["status"] = rec.get("status")
+            entry["created_at"] = rec.get("created_at")
+            entry["evidence_score"] = derive_evidence_score(rec)
+        except Exception as exc:
+            print(f"[WARNING] tracker.get failed for {rid}: {exc}", file=sys.stderr)
+        try:
+            neighbors = _unwrap(search_fn(
+                action="tracker.graphsearch",
+                arguments={"search_type": "neighbors", "project_id": project_id,
+                           "record_id": rid, "direction": "in"},
+            ))
+            entry["inbound_edges"] = inbound_edges_from_neighbors(neighbors, rid)
+        except Exception as exc:
+            print(f"[WARNING] neighbors failed for {rid}: {exc}", file=sys.stderr)
+        metadata[rid] = entry
+    return metadata
+
+
+# ===========================================================================
+# SINK layer — mirror H91's local + best-effort S3 + stdout-degraded sink
+# ===========================================================================
+def _clusters_to_jsonl(clusters: Sequence[Dict[str, Any]]) -> str:
+    return "".join(json.dumps(c, default=str) + "\n" for c in clusters)
+
+
+def write_results(clusters: Sequence[Dict[str, Any]], stats: Dict[str, Any],
+                  args: argparse.Namespace) -> Dict[str, Any]:
+    """SINK entrypoint. ALWAYS writes ``clusters.jsonl`` + ``summary.json`` to
+    ``--out`` and emits one ``DEDUP_RESULTS {json}`` stdout line. When
+    ``DEDUP_RESULTS_BUCKET`` is set, ALSO best-effort PUTs both files to S3; an
+    S3 failure is caught and never aborts the local write."""
+    out_dir = getattr(args, "out", DEFAULT_OUT_DIR)
+    os.makedirs(out_dir, exist_ok=True)
+
+    clusters_path = os.path.join(out_dir, CLUSTERS_FILENAME)
+    summary_path = os.path.join(out_dir, SUMMARY_FILENAME)
+
+    clusters_body = _clusters_to_jsonl(clusters)
+    summary_obj = dict(stats)
+
+    with open(clusters_path, "w", encoding="utf-8") as fh:
+        fh.write(clusters_body)
+
+    bucket = os.environ.get(RESULTS_BUCKET_ENV, "").strip()
+    prefix = (os.environ.get(RESULTS_PREFIX_ENV, DEFAULT_RESULTS_PREFIX).strip()
+              or DEFAULT_RESULTS_PREFIX).rstrip("/")
+    s3_uris: Dict[str, str] = {}
+    if bucket:
+        try:
+            client = h91._get_s3()
+            clusters_key = f"{prefix}/{CLUSTERS_FILENAME}"
+            summary_key = f"{prefix}/{SUMMARY_FILENAME}"
+            client.put_object(
+                Bucket=bucket, Key=clusters_key,
+                Body=clusters_body.encode("utf-8"),
+                ContentType="application/x-ndjson",
+            )
+            s3_uris = {
+                "clusters": f"s3://{bucket}/{clusters_key}",
+                "summary": f"s3://{bucket}/{summary_key}",
+            }
+        except Exception as exc:
+            print(f"[WARNING] dedup results S3 put failed ({exc}); local write retained",
+                  file=sys.stderr)
+            s3_uris = {}
+
+    summary_obj["artifacts"] = {
+        "clusters_local": clusters_path,
+        "summary_local": summary_path,
+        **({"clusters_s3": s3_uris["clusters"], "summary_s3": s3_uris["summary"]} if s3_uris else {}),
+    }
+
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary_obj, fh, indent=2, default=str)
+
+    if bucket and s3_uris:
+        try:
+            client = h91._get_s3()
+            client.put_object(
+                Bucket=bucket, Key=f"{prefix}/{SUMMARY_FILENAME}",
+                Body=json.dumps(summary_obj, default=str).encode("utf-8"),
+                ContentType="application/json",
+            )
+        except Exception as exc:
+            print(f"[WARNING] dedup summary S3 put failed ({exc}); local summary retained",
+                  file=sys.stderr)
+
+    print("DEDUP_RESULTS " + json.dumps(summary_obj, default=str))
+    return summary_obj
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="dedup_cluster_i05",
+        description=(
+            "ENC-TSK-I05 duplicate-cluster detection over the Enceladus "
+            "n.embedding corpus: same-type same-project >=0.95 cosine graph -> "
+            "connected components -> deterministic canonical suggestion. "
+            "Mutation-free; reads via the ENC-TSK-H89/H91 vector_read path."
+        ),
+    )
+    p.add_argument("--source", choices=["gamma", "mcp", "file", "pairs"], default="gamma",
+                   help="Corpus read surface, or 'pairs' to ingest an H91 pairs.jsonl edge set.")
+    p.add_argument("--input", default=None,
+                   help="Path for --source file (corpus JSON) or --source pairs (pairs.jsonl).")
+    p.add_argument("--metadata", default=None,
+                   help="Optional JSON file of per-record canonical-ranking signals "
+                        "{record_id: {status, created_at, evidence_score?, inbound_edges?}}.")
+    p.add_argument("--project-id", dest="project_id", default=DEFAULT_PROJECT_ID,
+                   help="Project id to read / default partition (default: enceladus).")
+    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                   help="Edge if cosine >= this within a (project,type) group (default: 0.95).")
+    p.add_argument("--page-limit", dest="page_limit", type=int, default=DEFAULT_PAGE_LIMIT,
+                   help="vector_read page size (default: 200).")
+    p.add_argument("--out", default=DEFAULT_OUT_DIR,
+                   help="Local output directory (default: ./i05_results).")
+    p.add_argument("--gamma-function", dest="gamma_function", default=DEFAULT_GAMMA_FUNCTION,
+                   help="Gamma graph-query Lambda name (default: devops-graph-query-api-gamma).")
+    p.add_argument("--generated-at", dest="generated_at", default=None,
+                   help="Optional ISO timestamp stamped into stats.generated_at.")
+    return p
+
+
+def _load_edges_or_nodes(args: argparse.Namespace) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+    """Resolve the READ layer into either (nodes, None) for the compute-graph
+    path or (None, precomputed_edges) for the --source pairs path."""
+    if args.source == "pairs":
+        if not args.input:
+            raise ValueError("--input PATH (an H91 pairs.jsonl) is required for --source pairs")
+        pairs: List[Dict[str, Any]] = []
+        with open(args.input, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    pairs.append(json.loads(line))
+        return None, edges_from_pairs(pairs, args.threshold)
+
+    nodes = h91.load_corpus(args)
+    # Stamp the read-scope project onto nodes lacking it so the partition rule
+    # can enforce same-project (vector_read payloads omit project_id).
+    for n in nodes:
+        n.setdefault("project_id", args.project_id)
+    return nodes, None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        nodes, precomputed_edges = _load_edges_or_nodes(args)
+    except Exception as exc:
+        print(f"[ERROR] corpus/edge read failed (source={args.source}): {exc}", file=sys.stderr)
+        return 2
+
+    metadata: Optional[Dict[str, Any]] = None
+    if args.metadata:
+        try:
+            metadata = load_metadata_from_file(args.metadata)
+        except Exception as exc:
+            print(f"[ERROR] metadata read failed ({args.metadata}): {exc}", file=sys.stderr)
+            return 2
+
+    if precomputed_edges is not None:
+        print(f"[INFO] ingested {len(precomputed_edges)} same-type edges from pairs "
+              f"(threshold={args.threshold})", file=sys.stderr)
+    else:
+        print(f"[INFO] loaded {len(nodes or [])} nodes from source={args.source}; "
+              f"threshold={args.threshold}", file=sys.stderr)
+
+    clusters, stats = build_clusters(
+        nodes, args.threshold, metadata=metadata,
+        default_project=args.project_id,
+        precomputed_edges=precomputed_edges,
+        generated_at=args.generated_at,
+    )
+    write_results(clusters, stats, args)
+
+    print(f"[SUCCESS] {stats['num_clusters']} duplicate clusters over "
+          f"{stats['num_records_in_clusters']} records "
+          f"(largest={stats['largest_cluster_size']}, edges={stats['num_edges']})",
+          file=sys.stderr)
+    if metadata is None and clusters:
+        print("[WARNING] no --metadata supplied; canonical suggestions fell back to the "
+              "deterministic record_id tiebreak (evidence/inbound/lifecycle/age unknown)",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_dedup_cluster_i05.py
+++ b/tools/test_dedup_cluster_i05.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Unit tests for ENC-TSK-I05 duplicate-cluster detection (tools/dedup_cluster_i05.py).
+
+stdlib unittest (NOT pytest), matching test_correlation_analysis_h91. Synthetic
+in-memory data only — no network, no S3, no live corpus. Exercises:
+  * the same-type same-project >= threshold edge rule (incl. the >= boundary),
+  * union-find connected components (transitivity, singleton exclusion),
+  * deterministic canonical selection across every signal level + tiebreak,
+  * the ranking-signal helpers (lifecycle/age/evidence/inbound),
+  * the cluster + summary shape and clusters.jsonl roundtrip,
+  * the H91 pairs.jsonl reuse path,
+  * the pure-Python (numpy-absent) graph path.
+"""
+
+import json
+import math
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dedup_cluster_i05 as dc  # noqa: E402
+
+
+def _node(rid, vec, rtype="issue", project="enceladus"):
+    return {
+        "record_id": rid,
+        "record_type": rtype,
+        "project_id": project,
+        dc.EMBEDDING_PROPERTY: list(vec),
+    }
+
+
+# ===========================================================================
+# GRAPH layer — same-type same-project >= threshold edges
+# ===========================================================================
+class SimilarityEdgeTest(unittest.TestCase):
+    def test_same_type_near_identical_makes_edge(self):
+        nodes = [_node("ENC-ISS-A", [1.0, 0.0, 0.0]), _node("ENC-ISS-B", [1.0, 0.0001, 0.0])]
+        edges = dc.similarity_edges(nodes, threshold=0.95)
+        self.assertEqual(len(edges), 1)
+        self.assertEqual({edges[0]["a"], edges[0]["b"]}, {"ENC-ISS-A", "ENC-ISS-B"})
+        self.assertEqual(edges[0]["record_type"], "issue")
+        self.assertGreaterEqual(edges[0]["cosine"], 0.95)
+
+    def test_cross_type_identical_vectors_no_edge(self):
+        # Identical embeddings but different record_type -> never an edge.
+        nodes = [_node("ENC-ISS-A", [1.0, 2.0, 3.0], "issue"),
+                 _node("ENC-TSK-B", [1.0, 2.0, 3.0], "task")]
+        self.assertEqual(dc.similarity_edges(nodes, threshold=0.95), [])
+
+    def test_cross_project_identical_vectors_no_edge(self):
+        nodes = [_node("ENC-ISS-A", [1.0, 2.0, 3.0], "issue", project="enceladus"),
+                 _node("ENC-ISS-B", [1.0, 2.0, 3.0], "issue", project="harrisonfamily")]
+        self.assertEqual(dc.similarity_edges(nodes, threshold=0.95), [])
+
+    def test_identical_vectors_flag_at_threshold(self):
+        # Identical embeddings -> cosine ~1.0, comfortably flagged at 0.95.
+        # (Exact >=-boundary inclusivity is asserted deterministically in
+        # EdgesFromPairsTest where the cosine is an explicit value, not a
+        # float-normalized self-dot that lands at 0.9999999999999999.)
+        nodes = [_node("ENC-ISS-A", [2.0, 1.0]), _node("ENC-ISS-B", [2.0, 1.0])]
+        edges = dc.similarity_edges(nodes, threshold=0.95)
+        self.assertEqual(len(edges), 1)
+        self.assertAlmostEqual(edges[0]["cosine"], 1.0, places=9)
+
+    def test_below_threshold_excluded(self):
+        nodes = [_node("ENC-ISS-A", [1.0, 0.0]), _node("ENC-ISS-B", [0.0, 1.0])]
+        self.assertEqual(dc.similarity_edges(nodes, threshold=0.95), [])
+
+    def test_edge_orientation_is_stable(self):
+        # 'a' is always the lexicographically smaller id regardless of input order.
+        nodes = [_node("ENC-ISS-Z", [1.0, 1.0]), _node("ENC-ISS-A", [1.0, 1.0])]
+        edges = dc.similarity_edges(nodes, threshold=0.5)
+        self.assertEqual(edges[0]["a"], "ENC-ISS-A")
+        self.assertEqual(edges[0]["b"], "ENC-ISS-Z")
+
+    def test_zero_norm_vector_never_edges(self):
+        nodes = [_node("ZERO", [0.0, 0.0]), _node("ENC-ISS-A", [1.0, 0.0]),
+                 _node("ENC-ISS-B", [1.0, 0.0])]
+        edges = dc.similarity_edges(nodes, threshold=0.5)
+        self.assertEqual(len(edges), 1)
+        self.assertNotIn("ZERO", {edges[0]["a"], edges[0]["b"]})
+
+
+# ===========================================================================
+# COMPONENTS layer — union-find
+# ===========================================================================
+class ConnectedComponentsTest(unittest.TestCase):
+    def test_chain_collapses_to_one_cluster(self):
+        # A-B and B-C edges (no A-C edge) still form a single component {A,B,C}.
+        edges = [{"a": "A", "b": "B", "cosine": 0.99},
+                 {"a": "B", "b": "C", "cosine": 0.98}]
+        comps = dc.connected_components(edges)
+        self.assertEqual(comps, [["A", "B", "C"]])
+
+    def test_disjoint_components(self):
+        edges = [{"a": "A", "b": "B", "cosine": 0.99},
+                 {"a": "X", "b": "Y", "cosine": 0.97},
+                 {"a": "Y", "b": "Z", "cosine": 0.96}]
+        comps = dc.connected_components(edges)
+        # Sorted by size desc then smallest member: {X,Y,Z} before {A,B}.
+        self.assertEqual(comps, [["X", "Y", "Z"], ["A", "B"]])
+
+    def test_singletons_excluded(self):
+        # A node never appears unless it has at least one edge; a lone edge pair
+        # is size 2 (kept), but there are no size-1 components by construction.
+        edges = [{"a": "A", "b": "B", "cosine": 0.99}]
+        comps = dc.connected_components(edges)
+        self.assertEqual(comps, [["A", "B"]])
+
+    def test_no_edges_no_clusters(self):
+        self.assertEqual(dc.connected_components([]), [])
+
+    def test_members_sorted_ascending(self):
+        edges = [{"a": "C", "b": "A", "cosine": 0.99}, {"a": "B", "b": "C", "cosine": 0.99}]
+        self.assertEqual(dc.connected_components(edges), [["A", "B", "C"]])
+
+
+# ===========================================================================
+# CANONICAL selection — argmax over evidence > inbound > lifecycle > age > id
+# ===========================================================================
+class CanonicalSelectionTest(unittest.TestCase):
+    def test_evidence_dominates(self):
+        meta = {
+            "A": {"evidence_score": 1.0, "inbound_edges": 99, "status": "open", "created_at": "2020-01-01T00:00:00Z"},
+            "B": {"evidence_score": 5.0, "inbound_edges": 0, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+        }
+        canonical, rationale = dc.select_canonical(["A", "B"], meta)
+        self.assertEqual(canonical, "B")
+        self.assertEqual(rationale["tiebreak"], "evidence")
+
+    def test_inbound_breaks_evidence_tie(self):
+        meta = {
+            "A": {"evidence_score": 2.0, "inbound_edges": 1, "status": "closed", "created_at": "2020-01-01T00:00:00Z"},
+            "B": {"evidence_score": 2.0, "inbound_edges": 7, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+        }
+        canonical, rationale = dc.select_canonical(["A", "B"], meta)
+        self.assertEqual(canonical, "B")
+        self.assertEqual(rationale["tiebreak"], "inbound_edges")
+
+    def test_lifecycle_breaks_evidence_and_inbound_tie(self):
+        meta = {
+            "A": {"evidence_score": 2.0, "inbound_edges": 3, "status": "open", "created_at": "2020-01-01T00:00:00Z"},
+            "B": {"evidence_score": 2.0, "inbound_edges": 3, "status": "closed", "created_at": "2026-01-01T00:00:00Z"},
+        }
+        canonical, rationale = dc.select_canonical(["A", "B"], meta)
+        self.assertEqual(canonical, "B")
+        self.assertEqual(rationale["tiebreak"], "lifecycle")
+
+    def test_age_breaks_remaining_tie_oldest_wins(self):
+        meta = {
+            "NEW": {"evidence_score": 2.0, "inbound_edges": 3, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+            "OLD": {"evidence_score": 2.0, "inbound_edges": 3, "status": "open", "created_at": "2020-01-01T00:00:00Z"},
+        }
+        canonical, rationale = dc.select_canonical(["NEW", "OLD"], meta)
+        self.assertEqual(canonical, "OLD")
+        self.assertEqual(rationale["tiebreak"], "age")
+
+    def test_record_id_is_final_deterministic_tiebreak(self):
+        # Fully-tied signals -> smallest record_id wins, deterministically.
+        meta = {
+            "ENC-ISS-ZZZ": {"evidence_score": 1.0, "inbound_edges": 1, "status": "open", "created_at": "2025-01-01T00:00:00Z"},
+            "ENC-ISS-AAA": {"evidence_score": 1.0, "inbound_edges": 1, "status": "open", "created_at": "2025-01-01T00:00:00Z"},
+        }
+        canonical, rationale = dc.select_canonical(["ENC-ISS-ZZZ", "ENC-ISS-AAA"], meta)
+        self.assertEqual(canonical, "ENC-ISS-AAA")
+        self.assertEqual(rationale["tiebreak"], "record_id")
+
+    def test_no_metadata_falls_back_to_record_id(self):
+        canonical, rationale = dc.select_canonical(["ENC-ISS-B", "ENC-ISS-A", "ENC-ISS-C"], None)
+        self.assertEqual(canonical, "ENC-ISS-A")
+        self.assertFalse(rationale["has_metadata"])
+
+    def test_selection_is_order_independent(self):
+        meta = {
+            "A": {"evidence_score": 1.0, "inbound_edges": 0, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+            "B": {"evidence_score": 9.0, "inbound_edges": 0, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+            "C": {"evidence_score": 3.0, "inbound_edges": 0, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+        }
+        for order in (["A", "B", "C"], ["C", "B", "A"], ["B", "A", "C"]):
+            self.assertEqual(dc.select_canonical(order, meta)[0], "B")
+
+    def test_empty_member_list_raises(self):
+        with self.assertRaises(ValueError):
+            dc.select_canonical([], {})
+
+
+# ===========================================================================
+# Ranking-signal helpers
+# ===========================================================================
+class RankingHelperTest(unittest.TestCase):
+    def test_lifecycle_rank_ordering(self):
+        self.assertGreater(dc._lifecycle_rank("closed"), dc._lifecycle_rank("open"))
+        self.assertGreater(dc._lifecycle_rank("merged-main"), dc._lifecycle_rank("in-progress"))
+        self.assertEqual(dc._lifecycle_rank("CLOSED"), dc._lifecycle_rank("closed"))
+        self.assertEqual(dc._lifecycle_rank("nonsense-status"), 0)
+        self.assertEqual(dc._lifecycle_rank(None), 0)
+
+    def test_age_epoch_older_is_smaller(self):
+        self.assertLess(dc._age_epoch("2020-01-01T00:00:00Z"), dc._age_epoch("2026-01-01T00:00:00Z"))
+
+    def test_age_epoch_handles_z_and_offset(self):
+        self.assertAlmostEqual(
+            dc._age_epoch("2026-01-01T00:00:00Z"),
+            dc._age_epoch("2026-01-01T00:00:00+00:00"),
+            places=6,
+        )
+
+    def test_age_epoch_missing_is_infinity(self):
+        self.assertEqual(dc._age_epoch(None), math.inf)
+        self.assertEqual(dc._age_epoch(""), math.inf)
+        self.assertEqual(dc._age_epoch("not-a-date"), math.inf)
+
+    def test_derive_evidence_score_weights(self):
+        rec = {
+            "acceptance_criteria": [
+                {"evidence_acceptance": True, "evidence": "x"},   # +3
+                {"evidence_acceptance": False, "evidence": "y"},  # +1
+                {"evidence_acceptance": False, "evidence": ""},   # +0
+                "legacy-string-criterion",                         # +0
+            ],
+            "resolution": "fixed in PR #1",                        # +2
+            "description": "a description",                        # +0.5
+        }
+        self.assertAlmostEqual(dc.derive_evidence_score(rec), 6.5, places=9)
+
+    def test_derive_evidence_score_empty(self):
+        self.assertEqual(dc.derive_evidence_score({}), 0.0)
+
+    def test_inbound_edges_counts_only_inbound(self):
+        payload = {"edges": [
+            {"source": "X", "target": "ME"},     # inbound -> +1
+            {"from": "Y", "to": "ME"},            # inbound (alt keys) -> +1
+            {"source": "ME", "target": "Z"},      # outbound -> 0
+            {"source": "ME", "target": "ME"},     # self -> 0
+            {"source": "W", "target": "OTHER"},   # unrelated -> 0
+        ]}
+        self.assertEqual(dc.inbound_edges_from_neighbors(payload, "ME"), 2)
+
+    def test_inbound_edges_node_object_endpoints(self):
+        payload = {"edges": [{"source": {"record_id": "X"}, "target": {"record_id": "ME"}}]}
+        self.assertEqual(dc.inbound_edges_from_neighbors(payload, "ME"), 1)
+
+    def test_inbound_edges_tolerates_garbage(self):
+        self.assertEqual(dc.inbound_edges_from_neighbors(None, "ME"), 0)
+        self.assertEqual(dc.inbound_edges_from_neighbors({}, "ME"), 0)
+        self.assertEqual(dc.inbound_edges_from_neighbors({"edges": "nope"}, "ME"), 0)
+        self.assertEqual(dc.inbound_edges_from_neighbors('{"edges":[]}', "ME"), 0)
+
+
+# ===========================================================================
+# Assembly — build_clusters end to end
+# ===========================================================================
+class BuildClustersTest(unittest.TestCase):
+    def _corpus(self):
+        # Two issue duplicates (A,B) + one unrelated issue (C) + a task pair
+        # (T1,T2) that must NOT merge with the issues despite identical vectors.
+        return [
+            _node("ENC-ISS-A", [1.0, 0.0, 0.0], "issue"),
+            _node("ENC-ISS-B", [1.0, 0.0005, 0.0], "issue"),
+            _node("ENC-ISS-C", [0.0, 1.0, 0.0], "issue"),
+            _node("ENC-TSK-T1", [1.0, 0.0, 0.0], "task"),
+            _node("ENC-TSK-T2", [1.0, 0.0, 0.0], "task"),
+        ]
+
+    def test_clusters_partition_by_type(self):
+        clusters, stats = dc.build_clusters(self._corpus(), threshold=0.95)
+        self.assertEqual(stats["num_clusters"], 2)
+        by_members = {tuple(c["members"]): c for c in clusters}
+        self.assertIn(("ENC-ISS-A", "ENC-ISS-B"), by_members)
+        self.assertIn(("ENC-TSK-T1", "ENC-TSK-T2"), by_members)
+        # C is a singleton (not a duplicate) -> excluded.
+        self.assertNotIn("ENC-ISS-C", [m for c in clusters for m in c["members"]])
+
+    def test_cluster_shape_and_canonical(self):
+        meta = {
+            "ENC-ISS-A": {"evidence_score": 5.0, "inbound_edges": 2, "status": "closed", "created_at": "2024-01-01T00:00:00Z"},
+            "ENC-ISS-B": {"evidence_score": 1.0, "inbound_edges": 0, "status": "open", "created_at": "2026-01-01T00:00:00Z"},
+        }
+        clusters, _ = dc.build_clusters(self._corpus(), threshold=0.95, metadata=meta)
+        iss = next(c for c in clusters if c["record_type"] == "issue")
+        self.assertEqual(set(iss.keys()), {
+            "cluster_id", "record_type", "project_id", "size", "members",
+            "canonical", "duplicates", "canonical_rationale", "edges",
+            "max_cosine", "min_cosine", "mean_cosine",
+        })
+        self.assertEqual(iss["canonical"], "ENC-ISS-A")
+        self.assertEqual(iss["duplicates"], ["ENC-ISS-B"])
+        self.assertEqual(iss["project_id"], "enceladus")
+        self.assertTrue(iss["cluster_id"].startswith(dc._CLUSTER_ID_PREFIX))
+        self.assertEqual(len(iss["edges"]), 1)
+        self.assertGreaterEqual(iss["max_cosine"], 0.95)
+
+    def test_summary_stats_keys(self):
+        clusters, stats = dc.build_clusters(self._corpus(), threshold=0.95,
+                                            generated_at="2026-06-25T00:00:00Z")
+        for key in ("corpus_size", "embedding_dim", "threshold", "num_edges",
+                    "num_clusters", "num_records_in_clusters", "largest_cluster_size",
+                    "cluster_size_histogram", "by_type", "metadata_coverage",
+                    "generated_at"):
+            self.assertIn(key, stats)
+        self.assertEqual(stats["corpus_size"], 5)
+        self.assertEqual(stats["embedding_dim"], 3)
+        self.assertEqual(stats["generated_at"], "2026-06-25T00:00:00Z")
+        self.assertEqual(stats["largest_cluster_size"], 2)
+        self.assertEqual(stats["by_type"]["issue"]["clusters"], 1)
+
+    def test_metadata_coverage_reported(self):
+        meta = {"ENC-ISS-A": {"status": "closed", "created_at": "2024-01-01T00:00:00Z"}}
+        _, stats = dc.build_clusters(self._corpus(), threshold=0.95, metadata=meta)
+        cov = stats["metadata_coverage"]
+        self.assertTrue(cov["metadata_supplied"])
+        self.assertEqual(cov["records_with_metadata"], 1)
+
+    def test_empty_corpus(self):
+        clusters, stats = dc.build_clusters([], threshold=0.95)
+        self.assertEqual(clusters, [])
+        self.assertEqual(stats["num_clusters"], 0)
+        self.assertEqual(stats["largest_cluster_size"], 0)
+
+
+# ===========================================================================
+# pairs.jsonl reuse path
+# ===========================================================================
+class EdgesFromPairsTest(unittest.TestCase):
+    def test_same_type_pairs_kept_cross_type_dropped(self):
+        pairs = [
+            {"a": "ENC-ISS-A", "b": "ENC-ISS-B", "a_type": "issue", "b_type": "issue", "cosine": 0.99},
+            {"a": "ENC-ISS-D", "b": "ENC-TSK-E", "a_type": "issue", "b_type": "task", "cosine": 0.999},
+            {"a": "ENC-ISS-F", "b": "ENC-ISS-G", "a_type": "issue", "b_type": "issue", "cosine": 0.80},
+        ]
+        edges = dc.edges_from_pairs(pairs, threshold=0.95)
+        self.assertEqual(len(edges), 1)
+        self.assertEqual({edges[0]["a"], edges[0]["b"]}, {"ENC-ISS-A", "ENC-ISS-B"})
+
+    def test_threshold_inclusive_at_exact_boundary(self):
+        # cosine == threshold must be KEPT (>=); a strict-> rule would drop it.
+        pairs = [{"a": "ENC-ISS-A", "b": "ENC-ISS-B", "a_type": "issue",
+                  "b_type": "issue", "cosine": 0.95}]
+        self.assertEqual(len(dc.edges_from_pairs(pairs, threshold=0.95)), 1)
+        # And just below the boundary is dropped.
+        pairs_below = [{"a": "ENC-ISS-A", "b": "ENC-ISS-B", "a_type": "issue",
+                        "b_type": "issue", "cosine": 0.9499999}]
+        self.assertEqual(dc.edges_from_pairs(pairs_below, threshold=0.95), [])
+
+    def test_build_clusters_from_precomputed_edges(self):
+        pairs = [
+            {"a": "ENC-ISS-A", "b": "ENC-ISS-B", "a_type": "issue", "b_type": "issue", "cosine": 0.999},
+            {"a": "ENC-ISS-B", "b": "ENC-ISS-C", "a_type": "issue", "b_type": "issue", "cosine": 0.998},
+        ]
+        edges = dc.edges_from_pairs(pairs, threshold=0.95)
+        clusters, stats = dc.build_clusters(None, threshold=0.95, precomputed_edges=edges)
+        self.assertEqual(stats["num_clusters"], 1)
+        self.assertEqual(clusters[0]["members"], ["ENC-ISS-A", "ENC-ISS-B", "ENC-ISS-C"])
+        self.assertIsNone(stats["corpus_size"])  # no corpus was read
+
+
+# ===========================================================================
+# SINK shape
+# ===========================================================================
+class SinkTest(unittest.TestCase):
+    def test_clusters_to_jsonl_roundtrip(self):
+        clusters = [{"cluster_id": "i05-cluster-0001", "members": ["A", "B"], "canonical": "A"}]
+        text = dc._clusters_to_jsonl(clusters)
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(json.loads(lines[0]), clusters[0])
+
+    def test_write_results_emits_local_files(self):
+        clusters = [{"cluster_id": "i05-cluster-0001", "record_type": "issue",
+                     "members": ["A", "B"], "canonical": "A", "size": 2}]
+        stats = {"num_clusters": 1, "generated_at": None}
+        with tempfile.TemporaryDirectory() as tmp:
+            args = dc.build_parser().parse_args(["--out", tmp])
+            summary = dc.write_results(clusters, stats, args)
+            self.assertTrue((Path(tmp) / dc.CLUSTERS_FILENAME).exists())
+            self.assertTrue((Path(tmp) / dc.SUMMARY_FILENAME).exists())
+            self.assertIn("artifacts", summary)
+            self.assertEqual(summary["artifacts"]["clusters_local"],
+                             str(Path(tmp) / dc.CLUSTERS_FILENAME))
+
+
+# ===========================================================================
+# Pure-Python (numpy-absent) graph path
+# ===========================================================================
+class PurePythonPathTest(unittest.TestCase):
+    def setUp(self):
+        self._saved_np = dc.np
+        dc.np = None  # type: ignore[assignment]
+
+    def tearDown(self):
+        dc.np = self._saved_np  # type: ignore[assignment]
+
+    def test_edges_without_numpy(self):
+        self.assertIsNone(dc.np)
+        nodes = [_node("ENC-ISS-A", [1.0, 0.0, 0.0]), _node("ENC-ISS-B", [1.0, 0.0001, 0.0]),
+                 _node("ENC-ISS-C", [0.0, 1.0, 0.0])]
+        edges = dc.similarity_edges(nodes, threshold=0.95)
+        self.assertEqual(len(edges), 1)
+        self.assertEqual({edges[0]["a"], edges[0]["b"]}, {"ENC-ISS-A", "ENC-ISS-B"})
+
+    def test_build_clusters_without_numpy(self):
+        self.assertIsNone(dc.np)
+        nodes = [_node("ENC-ISS-A", [1.0, 0.0]), _node("ENC-ISS-B", [1.0, 0.0]),
+                 _node("ENC-ISS-C", [1.0, 0.0])]
+        clusters, stats = dc.build_clusters(nodes, threshold=0.95)
+        self.assertEqual(stats["num_clusters"], 1)
+        self.assertEqual(clusters[0]["members"], ["ENC-ISS-A", "ENC-ISS-B", "ENC-ISS-C"])
+
+
+# ===========================================================================
+# DSU internals
+# ===========================================================================
+class DSUTest(unittest.TestCase):
+    def test_union_find_basic(self):
+        dsu = dc._DSU()
+        dsu.union("A", "B")
+        dsu.union("B", "C")
+        self.assertEqual(dsu.find("A"), dsu.find("C"))
+        dsu.union("X", "Y")
+        self.assertNotEqual(dsu.find("A"), dsu.find("X"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## ENC-TSK-I05 — Dedup P1: duplicate-cluster detection

Phase 2 of the PLN-052 dedup track. After on-retrieval correlation *encoding*
(H92 query-side, I03 symmetric re-rank) missed the +5% recall bar, the residual
near-duplicate mass measured by ENC-TSK-H91 (2281 issue/issue + 209 task/task
pairs at mean cosine 0.9998) is addressed here by **deduplication** instead of
further encoding.

### What this adds (mutation-free `tools/` script — no tracker writes)
`tools/dedup_cluster_i05.py` — `READ → GRAPH → COMPONENTS → CANONICAL → SINK`:
- **READ** reuses the ENC-TSK-H89/H91 `vector_read` loaders verbatim (one
  governed read path). `--source pairs` ingests an H91 `pairs.jsonl` edge set
  directly (no corpus re-read).
- **GRAPH** partitions nodes by `(project_id, record_type)` and flags
  within-group cosine **>= 0.95** → same-type + same-project is structural,
  not a post-filter (numpy + pure-Python fallback).
- **COMPONENTS** union-find (DSU) → connected components of size >= 2.
- **CANONICAL** deterministic argmax `evidence > inbound-edges > lifecycle >
  age(oldest)`, with `record_id` as the final tiebreak; emits a
  `canonical_rationale` recording which signal decided it. Signals come from an
  optional `--metadata` map (`vector_read` carries only id/type/embedding).
- **SINK** mirrors H91: `clusters.jsonl` + `summary.json` local, optional S3
  (`DEDUP_RESULTS_BUCKET`), CloudWatch-degraded `DEDUP_RESULTS {json}` stdout.

`tools/test_dedup_cluster_i05.py` — 42 unit tests (stdlib unittest), incl. the
numpy-absent path. H91 suite still 18/18 (no regression).

### Live pass (over the real H91 pair set)
2491 same-type edges (4 cross-type dropped) → **108 duplicate clusters over 322
records** (largest 68-issue cluster; 78×size-2, 23×size-3, 5×size-4, 1×size-9).
Canonical verified on real records: the env-drift-auditor storm cluster
{ENC-ISS-287, 288, 290} resolves to **ENC-ISS-287** (the closed/remediated one)
by the *evidence* signal; the 4× replicated errata cluster {ENC-TSK-074, 180,
251, 387} resolves by the deterministic *record_id* tiebreak (all signals tie).

### Lifecycle
`code_only` — closes at `merged-main` with `code_on_main_evidence`.

Checkout: webui-alpha-i05-997255a1f3f3
CCI-f7f017cd544c49a99151316958d83c74

🤖 Generated with [Claude Code](https://claude.com/claude-code)