### PR TITLE
ENC-TSK-I14: codify ENC-ISS-410 gamma-connector remediation in IaC

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3599,6 +3599,17 @@ Resources:
           ENCELADUS_COGNITO_DOMAIN: https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com
           MCP_AUDIT_CALLER_IDENTITY: devops-coordination-api-gamma
           MCP_SERVER_LOG_GROUP: /enceladus/mcp/server
+          # ENC-ISS-410 / ENC-TSK-I14: gamma backend bases. The MCP front-end (server.py)
+          # proxies the coordination, tracker, and graph planes to these hosts; if unset it
+          # falls back to hardcoded prod defaults (https://jreese.net/... and the prod
+          # graphsearch APIGW), which silently routes the 'gamma' connector's tracker+graph
+          # planes to the PROD corpus (the ENC-ISS-410 misroute). Round-1/round-2 set these
+          # live on enceladus-mcp-streamable-gamma; codified here so they survive a stack
+          # deploy. All three resolve to the gamma gateway (enceladus-gamma.jreese.net) and
+          # are values verified against the live function on 2026-06-25.
+          ENCELADUS_COORDINATION_API_URL: https://enceladus-gamma.jreese.net/api/v1
+          ENCELADUS_TRACKER_API_BASE: https://enceladus-gamma.jreese.net/api/v1/tracker
+          ENCELADUS_GRAPH_QUERY_API_BASE: https://enceladus-gamma.jreese.net/api/v1/tracker/graphsearch
           # ENC-TSK-F63 AC-1 / ENC-ISS-313 H02 audit: flags are migrating to AppConfig, but the
           # AppConfig application/environment are not yet provisioned on this stack (IDs empty),
           # so these ENABLE_* remain as the appconfig_flags.flag() env_fallback to keep gamma's

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -348,6 +348,156 @@ Resources:
       Target: !Sub integrations/${TrackerMutationIntegration}
 
   # ---------------------------------------------------------------------------
+  # Gamma tracker plane — full mutation + read route set (ENC-ISS-410 / ENC-TSK-I14)
+  #
+  # The 'enceladus gamma' MCP front-end (enceladus-mcp-streamable-gamma) proxies
+  # every tracker read+write to ENCELADUS_TRACKER_API_BASE =
+  # https://enceladus-gamma.jreese.net/api/v1/tracker. ENC-ISS-410 round-1 (write)
+  # and round-2 (read) added the full tracker mutation+read route set on
+  # devops-tracker-api-gamma (hi0dzmvqrc), wired to the devops-tracker-mutation-api
+  # **:live** alias (so the gamma supersession / I07 generalized domain is reachable
+  # instead of the prod pre-I07 backend). Those were live console edits and drift on
+  # the next gamma stack deploy — codified here so they survive.
+  #
+  # Condition: IsGamma keeps prod (EnvironmentSuffix="") untouched: prod's equivalent
+  # tracker-mutation routes are provisioned out-of-band by the per-Lambda deploy
+  # scripts (same pattern as the Changelog / GitHub / Checkout-task notes below), so
+  # adding them unconditionally would collide on a prod deploy. DeletionPolicy: Retain
+  # protects the live routes during IMPORT adoption into enceladus-api-gamma.
+  # The two PATCH routes above already target devops-tracker-mutation-api-gamma (bare,
+  # bssof7u) via TrackerMutationIntegration and match the live gamma gateway — left
+  # unchanged.
+  # ---------------------------------------------------------------------------
+
+  TrackerMutationGammaLiveIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}:live"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  # Typed relationship edges (incl. ENC-TSK-I07 superseded-by) — POST / GET / DELETE
+  RouteTrackerRelationshipCreateGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  RouteTrackerRelationshipGetGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  RouteTrackerRelationshipDeleteGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # Create record (POST {recordType})
+  RouteTrackerCreateRecordGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # Worklog append
+  RouteTrackerLogGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/log
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # Acceptance evidence
+  RouteTrackerAcceptanceEvidenceGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # Checkout — POST (acquire) / DELETE (release)
+  RouteTrackerCheckoutGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  RouteTrackerCheckoutReleaseGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # Checkout extend
+  RouteTrackerExtendGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # GET single record (also serves validation_rules + plan-get on the same Lambda)
+  RouteTrackerGetRecordGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}/{recordType}/{recordId}
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # GET list by project
+  RouteTrackerListGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # GET pending PWA updates
+  RouteTrackerPendingUpdatesGamma:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/pending-updates
+      Target: !Sub integrations/${TrackerMutationGammaLiveIntegration}
+
+  # ---------------------------------------------------------------------------
   # Routes — Document API
   # ---------------------------------------------------------------------------
 
@@ -623,6 +773,58 @@ Resources:
       ApiId: !Ref HttpApi
       RouteKey: GET /api/v1/checkout/{project}/plan/{planId}/status
       Target: !Sub integrations/${CheckoutServiceIntegration}
+
+  # ---------------------------------------------------------------------------
+  # Graph Query API → graphsearch ingress (ENC-TSK-H57 / ENC-PLN-050)
+  # Added gamma-first by ENC-TSK-H64 and live on enceladus-api-gamma; reconciled
+  # into the canonical template here (ENC-TSK-I14) so a gamma stack deploy no longer
+  # DELETES the gamma graph plane. Condition: IsGamma — prod (EnvironmentSuffix="")
+  # serves graphsearch out-of-band; gating keeps prod untouched. EnvironmentSuffix
+  # resolves the integration to devops-graph-query-api-gamma (the gamma AuraDB).
+  # Logical IDs match the deployed enceladus-api-gamma stack (in-place update).
+  # ---------------------------------------------------------------------------
+  GraphQueryIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  GraphQueryApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*/api/v1/tracker/graphsearch*"
+
+  RouteGraphSearch:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchHealth:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch/health
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchOptions:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
 
 Outputs:
   ApiEndpoint:


### PR DESCRIPTION
## ENC-TSK-I14 — Codify ENC-ISS-410 gamma-connector remediation in IaC

Codifies the ENC-ISS-410 round-1/round-2 gamma-connector fix (currently live-console-only) so it survives a gamma stack deploy. Gamma-only; honors ENC-PLN-006.

CCI-8bf0af808c6e4171b63ee36c5bdb9e89

### AC-0 — `03-api.yaml` gamma tracker route set
- Adds the 12 tracker mutation/read routes (relationship POST/GET/DELETE, create-record, log, acceptance-evidence, checkout POST/DELETE, extend, GET record, GET list, pending-updates) + `TrackerMutationGammaLiveIntegration` → `devops-tracker-mutation-api-gamma:live`, all `Condition: IsGamma` + `DeletionPolicy: Retain`.
- Folds the ENC-TSK-H57/H64 graphsearch ingress block into the canonical template (`Condition: IsGamma`) so a gamma stack deploy no longer **deletes** the gamma graph plane (it is live in the deployed stack but was absent from v4/main's template).
- Gamma tracker route set matches the live gamma gateway (hi0dzmvqrc) **exactly — 17/17**.
- **Prod-safe**: every addition is `Condition: IsGamma`, so a prod deploy (`EnvironmentSuffix=""`) stays byte-identical; prod's tracker routes remain provisioned out-of-band by the per-Lambda deploy scripts.

### AC-1 — `02-compute.yaml` gamma MCP env
- `EnceladusMcpCodeGammaFunction` env += `ENCELADUS_COORDINATION_API_URL` / `ENCELADUS_TRACKER_API_BASE` / `ENCELADUS_GRAPH_QUERY_API_BASE` (all → `enceladus-gamma.jreese.net`), matching the live `enceladus-mcp-streamable-gamma` env, so the round-1/2 fix survives a stack deploy.

### Deploy / landing notes (AC-2)
- Merge → `_deploy.yml` redeploys the MCP code (`update-function-code`, code-only) — retires the stale 2026-04-26 build and **preserves** the live env fix.
- The 12 ISS-410 routes already exist as orphans on the gamma gateway; clean adoption into `enceladus-api-gamma` needs an IMPORT change-set (reconciliation tracked with ENC-TSK-H64 / ENC-ISS-394). `DeletionPolicy: Retain` protects them meanwhile.

Refs ENC-ISS-410, ENC-TSK-I14, ENC-PLN-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)