### PR TITLE
fix(ci): handle empty S3 notification config in wiring workflow (I28)

### DIFF
--- a/.github/workflows/s3-governance-notification-wire.yml
+++ b/.github/workflows/s3-governance-notification-wire.yml
@@ -73,10 +73,17 @@ jobs:
           lambda_arn="arn:aws:lambda:${region}:${account}:function:${fn}"
           entry_id="GovernanceLiveRecompute${SUFFIX//-/}"
 
-          # Fetch current notification config into a temp file (preserves other notifications)
+          # Fetch current notification config into a temp file (preserves other notifications).
+          # The CLI returns empty string (not "{}") when no notifications exist, so we check
+          # the file size and write an explicit empty config if the output was empty.
           aws s3api get-bucket-notification-configuration \
             --bucket "${bucket}" --region "${region}" \
-            > /tmp/s3-notify-current.json 2>/dev/null || echo '{}' > /tmp/s3-notify-current.json
+            > /tmp/s3-notify-current.json 2>/dev/null || true
+          if [ ! -s /tmp/s3-notify-current.json ]; then
+            echo '{}' > /tmp/s3-notify-current.json
+          fi
+          echo "Current config:"
+          cat /tmp/s3-notify-current.json
 
           # Build the new LambdaFunctionConfigurations entry in a temp file
           cat > /tmp/s3-notify-new.json <<JSON


### PR DESCRIPTION
## Summary

`aws s3api get-bucket-notification-configuration` returns an empty string (not `{}`) when the bucket has no existing notification configuration. The Python merge script failed with `JSONDecodeError` on the empty file.

Adds a file-size check after fetching the current config: if the file is empty (0 bytes), writes an explicit `{}` so the Python merge works correctly.

CCI-d4fe751637674c378f4a6abe6f5c062b (I27)
CCI-7e227873151e4c94baf80f1789a0f4d7 (I28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)