### PR TITLE
feat(governance): backfill script + drift-detection backstop (ENC-TSK-I32)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.04",
-  "updated_at": "2026-06-27T08:00:00Z",
-  "last_change_summary": "ENC-TSK-I29 / ENC-FTR-116 Wave 2: governance hash cutover — canonical DDB-primary resolution in coordination_api (_compute_governance_hash_local) and enceladus-mcp-server (_get_governance_hash_via_api). Docstore-catalog fallback removed from call chain in both. New entities: coordination_api.governance_hash_resolution, mcp_server.governance_hash_resolution.",
+  "version": "2026-06-27.05",
+  "updated_at": "2026-06-27T08:10:00Z",
+  "last_change_summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop (governance_drift_check Lambda) — reads canonical DDB + live S3 checksums, emits GovernanceVersionDrift CloudWatch metric and SNS alert on mismatch. Read-only; never writes canonical record. New entity: governance_drift_check.handler.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5612,10 +5612,36 @@
           "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma. GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
         }
       }
+    },
+    "governance_drift_check.handler": {
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "fields": {
+        "drift_metric": {
+          "type": "object",
+          "definition": "CloudWatch metric GovernanceVersionDrift in namespace Enceladus/Governance. 1.0 = drift detected or recompute failed; 0.0 = canonical record agrees with live S3. CloudWatch alarm fires on 1.0. DRIFT_METRIC_NAMESPACE env var (default: Enceladus/Governance)."
+        },
+        "sns_alert": {
+          "type": "object",
+          "definition": "SNS notification (GOVERNANCE_ALERT_SNS_ARN env var) published when drift is detected, recompute fails, or the canonical record is missing. Same topic as governance_audit anomaly alerts."
+        },
+        "read_only_invariant": {
+          "type": "object",
+          "definition": "This Lambda NEVER writes the canonical governance-version record (sole-writer = devops-recompute-governance, I28) and never writes to governance/live/* (recursion safety). It is a read-only auditor."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE (default: governance-version), GOVERNANCE_S3_BUCKET (default: jreese-net), DRIFT_METRIC_NAMESPACE (default: Enceladus/Governance), GOVERNANCE_ALERT_SNS_ARN."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
   "change_log": [
+    {
+      "version": "2026-06-27.05",
+      "date": "2026-06-27",
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
     {
       "version": "2026-06-27.01",
       "date": "2026-06-27",

--- a/backend/lambda/governance_drift_check/deploy.sh
+++ b/backend/lambda/governance_drift_check/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/governance_drift_check/lambda_function.py
+++ b/backend/lambda/governance_drift_check/lambda_function.py
@@ -1,0 +1,359 @@
+"""Governance drift-detection backstop — canonical record vs. live S3 reconcile.
+
+ENC-TSK-I32 / ENC-FTR-116 — DOC-6F7A14667E7D §8 ("the drift backstop") + §3
+("a drift backstop reconciles").
+
+The storage-event recompute Lambda (``recompute_governance``) keeps the canonical
+``governance-version`` DynamoDB record in agreement with live S3 by reacting to
+``s3:ObjectCreated`` events. S3 event delivery is at-least-once and unordered,
+and an event can in principle be lost; the recompute can also fail. This Lambda
+is the Argo/FIM-style backstop: on a schedule it independently recomputes the
+§4.3 bundle hash from current live S3 object checksums and compares it against
+the stored canonical record. Disagreement (or a failed recompute, or a missing
+record) is surfaced as:
+
+  * a CloudWatch metric ``GovernanceVersionDrift`` (1.0 = drift, 0.0 = agree) in
+    namespace ``Enceladus/Governance`` — a CloudWatch alarm fires on this; and
+  * an SNS alert (same topic/style as the governance_audit anomaly detector).
+
+Read-only with respect to governance: this Lambda NEVER writes the canonical
+record (that is the recompute Lambda's sole-writer responsibility, I28) and never
+writes back to ``governance/live/*`` (recursion safety). It only reads S3 + DDB
+and emits a metric / alert.
+
+The §4.3 hashing contract below MUST stay byte-for-byte in sync with
+``recompute_governance/lambda_function.py`` — ``test_lambda_function`` pins it to
+the spec value so a divergence is caught in CI.
+
+Related: ENC-ISS-390, ENC-LSN-055, ENC-TSK-I27, ENC-TSK-I28.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# ---------------------------------------------------------------------------
+# Configuration (mirrors recompute_governance for the shared contract)
+# ---------------------------------------------------------------------------
+
+S3_BUCKET = os.environ.get("GOVERNANCE_S3_BUCKET", "jreese-net")
+S3_GOVERNANCE_PREFIX = "governance/live"
+TABLE_NAME = os.environ.get("GOVERNANCE_VERSION_TABLE", "governance-version")
+CANONICAL_ITEM_KEY = "governance-version-current"
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+DRIFT_METRIC_NAMESPACE = os.environ.get("DRIFT_METRIC_NAMESPACE", "Enceladus/Governance")
+DRIFT_METRIC_NAME = "GovernanceVersionDrift"
+SNS_TOPIC_ARN = os.environ.get(
+    "GOVERNANCE_ALERT_SNS_ARN",
+    "arn:aws:sns:us-west-2:356364570033:devops-project-json-sync",
+)
+
+_s3_client = None
+_ddb_client = None
+_cw_client = None
+_sns_client = None
+
+
+def _get_s3():
+    global _s3_client
+    if _s3_client is None:
+        import boto3
+        _s3_client = boto3.client("s3", region_name=REGION)
+    return _s3_client
+
+
+def _get_ddb():
+    global _ddb_client
+    if _ddb_client is None:
+        import boto3
+        _ddb_client = boto3.client("dynamodb", region_name=REGION)
+    return _ddb_client
+
+
+def _get_cw():
+    global _cw_client
+    if _cw_client is None:
+        import boto3
+        _cw_client = boto3.client("cloudwatch", region_name=REGION)
+    return _cw_client
+
+
+def _get_sns():
+    global _sns_client
+    if _sns_client is None:
+        import boto3
+        _sns_client = boto3.client("sns", region_name=REGION)
+    return _sns_client
+
+
+# ---------------------------------------------------------------------------
+# Canonical file set + §4.3 hashing — keep in sync with recompute_governance
+# ---------------------------------------------------------------------------
+
+def _s3_key_to_uri(s3_key: str) -> str:
+    rel = s3_key[len(S3_GOVERNANCE_PREFIX) + 1:]
+    return f"governance://{rel}"
+
+
+def _list_canonical_files() -> list[tuple[str, str]]:
+    """Return (governance_uri, s3_key) for all canonical files, lex-sorted by URI."""
+    files: list[tuple[str, str]] = []
+
+    agents_md = f"{S3_GOVERNANCE_PREFIX}/agents.md"
+    try:
+        _get_s3().head_object(Bucket=S3_BUCKET, Key=agents_md)
+        files.append((_s3_key_to_uri(agents_md), agents_md))
+    except Exception:
+        logger.warning("agents.md not found in S3; excluding from canonical set")
+
+    paginator = _get_s3().get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=f"{S3_GOVERNANCE_PREFIX}/agents/"):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            files.append((_s3_key_to_uri(key), key))
+
+    files.sort(key=lambda t: t[0])
+    return files
+
+
+def _get_file_checksum(s3_key: str) -> tuple[str, str]:
+    """Return (checksum_sha256_hex, s3_version_id) via GetObjectAttributes."""
+    resp = _get_s3().get_object_attributes(
+        Bucket=S3_BUCKET,
+        Key=s3_key,
+        ObjectAttributes=["Checksum"],
+    )
+    b64 = (resp.get("Checksum") or {}).get("ChecksumSHA256")
+    if not b64:
+        raise ValueError(
+            f"No ChecksumSHA256 on {s3_key}. "
+            "Governance uploads must carry SHA256 additional checksum."
+        )
+    return base64.b64decode(b64).hex(), resp.get("VersionId", "")
+
+
+def _read_governance_revision(agents_md_key: str) -> str:
+    resp = _get_s3().get_object(Bucket=S3_BUCKET, Key=agents_md_key)
+    content = resp["Body"].read().decode("utf-8")
+    m = re.search(r"(?:^|\n)governance_revision:\s*(\S+)", content)
+    return m.group(1).strip() if m else "unknown"
+
+
+def _compute_bundle_hash(file_entries: list[dict[str, str]]) -> str:
+    """§4.3: sha256( concat(URI + \\n + hex_fingerprint + \\n) ) in lex URI order."""
+    h = hashlib.sha256()
+    for entry in file_entries:
+        h.update(entry["uri"].encode())
+        h.update(b"\n")
+        h.update(entry["checksum_sha256_hex"].encode())
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def _recompute_live_state() -> dict[str, Any]:
+    """Recompute governance_hash + per-file fingerprints from current live S3."""
+    canonical = _list_canonical_files()
+    if not canonical:
+        raise RuntimeError("Canonical governance file set is empty in live S3")
+
+    agents_md_key = f"{S3_GOVERNANCE_PREFIX}/agents.md"
+    governance_revision = _read_governance_revision(agents_md_key)
+
+    file_entries: list[dict[str, str]] = []
+    for uri, s3_key in canonical:
+        checksum_hex, version_id = _get_file_checksum(s3_key)
+        file_entries.append(
+            {
+                "uri": uri,
+                "s3_key": s3_key,
+                "s3_version_id": version_id,
+                "checksum_sha256_hex": checksum_hex,
+            }
+        )
+
+    return {
+        "governance_hash": _compute_bundle_hash(file_entries),
+        "governance_revision": governance_revision,
+        "files": file_entries,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Canonical record read
+# ---------------------------------------------------------------------------
+
+def _read_canonical_record() -> dict[str, Any] | None:
+    resp = _get_ddb().get_item(
+        TableName=TABLE_NAME,
+        Key={"version_id": {"S": CANONICAL_ITEM_KEY}},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item")
+    if not item:
+        return None
+    files_raw = item.get("files", {}).get("S", "[]")
+    try:
+        files = json.loads(files_raw)
+    except (ValueError, TypeError):
+        files = []
+    return {
+        "governance_hash": item.get("governance_hash", {}).get("S", ""),
+        "governance_revision": item.get("governance_revision", {}).get("S", ""),
+        "generation": int(item.get("generation", {}).get("N", "0")),
+        "files": files,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Drift comparison
+# ---------------------------------------------------------------------------
+
+def _file_fingerprints(files: list[dict[str, str]]) -> dict[str, str]:
+    """Map uri -> checksum_sha256_hex for a cheap per-file comparison."""
+    return {f.get("uri", ""): f.get("checksum_sha256_hex", "") for f in files}
+
+
+def detect_drift() -> dict[str, Any]:
+    """Compare the canonical record against freshly-recomputed live S3 state.
+
+    Returns a result dict with ``drift`` (bool), ``reason``, and detail fields.
+    A recompute failure or a missing record is treated as drift (fail-closed).
+    """
+    try:
+        live = _recompute_live_state()
+    except Exception as exc:  # recompute failure is itself a drift signal
+        logger.error("[DRIFT] recompute from live S3 failed: %s", exc)
+        return {
+            "drift": True,
+            "reason": "recompute_failure",
+            "message": f"Failed to recompute governance hash from live S3: {exc}",
+        }
+
+    record = _read_canonical_record()
+    if record is None:
+        return {
+            "drift": True,
+            "reason": "record_missing",
+            "message": (
+                "Canonical governance-version record does not exist; run the "
+                "backfill seed (ENC-TSK-I32) or check the recompute Lambda."
+            ),
+            "live_governance_hash": live["governance_hash"],
+            "live_governance_revision": live["governance_revision"],
+        }
+
+    hash_agrees = record["governance_hash"] == live["governance_hash"]
+    revision_agrees = record["governance_revision"] == live["governance_revision"]
+
+    live_fp = _file_fingerprints(live["files"])
+    record_fp = _file_fingerprints(record["files"])
+    mismatched_files = sorted(
+        uri
+        for uri in set(live_fp) | set(record_fp)
+        if live_fp.get(uri) != record_fp.get(uri)
+    )
+
+    drift = not hash_agrees or bool(mismatched_files)
+    result = {
+        "drift": drift,
+        "reason": "hash_mismatch" if drift else "agree",
+        "generation": record["generation"],
+        "hash_agrees": hash_agrees,
+        "revision_agrees": revision_agrees,
+        "record_governance_hash": record["governance_hash"],
+        "live_governance_hash": live["governance_hash"],
+        "record_governance_revision": record["governance_revision"],
+        "live_governance_revision": live["governance_revision"],
+        "mismatched_files": mismatched_files,
+    }
+    if drift:
+        result["message"] = (
+            "Canonical governance-version record disagrees with live S3: "
+            f"hash_agrees={hash_agrees}, mismatched_files={mismatched_files}."
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Emit: CloudWatch metric + SNS alert
+# ---------------------------------------------------------------------------
+
+def _emit_metric(drift: bool) -> None:
+    try:
+        _get_cw().put_metric_data(
+            Namespace=DRIFT_METRIC_NAMESPACE,
+            MetricData=[
+                {
+                    "MetricName": DRIFT_METRIC_NAME,
+                    "Value": 1.0 if drift else 0.0,
+                    "Unit": "Count",
+                }
+            ],
+        )
+    except Exception as exc:  # never let telemetry failure mask the check
+        logger.error("[ERROR] Failed to emit CloudWatch metric: %s", exc)
+
+
+def _publish_alert(result: dict[str, Any]) -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    alert = {
+        "alert_type": "GOVERNANCE_VERSION_DRIFT",
+        "reason": result.get("reason"),
+        "message": result.get("message", "governance version drift detected"),
+        "record_governance_hash": result.get("record_governance_hash"),
+        "live_governance_hash": result.get("live_governance_hash"),
+        "mismatched_files": result.get("mismatched_files"),
+        "generation": result.get("generation"),
+        "detected_at": now,
+    }
+    subject = f"[GOVERNANCE] Version drift detected: {result.get('reason')}"
+    try:
+        _get_sns().publish(
+            TopicArn=SNS_TOPIC_ARN,
+            Subject=subject[:100],
+            Message=json.dumps(alert, indent=2),
+            MessageAttributes={
+                "alert_type": {
+                    "DataType": "String",
+                    "StringValue": "GOVERNANCE_VERSION_DRIFT",
+                },
+            },
+        )
+        logger.warning("[GOVERNANCE] Drift alert published: %s", result.get("reason"))
+    except Exception as exc:
+        logger.error("[ERROR] Failed to publish SNS drift alert: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def handler(event: dict, context: Any) -> dict[str, Any]:
+    """Scheduled (or on-demand) drift check. Emits metric + alert; returns result."""
+    result = detect_drift()
+    drift = bool(result.get("drift"))
+
+    _emit_metric(drift)
+    if drift:
+        _publish_alert(result)
+        logger.warning("[GOVERNANCE] %s", result.get("message", "drift detected"))
+    else:
+        logger.info(
+            "[GOVERNANCE] No drift: generation=%s hash=%s",
+            result.get("generation"),
+            str(result.get("record_governance_hash"))[:16],
+        )
+
+    logger.info("[END] Governance drift check: %s", json.dumps({k: result[k] for k in ("drift", "reason")}))
+    return result

--- a/backend/lambda/governance_drift_check/test_lambda_function.py
+++ b/backend/lambda/governance_drift_check/test_lambda_function.py
@@ -1,0 +1,210 @@
+"""Tests for governance_drift_check Lambda — ENC-TSK-I32 / ENC-FTR-116.
+
+Covers:
+  - No drift when the canonical record agrees with live S3
+  - Drift on bundle-hash mismatch (per-file checksum change)
+  - Drift when the canonical record is missing (fail-closed)
+  - Drift when the recompute from live S3 fails (fail-closed)
+  - The metric + SNS alert fire only on drift
+  - Read-only: handler never writes DDB or S3
+  - §4.3 bundle-hash contract pinned to the spec value (kept in sync with
+    recompute_governance)
+"""
+
+import hashlib
+
+import lambda_function as mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _live(hash_="h_live", revision="2026-06-27.01", files=None):
+    if files is None:
+        files = [
+            {
+                "uri": "governance://agents.md",
+                "s3_key": "governance/live/agents.md",
+                "s3_version_id": "v1",
+                "checksum_sha256_hex": "aabbcc",
+            }
+        ]
+    return {"governance_hash": hash_, "governance_revision": revision, "files": files}
+
+
+def _record(hash_="h_live", revision="2026-06-27.01", generation=1, files=None):
+    if files is None:
+        files = [
+            {
+                "uri": "governance://agents.md",
+                "s3_key": "governance/live/agents.md",
+                "s3_version_id": "v1",
+                "checksum_sha256_hex": "aabbcc",
+            }
+        ]
+    return {
+        "governance_hash": hash_,
+        "governance_revision": revision,
+        "generation": generation,
+        "files": files,
+    }
+
+
+def _patch_emit(monkeypatch):
+    """Capture metric + alert emissions instead of calling AWS."""
+    emitted = {"metric": [], "alerts": []}
+    monkeypatch.setattr(mod, "_emit_metric", lambda drift: emitted["metric"].append(drift))
+    monkeypatch.setattr(mod, "_publish_alert", lambda result: emitted["alerts"].append(result))
+    return emitted
+
+
+# ---------------------------------------------------------------------------
+# detect_drift
+# ---------------------------------------------------------------------------
+
+def test_no_drift_when_record_agrees(monkeypatch):
+    monkeypatch.setattr(mod, "_recompute_live_state", lambda: _live())
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: _record())
+
+    result = mod.detect_drift()
+
+    assert result["drift"] is False
+    assert result["reason"] == "agree"
+    assert result["hash_agrees"] is True
+    assert result["mismatched_files"] == []
+
+
+def test_drift_on_hash_mismatch(monkeypatch):
+    live_files = [
+        {
+            "uri": "governance://agents.md",
+            "s3_key": "governance/live/agents.md",
+            "s3_version_id": "v2",
+            "checksum_sha256_hex": "NEWSUM",
+        }
+    ]
+    monkeypatch.setattr(mod, "_recompute_live_state", lambda: _live(hash_="h_new", files=live_files))
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: _record(hash_="h_old"))
+
+    result = mod.detect_drift()
+
+    assert result["drift"] is True
+    assert result["reason"] == "hash_mismatch"
+    assert result["hash_agrees"] is False
+    assert "governance://agents.md" in result["mismatched_files"]
+
+
+def test_drift_when_record_missing(monkeypatch):
+    monkeypatch.setattr(mod, "_recompute_live_state", lambda: _live())
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: None)
+
+    result = mod.detect_drift()
+
+    assert result["drift"] is True
+    assert result["reason"] == "record_missing"
+
+
+def test_drift_when_recompute_fails(monkeypatch):
+    def _boom():
+        raise RuntimeError("S3 unavailable")
+
+    monkeypatch.setattr(mod, "_recompute_live_state", _boom)
+    # _read_canonical_record must not even be needed
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: (_ for _ in ()).throw(AssertionError))
+
+    result = mod.detect_drift()
+
+    assert result["drift"] is True
+    assert result["reason"] == "recompute_failure"
+
+
+def test_revision_bump_without_byte_change_is_not_silent(monkeypatch):
+    """A revision change with identical bytes keeps hash agreement but is flagged."""
+    monkeypatch.setattr(mod, "_recompute_live_state", lambda: _live(revision="2026-06-27.02"))
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: _record(revision="2026-06-27.01"))
+
+    result = mod.detect_drift()
+
+    # Hash still agrees (same checksums) so it is not hard drift, but the
+    # revision disagreement is reported for the §4.6 dual-signal discipline.
+    assert result["revision_agrees"] is False
+    assert result["hash_agrees"] is True
+
+
+# ---------------------------------------------------------------------------
+# handler emissions
+# ---------------------------------------------------------------------------
+
+def test_handler_emits_metric_zero_and_no_alert_on_agreement(monkeypatch):
+    emitted = _patch_emit(monkeypatch)
+    monkeypatch.setattr(mod, "detect_drift", lambda: {"drift": False, "reason": "agree", "generation": 1, "record_governance_hash": "h"})
+
+    mod.handler({}, None)
+
+    assert emitted["metric"] == [False]
+    assert emitted["alerts"] == []
+
+
+def test_handler_emits_metric_one_and_alert_on_drift(monkeypatch):
+    emitted = _patch_emit(monkeypatch)
+    monkeypatch.setattr(
+        mod, "detect_drift",
+        lambda: {"drift": True, "reason": "hash_mismatch", "message": "boom"},
+    )
+
+    result = mod.handler({}, None)
+
+    assert emitted["metric"] == [True]
+    assert len(emitted["alerts"]) == 1
+    assert result["reason"] == "hash_mismatch"
+
+
+def test_handler_is_read_only(monkeypatch):
+    """Handler must never write DDB or S3."""
+    monkeypatch.setattr(mod, "_recompute_live_state", lambda: _live())
+    monkeypatch.setattr(mod, "_read_canonical_record", lambda: _record())
+
+    metric_calls = []
+
+    class SafeCW:
+        def put_metric_data(self, **kwargs):
+            metric_calls.append(kwargs)
+
+    class ForbiddenDDB:
+        def put_item(self, **kwargs):
+            raise AssertionError("drift check must not write DDB")
+
+        def update_item(self, **kwargs):
+            raise AssertionError("drift check must not write DDB")
+
+    class ForbiddenS3:
+        def put_object(self, **kwargs):
+            raise AssertionError("drift check must not write S3")
+
+    monkeypatch.setattr(mod, "_cw_client", SafeCW())
+    monkeypatch.setattr(mod, "_ddb_client", ForbiddenDDB())
+    monkeypatch.setattr(mod, "_s3_client", ForbiddenS3())
+    monkeypatch.setattr(mod, "_publish_alert", lambda result: None)
+
+    mod.handler({}, None)
+
+    assert metric_calls and metric_calls[0]["MetricData"][0]["Value"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# §4.3 contract pin (must match recompute_governance byte-for-byte)
+# ---------------------------------------------------------------------------
+
+def test_bundle_hash_matches_spec():
+    entries = [
+        {"uri": "governance://agents.md", "checksum_sha256_hex": "aabbcc"},
+        {"uri": "governance://agents/plan.md", "checksum_sha256_hex": "112233"},
+    ]
+    h = hashlib.sha256()
+    for e in entries:
+        h.update(e["uri"].encode())
+        h.update(b"\n")
+        h.update(e["checksum_sha256_hex"].encode())
+        h.update(b"\n")
+    assert mod._compute_bundle_hash(entries) == h.hexdigest()

--- a/backend/lambda/recompute_governance/backfill_governance_version.py
+++ b/backend/lambda/recompute_governance/backfill_governance_version.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Backfill the canonical governance-version DDB record from current live S3 state.
+
+ENC-TSK-I32 / ENC-FTR-116 — DOC-6F7A14667E7D §8 (backfill and migration).
+
+The canonical ``governance-version-current`` record is normally written only by
+the storage-event recompute Lambda (``lambda_function.handler``). Before that
+Lambda has fired for the first time the record does not exist, so the §13
+version-agreement gate and ``connection_health`` have nothing to read. This
+script performs the one-time seed: it reads the current live S3 state of the
+canonical governance file set, computes the §4.3 bundle hash, captures each
+file's ``versionId`` + ``checksum_sha256_hex`` and the embedded
+``governance_revision``, and writes generation 1 under a first-write CAS guard
+(``attribute_not_exists(version_id)``) — exactly the shape the recompute Lambda
+would have produced.
+
+Safety model (DOC-6F7A14667E7D §8 + the ENC-TSK-I32 row split):
+  * DRY-RUN BY DEFAULT. The actual mutation is deferred to the privileged run.
+    Without ``--commit`` the script only reads, builds the planned record, and
+    emits before/after evidence — it never writes.
+  * IDEMPOTENT SEED. The backfill is a first-write only. If the record already
+    exists (the recompute Lambda already fired, or a prior backfill ran) the
+    script reports ``already_seeded`` and makes no write, even with ``--commit``.
+  * COMPLETE-MEDIATION SAFE. ``--commit`` must run under the sole-writer
+    recompute role (I28 IAM). Every other principal is denied write to the
+    record; a ``--commit`` from an unprivileged principal fails closed at DDB.
+
+Evidence: the script always prints a JSON ``backfill_evidence`` block (and writes
+it to ``--evidence-out`` when given) carrying ``before`` (the record state prior
+to the seed, or null), ``seed`` (the planned/written record), ``after`` (the
+record state after, or the would-be record in dry-run), and ``committed``. This
+is the before/after evidence the ENC-TSK-I32 acceptance criterion requires.
+
+Usage:
+  # Dry-run (default) — read live S3, print the planned record + evidence:
+  python backfill_governance_version.py
+
+  # Privileged seed — actually write generation 1 (sole-writer role required):
+  python backfill_governance_version.py --commit --evidence-out backfill.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+# Import the recompute Lambda module so the backfill reuses the *identical*
+# §4.3 hashing / checksum / canonical-file-set contract. Co-located in this
+# directory; add it to the path so the script runs from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lambda_function as recompute  # noqa: E402
+
+
+def _utcnow_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_full_record() -> dict[str, Any] | None:
+    """Read the full canonical item (all attributes) for before/after evidence.
+
+    Returns a plain-Python projection of the DDB item, or None if absent.
+    """
+    resp = recompute._get_ddb().get_item(
+        TableName=recompute.TABLE_NAME,
+        Key={"version_id": {"S": recompute.CANONICAL_ITEM_KEY}},
+        ConsistentRead=True,
+    )
+    item = resp.get("Item")
+    if not item:
+        return None
+    out: dict[str, Any] = {}
+    for key, attr in item.items():
+        if "S" in attr:
+            out[key] = attr["S"]
+        elif "N" in attr:
+            out[key] = int(attr["N"])
+        else:
+            out[key] = attr
+    # files / source_event are stored as JSON strings; decode for readability.
+    for json_field in ("files", "source_event"):
+        raw = out.get(json_field)
+        if isinstance(raw, str):
+            try:
+                out[json_field] = json.loads(raw)
+            except (ValueError, TypeError):
+                pass
+    return out
+
+
+def build_seed_state() -> dict[str, Any]:
+    """Recompute the canonical seed record from current live S3 state.
+
+    Mirrors ``recompute.handler`` for a first-write: generation 1, per-file
+    versionId + checksum captured, bundle hash + embedded governance_revision.
+    """
+    canonical = recompute._list_canonical_files()
+    if not canonical:
+        raise RuntimeError(
+            "Canonical governance file set is empty in live S3; refusing to "
+            "seed an empty governance-version record."
+        )
+
+    agents_md_key = f"{recompute.S3_GOVERNANCE_PREFIX}/agents.md"
+    governance_revision = recompute._read_governance_revision(agents_md_key)
+
+    file_entries: list[dict[str, str]] = []
+    for uri, s3_key in canonical:
+        checksum_hex, version_id = recompute._get_file_checksum(s3_key)
+        file_entries.append(
+            {
+                "uri": uri,
+                "s3_key": s3_key,
+                "s3_version_id": version_id,
+                "checksum_sha256_hex": checksum_hex,
+            }
+        )
+
+    governance_hash = recompute._compute_bundle_hash(file_entries)
+
+    return {
+        "version_id": recompute.CANONICAL_ITEM_KEY,
+        "governance_revision": governance_revision,
+        "governance_hash": governance_hash,
+        "generation": 1,
+        "cas_version": 1,
+        "files": file_entries,
+        # Marks the record's provenance as a backfill seed (no triggering S3
+        # event). An empty s3_sequencer means the first real recompute event
+        # will not dedup against it and will advance to generation 2.
+        "source_event": {
+            "s3_sequencer": "",
+            "trigger_s3_key": "",
+            "backfill": True,
+            "backfilled_at": _utcnow_iso(),
+        },
+    }
+
+
+def perform_backfill(commit: bool) -> dict[str, Any]:
+    """Run the backfill (dry-run unless commit=True). Returns the evidence dict."""
+    before = _read_full_record()
+    seed = build_seed_state()
+
+    already_seeded = before is not None
+    wrote = False
+    note = ""
+
+    if already_seeded:
+        note = (
+            "Record already exists (generation={}); backfill is a first-write "
+            "seed only and makes no change.".format(before.get("generation"))
+        )
+    elif commit:
+        wrote = recompute._cas_write(
+            governance_revision=seed["governance_revision"],
+            governance_hash=seed["governance_hash"],
+            generation=seed["generation"],
+            file_entries=seed["files"],
+            source_event=seed["source_event"],
+            expected_cas=None,  # first-write guard: attribute_not_exists
+        )
+        note = (
+            "Seed committed (generation=1)."
+            if wrote
+            else "First-write CAS lost a race; another writer seeded the record "
+            "concurrently. No change by this run."
+        )
+    else:
+        note = (
+            "DRY-RUN: no write performed. Re-run with --commit under the "
+            "sole-writer recompute role to seed the record."
+        )
+
+    after = _read_full_record()
+
+    return {
+        "backfill_evidence": {
+            "table": recompute.TABLE_NAME,
+            "version_id": recompute.CANONICAL_ITEM_KEY,
+            "captured_at": _utcnow_iso(),
+            "committed": wrote,
+            "dry_run": not commit,
+            "already_seeded": already_seeded,
+            "note": note,
+            "before": before,
+            "seed": seed,
+            "after": after,
+        }
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill the canonical governance-version record from live S3 "
+            "state (ENC-TSK-I32 / DOC-6F7A14667E7D §8). Dry-run by default."
+        )
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help=(
+            "Actually write the seed record (requires the sole-writer recompute "
+            "role). Without this flag the script is read-only."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-out",
+        metavar="PATH",
+        default=None,
+        help="Write the before/after evidence JSON to this path.",
+    )
+    args = parser.parse_args(argv)
+
+    evidence = perform_backfill(commit=args.commit)
+    rendered = json.dumps(evidence, indent=2, default=str)
+    print(rendered)
+
+    if args.evidence_out:
+        with open(args.evidence_out, "w", encoding="utf-8") as fh:
+            fh.write(rendered + "\n")
+
+    ev = evidence["backfill_evidence"]
+    # Non-zero exit only on a genuine failure to leave the record seeded after a
+    # commit. Dry-runs and idempotent already-seeded runs are success (0).
+    if args.commit and not ev["already_seeded"] and not ev["committed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/lambda/recompute_governance/test_backfill_governance_version.py
+++ b/backend/lambda/recompute_governance/test_backfill_governance_version.py
@@ -1,0 +1,126 @@
+"""Tests for backfill_governance_version — ENC-TSK-I32 / DOC-6F7A14667E7D §8.
+
+Covers:
+  - build_seed_state captures generation 1, per-file checksum+versionId,
+    governance_revision, and the §4.3 bundle hash from live S3
+  - dry-run (default) performs NO write and emits before/after evidence
+  - --commit on an empty table performs a first-write seed
+  - backfill is idempotent: an existing record is never overwritten
+  - source_event marks the seed as a backfill with an empty sequencer
+"""
+
+import backfill_governance_version as bf
+import lambda_function as recompute
+
+
+def _stub_live(monkeypatch, files=None, revision="2026-06-27.01"):
+    if files is None:
+        files = [("governance://agents.md", "governance/live/agents.md")]
+    monkeypatch.setattr(recompute, "_list_canonical_files", lambda: files)
+    checksums = {s3_key: (f"sum{i}", f"vid-{i}") for i, (_, s3_key) in enumerate(files)}
+    monkeypatch.setattr(recompute, "_get_file_checksum", lambda key: checksums[key])
+    monkeypatch.setattr(recompute, "_read_governance_revision", lambda key: revision)
+
+
+def test_build_seed_state_shape(monkeypatch):
+    _stub_live(
+        monkeypatch,
+        files=[
+            ("governance://agents.md", "governance/live/agents.md"),
+            ("governance://agents/plan.md", "governance/live/agents/plan.md"),
+        ],
+    )
+
+    seed = bf.build_seed_state()
+
+    assert seed["version_id"] == recompute.CANONICAL_ITEM_KEY
+    assert seed["generation"] == 1
+    assert seed["cas_version"] == 1
+    assert seed["governance_revision"] == "2026-06-27.01"
+    assert len(seed["files"]) == 2
+    # per-file checksum + versionId captured
+    assert seed["files"][0]["checksum_sha256_hex"] == "sum0"
+    assert seed["files"][0]["s3_version_id"] == "vid-0"
+    # bundle hash equals the §4.3 contract value from the recompute module
+    assert seed["governance_hash"] == recompute._compute_bundle_hash(seed["files"])
+    # backfill provenance: empty sequencer so the first real event advances gen
+    assert seed["source_event"]["backfill"] is True
+    assert seed["source_event"]["s3_sequencer"] == ""
+
+
+def test_build_seed_state_refuses_empty_file_set(monkeypatch):
+    monkeypatch.setattr(recompute, "_list_canonical_files", lambda: [])
+    try:
+        bf.build_seed_state()
+        assert False, "expected RuntimeError on empty canonical set"
+    except RuntimeError:
+        pass
+
+
+def test_dry_run_performs_no_write(monkeypatch):
+    _stub_live(monkeypatch)
+    monkeypatch.setattr(bf, "_read_full_record", lambda: None)
+
+    cas_calls = []
+    monkeypatch.setattr(recompute, "_cas_write", lambda **kwargs: cas_calls.append(kwargs) or True)
+
+    evidence = bf.perform_backfill(commit=False)
+    ev = evidence["backfill_evidence"]
+
+    assert not cas_calls, "dry-run must not write"
+    assert ev["dry_run"] is True
+    assert ev["committed"] is False
+    assert ev["before"] is None
+    assert ev["seed"]["generation"] == 1
+
+
+def test_commit_first_write_seeds_record(monkeypatch):
+    _stub_live(monkeypatch)
+
+    # before: empty; after: the seeded record
+    states = iter([None, {"generation": 1, "governance_hash": "h"}])
+    monkeypatch.setattr(bf, "_read_full_record", lambda: next(states))
+
+    cas_calls = []
+
+    def _cas(**kwargs):
+        cas_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(recompute, "_cas_write", _cas)
+
+    evidence = bf.perform_backfill(commit=True)
+    ev = evidence["backfill_evidence"]
+
+    assert len(cas_calls) == 1
+    assert cas_calls[0]["expected_cas"] is None  # first-write guard
+    assert cas_calls[0]["generation"] == 1
+    assert ev["committed"] is True
+    assert ev["already_seeded"] is False
+
+
+def test_backfill_is_idempotent_when_record_exists(monkeypatch):
+    _stub_live(monkeypatch)
+    monkeypatch.setattr(bf, "_read_full_record", lambda: {"generation": 7, "governance_hash": "h"})
+
+    cas_calls = []
+    monkeypatch.setattr(recompute, "_cas_write", lambda **kwargs: cas_calls.append(kwargs) or True)
+
+    evidence = bf.perform_backfill(commit=True)
+    ev = evidence["backfill_evidence"]
+
+    assert not cas_calls, "existing record must never be overwritten by backfill"
+    assert ev["already_seeded"] is True
+    assert ev["committed"] is False
+
+
+def test_main_dry_run_exit_zero(monkeypatch, capsys):
+    _stub_live(monkeypatch)
+    monkeypatch.setattr(bf, "_read_full_record", lambda: None)
+    monkeypatch.setattr(recompute, "_cas_write", lambda **kwargs: True)
+
+    rc = bf.main([])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "backfill_evidence" in out

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -72,6 +72,7 @@ function_name_map:
   feed_query: devops-feed-query-api-gamma
   github_integration: devops-github-integration-gamma
   governance_audit: enceladus-governance-audit-gamma
+  governance_drift_check: devops-governance-drift-check-gamma
   graph_health_metrics: enceladus-graph-health-metrics-gamma
   graph_query_api: devops-graph-query-api-gamma
   graph_sync: devops-graph-sync-gamma

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3723,6 +3723,210 @@ Resources:
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
 
+  # ENC-TSK-I32 / ENC-FTR-116: governance drift-detection backstop.
+  # Scheduled Argo/FIM-style reconcile — recomputes the §4.3 bundle hash from
+  # live S3 and compares it against the canonical governance-version record.
+  # Read-only (never writes the record or governance/live/*); emits a
+  # CloudWatch metric + SNS alert on disagreement or recompute failure.
+  GovernanceDriftCheckFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-governance-drift-check${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GovernanceDriftCheckRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          GOVERNANCE_VERSION_TABLE: !Sub "governance-version${EnvironmentSuffix}"
+          GOVERNANCE_S3_BUCKET: jreese-net
+          DRIFT_METRIC_NAMESPACE: Enceladus/Governance
+          GOVERNANCE_ALERT_SNS_ARN: !ImportValue
+            Fn::Sub: ${DataStackName}-DeadLetterTopicArn
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance
+
+  GovernanceDriftCheckRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-governance-drift-check-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3GovernanceRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadGovernanceLiveObjects
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:HeadObject
+                  - s3:GetObjectAttributes
+                Resource: "arn:aws:s3:::jreese-net/governance/live/*"
+              - Sid: ListGovernanceLivePrefix
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::jreese-net"
+                Condition:
+                  StringLike:
+                    "s3:prefix": "governance/live/*"
+        - PolicyName: GovernanceVersionDDBRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Read-only: drift check NEVER writes the canonical record (I28
+              # reserves writes to the recompute role alone).
+              - Sid: ReadCanonicalRecord
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GovernanceVersionTableArn
+        - PolicyName: DriftTelemetry
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EmitDriftMetric
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "cloudwatch:namespace": Enceladus/Governance
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  # SNS publish to the existing dead-letter/alert topic for drift alerts.
+  GovernanceDriftCheckSnsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "governance-drift-check-sns-publish${EnvironmentSuffix}"
+      Roles:
+        - !Ref GovernanceDriftCheckRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: PublishDriftAlert
+            Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !ImportValue
+              Fn::Sub: ${DataStackName}-DeadLetterTopicArn
+
+  # Hourly schedule — the FIM-style backstop cadence (recompute already keeps
+  # the record warm on every write; this catches lost events / silent drift).
+  GovernanceDriftCheckSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "governance-drift-check${EnvironmentSuffix}"
+      Description: Hourly governance-version drift reconcile (ENC-TSK-I32).
+      ScheduleExpression: "rate(1 hour)"
+      State: ENABLED
+      Targets:
+        - Id: GovernanceDriftCheckTarget
+          Arn: !GetAtt GovernanceDriftCheckFunction.Arn
+
+  GovernanceDriftCheckSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GovernanceDriftCheckFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GovernanceDriftCheckSchedule.Arn
+
+  # Drift alarm — fires when the canonical record disagrees with live S3.
+  GovernanceVersionDriftAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-governance-version-drift${EnvironmentSuffix}"
+      AlarmDescription: >-
+        Canonical governance-version record disagrees with live S3 checksums
+        (ENC-ISS-390 backstop). The drift-check Lambda emits
+        GovernanceVersionDrift=1 on hash mismatch, a missing record, or a
+        failed recompute from live S3.
+      Namespace: Enceladus/Governance
+      MetricName: GovernanceVersionDrift
+      Statistic: Maximum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # Recompute-failure alarm — the canonical record cannot rotate if the
+  # storage-event recompute Lambda is erroring.
+  RecomputeGovernanceErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-recompute-governance-errors${EnvironmentSuffix}"
+      AlarmDescription: >-
+        The recompute-governance Lambda is failing; canonical governance-version
+        record may be stale relative to live S3 (ENC-ISS-390 backstop).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref RecomputeGovernanceFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # The drift-checker itself failing is a blind-spot — alarm on its errors too.
+  GovernanceDriftCheckErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-governance-drift-check-errors${EnvironmentSuffix}"
+      AlarmDescription: >-
+        The governance drift-check Lambda is failing; drift detection is blind
+        until it recovers (ENC-TSK-I32).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref GovernanceDriftCheckFunction
+      Statistic: Sum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
 Outputs:
   CoordinationApiFunctionArn:
     Value: !GetAtt CoordinationApiFunction.Arn

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -217,6 +217,12 @@
       "lambda_dir": "backend/lambda/recompute_governance",
       "workflow_file": ".github/workflows/_deploy.yml",
       "deploy_script": "backend/lambda/recompute_governance/deploy.sh"
+    },
+    {
+      "function_name": "devops-governance-drift-check",
+      "lambda_dir": "backend/lambda/governance_drift_check",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/governance_drift_check/deploy.sh"
     }
   ]
 }


### PR DESCRIPTION
## ENC-TSK-I32 — code half (backfill + drift alarm)

ENC-FTR-116 governance version re-homing. Design: **DOC-6F7A14667E7D §8** (backfill/migration) + the drift backstop (§3). Scope is the **code half only** — the live e2e §13 rotation (closing ENC-ISS-390) and the privileged `--commit` backfill mutation are deferred to the privileged/product-lead rows.

### What's here
1. **`recompute_governance/backfill_governance_version.py`** — one-time seed of the canonical `governance-version-current` record from live S3 (`generation`, per-file `versionId`+`checksum_sha256_hex`, `governance_revision`, §4.3 bundle hash), reusing the recompute module's exact contract.
   - **Dry-run by default** (mutation deferred); `--commit` writes under the sole-writer recompute role.
   - First-write CAS (`attribute_not_exists`), **idempotent** (never overwrites an existing record), before/after JSON evidence.
2. **`governance_drift_check/`** — scheduled Argo/FIM-style backstop Lambda. Recomputes the §4.3 hash from live S3 and compares it to the canonical record; emits CloudWatch `GovernanceVersionDrift` (1/0) + an SNS alert on **hash mismatch**, **missing record**, or **recompute failure**. Read-only (never writes the record or `governance/live/*`).
3. **`02-compute.yaml`** — drift-check Function + least-privilege Role (S3 read, DDB `GetItem` only, namespace-scoped `PutMetricData`, SNS publish), hourly EventBridge schedule, and three alarms: `GovernanceVersionDriftAlarm`, `RecomputeGovernanceErrorsAlarm`, `GovernanceDriftCheckErrorsAlarm`. Gamma-aware (arm64 / py3.12).
4. Registered in `lambda_workflow_manifest.json` + `envs/v4-gamma.yaml` function map.

### Tests
22 passing — 9 drift-check, 6 backfill, 7 recompute regression — including the §4.3 bundle-hash contract pin (kept byte-for-byte in sync with `recompute_governance`).

### Acceptance mapping
- AC1 (canonical record seeded from live state, before/after evidence) — backfill script + evidence block (privileged `--commit` run produces the live before/after).
- AC2 (drift alarm fires on record-vs-live disagreement or recompute failure) — drift-check Lambda + `GovernanceVersionDriftAlarm` + recompute-errors alarm.
- AC3 (live e2e §13 rotation closing ISS-390) — **out of scope here**; deferred to the privileged run (depends on I31 §13 rewrite).

CCI-7976e4abbdf948bc9714baf2c43d702c