### PR TITLE
ci: add dispatch workflows for gamma data stack unblock (DeploymentManagerTable GSIs + CFN role patch)

### DIFF
--- a/.github/workflows/ddb-add-deployment-manager-gsis.yml
+++ b/.github/workflows/ddb-add-deployment-manager-gsis.yml
@@ -1,0 +1,134 @@
+name: DDB — Add DeploymentManagerTable GSIs (gamma)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this operation is needed"
+        type: string
+        required: false
+        default: "Add missing GSIs to devops-deployment-manager-gamma (blocked 01-data CFN deploy)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  add-gsis:
+    name: Add status-created, generation-created, target-created GSIs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Check existing GSIs
+        run: |
+          echo "=== Current GSIs on devops-deployment-manager-gamma ==="
+          aws dynamodb describe-table \
+            --table-name devops-deployment-manager-gamma \
+            --region us-west-2 \
+            --query 'Table.GlobalSecondaryIndexes[*].{Name:IndexName,Status:IndexStatus}' \
+            --output table
+
+      - name: Add status-created-index GSI
+        run: |
+          set -euo pipefail
+          # Skip if already exists
+          existing=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+            --region us-west-2 --query "Table.GlobalSecondaryIndexes[?IndexName=='status-created-index'].IndexName" \
+            --output text 2>/dev/null || echo "")
+          if [ -n "${existing}" ]; then
+            echo "status-created-index already exists, skipping."
+          else
+            aws dynamodb update-table \
+              --table-name devops-deployment-manager-gamma \
+              --region us-west-2 \
+              --attribute-definitions \
+                AttributeName=status,AttributeType=S \
+                AttributeName=created_at,AttributeType=S \
+              --global-secondary-index-updates '[{"Create":{"IndexName":"status-created-index","KeySchema":[{"AttributeName":"status","KeyType":"HASH"},{"AttributeName":"created_at","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}}]'
+            echo "Waiting for status-created-index to become ACTIVE..."
+            aws dynamodb wait table-exists --table-name devops-deployment-manager-gamma --region us-west-2
+            # Poll until GSI is ACTIVE
+            for i in $(seq 1 60); do
+              status=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+                --region us-west-2 \
+                --query "Table.GlobalSecondaryIndexes[?IndexName=='status-created-index'].IndexStatus" \
+                --output text 2>/dev/null || echo "UNKNOWN")
+              echo "  status-created-index: ${status}"
+              [ "${status}" = "ACTIVE" ] && break
+              sleep 10
+            done
+          fi
+
+      - name: Add generation-created-index GSI
+        run: |
+          set -euo pipefail
+          existing=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+            --region us-west-2 --query "Table.GlobalSecondaryIndexes[?IndexName=='generation-created-index'].IndexName" \
+            --output text 2>/dev/null || echo "")
+          if [ -n "${existing}" ]; then
+            echo "generation-created-index already exists, skipping."
+          else
+            aws dynamodb update-table \
+              --table-name devops-deployment-manager-gamma \
+              --region us-west-2 \
+              --attribute-definitions \
+                AttributeName=generation_id,AttributeType=S \
+                AttributeName=created_at,AttributeType=S \
+              --global-secondary-index-updates '[{"Create":{"IndexName":"generation-created-index","KeySchema":[{"AttributeName":"generation_id","KeyType":"HASH"},{"AttributeName":"created_at","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}}]'
+            echo "Waiting for generation-created-index to become ACTIVE..."
+            for i in $(seq 1 60); do
+              status=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+                --region us-west-2 \
+                --query "Table.GlobalSecondaryIndexes[?IndexName=='generation-created-index'].IndexStatus" \
+                --output text 2>/dev/null || echo "UNKNOWN")
+              echo "  generation-created-index: ${status}"
+              [ "${status}" = "ACTIVE" ] && break
+              sleep 10
+            done
+          fi
+
+      - name: Add target-created-index GSI
+        run: |
+          set -euo pipefail
+          existing=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+            --region us-west-2 --query "Table.GlobalSecondaryIndexes[?IndexName=='target-created-index'].IndexName" \
+            --output text 2>/dev/null || echo "")
+          if [ -n "${existing}" ]; then
+            echo "target-created-index already exists, skipping."
+          else
+            aws dynamodb update-table \
+              --table-name devops-deployment-manager-gamma \
+              --region us-west-2 \
+              --attribute-definitions \
+                AttributeName=final_target,AttributeType=S \
+                AttributeName=created_at,AttributeType=S \
+              --global-secondary-index-updates '[{"Create":{"IndexName":"target-created-index","KeySchema":[{"AttributeName":"final_target","KeyType":"HASH"},{"AttributeName":"created_at","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"}}}]'
+            echo "Waiting for target-created-index to become ACTIVE..."
+            for i in $(seq 1 60); do
+              status=$(aws dynamodb describe-table --table-name devops-deployment-manager-gamma \
+                --region us-west-2 \
+                --query "Table.GlobalSecondaryIndexes[?IndexName=='target-created-index'].IndexStatus" \
+                --output text 2>/dev/null || echo "UNKNOWN")
+              echo "  target-created-index: ${status}"
+              [ "${status}" = "ACTIVE" ] && break
+              sleep 10
+            done
+          fi
+
+      - name: Verify all GSIs active
+        run: |
+          echo "=== Final GSI state ==="
+          aws dynamodb describe-table \
+            --table-name devops-deployment-manager-gamma \
+            --region us-west-2 \
+            --query 'Table.GlobalSecondaryIndexes[*].{Name:IndexName,Status:IndexStatus}' \
+            --output table


### PR DESCRIPTION
## Summary

Two dispatch workflows to unblock the I27 `GovernanceVersionTable` data stack deploy on gamma.

### Problem chain

1. PR #576 (I27/I28) added `GovernanceVersionTable` to `01-data.yaml` and merged to `v4/main`
2. CI compute stack deploy fails: `No export named enceladus-data-gamma-GovernanceVersionTableArn` → PR #577 fixed the ordering
3. Data stack deploy fails: `AccessDenied: dynamodb:DescribeTable` (stale github-roles stack) → PR #580 patched the IAM role (merged)
4. Data stack deploy fails: `AgentSessionsTable` missing resource → PR #578 restored the resource defs
5. Data stack deploy now fails: `Cannot perform more than one GSI creation or deletion in a single update` on `DeploymentManagerTable` (needs 3 new GSIs, DynamoDB only allows 1 at a time)

### This PR (adds to `main` for workflow_dispatch availability)

- **`iam-cfn-deploy-role-gamma-patch.yml`**: Grants DynamoDB+SNS gamma permissions to the CFN deploy role (already merged and triggered separately)
- **`ddb-add-deployment-manager-gsis.yml`**: Adds `status-created-index`, `generation-created-index`, and `target-created-index` GSIs to `devops-deployment-manager-gamma` sequentially

### After merging

```bash
gh workflow run ddb-add-deployment-manager-gsis.yml
# wait for it to complete...
gh workflow run cloudformation-compute-stack-deploy.yml --ref v4/main
```

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)