### PR TITLE
fix(data): omit DeploymentManagerTable GSIs that CFN cannot add multi-at-once (I27 unblock)

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -199,14 +199,6 @@ Resources:
           AttributeType: S
         - AttributeName: record_type
           AttributeType: S
-        - AttributeName: status
-          AttributeType: S
-        - AttributeName: created_at
-          AttributeType: S
-        - AttributeName: generation_id
-          AttributeType: S
-        - AttributeName: final_target
-          AttributeType: S
       KeySchema:
         - AttributeName: project_id
           KeyType: HASH
@@ -221,31 +213,12 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-        # GMF GSIs (DOC-63420302EF65 §4.2)
-        - IndexName: status-created-index
-          KeySchema:
-            - AttributeName: status
-              KeyType: HASH
-            - AttributeName: created_at
-              KeyType: RANGE
-          Projection:
-            ProjectionType: ALL
-        - IndexName: generation-created-index
-          KeySchema:
-            - AttributeName: generation_id
-              KeyType: HASH
-            - AttributeName: created_at
-              KeyType: RANGE
-          Projection:
-            ProjectionType: ALL
-        - IndexName: target-created-index
-          KeySchema:
-            - AttributeName: final_target
-              KeyType: HASH
-            - AttributeName: created_at
-              KeyType: RANGE
-          Projection:
-            ProjectionType: ALL
+        # NOTE: status-created-index, generation-created-index, target-created-index
+        # (DOC-63420302EF65 §4.2) were added manually via ddb-add-deployment-manager-gsis
+        # workflow (ENC-TSK-I27) because CloudFormation cannot add multiple GSIs in one
+        # UpdateTable call. They exist in DDB but are intentionally omitted here to avoid
+        # CFN drift-update failures. Re-add one-by-one in future template updates if CFN
+        # tracking is needed.
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary

CloudFormation cannot add multiple GSIs to a DynamoDB table in a single `UpdateTable` call.

The 3 new GSIs (`status-created-index`, `generation-created-index`, `target-created-index`) from DOC-63420302EF65 §4.2 were already added to `devops-deployment-manager-gamma` manually via the `ddb-add-deployment-manager-gsis.yml` dispatch workflow (PR #581). The CFN stack's tracked state still shows only the original `record-type-index`.

When CFN attempts the update, it tries to add all 3 GSIs in one `UpdateTable` call → DynamoDB error: `Cannot perform more than one GSI creation or deletion in a single update`.

This PR removes the 3 GSIs from the template so CFN sees no diff on `DeploymentManagerTable`. The GSIs exist in DynamoDB and are available for queries; they are intentionally untracked by CFN with a documenting comment.

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)