### PR TITLE
fix(promote): add ref: main to checkout (ENC-TSK-I47)

### DIFF
--- a/.github/workflows/promote-gamma-to-prod-request.yml
+++ b/.github/workflows/promote-gamma-to-prod-request.yml
@@ -44,14 +44,15 @@ jobs:
     timeout-minutes: 15   # ENC-TSK-H58: +gate warm-projection latency budget
     steps:
       # ENC-TSK-H58: check out the DEFAULT branch (main), where the gate tooling
-      # lives. A workflow_run job runs from main and github.sha already points at
-      # main's HEAD, so the default checkout (no ref) gets tools/gamma_validation_gate.sh
-      # + the env-parity tooling + template. Do NOT check out the promoted head_sha:
-      # v4/main is FORKED (PLN-006 fork-mode, sync-main-to-v4main disabled) and does
-      # NOT carry the gate script — checking it out would break the gate on every run.
+      # lives. MUST use ref: main explicitly — in workflow_run events github.sha is
+      # the triggering workflow's HEAD SHA (v4/main), NOT main's HEAD. Without ref:main
+      # the checkout grabs the v4/main SHA which is FORKED (PLN-006 fork-mode,
+      # sync-main-to-v4main disabled) and may lack the latest gate tooling on main.
       # The gate probes the LIVE gamma environment, so it does not need the deployed tree.
       - name: Checkout gate tooling (default branch / main)
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

- `promote-gamma-to-prod-request.yml` checkout had no explicit `ref`, relying on the (wrong) assumption that `github.sha` points at main's HEAD in `workflow_run` events
- In `workflow_run` events, `github.sha` is the HEAD SHA of the **triggering** workflow's branch (`v4/main`), not the default branch HEAD
- Since `v4/main` is forked (PLN-006) and sync is disabled, the gate tooling from main was never picked up — any gate fix landed on main was silently ignored on re-runs
- This explains why the `#574` gate fix (GDS-configured-aware graph-probe) wasn't applied despite being merged to main

## Fix

Add `ref: main` to `actions/checkout@v4` so the gate tooling is always fetched from the default branch regardless of which SHA triggered `workflow_run`.

CCI-94bbba972aad4ccdb3e75ce605dd28a9

🤖 Generated with [Claude Code](https://claude.com/claude-code)