### PR TITLE
[ENC-TSK-B63] PLN-006 Objective: Phase 2 Gate — tracker_mutation Decomposed

### DIFF
--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -499,6 +499,49 @@ _TRACKER_CREATE_MAX_ATTEMPTS = 32
 # Relation fields
 _RELATION_ID_FIELDS = {"related_task_ids", "related_issue_ids", "related_feature_ids"}
 
+# ENC-TSK-B63 AC-7 / ENC-ISS-241: bidirectional related_*_ids enforcement.
+# The related_{task,issue,feature}_ids field name encodes the TARGET record's type;
+# the inverse field on each target encodes the SOURCE record's type. So when record A
+# (type src) lists record B in related_{B_type}_ids, B must list A in related_{src}_ids —
+# atomically, in the same DynamoDB transaction, with fail-atomic semantics when any
+# target record does not exist (no silent unidirectional edges, the ENC-ISS-241 defect).
+_RELATION_FIELD_TO_TARGET_TYPE = {
+    "related_task_ids": "task",
+    "related_issue_ids": "issue",
+    "related_feature_ids": "feature",
+}
+# Only these source record types have a canonical related_<src>_ids inverse field.
+_BIDIRECTIONAL_SOURCE_TYPES = frozenset({"task", "issue", "feature"})
+# DynamoDB TransactWriteItems hard limit (source primary + N inverse target writes).
+_RELATION_TXN_MAX_ITEMS = 100
+
+
+def _bidirectional_relations_enabled() -> bool:
+    """ENC-TSK-B63 AC-4/AC-7: independently toggleable bidirectional relation
+    enforcement (rollback validated). Default ON; flip the AppConfig flag
+    ``enable_bidirectional_relations`` (or set ENABLE_BIDIRECTIONAL_RELATIONS=false)
+    to fall back to the legacy single-sided write path without a redeploy."""
+    return _appconfig_flag(
+        "enable_bidirectional_relations",
+        env_fallback="ENABLE_BIDIRECTIONAL_RELATIONS",
+        default=True,
+    )
+
+
+def _inverse_relation_field(source_type: str) -> Optional[str]:
+    """Field on a TARGET record that should list a SOURCE record of source_type."""
+    if source_type in _BIDIRECTIONAL_SOURCE_TYPES:
+        return f"related_{source_type}_ids"
+    return None
+
+
+def _resolve_target_project(target_id: str) -> Optional[str]:
+    """Resolve a target record's project from its ID prefix (e.g. ENC-TSK-001 -> enceladus)."""
+    parts = target_id.strip().upper().split("-")
+    if not parts or not parts[0]:
+        return None
+    return _get_prefix_map_cached().get(parts[0])
+
 # ENC-TSK-F41 / DOC-546B896390EA §5: server-side-only counter fields on task
 # records. Incremented atomically by the tracker lifecycle handler (closed_count
 # on every task->closed transition; checkout_count on every successful
@@ -3891,6 +3934,21 @@ def _handle_update_field(
                 "checkout": False, "checkout_state": "checked_in", "updated_at": now,
             })
 
+    # --- ENC-TSK-B63 AC-7 / ENC-ISS-241: atomic bidirectional relation enforcement ---
+    # When a related_*_ids field is written on a task/issue/feature, write the inverse
+    # field on every affected target in the SAME DynamoDB transaction (fail-atomic on a
+    # missing target). The flag-OFF path falls through to the legacy single-sided write.
+    if (
+        field in _RELATION_ID_FIELDS
+        and record_type in _BIDIRECTIONAL_SOURCE_TYPES
+        and _bidirectional_relations_enabled()
+    ):
+        bidi_result = _write_relation_field_bidirectional(
+            project_id, record_type, record_id, field, value, item_data, body,
+        )
+        if bidi_result is not None:
+            return bidi_result
+
     # --- Generic field update ---
     note_val = value if len(str(value)) <= 100 else str(value)[:100] + "..."
     note_text = f"Field '{field}' set to '{note_val}'{note_suffix}"
@@ -4784,6 +4842,271 @@ def _validate_rel_endpoints_exist(
     return None
 
 
+def _write_relation_field_bidirectional(
+    project_id: str,
+    record_type: str,
+    record_id: str,
+    field: str,
+    new_ids: Sequence[str],
+    item_data: Dict,
+    body: Dict,
+    *,
+    relate_note: Optional[str] = None,
+    force_add_targets: Optional[Sequence[str]] = None,
+) -> Optional[Dict]:
+    """Atomically write a related_*_ids field on the SOURCE record AND the inverse
+    field on every affected TARGET record, in a single DynamoDB transaction.
+
+    ENC-TSK-B63 AC-7 / ENC-ISS-241. Fail-atomic: if any added target record does not
+    exist, the whole transaction is rejected (HTTP 404) and the forward write never
+    lands — no silent unidirectional edges. Idempotent: an inverse already present on a
+    target is left untouched. Returns the governed HTTP response dict, or ``None`` when
+    the source record_type has no canonical inverse field (caller should fall back to
+    the plain single-field write path).
+    """
+    inverse_field = _inverse_relation_field(record_type)
+    if inverse_field is None:
+        return None  # signal: not handled here — caller does the legacy single write
+
+    ddb = _get_ddb()
+    now = _now_z()
+    source_id_u = record_id.strip().upper()
+    target_type = _RELATION_FIELD_TO_TARGET_TYPE[field]
+
+    # Normalize + dedup the desired forward list, preserving first-seen order.
+    seen: set = set()
+    forward_list: List[str] = []
+    for rid in new_ids:
+        ru = str(rid).strip().upper()
+        if ru and ru not in seen:
+            seen.add(ru)
+            forward_list.append(ru)
+
+    existing_set = {
+        str(x).strip().upper()
+        for x in (item_data.get(field) or [])
+        if str(x).strip()
+    }
+    new_set = set(forward_list)
+    additions = [t for t in forward_list if t not in existing_set]
+    removals = [t for t in existing_set if t not in new_set]
+
+    # force_add_targets lets tracker.relate guarantee (and self-heal) the inverse even
+    # when the forward edge already exists — additions diff alone would miss that case.
+    add_targets: List[str] = list(additions)
+    if force_add_targets:
+        add_seen = set(add_targets)
+        for t in force_add_targets:
+            tu = str(t).strip().upper()
+            if tu and tu in new_set and tu not in add_seen:
+                add_seen.add(tu)
+                add_targets.append(tu)
+
+    note_suffix = _write_source_note_suffix(body)
+    src_note = relate_note or f"Field '{field}' set to '{forward_list}'{note_suffix}"
+    src_history = {"M": {
+        "timestamp": _ser_s(now), "status": _ser_s("worklog"),
+        "description": _ser_s(src_note),
+    }}
+
+    transact_items: List[Dict] = [{
+        "Update": {
+            "TableName": DYNAMODB_TABLE,
+            "Key": _build_key(project_id, record_type, source_id_u),
+            "UpdateExpression": (
+                "SET #fld = :val, updated_at = :now, last_update_note = :note, "
+                "write_source = :wsrc, "
+                "sync_version = if_not_exists(sync_version, :zero) + :one, "
+                "history = list_append(if_not_exists(history, :empty), :hentry)"
+            ),
+            "ExpressionAttributeNames": {"#fld": field},
+            "ExpressionAttributeValues": {
+                ":val": _ser_value(forward_list),
+                ":now": _ser_s(now), ":note": _ser_s(src_note),
+                ":wsrc": _build_write_source(body),
+                ":zero": {"N": "0"}, ":one": {"N": "1"},
+                ":hentry": {"L": [src_history]}, ":empty": {"L": []},
+            },
+            "ConditionExpression": "attribute_exists(record_id)",
+        }
+    }]
+
+    affected: List[Dict[str, str]] = []
+    for action, targets in (("add", add_targets), ("remove", removals)):
+        for tid in targets:
+            tproj = _resolve_target_project(tid) or project_id
+            traw = _get_record_raw(tproj, target_type, tid)
+            if traw is None:
+                if action == "remove":
+                    # The source no longer references a target that has already
+                    # vanished — nothing to clean up, so don't fail the whole write.
+                    continue
+                return _error(
+                    404,
+                    (
+                        f"Cannot write bidirectional relation: target record '{tid}' "
+                        f"does not exist in project '{tproj}'. The '{field}' write is "
+                        f"rejected atomically so no unidirectional edge is created "
+                        f"(ENC-ISS-241 / ENC-TSK-B63 AC-7)."
+                    ),
+                    code="RELATION_TARGET_NOT_FOUND",
+                    field=field,
+                    target_id=tid,
+                )
+            tdata = _deser_item(traw)
+            tcur = [
+                str(x).strip().upper()
+                for x in (tdata.get(inverse_field) or [])
+                if str(x).strip()
+            ]
+            tcur_set = set(tcur)
+            if action == "add":
+                if source_id_u in tcur_set:
+                    continue  # inverse already present — idempotent, skip
+                tnew = tcur + [source_id_u]
+                tnote = (
+                    f"Inverse relation: added {source_id_u} to {inverse_field} "
+                    f"(bidirectional enforcement, ENC-ISS-241)"
+                )
+            else:  # remove
+                if source_id_u not in tcur_set:
+                    continue
+                tnew = [x for x in tcur if x != source_id_u]
+                tnote = (
+                    f"Inverse relation: removed {source_id_u} from {inverse_field} "
+                    f"(bidirectional enforcement, ENC-ISS-241)"
+                )
+            thistory = {"M": {
+                "timestamp": _ser_s(now), "status": _ser_s("worklog"),
+                "description": _ser_s(tnote),
+            }}
+            transact_items.append({
+                "Update": {
+                    "TableName": DYNAMODB_TABLE,
+                    "Key": _build_key(tproj, target_type, tid),
+                    "UpdateExpression": (
+                        "SET #inv = :inv, updated_at = :now, last_update_note = :tnote, "
+                        "sync_version = if_not_exists(sync_version, :zero) + :one, "
+                        "history = list_append(if_not_exists(history, :empty), :thentry)"
+                    ),
+                    "ExpressionAttributeNames": {"#inv": inverse_field},
+                    "ExpressionAttributeValues": {
+                        ":inv": _ser_value(tnew),
+                        ":now": _ser_s(now), ":tnote": _ser_s(tnote),
+                        ":zero": {"N": "0"}, ":one": {"N": "1"},
+                        ":thentry": {"L": [thistory]}, ":empty": {"L": []},
+                    },
+                    "ConditionExpression": "attribute_exists(record_id)",
+                }
+            })
+            affected.append({"target_id": tid, "action": action})
+
+    if len(transact_items) > _RELATION_TXN_MAX_ITEMS:
+        return _error(
+            400,
+            (
+                f"Too many relation targets in one write "
+                f"({len(transact_items) - 1}); DynamoDB transactions are limited to "
+                f"{_RELATION_TXN_MAX_ITEMS} items. Split the update into smaller batches."
+            ),
+            code="RELATION_BATCH_TOO_LARGE",
+            field=field,
+        )
+
+    try:
+        ddb.transact_write_items(TransactItems=transact_items)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "TransactionCanceledException":
+            # Source missing, or a target changed/vanished between read and write.
+            return _error(
+                409,
+                (
+                    "Bidirectional relation transaction was cancelled — a record "
+                    "changed concurrently or no longer exists. Retry the write."
+                ),
+                code="RELATION_TRANSACTION_CANCELLED",
+                field=field,
+            )
+        logger.error("transact_write_items failed: %s", exc)
+        return _error(500, "Database write failed.")
+
+    return _response(200, {
+        "success": True,
+        "record_id": source_id_u,
+        "field": field,
+        "value": forward_list,
+        "updated_at": now,
+        "bidirectional": True,
+        "inverse_field": inverse_field,
+        "affected_targets": affected,
+    })
+
+
+def _handle_relate(project_id: str, body: Dict) -> Dict:
+    """POST /{project}/relate — ENC-TSK-B63 AC-7 convenience action.
+
+    Creates the symmetric related_*_ids cross-reference between two records and writes
+    BOTH sides under a single governance-hash-checked transaction: target is added to
+    source.related_{target_type}_ids and source is added to target.related_{source_type}_ids.
+    Idempotent and self-healing (a pre-existing forward edge with a missing inverse is
+    repaired). relation_type is optional metadata recorded in the worklog note.
+    """
+    source_id = str(body.get("source_id", "")).strip().upper()
+    target_id = str(body.get("target_id", "")).strip().upper()
+    relation_type = str(body.get("relation_type", "relates-to")).strip() or "relates-to"
+
+    if not source_id or not target_id:
+        return _error(400, "source_id and target_id are required for tracker.relate.")
+    if source_id == target_id:
+        return _error(400, "Cannot relate a record to itself (irreflexive).")
+
+    source_type = _record_type_from_id(source_id)
+    target_type = _record_type_from_id(target_id)
+    if source_type not in _BIDIRECTIONAL_SOURCE_TYPES:
+        return _error(
+            400,
+            (
+                f"tracker.relate source must be one of {sorted(_BIDIRECTIONAL_SOURCE_TYPES)}; "
+                f"could not resolve a valid type from '{source_id}'."
+            ),
+            code="RELATION_UNSUPPORTED_TYPE",
+        )
+    if target_type not in _BIDIRECTIONAL_SOURCE_TYPES:
+        return _error(
+            400,
+            (
+                f"tracker.relate target must be one of {sorted(_BIDIRECTIONAL_SOURCE_TYPES)}; "
+                f"could not resolve a valid type from '{target_id}'."
+            ),
+            code="RELATION_UNSUPPORTED_TYPE",
+        )
+
+    field = f"related_{target_type}_ids"
+    raw = _get_record_raw(project_id, source_type, source_id)
+    if raw is None:
+        return _error(404, f"Source record '{source_id}' not found in project '{project_id}'.")
+    item_data = _deser_item(raw)
+
+    existing = [
+        str(x).strip().upper()
+        for x in (item_data.get(field) or [])
+        if str(x).strip()
+    ]
+    new_ids = existing if target_id in set(existing) else existing + [target_id]
+
+    note = (
+        f"tracker.relate: {source_id} <-> {target_id} ({relation_type})"
+        f"{_write_source_note_suffix(body)}"
+    )
+    result = _write_relation_field_bidirectional(
+        project_id, source_type, source_id, field, new_ids, item_data, body,
+        relate_note=note, force_add_targets=[target_id],
+    )
+    if result is None:
+        return _error(500, "tracker.relate could not be applied (no inverse field for source type).")
+    return result
+
+
 def _handle_create_relationship(project_id: str, body: Dict) -> Dict:
     """Create a typed relationship edge with auto-maintained inverse."""
     source_id = str(body.get("source_id", "")).strip().upper()
@@ -5663,6 +5986,10 @@ _RE_DEDUP_REVIEW = re.compile(
 _RE_RELATIONSHIP = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/relationship$"
 )
+# ENC-TSK-B63 AC-7: tracker.relate convenience action (bidirectional related_*_ids).
+_RE_RELATE = re.compile(
+    r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/relate$"
+)
 _RE_RECORD_SUB = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/(?P<type>task|issue|feature|lesson|plan|generation)/(?P<id>[A-Za-z0-9_-]+)/(?P<sub>log|checkout|acceptance-evidence|extend)$"
 )
@@ -5723,6 +6050,25 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
             return _handle_dedup_approve(project_id, body, claims)
         else:
             return _error(400, "Field 'op' must be 'propose' or 'approve'.")
+
+    # --- Route: tracker.relate convenience action (ENC-TSK-B63 AC-7 / ENC-ISS-241) ---
+    m_relate = _RE_RELATE.match(path)
+    if m_relate:
+        project_id = m_relate.group("project")
+        if method != "POST":
+            return _error(405, "Method not allowed on /relate. Use POST.")
+        claims, auth_err = _authenticate(event, ["tracker:write"])
+        if auth_err:
+            return auth_err
+        project_err = _validate_project_exists(project_id)
+        if project_err:
+            return _error(404, project_err)
+        try:
+            body = json.loads(event.get("body") or "{}")
+        except (ValueError, TypeError):
+            return _error(400, "Invalid JSON body.")
+        _normalize_write_source(body, claims)
+        return _handle_relate(project_id, body)
 
     # --- Route: typed relationship edges (ENC-FTR-049) ---
     m_rel = _RE_RELATIONSHIP.match(path)

--- a/backend/lambda/tracker_mutation/test_bidirectional_relations_b63.py
+++ b/backend/lambda/tracker_mutation/test_bidirectional_relations_b63.py
@@ -1,0 +1,249 @@
+"""ENC-TSK-B63 AC-7 / ENC-ISS-241: bidirectional related_*_ids enforcement tests.
+
+Mock-based coverage of the atomic reverse-edge writer and the tracker.relate
+convenience action, in the established tracker_mutation house style (patch
+_get_ddb / _get_record_raw / _get_prefix_map_cached; no live AWS). The
+end-to-end Neo4j projection traversal of the now-symmetric edges is validated on
+gamma as the OGTM live-traversal criterion (related_*_ids already projects an
+existing edge type, so no new edge type is introduced).
+
+Run: python3 -m pytest test_bidirectional_relations_b63.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "lambda_function",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+lf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lf)
+
+
+def _raw(record_id_sk: str, **fields) -> dict:
+    """Build a raw DynamoDB item with related_*_ids list fields."""
+    item = {"record_id": {"S": record_id_sk}}
+    for k, v in fields.items():
+        if isinstance(v, list):
+            item[k] = {"L": [{"S": str(x)} for x in v]}
+        else:
+            item[k] = {"S": str(v)}
+    return item
+
+
+class TestPureHelpers(unittest.TestCase):
+    def test_inverse_relation_field(self):
+        self.assertEqual(lf._inverse_relation_field("task"), "related_task_ids")
+        self.assertEqual(lf._inverse_relation_field("issue"), "related_issue_ids")
+        self.assertEqual(lf._inverse_relation_field("feature"), "related_feature_ids")
+        # plan/lesson have no canonical related_<type>_ids inverse field.
+        self.assertIsNone(lf._inverse_relation_field("plan"))
+        self.assertIsNone(lf._inverse_relation_field("lesson"))
+
+    def test_field_to_target_type(self):
+        self.assertEqual(lf._RELATION_FIELD_TO_TARGET_TYPE["related_issue_ids"], "issue")
+        self.assertEqual(
+            set(lf._RELATION_FIELD_TO_TARGET_TYPE.values()),
+            set(lf._BIDIRECTIONAL_SOURCE_TYPES),
+        )
+
+    def test_flag_default_on(self):
+        # No AppConfig / env override in the test env -> default True.
+        os.environ.pop("ENABLE_BIDIRECTIONAL_RELATIONS", None)
+        self.assertTrue(lf._bidirectional_relations_enabled())
+
+    def test_flag_env_rollback(self):
+        with patch.dict(os.environ, {"ENABLE_BIDIRECTIONAL_RELATIONS": "false"}):
+            # AppConfig may still win in a real env, but in unit context the env
+            # fallback path resolves False (rollback validated, ENC-TSK-B63 AC-4).
+            self.assertFalse(lf._bidirectional_relations_enabled())
+
+
+class TestBidirectionalWriter(unittest.TestCase):
+    def setUp(self):
+        self.ddb = MagicMock()
+
+    def _call(self, *, field, new_ids, item_data, targets):
+        """targets: {record_id_sk: raw_item or None}."""
+        def _grr(project, rtype, rid):
+            sk = f"{rtype}#{rid.upper()}"
+            return targets.get(sk)
+
+        with patch.object(lf, "_get_ddb", return_value=self.ddb), \
+                patch.object(lf, "_get_record_raw", side_effect=_grr), \
+                patch.object(lf, "_get_prefix_map_cached", return_value={"ENC": "enceladus"}):
+            return lf._write_relation_field_bidirectional(
+                "enceladus", "task", "ENC-TSK-1", field, new_ids, item_data, {},
+            )
+
+    def test_addition_writes_inverse_atomically(self):
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=["ENC-ISS-9"],
+            item_data={"related_issue_ids": []},
+            targets={"issue#ENC-ISS-9": _raw("issue#ENC-ISS-9", related_task_ids=[])},
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.ddb.transact_write_items.assert_called_once()
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        # primary (source) + 1 inverse (target)
+        self.assertEqual(len(items), 2)
+        # inverse update targets the issue's related_task_ids with the source id
+        inv = items[1]["Update"]
+        self.assertEqual(inv["ExpressionAttributeNames"]["#inv"], "related_task_ids")
+        self.assertEqual(inv["Key"]["record_id"]["S"], "issue#ENC-ISS-9")
+        self.assertIn("attribute_exists(record_id)", inv["ConditionExpression"])
+
+    def test_missing_target_fails_atomically(self):
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=["ENC-ISS-404"],
+            item_data={"related_issue_ids": []},
+            targets={"issue#ENC-ISS-404": None},  # target does not exist
+        )
+        self.assertEqual(resp["statusCode"], 404)
+        import json as _json
+        body = _json.loads(resp["body"])
+        self.assertEqual(body["error_envelope"]["code"], "RELATION_TARGET_NOT_FOUND")
+        # No silent unidirectional edge: the transaction is never issued.
+        self.ddb.transact_write_items.assert_not_called()
+
+    def test_idempotent_skips_existing_inverse(self):
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=["ENC-ISS-9"],
+            item_data={"related_issue_ids": []},
+            targets={"issue#ENC-ISS-9": _raw(
+                "issue#ENC-ISS-9", related_task_ids=["ENC-TSK-1"])},
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        # inverse already present -> only the primary write, no target update
+        self.assertEqual(len(items), 1)
+        self.assertEqual(resp_affected(resp), [])
+
+    def test_removal_writes_inverse_removal(self):
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=[],  # clearing the list removes ENC-ISS-9
+            item_data={"related_issue_ids": ["ENC-ISS-9"]},
+            targets={"issue#ENC-ISS-9": _raw(
+                "issue#ENC-ISS-9", related_task_ids=["ENC-TSK-1", "ENC-TSK-2"])},
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        self.assertEqual(len(items), 2)
+        inv_vals = items[1]["Update"]["ExpressionAttributeValues"][":inv"]["L"]
+        remaining = [x["S"] for x in inv_vals]
+        self.assertEqual(remaining, ["ENC-TSK-2"])  # source removed from inverse
+
+    def test_removal_missing_target_is_tolerated(self):
+        # Removing a reference to an already-deleted target must not fail the write.
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=[],
+            item_data={"related_issue_ids": ["ENC-ISS-GONE"]},
+            targets={"issue#ENC-ISS-GONE": None},
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        self.assertEqual(len(items), 1)  # only the primary write
+
+    def test_transaction_cancelled_returns_409(self):
+        self.ddb.transact_write_items.side_effect = ClientError(
+            {"Error": {"Code": "TransactionCanceledException"}}, "TransactWriteItems"
+        )
+        resp = self._call(
+            field="related_issue_ids",
+            new_ids=["ENC-ISS-9"],
+            item_data={"related_issue_ids": []},
+            targets={"issue#ENC-ISS-9": _raw("issue#ENC-ISS-9", related_task_ids=[])},
+        )
+        self.assertEqual(resp["statusCode"], 409)
+
+
+def resp_affected(resp) -> list:
+    import json as _json
+    return _json.loads(resp["body"]).get("affected_targets", [])
+
+
+class TestHandleRelate(unittest.TestCase):
+    def setUp(self):
+        self.ddb = MagicMock()
+
+    def _relate(self, body, records):
+        def _grr(project, rtype, rid):
+            sk = f"{rtype}#{rid.upper()}"
+            return records.get(sk)
+
+        with patch.object(lf, "_get_ddb", return_value=self.ddb), \
+                patch.object(lf, "_get_record_raw", side_effect=_grr), \
+                patch.object(lf, "_get_prefix_map_cached", return_value={"ENC": "enceladus"}):
+            return lf._handle_relate("enceladus", body)
+
+    def test_relate_writes_both_sides(self):
+        resp = self._relate(
+            {"source_id": "ENC-TSK-1", "target_id": "ENC-FTR-7"},
+            {
+                "task#ENC-TSK-1": _raw("task#ENC-TSK-1", related_feature_ids=[]),
+                "feature#ENC-FTR-7": _raw("feature#ENC-FTR-7", related_task_ids=[]),
+            },
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0]["Update"]["ExpressionAttributeNames"]["#fld"], "related_feature_ids")
+        self.assertEqual(items[1]["Update"]["ExpressionAttributeNames"]["#inv"], "related_task_ids")
+
+    def test_relate_self_rejected(self):
+        resp = self._relate(
+            {"source_id": "ENC-TSK-1", "target_id": "ENC-TSK-1"}, {})
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_relate_unsupported_target_type_rejected(self):
+        resp = self._relate(
+            {"source_id": "ENC-TSK-1", "target_id": "ENC-PLN-1"},
+            {"task#ENC-TSK-1": _raw("task#ENC-TSK-1")},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_relate_missing_source_404(self):
+        resp = self._relate(
+            {"source_id": "ENC-TSK-404", "target_id": "ENC-FTR-7"},
+            {"task#ENC-TSK-404": None, "feature#ENC-FTR-7": _raw("feature#ENC-FTR-7")},
+        )
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_relate_self_heals_missing_inverse(self):
+        # Forward edge already present on source, but inverse missing on target.
+        resp = self._relate(
+            {"source_id": "ENC-TSK-1", "target_id": "ENC-FTR-7"},
+            {
+                "task#ENC-TSK-1": _raw("task#ENC-TSK-1", related_feature_ids=["ENC-FTR-7"]),
+                "feature#ENC-FTR-7": _raw("feature#ENC-FTR-7", related_task_ids=[]),
+            },
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        items = self.ddb.transact_write_items.call_args.kwargs["TransactItems"]
+        # force_add_targets ensures the inverse is repaired even with no forward diff.
+        self.assertEqual(len(items), 2)
+
+
+class TestRouting(unittest.TestCase):
+    def test_relate_route_registered(self):
+        self.assertIsNotNone(lf._RE_RELATE.match("/enceladus/relate"))
+        self.assertIsNotNone(lf._RE_RELATE.match("/api/v1/tracker/enceladus/relate"))
+        self.assertIsNone(lf._RE_RELATE.match("/enceladus/task/ENC-TSK-1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -7530,6 +7530,10 @@ _EXECUTE_ACTIONS: Dict[str, Dict[str, Any]] = {
         "tool": "tracker_set_acceptance_evidence",
         "requires_governance_hash": True,
     },
+    # ENC-TSK-B63 AC-7 / ENC-ISS-241: bidirectional related_*_ids convenience action.
+    # Core (not behind ENABLE_TYPED_RELATIONSHIPS) — operates on the canonical
+    # related_{task,issue,feature}_ids fields, not the FTR-049 typed-edge primitive.
+    "tracker.relate": {"tool": "tracker_relate", "requires_governance_hash": True},
     "documents.check_policy": {"tool": "check_document_policy"},
     "documents.put": {"tool": "documents_put", "requires_governance_hash": True},
     "documents.patch": {"tool": "documents_patch", "requires_governance_hash": True},
@@ -9046,6 +9050,30 @@ async def _tracker_create_relationship(args: dict) -> list:
     return _result_text(resp)
 
 
+async def _tracker_relate(args: dict) -> list:
+    """ENC-TSK-B63 AC-7 / ENC-ISS-241: create a symmetric related_*_ids cross-reference
+    between two records, writing BOTH sides under a single governance-hash-checked
+    transaction. Idempotent and self-healing for a pre-existing one-sided edge."""
+    governance_error = _require_governance_hash(args)
+    if governance_error:
+        return _result_text({"error": governance_error})
+
+    project_id = args.get("project_id", "")
+    if not project_id:
+        return _result_text({"error": "project_id is required"})
+
+    payload = {
+        "source_id": args.get("source_id", ""),
+        "target_id": args.get("target_id", ""),
+        "governance_hash": args.get("governance_hash", ""),
+    }
+    if args.get("relation_type") is not None:
+        payload["relation_type"] = args["relation_type"]
+
+    resp = _tracker_api_request("POST", f"/{project_id}/relate", payload=payload)
+    return _result_text(resp)
+
+
 async def _tracker_archive_relationship(args: dict) -> list:
     """Archive (soft-delete) a typed relationship edge. Data preserved in DynamoDB."""
     governance_error = _require_governance_hash(args)
@@ -10206,6 +10234,8 @@ _TOOL_HANDLERS = {
     "tracker_create_relationship": _tracker_create_relationship,
     "tracker_archive_relationship": _tracker_archive_relationship,
     "tracker_list_relationships": _tracker_list_relationships,
+    # ENC-TSK-B63 AC-7 / ENC-ISS-241: bidirectional related_*_ids convenience action
+    "tracker_relate": _tracker_relate,
     # ENC-FTR-037: Checkout service tools
     "checkout_task": _checkout_task,
     "release_task": _release_task,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **AC-7 — Bidirectional relation enforcement (ENC-ISS-241)** of the Phase 2 Gate. The decomposed Record Service now writes reverse edges for `related_*` field mutations **atomically**, closing the long-standing unidirectional-edge defect (orphan edges in Neo4j).

- **`_write_relation_field_bidirectional`** — when a `task`/`issue`/`feature` writes `related_{task,issue,feature}_ids`, the inverse field on every affected target (`related_{source_type}_ids`) is written in the **same DynamoDB `TransactWriteItems`** call. **Fail-atomic**: if any added target does not exist, the whole transaction is rejected (404 `RELATION_TARGET_NOT_FOUND`) and the forward write never lands — no silent unidirectional edges. Idempotent (existing inverse left untouched); handles additions and removals.
- **`tracker.relate(source, target, relation_type)`** — new `POST /{project}/relate` route + MCP `execute` action that performs **both sides under one governance-hash check**. Idempotent and self-healing for a pre-existing one-sided edge.
- **PATCH `related_*_ids`** now routes through the atomic writer (the documented ENC-ISS-241 vector).
- **Independently toggleable** via `enable_bidirectional_relations` (AppConfig flag, env fallback `ENABLE_BIDIRECTIONAL_RELATIONS`, default **ON**) — flips back to the legacy single-sided path with no redeploy (supports AC-4 rollback semantics).

No new edge type is introduced (`related_*_ids` already projects an existing graph edge), so OGTM is not newly triggered; the now-symmetric edges become traversable from both endpoints through the existing projection.

### Tests
- 16 new unit tests (`test_bidirectional_relations_b63.py`): atomic addition, fail-atomic missing target, idempotency, removal, removal-of-vanished-target tolerance, transaction-cancelled 409, `tracker.relate` both-sides / self-reject / unsupported-type / missing-source / self-heal, route registration, flag default+rollback.
- Existing **172** `tracker_mutation` tests still pass; MCP `execute`/handler mapping verified consistent (no missing handlers).

## Governed metadata

- **task_id**: ENC-TSK-B63
- **Satisfied AC indices**: **AC-7** (bidirectional relation enforcement + `tracker.relate`, code-complete; live OGTM end-to-end traversal of the symmetric edges to be confirmed on gamma). **AC-4** partially supported: the new service path is behind an independently toggleable feature flag with a validated flag-OFF rollback path.
- **Not addressed in this PR**: AC-1/AC-2/AC-3/AC-5 are operational/time-window gates (escalation-protocol prerequisite, 48h/24h zero-fallback stabilization windows, blast-radius observation) that are not code-deliverable in a single PR. **AC-6** (v4-enhanced ID Boundary) explicitly depends on ENC-FTR-069 reaching `deploy-success` first and is out of scope here.
- **governance_hash**: `584baae9044510d86bbd331d844529d357b7aacff5c5c127c696f8cf94dde0f1`
- **connection_health** (at init):
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "584baae9044510d86bbd331d844529d357b7aacff5c5c127c696f8cf94dde0f1",
  "checked_at": "2026-06-28T10:05:24Z",
  "server_version": "1.0.0",
  "graph_index": {
    "status": "healthy",
    "signals": {"vector": true, "graph": true, "keyword": true},
    "graph_projection": {"configured": true, "name": "gds_standing_enceladus", "exists": true, "stale": false}
  }
}
```
- **CCI (Commit Complete ID)**: **Cannot be obtained.** The session contract for this task explicitly forbids calling `checkout.task` / `checkout.advance`, and a CCI is only issued by the checkout service when a task advances to `committed`. The task is therefore not checked out and no CCI exists for this branch. Per the contract, this is stated here explicitly.

## Deploy target
v4/main only (v3-prod frozen). Branch: `claude/enc-tsk-b63`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da1c942d-e5c2-407b-a688-980b2af99b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da1c942d-e5c2-407b-a688-980b2af99b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

