### PR TITLE
[ENC-TSK-H84] Arc-Walker Phase 1 — deploy_policy project field

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.03",
-  "updated_at": "2026-06-28T07:26:56Z",
-  "last_change_summary": "ENC-TSK-I74 (ENC-ISS-417/418/422/424 sweep): checkout_service plan completion gate (ENC-TSK-A89) now resolves cross-project objectives in their own project partition (ISS-417); coordination_api .build_extras packages dispatch_plan_generator + handoff_mandate together (ISS-424); V4Gamma deploy role gains lambda publish/alias perms + _deploy.yml fails loud on alias errors (ISS-418); enceladus-mcp-streamable live Function URL codified in CFN (ISS-422). No data-dictionary schema change — bump satisfies the path-triggered Governance Dictionary Guard on the checkout_service lambda_function.py edit.",
+  "version": "2026-06-28.04",
+  "updated_at": "2026-06-28T12:05:00Z",
+  "last_change_summary": "ENC-TSK-H84 (Arc-Walker Phase 1): add project_service.deploy_policy entity — the per-project deploy_policy enum (ci_triggered / manual, default ci_triggered) on the projects-table record. project_service persists it at create + read-time defaults existing projects (enceladus = ci_triggered); the Lifecycle Service evaluate_auto_walk action reads it to gate deploy-init auto-walk per ruling O-2 (ENC-FTR-111 AC-5).",
   "owners": [
     "enceladus-platform"
   ],
@@ -1728,6 +1728,21 @@
         "uri": {
           "type": "string",
           "usage_guidance": "Resolved as governance://{file_name}. Registered file_names are pre-validated; arbitrary 'agents/' paths are accepted by the API and resolve if the S3 object exists."
+        }
+      }
+    },
+    "project_service.deploy_policy": {
+      "description": "ENC-TSK-H84 / ENC-FTR-111 (Universal Arc-Walker Phase 1): per-project deploy_policy attribute on the projects DynamoDB table record, declaring how a project's deployments are triggered. Written by project_service at create time and surfaced on GET/LIST; read by the Lifecycle Service (evaluate_auto_walk action) to gate deploy-init auto-walk per ruling O-2 (ENC-FTR-111 AC-5). Pairs with the existing projects-table deploy_mode attribute (deploy.spec / _get_project_deploy_mode, ENC-ISS-102) but is orthogonal: deploy_mode controls CodeBuild vs record-only finalize; deploy_policy controls whether the Arc-Walker may mechanically auto-advance the deploy-init gate.",
+      "fields": {
+        "deploy_policy": {
+          "type": "enum",
+          "enum": [
+            "ci_triggered",
+            "manual"
+          ],
+          "default": "ci_triggered",
+          "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
         }
       }
     },

--- a/backend/lambda/lifecycle_service/lambda_function.py
+++ b/backend/lambda/lifecycle_service/lambda_function.py
@@ -11,6 +11,10 @@ standalone, synchronously-invoked Lambda. The service is the authoritative owner
      coding-complete+ until every child has reached at least that stage.
   4. gate_class taxonomy              — ENC-FTR-111 scaffold (born-inside, consumed by the
      Universal Arc-Walker; this service does NOT implement the walker).
+  5. deploy-init auto-walk gating     — ENC-TSK-H84 / ENC-FTR-111 AC-5: the `evaluate_auto_walk`
+     action reads the project's deploy_policy (projects table) and applies ruling O-2 — deploy-init
+     is auto-walkable only on ci_triggered projects. The walker (FTR-111) consumes this verdict;
+     this service owns the read + the policy decision, not the walk loop itself.
 
 Scope boundary (ENC-TSK-H46, io-confirmed tracker_mutation-only):
   - EXTERNAL verifications that hit third-party APIs (the `committed` GitHub commit-exists check
@@ -56,6 +60,7 @@ from transition_type_matrix import (
     STRICTNESS_RANK,
     VALID_TRANSITION_TYPES,
     get_gate_class,
+    is_auto_walkable_class,
 )
 
 logger = logging.getLogger()
@@ -69,6 +74,19 @@ LIFECYCLE_SERVICE_VERSION = "1.0.0"  # ENC-TSK-H46
 DYNAMODB_TABLE = os.environ.get("DYNAMODB_TABLE", "devops-project-tracker")
 DYNAMODB_REGION = os.environ.get("DYNAMODB_REGION", "us-west-2")
 COMPONENTS_TABLE = os.environ.get("COMPONENTS_TABLE", "component-registry")
+# ENC-TSK-H84 / ENC-FTR-111: the projects table carries the per-project deploy_policy the
+# Universal Arc-Walker reads to gate deploy-init auto-walk (ruling O-2).
+PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
+
+# ENC-TSK-H84 / ENC-FTR-111 AC-5 — project deploy_policy enum (mirrors the project_service +
+# governance-dictionary contract). ci_triggered: deploys are kicked off by CI on merge, so the
+# system can mechanically auto-walk deploy-init. manual: a human/external actor triggers the
+# deploy, so the walker must NOT auto-advance deploy-init. Existing/absent values read as the
+# ci_triggered default (the seeded baseline — see project_service + tools/seed_deploy_policy.py).
+DEPLOY_POLICY_CI_TRIGGERED = "ci_triggered"
+DEPLOY_POLICY_MANUAL = "manual"
+VALID_DEPLOY_POLICIES = frozenset({DEPLOY_POLICY_CI_TRIGGERED, DEPLOY_POLICY_MANUAL})
+DEFAULT_DEPLOY_POLICY = DEPLOY_POLICY_CI_TRIGGERED
 
 _ddb_client = None
 
@@ -752,9 +770,103 @@ def validate_components_transition_type(req: dict) -> dict:
     return _allow(required_transition_type=required)
 
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-H84 / ENC-FTR-111 AC-5 — deploy_policy-gated deploy-init auto-walk (ruling O-2).
+#
+# The gate_class taxonomy (transition_type_matrix) classifies deploy-init as MECHANICAL, which
+# is the only Phase-1 auto-walkable class. Ruling O-2 (DOC-078C57FC1BE6 §3) adds a runtime
+# qualifier: deploy-init is mechanical ONLY on ci_triggered projects — on manual projects a
+# human/external actor owns the deploy trigger, so the Universal Arc-Walker must not synthesize
+# the advance. This service is the authoritative reader of that project field for the walker.
+# ---------------------------------------------------------------------------
+def _get_project_deploy_policy(project_id: str) -> str:
+    """Return the project's deploy_policy enum, defaulting to ci_triggered.
+
+    Mirrors deploy_orchestrator._get_project_deploy_mode (ENC-ISS-102 precedent): a missing
+    record, missing field, or unrecognized value all degrade to the ci_triggered seeded default
+    so an unseeded/legacy project never blocks the mechanical deploy-init walk. Fail-open WARN on
+    a DynamoDB read error for the same reason."""
+    pid = (project_id or "").strip()
+    if not pid:
+        return DEFAULT_DEPLOY_POLICY
+    try:
+        resp = _ddb().get_item(
+            TableName=PROJECTS_TABLE,
+            Key={"project_id": {"S": pid}},
+            ProjectionExpression="deploy_policy",
+        )
+        item = resp.get("Item") or {}
+        val = (item.get("deploy_policy", {}).get("S") or "").strip().lower()
+        if val in VALID_DEPLOY_POLICIES:
+            return val
+        return DEFAULT_DEPLOY_POLICY
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "[FTR-111] Failed to read deploy_policy for project '%s'; defaulting to '%s'",
+            pid, DEFAULT_DEPLOY_POLICY, exc_info=True,
+        )
+        return DEFAULT_DEPLOY_POLICY
+
+
+def evaluate_auto_walk(req: dict) -> dict:
+    """ENC-FTR-111 AC-5 — decide whether the Universal Arc-Walker may auto-advance a task across
+    a (transition_type, target_status) gate.
+
+    Eligibility derives SOLELY from the gate_class taxonomy (DOC-078C57FC1BE6 §7.2 — never from
+    whether the gate's evidence contract happens to be empty). The `mechanical` class is the only
+    Phase-1 auto-walkable class.
+
+    Ruling O-2 runtime qualifier: the `deploy-init` gate is mechanical, but auto-walkable only on
+    ci_triggered projects. On manual projects the deploy is human/externally triggered, so the
+    walker MUST NOT auto-advance — even though the static class is mechanical.
+
+    Required: target_status. Optional: transition_type (default github_pr_deploy), project_id
+    (required for a meaningful deploy-init decision). Returns a verdict dict the walker consumes.
+    """
+    transition_type = (req.get("transition_type") or "github_pr_deploy").strip().lower()
+    target_status = (req.get("target_status") or "").strip().lower()
+    project_id = (req.get("project_id") or "").strip()
+
+    gate_class = get_gate_class(transition_type, target_status)
+    auto_walkable = is_auto_walkable_class(gate_class)
+    reason: Optional[str] = None
+    deploy_policy: Optional[str] = None
+
+    if target_status == "deploy-init":
+        deploy_policy = _get_project_deploy_policy(project_id)
+        if auto_walkable and deploy_policy != DEPLOY_POLICY_CI_TRIGGERED:
+            # Ruling O-2: manual projects gate out of the mechanical auto-walk.
+            auto_walkable = False
+            reason = (
+                f"deploy-init auto-walk blocked (ruling O-2): project '{project_id or '<unknown>'}' "
+                f"deploy_policy='{deploy_policy}'. Only ci_triggered projects auto-walk deploy-init; "
+                "manual projects require a human/external deploy trigger."
+            )
+        elif auto_walkable:
+            reason = (
+                f"deploy-init auto-walk permitted (ruling O-2): project "
+                f"'{project_id or '<unknown>'}' deploy_policy='{deploy_policy}'."
+            )
+
+    out = {
+        "auto_walkable": auto_walkable,
+        "gate_class": gate_class,
+        "transition_type": transition_type,
+        "target_status": target_status,
+        "matrix_version": MATRIX_VERSION,
+        "lifecycle_service_version": LIFECYCLE_SERVICE_VERSION,
+    }
+    if deploy_policy is not None:
+        out["deploy_policy"] = deploy_policy
+    if reason is not None:
+        out["reason"] = reason
+    return out
+
+
 _ACTIONS = {
     "validate_transition": validate_transition,
     "validate_components_transition_type": validate_components_transition_type,
+    "evaluate_auto_walk": evaluate_auto_walk,
     "health": lambda req: {"ok": True, "service": "lifecycle_service",
                            "version": LIFECYCLE_SERVICE_VERSION, "matrix_version": MATRIX_VERSION},
 }

--- a/backend/lambda/lifecycle_service/test_lambda_function.py
+++ b/backend/lambda/lifecycle_service/test_lambda_function.py
@@ -135,6 +135,70 @@ def test_gate_class_carried_in_verdict():
     assert v["allow"] is True and v["gate_class"] == "mechanical", v
 
 
+# --- deploy_policy-gated deploy-init auto-walk (ENC-TSK-H84 / FTR-111 AC-5, ruling O-2) ------
+def _stub_deploy_policy(policy_by_pid, default=None):
+    """Monkeypatch the projects-table read so tests stay pure (no AWS)."""
+    def _fake_get_item(**kw):
+        pid = kw["Key"]["project_id"]["S"]
+        val = policy_by_pid.get(pid, default)
+        if val is None:
+            return {}  # no record / no field -> reader applies its ci_triggered default
+        return {"Item": {"deploy_policy": {"S": val}}}
+    lf._ddb = lambda: type("D", (), {"get_item": staticmethod(_fake_get_item)})()  # type: ignore
+
+
+def test_deploy_init_auto_walk_ci_triggered_permitted():
+    _stub_deploy_policy({"enceladus": "ci_triggered"})
+    v = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy",
+                               "target_status": "deploy-init", "project_id": "enceladus"})
+    assert v["auto_walkable"] is True, v
+    assert v["gate_class"] == "mechanical", v
+    assert v["deploy_policy"] == "ci_triggered", v
+
+
+def test_deploy_init_auto_walk_manual_blocked():
+    _stub_deploy_policy({"enceladus": "manual"})
+    v = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy",
+                               "target_status": "deploy-init", "project_id": "enceladus"})
+    assert v["auto_walkable"] is False, v
+    assert v["gate_class"] == "mechanical", v  # static class unchanged; O-2 is a runtime qualifier
+    assert v["deploy_policy"] == "manual", v
+    assert "ruling O-2" in v["reason"], v
+
+
+def test_deploy_init_unseeded_project_defaults_ci_triggered():
+    # No record / no field -> the reader's ci_triggered default keeps the mechanical walk open.
+    _stub_deploy_policy({}, default=None)
+    v = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy",
+                               "target_status": "deploy-init", "project_id": "brand-new"})
+    assert v["auto_walkable"] is True and v["deploy_policy"] == "ci_triggered", v
+
+
+def test_deploy_init_unknown_policy_value_defaults_ci_triggered():
+    _stub_deploy_policy({"enceladus": "garbage-value"})
+    v = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy",
+                               "target_status": "deploy-init", "project_id": "enceladus"})
+    assert v["auto_walkable"] is True and v["deploy_policy"] == "ci_triggered", v
+
+
+def test_evaluate_auto_walk_non_deploy_init_ignores_policy():
+    # deploy_policy only gates deploy-init; other gates derive purely from gate_class.
+    # `pr` is external-fact (ruling O-1) -> never auto-walkable, regardless of policy.
+    v_pr = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy", "target_status": "pr"})
+    assert v_pr["auto_walkable"] is False and v_pr["gate_class"] == "external-fact", v_pr
+    assert "deploy_policy" not in v_pr, v_pr
+    # coding-complete is the attestation floor -> never auto-walkable.
+    v_cc = lf.evaluate_auto_walk({"transition_type": "github_pr_deploy", "target_status": "coding-complete"})
+    assert v_cc["auto_walkable"] is False and v_cc["gate_class"] == "attestation", v_cc
+
+
+def test_evaluate_auto_walk_dispatch_via_handler():
+    _stub_deploy_policy({"enceladus": "manual"})
+    v = lf.lambda_handler({"action": "evaluate_auto_walk", "transition_type": "github_pr_deploy",
+                           "target_status": "deploy-init", "project_id": "enceladus"}, None)
+    assert v["auto_walkable"] is False and v["deploy_policy"] == "manual", v
+
+
 # --- dispatch ----------------------------------------------------------------
 def test_handler_unknown_action():
     v = lf.lambda_handler({"action": "frobnicate"}, None)

--- a/backend/lambda/project_service/lambda_function.py
+++ b/backend/lambda/project_service/lambda_function.py
@@ -133,6 +133,16 @@ _REPO_URL_PATTERN = re.compile(r"^https?://[^\s]+$")
 _VALID_CREATE_STATUSES = {"planning", "development", "active_production"}
 _ALL_STATUSES = _VALID_CREATE_STATUSES | {"closed", "archived"}
 
+# ENC-TSK-H84 / ENC-FTR-111: per-project deploy_policy. ci_triggered means deploys are kicked
+# off by CI on merge (the Universal Arc-Walker may mechanically auto-walk deploy-init, ruling
+# O-2); manual means a human/external actor triggers the deploy (the walker must not auto-walk).
+# Default ci_triggered. Existing/absent values read as the default (the seeded baseline) — see
+# _enrich_project and the lifecycle_service deploy-init gate.
+DEPLOY_POLICY_CI_TRIGGERED = "ci_triggered"
+DEPLOY_POLICY_MANUAL = "manual"
+_VALID_DEPLOY_POLICIES = {DEPLOY_POLICY_CI_TRIGGERED, DEPLOY_POLICY_MANUAL}
+_DEFAULT_DEPLOY_POLICY = DEPLOY_POLICY_CI_TRIGGERED
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -439,10 +449,18 @@ def _compute_days_since_active(project_id: str) -> Optional[int]:
 
 
 def _enrich_project(item: Dict[str, Any]) -> Dict[str, Any]:
-    """Add days_since_active to a project dict."""
+    """Add days_since_active to a project dict and normalize deploy_policy.
+
+    ENC-TSK-H84 / ENC-FTR-111: read-time defaulting seeds the effective deploy_policy for every
+    existing/legacy project that predates the field (including enceladus) to ci_triggered, and
+    coerces any unrecognized stored value back to the default. This keeps GET/LIST consumers and
+    the lifecycle_service deploy-init gate consistent even before the physical backfill
+    (tools/seed_deploy_policy.py) materializes the attribute on the DynamoDB record."""
     pid = item.get("project_id", "")
     days = _compute_days_since_active(pid)
     item["days_since_active"] = days
+    policy = str(item.get("deploy_policy") or "").strip().lower()
+    item["deploy_policy"] = policy if policy in _VALID_DEPLOY_POLICIES else _DEFAULT_DEPLOY_POLICY
     return item
 
 
@@ -477,11 +495,17 @@ def _validate_create_input(body: Dict) -> Tuple[Optional[Dict], Optional[str]]:
             repo = None
         elif len(repo) > 2048 or not _REPO_URL_PATTERN.match(repo):
             errors.append("repo: when provided, must be a valid http(s) URL up to 2048 characters")
+    # ENC-TSK-H84: optional deploy_policy enum, defaulting to ci_triggered.
+    deploy_policy = (body.get("deploy_policy") or _DEFAULT_DEPLOY_POLICY)
+    deploy_policy = str(deploy_policy).strip().lower()
+    if deploy_policy not in _VALID_DEPLOY_POLICIES:
+        errors.append(f"deploy_policy: must be one of {sorted(_VALID_DEPLOY_POLICIES)}")
     if errors:
         return None, "; ".join(errors)
     return {
         "name": name, "prefix": prefix, "summary": summary,
         "status": status, "parent": parent, "repo": repo,
+        "deploy_policy": deploy_policy,
     }, None
 
 
@@ -527,6 +551,7 @@ def _handle_create(body: Dict, claims: Dict) -> Dict:
     status = data["status"]
     parent = data["parent"]
     repo = data["repo"]
+    deploy_policy = data["deploy_policy"]
     now = _now_z()
     created_by = claims.get("sub", "unknown")
 
@@ -589,6 +614,9 @@ def _handle_create(body: Dict, claims: Dict) -> Dict:
         "path": {"S": path},
         "summary": {"S": summary},
         "status": {"S": status},
+        # ENC-TSK-H84 / ENC-FTR-111: persist deploy_policy at create so new projects carry it
+        # explicitly; existing projects rely on the read-time default in _enrich_project.
+        "deploy_policy": {"S": deploy_policy},
         "created_at": {"S": now},
         "updated_at": {"S": now},
         "created_by": {"S": created_by},
@@ -669,6 +697,7 @@ def _handle_create(body: Dict, claims: Dict) -> Dict:
         "summary": summary,
         "status": status,
         "parent": parent,
+        "deploy_policy": deploy_policy,
         "created_at": now,
         "updated_at": now,
         "created_by": created_by,

--- a/backend/lambda/project_service/test_deploy_policy_h84.py
+++ b/backend/lambda/project_service/test_deploy_policy_h84.py
@@ -1,0 +1,78 @@
+"""Tests for ENC-TSK-H84 / ENC-FTR-111 — project deploy_policy field.
+
+Covers AC-1: deploy_policy (enum ci_triggered / manual) exists on the project record, is
+validated at create time, defaults to ci_triggered, and read-time defaulting "seeds" the
+effective value for existing/legacy projects (including enceladus).
+
+Pure-logic units — no AWS. _compute_days_since_active is stubbed so _enrich_project stays pure.
+Runs under pytest (test_* discovery) and standalone (`python3 test_deploy_policy_h84.py`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "project_service",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+ps = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ps)
+
+
+class DeployPolicyValidationTests(unittest.TestCase):
+    def _valid_body(self, **over):
+        body = {"name": "demo", "prefix": "DMO", "summary": "a demo project"}
+        body.update(over)
+        return body
+
+    def test_default_is_ci_triggered(self):
+        data, err = ps._validate_create_input(self._valid_body())
+        self.assertIsNone(err, err)
+        self.assertEqual(data["deploy_policy"], "ci_triggered")
+
+    def test_explicit_manual_accepted(self):
+        data, err = ps._validate_create_input(self._valid_body(deploy_policy="manual"))
+        self.assertIsNone(err, err)
+        self.assertEqual(data["deploy_policy"], "manual")
+
+    def test_case_insensitive_and_trimmed(self):
+        data, err = ps._validate_create_input(self._valid_body(deploy_policy="  CI_Triggered "))
+        self.assertIsNone(err, err)
+        self.assertEqual(data["deploy_policy"], "ci_triggered")
+
+    def test_invalid_value_rejected(self):
+        data, err = ps._validate_create_input(self._valid_body(deploy_policy="rolling"))
+        self.assertIsNone(data)
+        self.assertIn("deploy_policy", err)
+
+
+class DeployPolicyEnrichTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = ps._compute_days_since_active
+        ps._compute_days_since_active = lambda pid: None  # keep _enrich_project pure
+
+    def tearDown(self):
+        ps._compute_days_since_active = self._orig
+
+    def test_existing_project_without_field_seeds_ci_triggered(self):
+        # Legacy project record (e.g. enceladus predating the field) reads as the seeded default.
+        out = ps._enrich_project({"project_id": "enceladus"})
+        self.assertEqual(out["deploy_policy"], "ci_triggered")
+
+    def test_explicit_manual_preserved(self):
+        out = ps._enrich_project({"project_id": "x", "deploy_policy": "manual"})
+        self.assertEqual(out["deploy_policy"], "manual")
+
+    def test_unknown_stored_value_coerced_to_default(self):
+        out = ps._enrich_project({"project_id": "x", "deploy_policy": "garbage"})
+        self.assertEqual(out["deploy_policy"], "ci_triggered")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -338,6 +338,8 @@ Resources:
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-H84 / ENC-FTR-111 AC-5: read the per-project deploy_policy to gate deploy-init auto-walk.
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
       Tags:
         - Key: Project
           Value: enceladus
@@ -2012,6 +2014,13 @@ Resources:
                 Action:
                   - dynamodb:GetItem
                 Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}"
+              # ENC-TSK-H84 / ENC-FTR-111 AC-5: read the projects table for the per-project
+              # deploy_policy that gates deploy-init auto-walk (evaluate_auto_walk action).
+              - Sid: DynamoDBProjectsRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
 
   DocumentApiRole:
     Type: AWS::IAM::Role

--- a/tools/seed_deploy_policy.py
+++ b/tools/seed_deploy_policy.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""ENC-TSK-H84 / ENC-FTR-111: idempotent backfill of project_service.deploy_policy.
+
+Seeds the per-project ``deploy_policy`` attribute (enum ci_triggered / manual) on existing
+records in the projects DynamoDB table. Every existing project is seeded to ``ci_triggered``
+(the default and the AC-1 value for enceladus); the write is conditional on the attribute being
+absent, so it is fully idempotent and NEVER overwrites a value a project already carries.
+
+Why a standalone script (not an MCP/agent path): project_service exposes create + read only —
+there is no governed PATCH route for an existing project record, and the ``enceladus-agent-cli``
+IAM principal is denied all DynamoDB writes (agents.md §14). This backfill therefore runs under a
+privileged session (io-dev-admin / product-lead terminal) AFTER the H84 PR merges and deploys.
+Until it runs, read-time defaulting in project_service._enrich_project and
+lifecycle_service._get_project_deploy_policy already make the effective value ci_triggered, so the
+backfill only materializes the attribute on the stored record — behavior is correct either way.
+
+Usage:
+    python3 tools/seed_deploy_policy.py [--dry-run] [--table projects] [--region us-west-2]
+                                        [--policy ci_triggered]
+
+    # gamma stack:
+    python3 tools/seed_deploy_policy.py --table projects-gamma
+
+The script is safe to re-run: it scans the table, skips any record that already has a
+``deploy_policy`` attribute, and sets the seed value on the rest via a conditional UpdateItem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+VALID_POLICIES = ("ci_triggered", "manual")
+
+
+def _scan_project_ids(ddb, table: str) -> list[str]:
+    ids: list[str] = []
+    kwargs = {"TableName": table, "ProjectionExpression": "project_id, deploy_policy"}
+    have_policy = 0
+    while True:
+        resp = ddb.scan(**kwargs)
+        for item in resp.get("Items", []):
+            pid = item.get("project_id", {}).get("S")
+            if not pid:
+                continue
+            if item.get("deploy_policy", {}).get("S"):
+                have_policy += 1
+                continue
+            ids.append(pid)
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+    print(f"[INFO] {len(ids)} project(s) need seeding; {have_policy} already carry deploy_policy.")
+    return ids
+
+
+def _seed_one(ddb, table: str, project_id: str, policy: str) -> str:
+    """Conditional UpdateItem — only sets deploy_policy when absent (idempotent, non-destructive)."""
+    try:
+        ddb.update_item(
+            TableName=table,
+            Key={"project_id": {"S": project_id}},
+            UpdateExpression="SET deploy_policy = :p",
+            ConditionExpression="attribute_not_exists(deploy_policy)",
+            ExpressionAttributeValues={":p": {"S": policy}},
+        )
+        return "seeded"
+    except ddb.exceptions.ConditionalCheckFailedException:
+        return "skipped (already set)"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="projects", help="projects table name (default: projects)")
+    parser.add_argument("--region", default="us-west-2", help="AWS region (default: us-west-2)")
+    parser.add_argument("--policy", default="ci_triggered", choices=VALID_POLICIES,
+                        help="seed value for records missing deploy_policy (default: ci_triggered)")
+    parser.add_argument("--dry-run", action="store_true", help="list what would change without writing")
+    args = parser.parse_args()
+
+    import boto3  # imported here so --help works without AWS deps installed
+
+    ddb = boto3.client("dynamodb", region_name=args.region)
+    print(f"[INFO] Backfilling deploy_policy='{args.policy}' on table '{args.table}' "
+          f"(region {args.region}){' [DRY-RUN]' if args.dry_run else ''}.")
+
+    to_seed = _scan_project_ids(ddb, args.table)
+    seeded = 0
+    for pid in to_seed:
+        if args.dry_run:
+            print(f"  would seed {pid} -> {args.policy}")
+            continue
+        result = _seed_one(ddb, args.table, pid, args.policy)
+        print(f"  {pid}: {result}")
+        if result == "seeded":
+            seeded += 1
+
+    if args.dry_run:
+        print(f"[OK] DRY-RUN complete — {len(to_seed)} project(s) would be seeded.")
+    else:
+        print(f"[OK] Backfill complete — {seeded} project(s) seeded to '{args.policy}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ENC-TSK-H84 — Arc-Walker Phase 1 — deploy_policy project field

**task_id:** ENC-TSK-H84
**Plan / Feature:** ENC-PLN-006 (v4) / ENC-FTR-111 (Universal Arc-Walker)
**Deploy target:** v4/main (gamma) — `target:gamma`. v3-prod is frozen; this PR never targets `main` and performs no deploy.
**Session:** ENC-SES-00B (cursor-cloud-agent / claude-opus-4-8, ENC-AGT-003)

### Summary
Adds a per-project `deploy_policy` enum (`ci_triggered` / `manual`, default `ci_triggered`) that the Universal Arc-Walker reads to gate `deploy-init` auto-walk (ruling O-2).

### Satisfied acceptance criteria
- **AC-1** — `deploy_policy` exists on the project record + governance dictionary; existing projects seeded (enceladus = `ci_triggered`):
  - `project_service` persists `deploy_policy` at create, validates the enum, and **read-time defaults** existing/legacy projects (incl. enceladus) to `ci_triggered` in `_enrich_project`.
  - New `project_service.deploy_policy` entity in `governance_data_dictionary.json` (version `2026-06-28.03` → `2026-06-28.04`, additive — no key removals).
  - `tools/seed_deploy_policy.py`: idempotent boto3 backfill to physically materialize the attribute under a privileged session post-deploy (agent-cli IAM cannot write the projects table).
- **AC-2** — Lifecycle Service reads `deploy_policy` to gate `deploy-init` auto-walk (supports ENC-FTR-111 AC-5):
  - `lifecycle_service`: `_get_project_deploy_policy` + new `evaluate_auto_walk` action. `deploy-init` is `gate_class=mechanical` but auto-walkable **only** when `deploy_policy=ci_triggered`; `manual` gates out. Eligibility derives from the gate_class taxonomy, never evidence-field emptiness (DOC-078C57FC1BE6 §7.2).
  - CFN `02-compute.yaml`: `PROJECTS_TABLE` env var + `DynamoDBProjectsRead` IAM on the Lifecycle Service role.

### Tests
- `lifecycle_service`: 21/21 (6 new `evaluate_auto_walk` cases: ci_triggered permit, manual block, unseeded/unknown default, non-deploy-init ignore, handler dispatch).
- `project_service`: 9/9 (6 new `deploy_policy` validation + read-time-default cases).

### Governance sync (§13)
`governance_data_dictionary.json` is committed in this PR; the live S3 sync is **owned by a product-lead terminal** (agent code-mode cannot write governance S3). A `GOVERNANCE_SYNC_REQUIRED` HANDOFF block is on the task worklog. The syncing session must bump `agents.md` `governance_revision` to `2026-06-28.04` in lockstep with the dictionary `version`.

### Commit gate
- **CCI:** `CCI-0021f80cee7849d997f5f73c2e7c72a3`
- **commit_sha:** `fbe7a903c43f5e4f710ca72f99acdaaff480c951`
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`

This session advances the task only to `committed`; the human owns merge + deploy + close-out.

### connection_health (init)
```json
{"dynamodb": "ok", "s3": "ok", "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447", "checked_at": "2026-06-28T11:57:54Z", "server_version": "1.0.0", "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}, "graph_projection": {"configured": true, "exists": true, "stale": false}}}
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e2a503-f397-4bb8-b821-f5742eb9b13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e2a503-f397-4bb8-b821-f5742eb9b13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

