### PR TITLE
feat(coordination,data): Agent ID v3 allocation stores + server-side ID minting (ENC-TSK-I37)

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -1,0 +1,319 @@
+"""agent_id_alloc.py — Server-side identity minting for ENC-SES / ENC-AGT (ENC-TSK-I37).
+
+Agent ID v3 (ENC-FTR-117). Allocates two governed identity primitives on the existing
+v3 stack, fronted by coordination_api (no new service — DOC-BADA8D801099 §4 Track A):
+
+  * ENC-SES-NNN — the session. Unique, ephemeral, monotonic single-assignment: a session
+    id minted once is never reissued (sessions retire, they do not recycle). Persisted to
+    the session-allocation store (AGENT_SESSIONS_TABLE), keyed by ``session_id``.
+  * ENC-AGT-NNN — the agent type. A durable directory entry for one surface-and-model
+    tuple. Persisted to the agent-type directory (AGENT_TYPES_TABLE), keyed by
+    ``agent_type_id``.
+
+This module REUSES tracker_mutation's minting discipline (the same pattern already present
+in lambda_function.py:_next_tracker_sequence): server-only allocation, a monotonic atomic
+counter (DynamoDB UpdateItem ``if_not_exists(next_num,:seed) + :one``), format-enforced
+base-36 ids, and a forbidden-field guard so callers can NEVER supply an id (ENC-TSK-B99 /
+ENC-ISS-132). It does NOT import tracker_mutation (separate Lambda package) — the discipline
+is replicated.
+
+BUILD-ONCE GATE (DOC-05C45B438FC1). The persisted item shapes below are deliberately
+VALUE-IDENTICAL to the intended v4 node property sets so that v4 promotion is a backfill,
+not a reshape (ENC-TSK-I37 AC#3, elevated to a binding release gate):
+
+    SES node properties:  agent_type_id, parent_session_id, runtime, created_at,
+                          claimed_at, status        (key: session_id = ENC-SES-NNN)
+    AGT node properties:  surface, model, cost_tier, status, usage_count
+                                                     (key: agent_type_id = ENC-AGT-NNN)
+
+The ENC-SES / ENC-AGT id-spaces are minted identically in v3 and v4 (``encode_seq`` is the
+canonical encoder both tracks share). At v4 cutover, v4 reads and backfills these same
+rows; node selection filters out the reserved ``counter#`` sentinel rows.
+
+Scope (ENC-TSK-I37): provisioning + minting primitives only. The ``coordination(action=
+agent.*)`` MCP surface is ENC-TSK-I38; the checkout active_agent_session_id value-swap is
+ENC-TSK-I40. The allocator is dormant until I38 wires an invocation path.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from config import AGENT_SESSIONS_TABLE, AGENT_TYPES_TABLE, logger
+from aws_clients import _get_ddb
+from serialization import _deserialize, _now_z, _serialize
+
+__all__ = [
+    "SESSION_ID_PREFIX",
+    "AGENT_TYPE_ID_PREFIX",
+    "SESSION_STATUSES",
+    "AGENT_TYPE_STATUSES",
+    "encode_seq",
+    "mint_session_id",
+    "mint_agent_type_id",
+    "get_session",
+    "get_agent_type",
+    "IdAllocationError",
+    "CallerSuppliedIdError",
+]
+
+# ---------------------------------------------------------------------------
+# Format constants — the shared v3/v4 id-space (the migration seam)
+# ---------------------------------------------------------------------------
+SESSION_ID_PREFIX = "ENC-SES"
+AGENT_TYPE_ID_PREFIX = "ENC-AGT"
+
+# Reserved partition-key sentinels for the per-table monotonic counters. These rows
+# coexist with node rows in the same table (tracker_mutation discipline) and are excluded
+# from v4 node backfill by filtering keys that begin with "counter#".
+_SESSION_COUNTER_KEY = "counter#ENC-SES"
+_AGENT_TYPE_COUNTER_KEY = "counter#ENC-AGT"
+
+_SEQ_MIN_WIDTH = 3
+_BASE36_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+_MINT_MAX_ATTEMPTS = 8
+
+# Status vocabularies. SES lifecycle: allocated -> claimed -> retired (pre-allocate/claim
+# flow); a self-allocated session is minted directly as claimed. AGT lifecycle: active ->
+# deprecated (when a model is superseded). v4 inherits these vocabularies verbatim.
+SESSION_STATUSES = ("allocated", "claimed", "retired")
+AGENT_TYPE_STATUSES = ("active", "deprecated")
+
+# The exact persisted property sets (excluding the partition key). Kept as module
+# constants so tests and v4 backfill can assert value-identity against them.
+SESSION_NODE_PROPERTIES = (
+    "agent_type_id",
+    "parent_session_id",
+    "runtime",
+    "created_at",
+    "claimed_at",
+    "status",
+)
+AGENT_TYPE_NODE_PROPERTIES = (
+    "surface",
+    "model",
+    "cost_tier",
+    "status",
+    "usage_count",
+)
+
+
+class IdAllocationError(RuntimeError):
+    """Raised when an id could not be allocated (counter or put failure after retries)."""
+
+
+class CallerSuppliedIdError(ValueError):
+    """Raised when a caller attempts to supply an identity id (ENC-TSK-B99 boundary)."""
+
+
+# ---------------------------------------------------------------------------
+# Encoding — clean, monotonic, unbounded base-36 (ENC-FTR-056 discipline)
+# ---------------------------------------------------------------------------
+def encode_seq(counter: int) -> str:
+    """Encode a positive counter into the canonical base-36 sequence string.
+
+    Zero-padded to a minimum of 3 chars (``1`` -> ``001``); grows beyond 3 chars naturally
+    past ``ZZZ`` (46655 -> ``1000``). Order-preserving and a bijection from counter to
+    string, so the counter's monotonic single-assignment carries to the id. This is the
+    canonical encoder shared by v3 and v4 — do not fork it.
+    """
+    if not isinstance(counter, int) or isinstance(counter, bool):
+        raise ValueError(f"counter must be an int, got {type(counter).__name__}")
+    if counter < 1:
+        raise ValueError(f"counter must be >= 1, got {counter}")
+    digits = ""
+    value = counter
+    while value:
+        value, remainder = divmod(value, 36)
+        digits = _BASE36_ALPHABET[remainder] + digits
+    return digits.rjust(_SEQ_MIN_WIDTH, "0")
+
+
+# ---------------------------------------------------------------------------
+# Forbidden-field guard — callers never supply an id (ENC-TSK-B99 / ENC-ISS-132)
+# ---------------------------------------------------------------------------
+def _assert_no_caller_id(payload: Optional[Mapping[str, Any]], id_field: str) -> None:
+    """Reject any caller-supplied identity id. Mirrors tracker_mutation's reserved-field
+    guard (lambda_function.py:2032): record IDs are generated server-side only."""
+    if payload and payload.get(id_field):
+        raise CallerSuppliedIdError(
+            f"Field '{id_field}' must not be provided — identity ids are minted "
+            f"server-side (ENC-TSK-B99)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Monotonic atomic counter (DynamoDB UpdateItem ADD discipline)
+# ---------------------------------------------------------------------------
+def _next_seq(table_name: str, key_attr: str, counter_key: str) -> int:
+    """Atomically allocate the next sequence number for an id-space.
+
+    The counter row is keyed by a reserved ``counter#`` sentinel in the same table as the
+    nodes (tracker_mutation pattern). ``if_not_exists(next_num, :zero) + :one`` makes the
+    first allocation 1 and every subsequent allocation strictly greater — the row is never
+    decremented and ids are never reissued (monotonic single-assignment).
+    """
+    ddb = _get_ddb()
+    try:
+        resp = ddb.update_item(
+            TableName=table_name,
+            Key={key_attr: _serialize(counter_key)},
+            UpdateExpression=(
+                "SET next_num = if_not_exists(next_num, :zero) + :one, "
+                "record_kind = if_not_exists(record_kind, :kind), "
+                "updated_at = :now"
+            ),
+            ExpressionAttributeValues={
+                ":zero": _serialize(0),
+                ":one": _serialize(1),
+                ":kind": _serialize("counter"),
+                ":now": _serialize(_now_z()),
+            },
+            ReturnValues="UPDATED_NEW",
+        )
+    except (BotoCoreError, ClientError) as exc:
+        raise IdAllocationError(f"Failed allocating sequence on {table_name}: {exc}") from exc
+
+    try:
+        return int(resp["Attributes"]["next_num"]["N"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise IdAllocationError(
+            f"Counter on {table_name} returned no usable next_num: {resp!r}"
+        ) from exc
+
+
+def _put_node(table_name: str, key_attr: str, item: Dict[str, Any]) -> None:
+    """Conditional put guarding against overwriting an existing node row."""
+    _get_ddb().put_item(
+        TableName=table_name,
+        Item={k: _serialize(v) for k, v in item.items()},
+        ConditionExpression=f"attribute_not_exists({key_attr})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session minting — ENC-SES-NNN
+# ---------------------------------------------------------------------------
+def mint_session_id(
+    *,
+    agent_type_id: str,
+    runtime: str,
+    parent_session_id: str = "root",
+    status: str = "allocated",
+    claimed_at: str = "",
+    caller_payload: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Mint a server-allocated ENC-SES-NNN and persist the session node. Returns the
+    persisted item (including the minted ``session_id``). The caller never supplies the id.
+
+    ``status`` defaults to ``allocated`` (the pre-allocate/claim flow for a dispatched
+    session); pass ``claimed`` for a self-allocating root/ad-hoc session, in which case
+    ``claimed_at`` defaults to mint time.
+    """
+    _assert_no_caller_id(caller_payload, "session_id")
+    if status not in SESSION_STATUSES:
+        raise ValueError(f"status must be one of {SESSION_STATUSES}, got {status!r}")
+    if not agent_type_id:
+        raise ValueError("agent_type_id is required to mint a session")
+
+    now = _now_z()
+    resolved_claimed_at = claimed_at or (now if status == "claimed" else "")
+
+    last_exc: Optional[Exception] = None
+    for _ in range(_MINT_MAX_ATTEMPTS):
+        seq = _next_seq(AGENT_SESSIONS_TABLE, "session_id", _SESSION_COUNTER_KEY)
+        session_id = f"{SESSION_ID_PREFIX}-{encode_seq(seq)}"
+        item: Dict[str, Any] = {
+            "session_id": session_id,
+            "agent_type_id": agent_type_id,
+            "parent_session_id": parent_session_id or "root",
+            "runtime": runtime,
+            "created_at": now,
+            "claimed_at": resolved_claimed_at,
+            "status": status,
+        }
+        try:
+            _put_node(AGENT_SESSIONS_TABLE, "session_id", item)
+            logger.info("[INFO] Minted session id %s (agent_type=%s)", session_id, agent_type_id)
+            return item
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                last_exc = exc
+                continue  # extraordinarily rare: counter raced an out-of-band write — retry
+            raise
+    raise IdAllocationError(
+        f"Failed minting session id after {_MINT_MAX_ATTEMPTS} attempts: {last_exc}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent-type minting — ENC-AGT-NNN
+# ---------------------------------------------------------------------------
+def mint_agent_type_id(
+    *,
+    surface: str,
+    model: str,
+    cost_tier: str,
+    status: str = "active",
+    usage_count: int = 0,
+    caller_payload: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Mint a server-allocated ENC-AGT-NNN and persist the agent-type directory node.
+    Returns the persisted item (including the minted ``agent_type_id``). The caller never
+    supplies the id."""
+    _assert_no_caller_id(caller_payload, "agent_type_id")
+    if status not in AGENT_TYPE_STATUSES:
+        raise ValueError(f"status must be one of {AGENT_TYPE_STATUSES}, got {status!r}")
+    if not (surface and model and cost_tier):
+        raise ValueError("surface, model, and cost_tier are required to mint an agent type")
+    if not isinstance(usage_count, int) or isinstance(usage_count, bool) or usage_count < 0:
+        raise ValueError(f"usage_count must be a non-negative int, got {usage_count!r}")
+
+    last_exc: Optional[Exception] = None
+    for _ in range(_MINT_MAX_ATTEMPTS):
+        seq = _next_seq(AGENT_TYPES_TABLE, "agent_type_id", _AGENT_TYPE_COUNTER_KEY)
+        agent_type_id = f"{AGENT_TYPE_ID_PREFIX}-{encode_seq(seq)}"
+        item: Dict[str, Any] = {
+            "agent_type_id": agent_type_id,
+            "surface": surface,
+            "model": model,
+            "cost_tier": cost_tier,
+            "status": status,
+            "usage_count": usage_count,
+        }
+        try:
+            _put_node(AGENT_TYPES_TABLE, "agent_type_id", item)
+            logger.info("[INFO] Minted agent type id %s (%s / %s)", agent_type_id, surface, model)
+            return item
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                last_exc = exc
+                continue
+            raise
+    raise IdAllocationError(
+        f"Failed minting agent type id after {_MINT_MAX_ATTEMPTS} attempts: {last_exc}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read helpers (server-side verification; full agent.list surface is ENC-TSK-I38)
+# ---------------------------------------------------------------------------
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    """Return the session node for ``session_id``, or None if absent."""
+    raw = _get_ddb().get_item(
+        TableName=AGENT_SESSIONS_TABLE,
+        Key={"session_id": _serialize(session_id)},
+        ConsistentRead=True,
+    ).get("Item")
+    return _deserialize(raw) if raw else None
+
+
+def get_agent_type(agent_type_id: str) -> Optional[Dict[str, Any]]:
+    """Return the agent-type node for ``agent_type_id``, or None if absent."""
+    raw = _get_ddb().get_item(
+        TableName=AGENT_TYPES_TABLE,
+        Key={"agent_type_id": _serialize(agent_type_id)},
+        ConsistentRead=True,
+    ).get("Item")
+    return _deserialize(raw) if raw else None

--- a/backend/lambda/coordination_api/config.py
+++ b/backend/lambda/coordination_api/config.py
@@ -33,6 +33,8 @@ def _first_nonempty_env(*names: str) -> str:
     return ""
 
 __all__ = [
+    "AGENT_SESSIONS_TABLE",
+    "AGENT_TYPES_TABLE",
     "ANTHROPIC_API_BASE_URL",
     "ANTHROPIC_API_KEY_SECRET_ID",
     "ANTHROPIC_API_STREAM_TIMEOUT_SECONDS",
@@ -170,6 +172,11 @@ COORDINATION_TABLE = os.environ.get("COORDINATION_TABLE", "coordination-requests
 TRACKER_TABLE = os.environ.get("TRACKER_TABLE", "devops-project-tracker")
 PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
 DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
+# Agent ID v3 identity stores (ENC-TSK-I37 / ENC-FTR-117). Defaults are the prod table
+# names (no suffix); gamma sets AGENT_SESSIONS_TABLE/AGENT_TYPES_TABLE to the "-gamma"
+# names. The allocator (agent_id_alloc.py) is dormant until the agent.* surface (I38).
+AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
+AGENT_TYPES_TABLE = os.environ.get("AGENT_TYPES_TABLE", "agent-types")
 DYNAMODB_REGION = os.environ.get("DYNAMODB_REGION", "us-west-2")
 SSM_REGION = os.environ.get("SSM_REGION", "us-west-2")
 CORS_ORIGIN = os.environ.get("CORS_ORIGIN", "https://jreese.net")

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.01",
-  "updated_at": "2026-06-27T03:10:00Z",
-  "last_change_summary": "ENC-TSK-I34: widened tracker REST router project-segment regexes from [a-z0-9_-]+ to [a-zA-Z0-9_-]+ in backend/lambda/tracker_mutation/lambda_function.py — no tracker field or schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff. Prior: ENC-TSK-I03 (ENC-FTR-082 AC-2 retry / ENC-PLN-052): the ENC-TSK-H92 query-side encoding measured not_met (precision@1 -0.9%); replaced it with a SYMMETRIC vector re-rank — HNSW recall uses the raw query, then candidates are re-scored by cosine(W*q, W*emb) in _hybrid_vector_ranks (transform W unchanged, applied to BOTH sides via _transform_unit); removed the query-side _apply_correlation_encoding. Also fixed ENC-ISS-404: _handle_search now passes vector_read pagination/embedding_property/embedding_dim through the response envelope (previously dropped, leaving has_more only in the summary string). Touched backend/lambda/graph_query_api/lambda_function.py. ENC-TSK-H92 (ENC-FTR-082 AC-2 / ENC-PLN-052): added flag-gated correlation-aware (pseudoinverse-style) encoding on the hybrid-retrieval vector path — OFF by default (byte-identical), applying an offline-fit de-correlating transform W (tools/fit_encoding_h92.py, fit from the ENC-TSK-H91 high-correlation pairs) to the query embedding before the HNSW search; added env flags CORRELATION_ENCODING_ENABLED / CORRELATION_ENCODING_TRANSFORM_URI and the graph_query_api.correlation_encoding dictionary entity. No new edge type (OGTM N/A). Touched backend/lambda/graph_query_api/lambda_function.py. ENC-TSK-H89 (ENC-FTR-082 AC-12 / ENC-PLN-052): added a governed bulk vector-read path (search_type=vector_read) over the n.embedding corpus in backend/lambda/graph_query_api/lambda_function.py — strip-EXEMPT (the hybrid path keeps stripping at :1785-1788), latency-bounded (_VECTOR_READ_DEADLINE_S) + server-side SKIP/LIMIT pagination; wired the MCP code-mode action graph_query.vector_read plus a tracker.graphsearch offset/limit passthrough in tools/enceladus-mcp-server/server.py; added the graph_query_api.vector_read dictionary entity and the vector_read (and hybrid) search_type enum values. No new edge type (OGTM N/A). Touched backend/lambda/graph_query_api/lambda_function.py and tools/enceladus-mcp-server/server.py. Live S3 governance store sync is a post-merge product-lead handoff. Prior: ENC-TSK-C72 (ENC-ISS-191): graph_sync CHILD_OF projection fix - placeholder-MERGE for unprojected parent nodes plus read-side parent-attribute alias shim (parent/parent_task_id/parent_id). No tracker/field schema change; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff. Prior change — ENC-FTR-082 Phase A (ENC-PLN-049): registered the PATHWAY_TRAVERSED/TRAVERSED_BY edge type (AC-6 OGTM) across graph_query_api _ALLOWED_EDGE_TYPES, graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL, and the four tracker_mutation relationship registries (_RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS, _DOMAIN_RANGE_CONSTRAINTS); added raw pathway telemetry (AC-1; one JSONL object per hybrid call to an S3 append-log partitioned by wave_id, degrading to a CloudWatch log line until the Wave-2 IAM/env CFN change) and the per-edge edge_participation output (AC-10; the ENC-FTR-108 AC-4 input contract) to graph_query_api hybrid retrieval, plus optional wave_id/intent_signature graphsearch params; added the tracker.pathway_traversed and graph_query_api.pathway_telemetry dictionary entities. Touched backend/lambda/graph_query_api/lambda_function.py, backend/lambda/graph_sync/lambda_function.py, backend/lambda/tracker_mutation/lambda_function.py. Live S3 governance store sync is a post-merge product-lead handoff. Prior change — ENC-TSK-H35 (ENC-FTR-101 / ENC-PLN-006, Option B): pre-materialized standing Neo4j Aura Graph Analytics projection for hybrid-retrieval Personalized PageRank. graph_query_api gains an env-gated (GDS_STANDING_PROJECTION_PREFIX) warm read path that runs gds.pageRank.stream against a standing named projection refreshed out-of-band by a single-writer action=refresh_projection invoke, with a hard fallback to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S (no regression when unset); the standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot) and /health gains a graph_projection staleness block. Updated the tracker.graphsearch entity description accordingly. Touched backend/lambda/graph_query_api/lambda_function.py. No tracker/field schema changes; this version bump satisfies the path-triggered Governance Dictionary Guard (backend/lambda/*/lambda_function.py glob). Live S3 governance store sync is a post-merge product-lead handoff. Reconciliation context: DOC-6EFD5DB32CD8 Rev 14 (F36 closed ENC-ISS-268 via Bolt-pool resilience, not session reuse; session reuse is ENC-ISS-271, open).",
+  "version": "2026-06-27.02",
+  "updated_at": "2026-06-27T04:08:55Z",
+  "last_change_summary": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3): documented two new governed stores — coordination.agent_session (ENC-SES-NNN session-allocation store) and coordination.agent_type (ENC-AGT-NNN agent-type directory) — provisioned in 01-data.yaml, minted server-side by coordination_api/agent_id_alloc.py. Property sets are value-identical to the intended v4 node schemas (DOC-05C45B438FC1). Also added AGENT_SESSIONS_TABLE/AGENT_TYPES_TABLE config constants (config.py) — the change that trips this guard. No existing field/schema changes.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5519,6 +5519,77 @@
           "definition": "h92.v1: {version:'h92.v1', dim:int, alpha:float, rank:int, W:[[float]*dim]*dim, fit_meta:{corpus_size, correlated_set_size, num_pairs, energy_captured, top_singular_values}, pairs_source, generated_at}. W is the D x D de-correlating map applied as q' = normalize(W @ q)."
         }
       }
+    },
+    "coordination.agent_session": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Session-allocation store (DynamoDB table agent-sessions${EnvironmentSuffix}) keyed by a server-minted ENC-SES-NNN; one row per governed agent session. Monotonic single-assignment: a minted, claimed, or retired id is never reissued (sessions retire, they do not recycle). v3 flat store; the property set is value-identical to the intended v4 session node so v4 promotion is a backfill, not a reshape (binding release gate, DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py) reusing tracker_mutation's discipline; callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-SES' sentinel row in the same table (excluded from v4 node backfill). No new graph node/edge in v3 (OGTM N/A). The coordination(action=agent.*) MCP surface is ENC-TSK-I38; the active_agent_session_id value-swap is ENC-TSK-I40.",
+      "fields": {
+        "session_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-SES-NNN (partition key). base-36 monotonic sequence (ENC-FTR-056 discipline). Never caller-supplied (ENC-TSK-B99 ID Boundary Rule)."
+        },
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Foreign key to coordination.agent_type (ENC-AGT-NNN) — the agent type this session is typed as."
+        },
+        "parent_session_id": {
+          "type": "string",
+          "definition": "ENC-SES-NNN of the dispatching parent session, or 'root' for a self-allocated (ad-hoc) session."
+        },
+        "runtime": {
+          "type": "string",
+          "definition": "Session runtime/surface descriptor (e.g. 'cc-desktop-opus48')."
+        },
+        "created_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC mint timestamp."
+        },
+        "claimed_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC claim timestamp; empty until claimed. A pre-allocated (dispatched) session stays 'allocated' with empty claimed_at until the child claims it (ENC-TSK-I38)."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "allocated",
+            "claimed",
+            "retired"
+          ],
+          "definition": "Session lifecycle. allocated -> claimed (allocated-to-claimed flip on claim) -> retired. A self-allocated session is minted directly as claimed. Append-only; retire never recycles the id."
+        }
+      }
+    },
+    "coordination.agent_type": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Agent-type directory (DynamoDB table agent-types${EnvironmentSuffix}) keyed by a server-minted ENC-AGT-NNN; one durable row per surface-and-model tuple (e.g. Claude Desktop / Opus 4.8). Low-volume controlled vocabulary, not a per-session record. Property set value-identical to the intended v4 agent-type node (DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py); callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-AGT' sentinel row. Agent-type nodes are the retrieval-eligible half of the Agent ID model; selection telemetry (usage_count) supports cheapest-sufficient agent-type choice.",
+      "fields": {
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-AGT-NNN (partition key). base-36 monotonic sequence. Never caller-supplied (ENC-TSK-B99)."
+        },
+        "surface": {
+          "type": "string",
+          "definition": "Agent surface (e.g. Claude Desktop, Claude Code Terminal, Cursor Cloud, Codex, Bedrock)."
+        },
+        "model": {
+          "type": "string",
+          "definition": "Model (e.g. Opus 4.8, Sonnet 4.6, Haiku 4.5)."
+        },
+        "cost_tier": {
+          "type": "string",
+          "definition": "Relative cost tier, used for the power-versus-cost agent-type selection decision."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "deprecated"
+          ],
+          "definition": "active, or deprecated when the underlying model is superseded."
+        },
+        "usage_count": {
+          "type": "integer",
+          "definition": "Server-incremented count of sessions of this agent type. Observed telemetry (earned-precision), not a hand-maintained fit assertion."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -5537,6 +5608,11 @@
       "version": "2026-04-22.01",
       "date": "2026-04-22",
       "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+    },
+    {
+      "version": "2026-06-27.02",
+      "date": "2026-06-27",
+      "summary": "ENC-TSK-I37 / ENC-FTR-117: add coordination.agent_session and coordination.agent_type entities (Agent ID v3 governed stores); v3 property sets value-identical to v4 node schemas per DOC-05C45B438FC1. Repo-file edit only — S3/DDB governance sync is a product-lead post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -1,0 +1,171 @@
+"""Tests for agent_id_alloc.py — server-side ENC-SES / ENC-AGT minting (ENC-TSK-I37).
+
+Verifies the four task acceptance criteria server-side against real DynamoDB semantics
+(moto): the two stores + monotonic counter (AC#1), server-only / monotonic / format-
+enforced minting with no caller-supplied ids (AC#2), and the persisted property sets being
+value-identical to the intended v4 node schemas (AC#3, the binding release gate).
+"""
+import os
+import unittest
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+import config  # noqa: E402
+import agent_id_alloc as alloc  # noqa: E402
+
+
+class EncodeSeqTest(unittest.TestCase):
+    def test_encoding_is_min_width_3_and_unbounded(self):
+        self.assertEqual(alloc.encode_seq(1), "001")
+        self.assertEqual(alloc.encode_seq(2), "002")
+        self.assertEqual(alloc.encode_seq(35), "00Z")
+        self.assertEqual(alloc.encode_seq(36), "010")
+        self.assertEqual(alloc.encode_seq(46655), "ZZZ")   # ZZZ = 36**3 - 1
+        self.assertEqual(alloc.encode_seq(46656), "1000")  # grows past 3 chars cleanly
+
+    def test_encoding_is_a_strictly_increasing_bijection(self):
+        seen = set()
+        prev = ""
+        for n in range(1, 2000):
+            s = alloc.encode_seq(n)
+            self.assertNotIn(s, seen)
+            seen.add(s)
+            # zero-padded fixed-width-per-magnitude strings sort with the counter
+            if len(s) == len(prev):
+                self.assertGreater(s, prev)
+            prev = s
+
+    def test_rejects_non_positive_and_bool(self):
+        for bad in (0, -1, True, False, 1.0, "1"):
+            with self.assertRaises(ValueError):
+                alloc.encode_seq(bad)  # type: ignore[arg-type]
+
+
+@mock_aws
+class MintingTest(unittest.TestCase):
+    def setUp(self):
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        for table, key in (
+            (config.AGENT_SESSIONS_TABLE, "session_id"),
+            (config.AGENT_TYPES_TABLE, "agent_type_id"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # -- AC#1 / AC#2: monotonic single-assignment ----------------------------
+    def test_session_ids_are_monotonic_and_formatted(self):
+        ids = [
+            alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="cc-desktop")["session_id"]
+            for _ in range(3)
+        ]
+        self.assertEqual(ids, ["ENC-SES-001", "ENC-SES-002", "ENC-SES-003"])
+        self.assertEqual(len(set(ids)), 3)
+
+    def test_agent_type_ids_are_monotonic_and_formatted(self):
+        ids = [
+            alloc.mint_agent_type_id(surface="Claude Desktop", model="Opus 4.8", cost_tier="premium")["agent_type_id"]
+            for _ in range(3)
+        ]
+        self.assertEqual(ids, ["ENC-AGT-001", "ENC-AGT-002", "ENC-AGT-003"])
+
+    def test_no_id_is_ever_reissued(self):
+        minted = {
+            alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r")["session_id"]
+            for _ in range(50)
+        }
+        self.assertEqual(len(minted), 50)  # monotonic single-assignment — no reuse
+
+    def test_session_and_agent_counters_are_independent(self):
+        s = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r")["session_id"]
+        a = alloc.mint_agent_type_id(surface="Codex", model="o-x", cost_tier="standard")["agent_type_id"]
+        self.assertEqual(s, "ENC-SES-001")
+        self.assertEqual(a, "ENC-AGT-001")  # each id-space has its own counter
+
+    # -- AC#2: callers can never supply an id --------------------------------
+    def test_caller_supplied_session_id_rejected(self):
+        with self.assertRaises(alloc.CallerSuppliedIdError):
+            alloc.mint_session_id(
+                agent_type_id="ENC-AGT-001", runtime="r",
+                caller_payload={"session_id": "ENC-SES-999"},
+            )
+
+    def test_caller_supplied_agent_type_id_rejected(self):
+        with self.assertRaises(alloc.CallerSuppliedIdError):
+            alloc.mint_agent_type_id(
+                surface="s", model="m", cost_tier="c",
+                caller_payload={"agent_type_id": "ENC-AGT-999"},
+            )
+
+    # -- AC#3 (binding gate): item shape value-identical to v4 node schema ----
+    def test_session_item_matches_v4_node_property_set(self):
+        item = alloc.mint_session_id(
+            agent_type_id="ENC-AGT-007", runtime="cc-desktop", parent_session_id="ENC-SES-001",
+        )
+        expected_keys = {"session_id", *alloc.SESSION_NODE_PROPERTIES}
+        self.assertEqual(set(item.keys()), expected_keys)
+        self.assertEqual(item["agent_type_id"], "ENC-AGT-007")
+        self.assertEqual(item["parent_session_id"], "ENC-SES-001")
+        self.assertEqual(item["status"], "allocated")  # dispatched default
+        self.assertEqual(item["claimed_at"], "")        # not claimed yet
+        self.assertTrue(item["created_at"])
+
+    def test_agent_type_item_matches_v4_node_property_set(self):
+        item = alloc.mint_agent_type_id(
+            surface="Claude Desktop", model="Opus 4.8", cost_tier="premium", usage_count=0,
+        )
+        expected_keys = {"agent_type_id", *alloc.AGENT_TYPE_NODE_PROPERTIES}
+        self.assertEqual(set(item.keys()), expected_keys)
+        self.assertEqual(item["surface"], "Claude Desktop")
+        self.assertEqual(item["model"], "Opus 4.8")
+        self.assertEqual(item["cost_tier"], "premium")
+        self.assertEqual(item["status"], "active")
+        self.assertEqual(item["usage_count"], 0)
+
+    def test_self_allocated_session_is_claimed_with_timestamp(self):
+        item = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r", status="claimed")
+        self.assertEqual(item["status"], "claimed")
+        self.assertEqual(item["claimed_at"], item["created_at"])
+
+    def test_invalid_status_rejected(self):
+        with self.assertRaises(ValueError):
+            alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r", status="bogus")
+        with self.assertRaises(ValueError):
+            alloc.mint_agent_type_id(surface="s", model="m", cost_tier="c", status="bogus")
+
+    # -- AC#1: counter row coexists but is not a node ------------------------
+    def test_counter_row_is_isolated_from_nodes(self):
+        alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r")
+        alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r")
+        scan = self.ddb.scan(TableName=config.AGENT_SESSIONS_TABLE)["Items"]
+        keys = [row["session_id"]["S"] for row in scan]
+        self.assertIn("counter#ENC-SES", keys)               # counter persisted in-table
+        nodes = [k for k in keys if not k.startswith("counter#")]
+        self.assertEqual(sorted(nodes), ["ENC-SES-001", "ENC-SES-002"])
+        counter_row = next(r for r in scan if r["session_id"]["S"] == "counter#ENC-SES")
+        self.assertEqual(counter_row["record_kind"]["S"], "counter")
+        self.assertEqual(counter_row["next_num"]["N"], "2")
+
+    # -- read helpers (server-side verification) -----------------------------
+    def test_get_round_trips_minted_records(self):
+        sid = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="r")["session_id"]
+        aid = alloc.mint_agent_type_id(surface="s", model="m", cost_tier="c")["agent_type_id"]
+        self.assertEqual(alloc.get_session(sid)["session_id"], sid)
+        self.assertEqual(alloc.get_agent_type(aid)["agent_type_id"], aid)
+        self.assertIsNone(alloc.get_session("ENC-SES-404"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -361,6 +361,63 @@ Resources:
           Value: governance
 
   # ---------------------------------------------------------------------------
+  # Agent ID v3 identity stores (ENC-TSK-I37 / ENC-FTR-117)
+  # Flat allocation stores fronted by coordination_api. Item property sets are
+  # value-identical to the intended v4 node property schemas so v4 promotion is a
+  # backfill, not a reshape (binding release gate — DOC-05C45B438FC1). Each table
+  # also holds its monotonic allocation counter as a reserved "counter#" sentinel
+  # row (tracker_mutation discipline); node backfill filters that key out.
+  # ---------------------------------------------------------------------------
+
+  # Session-allocation store, keyed ENC-SES-NNN.
+  # Node properties: agent_type_id, parent_session_id, runtime, created_at,
+  # claimed_at, status. Counter row: session_id = "counter#ENC-SES".
+  AgentSessionsTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "agent-sessions${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: !If [IsProduction, true, false]
+      AttributeDefinitions:
+        - AttributeName: session_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: session_id
+          KeyType: HASH
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+        - Key: Feature
+          Value: ENC-FTR-117
+
+  # Agent-type directory, keyed ENC-AGT-NNN.
+  # Node properties: surface, model, cost_tier, status, usage_count.
+  # Counter row: agent_type_id = "counter#ENC-AGT".
+  AgentTypesTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "agent-types${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: !If [IsProduction, true, false]
+      AttributeDefinitions:
+        - AttributeName: agent_type_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: agent_type_id
+          KeyType: HASH
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+        - Key: Feature
+          Value: ENC-FTR-117
+
+  # ---------------------------------------------------------------------------
   # SQS Queues
   # ---------------------------------------------------------------------------
 
@@ -574,3 +631,20 @@ Outputs:
     Value: !Ref ComponentRegistryEventsTopic
     Export:
       Name: !Sub ${AWS::StackName}-ComponentRegistryEventsTopicArn
+  # Agent ID v3 identity stores (ENC-TSK-I37 / ENC-FTR-117)
+  AgentSessionsTableName:
+    Value: !Ref AgentSessionsTable
+    Export:
+      Name: !Sub ${AWS::StackName}-AgentSessionsTable
+  AgentSessionsTableArn:
+    Value: !GetAtt AgentSessionsTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AgentSessionsTableArn
+  AgentTypesTableName:
+    Value: !Ref AgentTypesTable
+    Export:
+      Name: !Sub ${AWS::StackName}-AgentTypesTable
+  AgentTypesTableArn:
+    Value: !GetAtt AgentTypesTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AgentTypesTableArn

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -183,6 +183,9 @@ Resources:
           ENCELADUS_MCP_INTERFACE_MODE: code
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-I37 / ENC-FTR-117: Agent ID v3 identity stores (server-side allocator path)
+          AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
+          AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"
           # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
@@ -1601,6 +1604,18 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}/index/*"
+              # ENC-TSK-I37 / ENC-FTR-117: Agent ID v3 identity stores (server-side allocator path)
+              - Sid: AgentIdStoresAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-sessions${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-types${EnvironmentSuffix}"
               - Sid: GovernanceAndReferenceS3Read
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## ENC-TSK-I37 — Agent ID v3: allocation stores + server-side ID minting

Part of **ENC-FTR-117** (Agent ID v3) / **ENC-PLN-058**. Stands up the two flat identity stores + monotonic counter, the server-side allocator, and its access wiring on the existing v3 stack (DOC-BADA8D801099 Track A). The allocator is **dormant** until the `agent.*` MCP surface (ENC-TSK-I38); the only live-path change in this feature is the checkout value-swap (ENC-TSK-I40).

**PR Commit Gate:** CCI-587cb02914d44cd7953c95a20ee8b595

### Deploy authority (citation correction)
Ships to v3-prod under **DOC-05C45B438FC1** (io prod-exception, scoped to ENC-FTR-117). This **supersedes** the "surgical main lane (DOC-0824AA2FBF18)" citation in ENC-TSK-I37 AC#4 / ENC-FTR-117 AC#10 — DOC-0824AA2FBF18 is the ENC-PLN-053 AppConfig policy and explicitly classifies new DynamoDB tables as v4/main-only; it was cited in error. Deploy via the sanctioned Gen2 / CFN compute path (gamma-first → required-reviewer gate, **io is reviewer**); no ad-hoc CFN/lambda; live-drift reconciliation + pre-deploy health gate before any CFN deploy.

### ⭐ Binding release gate (AC#3) — schema value-identity to the v4 node property sets
Per DOC-05C45B438FC1 the v3 table schemas MUST be value-identical to the intended v4 node property sets so v4 promotion is a backfill, not a reshape. **KEYS are creation-locked — verify before approving prod.**

**Session-allocation store** — `agent-sessions${EnvironmentSuffix}`
- **KEY (creation-locked):** HASH `session_id` (S) = `ENC-SES-NNN`
- **GSIs:** none
- **Node properties (== v4 SES node):** `agent_type_id`, `parent_session_id`, `runtime`, `created_at`, `claimed_at`, `status` — exact match, asserted by test.

**Agent-type directory** — `agent-types${EnvironmentSuffix}`
- **KEY (creation-locked):** HASH `agent_type_id` (S) = `ENC-AGT-NNN`
- **GSIs:** none
- **Node properties (== v4 AGT node):** `surface`, `model`, `cost_tier`, `status`, `usage_count` — exact match, asserted by test.

The monotonic counter lives as a reserved `counter#ENC-SES` / `counter#ENC-AGT` sentinel row inside each table (tracker_mutation discipline); v4 node backfill filters `counter#*`. ENC-SES / ENC-AGT are minted by the shared base-36 `encode_seq` (canonical for v3 and v4 — the migration seam).

> **GSIs intentionally omitted.** Adding a GSI to a live table is an online, non-breaking op; I38's `agent.list` / `agent.type.list` query paths provision theirs when built. The gate is on the keys (a key change would be a table replacement) — keys are fixed here.

### Changes
- **infrastructure/cloudformation/01-data.yaml** (comp-cloudformation-data): `AgentSessionsTable` + `AgentTypesTable`; `PAY_PER_REQUEST`, `DeletionPolicy: Retain`, prod deletion-protection, name+ARN exports.
- **infrastructure/cloudformation/02-compute.yaml** (comp-cloudformation-app): coordination_api role grant (`AgentIdStoresAccess`: Get/Put/Update/Query/Scan on both tables) + `AGENT_SESSIONS_TABLE` / `AGENT_TYPES_TABLE` env (gamma-suffix aware) so the minting path has IAM + env the moment I38 activates it.
- **backend/lambda/coordination_api/agent_id_alloc.py**: server-only minting — atomic `UpdateItem` counter, base-36 encode, forbidden-field guard (callers never supply an id, ENC-TSK-B99).
- **backend/lambda/coordination_api/config.py**: `AGENT_SESSIONS_TABLE` / `AGENT_TYPES_TABLE` constants.
- **backend/lambda/coordination_api/test_agent_id_alloc.py**: 15 tests (moto).

### Acceptance criteria
- **AC#1** (two tables + monotonic counter): provisioned by 01-data.yaml; live on deploy.
- **AC#2** (server-side minting; server-only / monotonic / format-enforced; no caller id): **proven** — 15/15 tests.
- **AC#3** (schema mirrors v4 node property sets — binding gate): **proven** — tests assert exact key-set value-identity (above).
- **AC#4** (ships to v3-prod via the sanctioned lane, DOC-05C45B438FC1): on deploy.

### Test evidence
`python -m pytest test_agent_id_alloc.py` → **15 passed** (real DynamoDB semantics via moto): monotonic single-assignment (no reuse), ENC-SES/ENC-AGT format, server-only forbidden-id guard, AC#3 value-identity of both key-sets, counter-row isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
