### PR TITLE
fix(iam): add events:ListRules to BackendDeployRole for cfn-drift-audit (ENC-TSK-I94)

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -403,6 +403,14 @@ Resources:
                   - dynamodb:DescribeTable
                 Resource:
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/*-gamma"
+              # Required by cfn-drift-audit.yml (ENC-TSK-I94 / ENC-ISS-442):
+              # audit_cfn_drift.py calls `aws events list-rules` to compare
+              # live EventBridge rules against CFN-declared rules.
+              - Sid: CfnDriftAuditEventBridgeRead
+                Effect: Allow
+                Action:
+                  - events:ListRules
+                Resource: !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/*"
 
         - PolicyName: BackendDeployPolicy-LambdaArtifacts
           PolicyDocument:


### PR DESCRIPTION
## Summary

- Adds `events:ListRules` permission to `BackendDeployRole` in `infrastructure/cloudformation/04-github-roles.yaml`
- Fixes `cfn-drift-audit.yml` which has failed on every daily run since April with `AccessDeniedException` on `aws events list-rules`
- Scoped to `arn:aws:events:us-west-2:${AWS::AccountId}:rule/*` (read-only, no mutation permissions added)

**Root cause** (ENC-ISS-442): `audit_cfn_drift.py:127` calls `aws events list-rules --name-prefix enceladus-`. The `enceladus-backend-deploy-github-role` had zero EventBridge permissions across all 5 attached policies. 15+ consecutive daily failures confirmed.

## Deploy

CFN stack `enceladus-github-roles` already updated via product-lead terminal deploy (run 28413737443 verified green).

## Test plan

- [x] `04-github-roles` CFN stack updated successfully
- [x] `cfn-drift-audit.yml` `workflow_dispatch` run 28413737443 — all steps green, drift report produced

Fixes ENC-ISS-442

CCI-f5a9790b8ba64d36a8a6da04448cc065

🤖 Generated with [Claude Code](https://claude.com/claude-code)