### PR TITLE
fix(data): restore AgentSessionsTable + AgentTypesTable resources lost in I27 cherry-pick

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -497,6 +497,52 @@ Resources:
         - Key: Component
           Value: coordination
 
+  # Agent ID v3 identity stores (ENC-TSK-I37 / ENC-FTR-117)
+  AgentSessionsTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "agent-sessions${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: !If [IsProduction, true, false]
+      AttributeDefinitions:
+        - AttributeName: session_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: session_id
+          KeyType: HASH
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+        - Key: Feature
+          Value: ENC-FTR-117
+
+  # Agent-type directory, keyed ENC-AGT-NNN.
+  # Node properties: surface, model, cost_tier, status, usage_count.
+  # Counter row: agent_type_id = "counter#ENC-AGT".
+  AgentTypesTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "agent-types${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      DeletionProtectionEnabled: !If [IsProduction, true, false]
+      AttributeDefinitions:
+        - AttributeName: agent_type_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: agent_type_id
+          KeyType: HASH
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+        - Key: Feature
+          Value: ENC-FTR-117
+
   # ENC-TSK-I27 / ENC-FTR-116 Wave 2: canonical governance-version record.
   # Single-item table (version_id = "governance-version-current") written exclusively
   # by the recompute-governance Lambda (IAM sole-writer enforced by I28).


### PR DESCRIPTION
## Summary

During the I27 cherry-pick / rebase onto `v4/main`, the resource definitions for `AgentSessionsTable` and `AgentTypesTable` were accidentally dropped from `01-data.yaml`. Only the Outputs section referencing them was retained, causing the CFN data stack deploy to fail:

```
Unresolved resource dependencies [AgentSessionsTable] in the Outputs block
```

This PR restores the two DynamoDB resource definitions (ENC-TSK-I37 / ENC-FTR-117) so the data stack deploys cleanly, which in turn unblocks the compute stack deploy (which `!ImportValue`s `GovernanceVersionTableArn` from the data stack).

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)