### PR TITLE
feat(data): add GovernanceVersionTable to 01-data.yaml for prod (ENC-TSK-I48 / FTR-116)

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -554,6 +554,28 @@ Resources:
         - Key: Component
           Value: coordination
 
+  # ENC-TSK-I27 / ENC-FTR-116 Wave 2: canonical governance-version record.
+  # Single-item table (version_id = "governance-version-current") written exclusively
+  # by the recompute-governance Lambda (IAM sole-writer enforced by I28).
+  # Single-region only — Global Tables degrade optimistic locking (CAS on cas_version).
+  GovernanceVersionTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "governance-version${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: version_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: version_id
+          KeyType: HASH
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance
+
 Outputs:
   CoordinationTableName:
     Value: !Ref CoordinationRequestsTable
@@ -648,3 +670,12 @@ Outputs:
     Value: !GetAtt AgentTypesTable.Arn
     Export:
       Name: !Sub ${AWS::StackName}-AgentTypesTableArn
+  # ENC-TSK-I27 / ENC-FTR-116 Wave 2: governance-version canonical record table
+  GovernanceVersionTableName:
+    Value: !Ref GovernanceVersionTable
+    Export:
+      Name: !Sub ${AWS::StackName}-GovernanceVersionTable
+  GovernanceVersionTableArn:
+    Value: !GetAtt GovernanceVersionTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-GovernanceVersionTableArn


### PR DESCRIPTION
## What

Ports the `GovernanceVersionTable` DynamoDB resource (`DeletionPolicy: Retain`) + its `GovernanceVersionTableName` / `GovernanceVersionTableArn` Outputs exports from `v4/main` onto `main`'s `01-data.yaml`, so **prod IaC matches** the io-authorized FTR-116 prod-freeze exception deploy.

Resource block is **byte-identical** to the `origin/v4/main` definition (ENC-TSK-I27 / ENC-FTR-116 Wave 2).

## Why now (authorization)

- io authorized an in-session prod-freeze exception for **FTR-116 / I27** (analogous to `DOC-05C45B438FC1` for FTR-117; base freeze `DOC-499FA089EC30`).
- Landing on `main` first keeps prod IaC consistent — the prod data stack is only ever deployed via the io-authorized direct change-set path (no CI data-stack workflow exists), so this avoids live/IaC drift.

## Scope — data-stack piece ONLY

Deferred until **gamma is green** (per **ENC-LSN-039**; `enceladus-compute-gamma` is `UPDATE_ROLLBACK_COMPLETE` and `devops-recompute-governance-gamma` is absent):
- `RecomputeGovernanceFunction` + S3 `ObjectCreated` wiring (ENC-TSK-I28)
- ENC-ISS-306 / I24 `mcp-code` live Function URL import

## Deploy evidence (pre-merge)

Change-set preview vs prod `enceladus-data`: **exactly one change — `Add GovernanceVersionTable` (`AWS::DynamoDB::Table`), Replacement `None`, zero Modify/Remove/Replace** — satisfies the `DOC-05C45B438FC1` Add-only discipline. Template validates; no IAM capabilities required.

CCI-efa944ca9b334648b19547b1136f16bb

🤖 Generated with [Claude Code](https://claude.com/claude-code)