### PR TITLE
fix(recompute): unwrap SNS-wrapped S3 events (cross-region relay) — ENC-TSK-I55

### DIFF
--- a/backend/lambda/recompute_governance/lambda_function.py
+++ b/backend/lambda/recompute_governance/lambda_function.py
@@ -223,6 +223,21 @@ def handler(event: dict, context: Any) -> None:
         return
 
     record = records[0]
+    # Cross-region relay (ENC-ISS-390 e2e): the governance bucket lives in
+    # us-west-1 and cannot invoke this Lambda (us-west-2) directly, so S3
+    # ObjectCreated events are fanned out through an SNS topic. SNS wraps the
+    # S3 event as a JSON string in record["Sns"]["Message"]. Unwrap it so the
+    # handler sees the raw S3 event shape whether delivery is direct or via SNS.
+    if "Sns" in record:
+        try:
+            inner_records = json.loads(record["Sns"]["Message"]).get("Records", [])
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.error("Failed to unwrap SNS-wrapped S3 event: %s", exc)
+            return
+        if not inner_records:
+            logger.info("SNS message carried no S3 Records; nothing to do")
+            return
+        record = inner_records[0]
     s3_obj = record["s3"]["object"]
     trigger_key: str = s3_obj["key"]
     trigger_version_id: str = s3_obj.get("versionId", "")

--- a/backend/lambda/recompute_governance/test_lambda_function.py
+++ b/backend/lambda/recompute_governance/test_lambda_function.py
@@ -32,6 +32,26 @@ def _make_s3_event(key: str, sequencer: str = "AAAA", version_id: str = "v1") ->
     }
 
 
+def _make_sns_wrapped_event(key: str, sequencer: str = "AAAA", version_id: str = "v1") -> dict:
+    """S3 -> SNS -> Lambda delivery: the S3 event is a JSON string in Sns.Message.
+
+    This is the real cross-region relay shape (governance bucket us-west-1, Lambda
+    us-west-2). ENC-ISS-390 e2e.
+    """
+    inner = _make_s3_event(key, sequencer=sequencer, version_id=version_id)
+    return {
+        "Records": [
+            {
+                "EventSource": "aws:sns",
+                "Sns": {
+                    "Type": "Notification",
+                    "Message": json.dumps(inner),
+                },
+            }
+        ]
+    }
+
+
 def _stub_canonical(monkeypatch, files=None):
     """Monkeypatch _list_canonical_files + _get_file_checksum + _read_governance_revision."""
     if files is None:
@@ -185,3 +205,40 @@ def test_bundle_hash_matches_spec():
     expected = h.hexdigest()
 
     assert mod._compute_bundle_hash(entries) == expected
+
+
+def test_sns_wrapped_event_is_unwrapped_and_processed(monkeypatch):
+    """S3 -> SNS -> Lambda: the wrapped S3 event must be unwrapped and written."""
+    _stub_canonical(monkeypatch)
+    monkeypatch.setattr(mod, "_read_current_record", lambda: None)
+
+    written = {}
+    monkeypatch.setattr(
+        mod,
+        "_cas_write",
+        lambda *, governance_revision, governance_hash, generation, file_entries, source_event, expected_cas: (
+            written.update({"generation": generation, "seq": source_event.get("s3_sequencer")}) or True
+        ),
+    )
+
+    mod.handler(_make_sns_wrapped_event("governance/live/agents.md", sequencer="SNSSEQ1"), None)
+
+    assert written["generation"] == 1
+    assert written["seq"] == "SNSSEQ1"
+
+
+def test_malformed_sns_message_returns_without_write(monkeypatch):
+    """A non-JSON / Records-less SNS message is handled gracefully (no crash, no write)."""
+    _stub_canonical(monkeypatch)
+
+    cas_calls = []
+    monkeypatch.setattr(mod, "_cas_write", lambda **kwargs: cas_calls.append(kwargs) or True)
+    monkeypatch.setattr(mod, "_read_current_record", lambda: None)
+
+    bad = {"Records": [{"EventSource": "aws:sns", "Sns": {"Message": "not-json"}}]}
+    mod.handler(bad, None)  # must not raise
+
+    empty = {"Records": [{"EventSource": "aws:sns", "Sns": {"Message": json.dumps({"Records": []})}}]}
+    mod.handler(empty, None)  # must not raise
+
+    assert not cas_calls, "malformed/empty SNS messages must not produce a DDB write"


### PR DESCRIPTION
## ENC-TSK-I55 — recompute handler SNS-unwrap (ENC-ISS-390 e2e blocker)

The governance bucket `jreese-net` is in **us-west-1**; the recompute Lambda `devops-recompute-governance-gamma` is in **us-west-2**. S3 cannot invoke a cross-region Lambda directly, so `governance/live/*` `ObjectCreated` events are fanned out through an SNS topic (`enceladus-governance-live-relay-gamma`, us-west-1) whose sole subscriber is the recompute Lambda.

SNS wraps the S3 event as a JSON string in `record["Sns"]["Message"]`, but the handler read `record["s3"]` directly and crashed with `KeyError: 's3'` on **every** relayed event. Live logs confirm it: relayed invocations error, and the canonical `governance-version-gamma` record only ever moved via a manual raw-event test invocation — a real §13 write never updated it. This is the blocker preventing the ENC-ISS-390 live e2e (§13 write → recompute → generation rotation).

### Fix
Unwrap SNS-wrapped events so the handler sees the raw S3 event shape whether delivery is direct or via the SNS relay. Malformed / `Records`-less SNS messages return gracefully (no crash, no write). Recursion-safety, CAS, dedup, and the §4.3 hash contract are unchanged.

### Tests
9 passing (7 existing + 2 new): `test_sns_wrapped_event_is_unwrapped_and_processed`, `test_malformed_sns_message_returns_without_write`.

### Follow-on
After merge: redeploy `devops-recompute-governance-gamma`, then the ENC-TSK-I31 §13 write drives the ENC-TSK-I32 AC3 e2e (generation rotates, three-surface agreement) closing ENC-ISS-390.

CCI-0ed18437cc834880bba7de9aa9d01499