### PR TITLE
[ENC-TSK-H85] Arc-Walker Phase 1 core - synchronous inline mechanical walk

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.05",
-  "updated_at": "2026-06-28T12:41:27Z",
-  "last_change_summary": "ENC-TSK-I09 (Dedup P5) reconciled with ENC-TSK-H84 (Arc-Walker Phase 1) on merge to v4/main (PRs #625/#624). Adds tracker.dedup_auto_merge: the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (POST /{project}/dedup-review op=auto-merge, tracker:write) gated by four io-sovereignty rails — enable_dedup_auto_merge flag (dark/shadow default), dedup_auto_merge_kill_switch (instant halt), per-pair certificate precision-LCB>=0.999 against the chosen canonical (no transitive chain-drag), and the auto_walk_opt_out latch that demotes a record to ATTESTATION on any io walk-back — plus the record.dedup.auto_merged EventBridge audit feed. Updates tracker.task.status / tracker.issue.status 'superseded' notes (T-HIGH auto-merge no longer deferred). Retains the H84 project_service.deploy_policy entity added at version .04. Version 2026-06-28.04 -> 2026-06-28.05.",
+  "version": "2026-06-28.06",
+  "updated_at": "2026-06-28T13:20:00Z",
+  "last_change_summary": "ENC-TSK-H85 (Arc-Walker Phase 1 CORE — synchronous inline mechanical walk, ENC-FTR-111). Adds lifecycle_service.arc_walker_walk: after a successful forward task advance, tracker_mutation hands off to the Universal Arc-Walker, which loops forward across the two Phase-1 MECHANICAL legs — <deploy-arc>|merged-main -> deploy-init (ci_triggered only, ruling O-2) and code_only|merged-main -> closed (reuses the stored commit_sha + a system-run GitHub compare via the new github_integration /commits/compare-main route) — as idempotent conditional writes (advance iff status == expected_prior), behind the independent enable_arc_walker AppConfig flag. The walk honors the auto_walk_opt_out latch, pins the matrix_version, integrity-checks checkout_transition_type (409 halt on mismatch), halts at the first attestation/opt-out/gate-fail boundary, and emits a record.arc_walk.advanced Artifact-Genesis event per crossing. Eligibility is the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy), never evidence-field emptiness. Version 2026-06-28.05 -> 2026-06-28.06. PRIOR: ENC-TSK-I09 (Dedup P5) reconciled with ENC-TSK-H84 (Arc-Walker Phase 1) on merge to v4/main (PRs #625/#624). Adds tracker.dedup_auto_merge: the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (POST /{project}/dedup-review op=auto-merge, tracker:write) gated by four io-sovereignty rails — enable_dedup_auto_merge flag (dark/shadow default), dedup_auto_merge_kill_switch (instant halt), per-pair certificate precision-LCB>=0.999 against the chosen canonical (no transitive chain-drag), and the auto_walk_opt_out latch that demotes a record to ATTESTATION on any io walk-back — plus the record.dedup.auto_merged EventBridge audit feed. Updates tracker.task.status / tracker.issue.status 'superseded' notes (T-HIGH auto-merge no longer deferred). Retains the H84 project_service.deploy_policy entity added at version .04. Version 2026-06-28.04 -> 2026-06-28.05.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1774,6 +1774,39 @@
           "default": "ci_triggered",
           "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
           "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
+        }
+      }
+    },
+    "lifecycle_service.arc_walker_walk": {
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
+      "governing_feature": "ENC-FTR-111",
+      "governing_task": "ENC-TSK-H85",
+      "fields": {
+        "feature_flag": {
+          "type": "string",
+          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
+          "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
+        },
+        "phase1_legs": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "The only two gates Phase 1 auto-crosses: '<github_pr_deploy|lambda_deploy|web_deploy>|merged-main->deploy-init' (MECHANICAL, ci_triggered-only per O-2) and 'code_only|merged-main->closed' (MECHANICAL, commit_sha reuse + GitHub compare). All other gates are attestation or external-fact and are structurally unreachable in Phase 1 (deploy-success/closed/coding-complete/pr/committed/merged-main)."
+        },
+        "idempotent_conditional_write": {
+          "type": "object",
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
+        },
+        "safety_invariants": {
+          "type": "object",
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+        },
+        "write_source": {
+          "type": "string",
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+        },
+        "artifact_genesis": {
+          "type": "string",
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
         }
       }
     },

--- a/backend/lambda/github_integration/lambda_function.py
+++ b/backend/lambda/github_integration/lambda_function.py
@@ -1901,6 +1901,61 @@ def _handle_validate_commit(event: Dict, claims: Dict) -> Dict:
         return _error(502, f"GitHub API error ({exc.code})")
 
 
+def _handle_compare_main(event: Dict, claims: Dict) -> Dict:
+    """GET /api/v1/github/commits/compare-main?owner=X&repo=Y&sha=Z
+
+    ENC-TSK-H85 / ENC-FTR-111 Phase 1: confirm that a commit SHA is an ancestor of (or identical to)
+    the repository's default `main` branch. The Universal Arc-Walker's code_only|closed leg reuses
+    the commit_sha the agent already supplied at `committed` and asks this system-run GitHub compare
+    whether it is on main — a mechanical external-fact check, not a human attestation
+    (DOC-078C57FC1BE6 §3.1). Mirrors the checkout_service `_validate_code_on_main_evidence` contract
+    (ENC-ISS-161): compare base=sha head=main; status 'ahead' (main has commits sha does not) or
+    'identical' (sha IS main HEAD) both mean sha is an ancestor of main.
+    """
+    qs = event.get("queryStringParameters") or {}
+    owner = (qs.get("owner") or "").strip()
+    repo = (qs.get("repo") or "").strip()
+    sha = (qs.get("sha") or "").strip()
+
+    if not owner or not repo or not sha:
+        return _error(400, "Required query params: owner, repo, sha")
+    if not re.match(r"^[0-9a-f]{40}$", sha.lower()):
+        return _response(200, {"valid": False, "sha": sha, "reason": "sha_not_40_hex"})
+
+    full_repo = f"{owner}/{repo}"
+    if full_repo not in ALLOWED_REPOS:
+        return _error(403, f"Repository not allowed: {full_repo}")
+
+    token = _get_installation_token()
+    url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/compare/{sha}...main"
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            compare_status = data.get("status", "")
+            is_ancestor = compare_status in ("ahead", "identical")
+            return _response(200, {
+                "valid": is_ancestor,
+                "sha": sha,
+                "status": compare_status,
+                "reason": "" if is_ancestor else f"not_ancestor_of_main:{compare_status or 'unknown'}",
+            })
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 422):
+            return _response(200, {"valid": False, "sha": sha, "reason": "compare_not_found"})
+        body = exc.read().decode("utf-8", errors="replace")[:500]
+        logger.error("GitHub compare-main API error %s: %s", exc.code, body)
+        return _error(502, f"GitHub API error ({exc.code})")
+
+
 # ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
@@ -1927,6 +1982,8 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         return _handle_sync_to_project(event, claims)
     elif method == "GET" and "/github/projects" in path:
         return _handle_list_projects(event, claims)
+    elif method == "GET" and "/github/commits/compare-main" in path:
+        return _handle_compare_main(event, claims)
     elif method == "GET" and "/github/commits/validate" in path:
         return _handle_validate_commit(event, claims)
     elif method == "POST" and "/github/issues" in path:

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -185,6 +185,44 @@ def _lifecycle_service_enabled() -> bool:
     return _appconfig_flag("enable_lifecycle_service_extraction", env_fallback="ENABLE_LIFECYCLE_SERVICE")
 
 
+def _arc_walker_enabled() -> bool:
+    """ENC-TSK-H85 / ENC-FTR-111 Phase 1 — the Universal Arc-Walker is behind its OWN independent
+    feature flag, read at request time so it toggles (and rolls back) without a redeploy. It is
+    deliberately separate from enable_lifecycle_service_extraction: the validation extraction (H46)
+    and the synchronous mechanical walk (this task) graduate independently (DOC-078C57FC1BE6 §11)."""
+    return _appconfig_flag("enable_arc_walker", env_fallback="ENABLE_ARC_WALKER")
+
+
+def _invoke_lifecycle_action(payload: dict):
+    """Synchronously invoke the Lifecycle Service for an arbitrary action and return its raw verdict
+    dict, or None on ANY failure. Unlike _invoke_lifecycle_service this does NOT require an ``allow``
+    key, so it serves the ENC-TSK-H85 arc-walker which consumes the evaluate_auto_walk verdict
+    (auto_walkable / gate_class / matrix_version) in addition to validate_transition."""
+    fn = LIFECYCLE_SERVICE_FUNCTION
+    if not fn:
+        logger.error("[H85] LIFECYCLE_SERVICE_FUNCTION not configured; arc-walk skipped")
+        return None
+    try:
+        resp = _get_lambda_client().invoke(
+            FunctionName=fn,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(payload).encode("utf-8"),
+        )
+        if resp.get("FunctionError"):
+            logger.error("[H85] Lifecycle Service FunctionError=%s", resp.get("FunctionError"))
+            return None
+        body = resp.get("Payload")
+        raw = body.read() if hasattr(body, "read") else body
+        verdict = json.loads(raw)
+        if not isinstance(verdict, dict):
+            logger.error("[H85] Lifecycle Service returned malformed verdict: %r", verdict)
+            return None
+        return verdict
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[H85] Lifecycle Service invoke failed: %s", exc)
+        return None
+
+
 def _invoke_lifecycle_service(payload: dict):
     """Synchronously invoke the Lifecycle Service and return its verdict dict, or None on ANY
     failure (function not configured, invoke error, FunctionError, malformed verdict). Returning
@@ -479,6 +517,9 @@ EVENT_DETAIL_TYPE_OPT_OUT_LATCHED = "record.auto_walk_opt_out.latched"
 # auto-merge. One event streams per certificate-certified T-HIGH supersession the
 # walker executes (DOC-DF651F07D5C2 §8 — the kill-switch + audit-feed rail).
 EVENT_DETAIL_TYPE_AUTO_MERGED = "record.dedup.auto_merged"
+# ENC-TSK-H85 / ENC-FTR-111 Phase 1: Artifact-Genesis audit feed for every MECHANICAL gate the
+# synchronous inline arc-walker crosses on its own (DOC-078C57FC1BE6 §8/§10 — no silent mutations).
+EVENT_DETAIL_TYPE_ARC_WALK = "record.arc_walk.advanced"
 
 # ENC-FTR-111 / ENC-TSK-H83 — Universal Arc-Walker circuit breaker.
 # Reserved write_source identity the (future, FTR-111 Phase 1 core / T4) arc-walker writes under.
@@ -1554,6 +1595,290 @@ def _emit_auto_merge_event(project_id: str, record_type: str, superseded_id: str
         }])
     except Exception as exc:
         logger.error("auto-merge audit event emit failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-H85 / ENC-FTR-111 Phase 1 — Universal Arc-Walker: synchronous inline mechanical walk.
+#
+# After any successful FORWARD task advance, the walker loops forward across the Phase-1 MECHANICAL
+# gates in the SAME Lambda invocation before returning (DOC-078C57FC1BE6 §6.1). Phase 1 covers
+# exactly two legs (§3.1 / §11):
+#   - <deploy-arc>|merged-main -> deploy-init  (auto-walkable only on ci_triggered projects; O-2)
+#   - code_only|merged-main    -> closed       (reuses the stored commit_sha + a GitHub compare)
+#
+# Eligibility is decided SOLELY by the Lifecycle Service evaluate_auto_walk verdict (gate_class
+# MECHANICAL + the deploy_policy O-2 qualifier) — NEVER from evidence-field emptiness (§7.2, the
+# "coding-complete trap"). The walk honors the auto_walk_opt_out latch (§7.4), pins the matrix
+# version (§8), integrity-checks checkout_transition_type (B07/B08 → 409 halt), performs each step
+# as an idempotent conditional write (advance iff status == expected_prior), halts at the first
+# attestation / opt-out / gate-fail boundary, and emits an Artifact-Genesis record per crossing.
+# The walker writes under write_source=system:arc-walker and can NEVER clear the opt-out latch.
+# ---------------------------------------------------------------------------
+_ARC_WALK_MAX_STEPS = 8  # safety depth cap (§9 cascade-runaway mitigation); Phase 1 needs <= 1.
+_ARC_WALK_DEPLOY_ARC_TYPES = frozenset({"github_pr_deploy", "lambda_deploy", "web_deploy"})
+
+
+def _arc_walk_next_candidate(transition_type: str, current_status: str) -> Optional[str]:
+    """Propose the single forward status the Phase-1 arc-walker would attempt from current_status,
+    or None when there is no Phase-1 MECHANICAL leg out of current_status. This only PROPOSES a
+    target; the authoritative mechanical/deploy_policy eligibility ruling is the Lifecycle Service
+    evaluate_auto_walk verdict (DOC-078C57FC1BE6 §3.1/§11)."""
+    tt = (transition_type or "github_pr_deploy").strip().lower()
+    cur = (current_status or "").strip().lower()
+    if cur == "merged-main":
+        if tt == "code_only":
+            return "closed"
+        if tt in _ARC_WALK_DEPLOY_ARC_TYPES:
+            return "deploy-init"
+    return None
+
+
+def _arc_walk_compare_commit_to_main(owner: str, repo: str, sha: str) -> Tuple[bool, str]:
+    """code_only|closed is MECHANICAL because the system already holds the commit_sha (the agent
+    supplied it at `committed`); the gate's only action is a system-run GitHub compare confirming the
+    commit is an ancestor of main (DOC-078C57FC1BE6 §3.1). Routed through github_integration (the
+    GitHub external-fact surface); tracker_mutation never calls GitHub directly."""
+    if not GITHUB_INTEGRATION_API_BASE:
+        logger.warning("[H85] GITHUB_INTEGRATION_API_BASE not set; cannot compare %s to main", sha)
+        return False, "github_integration_unconfigured"
+    url = (
+        f"{GITHUB_INTEGRATION_API_BASE}/commits/compare-main"
+        f"?owner={urllib.parse.quote(owner)}"
+        f"&repo={urllib.parse.quote(repo)}"
+        f"&sha={urllib.parse.quote(sha)}"
+    )
+    req = urllib.request.Request(url, method="GET", headers={
+        "X-Coordination-Internal-Key": COORDINATION_INTERNAL_API_KEY,
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            if data.get("valid"):
+                return True, str(data.get("status", "ancestor"))
+            return False, str(data.get("reason", "not_ancestor_of_main"))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[H85] commit compare-main call failed: %s", exc)
+        return False, f"compare_service_error: {exc}"
+
+
+def _arc_walk_history_entry(now: str, from_status: str, to_status: str, gate_class: Optional[str],
+                            derivation: str, matrix_version: Any) -> Dict:
+    """Artifact-Genesis history entry for one auto-walk crossing (DOC-078C57FC1BE6 §8 — no silent
+    mutations). Carries advanced_by, the gate crossed + its class, the derivation, the matrix ref,
+    and the trigger (sync)."""
+    msg = (
+        f"[ARC-WALKER][AUTO-ADVANCE] {from_status or '?'} -> {to_status} "
+        f"(gate_class={gate_class}, trigger=sync, matrix_version={matrix_version}). "
+        f"{derivation} advanced_by={ARC_WALKER_ACTOR}."
+    )
+    return {"M": {
+        "timestamp": _ser_s(now), "status": _ser_s("worklog"), "description": _ser_s(msg),
+    }}
+
+
+def _emit_arc_walk_event(project_id: str, record_id: str, from_status: str, to_status: str,
+                         gate_class: Optional[str], derivation: str, matrix_version: Any,
+                         latency_ms: int) -> None:
+    """Emit the ARC_WALK Artifact-Genesis telemetry event (DOC-078C57FC1BE6 §10). Best-effort — a
+    telemetry failure never rolls back the (already-committed) conditional advance."""
+    detail = {
+        "project_id": project_id, "record_type": "task", "record_id": record_id,
+        "event": "arc_walk_advanced", "advanced_by": ARC_WALKER_ACTOR,
+        "from_status": from_status, "to_status": to_status, "gate_class": gate_class,
+        "derivation": derivation, "trigger": "sync", "matrix_version": matrix_version,
+        "latency_ms": latency_ms, "advanced_at": _now_z(),
+    }
+    try:
+        _get_events().put_events(Entries=[{
+            "Source": EVENT_SOURCE, "DetailType": EVENT_DETAIL_TYPE_ARC_WALK,
+            "Detail": json.dumps(detail), "EventBusName": EVENT_BUS,
+        }])
+    except Exception as exc:  # noqa: BLE001
+        logger.error("arc_walk event emit failed: %s", exc)
+
+
+def _arc_walk_after_advance(project_id: str, record_id: str, item_data: Dict,
+                            landed_status: str) -> Dict:
+    """ENC-TSK-H85 / ENC-FTR-111 Phase 1 (T4) — drive the synchronous inline mechanical walk.
+
+    Called after a successful forward task advance committed to `landed_status`. Loops forward across
+    the Phase-1 mechanical gates, halting at the first attestation / opt-out / gate-fail boundary.
+    Returns a structured summary (never raises into the caller's response). NEVER fails the agent's
+    original advance — the walk is a pure optimization on top of an already-committed transition."""
+    transition_type = (item_data.get("transition_type") or "github_pr_deploy").strip().lower()
+    checkout_tt = (item_data.get("checkout_transition_type") or "").strip().lower()
+    opt_out = _coerce_bool(item_data.get("auto_walk_opt_out", False))
+    commit_sha = (item_data.get("commit_sha") or "").strip().lower()
+    subtask_ids = item_data.get("subtask_ids") or []
+
+    pinned_raw = item_data.get("checkout_matrix_version")
+    try:
+        pinned_matrix = int(pinned_raw) if pinned_raw not in (None, "") else MATRIX_VERSION
+    except (TypeError, ValueError):
+        pinned_matrix = MATRIX_VERSION
+
+    summary: Dict[str, Any] = {"walked": [], "trigger": "sync", "matrix_version": pinned_matrix}
+
+    # §7.4 opt-out circuit breaker: a latched record is demoted to ATTESTATION. The walker halts
+    # before ANY evaluation or write and can never clear the latch (ENC-TSK-H83).
+    if opt_out:
+        summary["halted_reason"] = "opt_out_latched"
+        return summary
+
+    # §8 transition_type integrity (B07/B08): a mismatch between the type stamped at checkout and the
+    # live type is a governance-integrity violation — halt with 409 exactly as an agent advance would.
+    if checkout_tt and checkout_tt != transition_type:
+        summary["halted_reason"] = "transition_type_integrity_409"
+        summary["halt_status"] = 409
+        summary["checkout_transition_type"] = checkout_tt
+        summary["current_transition_type"] = transition_type
+        return summary
+
+    ddb = _get_ddb()
+    key = _build_key(project_id, "task", record_id)
+    current = (landed_status or "").strip().lower()
+
+    for _ in range(_ARC_WALK_MAX_STEPS):
+        target = _arc_walk_next_candidate(transition_type, current)
+        if target is None:
+            # No outgoing mechanical leg — the next gate is attestation / external-fact / terminal.
+            summary["halted_reason"] = "no_mechanical_gate"
+            break
+
+        step_start = dt.datetime.utcnow()
+
+        # (1) Eligibility — authoritative MECHANICAL + deploy_policy (O-2) verdict from the service.
+        verdict = _invoke_lifecycle_action({
+            "action": "evaluate_auto_walk",
+            "transition_type": transition_type,
+            "target_status": target,
+            "project_id": project_id,
+        })
+        if verdict is None:
+            summary["halted_reason"] = "lifecycle_service_unavailable"
+            break
+        gate_class = verdict.get("gate_class")
+        # §8 matrix pinning: never auto-cross under a matrix version other than the pinned one.
+        v_matrix = verdict.get("matrix_version")
+        if v_matrix is not None and int(v_matrix) != int(pinned_matrix):
+            summary["halted_reason"] = "matrix_version_mismatch"
+            summary["service_matrix_version"] = v_matrix
+            break
+        if not verdict.get("auto_walkable"):
+            # First attestation / external-fact / manual-deploy boundary — halt (§7).
+            summary["halted_reason"] = verdict.get("reason") or f"gate_not_auto_walkable:{gate_class}"
+            summary["gate_class"] = gate_class
+            break
+
+        # (2) Legality — reuse the full Lifecycle Service gate set (transition validity + subtask gate
+        # + evidence shape). code_only|closed evidence is the stored commit_sha the agent already gave.
+        evidence: Dict[str, Any] = {}
+        if target == "closed" and transition_type == "code_only":
+            evidence = {"code_on_main_evidence": {"commit_sha": commit_sha}}
+        legal = _invoke_lifecycle_action({
+            "action": "validate_transition",
+            "project_id": project_id, "record_id": record_id, "record_type": "task",
+            "current_status": current, "target_status": target,
+            "transition_type": transition_type, "transition_evidence": evidence,
+            "subtask_ids": subtask_ids, "is_checkout_service_request": True,
+        })
+        if legal is None:
+            summary["halted_reason"] = "lifecycle_service_unavailable"
+            break
+        if not legal.get("allow"):
+            err = legal.get("error") or {}
+            summary["halted_reason"] = f"gate_fail:{err.get('code', 'INVALID')}"
+            break
+
+        # (3) Per-leg derivation + extra evidence persistence.
+        extra_set = ""
+        extra_vals: Dict[str, Any] = {}
+        add_clause = ""
+        if target == "closed" and transition_type == "code_only":
+            if not re.match(r"^[0-9a-f]{40}$", commit_sha):
+                summary["halted_reason"] = "gate_fail:missing_commit_sha"
+                break
+            owner, repo = _resolve_github_repo(project_id)
+            if not owner or not repo:
+                summary["halted_reason"] = "gate_fail:repo_unresolved"
+                break
+            ok, why = _arc_walk_compare_commit_to_main(owner, repo, commit_sha)
+            if not ok:
+                summary["halted_reason"] = f"gate_fail:compare:{why}"
+                break
+            derivation = (
+                f"code_only|closed reuses commit_sha {commit_sha[:12]} (supplied at committed) and a "
+                f"system-run GitHub compare confirmed it is an ancestor of main ({why})."
+            )
+            extra_set = ", code_on_main_evidence = :coe"
+            extra_vals[":coe"] = {"M": {
+                "commit_sha": _ser_s(commit_sha), "github_verified": {"BOOL": True},
+            }}
+            add_clause = " ADD closed_count :one"
+        else:
+            derivation = (
+                "deploy-init records an initiation timestamp; on a ci_triggered project the merge "
+                "entails initiation (ruling O-2) — no new external-world claim is introduced."
+            )
+
+        # (4) Idempotent conditional write: advance iff status == expected_prior (§8 idempotency).
+        now2 = _now_z()
+        hentry = _arc_walk_history_entry(now2, current, target, gate_class, derivation, pinned_matrix)
+        note = f"[ARC-WALKER] auto-advanced {current} -> {target} (system:arc-walker)"
+        ws_av = {"M": {
+            "channel": _ser_s(ARC_WALKER_ACTOR), "provider": _ser_s(ARC_WALKER_ACTOR),
+            "dispatch_id": _ser_s(""), "coordination_request_id": _ser_s(""),
+            "timestamp": _ser_s(now2),
+        }}
+        update_expr = (
+            "SET #s = :next, updated_at = :now, last_update_note = :note, write_source = :wsrc, "
+            "sync_version = if_not_exists(sync_version, :zero) + :one, "
+            "history = list_append(if_not_exists(history, :empty), :hentry)"
+            + extra_set + add_clause
+        )
+        attr_vals = {
+            ":next": _ser_s(target), ":now": _ser_s(now2), ":note": _ser_s(note), ":wsrc": ws_av,
+            ":zero": {"N": "0"}, ":one": {"N": "1"},
+            ":hentry": {"L": [hentry]}, ":empty": {"L": []},
+            ":expected": _ser_s(current),
+        }
+        attr_vals.update(extra_vals)
+        try:
+            ddb.update_item(
+                TableName=DYNAMODB_TABLE, Key=key,
+                UpdateExpression=update_expr,
+                ConditionExpression="#s = :expected",
+                ExpressionAttributeNames={"#s": "status"},
+                ExpressionAttributeValues=attr_vals,
+            )
+        except ClientError as exc:
+            if _is_conditional_check_failed(exc):
+                # A concurrent advance moved the record off expected_prior. The conditional write is
+                # the idempotency guard (§8/§9): no double-step, no lost update — halt cleanly.
+                summary["halted_reason"] = "concurrent_advance"
+                break
+            logger.error("[H85] arc-walk conditional write failed: %s", exc)
+            summary["halted_reason"] = "write_error"
+            break
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[H85] arc-walk write error: %s", exc)
+            summary["halted_reason"] = "write_error"
+            break
+
+        latency_ms = int((dt.datetime.utcnow() - step_start).total_seconds() * 1000)
+        _emit_arc_walk_event(project_id, record_id, current, target, gate_class,
+                             derivation, pinned_matrix, latency_ms)
+        summary["walked"].append({
+            "from": current, "to": target, "gate_class": gate_class,
+            "derivation": derivation, "matrix_version": pinned_matrix, "latency_ms": latency_ms,
+        })
+        current = target
+    else:
+        # Loop exhausted the depth cap without an explicit halt (should be unreachable in Phase 1).
+        summary.setdefault("halted_reason", "max_steps_reached")
+
+    summary["final_status"] = current
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -4044,6 +4369,23 @@ def _handle_update_field(
     }
     if warnings:
         result["warnings"] = warnings
+
+    # ENC-TSK-H85 / ENC-FTR-111 Phase 1: after a successful FORWARD task status advance, hand off to
+    # the Universal Arc-Walker to walk forward across the mechanical gates in the same invocation
+    # (DOC-078C57FC1BE6 §6.1). Behind its own independent flag; wrapped so a walk failure NEVER
+    # affects the agent's already-committed advance (the walk is a pure optimization on top of it).
+    if (record_type == "task" and field == "status" and not is_revert
+            and _arc_walker_enabled()):
+        try:
+            arc_walk = _arc_walk_after_advance(project_id, record_id, item_data, new_lower)
+            if arc_walk and arc_walk.get("walked"):
+                result["arc_walk"] = arc_walk
+            elif arc_walk:
+                # Surface the halt reason too (observability) without implying any advance happened.
+                result["arc_walk"] = arc_walk
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[H85] arc-walk post-advance hook failed (non-fatal): %s", exc)
+
     return _response(200, result)
 
 

--- a/backend/lambda/tracker_mutation/test_arc_walker_phase1_h85.py
+++ b/backend/lambda/tracker_mutation/test_arc_walker_phase1_h85.py
@@ -1,0 +1,302 @@
+"""Tests for ENC-TSK-H85 / ENC-FTR-111 Phase 1 — synchronous inline mechanical arc-walk.
+
+Covers FTR-111 AC-1/AC-2 (this task's two acceptance criteria):
+  - Behind an independent flag, after a successful advance the walker advances the two Phase-1
+    mechanical legs via idempotent conditional writes:
+      * <deploy-arc>|merged-main -> deploy-init  (auto-walkable only on ci_triggered projects)
+      * code_only|merged-main    -> closed       (reuses stored commit_sha + GitHub compare)
+  - The walk honors opt_out, pinned matrix_version, transition_type integrity (409 halt), halts at
+    the first attestation / opt-out / gate-fail boundary, and emits Artifact-Genesis records.
+
+Pure-logic units plus integration over _arc_walk_after_advance, mocking the Lifecycle Service
+invoke, DynamoDB, EventBridge, and the GitHub compare. Runs standalone or under pytest.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import lambda_function as lf  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakeDDB:
+    def __init__(self, raise_conditional=False):
+        self.updates = []
+        self.raise_conditional = raise_conditional
+
+    def update_item(self, **kw):
+        self.updates.append(kw)
+        if self.raise_conditional:
+            raise ClientError(
+                {"Error": {"Code": "ConditionalCheckFailedException", "Message": "stale"}},
+                "UpdateItem",
+            )
+        return {}
+
+
+class _FakeEvents:
+    def __init__(self):
+        self.events = []
+
+    def put_events(self, **kw):
+        self.events.append(kw)
+        return {"FailedEntryCount": 0}
+
+
+def _install(ddb=None, events=None, verdicts=None, compare=(True, "ahead"), repo=("NX-2021-L", "enceladus")):
+    """Wire the module-level seams. `verdicts` is a callable(payload)->dict driving the Lifecycle
+    Service responses; defaults to the happy-path (auto_walkable + allow) for whatever is asked."""
+    ddb = ddb or _FakeDDB()
+    events = events or _FakeEvents()
+    lf._get_ddb = lambda: ddb                                   # type: ignore
+    lf._get_events = lambda: events                             # type: ignore
+    lf._build_key = lambda p, t, r: {"project_id": {"S": p}, "record_id": {"S": f"{t}#{r}"}}  # type: ignore
+    lf._resolve_github_repo = lambda p: repo                    # type: ignore
+    lf._arc_walk_compare_commit_to_main = lambda o, r, s: compare  # type: ignore
+
+    def _default_verdicts(payload):
+        action = payload.get("action")
+        if action == "evaluate_auto_walk":
+            return {"auto_walkable": True, "gate_class": "mechanical",
+                    "matrix_version": lf.MATRIX_VERSION, "target_status": payload.get("target_status")}
+        if action == "validate_transition":
+            return {"allow": True, "gate_class": "mechanical", "matrix_version": lf.MATRIX_VERSION}
+        return None
+
+    lf._invoke_lifecycle_action = verdicts or _default_verdicts  # type: ignore
+    return ddb, events
+
+
+_SHA = "a" * 40
+
+
+def _writes(ddb):
+    return [u for u in ddb.updates if ":next" in u.get("ExpressionAttributeValues", {})]
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — candidate proposal + flag
+# ---------------------------------------------------------------------------
+def test_next_candidate_legs():
+    assert lf._arc_walk_next_candidate("github_pr_deploy", "merged-main") == "deploy-init"
+    assert lf._arc_walk_next_candidate("lambda_deploy", "merged-main") == "deploy-init"
+    assert lf._arc_walk_next_candidate("web_deploy", "merged-main") == "deploy-init"
+    assert lf._arc_walk_next_candidate("code_only", "merged-main") == "closed"
+    # No mechanical leg out of these statuses / types.
+    assert lf._arc_walk_next_candidate("github_pr_deploy", "deploy-init") is None
+    assert lf._arc_walk_next_candidate("github_pr_deploy", "coding-complete") is None
+    assert lf._arc_walk_next_candidate("no_code", "merged-main") is None
+    assert lf._arc_walk_next_candidate("github_pr_deploy", "deploy-success") is None
+
+
+def test_flag_default_off():
+    for v in ("ENABLE_ARC_WALKER",):
+        os.environ.pop(v, None)
+    assert lf._arc_walker_enabled() is False
+    os.environ["ENABLE_ARC_WALKER"] = "true"
+    try:
+        assert lf._arc_walker_enabled() is True
+    finally:
+        os.environ.pop("ENABLE_ARC_WALKER", None)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — deploy arc: merged-main -> deploy-init (ci_triggered)
+# ---------------------------------------------------------------------------
+def test_deploy_arc_walks_to_deploy_init():
+    ddb, events = _install()
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+
+    assert summary["final_status"] == "deploy-init", summary
+    assert summary["halted_reason"] == "no_mechanical_gate", summary
+    assert len(summary["walked"]) == 1
+    step = summary["walked"][0]
+    assert (step["from"], step["to"], step["gate_class"]) == ("merged-main", "deploy-init", "mechanical")
+
+    w = _writes(ddb)
+    assert len(w) == 1, ddb.updates
+    upd = w[0]
+    # Idempotent conditional write: advance iff status == expected_prior.
+    assert upd["ConditionExpression"] == "#s = :expected"
+    assert upd["ExpressionAttributeValues"][":expected"] == {"S": "merged-main"}
+    assert upd["ExpressionAttributeValues"][":next"] == {"S": "deploy-init"}
+    # write_source attribution = system:arc-walker.
+    assert upd["ExpressionAttributeValues"][":wsrc"]["M"]["provider"]["S"] == lf.ARC_WALKER_ACTOR
+    # Artifact-Genesis history entry rode the write.
+    hist = upd["ExpressionAttributeValues"][":hentry"]["L"]
+    assert any("[ARC-WALKER][AUTO-ADVANCE]" in h["M"]["description"]["S"] for h in hist), hist
+    # deploy-init must NOT touch closed_count.
+    assert "ADD closed_count" not in upd["UpdateExpression"]
+    # ARC_WALK telemetry event fired.
+    assert len(events.events) == 1
+    detail = json.loads(events.events[0]["Entries"][0]["Detail"])
+    assert detail["event"] == "arc_walk_advanced"
+    assert detail["to_status"] == "deploy-init"
+    assert detail["trigger"] == "sync"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — code_only: merged-main -> closed (compare passes)
+# ---------------------------------------------------------------------------
+def test_code_only_walks_to_closed():
+    ddb, events = _install(compare=(True, "identical"))
+    item = {"transition_type": "code_only", "checkout_transition_type": "code_only",
+            "commit_sha": _SHA}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-Y", item, "merged-main")
+
+    assert summary["final_status"] == "closed", summary
+    assert len(summary["walked"]) == 1
+    w = _writes(ddb)
+    assert len(w) == 1
+    upd = w[0]
+    assert upd["ExpressionAttributeValues"][":next"] == {"S": "closed"}
+    # code_only|closed persists code_on_main_evidence + increments closed_count atomically.
+    assert "ADD closed_count :one" in upd["UpdateExpression"]
+    coe = upd["ExpressionAttributeValues"][":coe"]["M"]
+    assert coe["commit_sha"]["S"] == _SHA
+    assert coe["github_verified"]["BOOL"] is True
+    assert len(events.events) == 1
+
+
+def test_code_only_halts_when_not_ancestor():
+    ddb, events = _install(compare=(False, "diverged"))
+    item = {"transition_type": "code_only", "checkout_transition_type": "code_only",
+            "commit_sha": _SHA}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-Y", item, "merged-main")
+    assert summary["walked"] == []
+    assert summary["halted_reason"].startswith("gate_fail:compare"), summary
+    assert _writes(ddb) == []
+    assert events.events == []
+
+
+def test_code_only_halts_when_commit_sha_missing():
+    ddb, _ = _install()
+    item = {"transition_type": "code_only", "checkout_transition_type": "code_only", "commit_sha": ""}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-Y", item, "merged-main")
+    # validate_transition (default happy stub) allows, but the walker's own 40-hex guard halts.
+    assert summary["halted_reason"] in ("gate_fail:missing_commit_sha", "gate_fail:INVALID"), summary
+    assert _writes(ddb) == []
+
+
+# ---------------------------------------------------------------------------
+# Safety boundaries
+# ---------------------------------------------------------------------------
+def test_opt_out_latched_halts_before_any_eval_or_write():
+    ddb, events = _install()
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy",
+            "auto_walk_opt_out": True}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "opt_out_latched"
+    assert summary["walked"] == []
+    assert ddb.updates == []
+    assert events.events == []
+
+
+def test_opt_out_string_true_coerced():
+    ddb, _ = _install()
+    item = {"transition_type": "github_pr_deploy", "auto_walk_opt_out": "true"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "opt_out_latched"
+    assert ddb.updates == []
+
+
+def test_transition_type_integrity_409():
+    ddb, _ = _install()
+    # checkout stamped code_only but the live type is now github_pr_deploy — integrity violation.
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "code_only"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "transition_type_integrity_409"
+    assert summary["halt_status"] == 409
+    assert ddb.updates == []
+
+
+def test_manual_deploy_policy_halts(deploy_arc=True):
+    # evaluate_auto_walk returns auto_walkable False with the O-2 reason (manual project).
+    def _verdicts(payload):
+        if payload.get("action") == "evaluate_auto_walk":
+            return {"auto_walkable": False, "gate_class": "mechanical",
+                    "matrix_version": lf.MATRIX_VERSION,
+                    "reason": "deploy-init auto-walk blocked (ruling O-2): deploy_policy='manual'."}
+        return {"allow": True}
+    ddb, _ = _install(verdicts=_verdicts)
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert "O-2" in summary["halted_reason"], summary
+    assert _writes(ddb) == []
+
+
+def test_matrix_version_mismatch_halts():
+    def _verdicts(payload):
+        if payload.get("action") == "evaluate_auto_walk":
+            return {"auto_walkable": True, "gate_class": "mechanical", "matrix_version": 999}
+        return {"allow": True}
+    ddb, _ = _install(verdicts=_verdicts)
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "matrix_version_mismatch", summary
+    assert summary["service_matrix_version"] == 999
+    assert _writes(ddb) == []
+
+
+def test_subtask_gate_fail_halts():
+    def _verdicts(payload):
+        if payload.get("action") == "evaluate_auto_walk":
+            return {"auto_walkable": True, "gate_class": "mechanical", "matrix_version": lf.MATRIX_VERSION}
+        # validate_transition rejects on the subtask gate.
+        return {"allow": False, "error": {"code": "SUBTASK_GATE", "status": 400}}
+    ddb, _ = _install(verdicts=_verdicts)
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "gate_fail:SUBTASK_GATE", summary
+    assert _writes(ddb) == []
+
+
+def test_no_mechanical_gate_is_noop():
+    ddb, events = _install()
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "coding-complete")
+    assert summary["halted_reason"] == "no_mechanical_gate"
+    assert summary["walked"] == []
+    assert ddb.updates == []
+    assert events.events == []
+
+
+def test_lifecycle_service_unavailable_halts():
+    ddb, _ = _install(verdicts=lambda payload: None)
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "lifecycle_service_unavailable"
+    assert _writes(ddb) == []
+
+
+def test_concurrent_advance_halts_idempotently():
+    ddb = _FakeDDB(raise_conditional=True)
+    _install(ddb=ddb)
+    item = {"transition_type": "github_pr_deploy", "checkout_transition_type": "github_pr_deploy"}
+    summary = lf._arc_walk_after_advance("enceladus", "ENC-TSK-X", item, "merged-main")
+    assert summary["halted_reason"] == "concurrent_advance", summary
+    assert summary["walked"] == []  # the write was attempted but the conditional guard rejected it.
+
+
+if __name__ == "__main__":
+    fns = [g for n, g in sorted(globals().items()) if n.startswith("test_") and callable(g)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ENC-TSK-H85 — Arc-Walker Phase 1 core (synchronous inline mechanical walk)

**task_id:** ENC-TSK-H85 (ENC-FTR-111 Universal Arc-Walker, Phase 1 CORE / T4)
**Governing design:** DOC-078C57FC1BE6 §3.1, §6.1, §7, §8, §11
**Deploy target:** gamma (v4/main). v3-prod is FROZEN — not touched.
**commit-complete-id:** `CCI-1befd740fcd740f28a50af25cce2a32c`
**governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`

### connection_health (session init)
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-28T13:06:59Z",
  "server_version": "1.0.0",
  "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true},
                   "graph_projection": {"configured": true, "exists": true, "stale": false}}
}
```

### Satisfied acceptance criteria
- **AC-1 (met):** Behind the independent `enable_arc_walker` flag, after a successful forward advance the walk performs `<deploy-arc>|merged-main -> deploy-init` (deploy_policy=ci_triggered) and `code_only|merged-main -> closed` via **idempotent conditional writes** (advance iff `status == expected_prior`).
- **AC-2 (met):** The walk honors `auto_walk_opt_out`, pins `matrix_version`, integrity-checks `checkout_transition_type` (**409 halt** on mismatch), halts at the first attestation / opt-out / gate-fail boundary, and emits **Artifact-Genesis** records. Supports ENC-FTR-111 AC-3, AC-4, AC-7.

### What changed
- **`backend/lambda/tracker_mutation/lambda_function.py`**
  - `_arc_walker_enabled()` — independent AppConfig flag (`enable_arc_walker`, env_fallback `ENABLE_ARC_WALKER`, default off), distinct from `enable_lifecycle_service_extraction`.
  - `_arc_walk_after_advance()` — the synchronous inline walk loop, hooked after a successful forward task status advance in `_handle_update_field`. Wrapped so a walk failure **never** affects the agent's already-committed advance.
  - Eligibility is decided solely by the `lifecycle_service.evaluate_auto_walk` verdict (gate_class MECHANICAL + deploy_policy O-2), never evidence-field emptiness (§7.2). Legality reuses `validate_transition` (transition validity + ENC-ISS-106 subtask gate + evidence shape).
  - Each crossing: conditional `update_item` (`ConditionExpression #s = :expected`) under `write_source=system:arc-walker`, an `[ARC-WALKER][AUTO-ADVANCE]` history entry, and a `record.arc_walk.advanced` EventBridge event. `code_only|closed` persists `code_on_main_evidence` + increments `closed_count`.
- **`backend/lambda/github_integration/lambda_function.py`** — new `GET /api/v1/github/commits/compare-main` route (ancestor-of-main check; status `ahead`/`identical`), mirroring `checkout_service._validate_code_on_main_evidence` (ENC-ISS-161). The walker's `code_only|closed` leg reuses the stored `commit_sha` and calls this system-run compare.
- **`backend/lambda/coordination_api/governance_data_dictionary.json`** — add `lifecycle_service.arc_walker_walk` entity; bump `2026-06-28.05 -> 2026-06-28.06` (additive, zero key removals per ENC-LSN-055). A `GOVERNANCE_SYNC_REQUIRED` handoff is on the task worklog for the post-merge S3 sync to the gamma governance store.
- **`backend/lambda/tracker_mutation/test_arc_walker_phase1_h85.py`** — 15 unit tests.

### Testing
- New: `test_arc_walker_phase1_h85.py` — 15/15 pass (both legs, opt-out halt, transition_type 409, matrix mismatch, manual deploy_policy halt, subtask-gate fail, no-mechanical-gate no-op, lifecycle-unavailable halt, concurrent-advance idempotency).
- No regressions: H83 (9/9), I09 (20), lifecycle_wiring (7/7), lifecycle_service (21/21), and the rest of the tracker_mutation suite green.

### Scope notes
- Phase 1 only: the two mechanical legs. `pr` / `merged-main` / `deploy-success` (external-fact) and `coding-complete` / live-validation / `no_code` closed (attestation) remain structurally unreachable by the walker (Phase 2/3 + the attestation floor).
- Do not advance this task beyond `committed` — the human owns merge + deploy + close-out.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc1e9ec4-5a6e-45e9-b661-35ec37a426f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc1e9ec4-5a6e-45e9-b661-35ec37a426f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

