### PR TITLE
ENC-TSK-I58: hourly recompute backstop so prod canonical governance record refreshes (ENC-ISS-421 fix #2)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3878,6 +3878,38 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt GovernanceDriftCheckSchedule.Arn
 
+  # ENC-TSK-I58 / ENC-ISS-421 (durable fix #2): hourly recompute backstop.
+  # The S3 governance/live/* -> recompute relay is wired for gamma only (the relay
+  # SNS topic + bucket notification are out-of-band, us-west-1), so the PROD canonical
+  # governance-version record would otherwise freeze at the manual backfill seed and go
+  # stale on the next agents.md change (the drift-check Lambda only ALARMS, it never
+  # writes). This schedule invokes the recompute (the I28 sole-writer) hourly with a
+  # synthetic governance/live/agents.md S3 event so it recomputes the bundle hash from
+  # live S3 and refreshes the canonical record. Empty sequencer intentionally bypasses
+  # the recompute's exact-sequencer dedup (handler: `prev_seq and prev_seq == seq`), so
+  # every scheduled tick recomputes. Hourly latency is acceptable for a backstop and
+  # matches the GovernanceDriftCheckSchedule cadence above. Templated -> prod and gamma
+  # (gamma keeps its event-driven path; this is an additional safety net there).
+  RecomputeGovernanceSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "devops-recompute-governance-backstop${EnvironmentSuffix}"
+      Description: Hourly governance-version recompute backstop (ENC-TSK-I58 / ENC-ISS-421).
+      ScheduleExpression: "rate(1 hour)"
+      State: ENABLED
+      Targets:
+        - Id: RecomputeGovernanceBackstopTarget
+          Arn: !GetAtt RecomputeGovernanceFunction.Arn
+          Input: '{"Records":[{"eventSource":"aws:scheduled-backstop","s3":{"object":{"key":"governance/live/agents.md","sequencer":"","versionId":""}}}]}'
+
+  RecomputeGovernanceSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref RecomputeGovernanceFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt RecomputeGovernanceSchedule.Arn
+
   # Drift alarm — fires when the canonical record disagrees with live S3.
   GovernanceVersionDriftAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Durable fix #2 for ENC-ISS-421

The prod recompute Lambda `devops-recompute-governance` exists but is **never triggered**: the S3 `governance/live/*` → recompute relay (SNS topic + bucket notification) is wired for **gamma only** and is out-of-band (us-west-1). So the prod canonical `governance-version` record froze at the manual backfill seed and would go stale on the next `agents.md` change — and the drift-check Lambda only **alarms**, it never writes the record.

### Change
Adds `RecomputeGovernanceSchedule` (hourly EventBridge, templated for prod+gamma) + permission to `02-compute.yaml`, invoking the recompute (the I28 sole-writer) with a synthetic `governance/live/agents.md` S3 event so it recomputes the bundle hash from live S3 and refreshes the canonical record. Mirrors the existing `GovernanceDriftCheckSchedule` pattern.

- **No sole-writer code change** — pure CFN. The empty sequencer intentionally bypasses the recompute's exact-sequencer dedup so every tick recomputes.
- Hourly latency, acceptable for a backstop; matches the drift-check cadence.
- Gamma keeps its event-driven path; this is an added safety net there.

### Validated live (pre-deploy)
Direct-invoked prod `devops-recompute-governance` with the synthetic event → `StatusCode 200`, no error; canonical record **generation advanced 1→2**, hash unchanged `a9a9dfcf…` (bundle unchanged), `connection_health` still non-empty. So when `agents.md` actually changes, the next tick computes and stores the new hash.

CFN template parses; both new resources well-formed.

Related: ENC-ISS-421, ENC-FTR-116, ENC-TSK-I27, ENC-TSK-I32.

> Note: the event-driven S3→recompute relay for prod (matching gamma) was considered but deferred — it requires modifying the shared `jreese-net` bucket NotificationConfiguration / a cross-region SNS relay that isn't in this repo's CFN. The scheduled backstop is the lower-risk, fully-codified fix.

CCI-ed962da7658847ffb3b5dee61def7871