### PR TITLE
fix(cfn): ISS-418 alias grant on the real V4Gamma role Sid (V4GammaLambdaCodeDeploy) — ENC-TSK-I75

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -378,16 +378,6 @@ Resources:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
-                  # ENC-ISS-418: the V4Gamma deploy role could publish versions but had no
-                  # alias permissions, so the _deploy.yml direct-alias path got AccessDenied
-                  # (swallowed) and the gamma :live alias froze at v81 — every post-I07
-                  # tracker_mutation deploy was published-but-not-served. Grant publish + alias
-                  # (gamma-scoped) so deploys self-advance :live.
-                  - lambda:PublishVersion
-                  - lambda:ListVersionsByFunction
-                  - lambda:GetAlias
-                  - lambda:CreateAlias
-                  - lambda:UpdateAlias
                 Resource:
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:*-gamma"
                   - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:*-gamma:*"
@@ -671,6 +661,12 @@ Resources:
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
                   - lambda:ListVersionsByFunction
+                  # ENC-ISS-418: alias perms so _deploy.yml can advance/create the :live
+                  # alias on every v4-gamma deploy. Without these the direct-alias path
+                  # AccessDenied'd and gamma :live froze at v81 (published-but-not-served).
+                  - lambda:GetAlias
+                  - lambda:CreateAlias
+                  - lambda:UpdateAlias
                 Resource: "*"
               # S3 read for artifact version probing (belt-and-suspenders;
               # update-function-code fetches via Lambda service role, but


### PR DESCRIPTION
## ENC-TSK-I75 — corrective to ENC-TSK-I74 / ENC-ISS-418

The I74 ISS-418 grant was placed on Sid `GammaLambdaDeploy`, but the LIVE
`GitHubActions-V4Gamma-DeployRole` uses Sid **`V4GammaLambdaCodeDeploy`** (policy
`V4GammaLambdaDeployPolicy`, role `Gen2V4GammaDeployRole`). The gamma deploy after #615
hard-failed on `lambda:UpdateAlias` AccessDenied (418 fail-loud working as intended).

This moves `GetAlias`/`CreateAlias`/`UpdateAlias` to the correct Sid and reverts the
`GammaLambdaDeploy` edit. It matches the **AWS hotfix already applied** to the
`enceladus-github-roles` stack (io-dev-admin), resolving repo↔AWS drift so a future
github-roles deploy won't regress the gamma `:live` fix. The #615 gamma deploy is green
on re-run after the hotfix.

CCI-1375f7b656d542ba9b3ee11e795d5efc

🤖 Generated with [Claude Code](https://claude.com/claude-code)