### PR TITLE
[ENC-TSK-I81] FTR-088 - tracker.graph_laplacian MCP read action: CSR adjacency + Fiedler eigenvector

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -6015,6 +6015,29 @@
           "usage_guidance": "Defined in infrastructure/cloudformation/02-compute.yaml on GraphHealthMetricsFunction. The role gains cloudwatch:GetMetricStatistics/GetMetricData (in addition to the existing PutMetricData) to read the walk-back counters."
         }
       }
+    },
+    "graph_query_api.graph_laplacian": {
+      "description": "ENC-TSK-I81 (FTR-088): graph Laplacian read action via tracker.graph_laplacian. Returns adjacency_csr (base64 float32 CSR), fiedler_vector, eigenvalues[:k], vertex_map. Uses scipy.sparse.linalg.eigsh.",
+      "fields": {
+        "vertex_set_query": {
+          "type": "string"
+        },
+        "k": {
+          "type": "integer"
+        },
+        "adjacency_csr": {
+          "type": "string"
+        },
+        "fiedler_vector": {
+          "type": "array"
+        },
+        "eigenvalues": {
+          "type": "array"
+        },
+        "vertex_map": {
+          "type": "object"
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -66,7 +66,7 @@ MAX_DEPTH = 5
 MAX_RESULTS = 100
 QUERY_TIMEOUT_SECONDS = 10
 
-VALID_SEARCH_TYPES = {"adjacency", "dedup_convergence", "hybrid", "keyword", "neighbors", "path", "sheaf_cohomology", "traversal"}
+VALID_SEARCH_TYPES = {"adjacency", "dedup_convergence", "hybrid", "keyword", "laplacian", "neighbors", "path", "sheaf_cohomology", "traversal"}
 
 # ENC-TSK-I88 (ENC-FTR-085 comp-percolation-monitor): bounded page sizes for the
 # read-only adjacency export consumed by the nightly percolation Lambda. Mirrors
@@ -100,6 +100,15 @@ MAX_EMBEDDING_EGRESS_RECORD_IDS = 100
 # raw-embedding egress.
 _EGRESS_ADMIN_AGENT_TIER = "admin"
 _EGRESS_ADMIN_COGNITO_GROUP = "io-dev-admin"
+
+# ENC-TSK-I81 / ENC-FTR-088: graph_laplacian read action bounds.
+# A vertex-set query resolves an induced subgraph whose (sparse) Laplacian
+# spectrum is computed via scipy.sparse.linalg.eigsh. Cap the vertex count so a
+# pathological query can never build an O(n^2) dense fallback large enough to
+# blow the 180s SLO / Lambda memory; eigsh on the CSR operator stays cheap well
+# past this bound but the dense small-n fallback must not.
+LAPLACIAN_MAX_VERTICES = 500
+LAPLACIAN_DEFAULT_K = 3
 
 # ---------------------------------------------------------------------------
 # ENC-TSK-B92 Phase 1 hybrid retrieval constants
@@ -724,6 +733,273 @@ def _query_keyword(driver, project_id: str, params: Dict) -> Dict:
         "paths": [],
         "summary": f"Keyword '{search_query}': {matched} matches, {len(nodes)} total nodes (with neighbors)",
         "query_cypher": cypher,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-I81 / ENC-FTR-088: graph Laplacian read action
+# ---------------------------------------------------------------------------
+# Resolves a vertex set (keyword query or explicit record_ids), materializes the
+# induced subgraph adjacency over EXISTING typed edges (no new edge types — OGTM
+# N/A, AC-4), and computes the smallest-k Laplacian eigenpairs via
+# scipy.sparse.linalg.eigsh (AC-2). Returns a CSR adjacency (base64 float32 data
+# + base64 int32 indices/indptr), the Fiedler vector, the k smallest eigenvalues,
+# the degree vector, and an index->record_id vertex_map. From adjacency_csr +
+# degrees a client reconstructs L = D - A (combinatorial) or the symmetric
+# normalized Laplacian L_sym = I - D^{-1/2} A D^{-1/2} — the spectral object the
+# Wave-Close Drift Telemetry d_spectral measurement consumes (ENC-FTR-087, AC-3).
+#
+# The DEFAULT normalization is combinatorial (L = D - A): its smallest eigenvalue
+# is identically 0 for ANY graph (the constant vector is always in the null
+# space), so eigenvalues[0] < 0.001 holds even for an edge-sparse / disconnected
+# 10-node subgraph (AC-5). normalization='normalized' is offered as an opt-in for
+# scale-invariant spectral comparison.
+
+
+def _b64_array(arr, np_dtype: str) -> str:
+    """Base64-encode a numpy array's raw little-endian bytes for compact, lossless
+    transport of CSR components (AC-1 adjacency_csr 'base64 float32' contract)."""
+    import base64
+    import numpy as np
+    return base64.b64encode(
+        np.ascontiguousarray(arr, dtype=np_dtype).tobytes()
+    ).decode("ascii")
+
+
+def _laplacian_select_vertices(driver, project_id: str, params: Dict) -> Dict:
+    """Resolve the ordered vertex set for the induced subgraph.
+
+    Selection precedence: explicit record_ids (comma list) -> keyword
+    vertex_set_query (title/record_id CONTAINS) -> all project nodes. Placeholder
+    nodes (ENC-TSK-E06 is_placeholder) are excluded so edge-target stubs never
+    enter the spectrum. Returns {ids, query_cypher} or {error}.
+    """
+    try:
+        limit = int(params.get("limit", LAPLACIAN_MAX_VERTICES) or LAPLACIAN_MAX_VERTICES)
+    except (TypeError, ValueError):
+        return {"error": "limit must be an integer"}
+    limit = max(2, min(limit, LAPLACIAN_MAX_VERTICES))
+
+    record_ids_param = params.get("record_ids", "")
+    vertex_set_query = (params.get("vertex_set_query", "") or "").strip()
+
+    explicit_ids: List[str] = []
+    if record_ids_param:
+        if isinstance(record_ids_param, list):
+            explicit_ids = [str(x).strip() for x in record_ids_param if str(x).strip()]
+        else:
+            explicit_ids = [x.strip() for x in str(record_ids_param).split(",") if x.strip()]
+
+    if explicit_ids:
+        cypher = (
+            "MATCH (n) "
+            "WHERE n.project_id = $project_id AND n.record_id IN $ids "
+            "AND coalesce(n.is_placeholder, false) = false "
+            "RETURN DISTINCT n.record_id AS rid ORDER BY rid LIMIT $limit"
+        )
+        run_params = {"project_id": project_id, "ids": explicit_ids, "limit": limit}
+    elif vertex_set_query:
+        cypher = (
+            "MATCH (n) "
+            "WHERE n.project_id = $project_id "
+            "AND coalesce(n.is_placeholder, false) = false "
+            "AND (toLower(coalesce(n.title, '')) CONTAINS toLower($q) "
+            "OR n.record_id CONTAINS toUpper($q)) "
+            "RETURN DISTINCT n.record_id AS rid ORDER BY rid LIMIT $limit"
+        )
+        run_params = {"project_id": project_id, "q": vertex_set_query, "limit": limit}
+    else:
+        cypher = (
+            "MATCH (n) "
+            "WHERE n.project_id = $project_id "
+            "AND coalesce(n.is_placeholder, false) = false "
+            "RETURN DISTINCT n.record_id AS rid ORDER BY rid LIMIT $limit"
+        )
+        run_params = {"project_id": project_id, "limit": limit}
+
+    with driver.session() as session:
+        result = session.run(cypher, **run_params)
+        ids = [rec["rid"] for rec in result if rec.get("rid")]
+    return {"ids": ids, "query_cypher": cypher}
+
+
+def _query_laplacian(driver, project_id: str, params: Dict) -> Dict:
+    """Compute the induced-subgraph Laplacian spectrum (ENC-FTR-088).
+
+    Params: vertex_set_query | record_ids (selection), edge_type_filter
+    (restrict adjacency to existing edge types), k (smallest eigenpairs,
+    default 3), limit, normalization ('combinatorial' default | 'normalized').
+    """
+    # --- parameters ---
+    try:
+        k = int(params.get("k", LAPLACIAN_DEFAULT_K) or LAPLACIAN_DEFAULT_K)
+    except (TypeError, ValueError):
+        return {"error": "k must be an integer"}
+    if k < 1:
+        return {"error": "k must be >= 1"}
+
+    normalization = (params.get("normalization", "combinatorial") or "combinatorial").strip().lower()
+    if normalization not in {"combinatorial", "normalized"}:
+        return {"error": "normalization must be 'combinatorial' or 'normalized'"}
+
+    edge_type_filter = params.get("edge_type_filter", "")
+    etypes: List[str] = []
+    if edge_type_filter:
+        if isinstance(edge_type_filter, list):
+            etypes = [t.strip().upper() for t in edge_type_filter if str(t).strip()]
+        else:
+            etypes = [t.strip().upper() for t in str(edge_type_filter).split(",") if t.strip()]
+        invalid = [t for t in etypes if t not in _ALLOWED_EDGE_TYPES]
+        if invalid:
+            return {"error": f"Invalid edge_type_filter: {invalid}. Allowed: {sorted(_ALLOWED_EDGE_TYPES)}"}
+
+    # --- vertex set ---
+    selection = _laplacian_select_vertices(driver, project_id, params)
+    if "error" in selection:
+        return selection
+    ids: List[str] = selection["ids"]
+    n = len(ids)
+    if n < 2:
+        return {
+            "error": (
+                f"Laplacian requires at least 2 vertices; vertex set resolved {n}. "
+                "Broaden vertex_set_query, pass more record_ids, or raise limit."
+            )
+        }
+    idx = {rid: i for i, rid in enumerate(ids)}
+
+    # --- induced-subgraph edges over EXISTING edge types (no new edge types) ---
+    if etypes:
+        edge_cypher = (
+            "MATCH (a)-[r]-(b) "
+            "WHERE a.project_id = $project_id AND b.project_id = $project_id "
+            "AND a.record_id IN $ids AND b.record_id IN $ids AND type(r) IN $etypes "
+            "RETURN DISTINCT a.record_id AS s, b.record_id AS t"
+        )
+        edge_run = {"project_id": project_id, "ids": ids, "etypes": etypes}
+    else:
+        edge_cypher = (
+            "MATCH (a)-[r]-(b) "
+            "WHERE a.project_id = $project_id AND b.project_id = $project_id "
+            "AND a.record_id IN $ids AND b.record_id IN $ids "
+            "RETURN DISTINCT a.record_id AS s, b.record_id AS t"
+        )
+        edge_run = {"project_id": project_id, "ids": ids}
+
+    pairs: set = set()  # unordered {(i, j) : i < j} — binary, undirected adjacency
+    with driver.session() as session:
+        result = session.run(edge_cypher, **edge_run)
+        for rec in result:
+            s, t = rec.get("s"), rec.get("t")
+            if s is None or t is None or s == t:
+                continue
+            i, j = idx.get(s), idx.get(t)
+            if i is None or j is None:
+                continue
+            pairs.add((min(i, j), max(i, j)))
+
+    # --- sparse Laplacian + smallest-k eigenpairs via scipy.sparse.linalg.eigsh ---
+    import numpy as np
+    from scipy.sparse import csr_matrix, diags
+    from scipy.sparse.linalg import eigsh
+
+    rows: List[int] = []
+    cols: List[int] = []
+    data: List[float] = []
+    for (i, j) in pairs:
+        rows.extend((i, j))
+        cols.extend((j, i))
+        data.extend((1.0, 1.0))
+    adjacency = csr_matrix((data, (rows, cols)), shape=(n, n), dtype="float64")
+    adjacency.sum_duplicates()
+    adjacency.sort_indices()
+
+    degrees = np.asarray(adjacency.sum(axis=1)).ravel()
+
+    if normalization == "normalized":
+        with np.errstate(divide="ignore", invalid="ignore"):
+            d_inv_sqrt = 1.0 / np.sqrt(degrees)
+        d_inv_sqrt[~np.isfinite(d_inv_sqrt)] = 0.0  # isolated vertices -> 0
+        d_mat = diags(d_inv_sqrt)
+        laplacian = (diags(np.ones(n)) - (d_mat @ adjacency @ d_mat)).tocsr()
+        formula = "L_sym = I - D^(-1/2) A D^(-1/2)"
+    else:
+        laplacian = (diags(degrees) - adjacency).tocsr()
+        formula = "L = D - A"
+
+    k_req = min(k, n)
+    want = min(max(k_req, 2), n)  # at least 2 so the Fiedler vector (index 1) exists
+
+    # eigsh (ARPACK) requires 0 < want < n and is unstable for tiny / near-full
+    # spectra; it also rejects an all-zero operator ("Starting vector is zero"),
+    # which is exactly the edgeless-subgraph case (L = 0). Fall back to dense eigh
+    # for those, and on any convergence failure. The mandated
+    # scipy.sparse.linalg.eigsh drives the normal path (e.g. the AC-5 10-node
+    # subgraph). A deterministic start vector keeps repeated calls reproducible.
+    if n <= 3 or want >= n or laplacian.nnz == 0:
+        evals, evecs = np.linalg.eigh(laplacian.toarray())
+        eig_method = "dense_eigh"
+    else:
+        try:
+            v0 = np.random.default_rng(0).standard_normal(n)
+            evals, evecs = eigsh(laplacian, k=want, which="SA", v0=v0)
+            eig_method = "eigsh_SA"
+        except Exception:
+            logger.warning("[WARNING] eigsh failed; dense eigh fallback", exc_info=True)
+            evals, evecs = np.linalg.eigh(laplacian.toarray())
+            eig_method = "dense_eigh_fallback"
+
+    order = np.argsort(evals)
+    evals = evals[order]
+    evecs = evecs[:, order]
+
+    eigenvalues = [float(x) for x in evals[:k_req]]
+    fiedler = np.asarray(evecs[:, 1]).ravel()
+    fiedler_vector = [float(x) for x in fiedler]
+
+    adjacency_csr = {
+        "encoding": "base64",
+        "byte_order": "little",
+        "dtype": {"data": "float32", "indices": "int32", "indptr": "int32"},
+        "shape": [n, n],
+        "nnz": int(adjacency.nnz),
+        "data_b64": _b64_array(adjacency.data, "<f4"),
+        "indices_b64": _b64_array(adjacency.indices, "<i4"),
+        "indptr_b64": _b64_array(adjacency.indptr, "<i4"),
+    }
+
+    lambda0 = eigenvalues[0] if eigenvalues else float("nan")
+    return {
+        "nodes": [],
+        "edges": [],
+        "paths": [],
+        "vertex_map": ids,
+        "adjacency_csr": adjacency_csr,
+        "degrees": [float(x) for x in degrees],
+        "eigenvalues": eigenvalues,
+        "fiedler_vector": fiedler_vector,
+        "laplacian": {
+            "n": n,
+            "k": k_req,
+            "edge_count": len(pairs),
+            "normalization": normalization,
+            "formula": formula,
+            "weighted": False,
+            "eig_method": eig_method,
+            "edge_type_filter": etypes or None,
+            "reconstruct": (
+                "A = scipy.sparse.csr_matrix((b64decode(data_b64,float32), "
+                "b64decode(indices_b64,int32), b64decode(indptr_b64,int32)), shape); "
+                "D = diag(A.sum(axis=1)); combinatorial L = D - A; "
+                "normalized L_sym = D^(-1/2) (D - A) D^(-1/2)."
+            ),
+        },
+        "summary": (
+            f"Laplacian ({normalization}) over {n} vertices, {len(pairs)} edges; "
+            f"{len(eigenvalues)} smallest eigenvalues (lambda0={lambda0:.6g}), "
+            f"Fiedler dim {len(fiedler_vector)} via {eig_method}"
+        ),
+        "query_cypher": f"{selection['query_cypher']} ;; {edge_cypher}",
     }
 
 
@@ -2192,6 +2468,7 @@ SEARCH_HANDLERS = {
     "adjacency": _query_adjacency,
         "sheaf_cohomology": _query_sheaf_cohomology,
     "dedup_convergence": _query_dedup_convergence,
+    "laplacian": _query_laplacian,
 }
 
 
@@ -2303,6 +2580,13 @@ def _handle_search(event: Dict) -> Dict:
         "inconsistency_edges",
         "computation_ms",
         "convergence",
+        # ENC-TSK-I81 / ENC-FTR-088: graph_laplacian response fields.
+        "vertex_map",
+        "adjacency_csr",
+        "degrees",
+        "eigenvalues",
+        "fiedler_vector",
+        "laplacian",
     ):
         if hybrid_key in result:
             response_body[hybrid_key] = result[hybrid_key]

--- a/backend/lambda/graph_query_api/requirements.txt
+++ b/backend/lambda/graph_query_api/requirements.txt
@@ -1,1 +1,7 @@
 neo4j>=5.0,<6.0
+# ENC-TSK-I81 / ENC-FTR-088: graph_laplacian read action computes the induced-
+# subgraph Laplacian spectrum via scipy.sparse.linalg.eigsh on a scipy.sparse
+# CSR adjacency. numpy is scipy's hard dependency. Arch-correct manylinux2014
+# wheels are resolved by the _build.yml matrix (--platform/--only-binary).
+numpy>=1.26,<3.0
+scipy>=1.11,<2.0

--- a/backend/lambda/graph_query_api/test_graph_laplacian_ftr088.py
+++ b/backend/lambda/graph_query_api/test_graph_laplacian_ftr088.py
@@ -1,0 +1,187 @@
+"""Unit tests for ENC-TSK-I81 / ENC-FTR-088 graph_laplacian read action.
+
+Exercises the pure spectral logic of _query_laplacian against a mocked Neo4j
+driver (no live AuraDB / Bedrock). Validates the acceptance contract:
+
+  - returns adjacency_csr + fiedler_vector + eigenvalues + vertex_map (AC-1)
+  - scipy.sparse.linalg.eigsh drives the normal path (AC-2)
+  - the client can reconstruct L = D - A from adjacency_csr + degrees (AC-3)
+  - no new edge types are introduced; edge_type_filter validates against the
+    existing _ALLOWED_EDGE_TYPES set (AC-4)
+  - on a 10-node subgraph: len(fiedler_vector) == len(vertex_map) and
+    eigenvalues[0] < 0.001 (AC-5), including the edge-sparse worst case that the
+    combinatorial default is chosen to survive.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lambda_function as lf  # noqa: E402
+
+
+class _FakeResult(list):
+    """A neo4j-result stand-in: an iterable of dict rows (dict supports both
+    rec["k"] and rec.get("k"), matching the handler's access pattern)."""
+
+
+class _FakeSession:
+    def __init__(self, vertices, edges):
+        self._vertices = vertices
+        self._edges = edges
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, cypher, **params):
+        if "AS rid" in cypher:
+            ids = list(self._vertices)
+            if "n.record_id IN $ids" in cypher and "ids" in params:
+                wanted = set(params["ids"])
+                ids = [v for v in ids if v in wanted]
+            limit = params.get("limit")
+            if isinstance(limit, int):
+                ids = ids[:limit]
+            return _FakeResult({"rid": v} for v in ids)
+        if "AS s, b.record_id AS t" in cypher:
+            id_set = set(params.get("ids", []))
+            rows = []
+            for s, t in self._edges:
+                if s in id_set and t in id_set:
+                    rows.append({"s": s, "t": t})
+            return _FakeResult(rows)
+        return _FakeResult()
+
+
+class _FakeDriver:
+    def __init__(self, vertices, edges):
+        self._vertices = vertices
+        self._edges = edges
+
+    def session(self):
+        return _FakeSession(self._vertices, self._edges)
+
+
+def _decode_csr(adjacency_csr):
+    import numpy as np
+    from scipy.sparse import csr_matrix
+
+    data = np.frombuffer(base64.b64decode(adjacency_csr["data_b64"]), dtype="<f4")
+    indices = np.frombuffer(base64.b64decode(adjacency_csr["indices_b64"]), dtype="<i4")
+    indptr = np.frombuffer(base64.b64decode(adjacency_csr["indptr_b64"]), dtype="<i4")
+    shape = tuple(adjacency_csr["shape"])
+    return csr_matrix((data, indices, indptr), shape=shape)
+
+
+def _path_graph(n):
+    """0-1-2-...-(n-1): connected, so the combinatorial/normalized Laplacian both
+    have a single zero eigenvalue."""
+    vertices = [f"ENC-TSK-{i:03d}" for i in range(n)]
+    edges = [(vertices[i], vertices[i + 1]) for i in range(n - 1)]
+    return vertices, edges
+
+
+class TestGraphLaplacian(unittest.TestCase):
+    def test_ten_node_subgraph_ac1_ac5(self):
+        vertices, edges = _path_graph(10)
+        driver = _FakeDriver(vertices, edges)
+        result = lf._query_laplacian(
+            driver, "enceladus", {"record_ids": ",".join(vertices), "k": "3"}
+        )
+        self.assertNotIn("error", result)
+        # AC-1: all four payload keys present.
+        for key in ("adjacency_csr", "fiedler_vector", "eigenvalues", "vertex_map"):
+            self.assertIn(key, result)
+        # AC-5: 10-node subgraph contract.
+        self.assertEqual(len(result["vertex_map"]), 10)
+        self.assertEqual(len(result["fiedler_vector"]), len(result["vertex_map"]))
+        self.assertLess(result["eigenvalues"][0], 0.001)
+        # AC-2: the mandated eigsh path drives a non-trivial subgraph.
+        self.assertEqual(result["laplacian"]["eig_method"], "eigsh_SA")
+        self.assertEqual(len(result["eigenvalues"]), 3)
+
+    def test_reconstruct_combinatorial_laplacian_ac3(self):
+        import numpy as np
+
+        vertices, edges = _path_graph(10)
+        driver = _FakeDriver(vertices, edges)
+        result = lf._query_laplacian(driver, "enceladus", {"record_ids": ",".join(vertices)})
+
+        adjacency = _decode_csr(result["adjacency_csr"]).toarray()
+        # Symmetric binary adjacency with the expected number of undirected edges.
+        self.assertTrue(np.allclose(adjacency, adjacency.T))
+        self.assertEqual(int(adjacency.sum()) // 2, 9)
+
+        degrees = np.array(result["degrees"])
+        self.assertTrue(np.allclose(degrees, adjacency.sum(axis=1)))
+
+        # L = D - A; the constant vector is in the null space (L @ 1 == 0).
+        laplacian = np.diag(degrees) - adjacency
+        self.assertTrue(np.allclose(laplacian @ np.ones(10), np.zeros(10), atol=1e-9))
+
+    def test_normalized_normalization_connected(self):
+        vertices, edges = _path_graph(10)
+        driver = _FakeDriver(vertices, edges)
+        result = lf._query_laplacian(
+            driver,
+            "enceladus",
+            {"record_ids": ",".join(vertices), "normalization": "normalized"},
+        )
+        self.assertEqual(result["laplacian"]["normalization"], "normalized")
+        # Connected graph -> single zero eigenvalue in the normalized spectrum too.
+        self.assertLess(result["eigenvalues"][0], 0.001)
+        self.assertEqual(len(result["fiedler_vector"]), 10)
+
+    def test_combinatorial_survives_edgeless_subgraph_ac5(self):
+        # The worst case the combinatorial default is chosen for: 10 vertices, no
+        # induced edges. Combinatorial L = 0 -> all eigenvalues 0 -> AC-5 holds.
+        vertices = [f"ENC-ISS-{i:03d}" for i in range(10)]
+        driver = _FakeDriver(vertices, edges=[])
+        result = lf._query_laplacian(driver, "enceladus", {"record_ids": ",".join(vertices)})
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["vertex_map"]), 10)
+        self.assertLess(result["eigenvalues"][0], 0.001)
+        self.assertEqual(result["laplacian"]["edge_count"], 0)
+        # Edgeless L = 0 routes cleanly to dense eigh (no ARPACK zero-start).
+        self.assertEqual(result["laplacian"]["eig_method"], "dense_eigh")
+
+    def test_invalid_edge_type_filter_ac4(self):
+        vertices, edges = _path_graph(4)
+        driver = _FakeDriver(vertices, edges)
+        result = lf._query_laplacian(
+            driver,
+            "enceladus",
+            {"record_ids": ",".join(vertices), "edge_type_filter": "NOT_A_REAL_EDGE"},
+        )
+        self.assertIn("error", result)
+        self.assertIn("Invalid edge_type_filter", result["error"])
+
+    def test_valid_edge_type_filter_uses_existing_types(self):
+        # CHILD_OF is an existing edge type — must validate without error.
+        vertices, edges = _path_graph(6)
+        driver = _FakeDriver(vertices, edges)
+        result = lf._query_laplacian(
+            driver,
+            "enceladus",
+            {"record_ids": ",".join(vertices), "edge_type_filter": "CHILD_OF,RELATED_TO"},
+        )
+        self.assertNotIn("error", result)
+        self.assertEqual(result["laplacian"]["edge_type_filter"], ["CHILD_OF", "RELATED_TO"])
+
+    def test_too_few_vertices_errors(self):
+        driver = _FakeDriver(["ENC-TSK-001"], edges=[])
+        result = lf._query_laplacian(driver, "enceladus", {"record_ids": "ENC-TSK-001"})
+        self.assertIn("error", result)
+        self.assertIn("at least 2 vertices", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -7510,6 +7510,9 @@ _SEARCH_ACTIONS: Dict[str, Dict[str, Any]] = {
     "tracker.embeddings_for": {"tool": "tracker_embeddings_for"},
     # ENC-FTR-095 / ENC-TSK-I90: Sheaf Laplacian H1 inconsistency detection
     "tracker.sheaf_cohomology": {"tool": "tracker_sheaf_cohomology"},
+    # ENC-FTR-088 / ENC-TSK-I81: graph Laplacian read action (CSR adjacency +
+    # Fiedler eigenvector via scipy.sparse.linalg.eigsh in graph_query_api).
+    "tracker.graph_laplacian": {"tool": "tracker_graph_laplacian"},
     # ENC-FTR-097 / ENC-TSK-G27: Manifest Primitive v1 read actions
     "tracker.manifest": {"tool": "tracker_manifest"},
     "tracker.get_acs": {"tool": "tracker_get_acs"},
@@ -9118,6 +9121,35 @@ async def _tracker_sheaf_cohomology(args: dict) -> list[TextContent]:
     vertex_set_query = args.get("vertex_set_query")
     if vertex_set_query:
         query_params["vertex_set_query"] = vertex_set_query
+async def _tracker_graph_laplacian(args: dict) -> list[TextContent]:
+    """ENC-FTR-088 / ENC-TSK-I81: graph Laplacian read action.
+
+    Resolves an induced subgraph from a vertex set (vertex_set_query keyword or
+    explicit record_ids), then returns the CSR adjacency (base64 float32), the
+    Fiedler eigenvector, the k smallest Laplacian eigenvalues, the degree vector,
+    and an index->record_id vertex_map. Backed by the graph_query_api
+    search_type='laplacian' handler (scipy.sparse.linalg.eigsh). project_id
+    defaults to 'enceladus'. No new DynamoDB tables or edge types.
+    """
+    project_id = args.get("project_id") or "enceladus"
+    query_params: Dict[str, Any] = {
+        "search_type": "laplacian",
+        "project_id": project_id,
+    }
+    if args.get("vertex_set_query") is not None:
+        query_params["vertex_set_query"] = args["vertex_set_query"]
+    if args.get("record_ids") is not None:
+        rids = args["record_ids"]
+        query_params["record_ids"] = ",".join(rids) if isinstance(rids, list) else rids
+    if args.get("edge_type_filter") is not None:
+        etf = args["edge_type_filter"]
+        query_params["edge_type_filter"] = ",".join(etf) if isinstance(etf, list) else etf
+    if args.get("k") is not None:
+        query_params["k"] = str(args["k"])
+    if args.get("limit") is not None:
+        query_params["limit"] = str(args["limit"])
+    if args.get("normalization") is not None:
+        query_params["normalization"] = args["normalization"]
 
     resp = _graph_query_api_request(query=query_params)
     return _result_text(resp)
@@ -10336,6 +10368,8 @@ _TOOL_HANDLERS = {
     "tracker_embeddings_for": _tracker_embeddings_for,
     # ENC-FTR-095 / ENC-TSK-I90: Sheaf Laplacian H1 inconsistency detection
     "tracker_sheaf_cohomology": _tracker_sheaf_cohomology,
+    # ENC-FTR-088 / ENC-TSK-I81: graph Laplacian read action
+    "tracker_graph_laplacian": _tracker_graph_laplacian,
     # ENC-FTR-097 / ENC-TSK-G27: Manifest Primitive v1 read actions
     "tracker_manifest": _tracker_manifest,
     "tracker_get_acs": _tracker_get_acs,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **ENC-FTR-088** — the governed `tracker.graph_laplacian` MCP read action exposing CSR sparse adjacency + Fiedler eigenvector for the FTR-087 `d_spectral` Wave-Close Drift Telemetry measurement.

- **task_id:** `ENC-TSK-I81`
- **deploy_target:** `gamma` (v4/main only — v3-prod is FROZEN; no deploy performed)
- **commit-complete-id (CCI):** `CCI-3ed3a7a379894c5aa561337e0d87c3c6`
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`
- **session:** `ENC-SES-00K` (agent_type `ENC-AGT-003`, cursor-cloud-agent / claude-opus-4-8)

## What changed

- `backend/lambda/graph_query_api/lambda_function.py`: new `search_type="laplacian"` handler (`_query_laplacian` + `_laplacian_select_vertices`). Resolves a vertex set (keyword `vertex_set_query` **or** explicit `record_ids`), materializes the induced-subgraph **binary CSR adjacency** over EXISTING typed edges (optional `edge_type_filter` validated against `_ALLOWED_EDGE_TYPES`), then computes the smallest-`k` Laplacian eigenpairs via `scipy.sparse.linalg.eigsh`. Returns `adjacency_csr` (base64 float32 `data` + base64 int32 `indices`/`indptr` + `shape`), `fiedler_vector`, `eigenvalues[:k]`, `degrees`, and an index→record_id `vertex_map`. Response keys added to the `_handle_search` passthrough.
- `tools/enceladus-mcp-server/server.py`: registered `tracker.graph_laplacian` in `_SEARCH_ACTIONS` + handler `_tracker_graph_laplacian` + raw-tool dispatch entry (`project_id` defaults to `enceladus`).
- `backend/lambda/graph_query_api/requirements.txt`: added `numpy` + `scipy` (arch-correct manylinux wheels resolved by the `_build.yml` matrix).
- `backend/lambda/graph_query_api/test_graph_laplacian_ftr088.py`: 7 unit tests (all passing locally).

### Design note — default Laplacian
Default `normalization=combinatorial` (`L = D − A`): its smallest eigenvalue is identically 0 for **any** graph (the constant vector is always in the null space), so `eigenvalues[0] < 0.001` holds even for an edge-sparse/disconnected 10-node subgraph (AC-5 robustness). `normalization=normalized` (symmetric `L_sym = I − D^(-1/2) A D^(-1/2)`) is offered as an opt-in. `adjacency_csr` + `degrees` let a client reconstruct **either** form, which is exactly the `L = D − A` reconstruction AC-3 requires.

## Acceptance criteria

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 — action registered, returns `adjacency_csr + fiedler_vector + eigenvalues + vertex_map` | code-complete; **gamma-live pending deploy** (human-owned) | MCP `tracker.graph_laplacian` → graph_query_api `search_type=laplacian`; response keys passthrough |
| AC-2 — backend uses `scipy.sparse.linalg.eigsh`; no new DynamoDB tables/edge types | **satisfied** | `_query_laplacian` eigsh path; only existing `_ALLOWED_EDGE_TYPES` referenced |
| AC-3 — client can reconstruct `L = D − A` from returned data | **satisfied** | unit test decodes base64 CSR → A, verifies `L @ 1 == 0` |
| AC-4 — OGTM: no new edge types (graph_sync unchanged) | **satisfied** | `graph_sync` not in diff; `RELATIONSHIP_TYPE_TO_EDGE_LABEL` untouched |
| AC-5 — E2E 10-node: `len(fiedler_vector) == len(vertex_map)`, `eigenvalues[0] < 0.001` | logic verified locally; **gamma E2E pending deploy** (human-owned) | `test_ten_node_subgraph_ac1_ac5` (eigsh_SA path, λ0≈0) |

> Per the governed contract this task is advanced only to `committed`; the human owns merge + deploy + the live gamma E2E (AC-1/AC-5) close-out.

## Local test output
```
Ran 7 tests in 0.16s — OK
```

## connection_health (session init)
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-28T13:07:45Z",
  "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true},
    "graph_projection": {"configured": true, "name": "gds_standing_enceladus", "exists": true, "stale": false}}
}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3635beb4-29d4-42f2-b748-3ea2eea043e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3635beb4-29d4-42f2-b748-3ea2eea043e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

