### PR TITLE
fix(governance-sync): propagate dictionary sync into governance-policies DDB (ENC-TSK-I63)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.07",
-  "updated_at": "2026-06-27T20:02:00Z",
-  "last_change_summary": "ENC-TSK-I53 / ENC-FTR-116: recompute_governance Lambda now unwraps the SNS-relay Notification envelope (S3 → SNS us-west-1 → Lambda us-west-2) so real governance/live/* ObjectCreated events recompute the canonical version record; previously every real event failed KeyError 's3' because Lambda-protocol SNS cannot use raw message delivery. No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on lambda_function.py edits. Follows ENC-TSK-I32 (governance drift-detection backstop, governance_drift_check.handler).",
+  "version": "2026-06-28.01",
+  "updated_at": "2026-06-28T02:20:00Z",
+  "last_change_summary": "ENC-TSK-I63 / ENC-TSK-I62: devops-document-api _sync_governance_documents now propagates a governance_data_dictionary.json sync into the governance-policies DDB record (discrete version + updated_at + the served dictionary_json blob), closing the ENC-TSK-I61 gap that required a manual `aws dynamodb update-item`. Includes an S3-vs-DDB entities deep-equal drift pre-check (#v reserved-word alias; raw-S3-bytes blob write keeps the item 400KB-safe) plus the paired CFN change (DocumentApiRole +dynamodb:UpdateItem, DocumentApiFunction +GOVERNANCE_POLICIES_TABLE). No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on lambda_function.py edits.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -128,6 +128,13 @@ _INTERNAL_SCOPE_MAP_RAW = (
 GOVERNANCE_PROJECT_ID = os.environ.get("GOVERNANCE_PROJECT_ID", "devops")
 GOVERNANCE_KEYWORD = os.environ.get("GOVERNANCE_KEYWORD", "governance-file").strip().lower()
 PROJECT_REFERENCE_KEYWORD = os.environ.get("PROJECT_REFERENCE_KEYWORD", "project-reference").strip().lower()
+# ENC-TSK-I63 / ENC-TSK-I62: governance-policies DDB record that serves the live
+# governance.dictionary. A governance_data_dictionary.json sync must propagate into
+# this record (discrete `version` + `updated_at` + the served `dictionary_json` blob),
+# eliminating the manual `aws dynamodb update-item` gap discovered in ENC-TSK-I61.
+GOVERNANCE_POLICIES_TABLE = os.environ.get("GOVERNANCE_POLICIES_TABLE", "governance-policies")
+GOVERNANCE_DICTIONARY_POLICY_ID = "governance_data_dictionary"
+GOVERNANCE_DICTIONARY_FILE = "governance_data_dictionary.json"
 SYNC_CREATED_BY = "document-api-sync"
 CORS_ORIGIN = "https://jreese.net"
 MAX_CONTENT_SIZE = 1_048_576  # 1 MB max document content
@@ -1270,6 +1277,93 @@ def _list_governance_live_files() -> List[str]:
     return sorted(set(files))
 
 
+def _propagate_dictionary_to_governance_policies(s3_body: bytes) -> None:
+    """Propagate a governance_data_dictionary.json S3 sync into the governance-policies
+    DDB record so the three storage surfaces stay in lockstep (ENC-TSK-I63 / ENC-TSK-I62):
+
+      1. S3 live object  ........................ governance/live/governance_data_dictionary.json
+      2. governance-policies discrete `version` .. -> governance.dictionary source.version
+      3. governance-policies `dictionary_json` ... -> governance.dictionary dictionary_version
+                                                      (the live-served entities blob)
+
+    This closes the ENC-TSK-I61 gap where _governance_sync_push refreshed the docstore but
+    left the DDB record untouched, forcing a manual `aws dynamodb update-item`.
+
+    Implementation notes (gotchas from the source incident):
+      * Writes the *verified raw S3 bytes* as dictionary_json — byte-identical to the live
+        object, so it is inherently within the 400KB DynamoDB item limit (a pretty-print
+        round-trip would add ~65KB and risk ItemSizeLimitExceeded).
+      * `version` is a DynamoDB reserved word -> aliased as #v.
+      * Drift pre-check: the new S3 dictionary's `entities` MUST equal the live DDB blob's
+        `entities`. The discrete version and the blob are independent copies that can drift;
+        a version/metadata bump must never silently rewrite the served entities. On mismatch
+        we abort loudly rather than clobber.
+    """
+    try:
+        new_dict = json.loads(s3_body)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"governance dictionary S3 object is not valid JSON: {exc}") from exc
+    if not isinstance(new_dict, dict):
+        raise ValueError("governance dictionary S3 object must be a JSON object")
+    new_version = str(new_dict.get("version") or "").strip()
+    if not new_version:
+        raise ValueError("governance dictionary S3 object missing top-level 'version'")
+
+    ddb = _get_ddb()
+    resp = ddb.get_item(
+        TableName=GOVERNANCE_POLICIES_TABLE,
+        Key={"policy_id": {"S": GOVERNANCE_DICTIONARY_POLICY_ID}},
+    )
+    item = resp.get("Item")
+    if not item:
+        raise RuntimeError(
+            f"governance-policies record '{GOVERNANCE_DICTIONARY_POLICY_ID}' not found; "
+            "refusing to create it from a background sync"
+        )
+
+    current_version = str((item.get("version") or {}).get("S") or "")
+    current_blob = str((item.get("dictionary_json") or {}).get("S") or "")
+    blob_str = s3_body.decode("utf-8")
+
+    # Idempotent: nothing to do when the discrete version and served blob already match S3.
+    if current_version == new_version and current_blob == blob_str:
+        logger.info(
+            "[GOVERNANCE_SYNC] dictionary already in lockstep at version %s", new_version
+        )
+        return
+
+    # Drift pre-check — entities must be identical across surfaces before we overwrite.
+    if current_blob:
+        try:
+            current_dict = json.loads(current_blob)
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError(
+                f"existing governance dictionary_json blob is not valid JSON: {exc}"
+            ) from exc
+        if current_dict.get("entities") != new_dict.get("entities"):
+            raise RuntimeError(
+                "DICTIONARY DRIFT: governance_data_dictionary.json S3 entities != "
+                "governance-policies dictionary_json entities. Aborting propagation to avoid "
+                "clobbering divergent served entities — reconcile entities before the version bump."
+            )
+
+    ddb.update_item(
+        TableName=GOVERNANCE_POLICIES_TABLE,
+        Key={"policy_id": {"S": GOVERNANCE_DICTIONARY_POLICY_ID}},
+        UpdateExpression="SET #v = :ver, updated_at = :ts, dictionary_json = :blob",
+        ExpressionAttributeNames={"#v": "version"},
+        ExpressionAttributeValues={
+            ":ver": {"S": new_version},
+            ":ts": {"S": _now_z()},
+            ":blob": {"S": blob_str},
+        },
+    )
+    logger.info(
+        "[GOVERNANCE_SYNC] dictionary propagated to %s: version %s -> %s (blob=%d bytes)",
+        GOVERNANCE_POLICIES_TABLE, current_version or "(none)", new_version, len(blob_str),
+    )
+
+
 def _sync_governance_documents() -> None:
     docs = _query_project_documents(GOVERNANCE_PROJECT_ID)
     doc_by_file: Dict[str, Dict[str, Any]] = {}
@@ -1285,6 +1379,14 @@ def _sync_governance_documents() -> None:
     for rel_file in _list_governance_live_files():
         key = f"{S3_GOVERNANCE_PREFIX.rstrip('/')}/{rel_file}"
         existing = doc_by_file.get(rel_file)
+
+        # ENC-TSK-I63: the dictionary's DDB lockstep is propagated regardless of the
+        # docstore fast-path below — the docstore copy can be current while the
+        # governance-policies record is stale (the exact ENC-TSK-I61 drift). Fetch the
+        # live object and propagate before any content short-circuit.
+        if rel_file == GOVERNANCE_DICTIONARY_FILE:
+            dict_body = _get_s3().get_object(Bucket=S3_BUCKET, Key=key)["Body"].read()
+            _propagate_dictionary_to_governance_policies(dict_body)
 
         # Fast path: compare metadata hash when available.
         metadata_hash = ""

--- a/backend/lambda/document_api/test_lambda_function.py
+++ b/backend/lambda/document_api/test_lambda_function.py
@@ -491,5 +491,100 @@ class GovernanceSyncPushTests(unittest.TestCase):
         self.assertIn(resp["statusCode"], [200, 204])
 
 
+class DictionaryPropagationTests(unittest.TestCase):
+    """ENC-TSK-I63 / ENC-TSK-I62: governance_data_dictionary.json -> governance-policies DDB
+    propagation (discrete version + updated_at + dictionary_json blob) with drift pre-check."""
+
+    @staticmethod
+    def _dict_bytes(version, entities):
+        # Compact, like the live S3 object (no pretty-print bloat).
+        return json.dumps(
+            {"version": version, "entities": entities}, separators=(",", ":")
+        ).encode("utf-8")
+
+    def _ddb_item(self, version, entities):
+        return {
+            "Item": {
+                "policy_id": {"S": document_api.GOVERNANCE_DICTIONARY_POLICY_ID},
+                "version": {"S": version},
+                "updated_at": {"S": "2026-06-27T00:00:00Z"},
+                "dictionary_json": {
+                    "S": json.dumps(
+                        {"version": version, "entities": entities}, separators=(",", ":")
+                    )
+                },
+            }
+        }
+
+    @patch.object(document_api, "_get_ddb")
+    def test_propagates_version_bump_entities_unchanged(self, mock_ddb):
+        ddb = MagicMock()
+        ddb.get_item.return_value = self._ddb_item("2026-06-27.08", {"tracker.task": {"x": 1}})
+        mock_ddb.return_value = ddb
+        s3_body = self._dict_bytes("2026-06-27.09", {"tracker.task": {"x": 1}})
+
+        document_api._propagate_dictionary_to_governance_policies(s3_body)
+
+        ddb.update_item.assert_called_once()
+        kwargs = ddb.update_item.call_args.kwargs
+        # reserved-word alias for `version`
+        self.assertEqual(kwargs["ExpressionAttributeNames"], {"#v": "version"})
+        self.assertIn("#v = :ver", kwargs["UpdateExpression"])
+        self.assertEqual(kwargs["ExpressionAttributeValues"][":ver"]["S"], "2026-06-27.09")
+        # byte-identical raw S3 bytes are written -> inherently 400KB-safe (no round-trip bloat)
+        self.assertEqual(
+            kwargs["ExpressionAttributeValues"][":blob"]["S"], s3_body.decode("utf-8")
+        )
+        self.assertEqual(
+            kwargs["Key"], {"policy_id": {"S": document_api.GOVERNANCE_DICTIONARY_POLICY_ID}}
+        )
+
+    @patch.object(document_api, "_get_ddb")
+    def test_drift_aborts_when_entities_differ(self, mock_ddb):
+        ddb = MagicMock()
+        ddb.get_item.return_value = self._ddb_item("2026-06-27.08", {"tracker.task": {"x": 1}})
+        mock_ddb.return_value = ddb
+        # entities changed alongside the version bump -> must abort, never clobber
+        s3_body = self._dict_bytes("2026-06-27.09", {"tracker.task": {"x": 2}})
+
+        with self.assertRaises(RuntimeError) as ctx:
+            document_api._propagate_dictionary_to_governance_policies(s3_body)
+        self.assertIn("DRIFT", str(ctx.exception))
+        ddb.update_item.assert_not_called()
+
+    @patch.object(document_api, "_get_ddb")
+    def test_idempotent_when_already_in_lockstep(self, mock_ddb):
+        ddb = MagicMock()
+        body = self._dict_bytes("2026-06-27.08", {"tracker.task": {"x": 1}})
+        ddb.get_item.return_value = {
+            "Item": {
+                "policy_id": {"S": document_api.GOVERNANCE_DICTIONARY_POLICY_ID},
+                "version": {"S": "2026-06-27.08"},
+                "dictionary_json": {"S": body.decode("utf-8")},
+            }
+        }
+        mock_ddb.return_value = ddb
+
+        document_api._propagate_dictionary_to_governance_policies(body)
+        ddb.update_item.assert_not_called()
+
+    @patch.object(document_api, "_get_ddb")
+    def test_missing_record_raises(self, mock_ddb):
+        ddb = MagicMock()
+        ddb.get_item.return_value = {}  # no Item
+        mock_ddb.return_value = ddb
+        with self.assertRaises(RuntimeError):
+            document_api._propagate_dictionary_to_governance_policies(
+                self._dict_bytes("2026-06-27.09", {})
+            )
+        ddb.update_item.assert_not_called()
+
+    @patch.object(document_api, "_get_ddb")
+    def test_missing_version_raises(self, mock_ddb):
+        mock_ddb.return_value = MagicMock()
+        with self.assertRaises(ValueError):
+            document_api._propagate_dictionary_to_governance_policies(b'{"entities":{}}')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -281,6 +281,9 @@ Resources:
           S3_PREFIX: !Sub "${S3EnvPrefix}agent-documents"
           S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
           S3_GOVERNANCE_PREFIX: !Sub "${S3EnvPrefix}governance/live"
+          # ENC-TSK-I63 / ENC-TSK-I62: needed so the governance sync path can propagate a
+          # governance_data_dictionary.json change into the governance-policies record.
+          GOVERNANCE_POLICIES_TABLE: !Sub "governance-policies${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
@@ -3023,12 +3026,16 @@ Resources:
                   - dynamodb:GetItem
                   - dynamodb:Query
                 Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
-              - Sid: GovernancePoliciesRead
+              # ENC-TSK-I63 / ENC-TSK-I62: UpdateItem added so the governance sync path can
+              # propagate a dictionary version bump into the governance-policies record
+              # (discrete version + updated_at + dictionary_json blob). Read-only before.
+              - Sid: GovernancePoliciesReadWrite
                 Effect: Allow
                 Action:
                   - dynamodb:GetItem
                   - dynamodb:Query
                   - dynamodb:Scan
+                  - dynamodb:UpdateItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}/index/*"


### PR DESCRIPTION
## ENC-TSK-I63 (ENC-TSK-I62 sub-task A)

Closes the ENC-TSK-I61 gap: `devops-document-api` `_sync_governance_documents` now propagates a `governance_data_dictionary.json` sync into the `governance-policies` DDB record, so all three surfaces stay in lockstep without a manual `aws dynamodb update-item`:

1. S3 live object — `governance/live/governance_data_dictionary.json`
2. `governance-policies` discrete `version` → `governance.dictionary` `source.version`
3. `governance-policies` `dictionary_json` blob → `governance.dictionary` `dictionary_version`

### Changes
- **`document_api/lambda_function.py`** — `_propagate_dictionary_to_governance_policies()`: writes verified **raw S3 bytes** as `dictionary_json` (byte-identical → inherently 400KB-safe), `#v` alias for the reserved `version` word, **entities deep-equal drift pre-check** that aborts on mismatch, idempotent no-op when already in lockstep, raises if the record is missing. Wired into the sync loop before the docstore fast-path so an already-drifted DDB is still reconciled.
- **`infrastructure/cloudformation/02-compute.yaml`** — `DocumentApiRole` `+dynamodb:UpdateItem` on `governance-policies`; `DocumentApiFunction` `+GOVERNANCE_POLICIES_TABLE` env. (Compute-stack deploy required: gamma-first per DOC-499, then v3-prod under DOC-597.)
- **Bundled dictionary** bumped `2026-06-27.07` → `2026-06-28.01` (Governance Dictionary Guard; 110 entities unchanged).
- **Tests** — 5 new (happy / drift-abort / idempotent / missing-record / missing-version); full document_api suite (39) green.

Authorities: DOC-E06BACE0AFB9 (handoff) · DOC-499FA089EC30 (freeze) · DOC-597E1C6AEFB0 (dual-target prod exception).

CCI-0d100c42edb24d7d9cd78a98090c6bf6

🤖 Generated with [Claude Code](https://claude.com/claude-code)