### PR TITLE
fix(cfn): rename GovernanceDriftCheckSchedule EventBridge rule to devops-* prefix (I32 unblock)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3851,7 +3851,7 @@ Resources:
   GovernanceDriftCheckSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub "governance-drift-check${EnvironmentSuffix}"
+      Name: !Sub "devops-governance-drift-check${EnvironmentSuffix}"
       Description: Hourly governance-version drift reconcile (ENC-TSK-I32).
       ScheduleExpression: "rate(1 hour)"
       State: ENABLED


### PR DESCRIPTION
## ENC-TSK-I49 — I32 CFN deploy unblock

ENC-FTR-116 / ENC-TSK-I32 follow-up fix. The `enceladus-compute-gamma` stack update
(run [28283611445](https://github.com/NX-2021-L/enceladus/actions/runs/28283611445)) failed with
`AccessDenied` on `events:DescribeRule` for resource
`arn:aws:events:us-west-2:356364570033:rule/governance-drift-check-gamma`.

### Root cause
`CloudFormationDeployPolicy` scopes EventBridge ops to `devops-*` and `enceladus-*` ARN prefixes.
The I32 `GovernanceDriftCheckSchedule` rule name used bare `governance-drift-check-gamma`,
which falls outside both patterns.

### Fix
One-line rename in `02-compute.yaml`:
```
- Name: !Sub "governance-drift-check${EnvironmentSuffix}"
+ Name: !Sub "devops-governance-drift-check${EnvironmentSuffix}"
```

Consistent with the Lambda function name already using `devops-governance-drift-check${EnvironmentSuffix}` (line 3735).

CCI-151ff46e798a48409b50c1f8ede3c109