### PR TITLE
feat(ci): wire enceladus-mcp-code into Gen2 build/deploy pipeline (ENC-TSK-I39)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -201,3 +201,74 @@ jobs:
           path: /tmp/manifest-${{ matrix.arch }}.json
           retention-days: 30
           if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # BUILD-MCP-CODE — packages enceladus-mcp-code from tools/enceladus-mcp-server/
+  # (ENC-TSK-I39). server.py is the Lambda handler (Handler: server.lambda_handler)
+  # with deps bundled in-zip (no SharedLayer). x86_64/py311 only — matches the prod
+  # and gamma Lambda runtime. The matrix build skips mcp_code (no lambda_function.py).
+  # ---------------------------------------------------------------------------
+  build-mcp-code:
+    name: build-mcp-code (x86_64-py3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo at requested SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::356364570033:role/GitHubActions-Build-Role
+          aws-region: us-west-2
+
+      - name: Package enceladus-mcp-code
+        id: package
+        env:
+          SHA: ${{ inputs.commit_sha }}
+          BUCKET: ${{ inputs.artifact_bucket }}
+          PREFIX: ${{ inputs.artifact_key_prefix }}
+        run: |
+          set -euo pipefail
+          BUILD=$(mktemp -d)
+
+          # Handler and local runtime modules (server.py is the Lambda entry point).
+          cp tools/enceladus-mcp-server/server.py              "$BUILD/"
+          cp tools/enceladus-mcp-server/manifest_projection.py "$BUILD/"
+          cp tools/enceladus-mcp-server/dispatch_plan_generator.py "$BUILD/"
+          # appconfig_flags fallback: server.py imports enceladus_shared.appconfig_flags
+          # (SharedLayer) with a local-file try/except fallback for environments where
+          # the layer is absent. Copy the file so the fallback resolves cleanly.
+          cp backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py "$BUILD/"
+
+          # Install dependencies (x86_64 / py3.11 — must match enceladus-mcp-code runtime).
+          python -m pip install \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 3.11 \
+            --only-binary=:all: \
+            --upgrade \
+            --target "$BUILD" \
+            -r backend/lambda/mcp_code/requirements.txt \
+            --quiet
+
+          # Zip (matches Lambda handler expectation: server.lambda_handler).
+          ZIP="/tmp/mcp_code-${SHA}.zip"
+          (cd "$BUILD" && zip -qrX "$ZIP" .)
+
+          KEY="${PREFIX}/x86_64-py3.11/mcp_code-${SHA}.zip"
+          put_out=$(aws s3api put-object \
+            --bucket "$BUCKET" \
+            --key "$KEY" \
+            --body "$ZIP" \
+            --content-type application/zip \
+            --output json)
+          version_id=$(echo "$put_out" | python -c 'import sys,json; print(json.load(sys.stdin)["VersionId"])')
+          echo "version_id=${version_id}" >> "$GITHUB_OUTPUT"
+          echo "Uploaded s3://${BUCKET}/${KEY} VersionId=${version_id}"

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -196,6 +196,10 @@ jobs:
           mapfile -t FNS < <(find backend/lambda -maxdepth 2 -name lambda_function.py \
             | sed -E 's|backend/lambda/([^/]+)/lambda_function.py|\1|' | sort -u)
 
+          # mcp_code (enceladus-mcp-code) has no lambda_function.py — it is packaged
+          # by _build.yml build-mcp-code from tools/enceladus-mcp-server/ (ENC-TSK-I39).
+          FNS+=("mcp_code")
+
           echo "Probing ${#FNS[@]} Lambda functions for SHA=${SHA}, arch=${ARCH}-py${PY}"
 
           MISSING=()

--- a/.github/workflows/build-lambda-artifacts.yml
+++ b/.github/workflows/build-lambda-artifacts.yml
@@ -8,6 +8,9 @@ on:
       - 'tools/package_lambda_artifact.sh'
       - 'tools/check_lambda_pyjwt_requirements.py'
       - 'infrastructure/lambda_workflow_manifest.json'
+      - 'tools/enceladus-mcp-server/server.py'
+      - 'tools/enceladus-mcp-server/manifest_projection.py'
+      - 'tools/enceladus-mcp-server/dispatch_plan_generator.py'
       - '.github/workflows/build-lambda-artifacts.yml'
   push:
     branches: [main]
@@ -16,6 +19,9 @@ on:
       - 'tools/package_lambda_artifact.sh'
       - 'tools/check_lambda_pyjwt_requirements.py'
       - 'infrastructure/lambda_workflow_manifest.json'
+      - 'tools/enceladus-mcp-server/server.py'
+      - 'tools/enceladus-mcp-server/manifest_projection.py'
+      - 'tools/enceladus-mcp-server/dispatch_plan_generator.py'
       - '.github/workflows/build-lambda-artifacts.yml'
   workflow_call:
     outputs:
@@ -122,8 +128,52 @@ jobs:
           path: ${{ steps.package.outputs.zip_path }}
           retention-days: 7
 
+  # ---------------------------------------------------------------------------
+  # BUILD-MCP-CODE — packages enceladus-mcp-code from tools/enceladus-mcp-server/
+  # (ENC-TSK-I39). See _build.yml build-mcp-code for rationale.
+  # ---------------------------------------------------------------------------
+  build-mcp-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Package enceladus-mcp-code
+        run: |
+          set -euo pipefail
+          BUILD=$(mktemp -d)
+          cp tools/enceladus-mcp-server/server.py              "$BUILD/"
+          cp tools/enceladus-mcp-server/manifest_projection.py "$BUILD/"
+          cp tools/enceladus-mcp-server/dispatch_plan_generator.py "$BUILD/"
+          cp backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py "$BUILD/"
+          python -m pip install \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 3.11 \
+            --only-binary=:all: \
+            --upgrade \
+            --target "$BUILD" \
+            -r backend/lambda/mcp_code/requirements.txt \
+            --quiet
+          ZIP="/tmp/enceladus-mcp-code.zip"
+          (cd "$BUILD" && zip -qrX "$ZIP" .)
+          echo "zip_path=${ZIP}" >> "$GITHUB_OUTPUT"
+        id: package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-enceladus-mcp-code-x86_64-py311
+          path: /tmp/enceladus-mcp-code.zip
+          retention-days: 7
+
   upload-artifacts:
-    needs: build
+    needs: [build, build-mcp-code]
     # Upload on push to main (standalone) or when called via workflow_call (from deploy-orchestration)
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||


### PR DESCRIPTION
## Summary

- Adds `build-mcp-code` job to `_build.yml` that packages `tools/enceladus-mcp-server/server.py` (the Lambda handler), `manifest_projection.py`, `dispatch_plan_generator.py`, `appconfig_flags.py` fallback, and requirements from `backend/lambda/mcp_code/requirements.txt` into `lambda-artifacts/x86_64-py3.11/mcp_code-{sha}.zip` on S3.
- Extends `_deploy.yml` resolve probe to include `mcp_code` in `FNS` (it has no `lambda_function.py`, so it was previously invisible to the `find` command). This lets the probe discover the artifact and the deploy step update `enceladus-mcp-code` Lambda.
- Adds `tools/enceladus-mcp-server/` path triggers and a mirrored `build-mcp-code` job to `build-lambda-artifacts.yml` for PR CI visibility.

## Context

The `agent.*` action family (`register`, `claim`, `list`, `retire`, `type.list`, `type.register`) was wired into `coordination_api` and `server.py` in ENC-TSK-I38 (commit `0ed30029`). However, `enceladus-mcp-code` is tombstoned from the Gen2 matrix build (it has no `lambda_function.py`). The Lambda was never updated, so `coordination(action="agent.list")` returned `unknown_action` at runtime.

This PR integrates `enceladus-mcp-code` into the Gen2 pipeline so that future deploys keep the MCP server in sync with coordination_api. A `workflow_dispatch` on `_deploy.yml` targeting `v3-prod` (with `commit_sha=74e013aa161c6cdb908c85970484b57729a70f60`) will update the Lambda and expose `agent.*` via the `coordination()` code-mode meta-tool.

## Deploy

Gen2 `workflow_dispatch` → `target_environment: v3-prod`, `commit_sha: 74e013aa161c6cdb908c85970484b57729a70f60`

Gamma-first per DOC-05C45B438FC1: trigger v4-gamma first for io review, then v3-prod.

## Test plan

- [ ] `build-mcp-code` job succeeds in GitHub Actions (both in `_build.yml` and `build-lambda-artifacts.yml`)
- [ ] Gen2 `workflow_dispatch` to v3-prod deploys `enceladus-mcp-code` (logs show `mcp_code -> enceladus-mcp-code`)
- [ ] Smoke test: `coordination(action="agent.list")` returns session data instead of `unknown_action`
- [ ] `coordination(action="agent.register")` and `agent.claim` callable without error

CCI-88a114f2fd214ec6aaccceb922e29e01

🤖 Generated with [Claude Code](https://claude.com/claude-code)