### PR TITLE
fix(ci): add orphaned SNS topic cleanup before data stack deploy (I27 unblock)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -164,20 +164,29 @@ jobs:
           # When a previous 01-data deploy fails mid-flight and CFN rolls back with
           # DeletionPolicy:Retain, new SNS topics can be left untracked by the stack.
           # A subsequent deploy fails: "Topic creation failed because the topic already exists."
-          # Delete such orphans before deploying so CFN can create them cleanly.
-          suffix="${ENVIRONMENT_SUFFIX}"
+          # Delete any such topics that are NOT currently tracked by the data stack so CFN
+          # can create them cleanly. Delete-topic is idempotent on a missing ARN.
           stack_name="${{ steps.params.outputs.data_stack_name }}"
-          tracked=$(aws cloudformation list-stack-resources --stack-name "${stack_name}" \
-            --region "${AWS_REGION}" \
+          account="356364570033"
+          region="${AWS_REGION}"
+          suffix="${ENVIRONMENT_SUFFIX}"
+          # Topics the data stack template would CREATE — if suffix is empty this runs only
+          # for production; for gamma suffix="-gamma" and the pattern matches exactly.
+          candidate_topics=(
+            "arn:aws:sns:${region}:${account}:enceladus-component-registry-events${suffix}"
+          )
+          tracked_arns=$(aws cloudformation list-stack-resources \
+            --stack-name "${stack_name}" \
+            --region "${region}" \
             --query "StackResourceSummaries[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" \
-            --output text 2>/dev/null | tr '\t' '\n' | grep . || echo "")
-          all_gamma_topics=$(aws sns list-topics --region "${AWS_REGION}" \
-            --query "Topics[*].TopicArn" --output text | tr '\t' '\n' \
-            | grep "enceladus-.*${suffix}$" || true)
-          for arn in ${all_gamma_topics}; do
-            if [ -z "${tracked}" ] || ! grep -qF "${arn}" <<< "${tracked}"; then
+            --output text 2>/dev/null || echo "")
+          for arn in "${candidate_topics[@]}"; do
+            if echo "${tracked_arns}" | grep -qF "${arn}"; then
+              echo "Topic tracked by stack, skipping: ${arn}"
+            else
               echo "Deleting orphaned (untracked) SNS topic: ${arn}"
-              aws sns delete-topic --topic-arn "${arn}" --region "${AWS_REGION}" || echo "Warning: could not delete ${arn}"
+              aws sns delete-topic --topic-arn "${arn}" --region "${region}" \
+                2>&1 | grep -v "NotFound\|does not exist" || true
             fi
           done
 

--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -158,6 +158,29 @@ jobs:
             --template "${TEMPLATE_FILE}" \
             --region "${AWS_REGION}"
 
+      - name: Clean up orphaned SNS topics (pre-deploy idempotency guard)
+        run: |
+          set -euo pipefail
+          # When a previous 01-data deploy fails mid-flight and CFN rolls back with
+          # DeletionPolicy:Retain, new SNS topics can be left untracked by the stack.
+          # A subsequent deploy fails: "Topic creation failed because the topic already exists."
+          # Delete such orphans before deploying so CFN can create them cleanly.
+          suffix="${ENVIRONMENT_SUFFIX}"
+          stack_name="${{ steps.params.outputs.data_stack_name }}"
+          tracked=$(aws cloudformation list-stack-resources --stack-name "${stack_name}" \
+            --region "${AWS_REGION}" \
+            --query "StackResourceSummaries[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" \
+            --output text 2>/dev/null | tr '\t' '\n' | grep . || echo "")
+          all_gamma_topics=$(aws sns list-topics --region "${AWS_REGION}" \
+            --query "Topics[*].TopicArn" --output text | tr '\t' '\n' \
+            | grep "enceladus-.*${suffix}$" || true)
+          for arn in ${all_gamma_topics}; do
+            if [ -z "${tracked}" ] || ! grep -qF "${arn}" <<< "${tracked}"; then
+              echo "Deleting orphaned (untracked) SNS topic: ${arn}"
+              aws sns delete-topic --topic-arn "${arn}" --region "${AWS_REGION}" || echo "Warning: could not delete ${arn}"
+            fi
+          done
+
       - name: Deploy Data stack (01-data)
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

When a `01-data` CFN update fails mid-flight and rolls back with `DeletionPolicy:Retain`, SNS topics created before the failure are left untracked by the stack. The next deploy attempt fails:

```
Topic creation failed because the topic already exists
```

This adds a pre-step `Clean up orphaned SNS topics` before the data stack deploy. It lists `enceladus-*-gamma` topics, deletes any NOT currently tracked by the `enceladus-data-gamma` stack, and lets CFN create them cleanly.

Specifically unblocks `enceladus-component-registry-events-gamma` which was orphaned when previous I27 deploy attempts failed on the `DeploymentManagerTable` GSI constraint.

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)