### PR TITLE
[ENC-TSK-I10] Dedup P6 - Telemetry & convergence probe: stock/flow/percolation + walk-back-rate model-health loop

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.05",
-  "updated_at": "2026-06-28T12:41:27Z",
-  "last_change_summary": "ENC-TSK-I09 (Dedup P5) reconciled with ENC-TSK-H84 (Arc-Walker Phase 1) on merge to v4/main (PRs #625/#624). Adds tracker.dedup_auto_merge: the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (POST /{project}/dedup-review op=auto-merge, tracker:write) gated by four io-sovereignty rails — enable_dedup_auto_merge flag (dark/shadow default), dedup_auto_merge_kill_switch (instant halt), per-pair certificate precision-LCB>=0.999 against the chosen canonical (no transitive chain-drag), and the auto_walk_opt_out latch that demotes a record to ATTESTATION on any io walk-back — plus the record.dedup.auto_merged EventBridge audit feed. Updates tracker.task.status / tracker.issue.status 'superseded' notes (T-HIGH auto-merge no longer deferred). Retains the H84 project_service.deploy_policy entity added at version .04. Version 2026-06-28.04 -> 2026-06-28.05.",
+  "version": "2026-06-28.06",
+  "updated_at": "2026-06-28T13:30:00Z",
+  "last_change_summary": "ENC-TSK-I10 (Dedup P6) adds monitoring.dedup_convergence_probe: the duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily graph_health_metrics Lambda publishes five governed signals to CloudWatch namespace Enceladus/DedupConvergence (stock / precision@1 recovery proxy vs 0.3727 baseline / new-duplicate flow / same-type duplicate-graph LCC percolation->1 / production auto-merge walk-back-rate model-health loop that re-enters shadow on a (1-floor) breach), and graph_query_api gains a read-only search_type='dedup_convergence' snapshot surface. PRIOR: ENC-TSK-I09 (Dedup P5) reconciled with ENC-TSK-H84 (Arc-Walker Phase 1) on merge to v4/main (PRs #625/#624). Adds tracker.dedup_auto_merge: the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (POST /{project}/dedup-review op=auto-merge, tracker:write) gated by four io-sovereignty rails — enable_dedup_auto_merge flag (dark/shadow default), dedup_auto_merge_kill_switch (instant halt), per-pair certificate precision-LCB>=0.999 against the chosen canonical (no transitive chain-drag), and the auto_walk_opt_out latch that demotes a record to ATTESTATION on any io walk-back — plus the record.dedup.auto_merged EventBridge audit feed. Updates tracker.task.status / tracker.issue.status 'superseded' notes (T-HIGH auto-merge no longer deferred). Retains the H84 project_service.deploy_policy entity added at version .04. Version 2026-06-28.04 -> 2026-06-28.05.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5013,6 +5013,37 @@
           "type": "string",
           "definition": "CloudWatch metric name for per-function code size.",
           "usage_guidance": "Fixed value: LambdaCodeSize. Dimension: FunctionName."
+        }
+      }
+    },
+    "monitoring.dedup_convergence_probe": {
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "fields": {
+        "signals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "The five governed convergence signals (CloudWatch metric names under Enceladus/DedupConvergence). Stock: DuplicatePairStock (same-type same-project pairs at cosine >= DEDUP_COSINE_THRESHOLD). Precision@1 recovery: Precision1RecoveryProxy + Precision1RecoveryEstimate with Precision1Baseline (0.3727) and RecallCeiling (0.8242) reference metrics. Flow: NewDuplicateFlow (pairs whose newer endpoint was created within DEDUP_FLOW_WINDOW_DAYS). Percolation: DuplicateLCCSize (largest-connected-component of the same-type duplicate graph; -> 1 at convergence since isolated records are size-1 components) + NonTrivialComponentCount + EmbeddedRecordCount. Walk-back model-health loop: AutoMergeWalkBackRate + AutoMergeCount + WalkBackCount + WalkBackRateBreachedFloor.",
+          "usage_guidance": "Read via CloudWatch GetMetricStatistics on namespace Enceladus/DedupConvergence, or via the graph_query_api search_type='dedup_convergence' read surface for an on-demand snapshot (result.convergence)."
+        },
+        "precision_at_1_recovery_proxy": {
+          "type": "string",
+          "definition": "The labeled self-retrieval eval (DOC-4F1F5B99AAED, precision@1=0.3727 / recall ceiling 0.8242) is not reproducible inside a scheduled Lambda, so the probe emits a live recovery proxy: the fraction of embedded same-type records that have NO surviving near-duplicate twin (cosine >= threshold) among non-superseded peers.",
+          "usage_guidance": "Climbs toward 1.0 as duplicate twins are superseded (the I07 retrieval exclusion removes them from competition), tracking the same convergence quantity the eval measures. Precision1RecoveryEstimate maps the proxy onto the baseline->ceiling band for graphing."
+        },
+        "walk_back_model_health": {
+          "type": "object",
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 \u00a710). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (\u00a713/\u00a74.3), so the live walk-back rate is 0 / shadow until then."
+        },
+        "config_env_vars": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "graph_health_metrics environment configuration for the dedup probe: DEDUP_NAMESPACE (default Enceladus/DedupConvergence), DEDUP_AUDIT_NAMESPACE, DEDUP_COSINE_THRESHOLD (0.95), DEDUP_PRECISION_FLOOR (0.999), DEDUP_FLOW_WINDOW_DAYS (7), DEDUP_WALKBACK_WINDOW_DAYS (30), DEDUP_VECTOR_TOP_K (25).",
+          "usage_guidance": "Defined in infrastructure/cloudformation/02-compute.yaml on GraphHealthMetricsFunction. The role gains cloudwatch:GetMetricStatistics/GetMetricData (in addition to the existing PutMetricData) to read the walk-back counters."
         }
       }
     },

--- a/backend/lambda/graph_health_metrics/.build_extras
+++ b/backend/lambda/graph_health_metrics/.build_extras
@@ -1,0 +1,6 @@
+# ENC-TSK-G43 cross-Lambda module sharing manifest (honored by _build.yml).
+# ENC-TSK-I10 (Dedup P6): the daily convergence probe imports the pure dedup
+# convergence math owned by graph_query_api. Packaged here so `import
+# dedup_convergence` resolves at runtime (same precedent as graph_sync/embedding.py
+# -> graph_query_api). Keep in lockstep with the canonical owner.
+backend/lambda/graph_query_api/dedup_convergence.py

--- a/backend/lambda/graph_health_metrics/lambda_function.py
+++ b/backend/lambda/graph_health_metrics/lambda_function.py
@@ -21,10 +21,12 @@ Environment variables:
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 
 import boto3
+
+import dedup_convergence
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -32,6 +34,32 @@ logger.setLevel(logging.INFO)
 NEO4J_SECRET_NAME = os.environ.get("NEO4J_SECRET_NAME", "enceladus/neo4j/auradb-credentials")
 CLOUDWATCH_NAMESPACE = os.environ.get("CLOUDWATCH_NAMESPACE", "Enceladus/GraphHealth")
 PROJECT_ID = os.environ.get("PROJECT_ID", "enceladus")
+
+# --- ENC-TSK-I10 (Dedup P6) convergence-probe configuration ----------------
+# Governed dedup-convergence signals (DOC-DF651F07D5C2 §10) are published to
+# their own namespace so they don't dilute the C10 graph-health proxy metrics.
+DEDUP_NAMESPACE = os.environ.get("DEDUP_NAMESPACE", "Enceladus/DedupConvergence")
+# Namespace the production auto-merge / walk-back audit counters are emitted to
+# by the dedup auto-merge producer (tracker_mutation, flag-gated DARK until the
+# precision floor is certified — DOC-DF651F07D5C2 §13). Defaults to the dedup
+# namespace; the probe reads them back to compute the live walk-back rate.
+DEDUP_AUDIT_NAMESPACE = os.environ.get("DEDUP_AUDIT_NAMESPACE", DEDUP_NAMESPACE)
+DEDUP_AUTO_MERGE_METRIC = os.environ.get("DEDUP_AUTO_MERGE_METRIC", "AutoMergeCount")
+DEDUP_WALK_BACK_METRIC = os.environ.get("DEDUP_WALK_BACK_METRIC", "WalkBackCount")
+
+
+def _dedup_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _dedup_int(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.environ.get(name, default)))
+    except (TypeError, ValueError):
+        return default
 
 _neo4j_driver = None
 _creds_cache = None
@@ -128,14 +156,136 @@ def _publish_to_cloudwatch(metrics: Dict[str, float]) -> None:
         )
 
 
+def _read_walk_back_counts(window_days: float) -> Dict[str, int]:
+    """ENC-TSK-I10: read the production auto-merge + walk-back audit counters
+    (Sum) over the trailing window from CloudWatch.
+
+    These counters are emitted by the dedup auto-merge producer when io enables
+    MECHANICAL T-HIGH auto-walk (DOC-DF651F07D5C2 §5/§13). Until then auto-merge
+    is DARK, so both sums are 0 and the walk-back rate is definitionally 0
+    (shadow). A read failure degrades to 0 rather than failing the probe."""
+    try:
+        cw = boto3.client("cloudwatch")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("[WARNING] walk-back counter client init failed: %s", exc)
+        return {"auto_merges": 0, "walk_backs": 0}
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(days=max(1.0, window_days))
+    dimensions = [{"Name": "ProjectId", "Value": PROJECT_ID}]
+
+    def _sum(metric_name: str) -> int:
+        try:
+            resp = cw.get_metric_statistics(
+                Namespace=DEDUP_AUDIT_NAMESPACE,
+                MetricName=metric_name,
+                Dimensions=dimensions,
+                StartTime=start,
+                EndTime=now,
+                Period=int(max(1.0, window_days) * 86400),
+                Statistics=["Sum"],
+            )
+            return int(sum(dp.get("Sum", 0.0) for dp in resp.get("Datapoints", [])))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[WARNING] walk-back counter read failed (%s): %s", metric_name, exc)
+            return 0
+
+    return {
+        "auto_merges": _sum(DEDUP_AUTO_MERGE_METRIC),
+        "walk_backs": _sum(DEDUP_WALK_BACK_METRIC),
+    }
+
+
+def _compute_dedup_signals(driver) -> Dict[str, Any]:
+    """ENC-TSK-I10: assemble the full dedup-convergence snapshot — the four
+    graph-derived signals plus the walk-back model-health loop."""
+    cosine_threshold = _dedup_float("DEDUP_COSINE_THRESHOLD", dedup_convergence.DEFAULT_COSINE_THRESHOLD)
+    flow_window_days = _dedup_float("DEDUP_FLOW_WINDOW_DAYS", float(dedup_convergence.DEFAULT_FLOW_WINDOW_DAYS))
+    precision_floor = _dedup_float("DEDUP_PRECISION_FLOOR", dedup_convergence.DEFAULT_PRECISION_FLOOR)
+    vector_top_k = _dedup_int("DEDUP_VECTOR_TOP_K", dedup_convergence.DEFAULT_VECTOR_TOP_K)
+    walkback_window_days = _dedup_float(
+        "DEDUP_WALKBACK_WINDOW_DAYS", float(dedup_convergence.DEFAULT_WALKBACK_WINDOW_DAYS)
+    )
+
+    signals = dedup_convergence.compute_graph_signals(
+        driver,
+        PROJECT_ID,
+        cosine_threshold=cosine_threshold,
+        flow_window_days=flow_window_days,
+        vector_top_k=vector_top_k,
+    )
+    counts = _read_walk_back_counts(walkback_window_days)
+    signals["walk_back"] = dedup_convergence.walk_back_health(
+        counts["auto_merges"], counts["walk_backs"], precision_floor
+    )
+    signals["walk_back"]["window_days"] = walkback_window_days
+    return signals
+
+
+def _publish_dedup_signals(signals: Dict[str, Any]) -> Dict[str, float]:
+    """ENC-TSK-I10: publish the dedup-convergence signals as governed
+    CloudWatch metrics under DEDUP_NAMESPACE."""
+    wb = signals.get("walk_back", {})
+    metrics: Dict[str, float] = {
+        # Stock (§10): same-type duplicate-pair count, trending to floor.
+        "DuplicatePairStock": float(signals.get("stock_pairs", 0)),
+        # Precision@1 recovery (§10): live proxy + static baseline/ceiling refs.
+        "Precision1RecoveryProxy": float(signals.get("precision_at_1_recovery_proxy", 0.0)),
+        "Precision1RecoveryEstimate": float(signals.get("precision_at_1_recovery_fraction", 0.0)),
+        "Precision1Baseline": float(signals.get("precision_at_1_baseline", dedup_convergence.PRECISION_AT_1_BASELINE)),
+        "RecallCeiling": float(signals.get("recall_ceiling", dedup_convergence.RECALL_CEILING)),
+        # Flow (§10): new same-type duplicate pairs per window.
+        "NewDuplicateFlow": float(signals.get("new_duplicate_pairs", 0)),
+        # Percolation (§10): LCC size → 1 at convergence + cluster count.
+        "DuplicateLCCSize": float(signals.get("lcc_size", 0)),
+        "NonTrivialComponentCount": float(signals.get("nontrivial_component_count", 0)),
+        "EmbeddedRecordCount": float(signals.get("embedded_record_count", 0)),
+        # Walk-back model-health loop (§10): live certificate-precision estimate.
+        "AutoMergeWalkBackRate": float(wb.get("walk_back_rate", 0.0)),
+        "AutoMergeCount": float(wb.get("auto_merge_count", 0)),
+        "WalkBackCount": float(wb.get("walk_back_count", 0)),
+        "WalkBackRateBreachedFloor": 1.0 if wb.get("breached_floor") else 0.0,
+    }
+    cw = boto3.client("cloudwatch")
+    now = datetime.now(timezone.utc)
+    dimensions = [{"Name": "ProjectId", "Value": PROJECT_ID}]
+    metric_data = [
+        {"MetricName": name, "Value": value, "Unit": "None", "Timestamp": now, "Dimensions": dimensions}
+        for name, value in metrics.items()
+    ]
+    if metric_data:
+        cw.put_metric_data(Namespace=DEDUP_NAMESPACE, MetricData=metric_data)
+        logger.info(
+            "[SUCCESS] Published %d dedup-convergence signals to %s: %s",
+            len(metric_data), DEDUP_NAMESPACE, {k: round(v, 4) for k, v in metrics.items()},
+        )
+    return metrics
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """Lambda entry point — compute and publish graph health metrics."""
+    """Lambda entry point — compute and publish graph health metrics + the
+    ENC-TSK-I10 dedup-convergence signals (DOC-DF651F07D5C2 §10)."""
     logger.info("[START] Graph health metrics computation (proxy path)")
 
     try:
         driver = _get_neo4j_driver()
         metrics = _compute_metrics(driver)
         _publish_to_cloudwatch(metrics)
+
+        # ENC-TSK-I10: dedup-convergence probe. Isolated so a dedup failure
+        # (e.g. a missing vector index) never breaks the C10 graph-health path.
+        dedup_result: Dict[str, Any] = {"published": False}
+        try:
+            signals = _compute_dedup_signals(driver)
+            published = _publish_dedup_signals(signals)
+            dedup_result = {
+                "published": True,
+                "namespace": DEDUP_NAMESPACE,
+                "signals": signals,
+                "published_metrics": {k: round(v, 6) for k, v in published.items()},
+            }
+        except Exception as exc:
+            logger.error("[ERROR] Dedup-convergence probe failed: %s", exc, exc_info=True)
+            dedup_result = {"published": False, "error": str(exc)}
 
         return {
             "statusCode": 200,
@@ -145,6 +295,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "namespace": CLOUDWATCH_NAMESPACE,
                 "implementation_path": "cloudwatch_proxy",
                 "gds_available": False,
+                "dedup_convergence": dedup_result,
             }),
         }
     except Exception as exc:

--- a/backend/lambda/graph_health_metrics/test_dedup_probe_i10.py
+++ b/backend/lambda/graph_health_metrics/test_dedup_probe_i10.py
@@ -1,0 +1,153 @@
+"""Unit tests for ENC-TSK-I10 (Dedup P6) scheduled convergence probe.
+
+Validates the graph_health_metrics dedup section without Neo4j/CloudWatch:
+  - walk-back counter read sums datapoints and degrades to 0 on error
+  - all five governed signals are published to DEDUP_NAMESPACE
+  - the dedup probe is isolated: a dedup failure never breaks the base
+    graph-health metrics path (handler still returns 200).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+# The shared module is packaged in via .build_extras at deploy time; for local
+# tests resolve it from its canonical owner (graph_query_api), appended LAST so
+# it never shadows this dir's lambda_function.
+sys.path.append(str(_HERE.parent / "graph_query_api"))
+sys.path.insert(0, str(_HERE))
+
+import lambda_function as lf  # noqa: E402
+
+
+class _Sess:
+    def __init__(self, driver):
+        self._d = driver
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def run(self, cypher, **params):
+        if "RETURN count(n)" in cypher or "RETURN count(r)" in cypher or "orphans" in cypher:
+            return _Single({"total": 0, "orphans": 0})
+        if "index_name" in params:
+            return list(self._d.pair_rows)
+        return list(self._d.node_rows)
+
+
+class _Single:
+    def __init__(self, d):
+        self._d = d
+
+    def single(self):
+        return self._d
+
+
+class _Driver:
+    def __init__(self, node_rows, pair_rows):
+        self.node_rows = node_rows
+        self.pair_rows = pair_rows
+
+    def session(self):
+        return _Sess(self)
+
+
+class _FakeCloudWatch:
+    def __init__(self, datapoints=None):
+        self.put_calls = []
+        self._datapoints = datapoints or {}
+
+    def put_metric_data(self, Namespace, MetricData):
+        self.put_calls.append({"namespace": Namespace, "data": MetricData})
+
+    def get_metric_statistics(self, **kwargs):
+        return {"Datapoints": self._datapoints.get(kwargs["MetricName"], [])}
+
+
+class WalkBackCounterTests(unittest.TestCase):
+    def test_sums_datapoints(self):
+        cw = _FakeCloudWatch({"AutoMergeCount": [{"Sum": 10.0}, {"Sum": 5.0}], "WalkBackCount": [{"Sum": 1.0}]})
+        lf.boto3 = _Boto(cw)
+        counts = lf._read_walk_back_counts(30)
+        self.assertEqual(counts, {"auto_merges": 15, "walk_backs": 1})
+
+    def test_degrades_to_zero_on_error(self):
+        class _Boom:
+            def client(self, *_a, **_k):
+                raise RuntimeError("no creds")
+
+        lf.boto3 = _Boom()
+        counts = lf._read_walk_back_counts(30)
+        self.assertEqual(counts, {"auto_merges": 0, "walk_backs": 0})
+
+
+class _Boto:
+    def __init__(self, cw):
+        self._cw = cw
+
+    def client(self, name, *a, **k):
+        return self._cw
+
+
+class PublishTests(unittest.TestCase):
+    def test_publishes_all_signals(self):
+        cw = _FakeCloudWatch()
+        lf.boto3 = _Boto(cw)
+        signals = {
+            "stock_pairs": 7,
+            "precision_at_1_recovery_proxy": 0.6,
+            "precision_at_1_recovery_fraction": 0.5,
+            "precision_at_1_baseline": 0.3727,
+            "recall_ceiling": 0.8242,
+            "new_duplicate_pairs": 3,
+            "lcc_size": 4,
+            "nontrivial_component_count": 2,
+            "embedded_record_count": 20,
+            "walk_back": {"walk_back_rate": 0.002, "auto_merge_count": 1000,
+                          "walk_back_count": 2, "breached_floor": True},
+        }
+        published = lf._publish_dedup_signals(signals)
+        self.assertEqual(len(cw.put_calls), 1)
+        self.assertEqual(cw.put_calls[0]["namespace"], lf.DEDUP_NAMESPACE)
+        names = {m["MetricName"] for m in cw.put_calls[0]["data"]}
+        for expected in (
+            "DuplicatePairStock", "Precision1RecoveryProxy", "Precision1Baseline",
+            "RecallCeiling", "NewDuplicateFlow", "DuplicateLCCSize",
+            "NonTrivialComponentCount", "AutoMergeWalkBackRate", "WalkBackRateBreachedFloor",
+        ):
+            self.assertIn(expected, names)
+        self.assertEqual(published["DuplicatePairStock"], 7.0)
+        self.assertEqual(published["WalkBackRateBreachedFloor"], 1.0)
+
+
+class HandlerIsolationTests(unittest.TestCase):
+    def test_dedup_failure_does_not_break_base_metrics(self):
+        cw = _FakeCloudWatch()
+        lf.boto3 = _Boto(cw)
+        # Base metrics compute against a driver whose count queries succeed.
+        driver = _Driver(node_rows=[], pair_rows=[])
+        lf._get_neo4j_driver = lambda: driver  # type: ignore
+
+        # Force the dedup section to blow up after base metrics succeed.
+        def _boom(_drv):
+            raise RuntimeError("vector index missing")
+
+        lf._compute_dedup_signals = _boom  # type: ignore
+
+        resp = lf.handler({}, None)
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        self.assertFalse(body["dedup_convergence"]["published"])
+        self.assertIn("error", body["dedup_convergence"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/graph_query_api/dedup_convergence.py
+++ b/backend/lambda/graph_query_api/dedup_convergence.py
@@ -1,0 +1,388 @@
+"""ENC-TSK-I10 (Dedup P6) — Telemetry & convergence probe shared module.
+
+Pure, dependency-light convergence math for the duplicate-dedup track
+(DOC-DF651F07D5C2 §10). Owned by graph_query_api; copied into
+graph_health_metrics via ``.build_extras`` so the daily scheduled probe and the
+on-demand graphsearch read action compute byte-identical signals (the same
+cross-Lambda sharing precedent as graph_sync/embedding.py).
+
+The five governed signals (DOC-DF651F07D5C2 §10):
+
+1. **Stock** — same-type, same-project duplicate-pair count (cosine ≥ τ),
+   trending to floor as the backlog drains.
+2. **Precision@1 recovery** — vs the 0.3727 baseline toward the ~0.8242 recall
+   ceiling. The labeled self-retrieval eval (DOC-4F1F5B99AAED) is not
+   reproducible inside a scheduled Lambda, so the probe emits the static
+   baseline + ceiling references and a live **recovery proxy**: the fraction of
+   embedded same-type records that have NO surviving near-duplicate twin
+   (cosine ≥ τ) among non-superseded peers. As twins are superseded the proxy
+   climbs toward 1.0, tracking the same quantity the eval measures (one item no
+   longer loses its #1 slot to its own twin, §3).
+3. **Flow** — new same-type duplicate pairs per window (a pair counts as new
+   when its more-recent endpoint was created within the window). Backlog
+   cleanup alone is Sisyphean against live inflow.
+4. **Percolation** — largest-connected-component (LCC) size of the same-type
+   duplicate graph, plus the non-trivial component count. Isolated records are
+   size-1 components, so a fully converged corpus (no surviving duplicate edge)
+   has LCC → 1: one node per concept, driven below the giant-component
+   percolation threshold.
+5. **Walk-back rate** — the production auto-merge walk-back rate; the live
+   certificate-precision estimate. The certificate is miscalibrated and the
+   model-health loop must re-enter shadow when the rate breaches (1 − floor).
+
+All functions are pure (stdlib only). Cypher orchestration takes a neo4j
+``driver`` exposing ``.session()`` as a context manager; sessions expose
+``.run(cypher, **params)`` yielding mapping rows. This keeps the heavy math unit
+testable without a live AuraDB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+# --- Convergence constants (DOC-DF651F07D5C2 §2/§10) -----------------------
+
+#: Self-retrieval precision@1 measured on the gamma near-duplicate eval before
+#: any dedup (DOC-4F1F5B99AAED). The signal the whole track exists to recover.
+PRECISION_AT_1_BASELINE = 0.3727
+
+#: recall@10 ceiling on the same eval — the true item is in the top-10 ~82% of
+#: the time, so this is the practical ceiling precision@1 can recover toward.
+RECALL_CEILING = 0.8242
+
+#: Recall instrument for duplicate detection (§9 step 1): cosine ≥ this is a
+#: candidate near-duplicate. Confirmed identity is the certainty model's job.
+DEFAULT_COSINE_THRESHOLD = 0.95
+
+#: Certificate precision floor (§4.3). Walk-back rate breaching (1 − floor)
+#: means the certificate is miscalibrated → re-enter shadow (§10 model-health).
+DEFAULT_PRECISION_FLOOR = 0.999
+
+#: Flow accounting window — "new duplicate pairs per week" (§10 flow).
+DEFAULT_FLOW_WINDOW_DAYS = 7
+
+#: Walk-back rate accounting window for the model-health loop.
+DEFAULT_WALKBACK_WINDOW_DAYS = 30
+
+#: Per-node KNN fan-out when extracting near-duplicate pairs from the vector
+#: index. A dense duplicate cluster (mean degree ≈ 15, §2) needs k > degree.
+DEFAULT_VECTOR_TOP_K = 25
+
+#: Per-label HNSW vector indexes (ENC-TSK-B90). Mirrors graph_query_api's
+#: LABEL_VECTOR_INDEXES; passed in by callers but defaulted here so the probe
+#: and the read action cannot drift.
+DEFAULT_LABEL_VECTOR_INDEXES: Dict[str, str] = {
+    "Task": "governed_task_embedding",
+    "Issue": "governed_issue_embedding",
+    "Feature": "governed_feature_embedding",
+    "Plan": "governed_plan_embedding",
+    "Lesson": "governed_lesson_embedding",
+    "Document": "governed_document_embedding",
+}
+
+
+# --- Pure helpers ----------------------------------------------------------
+
+def normalize_pair(a: str, b: str) -> Tuple[str, str]:
+    """Orientation-stable pair key (uppercased, lexicographically ordered).
+
+    Matches the I05/I06/I09 ``_dedup_pair_key`` convention so a directed KNN
+    hit (a→b) and its mirror (b→a) collapse to one undirected duplicate edge.
+    """
+    a2, b2 = str(a).strip().upper(), str(b).strip().upper()
+    return (a2, b2) if a2 <= b2 else (b2, a2)
+
+
+def connected_components(
+    nodes: Iterable[str], pairs: Iterable[Tuple[str, str]]
+) -> List[Set[str]]:
+    """Union-find connected components over the duplicate graph.
+
+    ``nodes`` is the full participating corpus (so isolated records surface as
+    size-1 components — required for the percolation → 1 reading); ``pairs`` are
+    the undirected duplicate edges. Order-free and idempotent (§9 step 2).
+    """
+    parent: Dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        # Path compression.
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(x: str, y: str) -> None:
+        rx, ry = find(x), find(y)
+        if rx != ry:
+            parent[rx] = ry
+
+    for n in nodes:
+        find(str(n).strip().upper())
+    for a, b in pairs:
+        ua, ub = str(a).strip().upper(), str(b).strip().upper()
+        find(ua)
+        find(ub)
+        union(ua, ub)
+
+    groups: Dict[str, Set[str]] = {}
+    for node in list(parent.keys()):
+        groups.setdefault(find(node), set()).add(node)
+    return list(groups.values())
+
+
+def largest_component_size(components: Sequence[Set[str]]) -> int:
+    """LCC size. 0 for an empty corpus; 1 once fully converged (no edges)."""
+    return max((len(c) for c in components), default=0)
+
+
+def count_nontrivial_components(components: Sequence[Set[str]]) -> int:
+    """Count clusters of size ≥ 2 — the duplicate clusters still to collapse."""
+    return sum(1 for c in components if len(c) >= 2)
+
+
+def precision_recovery_proxy(records_without_twin: int, total_records: int) -> float:
+    """Live precision@1 recovery proxy: fraction of records with no surviving
+    same-type near-duplicate twin. 1.0 for an empty/converged corpus."""
+    if total_records <= 0:
+        return 1.0
+    return max(0.0, min(1.0, records_without_twin / total_records))
+
+
+def recovery_fraction(
+    value: float, baseline: float = PRECISION_AT_1_BASELINE, ceiling: float = RECALL_CEILING
+) -> float:
+    """Normalized progress of ``value`` from ``baseline`` (0.0) to ``ceiling``
+    (1.0). Convenient for graphing recovery; clamped to [0, 1]."""
+    span = ceiling - baseline
+    if span <= 0:
+        return 0.0
+    return max(0.0, min(1.0, (value - baseline) / span))
+
+
+def walk_back_rate(auto_merges: int, walk_backs: int) -> float:
+    """Production auto-merge walk-back rate = walk_backs / auto_merges.
+
+    0.0 when no auto-merges have been observed (the certificate has produced no
+    outcomes yet — the system is in shadow by construction)."""
+    if auto_merges <= 0:
+        return 0.0
+    return max(0.0, min(1.0, walk_backs / auto_merges))
+
+
+def breaches_floor(rate: float, precision_floor: float = DEFAULT_PRECISION_FLOOR) -> bool:
+    """Model-health predicate (§10): the certificate is miscalibrated when the
+    walk-back rate exceeds (1 − floor). True ⇒ tighten thresholds / re-enter
+    shadow."""
+    return rate > (1.0 - precision_floor)
+
+
+def walk_back_health(
+    auto_merges: int, walk_backs: int, precision_floor: float = DEFAULT_PRECISION_FLOOR
+) -> Dict[str, Any]:
+    """Assemble the walk-back model-health loop snapshot (§10).
+
+    ``recommended_mode`` is 'shadow' when the loop has breached the floor (or
+    when there is no evidence yet, the safe default), else 'live'.
+    """
+    rate = walk_back_rate(auto_merges, walk_backs)
+    breach = breaches_floor(rate, precision_floor)
+    has_evidence = auto_merges > 0
+    return {
+        "auto_merge_count": int(auto_merges),
+        "walk_back_count": int(walk_backs),
+        "walk_back_rate": rate,
+        "precision_floor": precision_floor,
+        "breach_threshold": 1.0 - precision_floor,
+        "breached_floor": breach,
+        "recommended_mode": "live" if (has_evidence and not breach) else "shadow",
+        "has_evidence": has_evidence,
+    }
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp (tolerating a trailing 'Z') to aware UTC."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    s = str(value).strip()
+    if not s:
+        return None
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def count_new_pairs(
+    pair_newest_ts: Iterable[Any], now: datetime, window_days: float
+) -> int:
+    """Flow: count duplicate pairs whose newest endpoint was created within the
+    trailing ``window_days`` of ``now`` (§10 flow). Unparseable timestamps are
+    treated as outside the window (conservative — never inflates inflow)."""
+    if window_days <= 0:
+        return 0
+    cutoff_seconds = window_days * 86400.0
+    count = 0
+    for ts in pair_newest_ts:
+        dt = _parse_ts(ts)
+        if dt is None:
+            continue
+        age = (now - dt).total_seconds()
+        if 0 <= age <= cutoff_seconds:
+            count += 1
+    return count
+
+
+# --- Neo4j orchestration (driver-bound; thin) ------------------------------
+
+# All embedded, non-superseded records of one label in a project. Defines the
+# percolation node set (so isolated records are size-1 components).
+_NODES_CYPHER = (
+    "MATCH (n:`{label}`) "
+    "WHERE n.project_id = $project_id "
+    "AND n.superseded_by IS NULL "
+    "AND n.embedding IS NOT NULL "
+    "RETURN n.record_id AS rid"
+)
+
+# Per-node KNN over the label's HNSW index → near-duplicate directed hits.
+# Excludes self, cross-project, and superseded twins (mirrors the I07 retrieval
+# exclusion at graph_query_api lambda_function.py). One CALL per source row.
+_PAIRS_CYPHER = (
+    "MATCH (n:`{label}`) "
+    "WHERE n.project_id = $project_id "
+    "AND n.superseded_by IS NULL "
+    "AND n.embedding IS NOT NULL "
+    "CALL db.index.vector.queryNodes($index_name, $k, n.embedding) "
+    "YIELD node AS m, score "
+    "WHERE m.record_id <> n.record_id "
+    "AND m.project_id = $project_id "
+    "AND m.superseded_by IS NULL "
+    "AND score >= $threshold "
+    "RETURN n.record_id AS a, m.record_id AS b, score AS score, "
+    "n.created_at AS a_ts, m.created_at AS b_ts"
+)
+
+
+def _newest_ts(a_ts: Any, b_ts: Any) -> Any:
+    """Return the more-recent of two timestamps (for flow accounting)."""
+    da, db = _parse_ts(a_ts), _parse_ts(b_ts)
+    if da is None:
+        return b_ts
+    if db is None:
+        return a_ts
+    return a_ts if da >= db else b_ts
+
+
+def compute_graph_signals(
+    driver: Any,
+    project_id: str,
+    *,
+    cosine_threshold: float = DEFAULT_COSINE_THRESHOLD,
+    flow_window_days: float = DEFAULT_FLOW_WINDOW_DAYS,
+    now: Optional[datetime] = None,
+    label_vector_indexes: Optional[Mapping[str, str]] = None,
+    vector_top_k: int = DEFAULT_VECTOR_TOP_K,
+) -> Dict[str, Any]:
+    """Compute the four graph-derived convergence signals (stock / precision@1
+    recovery proxy / flow / percolation) over the live Neo4j projection.
+
+    Pure of any AWS dependency; the walk-back model-health loop is layered on by
+    the scheduled probe via :func:`walk_back_health`.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    indexes = dict(label_vector_indexes or DEFAULT_LABEL_VECTOR_INDEXES)
+
+    all_nodes: Set[str] = set()
+    nodes_by_type: Dict[str, int] = {}
+    pair_score: Dict[Tuple[str, str], float] = {}
+    pair_newest: Dict[Tuple[str, str], Any] = {}
+    pair_label: Dict[Tuple[str, str], str] = {}
+
+    for label, index_name in indexes.items():
+        # Node set for this label.
+        node_cypher = _NODES_CYPHER.format(label=label)
+        label_nodes: Set[str] = set()
+        with driver.session() as session:
+            for row in session.run(node_cypher, project_id=project_id):
+                rid = row.get("rid") if hasattr(row, "get") else row["rid"]
+                if rid:
+                    rid_u = str(rid).strip().upper()
+                    label_nodes.add(rid_u)
+                    all_nodes.add(rid_u)
+        nodes_by_type[label] = len(label_nodes)
+        if not label_nodes:
+            continue
+
+        # Near-duplicate pairs for this label.
+        pair_cypher = _PAIRS_CYPHER.format(label=label)
+        with driver.session() as session:
+            rows = session.run(
+                pair_cypher,
+                project_id=project_id,
+                index_name=index_name,
+                k=int(vector_top_k),
+                threshold=float(cosine_threshold),
+            )
+            for row in rows:
+                get = row.get if hasattr(row, "get") else row.__getitem__
+                a, b = get("a"), get("b")
+                if not a or not b:
+                    continue
+                key = normalize_pair(a, b)
+                score = float(get("score") or 0.0)
+                if key not in pair_score or score > pair_score[key]:
+                    pair_score[key] = score
+                    pair_newest[key] = _newest_ts(get("a_ts"), get("b_ts"))
+                    pair_label[key] = label
+
+    pairs = list(pair_score.keys())
+    duplicate_nodes: Set[str] = set()
+    for a, b in pairs:
+        duplicate_nodes.add(a)
+        duplicate_nodes.add(b)
+
+    components = connected_components(all_nodes, pairs)
+    total_records = len(all_nodes)
+    records_without_twin = total_records - len(duplicate_nodes)
+    proxy = precision_recovery_proxy(records_without_twin, total_records)
+
+    stock_by_type: Dict[str, int] = {}
+    for key, label in pair_label.items():
+        stock_by_type[label] = stock_by_type.get(label, 0) + 1
+
+    return {
+        "project_id": project_id,
+        "cosine_threshold": float(cosine_threshold),
+        "embedded_record_count": total_records,
+        "embedded_record_count_by_type": nodes_by_type,
+        "stock_pairs": len(pairs),
+        "stock_pairs_by_type": stock_by_type,
+        "duplicate_node_count": len(duplicate_nodes),
+        "records_without_twin": records_without_twin,
+        "flow_window_days": float(flow_window_days),
+        "new_duplicate_pairs": count_new_pairs(
+            pair_newest.values(), now, flow_window_days
+        ),
+        "lcc_size": largest_component_size(components),
+        "nontrivial_component_count": count_nontrivial_components(components),
+        "precision_at_1_baseline": PRECISION_AT_1_BASELINE,
+        "recall_ceiling": RECALL_CEILING,
+        "precision_at_1_recovery_proxy": proxy,
+        "precision_at_1_recovery_fraction": recovery_fraction(
+            # Map the proxy (a fraction in [0,1]) onto the eval scale so the
+            # recovery is comparable to the baseline→ceiling band: at full
+            # convergence (proxy=1) the live precision should approach ceiling.
+            PRECISION_AT_1_BASELINE + proxy * (RECALL_CEILING - PRECISION_AT_1_BASELINE)
+        ),
+        "computed_at": now.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -37,6 +37,8 @@ import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs
 
+import dedup_convergence
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -54,7 +56,7 @@ MAX_DEPTH = 5
 MAX_RESULTS = 100
 QUERY_TIMEOUT_SECONDS = 10
 
-VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword", "hybrid"}
+VALID_SEARCH_TYPES = {"traversal", "neighbors", "path", "keyword", "hybrid", "dedup_convergence"}
 
 # ---------------------------------------------------------------------------
 # ENC-TSK-B92 Phase 1 hybrid retrieval constants
@@ -1872,12 +1874,59 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
 _EMBEDDING_PROPERTY = "embedding"
 
 
+def _query_dedup_convergence(driver, project_id: str, params: Dict) -> Dict:
+    """ENC-TSK-I10 (Dedup P6): on-demand duplicate-dedup convergence snapshot
+    (DOC-DF651F07D5C2 §10). Read-only; mutation-free.
+
+    Computes the four graph-derived signals — duplicate-pair stock, the
+    precision@1 recovery proxy (vs the 0.3727 baseline / ~0.8242 ceiling), new
+    duplicate flow per window, and the same-type duplicate graph's LCC
+    (percolation → 1) — over the live Neo4j projection. The production
+    auto-merge walk-back rate is layered on by the scheduled probe
+    (graph_health_metrics) from the audit-feed counters; it is not derivable
+    from the graph projection (supersession provenance is not a node property),
+    so this read surface returns the graph signals only.
+
+    Query params (all optional): cosine_threshold, flow_window_days,
+    vector_top_k.
+    """
+    def _flt(name: str, default: float) -> float:
+        try:
+            return float(params.get(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    def _intp(name: str, default: int) -> int:
+        try:
+            return max(1, int(params.get(name, default)))
+        except (TypeError, ValueError):
+            return default
+
+    cosine_threshold = _flt("cosine_threshold", dedup_convergence.DEFAULT_COSINE_THRESHOLD)
+    if not (0.0 <= cosine_threshold <= 1.0):
+        return {"error": "cosine_threshold must be in [0, 1]."}
+    flow_window_days = _flt("flow_window_days", float(dedup_convergence.DEFAULT_FLOW_WINDOW_DAYS))
+    vector_top_k = _intp("vector_top_k", dedup_convergence.DEFAULT_VECTOR_TOP_K)
+
+    signals = dedup_convergence.compute_graph_signals(
+        driver,
+        project_id,
+        cosine_threshold=cosine_threshold,
+        flow_window_days=flow_window_days,
+        label_vector_indexes=LABEL_VECTOR_INDEXES,
+        vector_top_k=vector_top_k,
+    )
+    # _handle_search audits node/edge/path counts; keep those keys present.
+    return {"nodes": [], "edges": [], "paths": [], "convergence": signals}
+
+
 SEARCH_HANDLERS = {
     "traversal": _query_traversal,
     "neighbors": _query_neighbors,
     "path": _query_path,
     "keyword": _query_keyword,
     "hybrid": _query_hybrid,
+    "dedup_convergence": _query_dedup_convergence,
 }
 
 
@@ -1969,6 +2018,7 @@ def _handle_search(event: Dict) -> Dict:
         "include_below_threshold",
         "edge_participation",
         "pathway",
+        "convergence",
     ):
         if hybrid_key in result:
             response_body[hybrid_key] = result[hybrid_key]

--- a/backend/lambda/graph_query_api/test_dedup_convergence.py
+++ b/backend/lambda/graph_query_api/test_dedup_convergence.py
@@ -1,0 +1,205 @@
+"""Unit tests for ENC-TSK-I10 (Dedup P6) convergence-probe math.
+
+Exercises the pure convergence functions (DOC-DF651F07D5C2 §10) without Neo4j or
+AWS, plus compute_graph_signals against a fake driver:
+  - stock pairing + orientation-stable dedupe
+  - percolation: connected components / LCC (→ 1 at convergence) / cluster count
+  - flow: new-pair-per-window accounting
+  - precision@1 recovery proxy
+  - walk-back model-health loop + (1 - floor) breach predicate
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import dedup_convergence as dc  # noqa: E402
+
+
+class PairAndComponentTests(unittest.TestCase):
+    def test_normalize_pair_orientation_stable(self):
+        self.assertEqual(dc.normalize_pair("enc-iss-2", "ENC-ISS-1"), ("ENC-ISS-1", "ENC-ISS-2"))
+        self.assertEqual(dc.normalize_pair("ENC-ISS-1", "enc-iss-2"), ("ENC-ISS-1", "ENC-ISS-2"))
+
+    def test_connected_components_includes_isolated_nodes(self):
+        nodes = ["A", "B", "C", "D"]
+        pairs = [("A", "B")]
+        comps = dc.connected_components(nodes, pairs)
+        sizes = sorted(len(c) for c in comps)
+        self.assertEqual(sizes, [1, 1, 2])  # A-B cluster, plus isolated C, D
+        self.assertEqual(dc.largest_component_size(comps), 2)
+        self.assertEqual(dc.count_nontrivial_components(comps), 1)
+
+    def test_lcc_chains_transitive_cluster(self):
+        # A-B, B-C, C-D forms one 4-node cluster (order-free union).
+        comps = dc.connected_components(["A", "B", "C", "D"], [("A", "B"), ("C", "B"), ("D", "C")])
+        self.assertEqual(dc.largest_component_size(comps), 4)
+        self.assertEqual(dc.count_nontrivial_components(comps), 1)
+
+    def test_converged_corpus_lcc_is_one(self):
+        # No duplicate edges => every record is its own size-1 component => LCC 1.
+        comps = dc.connected_components(["A", "B", "C"], [])
+        self.assertEqual(dc.largest_component_size(comps), 1)
+        self.assertEqual(dc.count_nontrivial_components(comps), 0)
+
+    def test_empty_corpus_lcc_is_zero(self):
+        self.assertEqual(dc.largest_component_size(dc.connected_components([], [])), 0)
+
+
+class PrecisionRecoveryTests(unittest.TestCase):
+    def test_proxy_full_when_no_twins(self):
+        self.assertEqual(dc.precision_recovery_proxy(10, 10), 1.0)
+
+    def test_proxy_zero_when_all_have_twins(self):
+        self.assertEqual(dc.precision_recovery_proxy(0, 10), 0.0)
+
+    def test_proxy_empty_corpus(self):
+        self.assertEqual(dc.precision_recovery_proxy(0, 0), 1.0)
+
+    def test_recovery_fraction_band(self):
+        self.assertAlmostEqual(dc.recovery_fraction(dc.PRECISION_AT_1_BASELINE), 0.0)
+        self.assertAlmostEqual(dc.recovery_fraction(dc.RECALL_CEILING), 1.0)
+        mid = (dc.PRECISION_AT_1_BASELINE + dc.RECALL_CEILING) / 2
+        self.assertAlmostEqual(dc.recovery_fraction(mid), 0.5)
+        self.assertEqual(dc.recovery_fraction(0.0), 0.0)   # clamped low
+        self.assertEqual(dc.recovery_fraction(1.0), 1.0)   # clamped high
+
+
+class FlowTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 6, 28, tzinfo=timezone.utc)
+
+    def test_counts_only_recent_pairs(self):
+        recent = (self.now - timedelta(days=3)).isoformat().replace("+00:00", "Z")
+        old = (self.now - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+        self.assertEqual(dc.count_new_pairs([recent, old, recent], self.now, 7), 2)
+
+    def test_unparseable_ts_excluded(self):
+        self.assertEqual(dc.count_new_pairs(["not-a-date", None], self.now, 7), 0)
+
+    def test_zero_window(self):
+        recent = self.now.isoformat().replace("+00:00", "Z")
+        self.assertEqual(dc.count_new_pairs([recent], self.now, 0), 0)
+
+
+class WalkBackHealthTests(unittest.TestCase):
+    def test_rate_zero_without_merges_is_shadow(self):
+        h = dc.walk_back_health(0, 0)
+        self.assertEqual(h["walk_back_rate"], 0.0)
+        self.assertFalse(h["breached_floor"])
+        self.assertEqual(h["recommended_mode"], "shadow")  # no evidence => shadow
+        self.assertFalse(h["has_evidence"])
+
+    def test_clean_merges_stay_live(self):
+        h = dc.walk_back_health(1000, 0, precision_floor=0.999)
+        self.assertEqual(h["walk_back_rate"], 0.0)
+        self.assertFalse(h["breached_floor"])
+        self.assertEqual(h["recommended_mode"], "live")
+
+    def test_breach_reenters_shadow(self):
+        # floor 0.999 => breach threshold 0.001; 2/1000 = 0.002 > 0.001.
+        h = dc.walk_back_health(1000, 2, precision_floor=0.999)
+        self.assertAlmostEqual(h["walk_back_rate"], 0.002)
+        self.assertTrue(h["breached_floor"])
+        self.assertEqual(h["recommended_mode"], "shadow")
+
+    def test_breaches_floor_predicate(self):
+        self.assertTrue(dc.breaches_floor(0.01, 0.999))
+        self.assertFalse(dc.breaches_floor(0.0005, 0.999))
+        self.assertFalse(dc.breaches_floor(0.001, 0.999))  # equal is not a breach
+
+
+# --- compute_graph_signals against a fake neo4j driver ---------------------
+
+class _FakeSession:
+    def __init__(self, driver):
+        self._driver = driver
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def run(self, cypher, **params):
+        # Pairs query carries an index_name; node query does not.
+        if "index_name" in params:
+            label = self._driver.index_to_label.get(params["index_name"])
+            return list(self._driver.pair_rows.get(label, []))
+        # Node query: parse the backtick-quoted label out of the MATCH clause.
+        label = None
+        for lbl in self._driver.node_rows:
+            if f"(n:`{lbl}`)" in cypher:
+                label = lbl
+                break
+        return list(self._driver.node_rows.get(label, []))
+
+
+class _FakeDriver:
+    def __init__(self, node_rows, pair_rows, index_to_label):
+        self.node_rows = node_rows
+        self.pair_rows = pair_rows
+        self.index_to_label = index_to_label
+
+    def session(self):
+        return _FakeSession(self)
+
+
+class ComputeGraphSignalsTests(unittest.TestCase):
+    def test_end_to_end_snapshot(self):
+        now = datetime(2026, 6, 28, tzinfo=timezone.utc)
+        recent = (now - timedelta(days=2)).isoformat().replace("+00:00", "Z")
+        old = (now - timedelta(days=90)).isoformat().replace("+00:00", "Z")
+        # Issue corpus: 3 records; A-B are duplicates (recent), C is alone.
+        node_rows = {
+            "Issue": [{"rid": "ENC-ISS-1"}, {"rid": "ENC-ISS-2"}, {"rid": "ENC-ISS-3"}],
+            "Task": [{"rid": "ENC-TSK-1"}, {"rid": "ENC-TSK-2"}],
+        }
+        pair_rows = {
+            # directed hits both ways collapse to one undirected pair
+            "Issue": [
+                {"a": "ENC-ISS-1", "b": "ENC-ISS-2", "score": 0.999, "a_ts": recent, "b_ts": old},
+                {"a": "ENC-ISS-2", "b": "ENC-ISS-1", "score": 0.999, "a_ts": old, "b_ts": recent},
+            ],
+            "Task": [],  # below threshold / no dupes
+        }
+        index_to_label = {"governed_issue_embedding": "Issue", "governed_task_embedding": "Task"}
+        # Only query the two labels we populated.
+        indexes = {"Issue": "governed_issue_embedding", "Task": "governed_task_embedding"}
+        driver = _FakeDriver(node_rows, pair_rows, index_to_label)
+
+        s = dc.compute_graph_signals(
+            driver, "enceladus", now=now, label_vector_indexes=indexes, flow_window_days=7
+        )
+        self.assertEqual(s["stock_pairs"], 1)
+        self.assertEqual(s["stock_pairs_by_type"], {"Issue": 1})
+        self.assertEqual(s["embedded_record_count"], 5)
+        self.assertEqual(s["duplicate_node_count"], 2)
+        self.assertEqual(s["records_without_twin"], 3)
+        self.assertEqual(s["new_duplicate_pairs"], 1)  # newest endpoint is recent
+        self.assertEqual(s["lcc_size"], 2)             # the A-B cluster
+        self.assertEqual(s["nontrivial_component_count"], 1)
+        self.assertAlmostEqual(s["precision_at_1_recovery_proxy"], 3 / 5)
+        self.assertEqual(s["precision_at_1_baseline"], dc.PRECISION_AT_1_BASELINE)
+        self.assertEqual(s["recall_ceiling"], dc.RECALL_CEILING)
+
+    def test_converged_corpus(self):
+        now = datetime(2026, 6, 28, tzinfo=timezone.utc)
+        node_rows = {"Issue": [{"rid": "ENC-ISS-1"}, {"rid": "ENC-ISS-2"}]}
+        pair_rows = {"Issue": []}
+        driver = _FakeDriver(node_rows, pair_rows, {"governed_issue_embedding": "Issue"})
+        s = dc.compute_graph_signals(
+            driver, "enceladus", now=now, label_vector_indexes={"Issue": "governed_issue_embedding"}
+        )
+        self.assertEqual(s["stock_pairs"], 0)
+        self.assertEqual(s["lcc_size"], 1)  # percolation -> 1
+        self.assertEqual(s["nontrivial_component_count"], 0)
+        self.assertEqual(s["precision_at_1_recovery_proxy"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1334,6 +1334,16 @@ Resources:
           CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
           PROJECT_ID: enceladus
           SECRETS_REGION: !Ref "AWS::Region"
+          # ENC-TSK-I10 (Dedup P6): convergence-probe signal configuration
+          # (DOC-DF651F07D5C2 §10). The walk-back model-health loop reads the
+          # production auto-merge/walk-back audit counters back from CloudWatch.
+          DEDUP_NAMESPACE: Enceladus/DedupConvergence
+          DEDUP_AUDIT_NAMESPACE: Enceladus/DedupConvergence
+          DEDUP_COSINE_THRESHOLD: "0.95"
+          DEDUP_PRECISION_FLOOR: "0.999"
+          DEDUP_FLOW_WINDOW_DAYS: "7"
+          DEDUP_WALKBACK_WINDOW_DAYS: "30"
+          DEDUP_VECTOR_TOP_K: "25"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
@@ -3461,6 +3471,14 @@ Resources:
                 Effect: Allow
                 Action:
                   - cloudwatch:PutMetricData
+                Resource: "*"
+              # ENC-TSK-I10 (Dedup P6): the walk-back model-health loop reads
+              # the auto-merge/walk-back audit counters back from CloudWatch.
+              - Sid: CloudWatchMetricsRead
+                Effect: Allow
+                Action:
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:GetMetricData
                 Resource: "*"
               - Sid: SecretsManagerNeo4j
                 Effect: Allow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task
- **task_id:** ENC-TSK-I10
- **Plan/track:** Dedup track (DOC-DF651F07D5C2 §10), PLN-006 (ENC-FTR-115 lineage)
- **Deploy target:** v4/main (gamma) ONLY. v3-prod is FROZEN (DOC-499FA089EC30) — not targeted, not touched, no deploy performed. The human owns merge + deploy + close-out.

## Commit gate
- **commit-complete-id:** CCI-7bb447c331194cd09b04d0fb1caf9f30
- **commit_sha:** d7fcd8fdf9e573402f7382e4033d929c81416518

## Satisfied acceptance criteria
- **AC[0] — satisfied.** A scheduled probe (`graph_health_metrics`, daily EventBridge) emits all five governed signals to CloudWatch namespace `Enceladus/DedupConvergence`:
  1. **Duplicate-pair stock count** → `DuplicatePairStock` (same-type, same-project pairs at cosine ≥ τ).
  2. **Precision@1 recovery vs the 0.3727 baseline (toward the ~0.82 recall ceiling)** → `Precision1RecoveryProxy` + `Precision1RecoveryEstimate`, with `Precision1Baseline` (0.3727) and `RecallCeiling` (0.8242) reference signals. The labeled self-retrieval eval (DOC-4F1F5B99AAED) is not reproducible in a scheduled Lambda, so the probe emits a live recovery proxy — the fraction of embedded same-type records with no surviving near-duplicate twin — which climbs toward the ceiling as twins are superseded.
  3. **New-duplicate flow per week** → `NewDuplicateFlow` (pairs whose newer endpoint was created within the window).
  4. **Largest-connected-component size of the same-type duplicate graph (percolation → 1)** → `DuplicateLCCSize` + `NonTrivialComponentCount` (union-find over the corpus; isolated records are size-1 components, so LCC → 1 at convergence).
  5. **Production auto-merge walk-back rate (re-enters shadow if it breaches 1 − floor)** → `AutoMergeWalkBackRate` + `WalkBackRateBreachedFloor` (the model-health loop), computed from the CloudWatch audit counters `AutoMergeCount`/`WalkBackCount`.

## What changed
- **New shared pure module** `backend/lambda/graph_query_api/dedup_convergence.py` — union-find connected-components/LCC, stock pairing, flow windowing, precision@1 recovery proxy, and the walk-back model-health loop with the `(1 − floor)` breach predicate (→ re-enter shadow). 100% stdlib, fully unit-tested.
- **`graph_query_api`** — new read-only `dedup_convergence` search_type exposing the four graph-derived signals on demand (`result.convergence`).
- **`graph_health_metrics`** (the scheduled probe, `comp-graph-health-metrics`) — computes the four graph signals via its Neo4j session and the walk-back rate from CloudWatch counters, then publishes the five governed signals. The dedup section is isolated so a dedup failure never breaks the existing C10 graph-health metrics. Module packaged via `.build_extras` (graph_sync/embedding.py precedent).
- **CFN** `02-compute.yaml` — `DEDUP_*` env vars on the probe function + `cloudwatch:GetMetricStatistics`/`GetMetricData` on `GraphHealthMetricsRole`.
- **Governance dictionary** `backend/lambda/coordination_api/governance_data_dictionary.json` — adds entity `monitoring.dedup_convergence_probe`, bumps `version` 2026-06-28.05 → 2026-06-28.06 (satisfies the Governance Dictionary Guard). See the `GOVERNANCE_SYNC_REQUIRED` worklog block on ENC-TSK-I10 — the post-merge S3/DDB three-surface sync and the agents.md `governance_revision` lockstep bump are the coordination-lead/io action (§13). `agents.md` itself is unchanged.

## Notes
- The walk-back producer counters (`AutoMergeCount`/`WalkBackCount`) are emitted by the dedup auto-merge / un-supersession walk-back path (tracker_mutation) when io enables MECHANICAL T-HIGH auto-walk. Auto-merge is currently DARK (flag-gated until the certificate precision floor is certified — DOC-DF651F07D5C2 §13), so the live walk-back rate is correctly `0` / `shadow` until then. The probe consumes; this PR's code stays scoped to the two declared components (`comp-graph-health-metrics`, `comp-graph-query-api`).

## Tests
- 18 pure-math unit tests (`test_dedup_convergence.py`) + 4 probe tests (`test_dedup_probe_i10.py`) — all green.
- Existing `graph_query_api` suite (46 tests) — green; CFN parses; dictionary JSON valid; Governance Dictionary Guard passes; changed modules `py_compile` clean.

## Governance
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`
- **connection_health (session init):**
```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-28T13:07:37Z",
  "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}}
}
```
- **session:** ENC-SES-00J · **agent_type:** ENC-AGT-003 (cursor-cloud-agent / claude-opus-4-8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a064876-2f43-4cfa-9e69-0f12de26eceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a064876-2f43-4cfa-9e69-0f12de26eceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

