### PR TITLE
fix(ci): add S3 notification + Lambda perms to CFN role, switch to CFN role for wiring (I28)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
@@ -83,6 +83,27 @@ jobs:
                   "sqs:UntagQueue"
                 ],
                 "Resource": "arn:aws:sqs:us-west-2:356364570033:devops-*-gamma*"
+              },
+              {
+                "Sid": "S3GovernanceBucketNotification",
+                "Effect": "Allow",
+                "Action": [
+                  "s3:GetBucketNotification",
+                  "s3:PutBucketNotification",
+                  "s3:GetBucketNotificationConfiguration",
+                  "s3:PutBucketNotificationConfiguration"
+                ],
+                "Resource": "arn:aws:s3:::jreese-net"
+              },
+              {
+                "Sid": "LambdaGovernancePermission",
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:AddPermission",
+                  "lambda:RemovePermission",
+                  "lambda:GetPolicy"
+                ],
+                "Resource": "arn:aws:lambda:us-west-2:356364570033:function:devops-recompute-governance*"
               }
             ]
           }

--- a/.github/workflows/s3-governance-notification-wire.yml
+++ b/.github/workflows/s3-governance-notification-wire.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
           aws-region: us-west-2
 
       - name: Verify caller identity


### PR DESCRIPTION
## Summary

Two fixes for ENC-TSK-I28 S3 notification wiring:

1. Extends `iam-cfn-deploy-role-gamma-patch.yml` to also grant `S3GovernanceBucketNotification` and `LambdaGovernancePermission` statements to `enceladus-cloudformation-deploy-github-role`. The backend deploy role lacks `s3:PutBucketNotification`.

2. Switches `s3-governance-notification-wire.yml` to use `AWS_CLOUDFORMATION_ROLE_TO_ASSUME` instead of `AWS_BACKEND_ROLE_TO_ASSUME`.

After merge: trigger `iam-cfn-deploy-role-gamma-patch.yml` to apply the new permissions, then trigger `s3-governance-notification-wire.yml`.

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)