### PR TITLE
ENC-TSK-I53: unwrap SNS-relay envelope in recompute_governance Lambda (FTR-116 event-path fix)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.04",
-  "updated_at": "2026-06-27T08:00:00Z",
-  "last_change_summary": "ENC-TSK-I29 / ENC-FTR-116 Wave 2: governance hash cutover — canonical DDB-primary resolution in coordination_api (_compute_governance_hash_local) and enceladus-mcp-server (_get_governance_hash_via_api). Docstore-catalog fallback removed from call chain in both. New entities: coordination_api.governance_hash_resolution, mcp_server.governance_hash_resolution.",
+  "version": "2026-06-27.05",
+  "updated_at": "2026-06-27T20:02:00Z",
+  "last_change_summary": "ENC-TSK-I53 / ENC-FTR-116: recompute_governance Lambda now unwraps the SNS-relay Notification envelope (S3 → SNS us-west-1 → Lambda us-west-2) so real governance/live/* ObjectCreated events recompute the canonical version record; previously every real event failed KeyError 's3' because Lambda-protocol SNS cannot use raw message delivery. No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on lambda_function.py edits.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/recompute_governance/lambda_function.py
+++ b/backend/lambda/recompute_governance/lambda_function.py
@@ -212,17 +212,63 @@ def _cas_write(
 
 
 # ---------------------------------------------------------------------------
+# Event normalization
+# ---------------------------------------------------------------------------
+
+def _extract_s3_record(event: dict) -> dict | None:
+    """Return the first S3 notification record, unwrapping an SNS envelope if present.
+
+    governance/live/* events are delivered S3 -> SNS relay (cross-region us-west-1
+    topic -> us-west-2 Lambda) because S3 cannot invoke a Lambda in another region.
+    Lambda-protocol SNS subscriptions cannot use raw message delivery (AWS rejects
+    SetSubscriptionAttributes RawMessageDelivery=true for protocol=lambda), so the
+    event arrives as an SNS Notification whose Message body is the S3 event JSON.
+
+    Direct S3 -> Lambda delivery (a raw S3 event) is also supported for
+    forward/back compatibility and for direct-invoke validation. SNS subscription
+    confirmations and s3:TestEvent payloads carry no S3 Records and are skipped.
+    """
+    records = event.get("Records", [])
+    if not records:
+        return None
+    first = records[0]
+
+    is_sns = (
+        "Sns" in first
+        or first.get("EventSource") == "aws:sns"
+        or first.get("eventSource") == "aws:sns"
+    )
+    if is_sns:
+        message = first.get("Sns", {}).get("Message", "")
+        try:
+            inner = json.loads(message)
+        except (TypeError, ValueError):
+            logger.error("SNS Message is not valid JSON; cannot unwrap; skipping")
+            return None
+        inner_records = inner.get("Records", [])
+        if not inner_records:
+            # s3:TestEvent or a non-S3 notification — nothing to recompute.
+            logger.info("SNS Message has no S3 Records (e.g. s3:TestEvent); skipping")
+            return None
+        return inner_records[0]
+
+    return first
+
+
+# ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
 
 def handler(event: dict, context: Any) -> None:
-    """S3 ObjectCreated event handler."""
-    records = event.get("Records", [])
-    if not records:
-        logger.info("No records; nothing to do")
+    """S3 ObjectCreated event handler (accepts raw S3 or SNS-wrapped delivery)."""
+    record = _extract_s3_record(event)
+    if record is None:
+        logger.info("No actionable S3 record; nothing to do")
+        return
+    if "s3" not in record:
+        logger.info("Record carries no s3 payload; skipping")
         return
 
-    record = records[0]
     s3_obj = record["s3"]["object"]
     trigger_key: str = s3_obj["key"]
     trigger_version_id: str = s3_obj.get("versionId", "")

--- a/backend/lambda/recompute_governance/test_lambda_function.py
+++ b/backend/lambda/recompute_governance/test_lambda_function.py
@@ -32,6 +32,37 @@ def _make_s3_event(key: str, sequencer: str = "AAAA", version_id: str = "v1") ->
     }
 
 
+def _make_sns_wrapped_event(key: str, sequencer: str = "AAAA", version_id: str = "v1") -> dict:
+    """Wrap a raw S3 event in an SNS Notification envelope (the real gamma delivery shape)."""
+    s3_event = _make_s3_event(key, sequencer=sequencer, version_id=version_id)
+    return {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "EventVersion": "1.0",
+                "Sns": {
+                    "Type": "Notification",
+                    "MessageId": "msg-1",
+                    "TopicArn": "arn:aws:sns:us-west-1:356364570033:enceladus-governance-live-relay-gamma",
+                    "Message": json.dumps(s3_event),
+                },
+            }
+        ]
+    }
+
+
+def _make_sns_test_event() -> dict:
+    """An s3:TestEvent relayed via SNS — Message has no S3 Records."""
+    return {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "Sns": {"Type": "Notification", "Message": json.dumps({"Service": "Amazon S3", "Event": "s3:TestEvent"})},
+            }
+        ]
+    }
+
+
 def _stub_canonical(monkeypatch, files=None):
     """Monkeypatch _list_canonical_files + _get_file_checksum + _read_governance_revision."""
     if files is None:
@@ -185,3 +216,60 @@ def test_bundle_hash_matches_spec():
     expected = h.hexdigest()
 
     assert mod._compute_bundle_hash(entries) == expected
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-I53: SNS-relay envelope unwrapping (real gamma delivery topology)
+# ---------------------------------------------------------------------------
+
+def test_extract_s3_record_handles_raw_and_sns():
+    raw = _make_s3_event("governance/live/agents.md", sequencer="R1")
+    rec_raw = mod._extract_s3_record(raw)
+    assert rec_raw["s3"]["object"]["sequencer"] == "R1"
+
+    wrapped = _make_sns_wrapped_event("governance/live/agents.md", sequencer="S1")
+    rec_sns = mod._extract_s3_record(wrapped)
+    assert rec_sns["s3"]["object"]["sequencer"] == "S1"
+    assert rec_sns["s3"]["object"]["key"] == "governance/live/agents.md"
+
+
+def test_sns_wrapped_event_increments_like_raw(monkeypatch):
+    """A real SNS-delivered governance/live/* event must recompute (regression for the KeyError 's3' defect)."""
+    _stub_canonical(monkeypatch)
+    monkeypatch.setattr(mod, "_read_current_record", lambda: None)
+
+    written = {}
+    monkeypatch.setattr(
+        mod,
+        "_cas_write",
+        lambda *, governance_revision, governance_hash, generation, file_entries, source_event, expected_cas: (
+            written.update({"generation": generation, "expected_cas": expected_cas, "seq": source_event["s3_sequencer"]}) or True
+        ),
+    )
+
+    mod.handler(_make_sns_wrapped_event("governance/live/agents.md", sequencer="SNSSEQ1"), None)
+
+    assert written["generation"] == 1
+    assert written["expected_cas"] is None
+    assert written["seq"] == "SNSSEQ1"
+
+
+def test_sns_test_event_skipped(monkeypatch):
+    """s3:TestEvent relayed through SNS carries no S3 Records and must be a no-op."""
+    read_calls = []
+    monkeypatch.setattr(mod, "_read_current_record", lambda: read_calls.append(1) or None)
+
+    mod.handler(_make_sns_test_event(), None)
+
+    assert not read_calls, "s3:TestEvent should bail before touching DDB"
+
+
+def test_malformed_sns_message_does_not_raise(monkeypatch):
+    """A non-JSON SNS Message must be skipped gracefully, not crash the handler."""
+    read_calls = []
+    monkeypatch.setattr(mod, "_read_current_record", lambda: read_calls.append(1) or None)
+
+    event = {"Records": [{"EventSource": "aws:sns", "Sns": {"Message": "not-json{{"}}]}
+    mod.handler(event, None)  # must not raise
+
+    assert not read_calls


### PR DESCRIPTION
## ENC-TSK-I53 — FTR-116 event-sourced recompute fix (gamma)

The recompute_governance Lambda never worked end-to-end on gamma. `governance/live/*`
events are delivered **S3 → SNS relay (us-west-1) → Lambda (us-west-2)** (S3 can't invoke a
cross-region Lambda), and **Lambda-protocol SNS subscriptions cannot enable raw message
delivery**. The handler read `record["s3"]` directly, so every real event failed with
`KeyError: 's3'` (51 such failures observed on gamma). The canonical DDB record was only
ever seeded via a synthetic direct invoke (ENC-TSK-I29), masking the broken event path.

### Change
- Add `_extract_s3_record()` to normalize delivery: unwrap SNS `Notification` envelopes
  (`json.loads(Sns.Message)`), pass raw S3 events through unchanged, and skip
  `s3:TestEvent` / malformed payloads gracefully instead of crashing.
- Recompute logic (hash, CAS, idempotency, recursion-safety) is **unchanged**.
- Tests cover both delivery shapes + test-event no-op + malformed-message guard (11 passing).

Relates: ENC-TSK-I27, ENC-TSK-I28, ENC-FTR-116

CCI-07572250a7054203b1a9ecb7e379a2f7

🤖 Generated with [Claude Code](https://claude.com/claude-code)