### PR TITLE
[DO-NOT-MERGE until prod CFN import] ENC-TSK-I15: codify prod graphsearch ingress (env-agnostic + Retain) — ENC-ISS-394

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -624,6 +624,61 @@ Resources:
       RouteKey: GET /api/v1/checkout/{project}/plan/{planId}/status
       Target: !Sub integrations/${CheckoutServiceIntegration}
 
+  # ---------------------------------------------------------------------------
+  # Graph Query API -> graphsearch ingress (ENC-TSK-H57 / ENC-PLN-050 / ENC-ISS-394 / ENC-TSK-I15)
+  # These routes + integration exist LIVE out-of-band on BOTH prod (API 8nkzqkmxqc)
+  # and gamma (API hi0dzmvqrc) and are adopted into their stacks via CFN
+  # resource-import (gamma: ENC-TSK-I14; prod: ENC-TSK-I15). Environment-agnostic
+  # (NO Condition) so prod (EnvironmentSuffix="") renders + MANAGES them, durably
+  # ending the ENC-ISS-394 route-tier drift; "${EnvironmentSuffix}" resolves the
+  # integration to devops-graph-query-api (prod) or devops-graph-query-api-gamma.
+  # DeletionPolicy: Retain so a template/stack divergence can never DELETE the live
+  # graph ingress (ENC-LSN-053 strip class, one tier up at the API-route layer).
+  # Logical IDs MUST match the imported physical resources (do not rename).
+  # ---------------------------------------------------------------------------
+  GraphQueryIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  GraphQueryApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*/api/v1/tracker/graphsearch*"
+
+  RouteGraphSearch:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchHealth:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/graphsearch/health
+      Target: !Sub integrations/${GraphQueryIntegration}
+
+  RouteGraphSearchOptions:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/graphsearch
+      Target: !Sub integrations/${GraphQueryIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint


### PR DESCRIPTION
## Summary
Codifies the PROD graphsearch ingress into `infrastructure/cloudformation/03-api.yaml` so the
`enceladus-api` (prod) stack render **manages** it — durably ending the **ENC-ISS-394** route-tier drift.

The graphsearch routes + integration that serve PROD live on API `8nkzqkmxqc` are **out-of-band** (in no
CFN template). ENC-TSK-H57/ENC-TSK-I14 codified them on `v4/main` **only** and gated them `Condition: IsGamma`,
so the prod render (`EnvironmentSuffix=""`) never managed them. This un-gates the single block
(environment-agnostic — one definition serves both envs via `${EnvironmentSuffix}`) and adds
`DeletionPolicy: Retain`. Gamma render is unchanged (an unconditional resource still renders on gamma).

Resources (logical IDs match the live prod orphans, required for CFN resource-import):
`GraphQueryIntegration`, `GraphQueryApiInvokePermission`, `RouteGraphSearch`, `RouteGraphSearchHealth`, `RouteGraphSearchOptions`.

## ⛔ DO NOT MERGE until the prod orphans are imported
A push to `main` touching `03-api.yaml` auto-triggers `cloudformation-api-stack-deploy.yml` against PROD
`enceladus-api`. If the live orphan routes are not yet adopted, that deploy hits `ResourceAlreadyExists` and
rolls the prod api stack to `UPDATE_ROLLBACK_COMPLETE` (exactly what happened to the gamma stack on the I14
merge). **Merge order: (1) run Phase A CFN resource-IMPORT of the prod orphans into `enceladus-api`
(`IMPORT_COMPLETE`); (2) only then merge this PR** — the resulting auto-deploy is then clean/additive (the
single `Add` = `GraphQueryApiInvokePermission`), which is the strip-risk-gone proof (AC-2).

Runbook + import artifacts: `workspace/enc-tsk-i15-prod-import/` (RUNBOOK.md, resources-to-import.json, README.md).

## Forward-sync note
When this syncs `main → v4/main`, the unconditional block here **supersedes** v4/main's current `IsGamma`
graphsearch block (resolve the conflict by taking this version). Net gamma behavior is unchanged — those
resources still render on gamma, now unconditionally.

## Governance
- Task: ENC-TSK-I15 · Issue: ENC-ISS-394 · mirrors gamma ENC-TSK-I14 (PR #564) one env up
- Component: `comp-enceladus-infrastructure` · transition_type `github_pr_deploy`
- No governance-dictionary change required (touches only `infrastructure/cloudformation/03-api.yaml`)

CCI-751ac5bd2c964b23ab8305996854b898

🤖 Generated with [Claude Code](https://claude.com/claude-code)