### PR TITLE
[ENC-TSK-I82] FTR-086 Ph1 - Convergence Surface: DDB counter table + SQS FIFO + Streams fan-out Lambda

### DIFF
--- a/backend/lambda/convergence_telemetry/canonicalize.py
+++ b/backend/lambda/convergence_telemetry/canonicalize.py
@@ -1,0 +1,72 @@
+"""Convergence Surface canonicalization (ENC-FTR-086 D2 / ENC-TSK-I82).
+
+Pure, dependency-free canonicalization of open-taxonomy attribute values so that
+near-synonyms collapse to a single canonical key before they are counted. The
+transform is versioned: any change to the algorithm MUST bump ``CANON_VERSION``
+so the increment path and the (later) read path can migrate in lockstep and so
+the deduplication identity for an observation changes deterministically.
+
+D2 contract:
+    Unicode NFC + lowercase + whitespace/underscore -> hyphen + strip
+    non-alphanumerics (keep hyphens) + collapse/trim hyphens.
+
+Examples (ENC-TSK-I82 AC-3):
+    "Implementation"   -> "implementation"
+    " implementation " -> "implementation"
+    "IMPLEMENTATION"   -> "implementation"
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import List
+
+# Bump on ANY change to canonicalize(); it is part of the observation dedup key.
+CANON_VERSION = 1
+
+# Open-taxonomy fields whose submitted values are counted by the Convergence
+# Surface. Scalar fields contribute a single value; list-typed fields (e.g.
+# tags) contribute one observation per element. category/priority are bounded
+# enums today but are explicitly in scope for ENC-TSK-I82 telemetry.
+OPEN_TAXONOMY_FIELDS = ("category", "priority", "tags")
+
+_WS_OR_UNDERSCORE = re.compile(r"[\s_]+")
+_NON_ALNUM_HYPHEN = re.compile(r"[^a-z0-9-]+")
+_MULTI_HYPHEN = re.compile(r"-{2,}")
+
+
+def canonicalize(raw: object) -> str:
+    """Return the canonical form of a raw attribute value.
+
+    Returns an empty string for values that canonicalize to nothing (e.g. None,
+    whitespace-only, or punctuation-only input); callers skip empty results.
+    """
+    if raw is None:
+        return ""
+    text = unicodedata.normalize("NFC", str(raw))
+    text = text.strip().lower()
+    text = _WS_OR_UNDERSCORE.sub("-", text)
+    text = _NON_ALNUM_HYPHEN.sub("", text)
+    text = _MULTI_HYPHEN.sub("-", text).strip("-")
+    return text
+
+
+def canonical_values(raw: object) -> List[str]:
+    """Canonicalize a scalar or list-typed raw value into distinct canonical keys.
+
+    A list/tuple/set input fans out to one canonical value per element. Empty
+    canonical results are dropped and duplicates within a single record are
+    de-duplicated (a record mentioning the same tag twice counts once).
+    """
+    if isinstance(raw, (list, tuple, set)):
+        items = list(raw)
+    else:
+        items = [raw]
+
+    seen: List[str] = []
+    for item in items:
+        canon = canonicalize(item)
+        if canon and canon not in seen:
+            seen.append(canon)
+    return seen

--- a/backend/lambda/convergence_telemetry/counter_store.py
+++ b/backend/lambda/convergence_telemetry/counter_store.py
@@ -1,0 +1,292 @@
+"""Convergence Surface counter store + record logic (ENC-FTR-086 / ENC-TSK-I82).
+
+This module holds the storage-agnostic counting core so the lifecycle behaviour
+(canonical-value increment, 10k capacity cap with lowest-count eviction, and
+per-deduplication-id idempotency) is unit-testable without AWS. Two concrete
+stores implement the same protocol:
+
+* ``InMemoryCounterStore`` — used by the unit tests (ENC-TSK-I82 AC-4, AC-5).
+* ``DynamoCounterStore`` — the runtime store backed by the
+  ``enceladus-convergence-telemetry`` DynamoDB table.
+
+Table schema (AC-1):
+    PK  attribute_name   "{project_id}#{record_type}#{field}"
+    SK  canonical_value
+    count (N), first_seen, last_seen, authors (SS), canon_version, expires_at (N TTL)
+    GSI attribute_name-index: HASH attribute_name, RANGE count
+        (count-ordered — drives both ranking reads and lowest-count eviction)
+
+Idempotency markers live in a reserved partition namespace so they never
+pollute the per-attribute distinct-value counts used for eviction.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Protocol, Tuple
+
+# Capacity cap per attribute partition (ENC-FTR-086 AC-6 / ENC-TSK-I82 AC-4).
+DEFAULT_CAP = 10000
+
+# Reserved PK prefix for per-dedup-id idempotency markers. The "#" keeps them in
+# a partition that the {project}#{type}#{field} attribute partitions can never
+# collide with, so distinct_count() of a real attribute never sees a marker.
+IDEMPOTENCY_PREFIX = "__idem__#"
+
+
+class CounterStore(Protocol):
+    """Storage protocol for the convergence counter logic."""
+
+    def get(self, attribute_name: str, canonical_value: str) -> Optional[Dict]:
+        ...
+
+    def put_new(
+        self,
+        attribute_name: str,
+        canonical_value: str,
+        observed_at: str,
+        author: str,
+        expires_at: int,
+    ) -> None:
+        ...
+
+    def increment(
+        self,
+        attribute_name: str,
+        canonical_value: str,
+        observed_at: str,
+        author: str,
+        expires_at: int,
+    ) -> None:
+        ...
+
+    def distinct_count(self, attribute_name: str) -> int:
+        ...
+
+    def lowest(self, attribute_name: str) -> Optional[Tuple[str, int]]:
+        ...
+
+    def delete(self, attribute_name: str, canonical_value: str) -> None:
+        ...
+
+    def mark_processed(self, dedup_id: str, expires_at: int) -> bool:
+        """Atomically claim a dedup id. True if newly claimed, False if seen before."""
+        ...
+
+
+def record_observation(
+    store: CounterStore,
+    attribute_name: str,
+    canonical_value: str,
+    *,
+    dedup_id: str,
+    observed_at: str,
+    author: str = "",
+    expires_at: int = 0,
+    cap: int = DEFAULT_CAP,
+) -> Dict:
+    """Idempotently record one canonical-value observation.
+
+    Behaviour:
+      1. Idempotency (AC-5): the first call for ``dedup_id`` proceeds; any later
+         call with the same id is a no-op returning ``status="duplicate"``.
+      2. Eviction (AC-4): inserting a *new* canonical value when the attribute
+         partition is already at ``cap`` first evicts the lowest-count entry, so
+         the partition never exceeds ``cap`` distinct values.
+      3. Increment: an existing canonical value's count is incremented.
+    """
+    if not store.mark_processed(dedup_id, expires_at):
+        return {"status": "duplicate", "dedup_id": dedup_id}
+
+    existing = store.get(attribute_name, canonical_value)
+    evicted: Optional[str] = None
+
+    if existing is None:
+        if store.distinct_count(attribute_name) >= cap:
+            low = store.lowest(attribute_name)
+            if low is not None:
+                store.delete(attribute_name, low[0])
+                evicted = low[0]
+        store.put_new(attribute_name, canonical_value, observed_at, author, expires_at)
+        new_count = 1
+    else:
+        store.increment(attribute_name, canonical_value, observed_at, author, expires_at)
+        new_count = int(existing.get("count", 0)) + 1
+
+    return {
+        "status": "recorded",
+        "attribute_name": attribute_name,
+        "canonical_value": canonical_value,
+        "count": new_count,
+        "evicted": evicted,
+    }
+
+
+class InMemoryCounterStore:
+    """Dict-backed CounterStore for unit tests (no AWS)."""
+
+    def __init__(self) -> None:
+        # {attribute_name: {canonical_value: {count, first_seen, last_seen, authors:set, expires_at}}}
+        self._data: Dict[str, Dict[str, Dict]] = {}
+        self._processed: Dict[str, int] = {}
+
+    def get(self, attribute_name: str, canonical_value: str) -> Optional[Dict]:
+        item = self._data.get(attribute_name, {}).get(canonical_value)
+        return dict(item) if item is not None else None
+
+    def put_new(self, attribute_name, canonical_value, observed_at, author, expires_at) -> None:
+        authors = {author} if author else set()
+        self._data.setdefault(attribute_name, {})[canonical_value] = {
+            "count": 1,
+            "first_seen": observed_at,
+            "last_seen": observed_at,
+            "authors": authors,
+            "expires_at": expires_at,
+        }
+
+    def increment(self, attribute_name, canonical_value, observed_at, author, expires_at) -> None:
+        item = self._data[attribute_name][canonical_value]
+        item["count"] += 1
+        item["last_seen"] = observed_at
+        item["expires_at"] = expires_at
+        if author:
+            item["authors"].add(author)
+
+    def distinct_count(self, attribute_name: str) -> int:
+        return len(self._data.get(attribute_name, {}))
+
+    def lowest(self, attribute_name: str) -> Optional[Tuple[str, int]]:
+        partition = self._data.get(attribute_name, {})
+        if not partition:
+            return None
+        # Lowest count first; tie-break on oldest last_seen (age-weighted), then value.
+        value = min(
+            partition.items(),
+            key=lambda kv: (kv[1]["count"], kv[1].get("last_seen", ""), kv[0]),
+        )[0]
+        return value, partition[value]["count"]
+
+    def delete(self, attribute_name: str, canonical_value: str) -> None:
+        self._data.get(attribute_name, {}).pop(canonical_value, None)
+
+    def mark_processed(self, dedup_id: str, expires_at: int) -> bool:
+        if dedup_id in self._processed:
+            return False
+        self._processed[dedup_id] = expires_at
+        return True
+
+
+class DynamoCounterStore:
+    """DynamoDB-backed CounterStore for the runtime Lambda."""
+
+    def __init__(self, table_name: Optional[str] = None, region: Optional[str] = None):
+        import boto3
+
+        self.table_name = table_name or os.environ["CONVERGENCE_TABLE"]
+        region = region or os.environ.get("DYNAMODB_REGION") or os.environ.get("AWS_REGION", "us-west-2")
+        self._table = boto3.resource("dynamodb", region_name=region).Table(self.table_name)
+
+    def get(self, attribute_name: str, canonical_value: str) -> Optional[Dict]:
+        resp = self._table.get_item(
+            Key={"attribute_name": attribute_name, "canonical_value": canonical_value}
+        )
+        item = resp.get("Item")
+        if item is None:
+            return None
+        return {"count": int(item.get("count", 0)), **item}
+
+    def put_new(self, attribute_name, canonical_value, observed_at, author, expires_at) -> None:
+        item = {
+            "attribute_name": attribute_name,
+            "canonical_value": canonical_value,
+            "count": 1,
+            "first_seen": observed_at,
+            "last_seen": observed_at,
+            "canon_version": _canon_version(),
+            "expires_at": int(expires_at),
+        }
+        if author:
+            item["authors"] = set([author])
+        self._table.put_item(Item=item)
+
+    def increment(self, attribute_name, canonical_value, observed_at, author, expires_at) -> None:
+        from boto3.dynamodb.conditions import Attr
+
+        update = "ADD #c :one SET last_seen = :ts, expires_at = :exp, canon_version = :cv"
+        names = {"#c": "count"}
+        values = {
+            ":one": 1,
+            ":ts": observed_at,
+            ":exp": int(expires_at),
+            ":cv": _canon_version(),
+        }
+        if author:
+            update += " ADD authors :author"
+            values[":author"] = set([author])
+        self._table.update_item(
+            Key={"attribute_name": attribute_name, "canonical_value": canonical_value},
+            UpdateExpression=update,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+
+    def distinct_count(self, attribute_name: str) -> int:
+        from boto3.dynamodb.conditions import Key
+
+        total = 0
+        kwargs = {
+            "KeyConditionExpression": Key("attribute_name").eq(attribute_name),
+            "Select": "COUNT",
+        }
+        while True:
+            resp = self._table.query(**kwargs)
+            total += resp.get("Count", 0)
+            lek = resp.get("LastEvaluatedKey")
+            if not lek:
+                break
+            kwargs["ExclusiveStartKey"] = lek
+        return total
+
+    def lowest(self, attribute_name: str) -> Optional[Tuple[str, int]]:
+        from boto3.dynamodb.conditions import Key
+
+        resp = self._table.query(
+            IndexName="attribute_name-index",
+            KeyConditionExpression=Key("attribute_name").eq(attribute_name),
+            ScanIndexForward=True,  # ascending count -> lowest first
+            Limit=1,
+        )
+        items = resp.get("Items") or []
+        if not items:
+            return None
+        item = items[0]
+        return item["canonical_value"], int(item.get("count", 0))
+
+    def delete(self, attribute_name: str, canonical_value: str) -> None:
+        self._table.delete_item(
+            Key={"attribute_name": attribute_name, "canonical_value": canonical_value}
+        )
+
+    def mark_processed(self, dedup_id: str, expires_at: int) -> bool:
+        from botocore.exceptions import ClientError
+
+        try:
+            self._table.put_item(
+                Item={
+                    "attribute_name": IDEMPOTENCY_PREFIX + dedup_id,
+                    "canonical_value": "_",
+                    "expires_at": int(expires_at),
+                },
+                ConditionExpression="attribute_not_exists(attribute_name)",
+            )
+            return True
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return False
+            raise
+
+
+def _canon_version() -> int:
+    from canonicalize import CANON_VERSION
+
+    return CANON_VERSION

--- a/backend/lambda/convergence_telemetry/deploy.sh
+++ b/backend/lambda/convergence_telemetry/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/convergence_telemetry/lambda_function.py
+++ b/backend/lambda/convergence_telemetry/lambda_function.py
@@ -1,0 +1,237 @@
+"""enceladus-convergence-telemetry Lambda (ENC-FTR-086 Ph1 / ENC-TSK-I82).
+
+The Convergence Surface fan-out + increment Lambda. A single deployed function
+serves two event sources, dispatched on ``eventSource``:
+
+1. DynamoDB Stream (tracker table) -> FAN-OUT (AC-2)
+   For each INSERT/MODIFY tracker record, canonicalize the open-taxonomy field
+   values (category, priority, tags) and emit one SQS FIFO message per
+   (attribute, canonical_value), partitioned by attribute_name (MessageGroupId)
+   with a deterministic MessageDeduplicationId.
+
+2. SQS FIFO (enceladus-convergence-telemetry-queue.fifo) -> INCREMENT (AC-5)
+   Consume the fan-out messages and idempotently increment the canonical
+   counters in the DynamoDB counter table, evicting the lowest-count entry when
+   an attribute partition exceeds the 10k cap (AC-4).
+
+D1 architectural separation (ENC-FTR-086): this Lambda has its own IAM role and
+imports nothing from the governance Lambdas. The tracker mutation path never
+waits on this Lambda — it is a fire-and-forget, read-only-derived telemetry
+surface; failures here never affect governed writes.
+
+Environment variables:
+  CONVERGENCE_TABLE        DynamoDB counter table name
+  CONVERGENCE_QUEUE_URL    SQS FIFO queue URL (fan-out target)
+  CONVERGENCE_TTL_DAYS     Sliding TTL applied to expires_at (default 90)
+  CONVERGENCE_CAP          Per-attribute capacity cap (default 10000)
+  DYNAMODB_REGION          AWS region (default us-west-2)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from canonicalize import CANON_VERSION, OPEN_TAXONOMY_FIELDS, canonical_values
+from counter_store import DEFAULT_CAP, record_observation
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+QUEUE_URL = os.environ.get("CONVERGENCE_QUEUE_URL", "")
+TTL_DAYS = int(os.environ.get("CONVERGENCE_TTL_DAYS", "90"))
+CAP = int(os.environ.get("CONVERGENCE_CAP", str(DEFAULT_CAP)))
+IDEMPOTENCY_TTL_DAYS = int(os.environ.get("CONVERGENCE_IDEMPOTENCY_TTL_DAYS", "7"))
+
+_sqs = None
+_store = None
+
+
+def _get_sqs():
+    global _sqs
+    if _sqs is None:
+        import boto3
+
+        region = os.environ.get("DYNAMODB_REGION") or os.environ.get("AWS_REGION", "us-west-2")
+        _sqs = boto3.client("sqs", region_name=region)
+    return _sqs
+
+
+def _get_store():
+    global _store
+    if _store is None:
+        from counter_store import DynamoCounterStore
+
+        _store = DynamoCounterStore()
+    return _store
+
+
+# ---------------------------------------------------------------------------
+# DynamoDB stream image helpers
+# ---------------------------------------------------------------------------
+
+def _deserialize_image(image: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a DynamoDB stream NewImage (typed) to plain Python values."""
+    from boto3.dynamodb.types import TypeDeserializer
+
+    deser = TypeDeserializer()
+    out: Dict[str, Any] = {}
+    for key, typed in (image or {}).items():
+        try:
+            out[key] = deser.deserialize(typed)
+        except Exception:  # pragma: no cover - defensive against odd attrs
+            continue
+    return out
+
+
+def _extract_author(record: Dict[str, Any]) -> str:
+    write_source = record.get("write_source")
+    if isinstance(write_source, dict):
+        provider = write_source.get("provider")
+        if provider:
+            return str(provider)
+    return str(record.get("created_by") or "")
+
+
+def make_dedup_id(record_id: str, field: str, canonical_value: str, version_token: str) -> str:
+    """Deterministic dedup id for one (record-version, attribute, value) observation.
+
+    Including ``version_token`` (the record's updated_at) means a later mutation
+    of the same record counts as a new observation, while stream retries of the
+    same record-version dedup to a single count.
+    """
+    raw = f"{record_id}|{field}|{canonical_value}|{version_token}|canon{CANON_VERSION}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _attribute_name(project_id: str, record_type: str, field: str) -> str:
+    return f"{project_id}#{record_type}#{field}"
+
+
+# ---------------------------------------------------------------------------
+# Fan-out path (DynamoDB stream -> SQS FIFO)
+# ---------------------------------------------------------------------------
+
+def _fanout_messages(record: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Build the per-(attribute,value) fan-out messages for one tracker record."""
+    project_id = str(record.get("project_id") or "")
+    record_type = str(record.get("record_type") or "")
+    record_id = str(record.get("record_id") or record.get("item_id") or "")
+    version_token = str(record.get("updated_at") or record.get("sync_version") or "")
+    author = _extract_author(record)
+
+    if not (project_id and record_type and record_id):
+        return []
+
+    messages: List[Dict[str, Any]] = []
+    for field in OPEN_TAXONOMY_FIELDS:
+        if field not in record:
+            continue
+        for canon in canonical_values(record.get(field)):
+            attribute_name = _attribute_name(project_id, record_type, field)
+            dedup_id = make_dedup_id(record_id, field, canon, version_token)
+            messages.append(
+                {
+                    "attribute_name": attribute_name,
+                    "canonical_value": canon,
+                    "project_id": project_id,
+                    "record_type": record_type,
+                    "record_id": record_id,
+                    "field": field,
+                    "author": author,
+                    "observed_at": version_token,
+                    "dedup_id": dedup_id,
+                    "canon_version": CANON_VERSION,
+                }
+            )
+    return messages
+
+
+def _handle_fanout(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    sqs = _get_sqs()
+    sent = 0
+    for rec in records:
+        if rec.get("eventName") not in ("INSERT", "MODIFY"):
+            continue
+        new_image = rec.get("dynamodb", {}).get("NewImage")
+        if not new_image:
+            continue
+        plain = _deserialize_image(new_image)
+        for msg in _fanout_messages(plain):
+            if not QUEUE_URL:
+                logger.warning("CONVERGENCE_QUEUE_URL unset; dropping fan-out message")
+                continue
+            sqs.send_message(
+                QueueUrl=QUEUE_URL,
+                MessageBody=json.dumps(msg),
+                MessageGroupId=msg["attribute_name"],
+                MessageDeduplicationId=msg["dedup_id"],
+            )
+            sent += 1
+    logger.info("convergence fan-out: %d messages sent from %d records", sent, len(records))
+    return {"fanned_out": sent, "source_records": len(records)}
+
+
+# ---------------------------------------------------------------------------
+# Increment path (SQS FIFO -> counter table)
+# ---------------------------------------------------------------------------
+
+def _expires_at(now_epoch: Optional[int] = None) -> int:
+    base = now_epoch if now_epoch is not None else int(time.time())
+    return base + TTL_DAYS * 86400
+
+
+def _idem_expires_at(now_epoch: Optional[int] = None) -> int:
+    base = now_epoch if now_epoch is not None else int(time.time())
+    return base + IDEMPOTENCY_TTL_DAYS * 86400
+
+
+def process_message(store, body: Dict[str, Any], now_epoch: Optional[int] = None) -> Dict[str, Any]:
+    """Idempotently apply one fan-out message to the counter store."""
+    return record_observation(
+        store,
+        body["attribute_name"],
+        body["canonical_value"],
+        dedup_id=body["dedup_id"],
+        observed_at=str(body.get("observed_at") or ""),
+        author=str(body.get("author") or ""),
+        expires_at=_expires_at(now_epoch),
+        cap=CAP,
+    )
+
+
+def _handle_increment(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    store = _get_store()
+    failures: List[Dict[str, str]] = []
+    for rec in records:
+        message_id = rec.get("messageId", "")
+        try:
+            body = json.loads(rec.get("body") or "{}")
+            process_message(store, body)
+        except Exception:  # noqa: BLE001 - report to SQS for redrive, never crash batch
+            logger.exception("convergence increment failed for message %s", message_id)
+            failures.append({"itemIdentifier": message_id})
+    return {"batchItemFailures": failures}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
+    records = event.get("Records", []) if isinstance(event, dict) else []
+    if not records:
+        return {"status": "noop", "reason": "no records"}
+
+    source = records[0].get("eventSource") or records[0].get("EventSource") or ""
+    if source == "aws:sqs":
+        return _handle_increment(records)
+    if source == "aws:dynamodb":
+        return _handle_fanout(records)
+
+    logger.warning("convergence: unrecognized event source %r", source)
+    return {"status": "noop", "reason": f"unrecognized source {source!r}"}

--- a/backend/lambda/convergence_telemetry/requirements.txt
+++ b/backend/lambda/convergence_telemetry/requirements.txt
@@ -1,0 +1,1 @@
+# boto3 is provided by the Lambda runtime; no third-party deps required.

--- a/backend/lambda/convergence_telemetry/test_canonicalize.py
+++ b/backend/lambda/convergence_telemetry/test_canonicalize.py
@@ -1,0 +1,54 @@
+"""ENC-TSK-I82 AC-3: canonicalization unit tests.
+
+'Implementation', ' implementation ', 'IMPLEMENTATION' all map to 'implementation'.
+"""
+
+import unittest
+
+from canonicalize import CANON_VERSION, canonical_values, canonicalize
+
+
+class TestCanonicalize(unittest.TestCase):
+    def test_ac3_case_and_whitespace_collapse(self):
+        for raw in ("Implementation", " implementation ", "IMPLEMENTATION"):
+            self.assertEqual(canonicalize(raw), "implementation", msg=raw)
+
+    def test_ac3_all_three_collapse_to_one_key(self):
+        keys = {canonicalize(r) for r in ("Implementation", " implementation ", "IMPLEMENTATION")}
+        self.assertEqual(keys, {"implementation"})
+
+    def test_underscore_and_whitespace_to_hyphen(self):
+        self.assertEqual(canonicalize("In Progress"), "in-progress")
+        self.assertEqual(canonicalize("in_progress"), "in-progress")
+        self.assertEqual(canonicalize("in   progress"), "in-progress")
+        self.assertEqual(canonicalize("in__progress"), "in-progress")
+
+    def test_strip_non_alphanumerics(self):
+        self.assertEqual(canonicalize("P0!!"), "p0")
+        self.assertEqual(canonicalize("bug/risk"), "bugrisk")
+        self.assertEqual(canonicalize("--lead--"), "lead")
+
+    def test_unicode_nfc_normalization(self):
+        # Composed vs decomposed forms of 'é' must canonicalize identically.
+        composed = "Caf\u00e9"          # café (single codepoint é)
+        decomposed = "Cafe\u0301"        # café (e + combining acute)
+        self.assertEqual(canonicalize(composed), canonicalize(decomposed))
+
+    def test_empty_and_none(self):
+        self.assertEqual(canonicalize(None), "")
+        self.assertEqual(canonicalize("   "), "")
+        self.assertEqual(canonicalize("!!!"), "")
+
+    def test_canonical_values_list_fanout_and_dedup(self):
+        out = canonical_values(["Backend", "backend ", "Infra"])
+        self.assertEqual(out, ["backend", "infra"])
+
+    def test_canonical_values_scalar(self):
+        self.assertEqual(canonical_values("Implementation"), ["implementation"])
+
+    def test_canon_version_is_int(self):
+        self.assertIsInstance(CANON_VERSION, int)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/convergence_telemetry/test_eviction.py
+++ b/backend/lambda/convergence_telemetry/test_eviction.py
@@ -1,0 +1,78 @@
+"""ENC-TSK-I82 AC-4: capacity-cap eviction unit test.
+
+The 10,001st canonical value for a single attribute evicts the lowest-count entry.
+"""
+
+import unittest
+
+from counter_store import InMemoryCounterStore, record_observation
+
+ATTR = "enceladus#task#tags"
+
+
+def _seed(store, n, base_count, *, observed_at="2026-06-28T00:00:00Z"):
+    """Insert n distinct canonical values, each with `base_count` observations."""
+    for i in range(n):
+        value = f"tag-{i:05d}"
+        for c in range(base_count):
+            record_observation(
+                store,
+                ATTR,
+                value,
+                dedup_id=f"{value}:{c}",
+                observed_at=observed_at,
+                expires_at=0,
+                cap=10000,
+            )
+
+
+class TestEviction(unittest.TestCase):
+    def test_ac4_10001st_value_evicts_lowest_count(self):
+        store = InMemoryCounterStore()
+        # 9,999 values at count=5, plus one deliberately-lowest value at count=1.
+        _seed(store, 9999, base_count=5)
+        record_observation(
+            store, ATTR, "lowest-value", dedup_id="lowest:1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0, cap=10000,
+        )
+        self.assertEqual(store.distinct_count(ATTR), 10000)
+        self.assertEqual(store.lowest(ATTR), ("lowest-value", 1))
+
+        # Insert the 10,001st distinct value -> must evict the lowest-count entry.
+        result = record_observation(
+            store, ATTR, "the-10001st", dedup_id="the-10001st:1",
+            observed_at="2026-06-28T01:00:00Z", expires_at=0, cap=10000,
+        )
+
+        self.assertEqual(result["status"], "recorded")
+        self.assertEqual(result["evicted"], "lowest-value")
+        self.assertEqual(store.distinct_count(ATTR), 10000)
+        self.assertIsNone(store.get(ATTR, "lowest-value"))
+        self.assertIsNotNone(store.get(ATTR, "the-10001st"))
+
+    def test_existing_value_increment_never_evicts(self):
+        store = InMemoryCounterStore()
+        _seed(store, 10000, base_count=1)
+        self.assertEqual(store.distinct_count(ATTR), 10000)
+        # Re-observing an existing value (new dedup id) increments, no eviction.
+        result = record_observation(
+            store, ATTR, "tag-00000", dedup_id="tag-00000:again",
+            observed_at="2026-06-28T02:00:00Z", expires_at=0, cap=10000,
+        )
+        self.assertEqual(result["status"], "recorded")
+        self.assertIsNone(result["evicted"])
+        self.assertEqual(store.distinct_count(ATTR), 10000)
+        self.assertEqual(store.get(ATTR, "tag-00000")["count"], 2)
+
+    def test_under_cap_no_eviction(self):
+        store = InMemoryCounterStore()
+        _seed(store, 5, base_count=1)
+        record_observation(
+            store, ATTR, "sixth", dedup_id="sixth:1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0, cap=10000,
+        )
+        self.assertEqual(store.distinct_count(ATTR), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/convergence_telemetry/test_handler.py
+++ b/backend/lambda/convergence_telemetry/test_handler.py
@@ -1,0 +1,111 @@
+"""ENC-TSK-I82 AC-2: fan-out + event dispatch unit tests.
+
+Covers the DynamoDB-stream fan-out (open-taxonomy fields category/priority/tags)
+and the SQS increment dispatch wiring, without AWS.
+"""
+
+import json
+import unittest
+
+import lambda_function as lf
+from counter_store import InMemoryCounterStore
+
+
+def _stream_record(image, event_name="INSERT"):
+    return {
+        "eventSource": "aws:dynamodb",
+        "eventName": event_name,
+        "dynamodb": {"NewImage": image},
+    }
+
+
+class TestFanout(unittest.TestCase):
+    def test_fanout_messages_for_open_taxonomy_fields(self):
+        record = {
+            "project_id": "enceladus",
+            "record_type": "task",
+            "record_id": "ENC-TSK-I82",
+            "updated_at": "2026-06-28T13:00:00Z",
+            "category": "Implementation",
+            "priority": "P2",
+            "tags": ["Backend", "infra"],
+            "title": "ignored non-taxonomy field",
+        }
+        msgs = lf._fanout_messages(record)
+        attrs = {(m["field"], m["canonical_value"]) for m in msgs}
+        self.assertIn(("category", "implementation"), attrs)
+        self.assertIn(("priority", "p2"), attrs)
+        self.assertIn(("tags", "backend"), attrs)
+        self.assertIn(("tags", "infra"), attrs)
+        # Non-taxonomy fields are never counted.
+        self.assertNotIn("title", {m["field"] for m in msgs})
+        # attribute_name is the {project}#{type}#{field} partition.
+        cat = next(m for m in msgs if m["field"] == "category")
+        self.assertEqual(cat["attribute_name"], "enceladus#task#category")
+
+    def test_dedup_id_is_deterministic_and_version_scoped(self):
+        a = lf.make_dedup_id("ENC-TSK-1", "category", "implementation", "v1")
+        b = lf.make_dedup_id("ENC-TSK-1", "category", "implementation", "v1")
+        c = lf.make_dedup_id("ENC-TSK-1", "category", "implementation", "v2")
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+    def test_fanout_skips_records_missing_identity(self):
+        self.assertEqual(lf._fanout_messages({"category": "implementation"}), [])
+
+    def test_handle_fanout_sends_per_attribute_messages(self):
+        sent = []
+
+        class FakeSqs:
+            def send_message(self, **kw):
+                sent.append(kw)
+
+        orig_sqs, orig_url = lf._sqs, lf.QUEUE_URL
+        lf._sqs = FakeSqs()
+        lf.QUEUE_URL = "https://sqs.example/q.fifo"
+        try:
+            event = {
+                "Records": [
+                    _stream_record(
+                        {
+                            "project_id": {"S": "enceladus"},
+                            "record_type": {"S": "task"},
+                            "record_id": {"S": "ENC-TSK-I82"},
+                            "updated_at": {"S": "2026-06-28T13:00:00Z"},
+                            "category": {"S": "Implementation"},
+                            "priority": {"S": "P2"},
+                        }
+                    )
+                ]
+            }
+            out = lf.handler(event)
+        finally:
+            lf._sqs, lf.QUEUE_URL = orig_sqs, orig_url
+
+        self.assertEqual(out["fanned_out"], 2)
+        groups = {m["MessageGroupId"] for m in sent}
+        self.assertEqual(groups, {"enceladus#task#category", "enceladus#task#priority"})
+        # Every message carries an explicit FIFO dedup id.
+        self.assertTrue(all(m.get("MessageDeduplicationId") for m in sent))
+
+
+class TestIncrementDispatch(unittest.TestCase):
+    def test_handle_increment_idempotent_across_batch(self):
+        store = InMemoryCounterStore()
+        body = {
+            "attribute_name": "enceladus#task#category",
+            "canonical_value": "implementation",
+            "dedup_id": "abc123",
+            "observed_at": "2026-06-28T13:00:00Z",
+            "author": "ENC-SES-00L",
+        }
+        lf.process_message(store, body)
+        lf.process_message(store, body)  # duplicate dedup id
+        self.assertEqual(store.get("enceladus#task#category", "implementation")["count"], 1)
+
+    def test_handler_noop_on_empty(self):
+        self.assertEqual(lf.handler({"Records": []})["status"], "noop")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/convergence_telemetry/test_idempotency.py
+++ b/backend/lambda/convergence_telemetry/test_idempotency.py
@@ -1,0 +1,53 @@
+"""ENC-TSK-I82 AC-5: idempotent processing on duplicate deduplication id.
+
+Processing the same deduplication id twice increments the counter exactly once.
+"""
+
+import unittest
+
+from counter_store import InMemoryCounterStore, record_observation
+
+ATTR = "enceladus#task#category"
+
+
+class TestIdempotency(unittest.TestCase):
+    def test_ac5_duplicate_dedup_id_counts_once(self):
+        store = InMemoryCounterStore()
+        first = record_observation(
+            store, ATTR, "implementation", dedup_id="dup-1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0,
+        )
+        second = record_observation(
+            store, ATTR, "implementation", dedup_id="dup-1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0,
+        )
+
+        self.assertEqual(first["status"], "recorded")
+        self.assertEqual(second["status"], "duplicate")
+        self.assertEqual(store.get(ATTR, "implementation")["count"], 1)
+
+    def test_distinct_dedup_ids_increment_each_time(self):
+        store = InMemoryCounterStore()
+        for i in range(3):
+            record_observation(
+                store, ATTR, "implementation", dedup_id=f"obs-{i}",
+                observed_at="2026-06-28T00:00:00Z", expires_at=0,
+            )
+        self.assertEqual(store.get(ATTR, "implementation")["count"], 3)
+
+    def test_duplicate_does_not_evict_or_create(self):
+        store = InMemoryCounterStore()
+        record_observation(
+            store, ATTR, "documentation", dedup_id="d-1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0,
+        )
+        before = store.distinct_count(ATTR)
+        record_observation(
+            store, ATTR, "documentation", dedup_id="d-1",
+            observed_at="2026-06-28T00:00:00Z", expires_at=0,
+        )
+        self.assertEqual(store.distinct_count(ATTR), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -6067,6 +6067,23 @@
           "type": "object"
         }
       }
+    },
+    "monitoring.convergence_telemetry": {
+      "description": "ENC-TSK-I82 (FTR-086 Ph1): Convergence Surface DDB counter table + SQS FIFO + Streams fan-out Lambda.",
+      "fields": {
+        "attribute_name": {
+          "type": "string"
+        },
+        "canonical_value": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "expires_at": {
+          "type": "integer"
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -448,6 +448,52 @@ Resources:
         - Key: Component
           Value: graph
 
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: write buffer between the convergence fan-out
+  # (DynamoDB-stream-triggered) and the idempotent counter increment. FIFO with
+  # per-attribute MessageGroupId so increments to one attribute are ordered while
+  # distinct attributes process concurrently. ContentBasedDeduplication is OFF —
+  # the fan-out supplies an explicit, deterministic MessageDeduplicationId.
+  ConvergenceTelemetryQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    Properties:
+      QueueName: !Sub "enceladus-convergence-telemetry-queue${EnvironmentSuffix}.fifo"
+      FifoQueue: true
+      ContentBasedDeduplication: false
+      # Must be >= the convergence Lambda Timeout (60) so a redelivery is not
+      # made visible mid-processing.
+      VisibilityTimeout: 120
+      MessageRetentionPeriod: 86400
+      ReceiveMessageWaitTimeSeconds: 20
+      SqsManagedSseEnabled: true
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt ConvergenceTelemetryDLQ.Arn
+        maxReceiveCount: 5
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: convergence
+        - Key: Feature
+          Value: ENC-FTR-086
+
+  ConvergenceTelemetryDLQ:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    Properties:
+      QueueName: !Sub "enceladus-convergence-telemetry-dlq${EnvironmentSuffix}.fifo"
+      FifoQueue: true
+      ContentBasedDeduplication: false
+      MessageRetentionPeriod: 1209600
+      SqsManagedSseEnabled: true
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: convergence
+        - Key: Feature
+          Value: ENC-FTR-086
+
   # ---------------------------------------------------------------------------
   # SNS Topics
   # ---------------------------------------------------------------------------
@@ -595,6 +641,41 @@ Resources:
       KeySchema:
         - AttributeName: pk
           KeyType: HASH
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: Convergence Surface attribute-value counter.
+  # Frequency-ranked telemetry over canonical open-taxonomy values. One partition
+  # per attribute (attribute_name = "{project_id}#{record_type}#{field}"); the
+  # attribute_name-index GSI is count-ordered so it serves both ranked reads and
+  # lowest-count eviction at the 10k cap. TTL on expires_at ages out stale rows.
+  ConvergenceTelemetryTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: attribute_name
+          AttributeType: S
+        - AttributeName: canonical_value
+          AttributeType: S
+        - AttributeName: count
+          AttributeType: N
+      KeySchema:
+        - AttributeName: attribute_name
+          KeyType: HASH
+        - AttributeName: canonical_value
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: attribute_name-index
+          KeySchema:
+            - AttributeName: attribute_name
+              KeyType: HASH
+            - AttributeName: count
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: true
       Tags:
         - Key: Project
           Value: enceladus
@@ -602,6 +683,9 @@ Resources:
           Value: percolation-monitor
         - Key: Feature
           Value: ENC-FTR-085
+          Value: convergence
+        - Key: Feature
+          Value: ENC-FTR-086
 
 Outputs:
   CoordinationTableName:
@@ -705,3 +789,24 @@ Outputs:
     Value: !GetAtt GovernanceVersionTable.Arn
     Export:
       Name: !Sub ${AWS::StackName}-GovernanceVersionTableArn
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: Convergence Surface
+  ConvergenceTelemetryTableName:
+    Value: !Ref ConvergenceTelemetryTable
+    Export:
+      Name: !Sub ${AWS::StackName}-ConvergenceTelemetryTable
+  ConvergenceTelemetryTableArn:
+    Value: !GetAtt ConvergenceTelemetryTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ConvergenceTelemetryTableArn
+  ConvergenceTelemetryQueueUrl:
+    Value: !Ref ConvergenceTelemetryQueue
+    Export:
+      Name: !Sub ${AWS::StackName}-ConvergenceTelemetryQueueUrl
+  ConvergenceTelemetryQueueArn:
+    Value: !GetAtt ConvergenceTelemetryQueue.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ConvergenceTelemetryQueueArn
+  ConvergenceTelemetryDLQArn:
+    Value: !GetAtt ConvergenceTelemetryDLQ.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ConvergenceTelemetryDLQArn

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1116,6 +1116,58 @@ Resources:
           Value: graph
 
   # ---------------------------------------------------------------------------
+  # Convergence Surface fan-out + increment Lambda (ENC-FTR-086 Ph1 / ENC-TSK-I82)
+  # ---------------------------------------------------------------------------
+  # One function, two event sources (dispatched on eventSource in the handler):
+  #   - DynamoDB Stream (tracker) -> fan-out per open-taxonomy attribute to SQS
+  #   - SQS FIFO -> idempotent counter increment with 10k-cap lowest-count eviction
+  # ENC-FTR-086 D1: isolated tier-1 service — its own IAM role, no import path
+  # from any governance Lambda; tracker mutations never wait on it.
+  ConvergenceTelemetryFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ConvergenceTelemetryRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          CONVERGENCE_TABLE: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
+          CONVERGENCE_QUEUE_URL: !ImportValue
+            Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueUrl
+          CONVERGENCE_TTL_DAYS: "90"
+          CONVERGENCE_CAP: "10000"
+          DYNAMODB_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: convergence
+        - Key: Feature
+          Value: ENC-FTR-086
+
+  # ---------------------------------------------------------------------------
   # Neo4j Backup Lambda
   # ---------------------------------------------------------------------------
 
@@ -1705,6 +1757,35 @@ Resources:
       BatchSize: 25
       MaximumBatchingWindowInSeconds: 30
       StartingPosition: LATEST
+      Enabled: true
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: tracker DynamoDB Stream -> convergence fan-out.
+  ConvergenceStreamTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      FunctionName: !Ref ConvergenceTelemetryFunction
+      BatchSize: 25
+      MaximumBatchingWindowInSeconds: 30
+      StartingPosition: LATEST
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Enabled: true
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: convergence SQS FIFO -> idempotent increment.
+  ConvergenceSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueArn
+      FunctionName: !Ref ConvergenceTelemetryFunction
+      BatchSize: 10
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
       Enabled: true
 
   # ---------------------------------------------------------------------------
@@ -3572,6 +3653,95 @@ Resources:
                   - bedrock:InvokeModel
                 Resource:
                   - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.titan-embed-text-v2:0"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: Convergence Surface Lambda role.
+  # D1 architectural separation: read-only on the tracker STREAM (never the
+  # governance tables) + read/write only on its own counter table + consume/send
+  # on its own FIFO queue. Governance Lambdas have no access to the counter table.
+  ConvergenceTelemetryRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-convergence-telemetry-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ReadTrackerStream
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+        - PolicyName: ConvergenceQueue
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeAndSendConvergenceQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:GetQueueUrl
+                  - sqs:SendMessage
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueArn
+        - PolicyName: ConvergenceCounterTable
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CounterTableReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                Resource:
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-ConvergenceTelemetryTableArn
+                  - !Sub
+                    - "${TableArn}/index/*"
+                    - TableArn: !ImportValue
+                        Fn::Sub: ${DataStackName}-ConvergenceTelemetryTableArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -241,6 +241,16 @@
       "lambda_dir": "backend/lambda/arc_walk_metrics",
       "workflow_file": ".github/workflows/_deploy.yml",
       "deploy_script": "backend/lambda/arc_walk_metrics/deploy.sh"
+    },
+    {
+      "function_name": "enceladus-convergence-telemetry",
+      "lambda_dir": "backend/lambda/convergence_telemetry",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/convergence_telemetry/deploy.sh",
+      "package_extra_files": [
+        "canonicalize.py",
+        "counter_store.py"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ENC-TSK-I82 — FTR-086 Ph1: Convergence Surface

**task_id:** ENC-TSK-I82
**Feature:** ENC-FTR-086 (Convergence Surface — attribute-value frequency telemetry)
**Deploy target:** `v4/main` (gamma) only — v3-prod is FROZEN (DOC-499FA089EC30). No deploy performed; human owns merge + deploy + close-out.
**Session:** ENC-SES-00L (cursor-cloud-agent / claude-opus-4-8)

**commit-complete-id (CCI):** `CCI-36fb501001a94cfc92379666e44260fc`
**commit_sha:** `e2a66732823bdcc7854f77eaade754c445fb3816`

### governance_hash
`22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`

### connection_health (init, abort-gate cleared: dynamodb=ok, s3=ok)
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-28T13:07:54Z",
  "graph_index": {"status": "healthy"}
}
```

### Acceptance criteria status

| AC | Description | Status at `committed` |
|----|-------------|------------------------|
| AC1 | `enceladus-convergence-telemetry` DDB table ACTIVE, TTL on `expires_at`, GSI `attribute_name-index` | **Authored** in `01-data.yaml` (PK `attribute_name`, SK `canonical_value`; GSI `attribute_name-index` = HASH `attribute_name` + RANGE `count`; TTL on `expires_at`). Live `describe-table` ACTIVE confirmation is gated on the human gamma deploy. |
| AC2 | DynamoDB Streams fan-out Lambda wired to tracker stream; increments canonical counters for category/priority/tags | **Authored**: `enceladus-convergence-telemetry` Lambda + `ConvergenceStreamTrigger` (tracker stream ESM, fan-out) + `ConvergenceSqsTrigger` (FIFO ESM, increment). Fan-out logic unit-tested. Live wiring confirmation gated on deploy. |
| AC3 | Canonicalization: `Implementation` / ` implementation ` / `IMPLEMENTATION` → `implementation` | ✅ **Satisfied** — `test_canonicalize.py` passes. |
| AC4 | 10,001st canonical value for a single attribute evicts lowest-count entry | ✅ **Satisfied** — `test_eviction.py` passes. |
| AC5 | SQS FIFO deployed; Lambda idempotent on duplicate deduplication id | **Authored**: `ConvergenceTelemetryQueue` FIFO + DLQ; idempotency (explicit `MessageDeduplicationId` + Lambda-level marker) ✅ unit-tested in `test_idempotency.py`. "Deployed" confirmation gated on deploy. |

Unit tests: **21 passing** (`test_canonicalize`, `test_eviction`, `test_idempotency`, `test_handler`). Arch-parity CI guard passes (29 CFN Lambdas, gamma=arm64/py3.12).

### Changes
- **`infrastructure/cloudformation/01-data.yaml`** — `ConvergenceTelemetryTable` (TTL + `attribute_name-index` GSI), `ConvergenceTelemetryQueue` SQS FIFO + `ConvergenceTelemetryDLQ`, stack outputs.
- **`infrastructure/cloudformation/02-compute.yaml`** — `ConvergenceTelemetryFunction`, `ConvergenceStreamTrigger`, `ConvergenceSqsTrigger`, dedicated `ConvergenceTelemetryRole`.
- **`backend/lambda/convergence_telemetry/`** — `canonicalize.py` (versioned, `CANON_VERSION`), `counter_store.py` (in-memory + DynamoDB stores; 10k-cap lowest-count eviction; per-dedup-id idempotency), `lambda_function.py` (stream fan-out + idempotent SQS increment dispatch), tests, `requirements.txt`, tombstone `deploy.sh`.
- **`infrastructure/lambda_workflow_manifest.json`** — registers the function for the deploy matrix.

### Design notes
- **D1 isolation (ENC-FTR-086):** dedicated IAM role — tracker stream read-only + own counter table RW + own FIFO only; no import path from governance Lambdas. Tracker mutations never wait on this Lambda (fire-and-forget telemetry).
- **Components:** `comp-cloudformation-data`, `comp-cloudformation-app` (infra). `transition_type=github_pr_deploy`.
- Scope is Ph1 infra only — the read Lambda + `search(action="telemetry.rank")` MCP surface (FTR-086 AC-3/AC-5) and dictionary `telemetry_eligible`/`vocabulary_bounded` flags (AC-7) are later phases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94a6492-caf0-4abd-8309-7f8c683308fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94a6492-caf0-4abd-8309-7f8c683308fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

