### PR TITLE
fix(cfn): make S3 agent-documents IAM resources env-prefix-aware — ENC-TSK-I73

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2059,7 +2059,7 @@ Resources:
                   - s3:PutObject
                   - s3:GetObject
                   - s3:DeleteObject
-                Resource: "arn:aws:s3:::jreese-net/agent-documents/*"
+                Resource: !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
               # ENC-TSK-I70 / ENC-TSK-I62: env-prefix-aware so the gamma stack can read its
               # own gamma/governance/live + gamma/mobile/v1/reference objects. Was hardcoded to
               # the unprefixed prod paths, so the gamma governance sync 500'd on s3:GetObject
@@ -2960,7 +2960,7 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
-                  - "arn:aws:s3:::jreese-net/agent-documents/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -3064,7 +3064,7 @@ Resources:
                   - s3:ListBucket
                 Resource:
                   - "arn:aws:s3:::jreese-net"
-                  - "arn:aws:s3:::jreese-net/agent-documents/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
                   - "arn:aws:s3:::jreese-net/reference/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:


### PR DESCRIPTION
## Summary

- `DocumentApiRole` `S3DocumentsObjectAccess` was hardcoded to `agent-documents/*` — causes `AccessDenied` on `s3:PutObject` to `gamma/agent-documents/*` → docstore sync 500s on gamma
- `DocPrepRole` `S3ReadDocs` and `BedrockActionsRole` `S3ReadAccess` had the same pattern (read-only but same env-prefix gap)
- Changed all three to `!Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"` — no-op for prod (`S3EnvPrefix` is empty), fixes gamma

## Task

ENC-TSK-I73 · P2 · comp-cloudformation-app

CCI-a76f8ab06e12420b835d56f6c02e13e4

## Deploy

CFN compute pipeline via `v4/main` push. Gamma only (PLN-006 invariant).