### PR TITLE
fix: ENC-ISS-417/418/422/424 sweep (plan gate, gamma alias, streamable URL, handoff_mandate) — ENC-TSK-I74

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -514,12 +514,25 @@ jobs:
                   capture_output=True, text=True,
               )
               if alias_r.returncode != 0:
-                  subprocess.run(
+                  create_r = subprocess.run(
                       ['aws', 'lambda', 'create-alias',
                        '--function-name', mapped_name, '--name', 'live',
                        '--function-version', new_version, '--region', region],
                       capture_output=True, text=True, check=False,
                   )
+                  if create_r.returncode != 0:
+                      # ENC-ISS-418: fail loud — do NOT swallow alias errors. The V4Gamma
+                      # deploy role previously lacked lambda:UpdateAlias/CreateAlias, so both
+                      # the update and the create silently AccessDenied while we still logged a
+                      # false 'live:N (direct)' success — freezing gamma :live at v81 for ~2
+                      # days (published-but-not-served). Raise so the worker records an error
+                      # and the deploy exits non-zero.
+                      err = ((alias_r.stderr or '').strip() + ' || ' + (create_r.stderr or '').strip()).strip()
+                      log(f'  [ERROR] {mapped_name}: could not advance :live to {new_version} '
+                          f'(update-alias AND create-alias both failed): {err}', err=True)
+                      raise RuntimeError(
+                          f'{mapped_name}: failed to advance :live alias to {new_version}: {err}'
+                      )
               log(f'  + {mapped_name} → live:{new_version} (direct)')
               return {'fn': fn, 'mapped_name': mapped_name, 'status': 'direct'}
 

--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -3041,6 +3041,48 @@ def _handle_plan_release(project_id: str, plan_id: str, body: dict) -> dict:
     return _response(200, {"success": True, "plan_id": plan_id})
 
 
+_PREFIX_MAP_CACHE: Optional[Dict[str, str]] = None
+_PREFIX_MAP_CACHE_AT: float = 0.0
+
+
+def _project_for_record_id(record_id: str, default_project: str) -> str:
+    """ENC-ISS-417: resolve a record's owning project from its ID prefix.
+
+    Objective IDs encode their project (e.g. ``INT-TSK-071`` -> ``intelligence``,
+    ``ENC-TSK-A89`` -> ``enceladus``). The plan completion gate (ENC-TSK-A89) must
+    resolve cross-project objective statuses in their OWN project partition, with
+    parity to plan.objectives_status — otherwise a cross-project objective resolves
+    as not_found in the plan's own partition and the plan can never complete.
+
+    Mirrors tracker_mutation._get_prefix_map_cached (projects table scan, 300s cache).
+    Falls back to ``default_project`` when the prefix is unmapped or the scan fails.
+    """
+    global _PREFIX_MAP_CACHE, _PREFIX_MAP_CACHE_AT
+    prefix = str(record_id or "").split("-", 1)[0].strip().upper()
+    if not prefix:
+        return default_project
+    now = time.time()
+    if _PREFIX_MAP_CACHE is None or (now - _PREFIX_MAP_CACHE_AT) >= 300.0:
+        try:
+            resp = _ddb.scan(
+                TableName=PROJECTS_TABLE,
+                ProjectionExpression="project_id, prefix",
+            )
+            mapping: Dict[str, str] = {}
+            for item in resp.get("Items", []):
+                pid = item.get("project_id", {}).get("S", "")
+                pfx = item.get("prefix", {}).get("S", "")
+                if pid and pfx:
+                    mapping[pfx.upper()] = pid
+            _PREFIX_MAP_CACHE = mapping
+            _PREFIX_MAP_CACHE_AT = now
+        except Exception as exc:
+            logger.warning("ENC-ISS-417: projects prefix-map scan failed: %s", exc)
+            if _PREFIX_MAP_CACHE is None:
+                return default_project
+    return (_PREFIX_MAP_CACHE or {}).get(prefix, default_project)
+
+
 def _validate_plan_objectives_complete(
     project_id: str,
     plan: dict,
@@ -3059,11 +3101,15 @@ def _validate_plan_objectives_complete(
         obj_id = str(obj_id).strip()
         if not obj_id:
             continue
-        obj_status_code, obj_record = _get_task(project_id, obj_id)
+        # ENC-ISS-417: resolve each objective in its OWN project partition (derived
+        # from the ID prefix) so cross-project objectives are validated correctly
+        # instead of resolving as not_found in the plan's own project.
+        obj_project = _project_for_record_id(obj_id, project_id)
+        obj_status_code, obj_record = _get_task(obj_project, obj_id)
         if obj_status_code != 200:
             for rtype in ("feature", "issue", "plan"):
                 obj_status_code, obj_record = _tracker_request(
-                    "GET", f"/{project_id}/{rtype}/{obj_id}",
+                    "GET", f"/{obj_project}/{rtype}/{obj_id}",
                 )
                 if obj_status_code == 200:
                     if isinstance(obj_record, dict) and isinstance(obj_record.get("record"), dict):

--- a/backend/lambda/checkout_service/test_plan_completion_crossproject.py
+++ b/backend/lambda/checkout_service/test_plan_completion_crossproject.py
@@ -1,0 +1,110 @@
+"""ENC-ISS-417: plan completion gate (ENC-TSK-A89) must resolve cross-project
+objectives in their OWN project partition, with parity to plan.objectives_status.
+
+Regression for: a plan (project=enceladus) whose objectives_set contains a CLOSED
+cross-project task (e.g. INT-TSK-071, project=intelligence) could never complete,
+because the gate looked the objective up in the plan's own (enceladus) partition and
+got not_found.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_lambda",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = checkout_lambda
+_SPEC.loader.exec_module(checkout_lambda)
+
+
+_PREFIX_SCAN = {
+    "Items": [
+        {"project_id": {"S": "enceladus"}, "prefix": {"S": "ENC"}},
+        {"project_id": {"S": "intelligence"}, "prefix": {"S": "INT"}},
+    ]
+}
+
+
+def _reset_prefix_cache():
+    checkout_lambda._PREFIX_MAP_CACHE = None
+    checkout_lambda._PREFIX_MAP_CACHE_AT = 0.0
+
+
+class ProjectForRecordIdTests(unittest.TestCase):
+    def setUp(self):
+        _reset_prefix_cache()
+
+    def test_resolves_prefix_to_project(self):
+        with mock.patch.object(checkout_lambda._ddb, "scan", return_value=_PREFIX_SCAN):
+            self.assertEqual(
+                checkout_lambda._project_for_record_id("INT-TSK-071", "enceladus"),
+                "intelligence",
+            )
+            self.assertEqual(
+                checkout_lambda._project_for_record_id("ENC-TSK-A89", "enceladus"),
+                "enceladus",
+            )
+
+    def test_unmapped_prefix_falls_back_to_default(self):
+        with mock.patch.object(checkout_lambda._ddb, "scan", return_value=_PREFIX_SCAN):
+            self.assertEqual(
+                checkout_lambda._project_for_record_id("ZZZ-TSK-001", "enceladus"),
+                "enceladus",
+            )
+
+    def test_scan_failure_falls_back_to_default(self):
+        with mock.patch.object(checkout_lambda._ddb, "scan", side_effect=RuntimeError("boom")):
+            self.assertEqual(
+                checkout_lambda._project_for_record_id("INT-TSK-071", "enceladus"),
+                "enceladus",
+            )
+
+
+class PlanCompletionGateCrossProjectTests(unittest.TestCase):
+    def setUp(self):
+        _reset_prefix_cache()
+
+    def test_closed_crossproject_objective_passes_gate(self):
+        """All objectives closed incl. a cross-project one -> gate returns None (pass)."""
+        plan = {"objectives_set": ["ENC-TSK-100", "INT-TSK-071"]}
+        seen_projects = {}
+
+        def _fake_get_task(project, obj_id):
+            seen_projects[obj_id] = project
+            return 200, {"status": "closed"}
+
+        with mock.patch.object(checkout_lambda._ddb, "scan", return_value=_PREFIX_SCAN), \
+                mock.patch.object(checkout_lambda, "_get_task", side_effect=_fake_get_task):
+            result = checkout_lambda._validate_plan_objectives_complete("enceladus", plan)
+
+        self.assertIsNone(result)  # gate passes
+        # cross-project objective was resolved in ITS project, not the plan's
+        self.assertEqual(seen_projects["INT-TSK-071"], "intelligence")
+        self.assertEqual(seen_projects["ENC-TSK-100"], "enceladus")
+
+    def test_open_crossproject_objective_reports_real_status_not_notfound(self):
+        plan = {"objectives_set": ["INT-TSK-071"]}
+
+        def _fake_get_task(project, obj_id):
+            return 200, {"status": "in-progress"}
+
+        with mock.patch.object(checkout_lambda._ddb, "scan", return_value=_PREFIX_SCAN), \
+                mock.patch.object(checkout_lambda, "_get_task", side_effect=_fake_get_task):
+            result = checkout_lambda._validate_plan_objectives_complete("enceladus", plan)
+
+        self.assertIsNotNone(result)  # gate blocks
+        body = result.get("body", "") if isinstance(result, dict) else ""
+        self.assertIn("in-progress", body)
+        self.assertNotIn("not_found", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/.build_extras
+++ b/backend/lambda/coordination_api/.build_extras
@@ -1,0 +1,13 @@
+# ENC-TSK-G43: cross-Lambda module sharing manifest.
+# Each non-comment line is a repo-relative path to a single file; the build
+# step copies it to the function root so the Lambda can `import` it normally.
+# Honored by .github/workflows/_build.yml.
+#
+# ENC-ISS-424: coordination(action=dispatch_plan.generate / dry_run) dynamically
+# loads dispatch_plan_generator.py, whose import shim does `import handoff_mandate`
+# (retrying after inserting its OWN directory onto sys.path). Both modules live in
+# tools/enceladus-mcp-server/ and MUST be co-located at the Lambda function root,
+# else the generator loads but the shim fails with "No module named 'handoff_mandate'"
+# (observed during ENC-TSK-I44 prod E2E). Declaring both here packages them together.
+tools/enceladus-mcp-server/dispatch_plan_generator.py
+tools/enceladus-mcp-server/handoff_mandate.py

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.01",
-  "updated_at": "2026-06-28T02:20:00Z",
-  "last_change_summary": "ENC-TSK-I63 / ENC-TSK-I62: devops-document-api _sync_governance_documents now propagates a governance_data_dictionary.json sync into the governance-policies DDB record (discrete version + updated_at + the served dictionary_json blob), closing the ENC-TSK-I61 gap that required a manual `aws dynamodb update-item`. Includes an S3-vs-DDB entities deep-equal drift pre-check (#v reserved-word alias; raw-S3-bytes blob write keeps the item 400KB-safe) plus the paired CFN change (DocumentApiRole +dynamodb:UpdateItem, DocumentApiFunction +GOVERNANCE_POLICIES_TABLE). No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on lambda_function.py edits.",
+  "version": "2026-06-28.02",
+  "updated_at": "2026-06-28T03:55:00Z",
+  "last_change_summary": "ENC-TSK-I74 (ENC-ISS-417/418/422/424 sweep): checkout_service plan completion gate (ENC-TSK-A89) now resolves cross-project objectives in their own project partition (ISS-417); coordination_api .build_extras packages dispatch_plan_generator + handoff_mandate together (ISS-424); V4Gamma deploy role gains lambda publish/alias perms + _deploy.yml fails loud on alias errors (ISS-418); enceladus-mcp-streamable live Function URL codified in CFN (ISS-422). No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on the checkout_service lambda_function.py edit.",
   "owners": [
     "enceladus-platform"
   ],

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3667,6 +3667,49 @@ Resources:
         - Key: Environment
           Value: gamma
 
+
+  # ---------------------------------------------------------------------------
+  # ENC-ISS-422 (residual of ENC-ISS-306): enceladus-mcp-streamable Function URL
+  # was left at Qualifier=NONE (-> $LATEST) when ENC-TSK-I24 fixed only mcp-code,
+  # so any update-function-code on streamable is an unguarded prod traffic switch
+  # (same class as the 2026-04-25 mcp-code Sev1). Mirror the I24 mcp-code mitigation:
+  # repoint the streamable Function URL to the `live` alias and codify it here so it
+  # is stack-managed. As with mcp-code, the `live` ALIAS itself is deliberately NOT
+  # codified (AWS::Lambda::Alias requires a FunctionVersion ops moves on every
+  # promotion -> ENC-ISS-313 CFN-stomp class); the Url references the alias by name
+  # and the alias stays operationally managed.
+  #
+  # ADOPTED OUT-OF-BAND (import-first, like EnceladusMcpCodeLiveFunctionUrl): ops
+  # creates the streamable `live` alias, repoints the Function URL to Qualifier=live,
+  # then a non-destructive CFN IMPORT adopts THIS resource with the identical physical
+  # id (mcp.jreese.net served uninterrupted). Do not let a normal compute deploy try to
+  # CREATE it. Prod-only (Condition: IsProduction) — not rendered on the gamma stack.
+  # ---------------------------------------------------------------------------
+  EnceladusMcpStreamableLiveFunctionUrl:
+    Type: AWS::Lambda::Url
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      TargetFunctionArn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-streamable"
+      Qualifier: live
+      AuthType: NONE
+      InvokeMode: BUFFERED
+      Cors:
+        AllowCredentials: true
+        AllowHeaders:
+          - content-type
+          - authorization
+          - accept
+          - mcp-session-id
+        AllowMethods:
+          - "*"
+        AllowOrigins:
+          - "https://claude.ai"
+        ExposeHeaders:
+          - mcp-session-id
+        MaxAge: 86400
+
   # ENC-TSK-I27 / ENC-FTR-116 Wave 2: recompute-governance Lambda.
   # Triggered by S3 ObjectCreated on governance/live/*; writes canonical
   # governance-version DDB record. IAM sole-writer grant (I28).

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -378,6 +378,16 @@ Resources:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
+                  # ENC-ISS-418: the V4Gamma deploy role could publish versions but had no
+                  # alias permissions, so the _deploy.yml direct-alias path got AccessDenied
+                  # (swallowed) and the gamma :live alias froze at v81 — every post-I07
+                  # tracker_mutation deploy was published-but-not-served. Grant publish + alias
+                  # (gamma-scoped) so deploys self-advance :live.
+                  - lambda:PublishVersion
+                  - lambda:ListVersionsByFunction
+                  - lambda:GetAlias
+                  - lambda:CreateAlias
+                  - lambda:UpdateAlias
                 Resource:
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:*-gamma"
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:*-gamma:*"


### PR DESCRIPTION
## ENC-TSK-I74 — issue sweep (gamma-first / v4/main)

Code fixes for four issues (ops-only 419/420, already-closed 421, evidence-resolved 423 handled separately).

- **ENC-ISS-424** — `coordination_api/.build_extras` packages `dispatch_plan_generator.py` + `handoff_mandate.py` at the function root (fixes `dispatch_plan.generate/dry_run` "No module named 'handoff_mandate'").
- **ENC-ISS-417** — `checkout_service` plan completion gate (ENC-TSK-A89) resolves cross-project objectives in their own project partition (prefix→project map) + regression tests. Unblocks cross-project plans like ENC-PLN-055.
- **ENC-ISS-418** — V4Gamma deploy role gains `PublishVersion`/`ListVersionsByFunction`/`Get|Create|UpdateAlias` (gamma-scoped); `_deploy.yml` now **raises** on alias failure instead of swallowing it (root cause of gamma `:live` freeze at v81).
- **ENC-ISS-422** — codifies `enceladus-mcp-streamable` live Function URL in `02-compute.yaml` (I24 mcp-code pattern, prod-conditioned, Retain; adopted via CFN import out-of-band).

Bundled dictionary bumped `2026-06-28.02` (Guard). checkout_service suite green; all CFN/workflow YAML parse.

Gamma-first per DOC-499 (prod adoption of 418 `:live` de-pin / 422 import are io-dev-admin ops follow-ups).

CCI-c6583d5cf620453799678d368cb06ab7

🤖 Generated with [Claude Code](https://claude.com/claude-code)