### PR TITLE
[ENC-TSK-I93] FTR-084 Ph1 - Session-init intent classifier: Titan V2 nearest-neighbor prediction + applied_entelechy_override (inference-only, no training writes)

### DIFF
--- a/backend/lambda/coordination_api/config.py
+++ b/backend/lambda/coordination_api/config.py
@@ -58,6 +58,8 @@ __all__ = [
     "COORDINATION_INTERNAL_API_KEY_PREVIOUS",
     "COORDINATION_INTERNAL_API_KEYS",
     "COORDINATION_MCP_HTTP_PATH",
+    "DRIFT_TELEMETRY_TABLE",
+    "GRAPH_QUERY_API_URL",
     "COORDINATION_PUBLIC_BASE_URL",
     "COORDINATION_TABLE",
     "CORS_ORIGIN",
@@ -175,6 +177,15 @@ SSM_REGION = os.environ.get("SSM_REGION", "us-west-2")
 CORS_ORIGIN = os.environ.get("CORS_ORIGIN", "https://jreese.net")
 GOVERNANCE_PROJECT_ID = os.environ.get("GOVERNANCE_PROJECT_ID", "devops")
 GOVERNANCE_KEYWORD = os.environ.get("GOVERNANCE_KEYWORD", "governance-file")
+
+# --- ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier ---
+# graph_query_api hybrid endpoint used by the default nearest-neighbor provider
+# (Titan V2 vector search). Empty => the classifier degrades to no neighbors so
+# session-init inference never blocks. Set on the gamma stack to enable real
+# predictions. The drift-telemetry table is owned by FTR-087 (planned); empty
+# default keeps the new intent_centroid_drift column write a graceful no-op.
+GRAPH_QUERY_API_URL = os.environ.get("GRAPH_QUERY_API_URL", "").strip()
+DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
 
 COGNITO_USER_POOL_ID = os.environ.get("COGNITO_USER_POOL_ID", "")
 COGNITO_CLIENT_ID = os.environ.get("COGNITO_CLIENT_ID", "")

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -5911,6 +5911,35 @@
         }
       }
     },
+    "coordination_api.session_init_intent_classifier": {
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized \u2014 same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced \u2014 predictions are returned inline (AC-4). Scope guard (AC-5): inference-only \u2014 intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "fields": {
+        "routes": {
+          "type": "object",
+          "definition": "POST /api/v1/coordination/session-init/classify-intent -> _handle_session_init_classify_intent(event, claims). POST /api/v1/coordination/session-init/intent-centroid-drift -> _handle_session_init_intent_drift(event, claims). Both registered before the 404 fallback in lambda_handler; auth via the standard coordination auth gate (Cognito or X-Coordination-Internal-Key)."
+        },
+        "mcp_actions": {
+          "type": "object",
+          "definition": "coordination(action='session.classify_intent') -> raw tool coordination_classify_intent; coordination(action='session.intent_centroid_drift') -> raw tool coordination_intent_centroid_drift. Both proxy to the coordination API HTTP routes via _coordination_api_request."
+        },
+        "classify_intent_request": {
+          "type": "object",
+          "definition": "{first_turn_text:str (required; request_text accepted as alias), session_metadata:object?, applied_entelechy_override:list[str]|str|{node_ids:[...]}?, top_k:int? (default 5, max 25), project_id:str? (default 'enceladus')}."
+        },
+        "classify_intent_response": {
+          "type": "object",
+          "definition": "{success:true, predicted_entelechy:{node_ids:list[str], confidence:float in [0,1]}, applied_entelechy:{node_ids:list[str], confidence:float, source:'classifier'|'io_override'}, override_applied:bool, neighbors:list[{record_id,score}], query_embedding_dim:int, model_id:str, inference_only:true, ...}. predicted_entelechy always carries the classifier's own prediction even when overridden (it is logged)."
+        },
+        "intent_centroid_drift_contract": {
+          "type": "object",
+          "definition": "Request {wave_id:str (required), embeddings:list[list[float]] (FTR-089 embeddings for dispatched records; dispatched_record_embeddings accepted as alias), previous_centroid:list[float]?, persist:bool? (default true), project_id:str?}. Response {success:true, wave_id, intent_centroid_dim:int, intent_centroid_drift:float|null, record_count:int, persistence:{persisted:bool, ...}}."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GRAPH_QUERY_API_URL (default empty -> classifier degrades to no neighbors). DRIFT_TELEMETRY_TABLE (default empty -> intent_centroid_drift persistence is a graceful no-op; the table is owned by FTR-087). BEDROCK_REGION (default us-west-2) for the Titan V2 embed; requires bedrock:InvokeModel on amazon.titan-embed-text-v2:0 on the coordination_api role for live (gamma) predictions."
+        }
+      }
+    },
     "mcp_server.governance_hash_resolution": {
       "description": "Hash resolution chain in enceladus-mcp-server._get_governance_hash_via_api() after the ENC-TSK-I29 cutover. Four-tier resolution with 60s TTL cache.",
       "fields": {

--- a/backend/lambda/coordination_api/intent_classifier.py
+++ b/backend/lambda/coordination_api/intent_classifier.py
@@ -1,0 +1,428 @@
+"""intent_classifier.py — Session-init proactive intent classifier (ENC-FTR-084 Phase 1).
+
+ENC-TSK-I93. Inference-only Titan V2 nearest-neighbor intent prediction for the
+coordination_api session-init path.
+
+Given the first-turn request text and session metadata, this module:
+  1. Embeds the first-turn text with `amazon.titan-embed-text-v2:0` (256-dim,
+     normalized) — the SAME contract as backend/lambda/graph_sync/embedding.py so
+     the query vector lives in the same space as the governed corpus embeddings.
+  2. Finds the nearest-neighbor governed records by cosine similarity and returns
+     a `predicted_entelechy` = {node_ids: list[str], confidence: float}.
+  3. Honors an optional `applied_entelechy_override`: when io supplies it the
+     classifier prediction is still computed and logged, but the applied value is
+     the io-supplied override (override wins — AC-2).
+
+SCOPE GUARD (AC-5): This module is INFERENCE-ONLY. It performs NO model training,
+NO weight/parameter persistence, and NO governed graph mutation. There is no
+training loop here; the persistent-model-mutation arc (FTR-084 AC-3) is a
+deferred follow-on task pending io review. `INFERENCE_ONLY`/`TRAINING_ENABLED`
+below are asserted by the unit-test suite.
+
+OGTM note (AC-4): Phase 1 returns predictions inline and introduces NO new edge
+type, record type, or relational field. The Ontological Graph Traversability
+Mandate (ENC-FTR-066) therefore has nothing to validate for this task. A future
+phase that persists a PREDICTS edge from a session to its predicted records MUST
+complete all four OGTM gates (graph_sync reconcile + label map, graph_query_api
+_ALLOWED_EDGE_TYPES, and live E2E traversal) before advancing.
+
+Corpus sourcing: the canonical "Titan V2 nearest-neighbor" primitive
+(`cosine_similarity` + `rank_neighbors`) operates on a raw-embedding corpus of
+{record_id, embedding} pairs. In production the raw-embedding egress is the
+FTR-089 deliverable; until it lands, the default neighbor provider delegates the
+vector search to the already-deployed graph vector index via the graph_query_api
+hybrid endpoint. Both providers are pluggable so the classifier is fully unit
+testable without any network or AWS dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Contract constants (shared with graph_sync/embedding.py)
+# ---------------------------------------------------------------------------
+
+TITAN_MODEL_ID = "amazon.titan-embed-text-v2:0"
+EMBEDDING_DIMENSIONS = 256
+EMBEDDING_NORMALIZE = True
+BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-west-2")
+
+# Inference-only scope guard markers (asserted by the test suite — AC-5).
+INFERENCE_ONLY = True
+TRAINING_ENABLED = False
+
+# Default nearest-neighbor breadth.
+DEFAULT_TOP_K = 5
+MAX_TOP_K = 25
+MAX_INPUT_CHARS = 24_000
+
+# graph_query_api endpoint used by the default neighbor provider until the
+# FTR-089 raw-embedding egress lands. Empty => provider degrades to no neighbors
+# (the classifier never raises; session-init must never be blocked by inference).
+GRAPH_QUERY_API_URL = os.environ.get("GRAPH_QUERY_API_URL", "").strip()
+GRAPH_QUERY_API_TIMEOUT_S = float(os.environ.get("GRAPH_QUERY_API_TIMEOUT_S", "8"))
+
+_SSL_CTX = ssl.create_default_context()
+
+# Lazy bedrock-runtime client (cold-start cached).
+_bedrock_runtime = None
+
+
+# ---------------------------------------------------------------------------
+# Titan V2 embedding (default embed_fn)
+# ---------------------------------------------------------------------------
+
+def _get_bedrock_runtime():
+    global _bedrock_runtime
+    if _bedrock_runtime is None:
+        import boto3
+        from botocore.config import Config
+
+        _bedrock_runtime = boto3.client(
+            "bedrock-runtime",
+            region_name=BEDROCK_REGION,
+            config=Config(
+                retries={"max_attempts": 3, "mode": "standard"},
+                read_timeout=10,
+                connect_timeout=5,
+            ),
+        )
+    return _bedrock_runtime
+
+
+def embed_query_text(text: str) -> Optional[List[float]]:
+    """Embed query text with Titan V2 (256-dim, normalized). None on any failure.
+
+    Mirrors backend/lambda/graph_sync/embedding.py::invoke_titan_v2 so the query
+    vector is comparable to the governed corpus embeddings. Never raises.
+    """
+    if not text:
+        return None
+    text = text[:MAX_INPUT_CHARS]
+    try:
+        client = _get_bedrock_runtime()
+    except Exception:
+        logger.exception("[ERROR] intent_classifier: failed to build bedrock-runtime client")
+        return None
+
+    body = {
+        "inputText": text,
+        "dimensions": EMBEDDING_DIMENSIONS,
+        "normalize": EMBEDDING_NORMALIZE,
+    }
+    try:
+        resp = client.invoke_model(
+            modelId=TITAN_MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        payload = json.loads(resp["body"].read())
+    except Exception:
+        logger.exception("[ERROR] intent_classifier: Titan V2 invoke failed")
+        return None
+
+    embedding = payload.get("embedding")
+    if not isinstance(embedding, list) or len(embedding) != EMBEDDING_DIMENSIONS:
+        logger.error(
+            "[ERROR] intent_classifier: malformed Titan response (len=%s)",
+            len(embedding) if isinstance(embedding, list) else "n/a",
+        )
+        return None
+    return [float(x) for x in embedding]
+
+
+# ---------------------------------------------------------------------------
+# Nearest-neighbor primitives (canonical Titan V2 cosine NN — pure, testable)
+# ---------------------------------------------------------------------------
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity in [-1, 1]; 0.0 for degenerate/empty/mismatched inputs."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        xf = float(x)
+        yf = float(y)
+        dot += xf * yf
+        na += xf * xf
+        nb += yf * yf
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def _calibrate(cosine: float) -> float:
+    """Map cosine [-1, 1] to a [0, 1] similarity score."""
+    score = (cosine + 1.0) / 2.0
+    if score < 0.0:
+        return 0.0
+    if score > 1.0:
+        return 1.0
+    return score
+
+
+def rank_neighbors(
+    query_embedding: Sequence[float],
+    corpus: Sequence[Dict[str, Any]],
+    top_k: int = DEFAULT_TOP_K,
+) -> List[Dict[str, Any]]:
+    """Rank a raw-embedding corpus by cosine similarity to the query embedding.
+
+    `corpus` is a sequence of {"record_id": str, "embedding": [floats]} dicts.
+    Returns the top_k as [{"record_id", "similarity" (cosine), "score" ([0,1])}]
+    sorted by descending similarity. This is the canonical Titan V2
+    nearest-neighbor primitive (and the FTR-089 raw-egress consumption path).
+    """
+    if not query_embedding or top_k <= 0:
+        return []
+    scored: List[Dict[str, Any]] = []
+    for entry in corpus or []:
+        if not isinstance(entry, dict):
+            continue
+        rid = str(entry.get("record_id") or "").strip()
+        emb = entry.get("embedding")
+        if not rid or not isinstance(emb, (list, tuple)):
+            continue
+        cos = cosine_similarity(query_embedding, emb)
+        scored.append({"record_id": rid, "similarity": cos, "score": _calibrate(cos)})
+    scored.sort(key=lambda d: d["similarity"], reverse=True)
+    return scored[:top_k]
+
+
+def make_corpus_neighbor_provider(
+    corpus: Sequence[Dict[str, Any]],
+) -> Callable[[str, Optional[Sequence[float]], int, str], List[Dict[str, Any]]]:
+    """Build a neighbor provider backed by an in-memory raw-embedding corpus.
+
+    This is the production path once FTR-089 raw-embedding egress is wired, and
+    the path exercised by the unit tests. Requires a query embedding.
+    """
+
+    def _provider(
+        query_text: str,
+        query_embedding: Optional[Sequence[float]],
+        top_k: int,
+        project_id: str,
+    ) -> List[Dict[str, Any]]:
+        if not query_embedding:
+            return []
+        return [
+            {"record_id": n["record_id"], "score": n["score"]}
+            for n in rank_neighbors(query_embedding, corpus, top_k)
+        ]
+
+    return _provider
+
+
+def graph_query_hybrid_provider(
+    query_text: str,
+    query_embedding: Optional[Sequence[float]],
+    top_k: int,
+    project_id: str,
+) -> List[Dict[str, Any]]:
+    """Default neighbor provider: delegate vector NN to the deployed graph index.
+
+    Calls the graph_query_api hybrid search (which itself runs Titan V2 vector
+    nearest-neighbor over the governed corpus). Returns ranked
+    [{"record_id", "score"}] with scores min-max normalized to [0, 1]. Best
+    effort: any failure (unset URL, network, HTTP error) returns [] so that
+    session-init inference degrades gracefully and never raises.
+    """
+    if not GRAPH_QUERY_API_URL or not query_text:
+        return []
+    payload = {
+        "search_type": "hybrid",
+        "project_id": project_id,
+        "query": query_text,
+        "top_n": max(1, min(int(top_k or DEFAULT_TOP_K), MAX_TOP_K)),
+    }
+    try:
+        req = urllib.request.Request(
+            url=GRAPH_QUERY_API_URL,
+            method="POST",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=GRAPH_QUERY_API_TIMEOUT_S, context=_SSL_CTX) as resp:
+            body = json.loads(resp.read().decode("utf-8") or "{}")
+    except Exception as exc:  # noqa: BLE001 — best-effort inference, never raise
+        logger.warning("intent_classifier: graph_query hybrid neighbor lookup failed: %s", exc)
+        return []
+
+    nodes = body.get("nodes")
+    if not isinstance(nodes, list):
+        result = body.get("result") if isinstance(body.get("result"), dict) else {}
+        nodes = result.get("nodes") if isinstance(result, dict) else None
+    if not isinstance(nodes, list):
+        return []
+
+    raw: List[Tuple[str, float]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        rid = str(node.get("record_id") or node.get("id") or "").strip()
+        if not rid:
+            continue
+        score = node.get("_fused_score")
+        if score is None:
+            score = node.get("score")
+        try:
+            raw.append((rid, float(score)))
+        except (TypeError, ValueError):
+            raw.append((rid, 0.0))
+
+    if not raw:
+        return []
+    scores = [s for _, s in raw]
+    hi = max(scores)
+    lo = min(scores)
+    span = hi - lo
+    out: List[Dict[str, Any]] = []
+    for rid, s in raw[: max(1, min(int(top_k or DEFAULT_TOP_K), MAX_TOP_K))]:
+        norm = 1.0 if span <= 0 else (s - lo) / span
+        out.append({"record_id": rid, "score": norm})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Override normalization
+# ---------------------------------------------------------------------------
+
+def normalize_override(override: Any) -> Optional[List[str]]:
+    """Normalize an applied_entelechy_override into a list[str] of node_ids.
+
+    Accepts a list of ids, a single id string, or a dict carrying a
+    `node_ids` list. Returns None when no usable override is supplied (empty
+    list/str/dict all normalize to None so the classifier prediction is used).
+    """
+    if override is None:
+        return None
+    if isinstance(override, str):
+        rid = override.strip()
+        return [rid] if rid else None
+    if isinstance(override, dict):
+        return normalize_override(override.get("node_ids"))
+    if isinstance(override, (list, tuple)):
+        ids = [str(x).strip() for x in override if str(x).strip()]
+        return ids or None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Classifier entry point
+# ---------------------------------------------------------------------------
+
+def classify_session_intent(
+    first_turn_text: str,
+    session_metadata: Optional[Dict[str, Any]] = None,
+    *,
+    applied_entelechy_override: Any = None,
+    top_k: int = DEFAULT_TOP_K,
+    project_id: str = "enceladus",
+    embed_fn: Optional[Callable[[str], Optional[List[float]]]] = None,
+    neighbor_provider: Optional[
+        Callable[[str, Optional[Sequence[float]], int, str], List[Dict[str, Any]]]
+    ] = None,
+) -> Dict[str, Any]:
+    """Predict session-init intent (𝔈) and resolve the applied entelechy.
+
+    Returns a dict with:
+      predicted_entelechy: {node_ids: [str], confidence: float}  (always the
+        classifier's own prediction — logged even when overridden)
+      applied_entelechy:   {node_ids: [str], confidence: float, source: str}
+      override_applied:    bool
+      neighbors, query_embedding_dim, model_id, inference_only, ...
+
+    Pure-inference. `embed_fn` defaults to Titan V2; `neighbor_provider` defaults
+    to the graph_query_api hybrid vector search. Both are injectable for tests.
+    """
+    text = (first_turn_text or "").strip()
+    metadata = session_metadata if isinstance(session_metadata, dict) else {}
+    try:
+        top_k = int(top_k)
+    except (TypeError, ValueError):
+        top_k = DEFAULT_TOP_K
+    top_k = max(1, min(top_k, MAX_TOP_K))
+
+    embed = embed_fn or embed_query_text
+    provider = neighbor_provider or graph_query_hybrid_provider
+
+    query_embedding: Optional[List[float]] = None
+    if text:
+        try:
+            query_embedding = embed(text)
+        except Exception:  # noqa: BLE001 — inference must never raise upstream
+            logger.exception("[ERROR] intent_classifier: embed_fn raised")
+            query_embedding = None
+
+    neighbors: List[Dict[str, Any]] = []
+    if text:
+        try:
+            neighbors = provider(text, query_embedding, top_k, project_id) or []
+        except Exception:  # noqa: BLE001
+            logger.exception("[ERROR] intent_classifier: neighbor_provider raised")
+            neighbors = []
+
+    node_ids: List[str] = []
+    for n in neighbors:
+        rid = str((n or {}).get("record_id") or "").strip()
+        if rid and rid not in node_ids:
+            node_ids.append(rid)
+
+    confidence = 0.0
+    if neighbors:
+        try:
+            confidence = float(neighbors[0].get("score") or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = max(0.0, min(1.0, confidence))
+
+    predicted_entelechy = {"node_ids": node_ids, "confidence": round(confidence, 6)}
+
+    override_ids = normalize_override(applied_entelechy_override)
+    if override_ids is not None:
+        # io override wins; classifier prediction is computed + logged, not applied.
+        applied_entelechy = {
+            "node_ids": override_ids,
+            "confidence": 1.0,
+            "source": "io_override",
+        }
+        override_applied = True
+        logger.info(
+            "[INFO] intent_classifier: applied_entelechy_override active "
+            "(override=%s overrode predicted=%s)",
+            override_ids,
+            node_ids,
+        )
+    else:
+        applied_entelechy = {
+            "node_ids": list(node_ids),
+            "confidence": predicted_entelechy["confidence"],
+            "source": "classifier",
+        }
+        override_applied = False
+
+    return {
+        "predicted_entelechy": predicted_entelechy,
+        "applied_entelechy": applied_entelechy,
+        "override_applied": override_applied,
+        "neighbors": neighbors,
+        "query_embedding_dim": len(query_embedding) if query_embedding else 0,
+        "model_id": TITAN_MODEL_ID,
+        "project_id": project_id,
+        "inference_only": INFERENCE_ONLY,
+        "session_metadata_keys": sorted(metadata.keys()),
+    }

--- a/backend/lambda/coordination_api/intent_drift.py
+++ b/backend/lambda/coordination_api/intent_drift.py
@@ -1,0 +1,171 @@
+"""intent_drift.py — Wave-level intent-centroid drift telemetry (ENC-FTR-084 Phase 1, AC-3).
+
+ENC-TSK-I93. Computes a rolling intent vector per coordination wave as the mean
+of the Titan V2 embeddings (the FTR-089 raw-embedding egress) for the records
+dispatched in that wave, derives a scalar `intent_centroid_drift` (cosine
+distance between consecutive wave centroids), and best-effort persists that
+scalar into the `enceladus-drift-telemetry` table ALONGSIDE the FTR-087
+`d_centroid` field as a NEW, NULLABLE, BACKWARD-COMPATIBLE column.
+
+Backward-compatibility contract:
+  * The drift-telemetry table is owned by FTR-087 (Wave-Close Drift Telemetry),
+    which is still `planned`. This module therefore NEVER creates the table and
+    NEVER writes the FTR-087 `d_centroid` / `d_spectral` fields — it only SETs
+    the new `intent_centroid_drift` column (plus a timestamp). When the table or
+    env var is absent, persistence is a graceful no-op.
+  * `intent_centroid_drift` is nullable: the first wave (no previous centroid)
+    yields None, stored as a DynamoDB NULL, and readers must tolerate its
+    absence on pre-existing rows.
+
+Inference-only (AC-5): no training, no weight writes.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Owned by FTR-087; empty default => persistence no-ops until the table is
+# provisioned and the env var is set on the gamma stack.
+DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
+DRIFT_TELEMETRY_WAVE_KEY = os.environ.get("DRIFT_TELEMETRY_WAVE_KEY", "wave_id").strip() or "wave_id"
+
+# New nullable columns this task contributes (never overwrites FTR-087 fields).
+INTENT_CENTROID_DRIFT_ATTR = "intent_centroid_drift"
+INTENT_CENTROID_DRIFT_TS_ATTR = "intent_centroid_drift_updated_at"
+
+
+def compute_intent_centroid(
+    embeddings: Sequence[Sequence[float]],
+) -> Optional[List[float]]:
+    """Rolling intent vector for a wave = element-wise mean of the embeddings.
+
+    Returns the mean vector, or None when there are no usable embeddings.
+    Embeddings of inconsistent dimensionality are skipped defensively (the
+    dimension of the first valid embedding sets the expected width).
+    """
+    if not embeddings:
+        return None
+    accum: Optional[List[float]] = None
+    dim = 0
+    count = 0
+    for emb in embeddings:
+        if not isinstance(emb, (list, tuple)) or not emb:
+            continue
+        if accum is None:
+            dim = len(emb)
+            accum = [0.0] * dim
+        if len(emb) != dim:
+            continue
+        for i in range(dim):
+            try:
+                accum[i] += float(emb[i])
+            except (TypeError, ValueError):
+                accum = None
+                break
+        if accum is None:
+            return None
+        count += 1
+    if accum is None or count == 0:
+        return None
+    return [v / count for v in accum]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = na = nb = 0.0
+    for x, y in zip(a, b):
+        xf = float(x)
+        yf = float(y)
+        dot += xf * yf
+        na += xf * xf
+        nb += yf * yf
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def compute_intent_centroid_drift(
+    previous_centroid: Optional[Sequence[float]],
+    current_centroid: Optional[Sequence[float]],
+) -> Optional[float]:
+    """Cosine distance (1 - cosine similarity) between consecutive wave centroids.
+
+    Returns None when either centroid is missing (e.g. the first wave) — the
+    nullable, backward-compatible contract. Result is clamped to [0.0, 2.0].
+    """
+    if not previous_centroid or not current_centroid:
+        return None
+    if len(previous_centroid) != len(current_centroid):
+        return None
+    drift = 1.0 - _cosine(previous_centroid, current_centroid)
+    if drift < 0.0:
+        return 0.0
+    if drift > 2.0:
+        return 2.0
+    return drift
+
+
+def persist_intent_centroid_drift(
+    wave_id: str,
+    intent_centroid_drift: Optional[float],
+    *,
+    now_iso: str,
+    table_name: Optional[str] = None,
+    ddb: Any = None,
+) -> Dict[str, Any]:
+    """Best-effort write of the new nullable `intent_centroid_drift` column.
+
+    SETs only the new column (+ timestamp) on the wave's drift-telemetry item via
+    update_item, leaving any FTR-087 `d_centroid` / `d_spectral` attributes
+    untouched. Returns a status dict and NEVER raises: a missing table, missing
+    env var, key-schema mismatch, or access error degrades to
+    {"persisted": False, "reason": ...}.
+    """
+    table = (table_name or DRIFT_TELEMETRY_TABLE).strip()
+    if not table:
+        return {"persisted": False, "reason": "drift_telemetry_table_not_configured"}
+    wid = str(wave_id or "").strip()
+    if not wid:
+        return {"persisted": False, "reason": "missing_wave_id"}
+
+    if intent_centroid_drift is None:
+        drift_value: Dict[str, Any] = {"NULL": True}
+    else:
+        drift_value = {"N": repr(float(intent_centroid_drift))}
+
+    try:
+        if ddb is None:
+            from aws_clients import _get_ddb  # local import: keep module import-light
+
+            ddb = _get_ddb()
+        ddb.update_item(
+            TableName=table,
+            Key={DRIFT_TELEMETRY_WAVE_KEY: {"S": wid}},
+            UpdateExpression="SET #d = :d, #t = :t",
+            ExpressionAttributeNames={
+                "#d": INTENT_CENTROID_DRIFT_ATTR,
+                "#t": INTENT_CENTROID_DRIFT_TS_ATTR,
+            },
+            ExpressionAttributeValues={":d": drift_value, ":t": {"S": str(now_iso)}},
+        )
+        return {
+            "persisted": True,
+            "table": table,
+            "wave_id": wid,
+            "intent_centroid_drift": intent_centroid_drift,
+        }
+    except Exception as exc:  # noqa: BLE001 — telemetry is best-effort, never fatal
+        logger.warning(
+            "intent_drift: best-effort persist of intent_centroid_drift skipped "
+            "(table=%s wave=%s): %s",
+            table,
+            wid,
+            exc,
+        )
+        return {"persisted": False, "reason": "persist_failed", "error": str(exc)[:300]}

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -60,6 +60,20 @@ except ModuleNotFoundError:
     _MCP_SPEC.loader.exec_module(_MCP_MODULE)
     CoordinationMcpClient = _MCP_MODULE.CoordinationMcpClient
 
+# ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier + drift.
+try:
+    import intent_classifier as _intent_classifier
+    import intent_drift as _intent_drift
+except ModuleNotFoundError:  # pragma: no cover - packaging fallback
+    _IC_PATH = pathlib.Path(__file__).with_name("intent_classifier.py")
+    _IC_SPEC = importlib.util.spec_from_file_location("intent_classifier", _IC_PATH)
+    _intent_classifier = importlib.util.module_from_spec(_IC_SPEC)  # type: ignore[arg-type]
+    _IC_SPEC.loader.exec_module(_intent_classifier)  # type: ignore[union-attr]
+    _ID_PATH = pathlib.Path(__file__).with_name("intent_drift.py")
+    _ID_SPEC = importlib.util.spec_from_file_location("intent_drift", _ID_PATH)
+    _intent_drift = importlib.util.module_from_spec(_ID_SPEC)  # type: ignore[arg-type]
+    _ID_SPEC.loader.exec_module(_intent_drift)  # type: ignore[union-attr]
+
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
@@ -340,6 +354,9 @@ CALLBACK_SQS_QUEUE_URL = os.environ.get("CALLBACK_SQS_QUEUE_URL", "")
 CALLBACK_EVENT_SOURCE = os.environ.get("CALLBACK_EVENT_SOURCE", "enceladus.coordination")
 CALLBACK_EVENT_DETAIL_TYPE = os.environ.get("CALLBACK_EVENT_DETAIL_TYPE", "coordination.callback")
 FEED_SUBSCRIPTIONS_TABLE = os.environ.get("FEED_SUBSCRIPTIONS_TABLE", "feed-subscriptions")
+# ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier config.
+GRAPH_QUERY_API_URL = os.environ.get("GRAPH_QUERY_API_URL", "").strip()
+DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
 FEED_PUSH_DEFAULT_EVENT_BUS = os.environ.get("FEED_PUSH_DEFAULT_EVENT_BUS", "default")
 FEED_PUSH_HTTP_TIMEOUT_SECONDS = float(os.environ.get("FEED_PUSH_HTTP_TIMEOUT_SECONDS", "5"))
 MCP_CONNECTIVITY_BACKOFF_SECONDS = (10, 30, 60)
@@ -13813,6 +13830,119 @@ def _handle_chat_message(
 
 
 # ---------------------------------------------------------------------------
+# ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier
+# ---------------------------------------------------------------------------
+
+
+def _handle_session_init_classify_intent(
+    event: Dict[str, Any], claims: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/session-init/classify-intent (ENC-FTR-084 Ph1).
+
+    Accepts the first-turn request text + session metadata and returns the
+    predicted_entelechy {node_ids, confidence} via Titan V2 nearest-neighbor
+    inference. Honors applied_entelechy_override (override wins; the classifier
+    prediction is still computed and logged). Inference-only: no governed
+    mutation, no training, no weight writes.
+    """
+    try:
+        raw_body = event.get("body") or "{}"
+        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
+    except (json.JSONDecodeError, TypeError):
+        return _error(400, "Invalid JSON body")
+    if not isinstance(body, dict):
+        return _error(400, "Request body must be a JSON object")
+
+    first_turn_text = str(body.get("first_turn_text") or body.get("request_text") or "").strip()
+    if not first_turn_text:
+        return _error(400, "Missing required field: first_turn_text")
+
+    session_metadata = body.get("session_metadata")
+    if session_metadata is not None and not isinstance(session_metadata, dict):
+        return _error(400, "'session_metadata' must be an object when provided")
+
+    project_id = str(body.get("project_id") or "enceladus").strip() or "enceladus"
+    top_k = body.get("top_k", _intent_classifier.DEFAULT_TOP_K)
+
+    try:
+        result = _intent_classifier.classify_session_intent(
+            first_turn_text,
+            session_metadata or {},
+            applied_entelechy_override=body.get("applied_entelechy_override"),
+            top_k=top_k,
+            project_id=project_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — inference must never 500 session-init
+        logger.exception("session-init classify-intent failed")
+        return _error(500, f"Intent classification failed: {exc}")
+
+    return _response(200, {"success": True, **result})
+
+
+def _handle_session_init_intent_drift(
+    event: Dict[str, Any], claims: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/session-init/intent-centroid-drift (ENC-FTR-084 Ph1, AC-3).
+
+    Computes the rolling intent vector for a wave (mean of the supplied FTR-089
+    embeddings for dispatched records), derives the scalar intent_centroid_drift
+    against the previous wave centroid, and best-effort persists that new nullable
+    column into enceladus-drift-telemetry alongside the FTR-087 d_centroid field.
+    """
+    try:
+        raw_body = event.get("body") or "{}"
+        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
+    except (json.JSONDecodeError, TypeError):
+        return _error(400, "Invalid JSON body")
+    if not isinstance(body, dict):
+        return _error(400, "Request body must be a JSON object")
+
+    wave_id = str(body.get("wave_id") or "").strip()
+    if not wave_id:
+        return _error(400, "Missing required field: wave_id")
+
+    embeddings = body.get("embeddings") or body.get("dispatched_record_embeddings") or []
+    if not isinstance(embeddings, list):
+        return _error(400, "'embeddings' must be a list of embedding vectors")
+
+    previous_centroid = body.get("previous_centroid")
+    if previous_centroid is not None and not isinstance(previous_centroid, list):
+        return _error(400, "'previous_centroid' must be a list when provided")
+
+    persist = body.get("persist", True)
+
+    try:
+        centroid = _intent_drift.compute_intent_centroid(embeddings)
+        drift = _intent_drift.compute_intent_centroid_drift(previous_centroid, centroid)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("intent-centroid-drift computation failed")
+        return _error(500, f"Centroid drift computation failed: {exc}")
+
+    persistence: Dict[str, Any] = {"persisted": False, "reason": "persist_disabled"}
+    if persist:
+        now_iso = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        persistence = _intent_drift.persist_intent_centroid_drift(
+            wave_id,
+            drift,
+            now_iso=now_iso,
+            table_name=DRIFT_TELEMETRY_TABLE or None,
+            ddb=_get_ddb(),
+        )
+
+    return _response(
+        200,
+        {
+            "success": True,
+            "wave_id": wave_id,
+            "intent_centroid_dim": len(centroid) if centroid else 0,
+            "intent_centroid_drift": drift,
+            "record_count": len([e for e in embeddings if isinstance(e, (list, tuple)) and e]),
+            "persistence": persistence,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main Lambda handler
 # ---------------------------------------------------------------------------
 
@@ -14056,5 +14186,13 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     if method == "POST" and match_session_msg:
         session_id = match_session_msg.group(1)
         return _handle_chat_message(event, session_id, claims or {})
+
+    # POST /api/v1/coordination/session-init/classify-intent (ENC-FTR-084 Ph1 / ENC-TSK-I93)
+    if method == "POST" and path == "/api/v1/coordination/session-init/classify-intent":
+        return _handle_session_init_classify_intent(event, claims or {})
+
+    # POST /api/v1/coordination/session-init/intent-centroid-drift (ENC-FTR-084 Ph1, AC-3)
+    if method == "POST" and path == "/api/v1/coordination/session-init/intent-centroid-drift":
+        return _handle_session_init_intent_drift(event, claims or {})
 
     return _error(404, f"Unsupported route: {method} {path}")

--- a/backend/lambda/coordination_api/test_intent_classifier.py
+++ b/backend/lambda/coordination_api/test_intent_classifier.py
@@ -1,0 +1,273 @@
+"""Tests for intent_classifier (ENC-FTR-084 Phase 1 / ENC-TSK-I93).
+
+Covers:
+  AC-1: classifier returns predicted_entelechy {node_ids: list[str], confidence: float}
+        via Titan V2 nearest-neighbor inference — verified with 3 synthetic
+        session-init payloads.
+  AC-2: applied_entelechy_override wins; the classifier prediction is still
+        computed and logged.
+  AC-5: scope guard — module is inference-only (no training / weight-write path).
+
+Pure-function tests: no AWS, no network (providers + embeddings injected).
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "intent_classifier",
+    os.path.join(os.path.dirname(__file__), "intent_classifier.py"),
+)
+ic = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = ic
+_SPEC.loader.exec_module(ic)
+
+
+# A tiny synthetic 4-dim corpus with clearly separable directions so cosine
+# nearest-neighbor is deterministic. Titan V2 produces normalized 256-dim
+# vectors in production; the math is dimension-agnostic.
+_CORPUS = [
+    {"record_id": "ENC-TSK-A", "embedding": [1.0, 0.0, 0.0, 0.0]},
+    {"record_id": "ENC-TSK-B", "embedding": [0.0, 1.0, 0.0, 0.0]},
+    {"record_id": "ENC-TSK-C", "embedding": [0.0, 0.0, 1.0, 0.0]},
+    {"record_id": "ENC-DOC-D", "embedding": [0.0, 0.0, 0.0, 1.0]},
+]
+
+
+class CosineTests(unittest.TestCase):
+    def test_identical_vectors_similarity_one(self):
+        self.assertAlmostEqual(ic.cosine_similarity([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]), 1.0, places=6)
+
+    def test_orthogonal_vectors_similarity_zero(self):
+        self.assertAlmostEqual(ic.cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0, places=6)
+
+    def test_degenerate_inputs(self):
+        self.assertEqual(ic.cosine_similarity([], [1.0]), 0.0)
+        self.assertEqual(ic.cosine_similarity([0.0, 0.0], [0.0, 0.0]), 0.0)
+        self.assertEqual(ic.cosine_similarity([1.0, 2.0], [1.0]), 0.0)
+
+
+class RankNeighborsTests(unittest.TestCase):
+    def test_ranks_by_similarity_descending(self):
+        q = [0.9, 0.1, 0.0, 0.0]  # closest to ENC-TSK-A
+        ranked = ic.rank_neighbors(q, _CORPUS, top_k=4)
+        self.assertEqual(ranked[0]["record_id"], "ENC-TSK-A")
+        sims = [r["similarity"] for r in ranked]
+        self.assertEqual(sims, sorted(sims, reverse=True))
+        # calibrated score in [0, 1]
+        for r in ranked:
+            self.assertGreaterEqual(r["score"], 0.0)
+            self.assertLessEqual(r["score"], 1.0)
+
+    def test_top_k_limits_results(self):
+        ranked = ic.rank_neighbors([1.0, 0.0, 0.0, 0.0], _CORPUS, top_k=2)
+        self.assertEqual(len(ranked), 2)
+
+    def test_empty_query_returns_empty(self):
+        self.assertEqual(ic.rank_neighbors([], _CORPUS, top_k=3), [])
+
+
+class ClassifyAC1Tests(unittest.TestCase):
+    """AC-1: predicted_entelechy shape + 3 synthetic session-init payloads."""
+
+    def _embed(self, text):
+        # Deterministic synthetic embedding keyed on the dominant token so each
+        # payload resolves to a distinct nearest neighbor.
+        mapping = {
+            "alpha": [1.0, 0.0, 0.0, 0.0],
+            "beta": [0.0, 1.0, 0.0, 0.0],
+            "gamma": [0.0, 0.0, 1.0, 0.0],
+        }
+        for token, vec in mapping.items():
+            if token in text.lower():
+                return vec
+        return [0.0, 0.0, 0.0, 1.0]
+
+    def _provider(self):
+        return ic.make_corpus_neighbor_provider(_CORPUS)
+
+    def test_predicted_entelechy_shape(self):
+        result = ic.classify_session_intent(
+            "please work on the alpha refactor",
+            {"surface": "cursor-cloud-agent"},
+            embed_fn=self._embed,
+            neighbor_provider=self._provider(),
+            top_k=3,
+        )
+        pe = result["predicted_entelechy"]
+        self.assertIn("node_ids", pe)
+        self.assertIn("confidence", pe)
+        self.assertIsInstance(pe["node_ids"], list)
+        self.assertTrue(all(isinstance(x, str) for x in pe["node_ids"]))
+        self.assertIsInstance(pe["confidence"], float)
+        self.assertGreaterEqual(pe["confidence"], 0.0)
+        self.assertLessEqual(pe["confidence"], 1.0)
+        self.assertEqual(pe["node_ids"][0], "ENC-TSK-A")
+        self.assertEqual(result["model_id"], ic.TITAN_MODEL_ID)
+        self.assertTrue(result["inference_only"])
+
+    def test_three_synthetic_session_init_payloads(self):
+        payloads = [
+            ("kick off the alpha migration", "ENC-TSK-A"),
+            ("investigate the beta regression", "ENC-TSK-B"),
+            ("document the gamma rollout", "ENC-TSK-C"),
+        ]
+        for text, expected_top in payloads:
+            with self.subTest(text=text):
+                result = ic.classify_session_intent(
+                    text,
+                    {"surface": "claude.ai-webui"},
+                    embed_fn=self._embed,
+                    neighbor_provider=self._provider(),
+                    top_k=2,
+                )
+                pe = result["predicted_entelechy"]
+                self.assertEqual(pe["node_ids"][0], expected_top)
+                self.assertGreater(pe["confidence"], 0.5)
+                self.assertFalse(result["override_applied"])
+
+    def test_missing_text_yields_empty_prediction(self):
+        result = ic.classify_session_intent(
+            "",
+            {},
+            embed_fn=self._embed,
+            neighbor_provider=self._provider(),
+        )
+        self.assertEqual(result["predicted_entelechy"]["node_ids"], [])
+        self.assertEqual(result["predicted_entelechy"]["confidence"], 0.0)
+
+
+class OverrideAC2Tests(unittest.TestCase):
+    """AC-2: io override wins; classifier prediction still computed + logged."""
+
+    def _embed(self, text):
+        return [1.0, 0.0, 0.0, 0.0]  # always nearest to ENC-TSK-A
+
+    def _provider(self):
+        return ic.make_corpus_neighbor_provider(_CORPUS)
+
+    def test_override_wins_over_prediction(self):
+        result = ic.classify_session_intent(
+            "alpha work",
+            {},
+            applied_entelechy_override=["ENC-TSK-OVERRIDE-1", "ENC-TSK-OVERRIDE-2"],
+            embed_fn=self._embed,
+            neighbor_provider=self._provider(),
+        )
+        # Applied value is the io override.
+        self.assertTrue(result["override_applied"])
+        self.assertEqual(
+            result["applied_entelechy"]["node_ids"],
+            ["ENC-TSK-OVERRIDE-1", "ENC-TSK-OVERRIDE-2"],
+        )
+        self.assertEqual(result["applied_entelechy"]["source"], "io_override")
+        # The classifier prediction is STILL computed (logged), and differs.
+        self.assertEqual(result["predicted_entelechy"]["node_ids"][0], "ENC-TSK-A")
+        self.assertNotEqual(
+            result["applied_entelechy"]["node_ids"],
+            result["predicted_entelechy"]["node_ids"],
+        )
+
+    def test_override_accepts_dict_and_string_forms(self):
+        as_dict = ic.classify_session_intent(
+            "alpha", {}, applied_entelechy_override={"node_ids": ["X-1"]},
+            embed_fn=self._embed, neighbor_provider=self._provider(),
+        )
+        self.assertEqual(as_dict["applied_entelechy"]["node_ids"], ["X-1"])
+
+        as_str = ic.classify_session_intent(
+            "alpha", {}, applied_entelechy_override="X-9",
+            embed_fn=self._embed, neighbor_provider=self._provider(),
+        )
+        self.assertEqual(as_str["applied_entelechy"]["node_ids"], ["X-9"])
+
+    def test_empty_override_falls_back_to_classifier(self):
+        for empty in ([], "", {}, {"node_ids": []}, None):
+            with self.subTest(empty=empty):
+                result = ic.classify_session_intent(
+                    "alpha", {}, applied_entelechy_override=empty,
+                    embed_fn=self._embed, neighbor_provider=self._provider(),
+                )
+                self.assertFalse(result["override_applied"])
+                self.assertEqual(result["applied_entelechy"]["source"], "classifier")
+                self.assertEqual(
+                    result["applied_entelechy"]["node_ids"],
+                    result["predicted_entelechy"]["node_ids"],
+                )
+
+    def test_normalize_override_helper(self):
+        self.assertIsNone(ic.normalize_override(None))
+        self.assertIsNone(ic.normalize_override([]))
+        self.assertIsNone(ic.normalize_override("  "))
+        self.assertEqual(ic.normalize_override("ENC-TSK-1"), ["ENC-TSK-1"])
+        self.assertEqual(ic.normalize_override(["a", " b ", ""]), ["a", "b"])
+        self.assertEqual(ic.normalize_override({"node_ids": ["z"]}), ["z"])
+
+
+class ScopeGuardAC5Tests(unittest.TestCase):
+    """AC-5: the classifier is inference-only — no training / weight writes."""
+
+    def test_inference_only_markers(self):
+        self.assertTrue(ic.INFERENCE_ONLY)
+        self.assertFalse(ic.TRAINING_ENABLED)
+
+    def test_no_training_or_weight_write_callables(self):
+        # Inspect callable (function) symbols only; the TRAINING_ENABLED marker
+        # constant is intentionally present (and asserted False above).
+        forbidden = ("train", "fit", "backprop", "gradient", "save_weight", "update_weight")
+        callables = [
+            n.lower()
+            for n in dir(ic)
+            if callable(getattr(ic, n)) and not n.startswith("__")
+        ]
+        for bad in forbidden:
+            self.assertFalse(
+                any(bad in n for n in callables),
+                msg=f"intent_classifier must not expose a '{bad}' callable (inference-only)",
+            )
+
+    def test_classify_performs_no_aws_calls(self):
+        # With injected providers the classifier must not touch boto3 at all.
+        sentinel = {"called": False}
+
+        def _embed(_text):
+            return [1.0, 0.0, 0.0, 0.0]
+
+        def _provider(_t, _e, _k, _p):
+            return [{"record_id": "ENC-TSK-A", "score": 0.9}]
+
+        orig = ic._get_bedrock_runtime
+
+        def _boom():
+            sentinel["called"] = True
+            raise AssertionError("bedrock must not be invoked when providers are injected")
+
+        ic._get_bedrock_runtime = _boom
+        try:
+            result = ic.classify_session_intent(
+                "alpha", {}, embed_fn=_embed, neighbor_provider=_provider
+            )
+        finally:
+            ic._get_bedrock_runtime = orig
+        self.assertFalse(sentinel["called"])
+        self.assertEqual(result["predicted_entelechy"]["node_ids"], ["ENC-TSK-A"])
+
+
+class HybridProviderDegradationTests(unittest.TestCase):
+    def test_unset_url_returns_no_neighbors(self):
+        orig = ic.GRAPH_QUERY_API_URL
+        ic.GRAPH_QUERY_API_URL = ""
+        try:
+            self.assertEqual(
+                ic.graph_query_hybrid_provider("alpha", [1.0, 0.0], 5, "enceladus"), []
+            )
+        finally:
+            ic.GRAPH_QUERY_API_URL = orig
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_intent_classifier.py
+++ b/backend/lambda/coordination_api/test_intent_classifier.py
@@ -271,3 +271,4 @@ class HybridProviderDegradationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/backend/lambda/coordination_api/test_intent_drift.py
+++ b/backend/lambda/coordination_api/test_intent_drift.py
@@ -1,0 +1,120 @@
+"""Tests for intent_drift (ENC-FTR-084 Phase 1, AC-3 / ENC-TSK-I93).
+
+Covers:
+  AC-3: rolling intent vector per wave = mean of FTR-089 embeddings; scalar
+        intent_centroid_drift; best-effort persistence of the new nullable
+        column into enceladus-drift-telemetry (no-op when table absent;
+        FTR-087 d_centroid never touched).
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "intent_drift",
+    os.path.join(os.path.dirname(__file__), "intent_drift.py"),
+)
+idr = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = idr
+_SPEC.loader.exec_module(idr)
+
+
+class CentroidTests(unittest.TestCase):
+    def test_mean_of_embeddings(self):
+        c = idr.compute_intent_centroid([[1.0, 0.0], [0.0, 2.0], [2.0, 4.0]])
+        self.assertEqual(c, [1.0, 2.0])
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(idr.compute_intent_centroid([]))
+        self.assertIsNone(idr.compute_intent_centroid([[], None]))
+
+    def test_mismatched_dims_skipped(self):
+        # First valid embedding sets width=2; the 3-dim entry is skipped.
+        c = idr.compute_intent_centroid([[2.0, 2.0], [1.0, 2.0, 3.0], [4.0, 6.0]])
+        self.assertEqual(c, [3.0, 4.0])
+
+
+class DriftTests(unittest.TestCase):
+    def test_none_when_previous_missing(self):
+        self.assertIsNone(idr.compute_intent_centroid_drift(None, [1.0, 0.0]))
+        self.assertIsNone(idr.compute_intent_centroid_drift([], [1.0, 0.0]))
+
+    def test_identical_centroids_zero_drift(self):
+        self.assertAlmostEqual(
+            idr.compute_intent_centroid_drift([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]), 0.0, places=6
+        )
+
+    def test_orthogonal_centroids_unit_drift(self):
+        self.assertAlmostEqual(
+            idr.compute_intent_centroid_drift([1.0, 0.0], [0.0, 1.0]), 1.0, places=6
+        )
+
+    def test_mismatched_dims_returns_none(self):
+        self.assertIsNone(idr.compute_intent_centroid_drift([1.0, 0.0], [1.0, 0.0, 0.0]))
+
+
+class _FakeDDB:
+    def __init__(self, raises=None):
+        self.calls = []
+        self._raises = raises
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises:
+            raise self._raises
+        return {"Attributes": {}}
+
+
+class PersistTests(unittest.TestCase):
+    def test_noop_when_table_not_configured(self):
+        out = idr.persist_intent_centroid_drift(
+            "WAVE-1", 0.25, now_iso="2026-06-28T00:00:00Z", table_name="", ddb=_FakeDDB()
+        )
+        self.assertFalse(out["persisted"])
+        self.assertEqual(out["reason"], "drift_telemetry_table_not_configured")
+
+    def test_noop_when_wave_id_missing(self):
+        out = idr.persist_intent_centroid_drift(
+            "", 0.25, now_iso="2026-06-28T00:00:00Z", table_name="t", ddb=_FakeDDB()
+        )
+        self.assertFalse(out["persisted"])
+        self.assertEqual(out["reason"], "missing_wave_id")
+
+    def test_writes_only_new_column_with_numeric_value(self):
+        ddb = _FakeDDB()
+        out = idr.persist_intent_centroid_drift(
+            "WAVE-7", 0.5, now_iso="2026-06-28T00:00:00Z",
+            table_name="enceladus-drift-telemetry-gamma", ddb=ddb,
+        )
+        self.assertTrue(out["persisted"])
+        self.assertEqual(len(ddb.calls), 1)
+        call = ddb.calls[0]
+        # Only the new column + its timestamp are written; FTR-087 fields untouched.
+        self.assertIn("intent_centroid_drift", call["ExpressionAttributeNames"].values())
+        self.assertEqual(call["ExpressionAttributeValues"][":d"], {"N": repr(0.5)})
+        self.assertEqual(call["Key"], {"wave_id": {"S": "WAVE-7"}})
+        self.assertNotIn("d_centroid", str(call["UpdateExpression"]))
+
+    def test_null_value_when_drift_none(self):
+        ddb = _FakeDDB()
+        out = idr.persist_intent_centroid_drift(
+            "WAVE-8", None, now_iso="2026-06-28T00:00:00Z", table_name="t", ddb=ddb,
+        )
+        self.assertTrue(out["persisted"])
+        self.assertEqual(ddb.calls[0]["ExpressionAttributeValues"][":d"], {"NULL": True})
+
+    def test_persist_failure_is_best_effort(self):
+        ddb = _FakeDDB(raises=RuntimeError("ResourceNotFoundException"))
+        out = idr.persist_intent_centroid_drift(
+            "WAVE-9", 0.1, now_iso="2026-06-28T00:00:00Z", table_name="missing", ddb=ddb,
+        )
+        self.assertFalse(out["persisted"])
+        self.assertEqual(out["reason"], "persist_failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_session_init_intent.py
+++ b/backend/lambda/coordination_api/test_session_init_intent.py
@@ -1,0 +1,128 @@
+"""Handler/route tests for the session-init intent classifier (ENC-TSK-I93).
+
+Exercises the coordination_api HTTP handlers end-to-end (request validation,
+override passthrough, drift persistence wiring) with the classifier/drift
+modules stubbed so no AWS/network is touched.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+cl = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = cl
+_SPEC.loader.exec_module(cl)
+
+
+def _event(body):
+    return {"body": json.dumps(body), "headers": {}, "requestContext": {}}
+
+
+class ClassifyIntentHandlerTests(unittest.TestCase):
+    def test_missing_text_returns_400(self):
+        resp = cl._handle_session_init_classify_intent(_event({"session_metadata": {}}), {})
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_bad_session_metadata_returns_400(self):
+        resp = cl._handle_session_init_classify_intent(
+            _event({"first_turn_text": "hi", "session_metadata": "nope"}), {}
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_happy_path_passes_through_and_returns_200(self):
+        fake = {
+            "predicted_entelechy": {"node_ids": ["ENC-TSK-A"], "confidence": 0.9},
+            "applied_entelechy": {"node_ids": ["ENC-TSK-A"], "confidence": 0.9, "source": "classifier"},
+            "override_applied": False,
+            "neighbors": [{"record_id": "ENC-TSK-A", "score": 0.9}],
+            "query_embedding_dim": 256,
+            "model_id": "amazon.titan-embed-text-v2:0",
+            "inference_only": True,
+        }
+        with mock.patch.object(
+            cl._intent_classifier, "classify_session_intent", return_value=fake
+        ) as m:
+            resp = cl._handle_session_init_classify_intent(
+                _event(
+                    {
+                        "first_turn_text": "work on the alpha migration",
+                        "session_metadata": {"surface": "cursor-cloud-agent"},
+                        "applied_entelechy_override": ["ENC-TSK-Z"],
+                        "top_k": 4,
+                        "project_id": "enceladus",
+                    }
+                ),
+                {},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        self.assertEqual(body["predicted_entelechy"]["node_ids"], ["ENC-TSK-A"])
+        # Handler forwards override + top_k + project_id to the classifier.
+        _, kwargs = m.call_args
+        self.assertEqual(kwargs["applied_entelechy_override"], ["ENC-TSK-Z"])
+        self.assertEqual(kwargs["top_k"], 4)
+        self.assertEqual(kwargs["project_id"], "enceladus")
+
+
+class IntentDriftHandlerTests(unittest.TestCase):
+    def test_missing_wave_id_returns_400(self):
+        resp = cl._handle_session_init_intent_drift(_event({"embeddings": [[1.0, 0.0]]}), {})
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_computes_drift_and_persists(self):
+        captured = {}
+
+        def _fake_persist(wave_id, drift, *, now_iso, table_name=None, ddb=None):
+            captured["wave_id"] = wave_id
+            captured["drift"] = drift
+            return {"persisted": True, "table": "t", "wave_id": wave_id, "intent_centroid_drift": drift}
+
+        with mock.patch.object(cl._intent_drift, "persist_intent_centroid_drift", _fake_persist), \
+             mock.patch.object(cl, "_get_ddb", return_value=object()):
+            resp = cl._handle_session_init_intent_drift(
+                _event(
+                    {
+                        "wave_id": "WAVE-42",
+                        "embeddings": [[1.0, 0.0], [1.0, 0.0]],
+                        "previous_centroid": [0.0, 1.0],
+                        "persist": True,
+                    }
+                ),
+                {},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["wave_id"], "WAVE-42")
+        self.assertEqual(body["record_count"], 2)
+        # current centroid [1,0] vs previous [0,1] => cosine 0 => drift 1.0
+        self.assertAlmostEqual(body["intent_centroid_drift"], 1.0, places=6)
+        self.assertTrue(body["persistence"]["persisted"])
+        self.assertEqual(captured["wave_id"], "WAVE-42")
+
+    def test_persist_disabled_skips_write(self):
+        with mock.patch.object(cl._intent_drift, "persist_intent_centroid_drift") as m:
+            resp = cl._handle_session_init_intent_drift(
+                _event({"wave_id": "WAVE-1", "embeddings": [[1.0, 0.0]], "persist": False}), {}
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        m.assert_not_called()
+        body = json.loads(resp["body"])
+        # First wave (no previous centroid) => nullable drift.
+        self.assertIsNone(body["intent_centroid_drift"])
+        self.assertFalse(body["persistence"]["persisted"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -4827,6 +4827,77 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="coordination_classify_intent",
+            description=(
+                "Session-init intent classifier (ENC-FTR-084 Ph1). Embeds the "
+                "first-turn request text via Titan V2 and returns predicted_entelechy "
+                "{node_ids, confidence}. Optional applied_entelechy_override wins over "
+                "the prediction (which is still computed + logged). Inference-only."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "first_turn_text": {
+                        "type": "string",
+                        "description": "The first-turn request text to classify.",
+                    },
+                    "session_metadata": {
+                        "type": "object",
+                        "description": "Optional session metadata (surface, model, etc.).",
+                    },
+                    "applied_entelechy_override": {
+                        "description": "Optional io override: list of node_ids, a single id, or {node_ids:[...]}. When present it overrides the prediction.",
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Nearest-neighbor breadth (default 5, max 25).",
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Project scope for the corpus (default 'enceladus').",
+                    },
+                },
+                "required": ["first_turn_text"],
+            },
+        ),
+        Tool(
+            name="coordination_intent_centroid_drift",
+            description=(
+                "Wave intent-centroid drift telemetry (ENC-FTR-084 Ph1, AC-3). Computes "
+                "the rolling intent vector (mean of FTR-089 embeddings for dispatched "
+                "records) and the scalar intent_centroid_drift vs the previous wave "
+                "centroid, best-effort persisted to enceladus-drift-telemetry."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "wave_id": {
+                        "type": "string",
+                        "description": "The coordination wave identifier.",
+                    },
+                    "embeddings": {
+                        "type": "array",
+                        "description": "List of embedding vectors for the records dispatched in this wave.",
+                        "items": {"type": "array", "items": {"type": "number"}},
+                    },
+                    "previous_centroid": {
+                        "type": "array",
+                        "description": "Optional previous wave centroid vector (drift is null without it).",
+                        "items": {"type": "number"},
+                    },
+                    "persist": {
+                        "type": "boolean",
+                        "description": "Best-effort persist the new intent_centroid_drift column (default true).",
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Project scope (default 'enceladus').",
+                    },
+                },
+                "required": ["wave_id"],
+            },
+        ),
+        Tool(
             name="coordination_cognito_session",
             description=(
                 "Create a Cognito-authenticated cookie bundle for terminal diagnostics "
@@ -7529,6 +7600,9 @@ _COORDINATION_ACTIONS: Dict[str, Dict[str, Any]] = {
     "auth.cognito_session": {"tool": "coordination_cognito_session"},
     "dispatch_plan.generate": {"tool": "dispatch_plan_generate"},
     "dispatch_plan.dry_run": {"tool": "dispatch_plan_dry_run"},
+    # ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier.
+    "session.classify_intent": {"tool": "coordination_classify_intent"},
+    "session.intent_centroid_drift": {"tool": "coordination_intent_centroid_drift"},
 }
 
 _EXECUTE_ACTIONS: Dict[str, Dict[str, Any]] = {
@@ -8792,6 +8866,45 @@ async def _coordination_cognito_session(args: dict) -> list[TextContent]:
         payload["include_tokens"] = bool(args.get("include_tokens"))
 
     result = _coordination_api_request("POST", "/auth/cognito/session", payload=payload)
+    return _result_text(result)
+
+
+async def _coordination_classify_intent(args: dict) -> list[TextContent]:
+    """Session-init intent classification (ENC-FTR-084 Ph1 / ENC-TSK-I93).
+
+    Embeds the first-turn text via Titan V2 and returns predicted_entelechy
+    {node_ids, confidence}. Honors applied_entelechy_override (override wins;
+    the prediction is still computed + logged). Inference-only.
+    """
+    payload: Dict[str, Any] = {}
+    for key in (
+        "first_turn_text",
+        "request_text",
+        "session_metadata",
+        "applied_entelechy_override",
+        "top_k",
+        "project_id",
+    ):
+        if key in args and args[key] is not None:
+            payload[key] = args[key]
+    result = _coordination_api_request("POST", "/session-init/classify-intent", payload=payload)
+    return _result_text(result)
+
+
+async def _coordination_intent_centroid_drift(args: dict) -> list[TextContent]:
+    """Wave intent-centroid drift telemetry (ENC-FTR-084 Ph1, AC-3 / ENC-TSK-I93)."""
+    payload: Dict[str, Any] = {}
+    for key in (
+        "wave_id",
+        "embeddings",
+        "dispatched_record_embeddings",
+        "previous_centroid",
+        "persist",
+        "project_id",
+    ):
+        if key in args and args[key] is not None:
+            payload[key] = args[key]
+    result = _coordination_api_request("POST", "/session-init/intent-centroid-drift", payload=payload)
     return _result_text(result)
 
 
@@ -10352,6 +10465,8 @@ _TOOL_HANDLERS = {
     "coordination_capabilities": _coordination_capabilities,
     "coordination_request_get": _coordination_request_get,
     "coordination_cognito_session": _coordination_cognito_session,
+    "coordination_classify_intent": _coordination_classify_intent,
+    "coordination_intent_centroid_drift": _coordination_intent_centroid_drift,
     "governance_update": _governance_update,
     "governance_hash": _governance_hash,
     "governance_get": _governance_get,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Task

- **task_id:** ENC-TSK-I93 (ENC-FTR-084 Phase 1)
- **transition_type:** github_pr_deploy
- **deploy target:** v4/main (gamma) only — v3-prod is FROZEN (DOC-499FA089EC30); this PR never targets `main` and performs no deploy.
- **commit-complete-id (CCI):** `CCI-2899e9188cac4290adb89ed817cd10f8`
- **commit_approval_id (CAI):** `CAI-a0f994f1520f4779995a7b8eae27be5e` (consumed)
- **commit_sha:** `14669b5b3c2bde65b7e3fb21b654ba62deb302cf`
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`

## Summary

Inference-only session-init proactive intent classifier for `coordination_api`.

- **`intent_classifier.py`** — embeds the first-turn request text with `amazon.titan-embed-text-v2:0` (256-dim, normalized; same contract as `graph_sync/embedding.py`) and returns `predicted_entelechy = {node_ids: list[str], confidence: float}` via cosine nearest-neighbor. The canonical NN primitive (`cosine_similarity` + `rank_neighbors`) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands, the default neighbor provider delegates the vector search to the deployed `graph_query_api` hybrid endpoint and degrades to zero neighbors when `GRAPH_QUERY_API_URL` is unset so session-init never blocks.
- **`applied_entelechy_override`** — optional; when supplied by io it overrides the prediction (override wins) while the classifier prediction is still computed and logged.
- **`intent_drift.py`** — rolling intent vector per wave (mean of FTR-089 embeddings for dispatched records) + scalar `intent_centroid_drift` (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a **new nullable column** `intent_centroid_drift` on the FTR-087-owned `enceladus-drift-telemetry` table **alongside** `d_centroid` (never overwritten; graceful no-op when the table/env var is absent).
- **Surfaces:** `POST /api/v1/coordination/session-init/classify-intent`, `POST /api/v1/coordination/session-init/intent-centroid-drift`, and MCP code-mode actions `coordination(action="session.classify_intent")` / `coordination(action="session.intent_centroid_drift")`.
- **Governance dictionary:** added entity `coordination_api.session_init_intent_classifier`, version `2026-06-28.05` → `2026-06-28.06` (additive). A `GOVERNANCE_SYNC_REQUIRED` worklog block on ENC-TSK-I93 requests the post-merge S3/DDB sync.

## Acceptance Criteria status

| AC | Status | Evidence |
|----|--------|----------|
| **AC-1** Classifier returns `predicted_entelechy {node_ids, confidence}` | Code complete; unit-verified | `intent_classifier.classify_session_intent`; `test_intent_classifier.py` incl. **3 synthetic session-init payloads**. Gamma runtime verification of 3 synthetic payloads is owned by the human post-deploy (this agent cannot deploy). |
| **AC-2** `applied_entelechy_override` wins; prediction still logged | **Satisfied** | `test_intent_classifier.OverrideAC2Tests` asserts override wins while `predicted_entelechy` is still computed/differs. |
| **AC-3** Rolling intent vector + nullable `intent_centroid_drift` alongside `d_centroid`, backward-compatible | **Satisfied** (code) | `intent_drift.py`; `test_intent_drift.py` (mean centroid, nullable drift, writes only the new column, best-effort no-op when table absent). Table provisioning belongs to FTR-087. |
| **AC-4** OGTM pre-flight if a new edge type is added | **Satisfied (N/A)** | Phase 1 introduces **no** new edge type / record type / relational field — predictions are returned inline. A future `PREDICTS`-edge phase must complete all four OGTM gates (incl. live E2E traversal). |
| **AC-5** Scope guard — no training loop / weight writes | **Satisfied** | `INFERENCE_ONLY=True` / `TRAINING_ENABLED=False`; `test_intent_classifier.ScopeGuardAC5Tests` asserts no training callable and no AWS calls when providers are injected. Training arc deferred to a follow-on per AC. |

## Tests

- 35 new tests pass (`test_intent_classifier.py`, `test_intent_drift.py`, `test_session_init_intent.py`).
- 172 existing `coordination_api` tests green (`test_lambda_function.py`, `test_components_propose.py`).
- All modified Python files `py_compile` clean.

## connection_health (session init)

```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-28T13:07:23Z",
  "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}}
}
```

## Post-merge notes (human-owned)

- Sync the repo `governance_data_dictionary.json` to S3 live + `governance-policies` DDB per the `GOVERNANCE_SYNC_REQUIRED` block on ENC-TSK-I93 (privileged terminal).
- Set `GRAPH_QUERY_API_URL` (and `bedrock:InvokeModel` on `amazon.titan-embed-text-v2:0` for the coordination_api role) on the gamma stack to enable live predictions, then verify AC-1 with 3 synthetic session-init payloads. `DRIFT_TELEMETRY_TABLE` is wired but no-ops until FTR-087 provisions the table.
- Task is left at `committed`; the human owns merge + deploy + close-out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efcd5985-84d3-4852-b4e6-c988d65a2cdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efcd5985-84d3-4852-b4e6-c988d65a2cdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

