### PR TITLE
ENC-FTR-116 / ENC-TSK-I29: governance hash cutover — canonical DDB primary, remove docstore fallback

### DIFF
--- a/.github/workflows/iam-coordination-api-gamma-govversion-grant.yml
+++ b/.github/workflows/iam-coordination-api-gamma-govversion-grant.yml
@@ -1,0 +1,72 @@
+name: IAM Coordination API Gamma — governance-version DDB Read Grant
+
+# ENC-FTR-116 / ENC-TSK-I29: grant devops-coordination-api-lambda-role-gamma
+# GetItem access to governance-version-gamma (the canonical governance hash record
+# created by ENC-TSK-I27 / devops-recompute-governance).
+#
+# Run ONCE after the table exists (created by 01-data CFN update in I27) and before
+# coordination_api + enceladus-mcp-code-gamma code deploys that read from it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this grant is being applied"
+        type: string
+        required: false
+        default: "ENC-TSK-I29: allow coordination_api + MCP server to read canonical governance-version-gamma record"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  grant:
+    name: Grant governance-version-gamma GetItem to coordination-api-gamma role
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy
+        run: |
+          set -euo pipefail
+          cat > /tmp/gov-version-read-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "GovernanceVersionTableRead",
+                "Effect": "Allow",
+                "Action": [
+                  "dynamodb:GetItem"
+                ],
+                "Resource": [
+                  "arn:aws:dynamodb:us-west-2:356364570033:table/governance-version-gamma"
+                ]
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "devops-coordination-api-lambda-role-gamma" \
+            --policy-name "enceladus-coordination-api-gamma-govversion-read-v1" \
+            --policy-document "file:///tmp/gov-version-read-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          set -euo pipefail
+          aws iam get-role-policy \
+            --role-name "devops-coordination-api-lambda-role-gamma" \
+            --policy-name "enceladus-coordination-api-gamma-govversion-read-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.03",
-  "updated_at": "2026-06-27T05:00:00Z",
-  "last_change_summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: document governance.version_record (canonical DDB record, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated Lambda contract).",
+  "version": "2026-06-27.04",
+  "updated_at": "2026-06-27T08:00:00Z",
+  "last_change_summary": "ENC-TSK-I29 / ENC-FTR-116 Wave 2: governance hash cutover — canonical DDB-primary resolution in coordination_api (_compute_governance_hash_local) and enceladus-mcp-server (_get_governance_hash_via_api). Docstore-catalog fallback removed from call chain in both. New entities: coordination_api.governance_hash_resolution, mcp_server.governance_hash_resolution.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5564,6 +5564,52 @@
         "env_vars": {
           "type": "object",
           "definition": "GOVERNANCE_VERSION_TABLE: table name (governance-version or governance-version-gamma). AWS_REGION: us-west-2."
+        }
+      }
+    },
+    "coordination_api.governance_hash_resolution": {
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "fields": {
+        "primary_source": {
+          "type": "object",
+          "definition": "dynamodb.get_item on GOVERNANCE_VERSION_TABLE (governance-version or governance-version-gamma). ConsistentRead=True. Returns governance_hash string from the governance-version-current record. Raises RuntimeError when record is missing or governance_hash attribute is empty."
+        },
+        "secondary_source": {
+          "type": "object",
+          "definition": "MCP server module _compute_governance_hash(force_refresh=True). Reads directly from S3 governance/live/ prefix. Only invoked when primary_source raises."
+        },
+        "removed_fallback": {
+          "type": "object",
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma (injected via CFN 02-compute.yaml EnvironmentSuffix sub). GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
+        }
+      }
+    },
+    "mcp_server.governance_hash_resolution": {
+      "description": "Hash resolution chain in enceladus-mcp-server._get_governance_hash_via_api() after the ENC-TSK-I29 cutover. Four-tier resolution with 60s TTL cache.",
+      "fields": {
+        "tier_1_api_hash": {
+          "type": "object",
+          "definition": "coordination API GET /hash endpoint. After I29 lands, the API's _compute_governance_hash_local() returns the canonical DDB value, so tier 1 is transitively canonical. TTL: 60s (GOVERNANCE_HASH_API_TTL)."
+        },
+        "tier_2_health_api": {
+          "type": "object",
+          "definition": "coordination API health endpoint governance_hash field. Auth-safe fallback for environments where the /hash endpoint requires internal API key."
+        },
+        "tier_3_canonical_ddb": {
+          "type": "object",
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+        },
+        "tier_4_s3_catalog": {
+          "type": "object",
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma. GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
         }
       }
     }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -121,6 +121,9 @@ PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
 COMPONENTS_TABLE = os.environ.get("COMPONENTS_TABLE", "component-registry")
 DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
 GOVERNANCE_POLICIES_TABLE = os.environ.get("GOVERNANCE_POLICIES_TABLE", "governance-policies")
+# ENC-TSK-I27 / ENC-FTR-116: canonical governance-version record written by devops-recompute-governance.
+GOVERNANCE_VERSION_TABLE = os.environ.get("GOVERNANCE_VERSION_TABLE", "governance-version")
+GOVERNANCE_VERSION_RECORD_ID = "governance-version-current"
 AUTH_TOKENS_TABLE = os.environ.get("AUTH_TOKENS_TABLE", GOVERNANCE_POLICIES_TABLE)
 DYNAMODB_REGION = os.environ.get("DYNAMODB_REGION", "us-west-2")
 SSM_REGION = os.environ.get("SSM_REGION", "us-west-2")
@@ -1498,12 +1501,50 @@ def _parse_mcp_result(result: Any) -> Dict[str, Any]:
     return {"result": data}
 
 
-def _compute_governance_hash_local() -> str:
-    """Compute hash from the MCP governance source (S3-backed) with fallback.
+def _get_canonical_governance_hash_ddb() -> str:
+    """Read governance_hash from the canonical governance-version DDB record (ENC-TSK-I27).
 
-    Keep coordination API hash aligned with MCP tool/resource reads to avoid
-    false GOVERNANCE_STALE rejections.
+    This record is the single authoritative source written by devops-recompute-governance Lambda,
+    which derives the hash from live S3 checksums (HeadObject). It is always consistent with
+    live S3 state and never returns a stale frozen hash after a governance/live/* change.
     """
+    ddb = _get_ddb()
+    resp = ddb.get_item(
+        TableName=GOVERNANCE_VERSION_TABLE,
+        Key={"version_id": {"S": GOVERNANCE_VERSION_RECORD_ID}},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item", {})
+    h = str((item.get("governance_hash") or {}).get("S", "")).strip()
+    if not h:
+        raise RuntimeError(
+            f"Canonical governance-version record missing or empty "
+            f"(table={GOVERNANCE_VERSION_TABLE}, key={GOVERNANCE_VERSION_RECORD_ID})"
+        )
+    return h
+
+
+def _compute_governance_hash_local() -> str:
+    """Read governance hash from authoritative sources (ENC-TSK-I29).
+
+    Resolution order:
+      1) Canonical governance-version DDB record (devops-recompute-governance output;
+         always live S3-consistent; never a frozen stale value).
+      2) Direct S3 recomputation via MCP server module (live-derived; tie-breaks if DDB
+         temporarily behind).
+
+    The docstore-catalog fallback is intentionally removed: it could silently serve a
+    frozen hash after a governance/live/* change, violating the complete-mediation
+    guarantee (DOC-63420302EF65 §2.3). If both sources fail, callers receive "" which
+    propagates as GOVERNANCE_STALE rather than a silently wrong hash.
+    """
+    try:
+        return _get_canonical_governance_hash_ddb()
+    except Exception as exc:
+        logger.warning(
+            "Canonical governance-version DDB unavailable; falling back to live S3 computation: %s", exc
+        )
+
     try:
         module = _load_mcp_server_module()
         compute = getattr(module, "_compute_governance_hash", None)
@@ -1516,12 +1557,18 @@ def _compute_governance_hash_local() -> str:
             if text:
                 return text
     except Exception as exc:
-        logger.warning("MCP-backed governance hash failed; falling back to docstore: %s", exc)
+        logger.warning("MCP-backed live S3 governance hash computation failed: %s", exc)
 
-    return _compute_governance_hash_docstore_fallback()
+    logger.error("All governance hash sources failed (canonical DDB + MCP S3); returning empty hash")
+    return ""
 
 
 def _compute_governance_hash_docstore_fallback() -> str:
+    """Deprecated: reads from docstore DDB scan (stale after live S3 changes). No longer called.
+
+    Retained for any external callers or tests that reference it directly.
+    Use _get_canonical_governance_hash_ddb() or _compute_governance_hash_local() instead.
+    """
     ddb = _get_ddb()
     resp = ddb.query(
         TableName=DOCUMENTS_TABLE,

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -183,6 +183,8 @@ Resources:
           ENCELADUS_MCP_INTERFACE_MODE: code
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-FTR-116 / ENC-TSK-I29: canonical governance-version DDB record.
+          GOVERNANCE_VERSION_TABLE: !Sub "governance-version${EnvironmentSuffix}"
           # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
@@ -3582,6 +3584,8 @@ Resources:
           DOCUMENTS_TABLE: documents-gamma
           GOVERNANCE_POLICIES_TABLE: governance-policies-gamma
           GOVERNANCE_DICTIONARY_POLICY_ID: governance_data_dictionary
+          # ENC-FTR-116 / ENC-TSK-I29: canonical governance-version DDB record.
+          GOVERNANCE_VERSION_TABLE: governance-version-gamma
           DYNAMODB_REGION: us-west-2
           SECRETS_REGION: us-west-2
           S3_BUCKET: jreese-net

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -158,6 +158,9 @@ GOVERNANCE_RESOURCE_BODY_TTL_SECONDS = float(
 )
 S3_GOVERNANCE_PREFIX = os.environ.get("ENCELADUS_S3_GOVERNANCE_PREFIX", "governance/live")
 S3_GOVERNANCE_HISTORY_PREFIX = os.environ.get("ENCELADUS_S3_GOVERNANCE_HISTORY_PREFIX", "governance/history")
+# ENC-TSK-I27 / ENC-FTR-116: canonical governance-version record written by devops-recompute-governance.
+GOVERNANCE_VERSION_TABLE = os.environ.get("GOVERNANCE_VERSION_TABLE", "governance-version")
+GOVERNANCE_VERSION_RECORD_ID = "governance-version-current"
 
 COORDINATION_API_BASE = os.environ.get(
     "ENCELADUS_COORDINATION_API_BASE",
@@ -1498,13 +1501,36 @@ _governance_hash_api_cache_at: float = 0.0
 _GOVERNANCE_HASH_API_TTL = 60.0  # seconds
 
 
+def _get_canonical_governance_hash_ddb() -> str:
+    """Read governance_hash from the canonical governance-version DDB record (ENC-TSK-I27).
+
+    Uses GOVERNANCE_VERSION_TABLE env var (default: "governance-version"). Bypasses HTTP
+    entirely — valid even when coordination API is unreachable.
+    """
+    ddb = _get_ddb()
+    resp = ddb.get_item(
+        TableName=GOVERNANCE_VERSION_TABLE,
+        Key={"version_id": {"S": GOVERNANCE_VERSION_RECORD_ID}},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item", {})
+    h = str((item.get("governance_hash") or {}).get("S", "")).strip()
+    if not h:
+        raise RuntimeError(
+            f"Canonical governance-version record missing or empty "
+            f"(table={GOVERNANCE_VERSION_TABLE}, key={GOVERNANCE_VERSION_RECORD_ID})"
+        )
+    return h
+
+
 def _get_governance_hash_via_api() -> str:
     """Fetch governance hash from HTTP API with short TTL cache.
 
-    Resolution order:
-      1) governance API /hash (authoritative)
-      2) health API governance_hash (auth-safe fallback)
-      3) local computation from governance resources
+    Resolution order (ENC-TSK-I29):
+      1) governance API /hash (canonical DDB-backed after I29 coordination_api cutover)
+      2) health API governance_hash (auth-safe HTTP fallback)
+      3) canonical governance-version DDB direct read (bypasses HTTP entirely)
+      4) local computation from S3 catalog (last resort; no docstore path)
     """
     global _governance_hash_api_cache, _governance_hash_api_cache_at
     now = time.time()
@@ -1535,7 +1561,15 @@ def _get_governance_hash_via_api() -> str:
     except Exception:
         pass
 
-    # Final fallback to local computation.
+    # Canonical DDB direct read — bypasses HTTP auth and coordination API dependency.
+    try:
+        h = _get_canonical_governance_hash_ddb()
+        if h:
+            return _cache_and_return(h)
+    except Exception:
+        pass
+
+    # Final fallback: local S3 catalog computation (no docstore path).
     return _compute_governance_hash()
 
 


### PR DESCRIPTION
## Summary

- **coordination_api `_compute_governance_hash_local()`**: new primary reads from `governance-version` DDB table (canonical record written by `devops-recompute-governance`; always live S3-consistent). MCP S3 module retained as secondary. Docstore-catalog fallback **removed from call chain** — could silently return a frozen hash after `governance/live/*` changes, violating complete-mediation guarantee (DOC-63420302EF65 §2.3).
- **`enceladus-mcp-server/server.py`**: `_get_canonical_governance_hash_ddb()` added; `_get_governance_hash_via_api()` resolution chain extended to: API /hash → health API → canonical DDB direct → S3 catalog (no docstore path anywhere).
- **`02-compute.yaml`**: `GOVERNANCE_VERSION_TABLE` env var wired to `CoordinationApiFunction` (prod/gamma via `!Sub`) and `enceladus-mcp-code-gamma` (hardcoded gamma).
- **`iam-coordination-api-gamma-govversion-grant.yml`**: `workflow_dispatch` to grant `dynamodb:GetItem` on `governance-version-gamma` to `devops-coordination-api-lambda-role-gamma` (shared by both `devops-coordination-api-gamma` and `enceladus-mcp-code-gamma`). **Run this before validating.**

## Deployment sequence (post-merge)

1. `v4/main` push triggers CFN compute stack update (adds `GOVERNANCE_VERSION_TABLE` env var)
2. Trigger `iam-coordination-api-gamma-govversion-grant` workflow (one-time IAM grant)
3. Lambda code deploy for `devops-coordination-api-gamma` (via `_deploy.yml` full-stack)
4. Redeploy `enceladus-mcp-code-gamma` (out-of-band `update-function-code`)

## Relation

Wave 2 of ENC-FTR-116. I29 (connection_health cutover) + I27 (canonical DDB record) together constitute the Wave 3 trigger.

CCI-431db7001698432aa76ff26fcf382675