### PR TITLE
ci(iam): add dispatch workflow for CFN deploy role gamma DDB+SNS perms (I27 unblock)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
@@ -1,0 +1,88 @@
+name: IAM CFN Deploy Role — Gamma DDB/SNS Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant DynamoDB+SNS gamma permissions to CFN deploy role (04-github-roles stale)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with gamma DynamoDB and SNS permissions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — gamma DynamoDB + SNS bootstrap
+        run: |
+          set -euo pipefail
+          cat > /tmp/gamma-ddb-sns-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "GammaDynamoDBBootstrap",
+                "Effect": "Allow",
+                "Action": [
+                  "dynamodb:CreateTable",
+                  "dynamodb:DescribeTable",
+                  "dynamodb:UpdateTable",
+                  "dynamodb:DeleteTable",
+                  "dynamodb:TagResource",
+                  "dynamodb:UntagResource",
+                  "dynamodb:ListTagsOfResource",
+                  "dynamodb:DescribeTimeToLive",
+                  "dynamodb:UpdateTimeToLive",
+                  "dynamodb:DescribeContinuousBackups",
+                  "dynamodb:UpdateContinuousBackups"
+                ],
+                "Resource": "arn:aws:dynamodb:us-west-2:356364570033:table/*-gamma"
+              },
+              {
+                "Sid": "GammaSNSBootstrap",
+                "Effect": "Allow",
+                "Action": [
+                  "sns:CreateTopic",
+                  "sns:GetTopicAttributes",
+                  "sns:SetTopicAttributes",
+                  "sns:DeleteTopic",
+                  "sns:TagResource",
+                  "sns:UntagResource",
+                  "sns:ListTagsForResource",
+                  "sns:Subscribe",
+                  "sns:Unsubscribe",
+                  "sns:GetSubscriptionAttributes"
+                ],
+                "Resource": "arn:aws:sns:us-west-2:356364570033:enceladus-*-gamma"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-ddb-sns-v1" \
+            --policy-document "file:///tmp/gamma-ddb-sns-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-ddb-sns-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table


### PR DESCRIPTION
## Summary

Adds `iam-cfn-deploy-role-gamma-patch.yml` to `main` (the default branch) so it can be triggered via `workflow_dispatch`. The workflow is identical to the one merged to `v4/main` via PR #579.

The `enceladus-github-roles` stack (which defines `enceladus-cloudformation-deploy-github-role`) was last deployed 2026-04-21 and is missing the `GammaDynamoDBBootstrap` and `GammaSNSBootstrap` inline permissions needed to create DynamoDB tables and SNS topics in the gamma namespace. This blocks the I27 `GovernanceVersionTable` data stack deploy.

After merging, trigger with:
```
gh workflow run iam-cfn-deploy-role-gamma-patch.yml
```

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)