### PR TITLE
fix(cfn): add APIGW routes for agent.* identity surface (ENC-TSK-I38/I39)

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -239,6 +239,52 @@ Resources:
       RouteKey: POST /api/v1/coordination/mcp
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # Agent Identity routes (ENC-TSK-I38 / ENC-TSK-I39)
+  # Lambda code lives in coordination_api. Routes missing from APIGW caused 404
+  # despite successful Lambda deploy (I38 shipped code but not CFN routes).
+
+  RouteCoordinationAgentSessionList:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/agents/sessions
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteCoordinationAgentSessionRegister:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteCoordinationAgentSessionClaim:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions/claim
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteCoordinationAgentSessionRetire:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions/{sessionId}/retire
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteCoordinationAgentTypeList:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/agents/types
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteCoordinationAgentTypeRegister:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/types
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
   # Component Registry routes (ENC-FTR-041)
   RouteComponentsList:
     Type: AWS::ApiGatewayV2::Route


### PR DESCRIPTION
## Summary

- Adds 6 missing `RouteCoordinationAgent*` resources to `03-api.yaml`
- `coordination_api` Lambda has agent.register/claim/list/retire/type.list/type.register handlers since I38 (run 28306329539) but the API Gateway v2 routes were never added to the CloudFormation stack
- Without explicit routes, all `/api/v1/coordination/agents/*` paths return 404 from APIGW before reaching the Lambda
- Merging fires `cloudformation-api-stack-deploy.yml` automatically (watches `03-api.yaml`)

## Routes added

| Route | Method | Path |
|-------|--------|------|
| RouteCoordinationAgentSessionList | GET | /api/v1/coordination/agents/sessions |
| RouteCoordinationAgentSessionRegister | POST | /api/v1/coordination/agents/sessions |
| RouteCoordinationAgentSessionClaim | POST | /api/v1/coordination/agents/sessions/claim |
| RouteCoordinationAgentSessionRetire | POST | /api/v1/coordination/agents/sessions/{sessionId}/retire |
| RouteCoordinationAgentTypeList | GET | /api/v1/coordination/agents/types |
| RouteCoordinationAgentTypeRegister | POST | /api/v1/coordination/agents/types |

## Blocker context

- I39 smoke test: `coordination(action="agent.list")` → 404 (this PR fixes it)
- Another agent session (I62/I63) blocked on `agent.register` for checkout.task

## Evidence

- I38 Lambda deploy: run 28306329539, job 83863122585, SHA `63794dd6`
- I39 mcp-code deploy: run 28307417065, job 83866619031, SHA `c2135d7f`
- Gap: `03-api.yaml` has no `/agents/*` routes — confirmed by reading CFN template

`CCI-PENDING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-6a2516b0fdb240e0bd46d2772e741bce