### PR TITLE
fix(ci): deploy 01-data before 02-compute (I27 GovernanceVersionTable export)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
       - 'v4/**'
     paths:
+      - "infrastructure/cloudformation/01-data.yaml"
       - "infrastructure/cloudformation/02-compute.yaml"
       - ".github/workflows/cloudformation-compute-stack-deploy.yml"
   workflow_dispatch:
@@ -156,6 +157,29 @@ jobs:
             --stack "${{ steps.params.outputs.stack_name }}" \
             --template "${TEMPLATE_FILE}" \
             --region "${AWS_REGION}"
+
+      - name: Deploy Data stack (01-data)
+        run: |
+          set -euo pipefail
+          # Deploy the data stack first so cross-stack exports (e.g. GovernanceVersionTableArn)
+          # exist before 02-compute is deployed. Uses previous values for all params not
+          # overridden here; EnvironmentSuffix and Environment are derived from the branch.
+          environment="${ENVIRONMENT_SUFFIX:+-gamma}"
+          environment="${environment:-production}"
+          # ENVIRONMENT_SUFFIX is "-gamma" or "". 'production' when empty.
+          [ -n "${ENVIRONMENT_SUFFIX}" ] && environment="gamma" || environment="production"
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.data_stack_name }}" \
+            --template-file infrastructure/cloudformation/01-data.yaml \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 01-data/ \
+            --parameter-overrides \
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" \
+              Environment="${environment}" \
+              DynamoDBRegion="${AWS_REGION}"
 
       - name: Deploy Compute stack (02-compute)
         id: deploy


### PR DESCRIPTION
## Summary

- Adds `infrastructure/cloudformation/01-data.yaml` to the push trigger paths for the compute CFN deploy workflow
- Adds a **Deploy Data stack (01-data)** step before the existing compute deploy step so cross-stack exports (`GovernanceVersionTableArn`, etc.) exist when `02-compute.yaml` references them via `!ImportValue`

## Root Cause

PR #576 (I27+I28) added `GovernanceVersionTable` to `01-data.yaml` and a cross-stack `!ImportValue` of `GovernanceVersionTableArn` in `02-compute.yaml` `RecomputeGovernanceRole`. The compute CFN deploy CI ran on merge but failed immediately:

```
No export named enceladus-data-gamma-GovernanceVersionTableArn found
```

The data stack had no CI deploy; only the compute stack had a path trigger. So the data stack was never updated and the export never existed.

## Fix

Pre-deploy the data stack inside the same workflow, before the compute deploy step. Uses `--no-fail-on-empty-changeset` so it's a no-op when 01-data has no pending changes.

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)