### PR TITLE
ENC-TSK-I54: land ENC-TSK-I29 governance-hash cutover unit tests on v4/main

### DIFF
--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -192,6 +192,71 @@ class CoordinationLambdaUnitTests(unittest.TestCase):
 
         self.assertEqual(result, "c" * 64)
 
+    # --- ENC-TSK-I29: connection_health authority cutover + docstore fallback removal ---
+
+    @staticmethod
+    def _fake_ddb_with_canonical(hash_value):
+        """DDB stub whose governance-version record returns hash_value."""
+        class _FakeDdb:
+            def get_item(self, TableName=None, Key=None, ConsistentRead=None, **_kwargs):
+                # Assert the canonical record is read consistently by id.
+                assert ConsistentRead is True, "canonical read must be ConsistentRead"
+                assert Key == {"version_id": {"S": coordination_lambda.GOVERNANCE_VERSION_RECORD_ID}}
+                if hash_value is None:
+                    return {}
+                return {"Item": {"governance_hash": {"S": hash_value}}}
+
+        return _FakeDdb()
+
+    def test_compute_governance_hash_local_prefers_canonical_ddb(self):
+        """AC#1: the served value is the canonical governance-version record's hash."""
+        mcp_module = MagicMock()  # must never be consulted when DDB resolves
+        with patch.object(
+            coordination_lambda, "_get_ddb",
+            return_value=self._fake_ddb_with_canonical("a" * 64),
+        ), patch.object(
+            coordination_lambda, "_load_mcp_server_module", mcp_module,
+        ):
+            result = coordination_lambda._compute_governance_hash_local()
+
+        self.assertEqual(result, "a" * 64)
+        mcp_module.assert_not_called()
+
+    def test_compute_governance_hash_local_live_s3_is_the_tiebreak(self):
+        """AC#3: when the canonical DDB warm value is absent, live-derived-from-S3 wins."""
+        class _FakeMcpServer:
+            def _compute_governance_hash(self, force_refresh=False):
+                return "b" * 64
+
+        with patch.object(
+            coordination_lambda, "_get_ddb",
+            return_value=self._fake_ddb_with_canonical(None),  # canonical record missing/empty
+        ), patch.object(
+            coordination_lambda, "_load_mcp_server_module",
+            return_value=_FakeMcpServer(),
+        ):
+            result = coordination_lambda._compute_governance_hash_local()
+
+        self.assertEqual(result, "b" * 64)
+
+    def test_compute_governance_hash_local_never_serves_docstore_fallback(self):
+        """AC#2: with both authoritative sources down, no frozen docstore value is served."""
+        docstore = MagicMock(return_value="f" * 64)  # the formerly-silent stale path
+        with patch.object(
+            coordination_lambda, "_get_ddb",
+            side_effect=RuntimeError("ddb down"),
+        ), patch.object(
+            coordination_lambda, "_load_mcp_server_module",
+            side_effect=RuntimeError("mcp down"),
+        ), patch.object(
+            coordination_lambda, "_compute_governance_hash_docstore_fallback", docstore,
+        ):
+            result = coordination_lambda._compute_governance_hash_local()
+
+        # Empty string propagates as GOVERNANCE_STALE rather than a silently-wrong hash.
+        self.assertEqual(result, "")
+        docstore.assert_not_called()
+
     def test_build_ssm_commands_uses_idempotent_mcp_profile_bootstrap(self):
         request = {
             "request_id": "CRQ-MCP001",
@@ -960,11 +1025,18 @@ class CoordinationLambdaUnitTests(unittest.TestCase):
         parsed = coordination_lambda._parse_mcp_result(content)
         self.assertEqual(parsed, {"success": True})
 
+    # ENC-TSK-I29: pin the governance hash so this test exercises decomposition
+    # helpers hermetically rather than depending on ambient hash resolution
+    # (the old docstore-empty deterministic fallback was removed by I29).
     @patch.object(coordination_lambda, "_load_project_meta")
     @patch.object(coordination_lambda, "_append_tracker_history")
     @patch.object(coordination_lambda, "_create_tracker_record_auto")
+    @patch.object(
+        coordination_lambda, "_compute_governance_hash_local", return_value="d" * 64
+    )
     def test_decomposition_uses_tracker_helpers_with_metadata(
         self,
+        mock_compute_governance_hash_local,
         mock_create_tracker_record_auto,
         mock_append_tracker_history,
         mock_load_project_meta,

--- a/tools/enceladus-mcp-server/test_code_mode.py
+++ b/tools/enceladus-mcp-server/test_code_mode.py
@@ -212,3 +212,29 @@ def test_execute_dry_run_resolves_without_calling_mutation_handler():
     assert payload["step_results"][0]["status"] == "dry_run"
     assert payload["underlying_calls"][0]["tool"] == "tracker_set"
     assert calls["tracker_set"] == 0
+
+
+def test_canonical_governance_hash_ddb_reads_same_record_as_coordination_api():
+    """ENC-TSK-I29 / AC#1: the MCP write-validation path resolves the governance
+    hash from the same canonical governance-version record the coordination API
+    serves -- same table, same record id, consistent read."""
+    server = _load_server(ENCELADUS_MCP_INTERFACE_MODE="code")
+
+    captured = {}
+
+    class _FakeDdb:
+        def get_item(self, TableName=None, Key=None, ConsistentRead=None, **_kwargs):
+            captured["TableName"] = TableName
+            captured["Key"] = Key
+            captured["ConsistentRead"] = ConsistentRead
+            return {"Item": {"governance_hash": {"S": "e" * 64}}}
+
+    with patch.object(server, "_get_ddb", return_value=_FakeDdb()):
+        result = server._get_canonical_governance_hash_ddb()
+
+    assert result == "e" * 64
+    assert captured["TableName"] == server.GOVERNANCE_VERSION_TABLE
+    assert captured["Key"] == {"version_id": {"S": server.GOVERNANCE_VERSION_RECORD_ID}}
+    assert captured["ConsistentRead"] is True
+    # Aligned to the coordination API's canonical record identity.
+    assert server.GOVERNANCE_VERSION_RECORD_ID == "governance-version-current"


### PR DESCRIPTION
## What

Lands the unit tests authored for **ENC-TSK-I29** (governance-hash authority cutover) that missed the PR #594 merge. The I29 production cutover merged at `6c21333` before the test commit `bd6d0ed` registered (merge race), so `v4/main` has the production code with no coverage for it — while the I29 closure evidence cites these tests as passing. This makes reality match that evidence.

Test-only diff; no Lambda source change.

## Tests added

`backend/lambda/coordination_api/test_lambda_function.py`:
- `test_compute_governance_hash_local_prefers_canonical_ddb` — AC#1: served value is the canonical `governance-version` DDB record
- `test_compute_governance_hash_local_live_s3_is_the_tiebreak` — AC#3: live-S3 wins when the canonical warm value is absent
- `test_compute_governance_hash_local_never_serves_docstore_fallback` — AC#2: removed docstore fallback is never served; total failure → `""`
- `test_decomposition_uses_tracker_helpers_with_metadata` made hermetic (it relied on the docstore-empty deterministic hash removed by I29)

`tools/enceladus-mcp-server/test_code_mode.py`:
- `test_canonical_governance_hash_ddb_reads_same_record_as_coordination_api` — AC#1: write-validation path reads the same canonical record

## Verification

Against merged `v4/main`: coordination_api **165 passed**, mcp-server code-mode **6 passed**.

Related: ENC-FTR-116, ENC-TSK-I29. Supersedes ENC-TSK-I52.

CCI-d68bdeb59b78420c8bd82f731d348fb9