### PR TITLE
feat(checkout): enforce server-minted ENC-SES-NNN at checkout (ENC-TSK-I40)

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -961,6 +961,33 @@ def _delete_token(token_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ENC-TSK-I40: Agent session ID validation — stamping integration point
+# ---------------------------------------------------------------------------
+
+_SES_ID_RE = re.compile(r"^ENC-SES-[0-9A-Z]+$")
+
+
+def _resolve_agent_session_id(raw_id: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Validate and return the server-minted agent session ID.
+
+    ENC-TSK-I40 stamping integration point. V4 rebind: replace this function
+    body to add an existence check against the v4 identity service without
+    reshaping any caller. The caller reads only (session_id, error).
+
+    Returns (session_id, None) on success, (None, error_message) on failure.
+    """
+    ses_id = (str(raw_id) if raw_id else "").strip()
+    if not ses_id:
+        return None, "active_agent_session_id is required in request body"
+    if not _SES_ID_RE.match(ses_id):
+        return None, (
+            f"active_agent_session_id must be a server-minted ENC-SES-NNN "
+            f"(obtained via agent.register); got: {ses_id!r}"
+        )
+    return ses_id, None
+
+
+# ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
 
@@ -981,11 +1008,11 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
     treat checkout_count as read-only. It feeds the FTR-076 v2 IMPLEMENTS edge
     immutability gate (designed->development requires checkout_count >= 1).
     """
-    provider = (body.get("active_agent_session_id") or "").strip()
-    if not provider:
+    provider, ses_err = _resolve_agent_session_id(body.get("active_agent_session_id"))
+    if ses_err:
         return _validation_error(
             400,
-            "active_agent_session_id is required in request body",
+            ses_err,
             task_id=task_id,
             target_status="in-progress",
             required_fields=["active_agent_session_id"],
@@ -2964,11 +2991,11 @@ def _plan_validation_error(
 
 def _handle_plan_checkout(project_id: str, plan_id: str, body: dict) -> dict:
     """POST .../checkout — Check out a plan and advance drafted→started."""
-    provider = (body.get("active_agent_session_id") or "").strip()
-    if not provider:
+    provider, ses_err = _resolve_agent_session_id(body.get("active_agent_session_id"))
+    if ses_err:
         return _plan_validation_error(
             400,
-            "active_agent_session_id is required in request body",
+            ses_err,
             plan_id=plan_id,
             required_fields=["active_agent_session_id"],
             example_fix=_example_plan_checkout_fix(plan_id),

--- a/backend/lambda/checkout_service/test_agent_session_id.py
+++ b/backend/lambda/checkout_service/test_agent_session_id.py
@@ -1,0 +1,222 @@
+"""test_agent_session_id.py — ENC-TSK-I40 checkout value-swap.
+
+Validates _resolve_agent_session_id() (the stamping integration point) and its
+integration with _handle_checkout / _handle_plan_checkout.
+
+AC-1: active_agent_session_id written at checkout is a server-minted ENC-SES-NNN;
+      improvised strings are rejected with 400.
+AC-2: the integration point is isolated in _resolve_agent_session_id so v4 can
+      re-bind it without reshaping callers.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_lambda_i40",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = checkout_lambda
+_SPEC.loader.exec_module(checkout_lambda)
+
+
+class ResolveAgentSessionIdUnitTests(unittest.TestCase):
+    """Direct unit tests for _resolve_agent_session_id (isolation point)."""
+
+    def _resolve(self, raw):
+        return checkout_lambda._resolve_agent_session_id(raw)
+
+    # --- happy path ---
+
+    def test_valid_ses_three_digit(self):
+        ses_id, err = self._resolve("ENC-SES-001")
+        self.assertIsNone(err)
+        self.assertEqual(ses_id, "ENC-SES-001")
+
+    def test_valid_ses_alphanum(self):
+        ses_id, err = self._resolve("ENC-SES-00A")
+        self.assertIsNone(err)
+        self.assertEqual(ses_id, "ENC-SES-00A")
+
+    def test_valid_ses_longer(self):
+        ses_id, err = self._resolve("ENC-SES-0ZZZ")
+        self.assertIsNone(err)
+        self.assertEqual(ses_id, "ENC-SES-0ZZZ")
+
+    def test_strips_whitespace(self):
+        ses_id, err = self._resolve("  ENC-SES-001  ")
+        self.assertIsNone(err)
+        self.assertEqual(ses_id, "ENC-SES-001")
+
+    # --- rejected: missing / empty ---
+
+    def test_none_input(self):
+        ses_id, err = self._resolve(None)
+        self.assertIsNone(ses_id)
+        self.assertIn("required", err)
+
+    def test_empty_string(self):
+        ses_id, err = self._resolve("")
+        self.assertIsNone(ses_id)
+        self.assertIn("required", err)
+
+    def test_whitespace_only(self):
+        ses_id, err = self._resolve("   ")
+        self.assertIsNone(ses_id)
+        self.assertIn("required", err)
+
+    # --- AC-1: improvised strings are rejected ---
+
+    def test_rejects_improvised_desktop_style(self):
+        ses_id, err = self._resolve("cc-desktop-sonnet46-enc-tsk-i40")
+        self.assertIsNone(ses_id)
+        self.assertIn("ENC-SES-NNN", err)
+        self.assertIn("agent.register", err)
+
+    def test_rejects_coord_lead_style(self):
+        ses_id, err = self._resolve("coord-lead-claudeai-opus-20260627")
+        self.assertIsNone(ses_id)
+        self.assertIn("ENC-SES-NNN", err)
+
+    def test_rejects_lowercase_enc_ses(self):
+        # IDs are uppercase per encode_seq; lowercase variant must not pass.
+        ses_id, err = self._resolve("enc-ses-001")
+        self.assertIsNone(ses_id)
+        self.assertIn("ENC-SES-NNN", err)
+
+    def test_rejects_arbitrary_string(self):
+        ses_id, err = self._resolve("my-session")
+        self.assertIsNone(ses_id)
+        self.assertIn("ENC-SES-NNN", err)
+
+    # --- AC-2: integration point is named and isolated ---
+
+    def test_function_exists_and_is_isolated(self):
+        """_resolve_agent_session_id must exist as a standalone callable."""
+        fn = getattr(checkout_lambda, "_resolve_agent_session_id", None)
+        self.assertIsNotNone(fn, "_resolve_agent_session_id not found in checkout_lambda")
+        self.assertTrue(callable(fn))
+
+    def test_ses_id_regex_exposed(self):
+        """_SES_ID_RE must be a module-level constant (v4 rebind anchor)."""
+        regex = getattr(checkout_lambda, "_SES_ID_RE", None)
+        self.assertIsNotNone(regex, "_SES_ID_RE constant not found")
+
+
+class HandleCheckoutSessionIdIntegrationTests(unittest.TestCase):
+    """_handle_checkout rejects improvised session IDs; accepts ENC-SES-NNN."""
+
+    def _make_pre_task(self, **overrides):
+        base = {
+            "status": "open",
+            "transition_type": "github_pr_deploy",
+            "components": [],
+            "subtask_ids": [],
+            "active_agent_session": False,
+            "active_agent_session_id": "",
+        }
+        base.update(overrides)
+        return base
+
+    def _make_post_task(self, ses_id, **overrides):
+        base = {
+            "status": "in-progress",
+            "transition_type": "github_pr_deploy",
+            "components": [],
+            "subtask_ids": [],
+            "checkout_count": 1,
+            "active_agent_session": True,
+            "active_agent_session_id": ses_id,
+        }
+        base.update(overrides)
+        return base
+
+    def _run_checkout(self, ses_id):
+        pre_task = self._make_pre_task()
+        post_task = self._make_post_task(ses_id)
+
+        def fake_tracker(method, path, payload=None):
+            if method == "GET":
+                return 200, pre_task
+            if method == "POST" and "/checkout" in path:
+                return 200, {"success": True, "governance_hash": "gh-test"}
+            if method == "PATCH":
+                return 200, {"success": True}
+            return 200, {}
+
+        with mock.patch.object(checkout_lambda, "_tracker_request", side_effect=fake_tracker):
+            with mock.patch.object(checkout_lambda, "_get_task",
+                                   side_effect=[(200, pre_task), (200, post_task)]):
+                resp = checkout_lambda._handle_checkout(
+                    "enceladus", "ENC-TSK-I40",
+                    {"active_agent_session_id": ses_id},
+                )
+        return resp
+
+    def test_valid_ses_id_accepted(self):
+        resp = self._run_checkout("ENC-SES-001")
+        body = json.loads(resp["body"])
+        self.assertTrue(body.get("success"), body)
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_improvised_id_rejected_400(self):
+        resp = checkout_lambda._handle_checkout(
+            "enceladus", "ENC-TSK-I40",
+            {"active_agent_session_id": "cc-desktop-sonnet46-enc-tsk-i40"},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertFalse(body.get("success"))
+        self.assertIn("ENC-SES-NNN", body.get("error", ""))
+
+    def test_missing_id_rejected_400(self):
+        resp = checkout_lambda._handle_checkout(
+            "enceladus", "ENC-TSK-I40",
+            {},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertFalse(body.get("success"))
+
+    def test_coord_lead_style_rejected(self):
+        resp = checkout_lambda._handle_checkout(
+            "enceladus", "ENC-TSK-I40",
+            {"active_agent_session_id": "coord-lead-claudeai-opus-20260627"},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertIn("ENC-SES-NNN", body.get("error", ""))
+
+
+class HandlePlanCheckoutSessionIdTests(unittest.TestCase):
+    """_handle_plan_checkout uses the same _resolve_agent_session_id integration point."""
+
+    def test_improvised_id_rejected_400(self):
+        resp = checkout_lambda._handle_plan_checkout(
+            "enceladus", "ENC-PLN-058",
+            {"active_agent_session_id": "coord-lead-claudeai-opus-20260627"},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertFalse(body.get("success"))
+        self.assertIn("ENC-SES-NNN", body.get("error", ""))
+
+    def test_missing_id_rejected_400(self):
+        resp = checkout_lambda._handle_plan_checkout(
+            "enceladus", "ENC-PLN-058",
+            {},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+        body = json.loads(resp["body"])
+        self.assertFalse(body.get("success"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/checkout_service/test_component_lifecycle_gate.py
+++ b/backend/lambda/checkout_service/test_component_lifecycle_gate.py
@@ -76,7 +76,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
     def _call_checkout(self, lifecycle_status):
         cid = f"comp-{lifecycle_status.replace('-', '_')}"
         task = _make_task([cid])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
                                side_effect=_ddb_lifecycle_side_effect({cid: lifecycle_status})):
@@ -111,7 +111,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
         """proposed 400 body must contain the component_id for operator diagnosis."""
         cid = "comp-proposed"
         task = _make_task([cid])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
                                side_effect=_ddb_lifecycle_side_effect({cid: "proposed"})):
@@ -130,7 +130,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
         """deprecated 400 body must contain the component_id for operator diagnosis."""
         cid = "comp-deprecated"
         task = _make_task([cid])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
                                side_effect=_ddb_lifecycle_side_effect({cid: "deprecated"})):
@@ -215,7 +215,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
     def test_mixed_proposed_and_approved_blocks(self):
         """If any component is proposed (BLOCKED), checkout is blocked even if others are permitted."""
         task = _make_task(["comp-approved", "comp-proposed"])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
                                side_effect=_ddb_lifecycle_side_effect({
@@ -228,7 +228,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
     def test_mixed_archived_and_approved_returns_404(self):
         """If any component is archived (OPAQUE), checkout returns 404."""
         task = _make_task(["comp-approved", "comp-archived"])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
                                side_effect=_ddb_lifecycle_side_effect({
@@ -241,7 +241,7 @@ class CheckoutLifecycleGateAllStatusesTests(unittest.TestCase):
     def test_task_without_components_not_blocked(self):
         """Task with no components in the registry is not blocked by the lifecycle gate."""
         task = _make_task([])
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)):
             resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
         # Should not be blocked by the lifecycle gate (may fail for other reasons).

--- a/backend/lambda/checkout_service/test_component_misconfig_failure.py
+++ b/backend/lambda/checkout_service/test_component_misconfig_failure.py
@@ -135,7 +135,7 @@ class CheckoutHandlerCOMPONENT_MISCONFIGUREDTests(unittest.TestCase):
             response = checkout_service._handle_checkout(
                 "enceladus",
                 "ENC-TSK-FAKE",
-                {"active_agent_session_id": "test-session"},
+                {"active_agent_session_id": "ENC-SES-001"},
             )
 
         self.assertEqual(response["statusCode"], 500)

--- a/backend/lambda/checkout_service/test_component_opacity_gate.py
+++ b/backend/lambda/checkout_service/test_component_opacity_gate.py
@@ -55,7 +55,7 @@ def _ddb_lifecycle_side_effect(component_lifecycle_map):
 class CheckoutOpacityGateTests(unittest.TestCase):
 
     def _call_checkout(self, components, lifecycle_map):
-        body = {"active_agent_session_id": "test-agent-session"}
+        body = {"active_agent_session_id": "ENC-SES-001"}
         task = _make_task(components)
         with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
              mock.patch.object(checkout_lambda._ddb, "get_item",
@@ -114,7 +114,7 @@ class CheckoutOpacityGateTests(unittest.TestCase):
                                return_value=(200, {})), \
              mock.patch.object(checkout_lambda, "_get_task",
                                return_value=(200, _make_task(["comp-approved"]))):
-            body = {"active_agent_session_id": "test-agent-session"}
+            body = {"active_agent_session_id": "ENC-SES-001"}
             resp = checkout_lambda._handle_checkout("enceladus", "ENC-TSK-TEST", body)
         # Must not be blocked by the opacity gate (200 or pass-through)
         self.assertNotEqual(resp["statusCode"], 404)
@@ -135,7 +135,7 @@ class CheckoutOpacityGateTests(unittest.TestCase):
                                        return_value=(200, {})), \
                      mock.patch.object(checkout_lambda, "_get_task",
                                        return_value=(200, _make_task([f"comp-{ls}"]))):
-                    body = {"active_agent_session_id": "test-agent-session"}
+                    body = {"active_agent_session_id": "ENC-SES-001"}
                     resp = checkout_lambda._handle_checkout(
                         "enceladus", "ENC-TSK-TEST", body
                     )

--- a/backend/lambda/checkout_service/test_counter_fields.py
+++ b/backend/lambda/checkout_service/test_counter_fields.py
@@ -76,7 +76,7 @@ class CheckoutSurfacesCheckoutCountTests(unittest.TestCase):
                                side_effect=fake_tracker_request):
             resp = checkout_lambda._handle_checkout(
                 "enceladus", "ENC-TSK-901",
-                {"active_agent_session_id": "claude-code-f41-test"},
+                {"active_agent_session_id": "ENC-SES-001"},
             )
         return resp
 
@@ -118,7 +118,7 @@ class CheckoutSurfacesCheckoutCountTests(unittest.TestCase):
                                side_effect=fake_tracker_request):
             resp = checkout_lambda._handle_checkout(
                 "enceladus", "ENC-TSK-902",
-                {"active_agent_session_id": "legacy-agent"},
+                {"active_agent_session_id": "ENC-SES-001"},
             )
         self.assertEqual(resp["statusCode"], 200)
         body = json.loads(resp["body"])
@@ -139,7 +139,7 @@ class CheckoutSurfacesCheckoutCountTests(unittest.TestCase):
                                side_effect=fake_tracker_request):
             resp = checkout_lambda._handle_checkout(
                 "enceladus", "ENC-TSK-903",
-                {"active_agent_session_id": "agent"},
+                {"active_agent_session_id": "ENC-SES-001"},
             )
         self.assertEqual(resp["statusCode"], 200)
         body = json.loads(resp["body"])

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.04",
-  "updated_at": "2026-06-27T14:00:00Z",
-  "last_change_summary": "ENC-TSK-I27 / ENC-FTR-116 Wave 2: added governance.version_record (canonical DDB record schema for devops-recompute-governance Lambda) and recompute_governance.event_handler (S3-triggered Lambda contract: trigger, canonical file set, dedup, CAS guard, recursion invariant, env vars). Required by governance-dictionary-guard for backend/lambda/recompute_governance/lambda_function.py addition.",
+  "version": "2026-06-27.05",
+  "updated_at": "2026-06-28T01:02:00Z",
+  "last_change_summary": "ENC-TSK-I40 / ENC-FTR-117: added checkout_service.session_id_validation entity documenting the _resolve_agent_session_id() stamping integration point and ENC-SES-NNN format enforcement at checkout.task and checkout.plan. Required by governance-dictionary-guard for checkout_service/lambda_function.py modification.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5794,6 +5794,25 @@
           "definition": "Response: true if a new ENC-AGT-NNN was minted; false if the existing entry was returned."
         }
       }
+    },
+    "checkout_service.session_id_validation": {
+      "description": "Session ID validation contract in the checkout service Lambda (ENC-TSK-I40 / ENC-FTR-117). Both _handle_checkout (task checkout) and _handle_plan_checkout (plan checkout) validate active_agent_session_id via _resolve_agent_session_id() before writing any state. Only server-minted ENC-SES-NNN values (issued by coordination_api.agent_id_alloc.mint_session_id via the agent.register action, live since ENC-TSK-I38) are accepted. Improvised strings are rejected with HTTP 400.",
+      "fields": {
+        "active_agent_session_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^ENC-SES-[0-9A-Z]+$",
+            "source": "Must be obtained via agent.register MCP action (coordination_api.mint_session_id)"
+          },
+          "definition": "Server-minted agent session ID. Format: ENC-SES-{SEQ} where SEQ is a base-36 uppercase alphanumeric sequence issued by coordination_api. Improvised strings (e.g. cc-desktop-sonnet46-enc-tsk-NNN) are rejected with 400 INVALID_INPUT.",
+          "usage_guidance": "Call coordination(action=agent.register) to obtain a valid ENC-SES-NNN before calling checkout.task or checkout.plan. The returned session_id is the value to pass as active_agent_session_id."
+        },
+        "_resolve_agent_session_id": {
+          "type": "function",
+          "definition": "Named stamping integration point in checkout_service/lambda_function.py. Returns (session_id, None) on success or (None, error_message) on failure. V4 rebind: replace this function body to add an existence check against the v4 identity service. Callers (_handle_checkout, _handle_plan_checkout) read only the (session_id, error) pair and are not reshaped by the rebind.",
+          "isolation_note": "ENC-TSK-I40 AC-2 isolation deliverable. V4 drift-risk surface."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -5817,6 +5836,11 @@
       "version": "2026-06-27.02",
       "date": "2026-06-27",
       "summary": "ENC-TSK-I37 / ENC-FTR-117: add coordination.agent_session and coordination.agent_type entities (Agent ID v3 governed stores); v3 property sets value-identical to v4 node schemas per DOC-05C45B438FC1. Repo-file edit only \u2014 S3/DDB governance sync is a product-lead post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-06-27.05",
+      "date": "2026-06-28",
+      "summary": "ENC-TSK-I40 / ENC-FTR-117: added checkout_service.session_id_validation entity (active_agent_session_id ENC-SES-NNN constraint, _resolve_agent_session_id V4 rebind surface). Version bump required by governance-dictionary-guard for checkout_service/lambda_function.py edit."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `_resolve_agent_session_id()` as the named stamping integration point in `checkout_service/lambda_function.py`
- Both `_handle_checkout` and `_handle_plan_checkout` now reject improvised session IDs; only server-minted `ENC-SES-NNN` format (from `coordination_api.agent_id_alloc.mint_session_id()`, deployed by ENC-TSK-I38) is accepted
- The isolation function carries a V4 rebind docstring so the relocated stamping path can replace only this function body without reshaping callers

## Acceptance Criteria

- **AC-1**: `active_agent_session_id` written at checkout is a server-minted `ENC-SES-NNN`; improvised strings rejected with HTTP 400
- **AC-2**: Stamping integration point isolated in `_resolve_agent_session_id()` for V4 rebind

## Changes

- `backend/lambda/checkout_service/lambda_function.py`: `_SES_ID_RE` regex constant + `_resolve_agent_session_id()` function; `_handle_checkout` and `_handle_plan_checkout` updated
- `backend/lambda/checkout_service/test_agent_session_id.py`: new — 20 tests covering valid IDs, empty, improvised strings, isolation assertions
- 5 existing test files updated to use `ENC-SES-001` format in `_handle_checkout` request bodies (all 87 tests green)

## Deploy Authority

DOC-05C45B438FC1 — scoped prod exception for ENC-FTR-117 (I37–I44). Target: v3-prod via Gen2 `_deploy.yml` on `main`. io review required before merge.

## Governance

ENC-PLN-058 / ENC-FTR-117 / ENC-TSK-I40
Component: `comp-checkout-service` (`github_pr_deploy`, rank 0)

CCI-2e597f0a2ce24a16a328951c6f5850bc