### PR TITLE
[ENC-TSK-I89] FTR-089 — tracker.embeddings_for MCP read action: research-only raw-embedding egress

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-30.03",
-  "updated_at": "2026-06-30T02:05:00Z",
-  "last_change_summary": "ENC-TSK-I88 / ENC-FTR-085: add graph_query_api.adjacency \u2014 read-only adjacency export via graph_query_api for nightly percolation Lambda. Version 2026-06-30.02 -> 2026-06-30.03. PRIOR: ENC-TSK-I83 (FTR-086 Ph2 \u2014 Convergence Surface telemetry.rank MCP read action). Adds the telemetry.eligible_fields entit...",
+  "version": "2026-06-30.04",
+  "updated_at": "2026-06-30T02:15:00Z",
+  "last_change_summary": "ENC-TSK-I89 (FTR-089 tracker.embeddings_for). Adds graph_query_api.embeddings_for: admin-scoped raw-embedding egress for Titan V2 vectors (256-dim). Version -> 2026-06-30.04. PRIOR: ENC-TSK-I88 / ENC-FTR-085: add graph_query_api.adjacency \u2014 read-only adjacency export via graph_quer...",
   "owners": [
     "enceladus-platform"
   ],
@@ -5956,6 +5956,12 @@
           "definition": "GOVERNANCE_VERSION_TABLE (default: governance-version), GOVERNANCE_S3_BUCKET (default: jreese-net), DRIFT_METRIC_NAMESPACE (default: Enceladus/Governance), GOVERNANCE_ALERT_SNS_ARN."
         }
       }
+    },
+    "graph_query_api.embeddings_for": {
+      "description": "Returns stored Amazon Titan Text Embeddings V2 vectors (256-dim, L2-normalised) for a list of record_ids in a project. search_type=embeddings_for on GET /api/v1/tracker/graphsearch. Admin-tier only. Returns {embeddings[], matrix(Nx256), missing[]}. No new edge types or graph writes (OGTM N/A).",
+      "owner": "graph-query-api",
+      "source": "ENC-TSK-I89 / ENC-FTR-089",
+      "telemetry_eligible": false
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -64,6 +64,32 @@ ADJACENCY_DEFAULT_LIMIT = 5000
 ADJACENCY_MAX_LIMIT = 20000
 
 # ---------------------------------------------------------------------------
+# ENC-FTR-089 / ENC-TSK-I89 — tracker.embeddings_for raw-embedding egress
+# ---------------------------------------------------------------------------
+# Research-only egress of the stored Amazon Titan Text Embeddings V2 vectors
+# (256-dim, L2-normalized) that graph_sync/embedding.py writes onto record
+# nodes under the `embedding` property. This is an IAM-scoped read: it exposes
+# raw model vectors, so it is gated to the internal service key and admin-tier
+# (io-dev-admin) Cognito tokens only — standard/elevated/observe agent tokens
+# are rejected with 403. It introduces NO new edge types or graph nodes and
+# does not touch graph_sync (OGTM AC-4): it reads the existing Titan V2
+# vectors in place. Callers stack the returned vectors into an (N x 256)
+# matrix and compute np.mean(matrix, axis=0) as a demand-centroid / Fréchet
+# barycenter approximation (FTR-084 / FTR-087).
+EMBEDDING_EGRESS_SEARCH_TYPE = "embeddings_for"
+EMBEDDING_EGRESS_DIMENSIONS = 256
+EMBEDDING_EGRESS_MODEL_ID = "amazon.titan-embed-text-v2:0"
+MAX_EMBEDDING_EGRESS_RECORD_IDS = 100
+
+# Admin-tier authorization tokens. `enc:agent_tier` is the governed claim the
+# ENC-FTR-074 pre-token Lambda stamps onto M2M access tokens (admin > elevated
+# > standard > observe); `io-dev-admin` is the product-lead Cognito group on
+# human/admin identities. Either one (or the internal service key) authorizes
+# raw-embedding egress.
+_EGRESS_ADMIN_AGENT_TIER = "admin"
+_EGRESS_ADMIN_COGNITO_GROUP = "io-dev-admin"
+
+# ---------------------------------------------------------------------------
 # ENC-TSK-B92 Phase 1 hybrid retrieval constants
 # ---------------------------------------------------------------------------
 
@@ -2108,6 +2134,245 @@ def _handle_search(event: Dict) -> Dict:
     return _response(200, response_body)
 
 
+# ---------------------------------------------------------------------------
+# ENC-FTR-089 / ENC-TSK-I89 — raw-embedding egress (admin-scoped)
+# ---------------------------------------------------------------------------
+
+def _extract_egress_token(headers: Dict[str, str]) -> str:
+    """Pull a JWT from the Authorization bearer header or the auth cookies."""
+    auth_header = headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        return auth_header[len("Bearer "):].strip()
+    cookie = headers.get("cookie", "")
+    for part in cookie.split(";"):
+        part = part.strip()
+        for cookie_name in ("enceladus_id_token=", "enceladus_access_token="):
+            if part.startswith(cookie_name):
+                return part[len(cookie_name):].strip()
+    return ""
+
+
+def _decode_jwt_claims(token: str) -> Dict[str, Any]:
+    """Best-effort decode of a JWT payload segment.
+
+    Signature verification is delegated to the API Gateway JWT authorizer
+    (ENC-FTR-074 Ph2 / ENC-TSK-I80) — this only reads the governed tier claim
+    for egress gating on the gamma research plane, mirroring the existing
+    in-Lambda auth posture where cryptographic validation is performed at the
+    edge. Returns an empty dict on any malformed input.
+    """
+    try:
+        segments = token.split(".")
+        if len(segments) < 2:
+            return {}
+        import base64
+
+        payload = segments[1]
+        payload += "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload.encode("utf-8"))
+        claims = json.loads(decoded.decode("utf-8"))
+        return claims if isinstance(claims, dict) else {}
+    except Exception:
+        return {}
+
+
+def _egress_jwt_claims(event: Dict) -> Dict[str, Any]:
+    """Resolve verified JWT claims, preferring authorizer-injected context."""
+    request_context = event.get("requestContext") or {}
+    authorizer = request_context.get("authorizer") or {}
+    jwt_context = authorizer.get("jwt") or {}
+    claims = jwt_context.get("claims")
+    if isinstance(claims, dict) and claims:
+        return claims
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    token = _extract_egress_token(headers)
+    if not token:
+        return {}
+    return _decode_jwt_claims(token)
+
+
+def _authorize_embedding_egress(event: Dict) -> Optional[str]:
+    """Authorize raw-embedding egress. Returns None if allowed, else a reason.
+
+    Accepted principals:
+      - the internal service key (X-Coordination-Internal-Key), used by the MCP
+        server's governed forward path;
+      - Cognito tokens carrying enc:agent_tier == 'admin' OR the io-dev-admin
+        group.
+    Standard / elevated / observe agent tokens (and anonymous callers) are
+    rejected so the caller can be answered with HTTP 403 (ENC-FTR-089 AC-2).
+    """
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+
+    internal_key = headers.get("x-coordination-internal-key", "")
+    if internal_key and COORDINATION_INTERNAL_API_KEY:
+        valid_keys = {COORDINATION_INTERNAL_API_KEY}
+        if COORDINATION_INTERNAL_API_KEY_PREVIOUS:
+            valid_keys.add(COORDINATION_INTERNAL_API_KEY_PREVIOUS)
+        if internal_key.strip() in valid_keys:
+            return None
+
+    claims = _egress_jwt_claims(event)
+    tier = str(claims.get("enc:agent_tier") or "").strip().lower()
+    if tier == _EGRESS_ADMIN_AGENT_TIER:
+        return None
+
+    raw_groups = claims.get("cognito:groups") or []
+    if isinstance(raw_groups, str):
+        raw_groups = raw_groups.replace(",", " ").split()
+    groups = {str(g).strip().lower() for g in raw_groups if str(g).strip()}
+    if _EGRESS_ADMIN_COGNITO_GROUP in groups:
+        return None
+
+    return (
+        "Raw-embedding egress requires the internal service key or an "
+        "admin-tier (io-dev-admin) Cognito token."
+    )
+
+
+def _parse_egress_record_ids(event: Dict) -> List[str]:
+    """Parse and de-duplicate record_ids from query params (csv or multiValue)."""
+    qs = event.get("queryStringParameters") or {}
+    multi_qs = event.get("multiValueQueryStringParameters") or {}
+
+    raw_ids: List[str] = []
+    if isinstance(multi_qs.get("record_ids"), list):
+        for value in multi_qs["record_ids"]:
+            raw_ids.extend(str(value).split(","))
+    else:
+        raw_ids.extend(str(qs.get("record_ids", "")).split(","))
+    # Tolerate the singular form for ergonomic single-record calls.
+    if not any(r.strip() for r in raw_ids) and qs.get("record_id"):
+        raw_ids = str(qs.get("record_id")).split(",")
+
+    seen: set = set()
+    ordered: List[str] = []
+    for candidate in raw_ids:
+        record_id = candidate.strip()
+        if record_id and record_id not in seen:
+            seen.add(record_id)
+            ordered.append(record_id)
+    return ordered
+
+
+def _handle_embeddings_for(event: Dict) -> Dict:
+    """Handle GET /api/v1/tracker/graphsearch?search_type=embeddings_for.
+
+    ENC-FTR-089 / ENC-TSK-I89. Returns the stored Titan V2 embedding vector
+    (256-dim float32, L2-normalized) for each requested record_id. Operates
+    over the existing `embedding` node property written by graph_sync — no new
+    edge types or graph nodes are introduced (OGTM AC-4).
+    """
+    auth_failure = _authorize_embedding_egress(event)
+    if auth_failure is not None:
+        return _error(403, auth_failure, code="PERMISSION_DENIED")
+
+    qs = event.get("queryStringParameters") or {}
+    project_id = qs.get("project_id", "")
+    if not project_id:
+        return _error(400, "project_id query parameter required")
+
+    record_ids = _parse_egress_record_ids(event)
+    if not record_ids:
+        return _error(400, "record_ids query parameter required (comma-separated record IDs)")
+    if len(record_ids) > MAX_EMBEDDING_EGRESS_RECORD_IDS:
+        return _error(
+            400,
+            f"record_ids exceeds the maximum of {MAX_EMBEDDING_EGRESS_RECORD_IDS} per request",
+        )
+
+    driver = _ensure_live_driver(_get_neo4j_driver())
+    if driver is None:
+        return _error(503, "Graph index temporarily unavailable. Use tracker_list for equivalent queries.",
+                      code="GRAPH_UNAVAILABLE", retryable=True)
+
+    cypher = (
+        "MATCH (n) WHERE n.project_id = $project_id AND n.record_id IN $record_ids "
+        f"RETURN n.record_id AS record_id, n.`{_EMBEDDING_PROPERTY}` AS embedding, "
+        "labels(n) AS labels"
+    )
+
+    start = time.time()
+    found: Dict[str, Dict[str, Any]] = {}
+    try:
+        with driver.session() as session:
+            result = session.run(cypher, project_id=project_id, record_ids=record_ids)
+            for record in result:
+                rid = record["record_id"]
+                if rid is None:
+                    continue
+                embedding = record["embedding"]
+                # A record_id should resolve to one node; if a stale duplicate
+                # exists, keep the first row that carries a usable vector.
+                existing = found.get(rid)
+                if existing is not None and existing.get("embedding") is not None:
+                    continue
+                found[rid] = {
+                    "embedding": list(embedding) if embedding is not None else None,
+                    "labels": sorted(record["labels"]) if record["labels"] else [],
+                }
+    except Exception:
+        logger.exception("[ERROR] embeddings_for query failed: project_id=%s", project_id)
+        return _error(503, "Graph index temporarily unavailable. Use tracker_list for equivalent queries.",
+                      code="GRAPH_UNAVAILABLE", retryable=True)
+
+    duration_ms = int((time.time() - start) * 1000)
+
+    embeddings: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    for rid in record_ids:
+        entry = found.get(rid)
+        vector = entry.get("embedding") if entry else None
+        if isinstance(vector, list) and len(vector) == EMBEDDING_EGRESS_DIMENSIONS:
+            embeddings.append({
+                "record_id": rid,
+                "embedding": vector,
+                "dimension": len(vector),
+                "labels": entry.get("labels", []),
+            })
+        else:
+            missing.append(rid)
+
+    # Row-aligned (N x 256) matrix of only the resolved vectors so a client can
+    # call np.mean(matrix, axis=0) directly for the demand-centroid / Fréchet
+    # barycenter approximation (ENC-FTR-089 AC-3).
+    matrix = [item["embedding"] for item in embeddings]
+
+    logger.info(
+        json.dumps({
+            "event": "embeddings_for_query",
+            "project_id": project_id,
+            "requested_count": len(record_ids),
+            "returned_count": len(embeddings),
+            "missing_count": len(missing),
+            "duration_ms": duration_ms,
+        })
+    )
+
+    return _response(200, {
+        "success": True,
+        "model_id": EMBEDDING_EGRESS_MODEL_ID,
+        "dimension": EMBEDDING_EGRESS_DIMENSIONS,
+        "normalize": True,
+        "requested_count": len(record_ids),
+        "returned_count": len(embeddings),
+        "embeddings": embeddings,
+        "matrix": matrix,
+        "missing": missing,
+        "duration_ms": duration_ms,
+        # ENC-FTR-089 AC-3: response-schema documentation for centroid use.
+        "response_schema": {
+            "embeddings": "Array of {record_id, embedding: float[256], dimension, labels}; "
+                          "row-order matches the requested record_ids minus any in `missing`.",
+            "matrix": "N x 256 float matrix of the resolved vectors (embeddings[*].embedding). "
+                      "Compute the demand centroid / Fréchet barycenter approximation as "
+                      "np.mean(np.asarray(matrix), axis=0); valid because Titan V2 vectors are "
+                      "L2-normalized so the Euclidean mean approximates the spherical barycenter.",
+            "missing": "record_ids with no graph node or no stored embedding (excluded from matrix).",
+        },
+    })
+
+
 def _handle_health(event: Dict) -> Dict:
     """Handle GET /api/v1/tracker/graphsearch/health.
 
@@ -2251,6 +2516,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     # Route dispatch
     if method == "GET" and "/graphsearch" in path and not path.endswith("/health"):
+        qs = event.get("queryStringParameters") or {}
+        # ENC-FTR-089 / ENC-TSK-I89: admin-scoped raw-embedding egress shares the
+        # graphsearch route via search_type=embeddings_for (no new API Gateway
+        # route or CFN change); the handler enforces its own stricter admin gate.
+        if (qs.get("search_type") or "") == EMBEDDING_EGRESS_SEARCH_TYPE:
+            return _handle_embeddings_for(event)
         return _handle_search(event)
 
     return _error(404, f"Route not found: {method} {path}")

--- a/backend/lambda/graph_query_api/test_embeddings_for_ftr089.py
+++ b/backend/lambda/graph_query_api/test_embeddings_for_ftr089.py
@@ -1,0 +1,300 @@
+"""Unit tests for ENC-FTR-089 / ENC-TSK-I89 raw-embedding egress.
+
+Exercises the admin-scoped `search_type=embeddings_for` handler in
+graph_query_api without requiring Neo4j or Bedrock:
+
+  - IAM scope gating (AC-2): internal key + admin-tier / io-dev-admin Cognito
+    tokens accepted; standard/elevated/observe and anonymous callers -> 403.
+  - Response shape (AC-1/AC-3/AC-5): 256-dim vectors per record_id, an N x 256
+    `matrix` supporting np.mean(matrix, axis=0), no nulls for resolved records.
+  - record_ids parsing (csv, multiValue, dedupe), bounds, and required params.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import lambda_function as lf  # noqa: E402
+
+
+def _b64url(payload: dict) -> str:
+    raw = json.dumps(payload).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def _jwt(claims: dict) -> str:
+    return f"{_b64url({'alg': 'RS256', 'typ': 'JWT'})}.{_b64url(claims)}.sig"
+
+
+class _FakeSession:
+    def __init__(self, records):
+        self._records = records
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def run(self, _cypher, **_kwargs):
+        return list(self._records)
+
+
+class _FakeDriver:
+    def __init__(self, records):
+        self._records = records
+
+    def session(self):
+        return _FakeSession(self._records)
+
+    def verify_connectivity(self):
+        return True
+
+
+def _vec(seed: float):
+    return [seed + i * 0.0 for i in range(lf.EMBEDDING_EGRESS_DIMENSIONS)]
+
+
+class _EmbeddingsForTestBase(unittest.TestCase):
+    def setUp(self):
+        self._orig_driver = lf._get_neo4j_driver
+        self._orig_key = lf.COORDINATION_INTERNAL_API_KEY
+        lf.COORDINATION_INTERNAL_API_KEY = "test-internal-key"
+
+    def tearDown(self):
+        lf._get_neo4j_driver = self._orig_driver
+        lf.COORDINATION_INTERNAL_API_KEY = self._orig_key
+
+    def _install_driver(self, records):
+        lf._get_neo4j_driver = lambda: _FakeDriver(records)
+
+    @staticmethod
+    def _event(qs=None, headers=None, multi=None):
+        return {
+            "requestContext": {"http": {"method": "GET"}},
+            "rawPath": "/api/v1/tracker/graphsearch",
+            "queryStringParameters": qs or {},
+            "multiValueQueryStringParameters": multi or {},
+            "headers": headers or {},
+        }
+
+    @staticmethod
+    def _body(resp):
+        return json.loads(resp["body"])
+
+
+class TestEgressAuthGating(_EmbeddingsForTestBase):
+    def setUp(self):
+        super().setUp()
+        self._install_driver([
+            {"record_id": "ENC-TSK-001", "embedding": _vec(0.1), "labels": ["Task"]},
+        ])
+
+    def _call(self, headers):
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": "ENC-TSK-001"},
+            headers=headers,
+        )
+        return lf._handle_embeddings_for(event)
+
+    def test_internal_key_accepted(self):
+        resp = self._call({"X-Coordination-Internal-Key": "test-internal-key"})
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_admin_tier_accepted(self):
+        token = _jwt({"enc:agent_tier": "admin"})
+        resp = self._call({"Authorization": f"Bearer {token}"})
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_io_dev_admin_group_accepted(self):
+        token = _jwt({"cognito:groups": ["io-dev-admin", "viewers"]})
+        resp = self._call({"Authorization": f"Bearer {token}"})
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_admin_tier_via_authorizer_claims(self):
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": "ENC-TSK-001"},
+            headers={},
+        )
+        event["requestContext"]["authorizer"] = {"jwt": {"claims": {"enc:agent_tier": "admin"}}}
+        resp = lf._handle_embeddings_for(event)
+        self.assertEqual(resp["statusCode"], 200)
+
+    def test_standard_agent_rejected_403(self):
+        token = _jwt({"enc:agent_tier": "standard"})
+        resp = self._call({"Authorization": f"Bearer {token}"})
+        self.assertEqual(resp["statusCode"], 403)
+        self.assertEqual(self._body(resp)["error_envelope"]["code"], "PERMISSION_DENIED")
+
+    def test_elevated_agent_rejected_403(self):
+        token = _jwt({"enc:agent_tier": "elevated"})
+        resp = self._call({"Authorization": f"Bearer {token}"})
+        self.assertEqual(resp["statusCode"], 403)
+
+    def test_observe_agent_rejected_403(self):
+        token = _jwt({"enc:agent_tier": "observe"})
+        resp = self._call({"Authorization": f"Bearer {token}"})
+        self.assertEqual(resp["statusCode"], 403)
+
+    def test_anonymous_rejected_403(self):
+        resp = self._call({})
+        self.assertEqual(resp["statusCode"], 403)
+
+    def test_wrong_internal_key_rejected_403(self):
+        resp = self._call({"X-Coordination-Internal-Key": "wrong-key"})
+        self.assertEqual(resp["statusCode"], 403)
+
+
+class TestEgressResponseShape(_EmbeddingsForTestBase):
+    def _admin_headers(self):
+        return {"X-Coordination-Internal-Key": "test-internal-key"}
+
+    def test_three_vectors_length_256_no_nulls(self):
+        ids = ["ENC-TSK-001", "ENC-ISS-002", "ENC-FTR-003"]
+        self._install_driver([
+            {"record_id": ids[0], "embedding": _vec(0.1), "labels": ["Task"]},
+            {"record_id": ids[1], "embedding": _vec(0.2), "labels": ["Issue"]},
+            {"record_id": ids[2], "embedding": _vec(0.3), "labels": ["Feature"]},
+        ])
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": ",".join(ids)},
+            headers=self._admin_headers(),
+        )
+        resp = lf._handle_embeddings_for(event)
+        body = self._body(resp)
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual(body["returned_count"], 3)
+        self.assertEqual(body["dimension"], 256)
+        self.assertEqual(body["model_id"], "amazon.titan-embed-text-v2:0")
+        self.assertEqual(len(body["embeddings"]), 3)
+        self.assertEqual(body["missing"], [])
+        for item in body["embeddings"]:
+            self.assertIsNotNone(item["embedding"])
+            self.assertEqual(len(item["embedding"]), 256)
+            self.assertEqual(item["dimension"], 256)
+
+    def test_matrix_supports_centroid_mean(self):
+        ids = ["A", "B"]
+        self._install_driver([
+            {"record_id": "A", "embedding": [1.0] * 256, "labels": ["Task"]},
+            {"record_id": "B", "embedding": [3.0] * 256, "labels": ["Task"]},
+        ])
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": ",".join(ids)},
+            headers=self._admin_headers(),
+        )
+        body = self._body(lf._handle_embeddings_for(event))
+        matrix = body["matrix"]
+        self.assertEqual(len(matrix), 2)
+        self.assertEqual(len(matrix[0]), 256)
+        # np.mean(matrix, axis=0) equivalent — column-wise mean is (1+3)/2 = 2.0.
+        centroid = [sum(col) / len(col) for col in zip(*matrix)]
+        self.assertEqual(len(centroid), 256)
+        self.assertTrue(all(abs(v - 2.0) < 1e-9 for v in centroid))
+
+    def test_missing_records_excluded_from_matrix(self):
+        self._install_driver([
+            {"record_id": "A", "embedding": _vec(0.1), "labels": ["Task"]},
+            # B has no stored embedding (null vector).
+            {"record_id": "B", "embedding": None, "labels": ["Task"]},
+        ])
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": "A,B,C"},
+            headers=self._admin_headers(),
+        )
+        body = self._body(lf._handle_embeddings_for(event))
+        self.assertEqual(body["returned_count"], 1)
+        self.assertEqual(sorted(body["missing"]), ["B", "C"])
+        self.assertEqual(len(body["matrix"]), 1)
+
+    def test_wrong_dimension_treated_as_missing(self):
+        self._install_driver([
+            {"record_id": "A", "embedding": [0.1, 0.2, 0.3], "labels": ["Task"]},
+        ])
+        event = self._event(
+            qs={"project_id": "enceladus", "record_ids": "A"},
+            headers=self._admin_headers(),
+        )
+        body = self._body(lf._handle_embeddings_for(event))
+        self.assertEqual(body["returned_count"], 0)
+        self.assertEqual(body["missing"], ["A"])
+
+
+class TestEgressInputParsing(_EmbeddingsForTestBase):
+    def _admin_headers(self):
+        return {"X-Coordination-Internal-Key": "test-internal-key"}
+
+    def test_missing_project_id(self):
+        self._install_driver([])
+        resp = lf._handle_embeddings_for(
+            self._event(qs={"record_ids": "A"}, headers=self._admin_headers())
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_missing_record_ids(self):
+        self._install_driver([])
+        resp = lf._handle_embeddings_for(
+            self._event(qs={"project_id": "enceladus"}, headers=self._admin_headers())
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_record_ids_dedupe_and_csv(self):
+        ids = lf._parse_egress_record_ids(
+            self._event(qs={"record_ids": "A, B ,A,, C"})
+        )
+        self.assertEqual(ids, ["A", "B", "C"])
+
+    def test_record_ids_multivalue(self):
+        ids = lf._parse_egress_record_ids(
+            self._event(multi={"record_ids": ["A,B", "C"]})
+        )
+        self.assertEqual(ids, ["A", "B", "C"])
+
+    def test_singular_record_id_supported(self):
+        ids = lf._parse_egress_record_ids(self._event(qs={"record_id": "ENC-TSK-009"}))
+        self.assertEqual(ids, ["ENC-TSK-009"])
+
+    def test_too_many_record_ids_rejected(self):
+        many = ",".join(f"ENC-TSK-{i:04d}" for i in range(lf.MAX_EMBEDDING_EGRESS_RECORD_IDS + 1))
+        self._install_driver([])
+        resp = lf._handle_embeddings_for(
+            self._event(qs={"project_id": "enceladus", "record_ids": many}, headers=self._admin_headers())
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+
+class TestEgressRouting(_EmbeddingsForTestBase):
+    def test_lambda_handler_routes_embeddings_for(self):
+        self._install_driver([
+            {"record_id": "ENC-TSK-001", "embedding": _vec(0.5), "labels": ["Task"]},
+        ])
+        event = self._event(
+            qs={"search_type": "embeddings_for", "project_id": "enceladus", "record_ids": "ENC-TSK-001"},
+            headers={"X-Coordination-Internal-Key": "test-internal-key"},
+        )
+        resp = lf.lambda_handler(event, None)
+        self.assertEqual(resp["statusCode"], 200)
+        body = self._body(resp)
+        self.assertEqual(body["returned_count"], 1)
+
+    def test_lambda_handler_standard_token_403(self):
+        self._install_driver([
+            {"record_id": "ENC-TSK-001", "embedding": _vec(0.5), "labels": ["Task"]},
+        ])
+        token = _jwt({"enc:agent_tier": "standard"})
+        event = self._event(
+            qs={"search_type": "embeddings_for", "project_id": "enceladus", "record_ids": "ENC-TSK-001"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        resp = lf.lambda_handler(event, None)
+        self.assertEqual(resp["statusCode"], 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3324,9 +3324,9 @@ def _code_mode_tool_catalog() -> list[Tool]:
                         "type": "string",
                         "description": (
                             "Read action identifier such as projects.list, tracker.get, "
-                            "tracker.graphsearch, documents.search, deploy.history, "
-                            "changelog.version, governance.dictionary, reference.search, "
-                            "telemetry.rank, or system.connection_health."
+                            "tracker.graphsearch, tracker.embeddings_for, documents.search, "
+                            "deploy.history, changelog.version, governance.dictionary, "
+                            "reference.search, or system.connection_health."
                         ),
                     },
                     "arguments": {
@@ -7506,6 +7506,8 @@ _SEARCH_ACTIONS: Dict[str, Dict[str, Any]] = {
     "system.connection_health": {"tool": "connection_health"},
     "github.projects_list": {"tool": "github_projects_list"},
     "tracker.graphsearch": {"tool": "tracker_graphsearch"},
+    # ENC-FTR-089 / ENC-TSK-I89: admin-scoped raw-embedding egress.
+    "tracker.embeddings_for": {"tool": "tracker_embeddings_for"},
     # ENC-FTR-097 / ENC-TSK-G27: Manifest Primitive v1 read actions
     "tracker.manifest": {"tool": "tracker_manifest"},
     "tracker.get_acs": {"tool": "tracker_get_acs"},
@@ -9059,6 +9061,43 @@ async def _telemetry_rank(args: dict) -> list[TextContent]:
     except Exception as exc:
         logger.warning("[telemetry.rank] degraded: %s", exc)
         return _result_text(telemetry_rank.degraded_payload(f"exception:{type(exc).__name__}"))
+async def _tracker_embeddings_for(args: dict) -> list[TextContent]:
+    """ENC-FTR-089 / ENC-TSK-I89 — raw-embedding egress (admin-scoped read).
+
+    Returns the stored Amazon Titan Text Embeddings V2 vector (256-dim
+    float32, L2-normalized) for each requested record_id, reading the existing
+    `embedding` graph node property (no new edge types/nodes). The response
+    carries an N x 256 `matrix` so callers can compute the demand centroid /
+    Fréchet barycenter approximation directly via np.mean(matrix, axis=0)
+    (FTR-084 / FTR-087).
+
+    IAM scope: gated downstream to the internal service key and admin-tier
+    (io-dev-admin) Cognito tokens; standard agent tokens receive HTTP 403.
+    """
+    project_id = args.get("project_id")
+    record_ids = args.get("record_ids")
+    if not project_id:
+        return _result_text({"error": "project_id is required"})
+    if record_ids is None or record_ids == "":
+        return _result_text({"error": "record_ids is required (list of record IDs)"})
+
+    if isinstance(record_ids, str):
+        ids = [r.strip() for r in record_ids.split(",") if r.strip()]
+    elif isinstance(record_ids, (list, tuple)):
+        ids = [str(r).strip() for r in record_ids if str(r).strip()]
+    else:
+        return _result_text({"error": "record_ids must be a list or comma-separated string"})
+
+    if not ids:
+        return _result_text({"error": "record_ids must contain at least one record ID"})
+
+    query_params: Dict[str, Any] = {
+        "search_type": "embeddings_for",
+        "project_id": project_id,
+        "record_ids": ",".join(ids),
+    }
+    resp = _graph_query_api_request(query=query_params)
+    return _result_text(resp)
 
 
 def _invoke_hybrid_retrieval(
@@ -10270,6 +10309,8 @@ _TOOL_HANDLERS = {
     "github_projects_list": _github_projects_list,
     # ENC-FTR-047: Graph search
     "tracker_graphsearch": _tracker_graphsearch,
+    # ENC-FTR-089 / ENC-TSK-I89: admin-scoped raw-embedding egress
+    "tracker_embeddings_for": _tracker_embeddings_for,
     # ENC-FTR-097 / ENC-TSK-G27: Manifest Primitive v1 read actions
     "tracker_manifest": _tracker_manifest,
     "tracker_get_acs": _tracker_get_acs,

--- a/tools/enceladus-mcp-server/test_code_mode.py
+++ b/tools/enceladus-mcp-server/test_code_mode.py
@@ -111,6 +111,63 @@ def test_search_uses_boundary_scoped_raw_tools():
     assert blocked["error"]["code"] == "boundary_denied"
 
 
+def test_search_registers_tracker_embeddings_for_action():
+    """ENC-FTR-089 / ENC-TSK-I89: tracker.embeddings_for is a registered search
+    action that forwards record_ids to the graph query API as a csv with
+    search_type=embeddings_for."""
+    server = _load_server(ENCELADUS_MCP_INTERFACE_MODE="code")
+
+    assert server._SEARCH_ACTIONS["tracker.embeddings_for"]["tool"] == "tracker_embeddings_for"
+    assert "tracker_embeddings_for" in server._TOOL_HANDLERS
+
+    captured = {}
+
+    def _fake_graph_request(query=None):
+        captured["query"] = query
+        return {
+            "success": True,
+            "model_id": "amazon.titan-embed-text-v2:0",
+            "dimension": 256,
+            "returned_count": 2,
+            "embeddings": [
+                {"record_id": "ENC-TSK-001", "embedding": [0.1] * 256, "dimension": 256},
+                {"record_id": "ENC-ISS-002", "embedding": [0.2] * 256, "dimension": 256},
+            ],
+            "matrix": [[0.1] * 256, [0.2] * 256],
+            "missing": [],
+        }
+
+    with patch.object(server, "_graph_query_api_request", _fake_graph_request):
+        payload = json.loads(
+            _run(
+                server.call_tool(
+                    "search",
+                    {
+                        "action": "tracker.embeddings_for",
+                        "arguments": {
+                            "project_id": "enceladus",
+                            "record_ids": ["ENC-TSK-001", "ENC-ISS-002"],
+                        },
+                    },
+                )
+            )[0].text
+        )
+
+    assert payload["success"] is True
+    assert captured["query"]["search_type"] == "embeddings_for"
+    assert captured["query"]["project_id"] == "enceladus"
+    assert captured["query"]["record_ids"] == "ENC-TSK-001,ENC-ISS-002"
+    assert payload["result"]["returned_count"] == 2
+    assert len(payload["result"]["matrix"]) == 2
+
+
+def test_tracker_embeddings_for_requires_record_ids():
+    server = _load_server(ENCELADUS_MCP_INTERFACE_MODE="code")
+    result = _run(server._tracker_embeddings_for({"project_id": "enceladus"}))
+    payload = json.loads(result[0].text)
+    assert "record_ids is required" in payload["error"]
+
+
 def test_get_compact_context_preserves_existing_codemap_payload():
     server = _load_server(ENCELADUS_MCP_INTERFACE_MODE="code")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **ENC-FTR-089** — the `tracker.embeddings_for` MCP read action, an IAM-scoped research egress for the stored Amazon Titan Text Embeddings V2 vectors (256-dim, L2-normalized) that `graph_sync` writes onto governed record nodes.

- **task_id:** ENC-TSK-I89
- **commit-complete-id (CCI):** `CCI-98b7f5102fc2478b9609218c568d26b4`
- **commit_sha:** `ffa0e3c1113c0425df218f1e63046c67779a71f4`
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`
- **deploy target:** v4/main (gamma) only — v3-prod is FROZEN; no deploy performed.

## Changes

**`backend/lambda/graph_query_api/lambda_function.py`**
- New `search_type=embeddings_for` branch on the existing `GET /api/v1/tracker/graphsearch` route — **no new API Gateway route or CloudFormation change**, and **`graph_sync` is untouched**. Reads the existing `embedding` node property by `record_id` + `project_id`; introduces **no new edge types or graph nodes** (OGTM AC-4).
- Returns `{embeddings[], matrix (N x 256), missing[]}` plus a `response_schema` documenting `np.mean(np.asarray(matrix), axis=0)` as the demand-centroid / Fréchet barycenter approximation (AC-3).
- Admin-tier authorization: accepts the internal service key and Cognito tokens with `enc:agent_tier == admin` or the `io-dev-admin` group; `standard`/`elevated`/`observe` agent tokens are rejected with **HTTP 403** (AC-2). Prefers authorizer-injected JWT claims (`requestContext.authorizer.jwt.claims`), falling back to JWT payload decode — signature verification is delegated to the ENC-FTR-074 Ph2 authorizer (ENC-TSK-I80).

**`tools/enceladus-mcp-server/server.py`**
- Registers the `tracker.embeddings_for` search action and the `_tracker_embeddings_for` handler, which forwards `record_ids` (csv) to graph_query_api.

**Tests**
- `backend/lambda/graph_query_api/test_embeddings_for_ftr089.py` — 21 unit tests (auth gating across all tiers, response shape/centroid, record_id parsing, routing).
- `tools/enceladus-mcp-server/test_code_mode.py` — 2 tests (action registration + forwarding).

## Acceptance Criteria

| AC | Status | Evidence |
|----|--------|----------|
| 1 — MCP `tracker.embeddings_for` returns 256-dim float per record_id | ✅ | Action + handler registered; response carries `embeddings[*].embedding` (len 256) + `matrix`. |
| 2 — internal-key + io-dev-admin accepted, standard rejected 403 | ✅ code / ⏳ live | Gate implemented + unit-tested; **E2E on gamma is human-owned post-deploy** (no-deploy constraint). |
| 3 — response shape supports `np.mean(matrix, axis=0)` centroid | ✅ | `matrix` (N x 256) + `response_schema` documented; centroid test passes. |
| 4 — OGTM: no new edge types/nodes, `graph_sync` not modified | ✅ | Reads existing `embedding` property only; `graph_sync` untouched. |
| 5 — E2E on gamma: 3 record_ids → 3 vectors of len 256, no nulls | ⏳ live | Logic unit-tested (`test_three_vectors_length_256_no_nulls`); **live gamma E2E human-owned post-deploy**. |

> AC-2/AC-5 live E2E verification requires the gamma deploy, which is owned by the human reviewer per the task constraints (agent does not deploy and does not advance beyond `committed`).

## connection_health (session init)

```json
{
  "dynamodb": "ok",
  "s3": "ok",
  "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447",
  "checked_at": "2026-06-30T01:22:28Z",
  "server_version": "1.0.0",
  "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}}
}
```

## Test results

- `graph_query_api`: 37 tests pass (21 new + 16 existing hybrid).
- MCP `test_code_mode.py`: 8 tests pass (incl. 2 new).
- `tools/check_mcp_api_boundary.py`: passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b31b1d56-e15d-498b-bf05-9a07fa724461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b31b1d56-e15d-498b-bf05-9a07fa724461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

