### PR TITLE
ENC-TSK-I57: codify coordination_api governance-version read grant in CFN (ENC-ISS-421 durable fix)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1718,6 +1718,17 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}/index/*"
+              # ENC-TSK-I57 / ENC-ISS-421: read the canonical governance-version record (ENC-TSK-I27/I29).
+              # The Lambda env sets GOVERNANCE_VERSION_TABLE and _compute_governance_hash_local() reads it;
+              # without this grant the prod role gets AccessDenied -> empty governance_hash -> global mutation block.
+              # ${EnvironmentSuffix} covers prod ("") and gamma ("-gamma"), superseding the one-shot gamma grant workflow.
+              - Sid: GovernanceVersionRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-version${EnvironmentSuffix}"
               - Sid: DocumentsTableRead
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Durable fix #1 for ENC-ISS-421 (prod governance_hash empty → global mutation block)

The prod `devops-coordination-api-lambda-role` had **no IAM grant to read the canonical `governance-version` DDB record**, even though the Lambda env sets `GOVERNANCE_VERSION_TABLE` and the I29 `_compute_governance_hash_local()` reads it. That gap (plus the unseeded record) produced `AccessDenied → empty governance_hash → GOVERNANCE_STALE on every governed mutation`, blocking all agents during the incident.

The incident was unblocked with a **manual inline-policy edit** + an I32 backfill seed — but the manual grant reverts on the next role redeploy. This codifies it.

### Change
Adds a `GovernanceVersionRead` statement (`dynamodb:GetItem`,`Query` on `governance-version${EnvironmentSuffix}`) to `CoordinationApiRole` in `infrastructure/cloudformation/02-compute.yaml`.

- `${EnvironmentSuffix}` ⟹ covers **prod** (`""`) and **gamma** (`"-gamma"`) from one definition, so it also supersedes the one-shot `iam-coordination-api-gamma-govversion-grant.yml` workflow.
- Durable: reapplied on every `CoordinationApiRole` redeploy (prod 02-compute deploys via v4/main merge per ENC-ISS-386).
- Replaces the manual inline-policy stopgap applied during incident response.

### Validation
CFN template parses (CFN-tag-tolerant load); `GovernanceVersionRead` well-formed in `CoordinationApiRole` (26 statements). `+11 / -0` diff.

Scope: IAM grant durability only. ENC-ISS-421 durable-fix #2 (prod has no recompute Lambda → canonical record freezes on the next `agents.md` change) remains a separate, larger effort tracked on the issue.

Related: ENC-ISS-421, ENC-FTR-116, ENC-TSK-I29, ENC-TSK-I32.

CCI-6a87f41a0922414697a8867de43d1df6