### PR TITLE
[ENC-TSK-B67] PLN-006 Objective: PWA 2.0 Governance Cockpit

### DIFF
--- a/backend/lambda/feed_realtime_publisher/deploy.sh
+++ b/backend/lambda/feed_realtime_publisher/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/feed_realtime_publisher/lambda_function.py
+++ b/backend/lambda/feed_realtime_publisher/lambda_function.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""devops-feed-realtime-publisher — DynamoDB Streams → AppSync Events publisher.
+
+This is the real-time delta path required by ENC-TSK-B67 (PWA 2.0 Governance
+Cockpit), complementing the existing SQS-FIFO → S3 snapshot pipeline
+(``feed_publisher``) which is preserved as the cold-start source and WebSocket
+fallback (AC-4). The two are complementary: S3 for snapshots, AppSync Events for
+live sub-500ms deltas (DOC-E470AC8CE9A8 §2.1).
+
+Pipeline (AC-2):
+
+    DynamoDB Streams (NEW_AND_OLD_IMAGES on devops-project-tracker)
+      → Event Source Mapping (BatchSize=1, MaximumBatchingWindowInSeconds=0,
+        ReportBatchItemFailures=true)
+      → this Lambda
+      → build lightweight event payload (realtime_payload.build_event_payload)
+      → HTTP POST to AppSync Events endpoint on channels:
+          /feed/updates, /records/{recordId}, /projects/{projectId}
+
+Both PWA mutations and MCP agent writes land in the same DynamoDB table and
+therefore flow through the same Streams trigger — source-agnostic propagation
+(AC-2 / AC-8).
+
+Environment variables:
+  APPSYNC_EVENTS_HTTP_ENDPOINT   AppSync Events HTTP endpoint
+                                 (https://<id>.appsync-api.<region>.amazonaws.com/event)
+  APPSYNC_EVENTS_API_KEY         API key for the Events API (x-api-key header)
+  APPSYNC_REGION                 region (default: us-west-2) — for SigV4 if no key
+  DRY_RUN                        "true" to skip the HTTP POST (unit/integration)
+  MAX_SUMMARY_BYTES              soft cap for the payload (default 500, AC-23)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+try:
+    from realtime_payload import (
+        appsync_endpoint,
+        build_event_payload,
+        channels_for_event,
+        payload_size_bytes,
+    )
+except ImportError as exc:  # pragma: no cover - import guard
+    logger.error("realtime_payload not bundled in the Lambda package: %s", exc)
+    raise
+
+DRY_RUN = os.environ.get("DRY_RUN", "").lower() in {"1", "true", "yes"}
+APPSYNC_API_KEY = os.environ.get("APPSYNC_EVENTS_API_KEY", "")
+MAX_PAYLOAD_BYTES = int(os.environ.get("MAX_SUMMARY_BYTES", "500"))
+
+try:  # boto3 is only needed for the live HTTP POST; tests run without it.
+    from boto3.dynamodb.types import TypeDeserializer
+
+    _deserializer = TypeDeserializer()
+except Exception:  # pragma: no cover - boto3 absent in pure unit context
+    _deserializer = None
+
+
+def _deserialize_image(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a DynamoDB Streams typed image into a plain dict."""
+    if not raw:
+        return {}
+    if _deserializer is not None:
+        out: Dict[str, Any] = {}
+        for key, val in raw.items():
+            try:
+                out[key] = _deserializer.deserialize(val)
+            except Exception:
+                out[key] = _shallow_unwrap(val)
+        return out
+    return {k: _shallow_unwrap(v) for k, v in raw.items()}
+
+
+def _shallow_unwrap(val: Any) -> Any:
+    """Minimal DynamoDB attribute-value unwrap (boto3-free fallback)."""
+    if not isinstance(val, dict) or not val:
+        return val
+    tag, inner = next(iter(val.items()))
+    if tag in ("S", "N"):
+        return float(inner) if tag == "N" and _is_number(inner) else inner
+    if tag == "BOOL":
+        return bool(inner)
+    if tag == "NULL":
+        return None
+    if tag == "L":
+        return [_shallow_unwrap(x) for x in inner]
+    if tag in ("SS", "NS"):
+        return list(inner)
+    if tag == "M":
+        return {k: _shallow_unwrap(v) for k, v in inner.items()}
+    return inner
+
+
+def _is_number(s: Any) -> bool:
+    try:
+        float(s)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _post_to_appsync(channel: str, payload: Dict[str, Any]) -> None:
+    """HTTP POST a single event to one AppSync Events channel.
+
+    AppSync Events expects {"channel": "<name>", "events": ["<json string>"]}.
+    """
+    endpoint = appsync_endpoint()
+    if DRY_RUN or not endpoint:
+        logger.info("DRY_RUN/no-endpoint: would publish to %s: %s", channel, payload.get("eventId"))
+        return
+
+    import urllib.request
+
+    body = json.dumps(
+        {"channel": channel, "events": [json.dumps(payload, separators=(",", ":"))]}
+    ).encode("utf-8")
+
+    headers = {"Content-Type": "application/json"}
+    if APPSYNC_API_KEY:
+        headers["x-api-key"] = APPSYNC_API_KEY
+
+    req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+        if resp.status >= 300:
+            raise RuntimeError(f"AppSync publish failed: HTTP {resp.status}")
+
+
+def process_record(record: Dict[str, Any], now_ms: int | None = None) -> Dict[str, Any]:
+    """Build and publish the event payload for a single stream record.
+
+    Returns a small result dict for logging/testing. Raises on publish failure
+    so the caller can register a partial-batch failure.
+    """
+    ddb = record.get("dynamodb", {})
+    new_image = _deserialize_image(ddb.get("NewImage", {}))
+    old_image = _deserialize_image(ddb.get("OldImage", {}))
+    approx_ms = None
+    approx = ddb.get("ApproximateCreationDateTime")
+    if approx is not None:
+        try:
+            approx_ms = int(float(approx) * 1000)
+        except (TypeError, ValueError):
+            approx_ms = None
+
+    payload = build_event_payload(
+        event_name=record.get("eventName", "MODIFY"),
+        new_image=new_image,
+        old_image=old_image,
+        approx_creation_ms=approx_ms,
+        now_ms=now_ms,
+    )
+    if payload is None:
+        return {"skipped": True}
+
+    size = payload_size_bytes(payload)
+    if size > MAX_PAYLOAD_BYTES:
+        logger.warning(
+            "feed_realtime_publisher: payload %s exceeds %d bytes (%d) — publishing anyway",
+            payload["eventId"], MAX_PAYLOAD_BYTES, size,
+        )
+
+    for channel in channels_for_event(payload):
+        _post_to_appsync(channel, payload)
+
+    return {"eventId": payload["eventId"], "recordId": payload["recordId"], "bytes": size}
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Lambda entry point for the DynamoDB Streams trigger.
+
+    Implements the ReportBatchItemFailures contract: a record that fails to
+    publish is reported by its sequence number so the stream redelivers only the
+    failed item rather than the whole batch.
+    """
+    records = event.get("Records", [])
+    logger.info("feed_realtime_publisher: invoked records=%d dry_run=%s", len(records), DRY_RUN)
+
+    failures: List[Dict[str, str]] = []
+    published = 0
+    for record in records:
+        seq = record.get("dynamodb", {}).get("SequenceNumber", "")
+        try:
+            result = process_record(record)
+            if not result.get("skipped"):
+                published += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.error("feed_realtime_publisher: publish failed seq=%s: %s", seq, exc, exc_info=True)
+            if seq:
+                failures.append({"itemIdentifier": seq})
+
+    logger.info("feed_realtime_publisher: published=%d failed=%d", published, len(failures))
+    return {"batchItemFailures": failures}

--- a/backend/lambda/feed_realtime_publisher/realtime_payload.py
+++ b/backend/lambda/feed_realtime_publisher/realtime_payload.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Pure payload-construction helpers for the real-time FeedPublisher.
+
+This module is deliberately dependency-free (stdlib only) so the full
+lightweight-event contract required by ENC-TSK-B67 (AC-2, AC-10, AC-22, AC-23)
+can be unit-tested without AWS, boto3, or a DynamoDB Streams event source.
+
+North Star contract (DOC-E470AC8CE9A8 §6.4): the FeedPublisher computes
+*everything* the client needs to render — the pre-rendered summary string, the
+derived action, the actor attribution, and the per-record context-node scores.
+The browser performs zero text generation, zero aggregation, and zero diffing;
+it only ``JSON.parse()`` and renders.
+
+Event payload shape (AC-10 / AC-23) — exactly these keys:
+
+    eventId       UUID v7 (timestamp-sortable, globally unique)
+    recordId      the mutated record id
+    record_type   task | issue | feature | plan | lesson | document | ...
+    action        created | updated | closed | status_changed | ... (pre-derived)
+    actorType     "human" | "agent"
+    actorId       actor identifier string
+    summary       pre-rendered human-readable display string
+    cursor        monotonically increasing integer
+    context_node  {freshness_score, structural_importance,
+                   information_density, access_frequency}  (AC-22)
+
+``occurred_at`` and ``channel`` are carried as transport metadata for latency
+instrumentation (AC-3) and routing (AC-1); they are not part of the AC-10 core
+model the client renders.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import secrets
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Versioning / constants
+# ---------------------------------------------------------------------------
+
+PAYLOAD_VERSION = "2.0"
+
+# Relationship fields the publisher can see on a tracker record. The count of
+# populated edges across these fields is the basis for the *absolute* degree
+# centrality used as structural_importance (DOC-310B93107B60 §4 — explicitly
+# NOT the query-relative seed-PPR metric).
+EDGE_FIELDS: Tuple[str, ...] = (
+    "parent",
+    "subtask_ids",
+    "related_task_ids",
+    "related_issue_ids",
+    "related_feature_ids",
+    "related_lesson_ids",
+    "related_document_ids",
+    "related_items",
+    "components",
+    "superseded_by",
+)
+
+# Degree saturation constant: degree/(degree+K) maps an unbounded edge count
+# into (0, 1). K=8 means a record with 8 edges scores 0.5.
+_DEGREE_SATURATION_K = 8.0
+
+# Freshness exponential-decay half-life in days.
+_FRESHNESS_HALFLIFE_DAYS = 7.0
+
+# Text fields used for the information-density (Shannon entropy) signal.
+_DENSITY_TEXT_FIELDS: Tuple[str, ...] = (
+    "title",
+    "description",
+    "intent",
+    "summary",
+    "content",
+    "update",
+)
+
+
+# ---------------------------------------------------------------------------
+# UUID v7 (RFC 9562) — timestamp-sortable, globally unique
+# ---------------------------------------------------------------------------
+
+
+def uuid7(ts_ms: Optional[int] = None) -> str:
+    """Return an RFC 9562 UUID v7 string.
+
+    The first 48 bits encode a Unix millisecond timestamp, making the value
+    lexicographically and chronologically sortable (the property AC-9/AC-10
+    rely on for dedup + ordering). The remaining bits are random.
+    """
+    if ts_ms is None:
+        ts_ms = int(time.time() * 1000)
+    ts_ms &= (1 << 48) - 1
+
+    rand_a = secrets.randbits(12)
+    rand_b = secrets.randbits(62)
+
+    # Assemble the 128-bit integer.
+    value = ts_ms << 80
+    value |= 0x7 << 76  # version 7
+    value |= rand_a << 64
+    value |= 0x2 << 62  # variant (10xx)
+    value |= rand_b
+
+    hex_str = f"{value:032x}"
+    return (
+        f"{hex_str[0:8]}-{hex_str[8:12]}-{hex_str[12:16]}-"
+        f"{hex_str[16:20]}-{hex_str[20:32]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cursor — monotonically increasing integer (AC-9 layer 3, AC-5.4 gap recovery)
+# ---------------------------------------------------------------------------
+
+
+def cursor_from_timestamp(ts_ms: Optional[int] = None) -> int:
+    """Derive a monotonically increasing cursor from a millisecond timestamp.
+
+    Using the DynamoDB-Streams approximate event time (ms since epoch) yields a
+    globally increasing integer without a shared counter. The client uses it for
+    cursor pagination and ``gap_too_large`` detection on reconnect.
+    """
+    if ts_ms is None:
+        ts_ms = int(time.time() * 1000)
+    return int(ts_ms)
+
+
+# ---------------------------------------------------------------------------
+# Actor attribution (AC-2, AC-10, AC-22)
+# ---------------------------------------------------------------------------
+
+
+def derive_actor(new_image: Dict[str, Any], old_image: Dict[str, Any]) -> Tuple[str, str]:
+    """Return ``(actorType, actorId)`` for a mutation.
+
+    A mutation is attributed to an *agent* when an agent session owns the
+    record's checkout or stamped the last write; otherwise it is a *human*
+    (PWA / Cognito) write. This is the source-agnostic attribution required by
+    AC-2 (both PWA and MCP agent mutations flow through the same trigger).
+    """
+    img = new_image or old_image or {}
+
+    session_id = (
+        img.get("active_agent_session_id")
+        or img.get("last_write_session_id")
+        or ""
+    )
+    if isinstance(session_id, str) and session_id.startswith("ENC-SES-"):
+        return "agent", session_id
+
+    write_source = img.get("write_source")
+    if isinstance(write_source, dict):
+        provider = str(write_source.get("provider", ""))
+        channel = str(write_source.get("channel", ""))
+        if "agent" in provider.lower() or "agent" in channel.lower() or provider.startswith("ENC-SES-"):
+            return "agent", provider or channel or "agent"
+        if provider:
+            return "human", provider
+
+    # last_update_note convention: "[USER-INITIATED] ..." → human override.
+    note = str(img.get("last_update_note", ""))
+    if "[USER-INITIATED]" in note:
+        return "human", str(img.get("initiated_by", "user"))
+
+    initiated_by = img.get("initiated_by")
+    if isinstance(initiated_by, str) and initiated_by:
+        return "human", initiated_by
+
+    return "human", "io"
+
+
+# ---------------------------------------------------------------------------
+# Action derivation (AC-10)
+# ---------------------------------------------------------------------------
+
+
+def derive_action(
+    event_name: str,
+    new_image: Dict[str, Any],
+    old_image: Dict[str, Any],
+) -> str:
+    """Derive the operation string the client renders, server-side.
+
+    ``event_name`` is the DynamoDB Streams event name (INSERT/MODIFY/REMOVE).
+    """
+    event_name = (event_name or "").upper()
+    if event_name == "INSERT":
+        return "created"
+    if event_name == "REMOVE":
+        return "removed"
+
+    old_status = (old_image or {}).get("status")
+    new_status = (new_image or {}).get("status")
+    if old_status != new_status and new_status is not None:
+        if new_status == "closed":
+            return "closed"
+        return "status_changed"
+
+    # Worklog / history append heuristic.
+    old_hist = _history_len(old_image)
+    new_hist = _history_len(new_image)
+    if new_hist > old_hist:
+        return "worklog_appended"
+
+    # Relationship edge added → create_relationship feed event (AC-22).
+    if _edge_count(new_image) > _edge_count(old_image):
+        return "create_relationship"
+
+    return "updated"
+
+
+def _history_len(image: Dict[str, Any]) -> int:
+    for key in ("worklog", "history", "update_history"):
+        val = (image or {}).get(key)
+        if isinstance(val, list):
+            return len(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Pre-rendered summary (AC-10, AC-23 — backend computes the display string)
+# ---------------------------------------------------------------------------
+
+
+def render_summary(
+    record_id: str,
+    record_type: str,
+    action: str,
+    actor_type: str,
+    actor_id: str,
+    new_image: Dict[str, Any],
+    old_image: Dict[str, Any],
+) -> str:
+    """Build the human-readable, ready-to-render summary string.
+
+    The client renders this verbatim; it performs no text generation (AC-10).
+    """
+    img = new_image or old_image or {}
+    title = str(img.get("title") or img.get("name") or record_id)
+    rtype = (record_type or "record").lower()
+    actor = "an agent" if actor_type == "agent" else "a human"
+    if actor_id and actor_id not in ("io", "user", "agent"):
+        actor = f"{actor_type} {actor_id}"
+
+    if action == "created":
+        return f"{actor} created {rtype} {record_id}: {title}"
+    if action == "closed":
+        return f"{actor} closed {rtype} {record_id}: {title}"
+    if action == "status_changed":
+        old_status = (old_image or {}).get("status", "?")
+        new_status = (new_image or {}).get("status", "?")
+        return (
+            f"{actor} moved {rtype} {record_id} from {old_status} to "
+            f"{new_status}: {title}"
+        )
+    if action == "worklog_appended":
+        return f"{actor} appended a worklog entry to {rtype} {record_id}: {title}"
+    if action == "create_relationship":
+        return f"{actor} added a relationship on {rtype} {record_id}: {title}"
+    if action == "removed":
+        return f"{actor} removed {rtype} {record_id}: {title}"
+    return f"{actor} updated {rtype} {record_id}: {title}"
+
+
+# ---------------------------------------------------------------------------
+# Context-node scoring (AC-22) — absolute, intrinsic, per-record signals
+# ---------------------------------------------------------------------------
+
+
+def _edge_count(image: Dict[str, Any]) -> int:
+    """Count populated relationship edges on a record (degree centrality)."""
+    if not image:
+        return 0
+    degree = 0
+    for field in EDGE_FIELDS:
+        val = image.get(field)
+        if val is None or val == "":
+            continue
+        if isinstance(val, (list, tuple, set)):
+            degree += len([v for v in val if v])
+        else:
+            degree += 1
+    return degree
+
+
+def compute_freshness(updated_at_ms: Optional[int], now_ms: Optional[int] = None) -> float:
+    """Exponential-decay freshness in [0, 1] from a last-update timestamp."""
+    if not updated_at_ms:
+        return 0.0
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+    age_days = max(0.0, (now_ms - updated_at_ms) / 86_400_000.0)
+    score = math.exp(-math.log(2) * age_days / _FRESHNESS_HALFLIFE_DAYS)
+    return round(_clamp01(score), 4)
+
+
+def compute_structural_importance(image: Dict[str, Any]) -> float:
+    """Absolute degree-centrality importance in [0, 1].
+
+    DOC-310B93107B60 §4 decision: ``structural_importance`` is redefined as an
+    ABSOLUTE metric (degree centrality, saturating), NOT the query-relative
+    seed-PPR value (which was stubbed to 0.5 in v3 and is ill-defined as a
+    fixed badge / edge label).
+    """
+    degree = _edge_count(image)
+    score = degree / (degree + _DEGREE_SATURATION_K)
+    return round(_clamp01(score), 4)
+
+
+def compute_information_density(image: Dict[str, Any]) -> float:
+    """Normalized Shannon entropy of the record's text content in [0, 1]."""
+    parts: List[str] = []
+    for field in _DENSITY_TEXT_FIELDS:
+        val = (image or {}).get(field)
+        if isinstance(val, str) and val:
+            parts.append(val)
+        elif isinstance(val, list):
+            parts.extend(str(v) for v in val if isinstance(v, str))
+    text = " ".join(parts).strip()
+    if not text:
+        return 0.0
+
+    counts: Dict[str, int] = {}
+    for ch in text:
+        counts[ch] = counts.get(ch, 0) + 1
+    total = len(text)
+    entropy = 0.0
+    for c in counts.values():
+        p = c / total
+        entropy -= p * math.log2(p)
+
+    # Normalize by the max entropy for the observed alphabet size, then weight
+    # by a length factor so a 3-char title does not score the same as a rich
+    # description. Both factors are absolute and intrinsic to the record.
+    alphabet = len(counts)
+    max_entropy = math.log2(alphabet) if alphabet > 1 else 1.0
+    norm_entropy = entropy / max_entropy if max_entropy > 0 else 0.0
+    length_factor = min(1.0, total / 400.0)
+    return round(_clamp01(norm_entropy * length_factor), 4)
+
+
+def compute_context_node(
+    image: Dict[str, Any],
+    updated_at_ms: Optional[int],
+    now_ms: Optional[int] = None,
+) -> Dict[str, float]:
+    """Assemble the four absolute context-node scores (AC-22)."""
+    access_frequency = 0
+    raw_af = (image or {}).get("access_frequency")
+    if isinstance(raw_af, (int, float)):
+        access_frequency = int(raw_af)
+    return {
+        "freshness_score": compute_freshness(updated_at_ms, now_ms),
+        "structural_importance": compute_structural_importance(image),
+        "information_density": compute_information_density(image),
+        "access_frequency": access_frequency,
+    }
+
+
+def _clamp01(x: float) -> float:
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Timestamp extraction
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_ms(value: Any) -> Optional[int]:
+    """Parse an ISO-8601 string into ms since epoch, tolerantly."""
+    if not isinstance(value, str) or not value:
+        return None
+    import datetime as _dt
+
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        dt = _dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_dt.timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def updated_at_ms_from_image(image: Dict[str, Any]) -> Optional[int]:
+    return _parse_iso_ms((image or {}).get("updated_at"))
+
+
+# ---------------------------------------------------------------------------
+# Top-level payload builder (AC-2, AC-10, AC-22, AC-23)
+# ---------------------------------------------------------------------------
+
+
+def build_event_payload(
+    *,
+    event_name: str,
+    new_image: Dict[str, Any],
+    old_image: Dict[str, Any],
+    approx_creation_ms: Optional[int] = None,
+    now_ms: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build the lightweight feed-event payload for one stream record.
+
+    Returns ``None`` when no renderable record id can be resolved (the record
+    is then skipped, contributing no feed noise).
+    """
+    img = new_image or old_image or {}
+    record_id = (
+        img.get("record_id")
+        or img.get("item_id")
+        or img.get("id")
+        or img.get("document_id")
+    )
+    if not record_id:
+        return None
+    record_id = str(record_id)
+
+    record_type = str(
+        img.get("record_type") or img.get("type") or _infer_type(record_id)
+    )
+    project_id = str(img.get("project_id") or "")
+
+    actor_type, actor_id = derive_actor(new_image, old_image)
+    action = derive_action(event_name, new_image, old_image)
+    summary = render_summary(
+        record_id, record_type, action, actor_type, actor_id, new_image, old_image
+    )
+
+    ts_ms = approx_creation_ms or int(time.time() * 1000)
+    updated_ms = updated_at_ms_from_image(img) or ts_ms
+    context_node = compute_context_node(img, updated_ms, now_ms)
+
+    import datetime as _dt
+
+    occurred_at = (
+        _dt.datetime.fromtimestamp(ts_ms / 1000, tz=_dt.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+        + "Z"
+    )
+
+    return {
+        "eventId": uuid7(ts_ms),
+        "recordId": record_id,
+        "record_type": record_type,
+        "action": action,
+        "actorType": actor_type,
+        "actorId": actor_id,
+        "summary": summary,
+        "cursor": cursor_from_timestamp(ts_ms),
+        "context_node": context_node,
+        # transport metadata (not part of the AC-10 core render model)
+        "projectId": project_id,
+        "occurred_at": occurred_at,
+        "version": PAYLOAD_VERSION,
+    }
+
+
+def channels_for_event(payload: Dict[str, Any]) -> List[str]:
+    """Return the AppSync Events channels a payload should be published to.
+
+    Maps the event onto the AC-1 channel model:
+      /feed/updates            global activity feed
+      /records/{recordId}      record-detail subscriptions
+      /projects/{projectId}    project-scoped events
+    """
+    channels = ["/feed/updates"]
+    rid = payload.get("recordId")
+    if rid:
+        channels.append(f"/records/{rid}")
+    pid = payload.get("projectId")
+    if pid:
+        channels.append(f"/projects/{pid}")
+    return channels
+
+
+def _infer_type(record_id: str) -> str:
+    seg = record_id.split("-")
+    if len(seg) >= 2:
+        code = seg[1].upper()
+        return {
+            "TSK": "task",
+            "ISS": "issue",
+            "FTR": "feature",
+            "PLN": "plan",
+            "LSN": "lesson",
+        }.get(code, "record")
+    if record_id.startswith("DOC-"):
+        return "document"
+    return "record"
+
+
+def payload_size_bytes(payload: Dict[str, Any]) -> int:
+    """Serialized JSON size in bytes — used to assert the AC-23 ≤500B budget."""
+    import json
+
+    return len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+
+def appsync_endpoint() -> Optional[str]:
+    return os.environ.get("APPSYNC_EVENTS_HTTP_ENDPOINT")

--- a/backend/lambda/feed_realtime_publisher/requirements.txt
+++ b/backend/lambda/feed_realtime_publisher/requirements.txt
@@ -1,0 +1,4 @@
+# Runtime dependencies for devops-feed-realtime-publisher.
+# boto3 is provided by the Lambda runtime; pinned here for local/dev parity.
+# The HTTP POST to AppSync Events uses urllib from the stdlib (no extra deps).
+boto3>=1.34.0

--- a/backend/lambda/feed_realtime_publisher/test_realtime_payload.py
+++ b/backend/lambda/feed_realtime_publisher/test_realtime_payload.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Unit tests for the real-time FeedPublisher payload contract (ENC-TSK-B67).
+
+Covers AC-2 (source-agnostic actor attribution), AC-10 (event data model +
+pre-rendered summary), AC-22 (absolute context-node scores), and AC-23
+(payload ≤500 bytes, JSON-serializable). Stdlib-only — no AWS, no boto3.
+
+Run: python3 -m pytest backend/lambda/feed_realtime_publisher/ -q
+ or: python3 backend/lambda/feed_realtime_publisher/test_realtime_payload.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import realtime_payload as rp  # noqa: E402
+
+
+class TestUuid7(unittest.TestCase):
+    def test_format_and_version(self):
+        u = rp.uuid7(1_700_000_000_000)
+        self.assertRegex(u, r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+    def test_timestamp_sortable(self):
+        early = rp.uuid7(1_700_000_000_000)
+        later = rp.uuid7(1_700_000_001_000)
+        self.assertLess(early, later)
+
+    def test_uniqueness(self):
+        ids = {rp.uuid7(1_700_000_000_000) for _ in range(500)}
+        self.assertEqual(len(ids), 500)
+
+
+class TestCursor(unittest.TestCase):
+    def test_monotonic_with_time(self):
+        self.assertLess(rp.cursor_from_timestamp(1000), rp.cursor_from_timestamp(2000))
+
+    def test_is_int(self):
+        self.assertIsInstance(rp.cursor_from_timestamp(1234), int)
+
+
+class TestActorAttribution(unittest.TestCase):
+    def test_agent_via_session_id(self):
+        actor_type, actor_id = rp.derive_actor({"active_agent_session_id": "ENC-SES-003"}, {})
+        self.assertEqual(actor_type, "agent")
+        self.assertEqual(actor_id, "ENC-SES-003")
+
+    def test_human_via_user_initiated(self):
+        actor_type, actor_id = rp.derive_actor(
+            {"last_update_note": "[USER-INITIATED] closed", "initiated_by": "jreese"}, {}
+        )
+        self.assertEqual(actor_type, "human")
+        self.assertEqual(actor_id, "jreese")
+
+    def test_default_human(self):
+        actor_type, actor_id = rp.derive_actor({"title": "x"}, {})
+        self.assertEqual(actor_type, "human")
+        self.assertEqual(actor_id, "io")
+
+    def test_agent_via_write_source(self):
+        actor_type, _ = rp.derive_actor({"write_source": {"provider": "ENC-SES-010"}}, {})
+        self.assertEqual(actor_type, "agent")
+
+
+class TestActionDerivation(unittest.TestCase):
+    def test_insert_is_created(self):
+        self.assertEqual(rp.derive_action("INSERT", {"status": "open"}, {}), "created")
+
+    def test_remove_is_removed(self):
+        self.assertEqual(rp.derive_action("REMOVE", {}, {"status": "open"}), "removed")
+
+    def test_status_to_closed(self):
+        self.assertEqual(
+            rp.derive_action("MODIFY", {"status": "closed"}, {"status": "pr"}), "closed"
+        )
+
+    def test_status_changed(self):
+        self.assertEqual(
+            rp.derive_action("MODIFY", {"status": "in-progress"}, {"status": "open"}),
+            "status_changed",
+        )
+
+    def test_worklog_appended(self):
+        old = {"status": "open", "worklog": [1]}
+        new = {"status": "open", "worklog": [1, 2]}
+        self.assertEqual(rp.derive_action("MODIFY", new, old), "worklog_appended")
+
+    def test_create_relationship(self):
+        old = {"status": "open", "related_task_ids": []}
+        new = {"status": "open", "related_task_ids": ["ENC-TSK-001"]}
+        self.assertEqual(rp.derive_action("MODIFY", new, old), "create_relationship")
+
+    def test_generic_update(self):
+        self.assertEqual(
+            rp.derive_action("MODIFY", {"status": "open", "title": "b"}, {"status": "open", "title": "a"}),
+            "updated",
+        )
+
+
+class TestSummary(unittest.TestCase):
+    def test_created_summary(self):
+        s = rp.render_summary(
+            "ENC-TSK-001", "task", "created", "agent", "ENC-SES-003",
+            {"title": "Do the thing"}, {},
+        )
+        self.assertIn("created", s)
+        self.assertIn("ENC-TSK-001", s)
+        self.assertIn("Do the thing", s)
+
+    def test_status_change_includes_both_states(self):
+        s = rp.render_summary(
+            "ENC-TSK-001", "task", "status_changed", "human", "io",
+            {"title": "T", "status": "pr"}, {"status": "committed"},
+        )
+        self.assertIn("committed", s)
+        self.assertIn("pr", s)
+
+
+class TestContextNode(unittest.TestCase):
+    def test_freshness_recent_is_high(self):
+        now = 1_700_000_000_000
+        self.assertGreater(rp.compute_freshness(now, now), 0.99)
+
+    def test_freshness_decays(self):
+        now = 1_700_000_000_000
+        week_ago = now - 7 * 86_400_000
+        self.assertAlmostEqual(rp.compute_freshness(week_ago, now), 0.5, places=2)
+
+    def test_structural_importance_absolute_degree(self):
+        none = rp.compute_structural_importance({"title": "x"})
+        many = rp.compute_structural_importance(
+            {"related_task_ids": ["a", "b"], "related_issue_ids": ["c"], "parent": "p", "components": ["x", "y"]}
+        )
+        self.assertEqual(none, 0.0)
+        self.assertGreater(many, none)
+        self.assertLessEqual(many, 1.0)
+
+    def test_structural_importance_not_stub_half(self):
+        # Must NOT be the v3 stubbed 0.5 seed-PPR value for an edge-less record.
+        self.assertNotEqual(rp.compute_structural_importance({"title": "x"}), 0.5)
+
+    def test_information_density_empty_is_zero(self):
+        self.assertEqual(rp.compute_information_density({}), 0.0)
+
+    def test_information_density_rich_text(self):
+        rich = rp.compute_information_density(
+            {"description": "The quick brown fox jumps over the lazy dog. " * 20}
+        )
+        self.assertGreater(rich, 0.0)
+        self.assertLessEqual(rich, 1.0)
+
+    def test_context_node_keys(self):
+        cn = rp.compute_context_node({"title": "x", "access_frequency": 3}, 1_700_000_000_000, 1_700_000_000_000)
+        self.assertEqual(
+            set(cn.keys()),
+            {"freshness_score", "structural_importance", "information_density", "access_frequency"},
+        )
+        self.assertEqual(cn["access_frequency"], 3)
+
+
+class TestBuildPayload(unittest.TestCase):
+    def _new_image(self):
+        return {
+            "record_id": "ENC-TSK-B67",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "title": "PWA 2.0 Governance Cockpit",
+            "status": "in-progress",
+            "updated_at": "2026-06-28T10:00:00Z",
+            "active_agent_session_id": "ENC-SES-003",
+            "related_issue_ids": ["ENC-ISS-121", "ENC-ISS-138"],
+        }
+
+    def test_payload_has_exact_core_keys(self):
+        p = rp.build_event_payload(
+            event_name="MODIFY", new_image=self._new_image(), old_image={"status": "open"},
+        )
+        for key in ("eventId", "recordId", "record_type", "action", "actorType", "actorId", "summary", "cursor", "context_node"):
+            self.assertIn(key, p)
+        self.assertEqual(p["recordId"], "ENC-TSK-B67")
+        self.assertEqual(p["actorType"], "agent")
+        self.assertEqual(p["action"], "status_changed")
+
+    def test_payload_json_serializable(self):
+        import json
+
+        p = rp.build_event_payload(event_name="INSERT", new_image=self._new_image(), old_image={})
+        json.loads(json.dumps(p))
+
+    def test_payload_under_500_bytes(self):
+        p = rp.build_event_payload(event_name="INSERT", new_image=self._new_image(), old_image={})
+        self.assertLessEqual(rp.payload_size_bytes(p), 500)
+
+    def test_no_record_id_returns_none(self):
+        self.assertIsNone(rp.build_event_payload(event_name="MODIFY", new_image={"title": "x"}, old_image={}))
+
+    def test_channels_mapping(self):
+        p = rp.build_event_payload(event_name="INSERT", new_image=self._new_image(), old_image={})
+        chans = rp.channels_for_event(p)
+        self.assertIn("/feed/updates", chans)
+        self.assertIn("/records/ENC-TSK-B67", chans)
+        self.assertIn("/projects/enceladus", chans)
+
+
+class TestHandler(unittest.TestCase):
+    def test_handler_dry_run_reports_no_failures(self):
+        os.environ["DRY_RUN"] = "true"
+        import importlib
+
+        import lambda_function as lf
+
+        importlib.reload(lf)
+        event = {
+            "Records": [
+                {
+                    "eventName": "INSERT",
+                    "dynamodb": {
+                        "SequenceNumber": "1",
+                        "NewImage": {
+                            "record_id": {"S": "ENC-TSK-B67"},
+                            "record_type": {"S": "task"},
+                            "project_id": {"S": "enceladus"},
+                            "title": {"S": "Cockpit"},
+                            "status": {"S": "open"},
+                            "updated_at": {"S": "2026-06-28T10:00:00Z"},
+                        },
+                    },
+                }
+            ]
+        }
+        result = lf.handler(event, None)
+        self.assertEqual(result, {"batchItemFailures": []})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/frontend/ui/package-lock.json
+++ b/frontend/ui/package-lock.json
@@ -15,7 +15,9 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
         "react-syntax-highlighter": "^16.1.0",
-        "react-window": "^2.2.7"
+        "react-window": "^2.2.7",
+        "sonner": "^2.0.7",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -9241,6 +9243,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -10923,6 +10935,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -20,7 +20,9 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "react-syntax-highlighter": "^16.1.0",
-    "react-window": "^2.2.7"
+    "react-window": "^2.2.7",
+    "sonner": "^2.0.7",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/ui/src/realtime/appsyncEventsClient.test.ts
+++ b/frontend/ui/src/realtime/appsyncEventsClient.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  AppSyncEventsClient,
+  computeBackoff,
+  BASE_RECONNECT_MS,
+  MAX_RECONNECT_MS,
+  MANUAL_RETRY_THRESHOLD,
+  type WebSocketLike,
+} from './appsyncEventsClient'
+
+class FakeSocket implements WebSocketLike {
+  onopen: ((ev?: unknown) => void) | null = null
+  onclose: ((ev?: unknown) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+  onmessage: ((ev: { data: unknown }) => void) | null = null
+  sent: string[] = []
+  closed = false
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {
+    this.closed = true
+    this.onclose?.()
+  }
+  emit(data: unknown) {
+    this.onmessage?.({ data })
+  }
+}
+
+const validEvent = (cursor: number, eventId?: string) => ({
+  eventId: eventId ?? `0190a1b2-c3d4-7e5f-8a9b-${cursor.toString(16).padStart(12, '0')}`,
+  recordId: 'ENC-TSK-B67',
+  record_type: 'task',
+  action: 'updated',
+  actorType: 'agent',
+  actorId: 'ENC-SES-003',
+  summary: 's',
+  cursor,
+})
+
+describe('computeBackoff (AC-4)', () => {
+  it('starts at ~500ms and grows exponentially within jitter band', () => {
+    const noJitter = () => 1 // jitter factor → 1.0 (max of band)
+    expect(computeBackoff(1, noJitter)).toBe(BASE_RECONNECT_MS)
+    expect(computeBackoff(2, noJitter)).toBe(BASE_RECONNECT_MS * 2)
+    expect(computeBackoff(3, noJitter)).toBe(BASE_RECONNECT_MS * 4)
+  })
+
+  it('caps at 30s', () => {
+    expect(computeBackoff(20, () => 1)).toBe(MAX_RECONNECT_MS)
+  })
+
+  it('applies 50-100% jitter', () => {
+    expect(computeBackoff(1, () => 0)).toBe(BASE_RECONNECT_MS * 0.5)
+    expect(computeBackoff(1, () => 0.999)).toBeGreaterThan(BASE_RECONNECT_MS * 0.74)
+  })
+})
+
+describe('AppSyncEventsClient', () => {
+  let sockets: FakeSocket[]
+  let onEvent: ReturnType<typeof vi.fn>
+  let onSnapshotRefetch: ReturnType<typeof vi.fn>
+  let timers: Array<{ cb: () => void; ms: number; id: number }>
+  let nextId: number
+
+  const flushTimer = (id: number) => {
+    const t = timers.find((x) => x.id === id)
+    if (t) t.cb()
+  }
+
+  const makeClient = (channels = ['/feed/updates']) =>
+    new AppSyncEventsClient({
+      channels,
+      createSocket: () => {
+        const s = new FakeSocket()
+        sockets.push(s)
+        return s
+      },
+      onEvent,
+      onSnapshotRefetch,
+      setTimeoutFn: (cb, ms) => {
+        const id = nextId++
+        timers.push({ cb, ms, id })
+        return id
+      },
+      clearTimeoutFn: (id) => {
+        timers = timers.filter((t) => t.id !== id)
+      },
+      random: () => 1,
+    })
+
+  beforeEach(() => {
+    sockets = []
+    timers = []
+    nextId = 1
+    onEvent = vi.fn()
+    onSnapshotRefetch = vi.fn()
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('connects and dispatches a valid event', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    expect(c.getStatus()).toBe('open')
+    sockets[0].emit(JSON.stringify(validEvent(5)))
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(c.getLastCursor()).toBe(5)
+  })
+
+  it('drops malformed frames', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    sockets[0].emit('{ not json')
+    sockets[0].emit(JSON.stringify({ foo: 'bar' }))
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('reconnects with backoff on close and resets attempts on open', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    sockets[0].onclose?.() // disconnect
+    expect(c.getStatus()).toBe('reconnecting')
+    expect(c.getReconnectAttempts()).toBe(1)
+    // a reconnect timer was scheduled
+    const timer = timers[timers.length - 1]
+    expect(timer.ms).toBe(BASE_RECONNECT_MS)
+    flushTimer(timer.id)
+    expect(sockets).toHaveLength(2)
+    sockets[1].onopen?.()
+    expect(c.getReconnectAttempts()).toBe(0)
+  })
+
+  it('surfaces manual_retry after 12 failed reconnects', () => {
+    const c = makeClient()
+    c.connect()
+    // simulate 12 consecutive close events without opening
+    for (let i = 0; i < MANUAL_RETRY_THRESHOLD; i++) {
+      const sock = sockets[sockets.length - 1]
+      sock.onclose?.()
+      const t = timers[timers.length - 1]
+      if (c.getStatus() === 'manual_retry') break
+      flushTimer(t.id)
+    }
+    expect(c.getStatus()).toBe('manual_retry')
+  })
+
+  it('retry() resets the backoff and reconnects', () => {
+    const c = makeClient()
+    c.connect()
+    for (let i = 0; i < MANUAL_RETRY_THRESHOLD; i++) {
+      sockets[sockets.length - 1].onclose?.()
+      const t = timers[timers.length - 1]
+      if (c.getStatus() === 'manual_retry') break
+      flushTimer(t.id)
+    }
+    expect(c.getStatus()).toBe('manual_retry')
+    c.retry()
+    expect(c.getReconnectAttempts()).toBe(0)
+  })
+
+  it('triggers S3 snapshot refetch on gap_too_large signal (AC-4)', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    sockets[0].emit(JSON.stringify({ type: 'gap_too_large', lastReceivedCursor: 3 }))
+    expect(onSnapshotRefetch).toHaveBeenCalledTimes(1)
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('triggers snapshot refetch when the live cursor gap exceeds threshold', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    sockets[0].emit(JSON.stringify(validEvent(1)))
+    sockets[0].emit(JSON.stringify(validEvent(5000)))
+    expect(onSnapshotRefetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends a heartbeat ping after the heartbeat interval', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    const hb = timers[timers.length - 1]
+    flushTimer(hb.id)
+    expect(sockets[0].sent.some((m) => m.includes('ping'))).toBe(true)
+  })
+
+  it('stops reconnecting after close()', () => {
+    const c = makeClient()
+    c.connect()
+    sockets[0].onopen?.()
+    c.close()
+    sockets[0].onclose?.()
+    expect(c.getStatus()).toBe('closed')
+  })
+})

--- a/frontend/ui/src/realtime/appsyncEventsClient.ts
+++ b/frontend/ui/src/realtime/appsyncEventsClient.ts
@@ -1,0 +1,248 @@
+/**
+ * AppSync Events WebSocket client (ENC-TSK-B67 AC-1, AC-4, AC-15, AC-23).
+ *
+ * A thin, dependency-injectable WebSocket subscriber for the AppSync Events
+ * channel model (DOC-E470AC8CE9A8 §1.5):
+ *   /feed/updates          global activity feed
+ *   /records/{recordId}    record detail subscriptions
+ *   /projects/{projectId}  project-scoped events
+ *
+ * Resilience (AC-4):
+ *   - exponential backoff from 500ms, capped at 30s, 50-100% jitter
+ *   - after 12 consecutive failed reconnects, surface a manual Retry button
+ *   - 30s application-level heartbeat (ping) to detect half-open connections
+ *   - on reconnect, send lastReceivedCursor; server replays missed events;
+ *     a `gap_too_large` signal triggers an S3 snapshot re-fetch
+ *
+ * Concurrency (AC-15): every state-changing dispatch is routed through an
+ * injected `scheduler` (React.startTransition in the app) so high-frequency
+ * server pushes never block user input.
+ *
+ * The transport is intentionally abstracted behind `WebSocketLike` +
+ * `createSocket` so the full reconnect/dedup/gap state machine is unit-testable
+ * with a fake socket and fake timers, no live AWS required.
+ */
+
+import { parseFeedEvent, isGapTooLarge, type FeedEvent } from './eventModel'
+
+export const BASE_RECONNECT_MS = 500
+export const MAX_RECONNECT_MS = 30_000
+export const HEARTBEAT_MS = 30_000
+export const MANUAL_RETRY_THRESHOLD = 12
+/** gap_too_large is signalled when the cursor gap exceeds this many events. */
+export const GAP_THRESHOLD = 1000
+
+export interface WebSocketLike {
+  send(data: string): void
+  close(): void
+  onopen: ((ev?: unknown) => void) | null
+  onclose: ((ev?: unknown) => void) | null
+  onerror: ((ev?: unknown) => void) | null
+  onmessage: ((ev: { data: unknown }) => void) | null
+}
+
+export type ConnectionStatus =
+  | 'connecting'
+  | 'open'
+  | 'reconnecting'
+  | 'manual_retry'
+  | 'closed'
+
+export interface AppSyncEventsClientOptions {
+  channels: string[]
+  createSocket: (channels: string[], sinceCursor: number | null) => WebSocketLike
+  onEvent: (event: FeedEvent) => void
+  /** Server signalled an oversize gap → caller should re-fetch the S3 snapshot. */
+  onSnapshotRefetch?: () => void
+  onStatusChange?: (status: ConnectionStatus) => void
+  /** Wrap state-mutating dispatch (use React.startTransition). */
+  scheduler?: (cb: () => void) => void
+  /** Injectable timers + RNG for deterministic tests. */
+  setTimeoutFn?: (cb: () => void, ms: number) => number
+  clearTimeoutFn?: (id: number) => void
+  random?: () => number
+  getCursor?: () => number | null
+}
+
+export function computeBackoff(attempt: number, random: () => number = Math.random): number {
+  // attempt is 1-based. Exponential from BASE, capped at MAX, then 50-100% jitter.
+  const exp = BASE_RECONNECT_MS * Math.pow(2, Math.max(0, attempt - 1))
+  const capped = Math.min(exp, MAX_RECONNECT_MS)
+  const jitter = 0.5 + random() * 0.5 // [0.5, 1.0)
+  return Math.round(capped * jitter)
+}
+
+export class AppSyncEventsClient {
+  private opts: Required<
+    Pick<
+      AppSyncEventsClientOptions,
+      'channels' | 'createSocket' | 'onEvent'
+    >
+  > &
+    AppSyncEventsClientOptions
+  private socket: WebSocketLike | null = null
+  private status: ConnectionStatus = 'closed'
+  private reconnectAttempts = 0
+  private reconnectTimer: number | null = null
+  private heartbeatTimer: number | null = null
+  private lastReceivedCursor: number | null = null
+  private stopped = false
+
+  private readonly schedule: (cb: () => void) => void
+  private readonly setT: (cb: () => void, ms: number) => number
+  private readonly clearT: (id: number) => void
+  private readonly rand: () => number
+
+  constructor(options: AppSyncEventsClientOptions) {
+    this.opts = options as typeof this.opts
+    this.schedule = options.scheduler ?? ((cb) => cb())
+    this.setT = options.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms) as unknown as number)
+    this.clearT = options.clearTimeoutFn ?? ((id) => clearTimeout(id))
+    this.rand = options.random ?? Math.random
+    if (options.getCursor) this.lastReceivedCursor = options.getCursor() ?? null
+  }
+
+  getStatus(): ConnectionStatus {
+    return this.status
+  }
+
+  getLastCursor(): number | null {
+    return this.lastReceivedCursor
+  }
+
+  getReconnectAttempts(): number {
+    return this.reconnectAttempts
+  }
+
+  connect(): void {
+    this.stopped = false
+    this.openSocket('connecting')
+  }
+
+  /** Manual Retry button handler — resets the backoff counter and reconnects. */
+  retry(): void {
+    this.reconnectAttempts = 0
+    this.clearReconnect()
+    this.openSocket('connecting')
+  }
+
+  close(): void {
+    this.stopped = true
+    this.clearReconnect()
+    this.clearHeartbeat()
+    if (this.socket) {
+      try {
+        this.socket.close()
+      } catch {
+        /* ignore */
+      }
+      this.socket = null
+    }
+    this.setStatus('closed')
+  }
+
+  private openSocket(initialStatus: ConnectionStatus): void {
+    this.setStatus(initialStatus)
+    const socket = this.opts.createSocket(this.opts.channels, this.lastReceivedCursor)
+    this.socket = socket
+
+    socket.onopen = () => {
+      this.reconnectAttempts = 0
+      this.setStatus('open')
+      this.startHeartbeat()
+    }
+    socket.onmessage = (ev) => this.handleMessage(ev.data)
+    socket.onerror = () => {
+      /* error precedes close; reconnection handled in onclose */
+    }
+    socket.onclose = () => {
+      this.clearHeartbeat()
+      if (this.stopped) return
+      this.scheduleReconnect()
+    }
+  }
+
+  private handleMessage(data: unknown): void {
+    let parsed: unknown = data
+    if (typeof data === 'string') {
+      try {
+        parsed = JSON.parse(data)
+      } catch {
+        return
+      }
+    }
+
+    if (isGapTooLarge(parsed)) {
+      this.schedule(() => this.opts.onSnapshotRefetch?.())
+      return
+    }
+
+    const event = parseFeedEvent(parsed)
+    if (!event) return
+
+    // Gap detection on the live stream (defense in depth vs server signal).
+    if (
+      this.lastReceivedCursor !== null &&
+      event.cursor - this.lastReceivedCursor > GAP_THRESHOLD
+    ) {
+      this.lastReceivedCursor = event.cursor
+      this.schedule(() => this.opts.onSnapshotRefetch?.())
+      return
+    }
+
+    this.lastReceivedCursor =
+      this.lastReceivedCursor === null
+        ? event.cursor
+        : Math.max(this.lastReceivedCursor, event.cursor)
+
+    this.schedule(() => this.opts.onEvent(event))
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectAttempts += 1
+    if (this.reconnectAttempts >= MANUAL_RETRY_THRESHOLD) {
+      this.setStatus('manual_retry')
+      return
+    }
+    this.setStatus('reconnecting')
+    const delay = computeBackoff(this.reconnectAttempts, this.rand)
+    this.reconnectTimer = this.setT(() => {
+      if (this.stopped) return
+      this.openSocket('reconnecting')
+    }, delay)
+  }
+
+  private startHeartbeat(): void {
+    this.clearHeartbeat()
+    const tick = () => {
+      if (this.stopped || !this.socket) return
+      try {
+        this.socket.send(JSON.stringify({ type: 'ping', ts: Date.now() }))
+      } catch {
+        /* ignore — onclose will trigger reconnect */
+      }
+      this.heartbeatTimer = this.setT(tick, HEARTBEAT_MS)
+    }
+    this.heartbeatTimer = this.setT(tick, HEARTBEAT_MS)
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      this.clearT(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer !== null) {
+      this.clearT(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    if (this.status === status) return
+    this.status = status
+    this.opts.onStatusChange?.(status)
+  }
+}

--- a/frontend/ui/src/realtime/entityStore.test.ts
+++ b/frontend/ui/src/realtime/entityStore.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useEntityStore } from './entityStore'
+
+describe('normalized entity store (AC-12 cross-page consistency)', () => {
+  beforeEach(() => useEntityStore.getState().reset())
+
+  it('upserts and reads back a single entity', () => {
+    useEntityStore.getState().upsert('task', 'ENC-TSK-B67', { status: 'open', title: 'Cockpit' })
+    const e = useEntityStore.getState().get('task', 'ENC-TSK-B67')
+    expect(e?.status).toBe('open')
+    expect(e?.title).toBe('Cockpit')
+    expect(e?.recordId).toBe('ENC-TSK-B67')
+  })
+
+  it('shallow-merges patches (single update propagates new field)', () => {
+    const s = useEntityStore.getState()
+    s.upsert('task', 'ENC-TSK-B67', { status: 'open', title: 'Cockpit' })
+    s.upsert('task', 'ENC-TSK-B67', { status: 'closed' })
+    const e = useEntityStore.getState().get('task', 'ENC-TSK-B67')
+    expect(e?.status).toBe('closed')
+    expect(e?.title).toBe('Cockpit')
+  })
+
+  it('a single upsert changes the entity reference for selector re-render', () => {
+    const s = useEntityStore.getState()
+    s.upsert('task', 'T1', { status: 'open' })
+    const before = useEntityStore.getState().get('task', 'T1')
+    s.upsert('task', 'T1', { status: 'closed' })
+    const after = useEntityStore.getState().get('task', 'T1')
+    expect(before).not.toBe(after) // new reference → subscribers re-render
+  })
+
+  it('hydrate bulk-loads a collection', () => {
+    useEntityStore.getState().hydrate('issue', [
+      { recordId: 'I1', record_type: 'issue', status: 'open' },
+      { recordId: 'I2', record_type: 'issue', status: 'closed' },
+    ])
+    expect(useEntityStore.getState().get('issue', 'I2')?.status).toBe('closed')
+  })
+
+  it('removes an entity', () => {
+    const s = useEntityStore.getState()
+    s.upsert('task', 'T1', { status: 'open' })
+    s.remove('task', 'T1')
+    expect(useEntityStore.getState().get('task', 'T1')).toBeUndefined()
+  })
+})

--- a/frontend/ui/src/realtime/entityStore.ts
+++ b/frontend/ui/src/realtime/entityStore.ts
@@ -1,0 +1,90 @@
+/**
+ * Normalized entity layer (ENC-TSK-B67 AC-12) — the cross-page consistency
+ * mechanism.
+ *
+ * Architectural decision (AC-12, AC-24 #1): the v4 launch ships the **Zustand
+ * normalized store** path rather than TanStack DB v0.6. Rationale committed to
+ * the task worklog / PR body: TanStack DB was still beta (v0.6) at gamma; the
+ * Zustand normalized store is production-stable, ~1KB, and gives fine-grained
+ * selector-driven re-renders. TanStack DB remains the documented future upgrade
+ * once it stabilizes (DOC-E470AC8CE9A8 §4.1/§9.2).
+ *
+ * Shape: `Record<EntityType, Record<ID, Entity>>`. A single `upsert(id, patch)`
+ * from the WebSocket event handler propagates to every component subscribed via
+ * a fine-grained `useEntity(type, id)` selector — detail page, embedded plan
+ * badges, and feed — with no per-view manual cache walking (AC-6, AC-12).
+ */
+
+import { create } from 'zustand'
+
+export type EntityType =
+  | 'task'
+  | 'issue'
+  | 'feature'
+  | 'plan'
+  | 'lesson'
+  | 'document'
+  | 'record'
+
+export interface NormalizedEntity {
+  recordId: string
+  record_type: EntityType | string
+  [key: string]: unknown
+}
+
+type EntityTable = Record<string, NormalizedEntity>
+
+interface EntityState {
+  entities: Record<string, EntityTable>
+  /** Insert or shallow-merge a single entity. */
+  upsert: (type: string, id: string, patch: Partial<NormalizedEntity>) => void
+  /** Bulk-load entities of a type (e.g. from a TanStack Query onSuccess). */
+  hydrate: (type: string, list: NormalizedEntity[]) => void
+  get: (type: string, id: string) => NormalizedEntity | undefined
+  remove: (type: string, id: string) => void
+  reset: () => void
+}
+
+export const useEntityStore = create<EntityState>((set, get) => ({
+  entities: {},
+  upsert: (type, id, patch) =>
+    set((state) => {
+      const table = state.entities[type] ?? {}
+      const prev = table[id]
+      const next: NormalizedEntity = {
+        ...prev,
+        ...patch,
+        recordId: id,
+        record_type: (patch.record_type as string) ?? prev?.record_type ?? type,
+      }
+      return { entities: { ...state.entities, [type]: { ...table, [id]: next } } }
+    }),
+  hydrate: (type, list) =>
+    set((state) => {
+      const table: EntityTable = { ...(state.entities[type] ?? {}) }
+      for (const e of list) {
+        const id = e.recordId
+        if (!id) continue
+        table[id] = { ...table[id], ...e, recordId: id }
+      }
+      return { entities: { ...state.entities, [type]: table } }
+    }),
+  get: (type, id) => get().entities[type]?.[id],
+  remove: (type, id) =>
+    set((state) => {
+      const table = state.entities[type]
+      if (!table || !(id in table)) return state
+      const next = { ...table }
+      delete next[id]
+      return { entities: { ...state.entities, [type]: next } }
+    }),
+  reset: () => set({ entities: {} }),
+}))
+
+/**
+ * Fine-grained selector hook. A component re-renders only when *its* entity
+ * reference changes (AC-12 propagation, AC-16 minimal re-render).
+ */
+export function useEntity(type: string, id: string | undefined): NormalizedEntity | undefined {
+  return useEntityStore((s) => (id ? s.entities[type]?.[id] : undefined))
+}

--- a/frontend/ui/src/realtime/eventModel.test.ts
+++ b/frontend/ui/src/realtime/eventModel.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { parseFeedEvent, isGapTooLarge } from './eventModel'
+
+const validEvent = {
+  eventId: '0190a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b',
+  recordId: 'ENC-TSK-B67',
+  record_type: 'task',
+  action: 'status_changed',
+  actorType: 'agent',
+  actorId: 'ENC-SES-003',
+  summary: 'agent ENC-SES-003 moved task ENC-TSK-B67 from open to in-progress',
+  cursor: 1782640000000,
+  context_node: {
+    freshness_score: 0.99,
+    structural_importance: 0.2,
+    information_density: 0.5,
+    access_frequency: 0,
+  },
+}
+
+describe('parseFeedEvent (AC-10 contract)', () => {
+  it('accepts a valid event object', () => {
+    const e = parseFeedEvent(validEvent)
+    expect(e).not.toBeNull()
+    expect(e?.recordId).toBe('ENC-TSK-B67')
+    expect(e?.actorType).toBe('agent')
+  })
+
+  it('parses a JSON string payload (client only JSON.parse + validate)', () => {
+    const e = parseFeedEvent(JSON.stringify(validEvent))
+    expect(e?.cursor).toBe(1782640000000)
+  })
+
+  it('rejects a non-UUIDv7 eventId', () => {
+    expect(parseFeedEvent({ ...validEvent, eventId: 'not-a-uuid' })).toBeNull()
+  })
+
+  it('rejects a v4 uuid (must be timestamp-sortable v7)', () => {
+    expect(
+      parseFeedEvent({ ...validEvent, eventId: '0190a1b2-c3d4-4e5f-8a9b-0c1d2e3f4a5b' }),
+    ).toBeNull()
+  })
+
+  it('rejects an invalid actorType', () => {
+    expect(parseFeedEvent({ ...validEvent, actorType: 'robot' })).toBeNull()
+  })
+
+  it('rejects a missing summary', () => {
+    const rest: Record<string, unknown> = { ...validEvent }
+    delete rest.summary
+    expect(parseFeedEvent(rest)).toBeNull()
+  })
+
+  it('rejects a non-numeric cursor', () => {
+    expect(parseFeedEvent({ ...validEvent, cursor: 'abc' })).toBeNull()
+  })
+
+  it('drops malformed JSON strings', () => {
+    expect(parseFeedEvent('{not json')).toBeNull()
+  })
+
+  it('omits context_node when malformed but keeps the event', () => {
+    const e = parseFeedEvent({ ...validEvent, context_node: { freshness_score: 'x' } })
+    expect(e).not.toBeNull()
+    expect(e?.context_node).toBeUndefined()
+  })
+})
+
+describe('isGapTooLarge', () => {
+  it('detects the gap signal', () => {
+    expect(isGapTooLarge({ type: 'gap_too_large', lastReceivedCursor: 5 })).toBe(true)
+  })
+  it('ignores normal events', () => {
+    expect(isGapTooLarge(validEvent)).toBe(false)
+  })
+})

--- a/frontend/ui/src/realtime/eventModel.ts
+++ b/frontend/ui/src/realtime/eventModel.ts
@@ -1,0 +1,124 @@
+/**
+ * Feed event data model + runtime validator (ENC-TSK-B67 AC-10 / AC-23).
+ *
+ * North Star contract (DOC-E470AC8CE9A8): the client is a thin reactive
+ * rendering surface. Every WebSocket message arriving from AppSync Events is a
+ * fully pre-rendered payload computed by the FeedPublisher Lambda. The client's
+ * ONLY responsibilities are `JSON.parse()` (done by the transport) and a cheap
+ * structural validation here — zero text generation, zero aggregation, zero
+ * diffing, zero summary computation.
+ *
+ * The shape mirrors backend `realtime_payload.build_event_payload` exactly.
+ */
+
+import type { ContextNodeMeta } from '../types/feeds'
+
+export type ActorType = 'human' | 'agent'
+
+export type FeedAction =
+  | 'created'
+  | 'updated'
+  | 'closed'
+  | 'status_changed'
+  | 'worklog_appended'
+  | 'create_relationship'
+  | 'removed'
+  | string
+
+/** The exact event contract delivered over AppSync Events (AC-10). */
+export interface FeedEvent {
+  /** UUID v7 — timestamp-sortable, globally unique (dedup + ordering). */
+  eventId: string
+  recordId: string
+  record_type: string
+  action: FeedAction
+  actorType: ActorType
+  actorId: string
+  /** Pre-rendered, ready-to-render display string. Backend computes it. */
+  summary: string
+  /** Monotonically increasing integer for pagination + gap detection. */
+  cursor: number
+  /** Absolute per-record context-node scores (AC-22). */
+  context_node?: ContextNodeMeta
+  /** Transport metadata (not part of the AC-10 core render model). */
+  projectId?: string
+  occurred_at?: string
+  version?: string
+  /** Client-only marker for an optimistic, not-yet-confirmed event. */
+  pending?: boolean
+}
+
+/** Control frames the server can push on the same channel. */
+export interface GapTooLargeSignal {
+  type: 'gap_too_large'
+  /** The cursor the client last saw; gap exceeds the replay threshold. */
+  lastReceivedCursor?: number
+}
+
+export type RealtimeFrame = FeedEvent | GapTooLargeSignal
+
+const UUID_V7_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function isGapTooLarge(frame: unknown): frame is GapTooLargeSignal {
+  return (
+    typeof frame === 'object' &&
+    frame !== null &&
+    (frame as { type?: unknown }).type === 'gap_too_large'
+  )
+}
+
+/**
+ * Validate-and-narrow an already-JSON-parsed frame into a FeedEvent.
+ *
+ * Returns null when the payload does not satisfy the AC-10 contract, so the
+ * client can drop malformed frames rather than rendering garbage. This is the
+ * full extent of client-side "processing" allowed by the North Star contract.
+ */
+export function parseFeedEvent(raw: unknown): FeedEvent | null {
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw)
+    } catch {
+      return null
+    }
+  }
+  if (typeof raw !== 'object' || raw === null) return null
+  const o = raw as Record<string, unknown>
+
+  if (typeof o.eventId !== 'string' || !UUID_V7_RE.test(o.eventId)) return null
+  if (typeof o.recordId !== 'string' || !o.recordId) return null
+  if (typeof o.record_type !== 'string') return null
+  if (typeof o.action !== 'string') return null
+  if (o.actorType !== 'human' && o.actorType !== 'agent') return null
+  if (typeof o.actorId !== 'string') return null
+  if (typeof o.summary !== 'string') return null
+  if (typeof o.cursor !== 'number' || !Number.isFinite(o.cursor)) return null
+
+  const event: FeedEvent = {
+    eventId: o.eventId,
+    recordId: o.recordId,
+    record_type: o.record_type,
+    action: o.action,
+    actorType: o.actorType,
+    actorId: o.actorId,
+    summary: o.summary,
+    cursor: o.cursor,
+  }
+  if (isContextNode(o.context_node)) event.context_node = o.context_node
+  if (typeof o.projectId === 'string') event.projectId = o.projectId
+  if (typeof o.occurred_at === 'string') event.occurred_at = o.occurred_at
+  if (typeof o.version === 'string') event.version = o.version
+  return event
+}
+
+function isContextNode(v: unknown): v is ContextNodeMeta {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.freshness_score === 'number' &&
+    typeof o.structural_importance === 'number' &&
+    typeof o.information_density === 'number' &&
+    typeof o.access_frequency === 'number'
+  )
+}

--- a/frontend/ui/src/realtime/feedBuffer.test.ts
+++ b/frontend/ui/src/realtime/feedBuffer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useFeedBuffer } from './feedBuffer'
+import type { FeedEvent } from './eventModel'
+
+function makeEvent(overrides: Partial<FeedEvent> = {}): FeedEvent {
+  return {
+    eventId: overrides.eventId ?? `0190a1b2-c3d4-7e5f-8a9b-${Math.random().toString(16).slice(2, 14).padEnd(12, '0')}`,
+    recordId: overrides.recordId ?? 'ENC-TSK-B67',
+    record_type: 'task',
+    action: 'updated',
+    actorType: 'agent',
+    actorId: 'ENC-SES-003',
+    summary: 'summary',
+    cursor: overrides.cursor ?? 1,
+    ...overrides,
+  }
+}
+
+describe('feedBuffer dedup + banner (AC-9, AC-11)', () => {
+  beforeEach(() => useFeedBuffer.getState().reset())
+
+  it('buffers incoming events without auto-injecting (banner count)', () => {
+    const s = useFeedBuffer.getState()
+    s.ingest(makeEvent({ eventId: 'a', cursor: 1 }))
+    s.ingest(makeEvent({ eventId: 'b', cursor: 2 }))
+    expect(useFeedBuffer.getState().bannerCount()).toBe(2)
+  })
+
+  it('drains buffer on banner click and clears it', () => {
+    const s = useFeedBuffer.getState()
+    s.ingest(makeEvent({ eventId: 'a', cursor: 1 }))
+    const drained = useFeedBuffer.getState().drain()
+    expect(drained).toHaveLength(1)
+    expect(useFeedBuffer.getState().bannerCount()).toBe(0)
+  })
+
+  it('Layer 1: replaces optimistic event by eventId instead of duplicating', () => {
+    const s = useFeedBuffer.getState()
+    s.registerOptimistic('evt-1')
+    // optimistic placeholder is in the buffer already (simulate prepend)
+    useFeedBuffer.setState((st) => ({
+      buffer: [makeEvent({ eventId: 'evt-1', cursor: 1, pending: true }), ...st.buffer],
+    }))
+    s.ingest(makeEvent({ eventId: 'evt-1', cursor: 1 }))
+    const buf = useFeedBuffer.getState().buffer
+    expect(buf).toHaveLength(1)
+    expect(buf[0].pending).toBe(false)
+  })
+
+  it('drops duplicate eventIds under replay (idempotent)', () => {
+    const s = useFeedBuffer.getState()
+    s.ingest(makeEvent({ eventId: 'dup', cursor: 1 }))
+    s.ingest(makeEvent({ eventId: 'dup', cursor: 1 }))
+    expect(useFeedBuffer.getState().bannerCount()).toBe(1)
+  })
+
+  it('tracks the highest received cursor for gap recovery', () => {
+    const s = useFeedBuffer.getState()
+    s.ingest(makeEvent({ eventId: 'a', cursor: 10 }))
+    s.ingest(makeEvent({ eventId: 'b', cursor: 5 }))
+    expect(useFeedBuffer.getState().lastReceivedCursor).toBe(10)
+  })
+})

--- a/frontend/ui/src/realtime/feedBuffer.ts
+++ b/frontend/ui/src/realtime/feedBuffer.ts
@@ -1,0 +1,106 @@
+/**
+ * Live-feed buffer + deduplication + new-activities banner (ENC-TSK-B67
+ * AC-9, AC-11).
+ *
+ * Incoming WebSocket events accumulate in this Zustand buffer and are NOT
+ * auto-injected into the feed DOM (AC-11 — banner click is the only path into
+ * the visible feed, preventing scroll disruption / layout shift).
+ *
+ * Deduplication (AC-9):
+ *   Layer 1 (eventId): `inFlight` tracks eventIds from in-PWA optimistic
+ *     mutations; an incoming event matching a known eventId REPLACES the
+ *     optimistic version rather than prepending a duplicate.
+ *   Layer 2 (eventual consistency): TanStack Query onSettled invalidation
+ *     reconciles drift (handled in optimisticMutations).
+ *   Layer 3 (cursor pagination): cursor-based getNextPageParam prevents
+ *     duplicate page boundaries (handled in the infinite-query options).
+ */
+
+import { create } from 'zustand'
+import type { FeedEvent } from './eventModel'
+
+interface FeedBufferState {
+  /** Buffered, not-yet-merged server events (newest first). */
+  buffer: FeedEvent[]
+  /** eventIds already known (optimistic in-flight or already merged). */
+  seen: Set<string>
+  /** eventIds of optimistic events still awaiting server confirmation. */
+  inFlight: Set<string>
+  /** Highest cursor observed — drives reconnect gap recovery. */
+  lastReceivedCursor: number | null
+
+  /** Count rendered by the "{N} new activities" banner. */
+  bannerCount: () => number
+
+  /** Register an optimistic event's id before the server echoes it back. */
+  registerOptimistic: (eventId: string) => void
+  /** Route an incoming server event into the buffer with full dedup. */
+  ingest: (event: FeedEvent) => void
+  /** Merge the buffer (banner click) and return the events to prepend. */
+  drain: () => FeedEvent[]
+  reset: () => void
+}
+
+export const useFeedBuffer = create<FeedBufferState>((set, get) => ({
+  buffer: [],
+  seen: new Set<string>(),
+  inFlight: new Set<string>(),
+  lastReceivedCursor: null,
+
+  bannerCount: () => get().buffer.length,
+
+  registerOptimistic: (eventId) =>
+    set((s) => {
+      const seen = new Set(s.seen)
+      const inFlight = new Set(s.inFlight)
+      seen.add(eventId)
+      inFlight.add(eventId)
+      return { seen, inFlight }
+    }),
+
+  ingest: (event) =>
+    set((s) => {
+      const cursor =
+        s.lastReceivedCursor === null
+          ? event.cursor
+          : Math.max(s.lastReceivedCursor, event.cursor)
+
+      // Layer 1: known eventId from an in-PWA optimistic mutation → replace the
+      // optimistic version in place (no duplicate prepend).
+      if (s.inFlight.has(event.eventId)) {
+        const inFlight = new Set(s.inFlight)
+        inFlight.delete(event.eventId)
+        const buffer = s.buffer.map((e) =>
+          e.eventId === event.eventId ? { ...event, pending: false } : e,
+        )
+        return { buffer, inFlight, lastReceivedCursor: cursor }
+      }
+
+      // Already buffered/merged → drop (idempotent under replay, AC-9).
+      if (s.seen.has(event.eventId)) {
+        return { lastReceivedCursor: cursor }
+      }
+
+      const seen = new Set(s.seen)
+      seen.add(event.eventId)
+      return {
+        buffer: [event, ...s.buffer],
+        seen,
+        lastReceivedCursor: cursor,
+      }
+    }),
+
+  drain: () => {
+    const drained = get().buffer
+    set({ buffer: [] })
+    return drained
+  },
+
+  reset: () =>
+    set({
+      buffer: [],
+      seen: new Set<string>(),
+      inFlight: new Set<string>(),
+      lastReceivedCursor: null,
+    }),
+}))

--- a/frontend/ui/src/realtime/governanceDocs.ts
+++ b/frontend/ui/src/realtime/governanceDocs.ts
@@ -1,0 +1,70 @@
+/**
+ * Live governance documentation reader (ENC-TSK-B67 AC-20, ENC-ISS-121).
+ *
+ * The PWA 2.0 serves ALL governance documentation — agents.md,
+ * lifecycle-primer.md, the governance data dictionary, and every docstore
+ * document — from the live governed store via the MCP read path. There is NO
+ * bundled/static mirror file imported anywhere: editing a governance document
+ * via `documents.patch` (or the §13 governance-sync path) is reflected on the
+ * next read with no PWA redeploy.
+ *
+ * This module deliberately contains zero `import './something.md'` static
+ * imports — the content always comes over the network from the governed read
+ * endpoints, satisfying the ENC-ISS-121 resolution required by AC-20.
+ */
+
+import { fetchWithAuth } from '../api/client'
+
+/** Governed read endpoints (backed by the MCP governance.get / documents.get). */
+const GOVERNANCE_BASE = '/api/v1/governance'
+const DOCUMENTS_BASE = '/api/v1/documents'
+
+export const governanceDocKeys = {
+  file: (fileName: string) => ['governance', 'file', fileName] as const,
+  dictionary: ['governance', 'dictionary'] as const,
+  document: (documentId: string) => ['governance', 'document', documentId] as const,
+}
+
+export interface GovernanceFile {
+  file_name: string
+  content: string
+  source: 'live-governed-store'
+  fetched_at: string
+}
+
+/**
+ * Fetch a live governance file (e.g. "agents.md", "agents/lifecycle-primer.md")
+ * from the governed store via the MCP read path.
+ */
+export async function fetchGovernanceFile(fileName: string): Promise<GovernanceFile> {
+  const res = await fetchWithAuth(`${GOVERNANCE_BASE}/${encodeURIComponent(fileName)}`, {
+    headers: { Accept: 'text/markdown,application/json;q=0.9,*/*;q=0.8' },
+  })
+  if (!res.ok) throw new Error(`Failed to fetch governance file ${fileName}: ${res.status}`)
+  const contentType = res.headers.get('content-type') ?? ''
+  const content = contentType.includes('application/json')
+    ? ((await res.json()).content ?? '')
+    : await res.text()
+  return {
+    file_name: fileName,
+    content,
+    source: 'live-governed-store',
+    fetched_at: new Date().toISOString(),
+  }
+}
+
+/** Fetch the live governance data dictionary (entity index). */
+export async function fetchGovernanceDictionary(): Promise<unknown> {
+  const res = await fetchWithAuth(`${GOVERNANCE_BASE}/dictionary`)
+  if (!res.ok) throw new Error(`Failed to fetch governance dictionary: ${res.status}`)
+  return res.json()
+}
+
+/** Fetch any docstore document live by id (e.g. DOC-FFB4C9D87BCC). */
+export async function fetchGovernedDocument(documentId: string): Promise<{ content: string }> {
+  const res = await fetchWithAuth(`${DOCUMENTS_BASE}/${encodeURIComponent(documentId)}`)
+  if (!res.ok) throw new Error(`Failed to fetch document ${documentId}: ${res.status}`)
+  const data = await res.json()
+  const doc = data.document ?? data
+  return { content: doc.content ?? '' }
+}

--- a/frontend/ui/src/realtime/graphModel.test.ts
+++ b/frontend/ui/src/realtime/graphModel.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPlanTree,
+  buildRelationshipGraph,
+  mergeGraphElements,
+  type GraphRecordInput,
+} from './graphModel'
+
+describe('buildPlanTree (AC-21 PLAN_CONTAINS)', () => {
+  it('emits a plan node plus PLAN_CONTAINS edges to every objective', () => {
+    const g = buildPlanTree(
+      { planId: 'ENC-PLN-006', title: 'v4', objectiveIds: ['ENC-TSK-B59', 'ENC-TSK-C08'] },
+    )
+    expect(g.nodes.map((n) => n.data.id)).toEqual(['ENC-PLN-006', 'ENC-TSK-B59', 'ENC-TSK-C08'])
+    expect(g.edges).toHaveLength(2)
+    expect(g.edges.every((e) => e.data.relationship_type === 'PLAN_CONTAINS')).toBe(true)
+    expect(g.edges[0].data.label).toBe('PLAN_CONTAINS')
+  })
+
+  it('uses provided objective records for labels/status', () => {
+    const g = buildPlanTree(
+      { planId: 'P1', objectiveIds: ['T1'] },
+      [{ recordId: 'T1', title: 'Task one', record_type: 'task', status: 'closed' }],
+    )
+    const node = g.nodes.find((n) => n.data.id === 'T1')
+    expect(node?.data.status).toBe('closed')
+    expect(node?.data.label).toContain('Task one')
+  })
+})
+
+describe('buildRelationshipGraph (AC-22 typed edges + context-node labels)', () => {
+  const records: GraphRecordInput[] = [
+    {
+      recordId: 'ENC-TSK-B67',
+      title: 'Cockpit',
+      record_type: 'task',
+      context_node: {
+        freshness_score: 0.9,
+        structural_importance: 0.42,
+        information_density: 0.5,
+        access_frequency: 0,
+      },
+      typed_relationships: [
+        {
+          relationship_type: 'INFORMED_BY',
+          target_id: 'DOC-E470AC8CE9A8',
+          weight: 1,
+          confidence: 1,
+          reason: null,
+          created_at: null,
+        },
+      ],
+    },
+  ]
+
+  it('renders the relationship type as the edge label', () => {
+    const g = buildRelationshipGraph(records)
+    const edge = g.edges[0]
+    expect(edge.data.relationship_type).toBe('INFORMED_BY')
+    expect(edge.data.label).toContain('INFORMED_BY')
+  })
+
+  it('surfaces structural_importance (context-node metadata) in the edge label', () => {
+    const g = buildRelationshipGraph(records)
+    expect(g.edges[0].data.label).toContain('S=0.42')
+  })
+
+  it('carries context-node scores on the node data', () => {
+    const g = buildRelationshipGraph(records)
+    const node = g.nodes.find((n) => n.data.id === 'ENC-TSK-B67')
+    expect(node?.data.context_node?.structural_importance).toBe(0.42)
+    expect(node?.data.structural_importance).toBe(0.42)
+  })
+
+  it('creates placeholder nodes for edge targets not in the record set', () => {
+    const g = buildRelationshipGraph(records)
+    expect(g.nodes.some((n) => n.data.id === 'DOC-E470AC8CE9A8')).toBe(true)
+  })
+})
+
+describe('mergeGraphElements', () => {
+  it('de-duplicates nodes and edges by id', () => {
+    const a = buildPlanTree({ planId: 'P1', objectiveIds: ['T1'] })
+    const b = buildPlanTree({ planId: 'P1', objectiveIds: ['T1'] })
+    const merged = mergeGraphElements(a, b)
+    expect(merged.nodes).toHaveLength(2)
+    expect(merged.edges).toHaveLength(1)
+  })
+})

--- a/frontend/ui/src/realtime/graphModel.ts
+++ b/frontend/ui/src/realtime/graphModel.ts
@@ -1,0 +1,187 @@
+/**
+ * Graph explorer model builder (ENC-TSK-B67 AC-21, AC-22).
+ *
+ * Pure, framework-free transform from governed records + typed relationships +
+ * context-node scores into Cytoscape.js element descriptors. Keeping the data
+ * transform separate from the canvas component makes the plan-tree (AC-21) and
+ * typed-relationship + context-node-edge-label (AC-22) logic unit-testable
+ * without a DOM/WebGL context.
+ *
+ * AC-21: PLAN_CONTAINS edges connect a plan to each objective task.
+ * AC-22: typed-relationship edges (INFORMED_BY, LEARNED_FROM, RELATED_TO,
+ *        PLAN_CONTAINS, BELONGS_TO, + custom dictionary types) render with the
+ *        relationship_type as the edge label; context-node scores render as node
+ *        metadata AND as edge labels (structural_importance on the edge).
+ */
+
+import type { ContextNodeMeta, TypedRelationshipEdge } from '../types/feeds'
+
+export interface CyNodeData {
+  id: string
+  label: string
+  record_type: string
+  status?: string
+  context_node?: ContextNodeMeta
+  /** Convenience: structural_importance surfaced for node sizing/labels. */
+  structural_importance?: number
+}
+
+export interface CyEdgeData {
+  id: string
+  source: string
+  target: string
+  /** Edge label rendered in the graph (relationship type, AC-22). */
+  label: string
+  relationship_type: string
+  weight?: number
+  confidence?: number
+}
+
+export interface CyElement<T> {
+  data: T
+}
+
+export interface GraphElements {
+  nodes: CyElement<CyNodeData>[]
+  edges: CyElement<CyEdgeData>[]
+}
+
+export interface GraphRecordInput {
+  recordId: string
+  title?: string
+  record_type: string
+  status?: string
+  context_node?: ContextNodeMeta
+  typed_relationships?: TypedRelationshipEdge[]
+}
+
+export interface PlanInput {
+  planId: string
+  title?: string
+  status?: string
+  /** Objective task IDs (PLAN_CONTAINS targets, AC-21). */
+  objectiveIds: string[]
+  context_node?: ContextNodeMeta
+}
+
+function nodeFromRecord(rec: GraphRecordInput): CyElement<CyNodeData> {
+  return {
+    data: {
+      id: rec.recordId,
+      label: rec.title ? `${rec.recordId}\n${rec.title}` : rec.recordId,
+      record_type: rec.record_type,
+      status: rec.status,
+      context_node: rec.context_node,
+      structural_importance: rec.context_node?.structural_importance,
+    },
+  }
+}
+
+/**
+ * Build PLAN_CONTAINS plan-tree elements (AC-21): the plan node plus one
+ * PLAN_CONTAINS edge to each objective task. Objective nodes are emitted as
+ * lightweight placeholders if not present in `objectiveRecords`.
+ */
+export function buildPlanTree(
+  plan: PlanInput,
+  objectiveRecords: GraphRecordInput[] = [],
+): GraphElements {
+  const byId = new Map(objectiveRecords.map((r) => [r.recordId, r]))
+  const nodes: CyElement<CyNodeData>[] = [
+    {
+      data: {
+        id: plan.planId,
+        label: plan.title ? `${plan.planId}\n${plan.title}` : plan.planId,
+        record_type: 'plan',
+        status: plan.status,
+        context_node: plan.context_node,
+        structural_importance: plan.context_node?.structural_importance,
+      },
+    },
+  ]
+  const edges: CyElement<CyEdgeData>[] = []
+
+  for (const objId of plan.objectiveIds) {
+    const rec = byId.get(objId)
+    nodes.push(
+      rec
+        ? nodeFromRecord(rec)
+        : { data: { id: objId, label: objId, record_type: 'task' } },
+    )
+    edges.push({
+      data: {
+        id: `${plan.planId}__PLAN_CONTAINS__${objId}`,
+        source: plan.planId,
+        target: objId,
+        label: 'PLAN_CONTAINS',
+        relationship_type: 'PLAN_CONTAINS',
+      },
+    })
+  }
+
+  return { nodes, edges }
+}
+
+/**
+ * Build typed-relationship + context-node graph elements (AC-22) for a set of
+ * records. Each record becomes a node carrying its context-node scores; each
+ * typed_relationships entry becomes a labeled edge. The edge label combines the
+ * relationship type with the source node's structural_importance so context-node
+ * metadata is visible as an edge label per AC-22.
+ */
+export function buildRelationshipGraph(records: GraphRecordInput[]): GraphElements {
+  const nodes: CyElement<CyNodeData>[] = []
+  const edges: CyElement<CyEdgeData>[] = []
+  const nodeIds = new Set<string>()
+  const edgeIds = new Set<string>()
+
+  const ensureNode = (rec: GraphRecordInput) => {
+    if (nodeIds.has(rec.recordId)) return
+    nodeIds.add(rec.recordId)
+    nodes.push(nodeFromRecord(rec))
+  }
+
+  for (const rec of records) {
+    ensureNode(rec)
+    for (const edge of rec.typed_relationships ?? []) {
+      if (!nodeIds.has(edge.target_id)) {
+        nodeIds.add(edge.target_id)
+        nodes.push({
+          data: { id: edge.target_id, label: edge.target_id, record_type: 'record' },
+        })
+      }
+      const edgeId = `${rec.recordId}__${edge.relationship_type}__${edge.target_id}`
+      if (edgeIds.has(edgeId)) continue
+      edgeIds.add(edgeId)
+      const si = rec.context_node?.structural_importance
+      const label =
+        si !== undefined
+          ? `${edge.relationship_type} · S=${si.toFixed(2)}`
+          : edge.relationship_type
+      edges.push({
+        data: {
+          id: edgeId,
+          source: rec.recordId,
+          target: edge.target_id,
+          label,
+          relationship_type: edge.relationship_type,
+          weight: edge.weight,
+          confidence: edge.confidence,
+        },
+      })
+    }
+  }
+
+  return { nodes, edges }
+}
+
+/** Merge multiple element sets, de-duplicating nodes and edges by id. */
+export function mergeGraphElements(...sets: GraphElements[]): GraphElements {
+  const nodes = new Map<string, CyElement<CyNodeData>>()
+  const edges = new Map<string, CyElement<CyEdgeData>>()
+  for (const set of sets) {
+    for (const n of set.nodes) nodes.set(n.data.id, n)
+    for (const e of set.edges) edges.set(e.data.id, e)
+  }
+  return { nodes: [...nodes.values()], edges: [...edges.values()] }
+}

--- a/frontend/ui/src/realtime/index.ts
+++ b/frontend/ui/src/realtime/index.ts
@@ -1,0 +1,22 @@
+/**
+ * PWA 2.0 real-time architecture library (ENC-TSK-B67).
+ *
+ * Barrel export for the Governance Cockpit real-time layer:
+ *   - eventModel:          AC-10/AC-23 feed-event contract + validator
+ *   - appsyncEventsClient: AC-1/AC-4/AC-15 WebSocket transport + resilience
+ *   - feedBuffer:          AC-9/AC-11 dedup + new-activities banner
+ *   - entityStore:         AC-12 normalized entity layer (cross-page consistency)
+ *   - uiStore:             AC-13 UI-only state ownership boundary
+ *   - optimisticMutations: AC-5/AC-6/AC-7/AC-19 optimistic + conflict resolution
+ *   - governanceDocs:      AC-20 live governed-docs read (no static mirror)
+ *   - graphModel:          AC-21/AC-22 plan-tree + typed-rel + context-node graph
+ */
+
+export * from './eventModel'
+export * from './appsyncEventsClient'
+export * from './feedBuffer'
+export * from './entityStore'
+export * from './uiStore'
+export * from './optimisticMutations'
+export * from './governanceDocs'
+export * from './graphModel'

--- a/frontend/ui/src/realtime/optimisticMutations.test.ts
+++ b/frontend/ui/src/realtime/optimisticMutations.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import {
+  createOptimisticHandlers,
+  resolveConflict,
+  ifMatchHeaders,
+  type RecordLike,
+  type StatusMutationVars,
+} from './optimisticMutations'
+
+const detailKey = (type: string, id: string) => ['record', type, id] as const
+const planKeyPrefix = ['plan'] as const
+const feedKey = ['feed', 'live'] as const
+
+describe('createOptimisticHandlers (AC-5, AC-6, AC-7)', () => {
+  let qc: QueryClient
+  beforeEach(() => {
+    qc = new QueryClient()
+    qc.setQueryData(detailKey('task', 'T1'), { recordId: 'T1', status: 'open' })
+    qc.setQueryData(['plan', 'P1'], {
+      recordId: 'P1',
+      tasks: [
+        { recordId: 'T1', status: 'open' },
+        { recordId: 'T2', status: 'open' },
+      ],
+    })
+    qc.setQueryData(feedKey, { events: [] })
+  })
+
+  const vars: StatusMutationVars = {
+    recordId: 'T1',
+    recordType: 'task',
+    patch: { status: 'closed' },
+    version: 7,
+  }
+
+  it('applies the optimistic update to the detail query (step 3a)', async () => {
+    const h = createOptimisticHandlers({ queryClient: qc, detailKey, planKeyPrefix, feedKey })
+    await h.onMutate(vars)
+    expect(qc.getQueryData<RecordLike>(detailKey('task', 'T1'))?.status).toBe('closed')
+  })
+
+  it('propagates across all cached plan pages in one predicate call (AC-6)', async () => {
+    const h = createOptimisticHandlers({ queryClient: qc, detailKey, planKeyPrefix, feedKey })
+    await h.onMutate(vars)
+    const plan = qc.getQueryData<RecordLike>(['plan', 'P1'])
+    expect(plan?.tasks?.find((t) => t.recordId === 'T1')?.status).toBe('closed')
+    expect(plan?.tasks?.find((t) => t.recordId === 'T2')?.status).toBe('open')
+  })
+
+  it('prepends an optimistic pending event to the feed (AC-9 setup)', async () => {
+    const registered: string[] = []
+    const h = createOptimisticHandlers({
+      queryClient: qc,
+      detailKey,
+      planKeyPrefix,
+      feedKey,
+      makeEventId: () => 'evt-opt-1',
+      registerOptimistic: (id) => registered.push(id),
+    })
+    await h.onMutate(vars)
+    const feed = qc.getQueryData<{ events: Array<{ pending?: boolean; action: string }> }>(feedKey)
+    expect(feed?.events[0].pending).toBe(true)
+    expect(feed?.events[0].action).toBe('closed')
+    expect(registered).toContain('evt-opt-1')
+  })
+
+  it('rolls back every snapshot atomically on error (AC-7)', async () => {
+    const h = createOptimisticHandlers({ queryClient: qc, detailKey, planKeyPrefix, feedKey })
+    const ctx = await h.onMutate(vars)
+    // sanity: optimistic applied
+    expect(qc.getQueryData<RecordLike>(detailKey('task', 'T1'))?.status).toBe('closed')
+    h.onError(new Error('500'), vars, ctx)
+    expect(qc.getQueryData<RecordLike>(detailKey('task', 'T1'))?.status).toBe('open')
+    const plan = qc.getQueryData<RecordLike>(['plan', 'P1'])
+    expect(plan?.tasks?.find((t) => t.recordId === 'T1')?.status).toBe('open')
+  })
+})
+
+describe('conflict resolution (AC-19)', () => {
+  it('builds an If-Match header from the version', () => {
+    expect(ifMatchHeaders(7)).toEqual({ 'If-Match': '7' })
+    expect(ifMatchHeaders(undefined)).toEqual({})
+  })
+
+  it('resolves governance-critical fields server-wins', () => {
+    const merges = resolveConflict(
+      { status: 'closed', priority: 'P1' },
+      { recordId: 'T1', status: 'pr', priority: 'P0' },
+    )
+    expect(merges.every((m) => m.resolution === 'server-wins')).toBe(true)
+    expect(merges.map((m) => m.field).sort()).toEqual(['priority', 'status'])
+  })
+
+  it('surfaces a field-level merge UI for independent fields', () => {
+    const merges = resolveConflict(
+      { description: 'local text' },
+      { recordId: 'T1', description: 'server text' },
+    )
+    expect(merges).toHaveLength(1)
+    expect(merges[0].resolution).toBe('merge-ui')
+  })
+
+  it('ignores identical values', () => {
+    const merges = resolveConflict(
+      { status: 'closed', title: 'same' },
+      { recordId: 'T1', status: 'closed', title: 'same' },
+    )
+    expect(merges).toHaveLength(0)
+  })
+})

--- a/frontend/ui/src/realtime/optimisticMutations.ts
+++ b/frontend/ui/src/realtime/optimisticMutations.ts
@@ -1,0 +1,197 @@
+/**
+ * Optimistic mutation layer (ENC-TSK-B67 AC-5, AC-6, AC-7, AC-19).
+ *
+ * Implements the canonical TanStack Query v5 cache-level `onMutate` pattern
+ * (DOC-E470AC8CE9A8 §3) as a reusable factory. The five enforced steps:
+ *
+ *   1. cancelQueries for ALL affected keys simultaneously (detail + plans + feed)
+ *   2. getQueryData snapshot of each affected key (atomic rollback context)
+ *   3. setQueryData surgical update on the detail query + setQueriesData
+ *      predicate update across every cached ['plan', ...] entry + feed prepend
+ *   4. return the snapshot context for onError rollback
+ *   5. onSettled invalidateQueries with fuzzy key matching for reconciliation
+ *
+ * Cross-page propagation (AC-6) uses a single `setQueriesData` predicate call —
+ * no per-page manual cache walking. Failure rollback (AC-7) restores every
+ * snapshot atomically. Conflict resolution (AC-19) detects HTTP 409 and applies
+ * server-wins for governance-critical fields, surfacing a field-level merge for
+ * independent fields.
+ */
+
+import type { QueryClient } from '@tanstack/react-query'
+
+/** Governance-critical fields resolve server-wins, no user intervention (AC-19). */
+export const GOVERNANCE_CRITICAL_FIELDS = [
+  'status',
+  'priority',
+  'transition_type',
+  'acceptance_criteria',
+] as const
+
+export interface RecordLike {
+  recordId: string
+  record_type?: string
+  status?: string
+  version?: number | string
+  tasks?: RecordLike[]
+  [key: string]: unknown
+}
+
+export interface StatusMutationVars {
+  recordId: string
+  recordType: string
+  patch: Partial<RecordLike>
+  /** Current record version → sent as If-Match for optimistic concurrency. */
+  version?: number | string
+}
+
+export interface OptimisticContext {
+  snapshots: Array<[readonly unknown[], unknown]>
+}
+
+export class ConflictError extends Error {
+  status = 409
+  serverRecord?: RecordLike
+  divergentFields: string[]
+  constructor(message: string, divergentFields: string[], serverRecord?: RecordLike) {
+    super(message)
+    this.name = 'ConflictError'
+    this.divergentFields = divergentFields
+    this.serverRecord = serverRecord
+  }
+}
+
+export interface FieldMerge {
+  field: string
+  resolution: 'server-wins' | 'merge-ui'
+  serverValue: unknown
+  localValue: unknown
+}
+
+/**
+ * Compute the conflict resolution plan for a 409 (AC-19): governance-critical
+ * fields resolve server-wins automatically; independent fields surface a merge.
+ */
+export function resolveConflict(
+  local: Partial<RecordLike>,
+  server: RecordLike,
+): FieldMerge[] {
+  const fields = new Set<string>([...Object.keys(local), ...Object.keys(server)])
+  const merges: FieldMerge[] = []
+  for (const field of fields) {
+    if (field === 'recordId' || field === 'version') continue
+    const serverValue = server[field]
+    const localValue = (local as Record<string, unknown>)[field]
+    if (JSON.stringify(serverValue) === JSON.stringify(localValue)) continue
+    const critical = (GOVERNANCE_CRITICAL_FIELDS as readonly string[]).includes(field)
+    merges.push({
+      field,
+      resolution: critical ? 'server-wins' : 'merge-ui',
+      serverValue,
+      localValue,
+    })
+  }
+  return merges
+}
+
+/** Build the If-Match request header for optimistic concurrency (AC-19). */
+export function ifMatchHeaders(version: number | string | undefined): Record<string, string> {
+  return version === undefined ? {} : { 'If-Match': String(version) }
+}
+
+export interface OptimisticHandlersDeps {
+  queryClient: QueryClient
+  detailKey: (recordType: string, recordId: string) => readonly unknown[]
+  planKeyPrefix?: readonly unknown[]
+  feedKey?: readonly unknown[]
+  /** Register the optimistic eventId so the WS echo dedups (AC-9 layer 1). */
+  registerOptimistic?: (eventId: string) => void
+  /** Generate a temporary optimistic eventId. */
+  makeEventId?: () => string
+}
+
+/**
+ * Create the `{ onMutate, onError, onSettled }` trio for a record-field/status
+ * mutation. Attach to any TanStack Query `useMutation`.
+ */
+export function createOptimisticHandlers(deps: OptimisticHandlersDeps) {
+  const { queryClient, detailKey, planKeyPrefix, feedKey } = deps
+
+  return {
+    async onMutate(vars: StatusMutationVars): Promise<OptimisticContext> {
+      const detail = detailKey(vars.recordType, vars.recordId)
+      const affected: ReadonlyArray<readonly unknown[]> = [
+        detail,
+        ...(planKeyPrefix ? [planKeyPrefix] : []),
+        ...(feedKey ? [feedKey] : []),
+      ]
+
+      // Step 1: cancel all affected refetches simultaneously.
+      await Promise.all(affected.map((key) => queryClient.cancelQueries({ queryKey: key })))
+
+      // Step 2: snapshot every affected key for atomic rollback.
+      const snapshots: Array<[readonly unknown[], unknown]> = []
+      snapshots.push([detail, queryClient.getQueryData(detail)])
+      if (planKeyPrefix) {
+        for (const [key, data] of queryClient.getQueriesData({ queryKey: planKeyPrefix })) {
+          snapshots.push([key, data])
+        }
+      }
+      if (feedKey) snapshots.push([feedKey, queryClient.getQueryData(feedKey)])
+
+      // Step 3a: surgical detail update.
+      queryClient.setQueryData<RecordLike>(detail, (old) =>
+        old ? { ...old, ...vars.patch } : old,
+      )
+
+      // Step 3b: cross-page propagation across ALL cached plan entries in ONE
+      // predicate call — no per-page manual walking (AC-6).
+      if (planKeyPrefix) {
+        queryClient.setQueriesData<RecordLike>({ queryKey: planKeyPrefix }, (plan) => {
+          if (!plan?.tasks?.some((t) => t.recordId === vars.recordId)) return plan
+          return {
+            ...plan,
+            tasks: plan.tasks.map((t) =>
+              t.recordId === vars.recordId ? { ...t, ...vars.patch } : t,
+            ),
+          }
+        })
+      }
+
+      // Step 3c: feed prepend with a pending optimistic event (AC-9 dedup setup).
+      if (feedKey) {
+        const eventId = deps.makeEventId?.()
+        if (eventId) deps.registerOptimistic?.(eventId)
+        queryClient.setQueryData<{ events: unknown[] }>(feedKey, (old) => {
+          const optimistic = {
+            eventId,
+            recordId: vars.recordId,
+            record_type: vars.recordType,
+            action: vars.patch.status === 'closed' ? 'closed' : 'updated',
+            pending: true,
+          }
+          if (!old?.events) return { events: [optimistic] }
+          return { ...old, events: [optimistic, ...old.events] }
+        })
+      }
+
+      // Step 4: return snapshots for onError.
+      return { snapshots }
+    },
+
+    onError(_err: unknown, _vars: StatusMutationVars, context?: OptimisticContext): void {
+      // Step 4 (cont.): atomically roll back every snapshot (AC-7).
+      if (!context) return
+      for (const [key, data] of context.snapshots) {
+        queryClient.setQueryData(key, data)
+      }
+    },
+
+    onSettled(_data: unknown, _err: unknown, vars: StatusMutationVars): void {
+      // Step 5: reconcile with server truth via fuzzy invalidation (AC-9 L2).
+      queryClient.invalidateQueries({ queryKey: detailKey(vars.recordType, vars.recordId) })
+      if (planKeyPrefix) queryClient.invalidateQueries({ queryKey: planKeyPrefix })
+      if (feedKey) queryClient.invalidateQueries({ queryKey: feedKey })
+    },
+  }
+}

--- a/frontend/ui/src/realtime/uiStore.ts
+++ b/frontend/ui/src/realtime/uiStore.ts
@@ -1,0 +1,55 @@
+/**
+ * UI-only client state (ENC-TSK-B67 AC-13).
+ *
+ * State ownership boundary: server state (record fields, feed events, plan
+ * hierarchy, document content) lives exclusively in TanStack Query / the
+ * normalized entity store. UI-only state — sidebar open/closed, selected record
+ * IDs, command palette open/query, Cytoscape viewport/zoom, and filter/sort
+ * preferences — flows exclusively through this Zustand store. No record field
+ * data is permitted here.
+ */
+
+import { create } from 'zustand'
+
+export interface CytoscapeViewport {
+  zoom: number
+  pan: { x: number; y: number }
+}
+
+interface UIState {
+  sidebarOpen: boolean
+  commandPaletteOpen: boolean
+  commandPaletteQuery: string
+  selectedRecordIds: string[]
+  graphViewport: CytoscapeViewport
+  filters: Record<string, string>
+  sort: string
+
+  setSidebarOpen: (open: boolean) => void
+  toggleSidebar: () => void
+  setCommandPaletteOpen: (open: boolean) => void
+  setCommandPaletteQuery: (q: string) => void
+  setSelectedRecordIds: (ids: string[]) => void
+  setGraphViewport: (vp: CytoscapeViewport) => void
+  setFilter: (key: string, value: string) => void
+  setSort: (sort: string) => void
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  sidebarOpen: true,
+  commandPaletteOpen: false,
+  commandPaletteQuery: '',
+  selectedRecordIds: [],
+  graphViewport: { zoom: 1, pan: { x: 0, y: 0 } },
+  filters: {},
+  sort: 'updated_at',
+
+  setSidebarOpen: (open) => set({ sidebarOpen: open }),
+  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
+  setCommandPaletteOpen: (open) => set({ commandPaletteOpen: open }),
+  setCommandPaletteQuery: (q) => set({ commandPaletteQuery: q }),
+  setSelectedRecordIds: (ids) => set({ selectedRecordIds: ids }),
+  setGraphViewport: (vp) => set({ graphViewport: vp }),
+  setFilter: (key, value) => set((s) => ({ filters: { ...s.filters, [key]: value } })),
+  setSort: (sort) => set({ sort }),
+}))

--- a/frontend/ui/vite.config.ts
+++ b/frontend/ui/vite.config.ts
@@ -91,6 +91,80 @@ export default defineConfig({
         // blocks ENC-TSK-E76 AC3). NetworkOnly ensures every method on this
         // prefix goes straight to CloudFront without SW cache involvement.
         runtimeCaching: [
+          // -------------------------------------------------------------------
+          // PWA 2.0 Governance Cockpit Workbox strategy map (ENC-TSK-B67 AC-17).
+          // Six strategy assignments + app-shell, per DOC-E470AC8CE9A8 §7.1.
+          // These are additive and scoped to the v4 /api/v1 read/mutation +
+          // feed routes; the legacy /mobile/v1 + /api/v1/deploy rules below are
+          // preserved unchanged.
+          // -------------------------------------------------------------------
+          // (b) StaleWhileRevalidate — /api/feed* (instant cache + bg refresh;
+          //     WebSocket signals invalidation). AC-17(b).
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/api/feed') ||
+              url.pathname.startsWith('/api/v1/feed'),
+            handler: 'StaleWhileRevalidate',
+            method: 'GET',
+            options: { cacheName: 'pwa2-feed-swr' },
+          },
+          // (e) NetworkOnly — Cognito auth endpoints; tokens must never cache.
+          //     AC-17(e). Placed before NetworkFirst record/doc rules.
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/api/v1/auth') ||
+              url.pathname.includes('/oauth2/') ||
+              url.pathname.startsWith('/callback'),
+            handler: 'NetworkOnly',
+          },
+          // (f) NetworkOnly + BackgroundSyncPlugin — mutation endpoints queue
+          //     offline writes for automatic replay on reconnect. AC-17(f)/AC-18.
+          ...(['POST', 'PUT', 'DELETE'] as const).map((method) => ({
+            urlPattern: ({ url }: { url: URL }) =>
+              url.pathname.startsWith('/api/v1/') &&
+              !url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly' as const,
+            method,
+            options: {
+              backgroundSync: {
+                name: `pwa2-mutation-queue-${method.toLowerCase()}`,
+                options: { maxRetentionTime: 24 * 60 },
+              },
+            },
+          })),
+          // (c) NetworkFirst (5s) — record + document detail reads. AC-17(c).
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/api/v1/records/') ||
+              url.pathname.startsWith('/api/v1/documents') ||
+              url.pathname.startsWith('/api/v1/governance'),
+            handler: 'NetworkFirst',
+            method: 'GET',
+            options: { cacheName: 'pwa2-detail-nf', networkTimeoutSeconds: 5 },
+          },
+          // (d) CacheFirst — S3 pre-computed payloads (invalidated only by an
+          //     explicit WebSocket gap_too_large signal). AC-17(d).
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/mobile/v1/feed'),
+            handler: 'CacheFirst',
+            method: 'GET',
+            options: {
+              cacheName: 'pwa2-s3-snapshot',
+              expiration: { maxEntries: 32, maxAgeSeconds: 7 * 24 * 60 * 60 },
+            },
+          },
+          // (a) CacheFirst — fonts/images (content-hashed JS/CSS are precached
+          //     via globPatterns; this covers runtime font/image assets). AC-17(a).
+          {
+            urlPattern: ({ request }) =>
+              request.destination === 'font' || request.destination === 'image',
+            handler: 'CacheFirst',
+            method: 'GET',
+            options: {
+              cacheName: 'pwa2-static-assets',
+              expiration: { maxEntries: 80, maxAgeSeconds: 30 * 24 * 60 * 60 },
+            },
+          },
           {
             urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
             handler: 'NetworkOnly',

--- a/infrastructure/cloudformation/08-realtime-appsync.yaml
+++ b/infrastructure/cloudformation/08-realtime-appsync.yaml
@@ -1,0 +1,156 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus v4 Real-Time Layer — AWS AppSync Events API + FeedPublisher
+  (real-time) Lambda wired to DynamoDB Streams. Delivers sub-500ms feed deltas
+  to the PWA 2.0 Governance Cockpit (ENC-TSK-B67, PLN-006 Phase 7).
+
+  Authoritative spec: DOC-E470AC8CE9A8 (Near-Zero Latency React PWA
+  Architecture). This is the live-delta path; the existing SQS-FIFO -> S3
+  snapshot pipeline (devops-feed-publisher) is preserved as the cold-start
+  source + WebSocket fallback (AC-4).
+
+  Deploy target: gamma (v4/main). v3-prod is frozen — production deploy is
+  gated behind the PLN-006 cutover (ENC-TSK-B69, Phase 8).
+
+Parameters:
+  Environment:
+    Type: String
+    Default: gamma
+    AllowedValues: [production, staging, gamma]
+  EnvironmentSuffix:
+    Type: String
+    Default: "-gamma"
+    AllowedValues: ["", "-gamma"]
+  TrackerStreamArn:
+    Type: String
+    Description: >
+      DynamoDB Streams ARN for the devops-project-tracker table (NEW_AND_OLD_IMAGES).
+      Sourced from the 01-data stack export TrackerTable.StreamArn.
+  LambdaCodeS3Bucket:
+    Type: String
+    Default: devops-agentcli-compute
+  LambdaCodeS3Key:
+    Type: String
+    Description: S3 key of the feed_realtime_publisher deployment zip.
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # AppSync Events API (AC-1) — pure pub/sub over serverless WebSockets.
+  # Channels: /feed/updates, /records/{recordId}, /projects/{projectId}.
+  # Channel wildcards (/feed/*) enable flexible scoping with no infra changes.
+  # ---------------------------------------------------------------------------
+  RealtimeEventsApi:
+    Type: AWS::AppSync::Api
+    Properties:
+      Name: !Sub "enceladus-realtime-events${EnvironmentSuffix}"
+      EventConfig:
+        AuthProviders:
+          - AuthType: API_KEY
+        ConnectionAuthModes:
+          - AuthType: API_KEY
+        DefaultPublishAuthModes:
+          - AuthType: API_KEY
+        DefaultSubscribeAuthModes:
+          - AuthType: API_KEY
+
+  RealtimeApiKey:
+    Type: AWS::AppSync::ApiKey
+    Properties:
+      ApiId: !GetAtt RealtimeEventsApi.ApiId
+      Description: PWA 2.0 realtime feed subscribe/publish key
+
+  # Namespace covering the /feed, /records, /projects channel families. A single
+  # namespace with onPublish/onSubscribe defaults is sufficient; per-family
+  # handlers can be added later without client changes (AC-1 wildcard scoping).
+  FeedChannelNamespace:
+    Type: AWS::AppSync::ChannelNamespace
+    Properties:
+      ApiId: !GetAtt RealtimeEventsApi.ApiId
+      Name: default
+
+  # ---------------------------------------------------------------------------
+  # FeedPublisher (real-time) Lambda execution role
+  # ---------------------------------------------------------------------------
+  RealtimePublisherRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "devops-feed-realtime-publisher-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: stream-read-and-appsync-publish
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !Ref TrackerStreamArn
+              - Effect: Allow
+                Action:
+                  - appsync:EventPublish
+                Resource: !Sub "${RealtimeEventsApi.ApiArn}/*"
+
+  RealtimePublisherFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "devops-feed-realtime-publisher${EnvironmentSuffix}"
+      Runtime: python3.12
+      Handler: lambda_function.handler
+      Timeout: 15
+      MemorySize: 256
+      Role: !GetAtt RealtimePublisherRole.Arn
+      Code:
+        S3Bucket: !Ref LambdaCodeS3Bucket
+        S3Key: !Ref LambdaCodeS3Key
+      Environment:
+        Variables:
+          APPSYNC_EVENTS_HTTP_ENDPOINT: !GetAtt RealtimeEventsApi.Dns.Http
+          # API key is injected post-deploy from the RealtimeApiKey resource to
+          # avoid embedding the key value in template parameters.
+          MAX_SUMMARY_BYTES: "500"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: realtime-feed
+
+  # ---------------------------------------------------------------------------
+  # Event Source Mapping (AC-2): BatchSize=1, MaximumBatchingWindowInSeconds=0
+  # for minimum latency, ReportBatchItemFailures for per-record retry.
+  # ---------------------------------------------------------------------------
+  RealtimeStreamMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      FunctionName: !Ref RealtimePublisherFunction
+      EventSourceArn: !Ref TrackerStreamArn
+      StartingPosition: LATEST
+      BatchSize: 1
+      MaximumBatchingWindowInSeconds: 0
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      MaximumRetryAttempts: 3
+      BisectBatchOnFunctionError: true
+
+Outputs:
+  RealtimeEventsApiId:
+    Value: !GetAtt RealtimeEventsApi.ApiId
+    Export:
+      Name: !Sub "enceladus-realtime-events-api-id${EnvironmentSuffix}"
+  RealtimeEventsHttpEndpoint:
+    Description: HTTP endpoint for FeedPublisher POSTs and PWA client config.
+    Value: !GetAtt RealtimeEventsApi.Dns.Http
+  RealtimeEventsRealtimeEndpoint:
+    Description: WebSocket (realtime) endpoint for the PWA AppSync Events client.
+    Value: !GetAtt RealtimeEventsApi.Dns.Realtime
+  RealtimePublisherFunctionName:
+    Value: !Ref RealtimePublisherFunction


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ENC-TSK-B67 — PWA 2.0 Governance Cockpit (PLN-006 Phase 7)

- **task_id:** ENC-TSK-B67
- **deploy target:** gamma (`v4/main`) only — v3-prod is frozen.
- **governance_hash:** `584baae9044510d86bbd331d844529d357b7aacff5c5c127c696f8cf94dde0f1`
- **authoritative spec:** DOC-E470AC8CE9A8 (North Star: thin reactive client, backend computes everything); design input DOC-310B93107B60 (`structural_importance` redefined as **absolute degree centrality**, not seed-PPR).

### connection_health output (init)
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "584baae9044510d86bbd331d844529d357b7aacff5c5c127c696f8cf94dde0f1",
  "checked_at": "2026-06-28T10:05:51Z",
  "server_version": "1.0.0",
  "graph_index": { "status": "healthy", "signals": { "vector": true, "graph": true, "keyword": true } }
}
```

### CCI (Commit Complete ID)
**Not obtainable in this session.** Obtaining a CCI requires advancing the task to `committed` via `checkout.advance`, which the session contract explicitly forbids (`NEVER call checkout.task or checkout.advance`), and the task is not checked out by this session. Per the contract, this is stated explicitly here. Head commit: `3951a7d6782385910d3466bcc53afe89b2b04d22`.

---

## What this PR delivers (code-complete, tested)

This objective's ACs are largely verified against a **live AWS deployment + browser DevTools** (AppSync Events handshakes, 24h CloudWatch error rates, P50/P99 over 100+ events, CLS, cache-storage inspection, airplane-mode replay). A cloud agent cannot deploy AppSync/Lambda/Streams or drive a browser, so this PR delivers the **reviewable, unit-tested code + IaC** that implements each AC's contract; final evidence stamping requires a gamma deploy + DevTools pass.

**Backend (`backend/lambda/feed_realtime_publisher/`)** — 31 stdlib-only unit tests passing
- `realtime_payload.py`: AC-10/AC-23 payload contract (UUIDv7 `eventId`, monotonic `cursor`, source-agnostic actor attribution, pre-rendered `summary`, ≤500B JSON), AC-22 absolute context-node scores (freshness decay, **degree-centrality** structural_importance, entropy density).
- `lambda_function.py`: DynamoDB-Streams → AppSync Events publisher (BatchSize=1 semantics, `ReportBatchItemFailures`, 3-channel fan-out).

**IaC (`infrastructure/cloudformation/08-realtime-appsync.yaml`)**
- AppSync Events API + channel namespace (`/feed/updates`, `/records/{id}`, `/projects/{id}`), Event Source Mapping (`BatchSize=1`, `MaximumBatchingWindowInSeconds=0`, `ReportBatchItemFailures`), IAM. Tracker table already streams `NEW_AND_OLD_IMAGES` (AC-2).

**Frontend (`frontend/ui/src/realtime/`)** — 48 vitest tests passing; build + lint clean
- `eventModel.ts` (AC-10/23), `appsyncEventsClient.ts` (AC-1/4/15: backoff 500ms→30s + 50-100% jitter, 30s heartbeat, cursor gap recovery, 12-fail manual retry, startTransition dispatch), `feedBuffer.ts` (AC-9 3-layer dedup + AC-11 banner), `entityStore.ts` (AC-12), `uiStore.ts` (AC-13), `optimisticMutations.ts` (AC-5/6/7 five-step + AC-19 If-Match/409), `governanceDocs.ts` (AC-20, no static mirror), `graphModel.ts` (AC-21 PLAN_CONTAINS + AC-22 typed-rel/context-node edge labels).
- `vite.config.ts`: AC-17/18 six-strategy Workbox map incl. BackgroundSync mutation queue.

### AC coverage summary
| AC | Code artifact | Status |
|----|---------------|--------|
| 1, 2 | AppSync IaC + FeedPublisher + ESM | code-complete; **live deploy + console/CloudWatch pending** |
| 3, 8 | payload timestamps/cursor + actor attribution + WS handler | code-complete; **live latency/propagation pending** |
| 4 | reconnect/heartbeat/gap + Workbox S3 CacheFirst; SQS→S3 preserved | code-complete; **live degradation test pending** |
| 5, 6, 7, 9, 10, 11, 12, 13, 19 | realtime library | **code-complete + unit-tested** |
| 15, 17, 18, 20, 21, 22, 23 | scheduler / Workbox / docs / graph / payload | code-complete; **live DevTools/measurement pending** |
| 14 | useSuspenseQuery + TanStack Router loaders | **deferred** — needs route-component migration (documented follow-on) |
| 16 | React Compiler | **deferred** — flipping on the shared v1 shell risks regression (documented follow-on) |
| 24 | gamma performance baseline (5 measurements) | **requires gamma runtime** — cannot be produced here; AC-24 #1 decision (Zustand normalized store over TanStack DB v0.6) is made + documented |

**Decision (AC-12 / AC-24 #1):** ship the Zustand normalized store for gamma (production-stable, ~1KB, fine-grained selectors) with TanStack DB v0.6 as the documented future upgrade.

### Tests
- Backend: `python3 -m unittest` → 31 passed.
- Frontend: `npx vitest run src/realtime` → 48 passed. Full suite: 144 passed / 1 pre-existing unrelated failure (`client.test.ts` cache-buster `_t` assertion, present before this branch). `npm run build` + `eslint src/realtime` clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb1ee5e5-9c08-40ab-8631-8a9dc13202e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb1ee5e5-9c08-40ab-8631-8a9dc13202e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

