### PR TITLE
fix(cfn): env-prefix-aware S3 governance read for DocumentApiRole (ENC-TSK-I70)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2060,13 +2060,17 @@ Resources:
                   - s3:GetObject
                   - s3:DeleteObject
                 Resource: "arn:aws:s3:::jreese-net/agent-documents/*"
+              # ENC-TSK-I70 / ENC-TSK-I62: env-prefix-aware so the gamma stack can read its
+              # own gamma/governance/live + gamma/mobile/v1/reference objects. Was hardcoded to
+              # the unprefixed prod paths, so the gamma governance sync 500'd on s3:GetObject
+              # (AccessDenied). No-op for prod (S3EnvPrefix is empty there).
               - Sid: S3ReferenceRead
                 Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
-                  - "arn:aws:s3:::jreese-net/governance/live/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}mobile/v1/reference/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}governance/live/*"
               - Sid: S3ListPrefixes
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## ENC-TSK-I70 — unblocks ENC-TSK-I63 gamma parity (ENC-TSK-I62)

`DocumentApiRole` `S3ReferenceRead` hardcoded the unprefixed prod paths
(`governance/live/*`, `mobile/v1/reference/*`). The gamma document-api reads from
`gamma/governance/live` (env-prefixed), so it got **AccessDenied** on `s3:GetObject`
and the gamma governance sync 500'd — surfaced while running the ENC-TSK-I63 gamma
parity test.

Fix: make the resources `${S3EnvPrefix}`-aware. **No-op for prod** (empty prefix);
grants `gamma/*` on the gamma stack. Deploys via the sanctioned CFN compute-stack
pipeline on the `v4/main` merge.

CCI-0a16faed320247ec9723b753dc3b6298

🤖 Generated with [Claude Code](https://claude.com/claude-code)