### PR TITLE
feat(coordination): scheduled agent-session idle-sweep backstop (ENC-TSK-I71 / ENC-FTR-117 AC#8)

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -36,13 +36,25 @@ ENC-TSK-I40. The allocator is dormant until I38 wires an invocation path.
 """
 from __future__ import annotations
 
+import datetime as dt
+import json
 from typing import Any, Dict, List, Mapping, Optional
 
 from botocore.exceptions import BotoCoreError, ClientError
 
-from config import AGENT_SESSIONS_TABLE, AGENT_TYPES_TABLE, logger
+from config import (
+    AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS,
+    AGENT_SESSIONS_TABLE,
+    AGENT_TYPES_TABLE,
+    logger,
+)
 from aws_clients import _get_ddb
 from serialization import _deserialize, _now_z, _serialize
+
+# Shared timestamp format — identical to serialization._now_z(); session timestamps
+# (created_at / claimed_at) are written with this format, so the idle-sweep renders its
+# cutoff the same way and compares lexicographically (a correct chronological compare).
+_TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 __all__ = [
     "SESSION_ID_PREFIX",
@@ -58,6 +70,7 @@ __all__ = [
     "get_agent_type",
     "claim_session",
     "retire_session",
+    "sweep_idle_sessions",
     "list_sessions",
     "list_agent_types",
     "find_agent_type",
@@ -431,6 +444,123 @@ def retire_session(session_id: str) -> Dict[str, Any]:
     updated = _deserialize(resp.get("Attributes", {}))
     logger.info("[INFO] Retired session %s", session_id)
     return updated
+
+
+# ---------------------------------------------------------------------------
+# Idle-sweep backstop — ENC-TSK-I71 (ENC-FTR-117 AC#8)
+# ---------------------------------------------------------------------------
+
+def _idle_reference(item: Mapping[str, Any]) -> str:
+    """Return the timestamp marking a session's last lifecycle transition.
+
+    For a claimed session that is ``claimed_at``; for an allocated (never-claimed) session
+    it is ``created_at``. There is no separate heartbeat attribute, so the most recent
+    lifecycle event stands in as the clock against which idleness is measured.
+    """
+    return str(item.get("claimed_at") or item.get("created_at") or "")
+
+
+def sweep_idle_sessions(
+    *,
+    idle_threshold_seconds: int = AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS,
+    now: Optional[dt.datetime] = None,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Reap abandoned sessions: flip live sessions (allocated/claimed) idle past the
+    threshold to ``retired``.
+
+    This is the TTL idle-sweep backstop of ENC-FTR-117 AC#8 — the third leg after
+    append-only storage (ENC-TSK-I37) and explicit ``agent.retire`` (ENC-TSK-I38). It is a
+    backstop for sessions whose agent died or hung without calling ``agent.retire``.
+
+    Idleness is measured from the session's last lifecycle transition (``_idle_reference``):
+    a session is a candidate when that timestamp is strictly older than
+    ``now - idle_threshold_seconds``.
+
+    Append-only and idempotent by construction:
+
+      * Each candidate is retired through ``retire_session`` — the SAME conditional
+        ``UpdateItem`` (``#st = :allocated OR #st = :claimed`` -> ``retired``) used by
+        ``agent.retire``. Nothing is ever deleted; this is deliberately NOT DynamoDB native
+        TTL (native TTL hard-deletes and would violate the append-only retire model).
+      * Already-retired sessions never enter the candidate set (the scan filters to live
+        statuses), so re-running produces no duplicate state changes.
+      * A candidate concurrently retired between scan and update fails the conditional check
+        and is recorded under ``skipped`` rather than erroring the whole sweep.
+
+    Args:
+        idle_threshold_seconds: age past which a live session is considered abandoned.
+        now: reference instant (defaults to current UTC); injectable for testing.
+        dry_run: when True, report candidates without mutating any session.
+
+    Returns a summary dict (counts + ids).
+    """
+    if isinstance(idle_threshold_seconds, bool) or not isinstance(idle_threshold_seconds, int):
+        raise ValueError(
+            f"idle_threshold_seconds must be an int, got {type(idle_threshold_seconds).__name__}"
+        )
+    if idle_threshold_seconds < 0:
+        raise ValueError(f"idle_threshold_seconds must be >= 0, got {idle_threshold_seconds}")
+
+    now_dt = now or dt.datetime.now(dt.timezone.utc)
+    cutoff = (now_dt - dt.timedelta(seconds=idle_threshold_seconds)).strftime(_TS_FORMAT)
+
+    ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": AGENT_SESSIONS_TABLE,
+        "FilterExpression": (
+            "NOT begins_with(session_id, :ctr_pfx) "
+            "AND (#st = :allocated OR #st = :claimed)"
+        ),
+        "ExpressionAttributeNames": {"#st": "status"},
+        "ExpressionAttributeValues": {
+            ":ctr_pfx": _serialize("counter#"),
+            ":allocated": _serialize("allocated"),
+            ":claimed": _serialize("claimed"),
+        },
+    }
+
+    scanned_live = 0
+    candidate_ids: List[str] = []
+    scan = ddb.scan(**scan_kwargs)
+    while True:
+        for raw in scan.get("Items", []):
+            item = _deserialize(raw)
+            scanned_live += 1
+            ref = _idle_reference(item)
+            if ref and ref < cutoff:
+                candidate_ids.append(item["session_id"])
+        last_key = scan.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        scan = ddb.scan(ExclusiveStartKey=last_key, **scan_kwargs)
+
+    retired: List[str] = []
+    skipped: List[Dict[str, str]] = []
+    if not dry_run:
+        for sid in candidate_ids:
+            try:
+                retire_session(sid)
+                retired.append(sid)
+            except ValueError as exc:
+                # Concurrently retired/transitioned between scan and update — idempotent skip.
+                skipped.append({"session_id": sid, "reason": str(exc)})
+
+    summary: Dict[str, Any] = {
+        "enabled": True,
+        "dry_run": dry_run,
+        "idle_threshold_seconds": idle_threshold_seconds,
+        "cutoff": cutoff,
+        "scanned_live": scanned_live,
+        "candidate_count": len(candidate_ids),
+        "candidate_ids": candidate_ids,
+        "retired_count": len(retired),
+        "retired": retired,
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+    }
+    logger.info("[INFO] Agent-session idle-sweep: %s", json.dumps(summary, default=str))
+    return summary
 
 
 # ---------------------------------------------------------------------------

--- a/backend/lambda/coordination_api/config.py
+++ b/backend/lambda/coordination_api/config.py
@@ -33,6 +33,8 @@ def _first_nonempty_env(*names: str) -> str:
     return ""
 
 __all__ = [
+    "AGENT_SESSIONS_IDLE_SWEEP_ENABLED",
+    "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS",
     "AGENT_SESSIONS_TABLE",
     "AGENT_TYPES_TABLE",
     "ANTHROPIC_API_BASE_URL",
@@ -177,6 +179,17 @@ DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
 # names. The allocator (agent_id_alloc.py) is dormant until the agent.* surface (I38).
 AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
 AGENT_TYPES_TABLE = os.environ.get("AGENT_TYPES_TABLE", "agent-types")
+# ENC-TSK-I71 / ENC-FTR-117 AC#8: scheduled idle-sweep backstop for abandoned agent
+# sessions. A session left in a live status (allocated/claimed) past the threshold is
+# reaped to 'retired' via an append-only status flip — NOT native DynamoDB TTL, which
+# hard-deletes and would violate the append-only retire model established in ENC-TSK-I38.
+# The threshold is operator-configurable; the sweep can be disabled via the enable flag.
+AGENT_SESSIONS_IDLE_SWEEP_ENABLED = (
+    os.environ.get("AGENT_SESSIONS_IDLE_SWEEP_ENABLED", "true").lower() == "true"
+)
+AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS = int(
+    os.environ.get("AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS", "86400")
+)
 DYNAMODB_REGION = os.environ.get("DYNAMODB_REGION", "us-west-2")
 SSM_REGION = os.environ.get("SSM_REGION", "us-west-2")
 CORS_ORIGIN = os.environ.get("CORS_ORIGIN", "https://jreese.net")

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.01",
-  "updated_at": "2026-06-28T03:01:00Z",
-  "last_change_summary": "ENC-TSK-I64 / ENC-TSK-I62: v3-prod landing of the governance-sync hardening — devops-document-api _sync_governance_documents propagates a governance_data_dictionary.json sync into the governance-policies record (discrete version + updated_at + dictionary_json blob), eliminating the manual aws dynamodb update-item (ENC-TSK-I61 gap). Paired CFN: DocumentApiRole +dynamodb:GetItem/UpdateItem on governance-policies, DocumentApiFunction +GOVERNANCE_POLICIES_TABLE. Gamma-verified (ENC-TSK-I63). Bump satisfies the path-triggered Governance Dictionary Guard on lambda_function.py edits.",
+  "version": "2026-06-28.02",
+  "updated_at": "2026-06-28T03:52:10Z",
+  "last_change_summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: agent-session TTL idle-sweep backstop. New coordination.agent_session_idle_sweep entity documents the scheduled EventBridge reaper (AgentSessionIdleSweepSchedule, rate(1 hour)) that flips sessions left allocated/claimed past AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS to 'retired' via the same append-only conditional UpdateItem as agent.retire — deliberately NOT DynamoDB native TTL, which would hard-delete and violate the append-only retire model from ENC-TSK-I38. Completes FTR-117 AC#8 (append-only storage + explicit agent.retire + idle-sweep backstop). Bump satisfies the path-triggered Governance Dictionary Guard on coordination_api lambda_function.py/config.py edits.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5749,6 +5749,27 @@
         }
       }
     },
+    "coordination.agent_session_idle_sweep": {
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8. Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose last lifecycle transition (claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent — already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge.",
+      "fields": {
+        "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits and reaps nothing."
+        },
+        "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS": {
+          "type": "integer",
+          "definition": "Env var (config.py + lambda_function.py), default 86400 (24h). A live session whose last lifecycle transition is older than this is reaped. Operator-configurable per ENC-TSK-I71 AC#2."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator. Fixed value 'agent_session_idle_sweep' routes lambda_handler to the sweep. Optional idle_threshold_seconds and dry_run keys in the Input override the configured defaults for an ad-hoc invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only — no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+        }
+      }
+    },
     "agent.type.list": {
       "description": "ENC-TSK-I38 / ENC-FTR-117. Request/response contract for GET /api/v1/coordination/agents/types (coordination action agent.type.list). Agent-type directory scan, excluding counter# sentinel rows. v4-SEAM facade.",
       "fields": {
@@ -5841,6 +5862,11 @@
       "version": "2026-06-27.05",
       "date": "2026-06-28",
       "summary": "ENC-TSK-I40 / ENC-FTR-117: added checkout_service.session_id_validation entity (active_agent_session_id ENC-SES-NNN constraint, _resolve_agent_session_id V4 rebind surface). Version bump required by governance-dictionary-guard for checkout_service/lambda_function.py edit."
+    },
+    {
+      "version": "2026-06-28.02",
+      "date": "2026-06-28",
+      "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip — NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -124,6 +124,13 @@ def _first_nonempty_env(*names: str) -> str:
 
 AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
 AGENT_TYPES_TABLE = os.environ.get("AGENT_TYPES_TABLE", "agent-types")
+# ENC-TSK-I71 / ENC-FTR-117 AC#8: scheduled idle-sweep backstop config (mirrors config.py).
+AGENT_SESSIONS_IDLE_SWEEP_ENABLED = (
+    os.environ.get("AGENT_SESSIONS_IDLE_SWEEP_ENABLED", "true").lower() == "true"
+)
+AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS = int(
+    os.environ.get("AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS", "86400")
+)
 COORDINATION_TABLE = os.environ.get("COORDINATION_TABLE", "coordination-requests")
 TRACKER_TABLE = os.environ.get("TRACKER_TABLE", "devops-project-tracker")
 PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
@@ -13675,6 +13682,46 @@ def _handle_agent_session_retire(
     return _response(200, {"session": item})
 
 
+def _handle_agent_session_idle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Scheduled backstop reaper for abandoned agent sessions (ENC-TSK-I71 / ENC-FTR-117 AC#8).
+
+    Invoked by the AgentSessionIdleSweepSchedule EventBridge rule, NOT an HTTP route — there
+    is no API Gateway envelope, auth, or claims on this path. Flips sessions left in a live
+    status (allocated/claimed) past the configured idle threshold to 'retired' via the
+    append-only conditional update in agent_id_alloc.sweep_idle_sessions (NOT a delete; NOT
+    native DynamoDB TTL). Returns a plain summary dict for CloudWatch.
+    """
+    if not _AGENT_ALLOC_AVAILABLE:
+        logger.error("[ERROR] idle-sweep invoked but agent_id_alloc module unavailable")
+        return {"enabled": False, "reason": "agent_id_alloc_unavailable", "retired_count": 0}
+    if not AGENT_SESSIONS_IDLE_SWEEP_ENABLED:
+        logger.info("[INFO] idle-sweep skipped — AGENT_SESSIONS_IDLE_SWEEP_ENABLED is false")
+        return {"enabled": False, "reason": "disabled", "retired_count": 0}
+    # The schedule delivers the rule's Input JSON verbatim; allow an optional per-invoke
+    # threshold/dry_run override, else fall back to the configured default.
+    raw_threshold = event.get("idle_threshold_seconds")
+    try:
+        threshold = (
+            int(raw_threshold)
+            if raw_threshold is not None
+            else AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS
+        )
+    except (TypeError, ValueError):
+        return {"enabled": True, "error": "idle_threshold_seconds must be an integer", "retired_count": 0}
+    dry_run = bool(event.get("dry_run", False))
+    try:
+        summary = _agent_alloc.sweep_idle_sessions(
+            idle_threshold_seconds=threshold, dry_run=dry_run
+        )
+    except ValueError as exc:
+        return {"enabled": True, "error": str(exc), "retired_count": 0}
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] idle-sweep DynamoDB failure: %s", exc)
+        return {"enabled": True, "error": "DynamoDB error during idle-sweep", "retired_count": 0}
+    logger.info("[SUCCESS] idle-sweep retired %d session(s)", summary.get("retired_count", 0))
+    return summary
+
+
 def _handle_agent_type_list(event: Dict[str, Any]) -> Dict[str, Any]:
     """GET /api/v1/coordination/agents/types — agent-type directory."""
     if not _AGENT_ALLOC_AVAILABLE:
@@ -13744,6 +13791,12 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     ):
         logger.info("[INFO] EventBridge callback event received")
         return _handle_eventbridge_callback(event)
+
+    # --- ENC-TSK-I71: scheduled agent-session idle-sweep (ENC-FTR-117 AC#8) ---
+    # The AgentSessionIdleSweepSchedule rule delivers its Input JSON verbatim as the event.
+    if event.get("action") == "agent_session_idle_sweep":
+        logger.info("[INFO] Scheduled agent-session idle-sweep invoked")
+        return _handle_agent_session_idle_sweep(event)
 
     # --- v0.3: SQS callback ingestion ---
     # SQS events have 'Records' with 'eventSource' = 'aws:sqs'.

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -5,6 +5,7 @@ Verifies the four task acceptance criteria server-side against real DynamoDB sem
 enforced minting with no caller-supplied ids (AC#2), and the persisted property sets being
 value-identical to the intended v4 node schemas (AC#3, the binding release gate).
 """
+import datetime as dt
 import os
 import unittest
 from unittest import mock
@@ -347,6 +348,163 @@ class AgentMutationTest(unittest.TestCase):
         found = alloc.find_agent_type(surface="s", model="m")
         self.assertIsNotNone(found)
         self.assertEqual(found["status"], "active")
+
+
+@mock_aws
+class IdleSweepTest(unittest.TestCase):
+    """ENC-TSK-I71: scheduled idle-sweep backstop (ENC-FTR-117 AC#8).
+
+    The append-only flip path (allocated/claimed -> retired) and idempotency are exercised
+    against real DynamoDB semantics via moto. Idleness is controlled deterministically by
+    injecting ``now`` rather than sleeping.
+    """
+
+    def setUp(self):
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        for table, key in (
+            (config.AGENT_SESSIONS_TABLE, "session_id"),
+            (config.AGENT_TYPES_TABLE, "agent_type_id"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        # An instant well after every session is minted, so freshly-minted sessions read as
+        # idle against a positive threshold.
+        self._future = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=2)
+
+    def _mint(self, **kw):
+        return alloc.mint_session_id(
+            agent_type_id=kw.get("agent_type_id", "ENC-AGT-001"),
+            runtime=kw.get("runtime", "cc-desktop"),
+            status=kw.get("status", "allocated"),
+        )
+
+    # -- AC#1: allocated/claimed idle sessions are reaped to retired ---------
+
+    def test_sweep_retires_idle_allocated_session(self):
+        sid = self._mint(status="allocated")["session_id"]
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertIn(sid, summary["retired"])
+        self.assertEqual(alloc.get_session(sid)["status"], "retired")
+
+    def test_sweep_retires_idle_claimed_session(self):
+        sid = self._mint(status="claimed")["session_id"]
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertIn(sid, summary["retired"])
+        self.assertEqual(alloc.get_session(sid)["status"], "retired")
+
+    # -- AC#1: fresh sessions within the threshold are left alone ------------
+
+    def test_sweep_leaves_fresh_sessions_untouched(self):
+        sid = self._mint(status="claimed")["session_id"]
+        # now() ~ mint time; a 24h threshold means the session is not yet idle.
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=86400)
+        self.assertEqual(summary["candidate_count"], 0)
+        self.assertEqual(summary["retired_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "claimed")
+
+    def test_sweep_keys_off_claimed_at_not_created_at(self):
+        # Idleness is measured from the LAST lifecycle transition (claimed_at), not from
+        # creation. A long-existing session that was only just (re)claimed must NOT be
+        # reaped — this guards against a regression that keys off created_at alone.
+        sid = self._mint(status="claimed")["session_id"]
+        fresh = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.ddb.update_item(
+            TableName=config.AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": sid}},
+            UpdateExpression="SET created_at = :old, claimed_at = :fresh",
+            ExpressionAttributeValues={
+                ":old": {"S": "2000-01-01T00:00:00Z"},  # ancient creation
+                ":fresh": {"S": fresh},                  # but claimed just now
+            },
+        )
+        now_soon = dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=5)
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=now_soon)
+        self.assertEqual(summary["candidate_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "claimed")
+
+    # -- AC#2: idempotent — already-retired sessions are skipped -------------
+
+    def test_sweep_is_idempotent_and_skips_already_retired(self):
+        sid = self._mint(status="allocated")["session_id"]
+        first = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertEqual(first["retired_count"], 1)
+        # Second run: the now-retired session is excluded from the live-status scan, so it
+        # is neither re-scanned nor re-retired — no duplicate state change.
+        second = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertEqual(second["scanned_live"], 0)
+        self.assertEqual(second["candidate_count"], 0)
+        self.assertEqual(second["retired_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "retired")
+
+    # -- AC#2: nothing is deleted (append-only) -----------------------------
+
+    def test_sweep_never_deletes_rows(self):
+        self._mint(status="allocated")
+        self._mint(status="claimed")
+        alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        rows = self.ddb.scan(TableName=config.AGENT_SESSIONS_TABLE)["Items"]
+        ids = sorted(r["session_id"]["S"] for r in rows)
+        # Both node rows AND the counter sentinel survive — only the status flipped.
+        self.assertEqual(ids, ["ENC-SES-001", "ENC-SES-002", "counter#ENC-SES"])
+        nodes = [r for r in rows if not r["session_id"]["S"].startswith("counter#")]
+        self.assertTrue(all(r["status"]["S"] == "retired" for r in nodes))
+
+    # -- AC#2: the idle threshold is configurable ---------------------------
+
+    def test_sweep_threshold_is_configurable(self):
+        sid = self._mint(status="claimed")["session_id"]
+        now_1h = dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1, minutes=1)
+        # A 2-hour threshold: the ~1h-old session is NOT yet idle.
+        wide = alloc.sweep_idle_sessions(idle_threshold_seconds=7200, now=now_1h)
+        self.assertEqual(wide["retired_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "claimed")
+        # A 30-minute threshold: the same session IS idle and gets reaped.
+        tight = alloc.sweep_idle_sessions(idle_threshold_seconds=1800, now=now_1h)
+        self.assertEqual(tight["retired_count"], 1)
+        self.assertEqual(alloc.get_session(sid)["status"], "retired")
+
+    # -- dry_run reports candidates without mutating ------------------------
+
+    def test_sweep_dry_run_reports_without_mutating(self):
+        sid = self._mint(status="allocated")["session_id"]
+        summary = alloc.sweep_idle_sessions(
+            idle_threshold_seconds=3600, now=self._future, dry_run=True
+        )
+        self.assertTrue(summary["dry_run"])
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertIn(sid, summary["candidate_ids"])
+        self.assertEqual(summary["retired_count"], 0)
+        # Untouched on disk.
+        self.assertEqual(alloc.get_session(sid)["status"], "allocated")
+
+    # -- the counter sentinel row is never a candidate ----------------------
+
+    def test_sweep_ignores_counter_row(self):
+        self._mint(status="allocated")  # also creates counter#ENC-SES
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertNotIn("counter#ENC-SES", summary["candidate_ids"])
+        self.assertNotIn("counter#ENC-SES", summary["retired"])
+        counter = self.ddb.get_item(
+            TableName=config.AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": "counter#ENC-SES"}},
+        ).get("Item")
+        self.assertIsNotNone(counter)
+
+    # -- input validation ---------------------------------------------------
+
+    def test_sweep_rejects_invalid_threshold(self):
+        for bad in (-1, True, "3600", 3.5):
+            with self.assertRaises(ValueError):
+                alloc.sweep_idle_sessions(idle_threshold_seconds=bad, now=self._future)
 
 
 if __name__ == "__main__":

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -186,6 +186,9 @@ Resources:
           # ENC-TSK-I37 / ENC-FTR-117: Agent ID v3 identity stores (server-side allocator path)
           AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
           AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"
+          # ENC-TSK-I71 / ENC-FTR-117 AC#8: idle-sweep backstop (scheduled append-only retire)
+          AGENT_SESSIONS_IDLE_SWEEP_ENABLED: "true"
+          AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS: "86400"
           # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
@@ -1330,6 +1333,34 @@ Resources:
       Targets:
         - Arn: !GetAtt CoordinationApiFunction.Arn
           Id: coordination-batch-poll
+
+  # ENC-TSK-I71 / ENC-FTR-117 AC#8: scheduled idle-sweep backstop. An hourly EventBridge
+  # rule invokes the coordination_api with a fixed Input action; the handler reaps sessions
+  # left allocated/claimed past AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS via an append-only flip
+  # to 'retired' (NOT native DynamoDB TTL — TTL hard-deletes and would break the append-only
+  # retire model from ENC-TSK-I38). Targets the unqualified function ARN, matching the
+  # CoordinationBatchPollerRule precedent above. Unlike that rule, this one ships with its
+  # required AWS::Lambda::Permission so EventBridge can actually invoke the function.
+  AgentSessionIdleSweepSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-session-idle-sweep${EnvironmentSuffix}"
+      Description: "ENC-TSK-I71: reap abandoned agent sessions (append-only retire backstop for ENC-FTR-117 AC#8)"
+      ScheduleExpression: rate(1 hour)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: agent-session-idle-sweep
+          Input: '{"action": "agent_session_idle_sweep"}'
+
+  AgentSessionIdleSweepPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AgentSessionIdleSweepSchedule.Arn
 
   DeployCodeBuildFinalizeRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
## ENC-TSK-I71 — agent-session TTL idle-sweep backstop (ENC-FTR-117 AC#8)

CCI-972e5b8cc5aa4d6495478050013d0af2

Completes the third leg of **ENC-FTR-117 AC#8**: append-only storage (I37) + explicit `agent.retire` (I38) + **TTL idle-sweep backstop (this PR)**.

### What
A scheduled EventBridge rule (`AgentSessionIdleSweepSchedule`, `rate(1 hour)`) invokes the coordination_api with `{"action":"agent_session_idle_sweep"}`. The handler reaps sessions left in a live status (`allocated`/`claimed`) whose last lifecycle transition (`claimed_at`, else `created_at`) is older than `AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS` (default 86400), flipping each to `retired` via the **same append-only conditional `UpdateItem`** as `agent.retire`.

### Why not native TTL
Deliberately **not** DynamoDB native TTL — TTL hard-deletes items, which would violate the append-only retire model established in ENC-TSK-I38. The sweep only flips status; nothing is ever deleted.

### Idempotency / append-only
- The live-status scan excludes already-retired rows → re-runs make no duplicate changes.
- A candidate concurrently retired between scan and update fails the conditional check and is skipped (not errored).

### Changes
- `agent_id_alloc.py`: `sweep_idle_sessions()` + `_idle_reference()`
- `lambda_function.py`: `_handle_agent_session_idle_sweep` + `lambda_handler` dispatch
- `config.py` / `lambda_function.py`: `AGENT_SESSIONS_IDLE_SWEEP_ENABLED`, `AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS`
- `02-compute.yaml`: new `AgentSessionIdleSweepSchedule` + `AgentSessionIdleSweepPermission` + 2 env vars (additive only; IAM `AgentIdStoresAccess` already grants Scan/UpdateItem; `AgentSessionsTable` has no `TimeToLiveSpecification`)
- `governance_data_dictionary.json`: `+coordination.agent_session_idle_sweep` entity, version `2026-06-28.02` (dictionary guard)

### Tests
46 unit tests pass (10 new): allocated→retired, claimed→retired, `claimed_at`-vs-`created_at` priority, idempotent / already-retired no-op, append-only (no delete), configurable threshold, dry-run, counter-row exclusion, input validation. Independent adversarial review verdict: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
