### PR TITLE
[ENC-TSK-I80] FTR-074 Ph2 — REQUEST-type Lambda authorizer + headersHelper .mcp.json + scope enforcement

### DIFF
--- a/infrastructure/cloudformation/08-agent-auth.yaml
+++ b/infrastructure/cloudformation/08-agent-auth.yaml
@@ -32,6 +32,39 @@ Parameters:
     Default: "https://jreese.net/enceladus"
     Description: Sign-out redirect URL for the human-interactive web UI client.
 
+  # --- ENC-FTR-074 Ph2 (ENC-TSK-I80) parameters ---------------------------------
+
+  ApiStackName:
+    Type: String
+    Default: "enceladus-api-gamma"
+    Description: >
+      Name of the deployed API stack (03-api.yaml) whose HTTP API the REQUEST authorizer and the
+      Tier 0 / Tier 1 self-test routes attach to. The ApiId is consumed via the cross-stack export
+      named "<ApiStackName>-ApiId". Defaults to the gamma API stack; v3-prod is FROZEN, never targeted.
+
+  HumanUserPoolId:
+    Type: String
+    Default: "us-east-1_b2D0V3E1k"
+    Description: >
+      Cognito User Pool ID for the human-interactive (PWA) principal class. The REQUEST authorizer
+      validates human JWTs (id/access tokens) against this pool's JWKS to discriminate the human
+      principal type from the M2M (agent-auth pool) and internal-key principal types.
+
+  InternalKeySecretId:
+    Type: String
+    Default: ""
+    Description: >
+      Optional Secrets Manager secret id/ARN whose SecretString holds the internal service key used
+      by trusted orchestrators (the X-Coordination-Internal-Key header). When set, the authorizer
+      recognizes and validates the internal-key principal type. When empty the internal-key path is
+      deny-closed (only human-JWT and M2M-scope-token principals are accepted). The value may be a
+      raw string or a JSON object with a "client_secret"/"key"/"internal_key" field.
+
+Conditions:
+  # ENC-FTR-074 Ph2: only grant the authorizer secretsmanager:GetSecretValue (and enable the
+  # internal-key principal path) when an internal-key secret id/ARN is supplied.
+  HasInternalKeySecret: !Not [!Equals [!Ref InternalKeySecretId, ""]]
+
 Resources:
 
   # ---------------------------------------------------------------------------
@@ -446,6 +479,529 @@ Resources:
       RotationRules:
         AutomaticallyAfterDays: 90
 
+  # ===========================================================================
+  # ENC-FTR-074 Ph2 (ENC-TSK-I80) — REQUEST-type API Gateway Lambda authorizer,
+  # governance-authority tier enforcement, and Tier 0 / Tier 1 self-test routes.
+  #
+  # The authorizer attaches to the HTTP API provisioned by 03-api.yaml (ApiId
+  # imported from "${ApiStackName}-ApiId"). All Phase-2 resources live in this
+  # gamma-only stack and add NEW, namespaced routes (/api/v1/agent/selftest/*),
+  # so existing 03-api routes and v3-prod are untouched.
+  # ===========================================================================
+
+  # --- REQUEST authorizer Lambda -------------------------------------------------
+
+  AgentAuthorizerLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "enceladus-agent-authorizer-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies: !If
+        - HasInternalKeySecret
+        - - PolicyName: read-internal-key-secret
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Sid: ReadInternalKeySecret
+                  Effect: Allow
+                  Action:
+                    - secretsmanager:GetSecretValue
+                  Resource: !Ref InternalKeySecretId
+        - !Ref "AWS::NoValue"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: agent-auth
+
+  AgentAuthorizerLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "enceladus-agent-authorizer${EnvironmentSuffix}"
+      Description: >
+        ENC-FTR-074 Ph2 REQUEST-type HTTP API Lambda authorizer. Discriminates three principal
+        types (internal-key, human JWT, M2M scope token) and enforces the route-tier
+        governance-authority boundary (agent.standard denied on Tier 0 routes).
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt AgentAuthorizerLambdaRole.Arn
+      Timeout: 10
+      MemorySize: 256
+      Architectures:
+        - arm64
+      Environment:
+        Variables:
+          AGENT_USER_POOL_ID: !Ref AgentUserPool
+          HUMAN_USER_POOL_ID: !Ref HumanUserPoolId
+          AGENT_M2M_CLIENT_ID: !Ref AgentM2MClient
+          RESOURCE_SERVER_ID: enceladus-api
+          INTERNAL_KEY_SECRET_ID: !Ref InternalKeySecretId
+      Code:
+        ZipFile: |
+          """ENC-FTR-074 Ph2 — REQUEST-type API Gateway (HTTP API) Lambda authorizer.
+
+          Discriminates three principal types and enforces a route-tier governance-authority
+          boundary:
+
+            * internal-key — trusted service/orchestrator presenting X-Coordination-Internal-Key
+                             (validated against the Secrets Manager value in INTERNAL_KEY_SECRET_ID);
+                             granted the highest tier (admin).
+            * human        — a human-interactive (PWA) Cognito JWT issued by HUMAN_USER_POOL_ID,
+                             presented as a Bearer token or the enceladus_id_token cookie. Humans
+                             are not scope-limited here; granted admin.
+            * m2m          — a headless agent client_credentials access token issued by
+                             AGENT_USER_POOL_ID carrying enceladus-api/agent.* scopes and the
+                             enc:agent_tier custom claim (ENC-TSK-I79 pre-token Lambda). The tier is
+                             taken from enc:agent_tier (fallback: derived from the scope set).
+
+          Tier model (governance-authority boundary): observe(0) < standard(1) < elevated(2) <
+          admin(3). A route declares the MINIMUM tier it requires; agent.standard (rank 1) is
+          accepted on a Tier 1 route (requires standard) and rejected (403) on a Tier 0 route
+          (governance-authority; requires elevated+).
+
+          Pure standard-library RS256 verification (verified by hand against the Cognito JWKS):
+          deliberately avoids PyJWT/cryptography so the authorizer does not inherit the shared-layer
+          .so ABI failure class (ENC-ISS-198 / ENC-LSN-020). boto3 ships in the Lambda runtime.
+          """
+          import base64
+          import hashlib
+          import hmac
+          import json
+          import os
+          import time
+          import urllib.request
+
+          import boto3
+
+          AGENT_USER_POOL_ID = os.environ.get("AGENT_USER_POOL_ID", "")
+          HUMAN_USER_POOL_ID = os.environ.get("HUMAN_USER_POOL_ID", "")
+          AGENT_M2M_CLIENT_ID = os.environ.get("AGENT_M2M_CLIENT_ID", "")
+          RESOURCE_SERVER_ID = os.environ.get("RESOURCE_SERVER_ID", "enceladus-api")
+          INTERNAL_KEY_SECRET_ID = os.environ.get("INTERNAL_KEY_SECRET_ID", "")
+
+          _TIER_RANK = {"observe": 0, "standard": 1, "elevated": 2, "admin": 3}
+
+          # SHA-256 DigestInfo prefix for PKCS#1 v1.5 (RFC 8017).
+          _SHA256_DIGEST_INFO = bytes.fromhex("3031300d060960864801650304020105000420")
+
+          _TIER0 = "elevated"   # governance-authority boundary — agent.standard denied
+          _TIER1 = "standard"   # standard governed mutation — agent.standard allowed
+
+          # Longest-prefix tier map. Unmatched non-GET routes default to standard (Tier 1).
+          _ROUTE_TIERS = (
+              ("/api/v1/agent/selftest/admin", _TIER0),
+              ("/api/v1/agent/selftest/standard", _TIER1),
+              ("/api/v1/tracker/", _TIER1),
+              ("/api/v1/documents", _TIER1),
+              ("/api/v1/checkout/", _TIER1),
+              ("/api/v1/coordination/components", _TIER1),
+          )
+          # Tier 0 governance-authority markers (deny agent.standard) matched by substring.
+          _TIER0_MARKERS = (
+              "/api/v1/agent/selftest/admin",
+              "/dedup-review",
+              "/deprecate",
+              "/restore",
+              "/revert",
+              "/api/v1/deploy/submit",
+              "/api/v1/deploy/trigger",
+              "/api/v1/deploy/decide",
+          )
+
+          _jwks_cache = {}
+          _jwks_fetched = {}
+          _JWKS_TTL = 3600.0
+          _internal_key_cache = None
+
+
+          def _b64url_decode(data):
+              if isinstance(data, str):
+                  data = data.encode("ascii")
+              return base64.urlsafe_b64decode(data + b"=" * (-len(data) % 4))
+
+
+          def _b64url_int(data):
+              return int.from_bytes(_b64url_decode(data), "big")
+
+
+          def _get_jwks(pool_id):
+              now = time.time()
+              cached = _jwks_cache.get(pool_id)
+              if cached and (now - _jwks_fetched.get(pool_id, 0.0)) < _JWKS_TTL:
+                  return cached
+              url = (
+                  "https://cognito-idp.%s.amazonaws.com/%s/.well-known/jwks.json"
+                  % (pool_id.split("_", 1)[0], pool_id)
+              )
+              with urllib.request.urlopen(url, timeout=5) as resp:
+                  data = json.loads(resp.read())
+              keys = {}
+              for k in data.get("keys", []):
+                  keys[k["kid"]] = (_b64url_int(k["n"]), _b64url_int(k["e"]))
+              _jwks_cache[pool_id] = keys
+              _jwks_fetched[pool_id] = now
+              return keys
+
+
+          def _rsa_verify(signing_input, signature, n, e):
+              k = (n.bit_length() + 7) // 8
+              if len(signature) != k:
+                  return False
+              s = int.from_bytes(signature, "big")
+              if s >= n:
+                  return False
+              em = pow(s, e, n).to_bytes(k, "big")
+              digest = hashlib.sha256(signing_input).digest()
+              t = _SHA256_DIGEST_INFO + digest
+              if k < len(t) + 11:
+                  return False
+              expected = b"\x00\x01" + b"\xff" * (k - len(t) - 3) + b"\x00" + t
+              return hmac.compare_digest(em, expected)
+
+
+          def _verify_jwt(token, pool_id):
+              parts = token.split(".")
+              if len(parts) != 3:
+                  raise ValueError("malformed token")
+              header = json.loads(_b64url_decode(parts[0]))
+              if header.get("alg") != "RS256":
+                  raise ValueError("unexpected alg")
+              claims = json.loads(_b64url_decode(parts[1]))
+              kid = header.get("kid")
+              key = _get_jwks(pool_id).get(kid)
+              if key is None:
+                  _jwks_fetched.pop(pool_id, None)
+                  key = _get_jwks(pool_id).get(kid)
+              if key is None:
+                  raise ValueError("unknown kid")
+              signing_input = (parts[0] + "." + parts[1]).encode("ascii")
+              if not _rsa_verify(signing_input, _b64url_decode(parts[2]), key[0], key[1]):
+                  raise ValueError("bad signature")
+              exp = claims.get("exp")
+              if exp is not None and time.time() > float(exp) + 5:
+                  raise ValueError("expired")
+              if not str(claims.get("iss", "")).endswith("/" + pool_id):
+                  raise ValueError("issuer mismatch")
+              return claims
+
+
+          def _tier_from_scope(scope_value):
+              names = [s.rsplit("/", 1)[-1] for s in str(scope_value or "").split()]
+              for tier in ("admin", "elevated", "standard", "observe"):
+                  if "agent." + tier in names:
+                      return tier
+              return "observe"
+
+
+          def _load_internal_key():
+              global _internal_key_cache
+              if _internal_key_cache is not None:
+                  return _internal_key_cache
+              if not INTERNAL_KEY_SECRET_ID:
+                  _internal_key_cache = ""
+                  return ""
+              try:
+                  raw = boto3.client("secretsmanager").get_secret_value(
+                      SecretId=INTERNAL_KEY_SECRET_ID
+                  )["SecretString"]
+              except Exception:
+                  _internal_key_cache = ""
+                  return ""
+              value = raw
+              try:
+                  obj = json.loads(raw)
+                  if isinstance(obj, dict):
+                      value = (
+                          obj.get("internal_key")
+                          or obj.get("key")
+                          or obj.get("client_secret")
+                          or ""
+                      )
+              except (ValueError, TypeError):
+                  value = raw
+              _internal_key_cache = (value or "").strip()
+              return _internal_key_cache
+
+
+          def _required_tier(method, path):
+              # Governance-authority markers (mutations) win regardless of method.
+              for marker in _TIER0_MARKERS:
+                  if marker in path:
+                      return _TIER0
+              # Read-only methods need only the observer tier (agent.observe taxonomy).
+              if str(method).upper() in ("GET", "HEAD", "OPTIONS"):
+                  return "observe"
+              best = None
+              for prefix, tier in _ROUTE_TIERS:
+                  if path.startswith(prefix) and (best is None or len(prefix) > len(best[0])):
+                      best = (prefix, tier)
+              if best is not None:
+                  return best[1]
+              return _TIER1
+
+
+          def _headers(event):
+              raw = event.get("headers") or {}
+              return {str(k).lower(): v for k, v in raw.items()}
+
+
+          def _bearer_token(headers, event):
+              auth = headers.get("authorization") or ""
+              if auth.lower().startswith("bearer "):
+                  return auth[7:].strip()
+              parts = [headers.get("cookie") or ""]
+              cookies = event.get("cookies") or []
+              if isinstance(cookies, list):
+                  parts.extend(cookies)
+              for chunk in parts:
+                  for piece in str(chunk).split(";"):
+                      piece = piece.strip()
+                      if piece.startswith("enceladus_id_token="):
+                          return piece[len("enceladus_id_token="):]
+              return ""
+
+
+          def _identify(event):
+              headers = _headers(event)
+              internal_key = (
+                  headers.get("x-coordination-internal-key")
+                  or headers.get("x-checkout-assistant-key")
+                  or ""
+              )
+              if internal_key:
+                  expected = _load_internal_key()
+                  if expected and hmac.compare_digest(internal_key, expected):
+                      return {"principal": "internal", "tier": "admin", "sub": "internal-key"}
+                  return {"principal": "internal", "tier": None, "error": "invalid internal key"}
+
+              token = _bearer_token(headers, event)
+              if not token:
+                  return {"principal": "anonymous", "tier": None, "error": "no credentials"}
+              try:
+                  unverified = json.loads(_b64url_decode(token.split(".")[1]))
+              except Exception:
+                  return {"principal": "unknown", "tier": None, "error": "undecodable token"}
+
+              iss = str(unverified.get("iss", ""))
+              if AGENT_USER_POOL_ID and iss.endswith("/" + AGENT_USER_POOL_ID):
+                  claims = _verify_jwt(token, AGENT_USER_POOL_ID)
+                  tier = (claims.get("enc:agent_tier") or "").strip() or _tier_from_scope(
+                      claims.get("scope")
+                  )
+                  return {
+                      "principal": "m2m",
+                      "tier": tier,
+                      "sub": claims.get("sub", ""),
+                      "client_id": claims.get("client_id", ""),
+                      "session_id": claims.get("enc:session_id", ""),
+                      "scope": claims.get("scope", ""),
+                  }
+              if HUMAN_USER_POOL_ID and iss.endswith("/" + HUMAN_USER_POOL_ID):
+                  claims = _verify_jwt(token, HUMAN_USER_POOL_ID)
+                  return {"principal": "human", "tier": "admin", "sub": claims.get("sub", "")}
+              return {"principal": "unknown", "tier": None, "error": "unrecognized issuer"}
+
+
+          def handler(event, context):
+              rc = event.get("requestContext") or {}
+              http = rc.get("http") or {}
+              method = http.get("method") or event.get("httpMethod") or ""
+              path = http.get("path") or event.get("rawPath") or ""
+              route_key = event.get("routeKey") or rc.get("routeKey") or ""
+              if route_key and " " in route_key:
+                  rk_method, rk_path = route_key.split(" ", 1)
+                  method = method or rk_method
+                  path = rk_path or path
+
+              try:
+                  identity = _identify(event)
+              except ValueError as exc:
+                  identity = {"principal": "invalid", "tier": None, "error": str(exc)}
+              except Exception as exc:  # fail closed on any verification error
+                  identity = {"principal": "error", "tier": None, "error": "verify error: %s" % exc}
+
+              required = _required_tier(method, path)
+              principal_tier = identity.get("tier")
+              authorized = (
+                  principal_tier is not None
+                  and _TIER_RANK.get(principal_tier, -1) >= _TIER_RANK.get(required, 99)
+              )
+              ctx = {
+                  "principalType": str(identity.get("principal", "")),
+                  "agentTier": str(principal_tier or ""),
+                  "requiredTier": str(required),
+                  "sub": str(identity.get("sub", "")),
+                  "sessionId": str(identity.get("session_id", "")),
+                  "clientId": str(identity.get("client_id", "")),
+                  "scope": str(identity.get("scope", "")),
+                  "authReason": "ok" if authorized else str(identity.get("error", "denied")),
+              }
+              return {"isAuthorized": bool(authorized), "context": ctx}
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: agent-auth
+
+  AgentAuthorizerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/enceladus-agent-authorizer${EnvironmentSuffix}"
+      RetentionInDays: 30
+
+  AgentAuthorizerInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AgentAuthorizerLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub
+        - "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiId}/*"
+        - ApiId: !ImportValue
+            "Fn::Sub": "${ApiStackName}-ApiId"
+
+  # REQUEST authorizer. IdentitySource omitted + AuthorizerResultTtlInSeconds 0 means the
+  # authorizer is invoked on EVERY request (no caching) — required because the principal may
+  # arrive via the Authorization header, the enceladus_id_token cookie, OR the internal-key
+  # header, and the decision is route-tier dependent.
+  AgentRequestAuthorizer:
+    Type: AWS::ApiGatewayV2::Authorizer
+    Properties:
+      ApiId: !ImportValue
+        "Fn::Sub": "${ApiStackName}-ApiId"
+      Name: !Sub "enceladus-agent-request-authorizer${EnvironmentSuffix}"
+      AuthorizerType: REQUEST
+      AuthorizerPayloadFormatVersion: "2.0"
+      EnableSimpleResponses: true
+      AuthorizerResultTtlInSeconds: 0
+      AuthorizerUri: !Sub
+        - "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FnArn}/invocations"
+        - FnArn: !GetAtt AgentAuthorizerLambda.Arn
+
+  # --- Self-test backend + Tier 0 / Tier 1 routes --------------------------------
+  # A tiny echo Lambda backs the demonstration routes. On a Tier 0 route an agent.standard
+  # token is rejected at the gateway (403) before reaching the integration; on a Tier 1 route
+  # it is admitted and the echo returns the resolved principal/tier context (ENC-TSK-I80 AC3).
+
+  AgentSelftestLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "enceladus-agent-selftest-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: agent-auth
+
+  AgentSelftestLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "enceladus-agent-selftest${EnvironmentSuffix}"
+      Description: >
+        ENC-FTR-074 Ph2 echo backend for the Tier 0 / Tier 1 authorizer self-test routes. Returns
+        200 and reflects the authorizer-resolved principal/tier context so an admitted request can
+        be confirmed end-to-end.
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt AgentSelftestLambdaRole.Arn
+      Timeout: 5
+      MemorySize: 128
+      Architectures:
+        - arm64
+      Code:
+        ZipFile: |
+          import json
+
+          def handler(event, context):
+              rc = event.get("requestContext") or {}
+              authz = rc.get("authorizer") or {}
+              lam = authz.get("lambda") or authz
+              body = {
+                  "ok": True,
+                  "service": "agent-auth-selftest",
+                  "routeKey": rc.get("routeKey") or event.get("routeKey", ""),
+                  "principalType": lam.get("principalType", ""),
+                  "agentTier": lam.get("agentTier", ""),
+                  "requiredTier": lam.get("requiredTier", ""),
+                  "scope": lam.get("scope", ""),
+              }
+              return {
+                  "statusCode": 200,
+                  "headers": {"Content-Type": "application/json"},
+                  "body": json.dumps(body),
+              }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: agent-auth
+
+  AgentSelftestLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/enceladus-agent-selftest${EnvironmentSuffix}"
+      RetentionInDays: 30
+
+  AgentSelftestInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AgentSelftestLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub
+        - "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiId}/*"
+        - ApiId: !ImportValue
+            "Fn::Sub": "${ApiStackName}-ApiId"
+
+  AgentSelftestIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !ImportValue
+        "Fn::Sub": "${ApiStackName}-ApiId"
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt AgentSelftestLambda.Arn
+      IntegrationMethod: POST
+      PayloadFormatVersion: "2.0"
+
+  # Tier 1 route — requires agent.standard; agent.standard tokens ARE admitted.
+  AgentSelftestStandardRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !ImportValue
+        "Fn::Sub": "${ApiStackName}-ApiId"
+      RouteKey: POST /api/v1/agent/selftest/standard
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref AgentRequestAuthorizer
+      Target: !Sub "integrations/${AgentSelftestIntegration}"
+
+  # Tier 0 route — governance-authority boundary; agent.standard tokens are REJECTED (403).
+  AgentSelftestAdminRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !ImportValue
+        "Fn::Sub": "${ApiStackName}-ApiId"
+      RouteKey: POST /api/v1/agent/selftest/admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref AgentRequestAuthorizer
+      Target: !Sub "integrations/${AgentSelftestIntegration}"
+
 Outputs:
   UserPoolId:
     Description: Agent-auth Cognito User Pool ID.
@@ -492,3 +1048,23 @@ Outputs:
     Value: !Ref AgentM2MClientSecret
     Export:
       Name: !Sub "${AWS::StackName}-M2MClientSecretArn"
+
+  # --- ENC-FTR-074 Ph2 (ENC-TSK-I80) outputs -----------------------------------
+
+  AgentRequestAuthorizerId:
+    Description: REQUEST-type Lambda authorizer id attached to the HTTP API (ENC-TSK-I80 AC1).
+    Value: !Ref AgentRequestAuthorizer
+    Export:
+      Name: !Sub "${AWS::StackName}-AgentRequestAuthorizerId"
+
+  AgentAuthorizerLambdaArn:
+    Description: REQUEST authorizer Lambda ARN (discriminates internal-key / human / M2M principals).
+    Value: !GetAtt AgentAuthorizerLambda.Arn
+
+  AgentSelftestTier1RouteKey:
+    Description: Tier 1 self-test route — agent.standard admitted.
+    Value: "POST /api/v1/agent/selftest/standard"
+
+  AgentSelftestTier0RouteKey:
+    Description: Tier 0 self-test route — agent.standard rejected (403).
+    Value: "POST /api/v1/agent/selftest/admin"

--- a/tests/infrastructure/test_agent_authorizer_ftr074.py
+++ b/tests/infrastructure/test_agent_authorizer_ftr074.py
@@ -1,0 +1,213 @@
+"""ENC-FTR-074 Ph2 (ENC-TSK-I80) — unit tests for the REQUEST-type Lambda authorizer.
+
+The authorizer handler is embedded inline (ZipFile) in
+``infrastructure/cloudformation/08-agent-auth.yaml`` (single source of truth, matching the
+Ph1 inline-handler pattern). These tests extract that inline code, exec it as a module, and
+exercise:
+
+  * the hand-rolled pure-stdlib RS256 verification against a generated RSA JWKS,
+  * three-principal discrimination (internal-key / human JWT / M2M scope token),
+  * the route-tier governance-authority boundary (agent.standard denied on Tier 0, admitted
+    on Tier 1).
+
+Test vectors are built with PyJWT + cryptography (dev-only deps); the Lambda itself uses
+neither at runtime.
+"""
+
+import base64
+import os
+import pathlib
+import time
+
+import jwt as pyjwt
+import pytest
+import yaml
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "infrastructure" / "cloudformation" / "08-agent-auth.yaml"
+
+AGENT_POOL = "us-west-2_AgentPoolTest"
+HUMAN_POOL = "us-east-1_HumanPoolTest"
+_KID = "test-kid-1"
+
+
+class _CfnLoader(yaml.SafeLoader):
+    pass
+
+
+_CfnLoader.add_multi_constructor("!", lambda loader, suffix, node: None)
+
+
+def _b64url_uint(value: int) -> str:
+    raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+@pytest.fixture(scope="module")
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def authorizer(rsa_key):
+    os.environ["AGENT_USER_POOL_ID"] = AGENT_POOL
+    os.environ["HUMAN_USER_POOL_ID"] = HUMAN_POOL
+    os.environ["AGENT_M2M_CLIENT_ID"] = "m2mclient123"
+    os.environ["INTERNAL_KEY_SECRET_ID"] = ""
+
+    doc = yaml.load(TEMPLATE.read_text(), Loader=_CfnLoader)
+    code = doc["Resources"]["AgentAuthorizerLambda"]["Properties"]["Code"]["ZipFile"]
+    ns: dict = {}
+    exec(compile(code, "agent_authorizer_inline", "exec"), ns)  # noqa: S102
+
+    pub = rsa_key.public_key().public_numbers()
+    jwks = {AGENT_POOL: {_KID: (pub.n, pub.e)}, HUMAN_POOL: {_KID: (pub.n, pub.e)}}
+    ns["_get_jwks"] = lambda pool_id: jwks[pool_id]
+    return ns
+
+
+def _make_token(rsa_key, pool, claims):
+    payload = {
+        "iss": f"https://cognito-idp.{pool.split('_', 1)[0]}.amazonaws.com/{pool}",
+        "exp": int(time.time()) + 600,
+        "iat": int(time.time()),
+        "sub": "sub-123",
+    }
+    payload.update(claims)
+    return pyjwt.encode(payload, rsa_key, algorithm="RS256", headers={"kid": _KID})
+
+
+def _event(route_key, *, bearer=None, cookie=None, internal_key=None):
+    headers = {}
+    if bearer:
+        headers["authorization"] = f"Bearer {bearer}"
+    if cookie:
+        headers["cookie"] = cookie
+    if internal_key:
+        headers["x-coordination-internal-key"] = internal_key
+    method, path = route_key.split(" ", 1)
+    return {
+        "version": "2.0",
+        "routeKey": route_key,
+        "headers": headers,
+        "requestContext": {"http": {"method": method, "path": path}, "routeKey": route_key},
+    }
+
+
+TIER1 = "POST /api/v1/agent/selftest/standard"
+TIER0 = "POST /api/v1/agent/selftest/admin"
+
+
+def test_m2m_standard_admitted_on_tier1(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.standard",
+         "client_id": "m2mclient123", "enc:agent_tier": "standard",
+         "enc:session_id": "ENC-SES-TST"},
+    )
+    res = authorizer["handler"](_event(TIER1, bearer=token), None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["principalType"] == "m2m"
+    assert res["context"]["agentTier"] == "standard"
+    assert res["context"]["sessionId"] == "ENC-SES-TST"
+
+
+def test_m2m_standard_rejected_on_tier0(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.standard",
+         "client_id": "m2mclient123", "enc:agent_tier": "standard"},
+    )
+    res = authorizer["handler"](_event(TIER0, bearer=token), None)
+    assert res["isAuthorized"] is False
+    assert res["context"]["requiredTier"] == "elevated"
+
+
+def test_m2m_elevated_admitted_on_tier0(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.elevated",
+         "client_id": "m2mclient123", "enc:agent_tier": "elevated"},
+    )
+    res = authorizer["handler"](_event(TIER0, bearer=token), None)
+    assert res["isAuthorized"] is True
+
+
+def test_tier_derived_from_scope_when_claim_absent(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.elevated"},
+    )
+    res = authorizer["handler"](_event(TIER0, bearer=token), None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["agentTier"] == "elevated"
+
+
+def test_human_jwt_is_admin_and_admitted_on_tier0(authorizer, rsa_key):
+    token = _make_token(rsa_key, HUMAN_POOL, {"token_use": "id", "aud": "webui"})
+    res = authorizer["handler"](_event(TIER0, bearer=token), None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["principalType"] == "human"
+
+
+def test_human_cookie_token_is_accepted(authorizer, rsa_key):
+    token = _make_token(rsa_key, HUMAN_POOL, {"token_use": "id", "aud": "webui"})
+    res = authorizer["handler"](_event(TIER1, cookie=f"enceladus_id_token={token}"), None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["principalType"] == "human"
+
+
+def test_tampered_signature_is_rejected(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.elevated",
+         "enc:agent_tier": "elevated"},
+    )
+    tampered = token[:-4] + ("AAAA" if token[-4:] != "AAAA" else "BBBB")
+    res = authorizer["handler"](_event(TIER1, bearer=tampered), None)
+    assert res["isAuthorized"] is False
+
+
+def test_unknown_issuer_is_rejected(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, "us-west-2_StrangerPool",
+        {"token_use": "access", "scope": "enceladus-api/agent.admin"},
+    )
+    res = authorizer["handler"](_event(TIER1, bearer=token), None)
+    assert res["isAuthorized"] is False
+    assert res["context"]["principalType"] == "unknown"
+
+
+def test_no_credentials_is_rejected(authorizer):
+    res = authorizer["handler"](_event(TIER1), None)
+    assert res["isAuthorized"] is False
+    assert res["context"]["principalType"] == "anonymous"
+
+
+def test_internal_key_admitted_when_configured(authorizer, monkeypatch):
+    monkeypatch.setitem(authorizer, "_internal_key_cache", None)
+    monkeypatch.setitem(authorizer, "INTERNAL_KEY_SECRET_ID", "secret-arn")
+    monkeypatch.setitem(authorizer, "_load_internal_key", lambda: "s3cr3t-key")
+    res = authorizer["handler"](_event(TIER0, internal_key="s3cr3t-key"), None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["principalType"] == "internal"
+
+
+def test_internal_key_wrong_value_rejected(authorizer, monkeypatch):
+    monkeypatch.setitem(authorizer, "_load_internal_key", lambda: "s3cr3t-key")
+    res = authorizer["handler"](_event(TIER1, internal_key="WRONG"), None)
+    assert res["isAuthorized"] is False
+    assert res["context"]["principalType"] == "internal"
+
+
+def test_get_read_route_allows_observe(authorizer, rsa_key):
+    token = _make_token(
+        rsa_key, AGENT_POOL,
+        {"token_use": "access", "scope": "enceladus-api/agent.observe",
+         "enc:agent_tier": "observe"},
+    )
+    ev = _event("GET /api/v1/tracker/enceladus", bearer=token)
+    res = authorizer["handler"](ev, None)
+    assert res["isAuthorized"] is True
+    assert res["context"]["requiredTier"] == "observe"

--- a/tools/enceladus-mcp-server/AGENT_M2M_AUTH.md
+++ b/tools/enceladus-mcp-server/AGENT_M2M_AUTH.md
@@ -1,0 +1,100 @@
+# Governed Headless Agent Auth — Cognito M2M (ENC-FTR-074 Ph2 / ENC-TSK-I80)
+
+This directory ships the **gamma** headless-agent authentication path for the Enceladus MCP
+gateway: a Cognito **client_credentials** (M2M) token flow plus a REQUEST-type API Gateway
+Lambda authorizer that tier-gates governed routes.
+
+> **Deploy target: gamma only.** v3-prod is FROZEN (DOC-499FA089EC30). The authorizer, the
+> agent-auth Cognito pool, and these profiles target the gamma stack. Nothing here touches
+> `main` / the production API.
+
+## Pieces
+
+| File | Role |
+| --- | --- |
+| `infrastructure/cloudformation/08-agent-auth.yaml` | Ph1 dual-client Cognito pool **+ Ph2** REQUEST authorizer Lambda, `AWS::ApiGatewayV2::Authorizer`, and Tier 0 / Tier 1 self-test routes. |
+| `agent_m2m_headers_helper.sh` | The **`.mcp.json` headersHelper**. Performs the client_credentials grant and emits a fresh `Authorization: Bearer <access_token>` header. |
+| `mcp.gamma-m2m.json` | `.mcp.json` profile for headless gamma sessions, wiring the headersHelper. |
+| `routines/run_pending_updates.sh` | Hourly Pending-Updates routine runner (authenticates with `agent.standard`). |
+| `routines/pending-updates-hourly.json` | Declarative routine spec (schedule + auth + target). |
+
+## Principal types discriminated by the authorizer (AC1)
+
+The REQUEST authorizer (`enceladus-agent-authorizer`) inspects each request and resolves one of
+three principal types, then enforces the route's required tier:
+
+1. **internal-key** — `X-Coordination-Internal-Key` header validated against the Secrets Manager
+   value in `InternalKeySecretId`. Granted `admin` (highest tier). Deny-closed when no secret id
+   is configured.
+2. **human** — a Cognito JWT issued by `HumanUserPoolId` (PWA), presented as `Authorization:
+   Bearer` or the `enceladus_id_token` cookie. Not scope-limited; granted `admin`.
+3. **m2m** — a headless-agent client_credentials access token issued by the agent-auth pool
+   (`AgentUserPool`), carrying `enceladus-api/agent.*` scopes and the `enc:agent_tier` claim. The
+   tier comes from `enc:agent_tier` (fallback: derived from the scopes).
+
+The token signature is verified with a **pure standard-library RS256** implementation against the
+pool JWKS — deliberately avoiding PyJWT/cryptography so the authorizer never inherits the
+shared-layer `.so` ABI failure class (ENC-ISS-198 / ENC-LSN-020).
+
+## Tier model & the governance-authority boundary (AC3)
+
+```
+observe (0)  <  standard (1)  <  elevated (2)  <  admin (3)
+```
+
+A route declares the **minimum** tier it requires. `agent.standard` (rank 1) is therefore:
+
+- **admitted** on a **Tier 1** route — e.g. `POST /api/v1/agent/selftest/standard`, tracker /
+  document / checkout mutations;
+- **rejected with 403** on a **Tier 0** route — the governance-authority boundary, e.g.
+  `POST /api/v1/agent/selftest/admin`, `dedup-review` approve, `deploy/submit|trigger|decide`,
+  component `deprecate|restore|revert`.
+
+GET/HEAD/OPTIONS reads require only `observe`.
+
+## Mint a token / inject headers (AC2)
+
+```bash
+# Fresh bearer header as JSON (default) — this is what the .mcp.json headersHelper calls:
+bash tools/enceladus-mcp-server/agent_m2m_headers_helper.sh --headers-json
+# {"Authorization":"Bearer eyJ..."}
+
+# Raw token, or export into the environment for the static-headers fallback:
+bash tools/enceladus-mcp-server/agent_m2m_headers_helper.sh --token
+eval "$(bash tools/enceladus-mcp-server/agent_m2m_headers_helper.sh --export)"   # sets ENCELADUS_M2M_BEARER
+```
+
+Required environment (gamma defaults shown):
+
+```bash
+export ENCELADUS_M2M_TOKEN_ENDPOINT="https://<agent-auth-domain>.auth.us-west-2.amazoncognito.com/oauth2/token"  # see 08-agent-auth.yaml TokenEndpoint output
+export ENCELADUS_M2M_SCOPE="enceladus-api/agent.standard"   # default
+# Credentials: either env or Secrets Manager (enceladus/agent-m2m/client-secret, hydrated by the Ph1 rotation Lambda)
+export ENCELADUS_M2M_CLIENT_ID=...        # optional if reading the secret
+export ENCELADUS_M2M_CLIENT_SECRET=...    # optional if reading the secret
+```
+
+Then connect a headless session with `mcp.gamma-m2m.json` and run any governed MCP call to verify.
+
+## Hourly Pending-Updates routine (AC4)
+
+`routines/run_pending_updates.sh` mints an `agent.standard` token and calls
+`search(action=tracker.pending_updates)` on the gamma MCP gateway every hour. Wire it with cron,
+a systemd timer, EventBridge Scheduler (`cron(0 * * * ? *)`), or a Claude Code routine per
+`routines/pending-updates-hourly.json`. A successful run logs `[SUCCESS] pending-updates routine
+completed (HTTP 200)` and is visible in the gamma MCP / coordination-api CloudWatch logs.
+
+## Live verification (post-deploy, human-owned)
+
+This task is delivered to `committed`; deploy + live AC verification on gamma are owned by the
+human reviewer:
+
+```bash
+# AC1 — authorizer exists on the gamma HTTP API:
+aws apigatewayv2 get-authorizers --api-id <gamma-api-id> --region us-west-2
+
+# AC3 — agent.standard rejected on Tier 0 (403) / admitted on Tier 1 (200):
+TOK=$(ENCELADUS_M2M_SCOPE=enceladus-api/agent.standard bash tools/enceladus-mcp-server/agent_m2m_headers_helper.sh --token)
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://enceladus-gamma.jreese.net/api/v1/agent/selftest/admin    -H "Authorization: Bearer $TOK"   # expect 403
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://enceladus-gamma.jreese.net/api/v1/agent/selftest/standard -H "Authorization: Bearer $TOK"   # expect 200
+```

--- a/tools/enceladus-mcp-server/agent_m2m_headers_helper.sh
+++ b/tools/enceladus-mcp-server/agent_m2m_headers_helper.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# agent_m2m_headers_helper.sh — ENC-FTR-074 Ph2 (ENC-TSK-I80) headers helper.
+#
+# Acquires a FRESH Cognito access_token for the headless agent (enceladus-agent-m2m App
+# Client) via the OAuth2 client_credentials grant against the agent-auth User Pool stood up
+# in Ph1 (08-agent-auth.yaml / ENC-TSK-I79), and injects it as an Authorization: Bearer
+# header for the gamma Enceladus MCP gateway. This is the ".mcp.json headersHelper" referenced
+# by tools/enceladus-mcp-server/mcp.gamma-m2m.json.
+#
+# The minted token carries the enc:agent_tier + enc:session_id custom claims (pre-token Lambda)
+# and the requested resource-server scope, so the Ph2 REQUEST authorizer can tier-gate it.
+#
+# Output modes (pick one):
+#   --headers-json   Print {"Authorization":"Bearer <token>"}            (default)
+#   --token          Print the raw access_token only
+#   --export         Print: export ENCELADUS_M2M_BEARER='Bearer <token>'
+#                            export ENCELADUS_M2M_ACCESS_TOKEN='<token>'
+#
+# Credential resolution (first match wins):
+#   1. ENCELADUS_M2M_CLIENT_ID + ENCELADUS_M2M_CLIENT_SECRET (env)
+#   2. Secrets Manager secret ENCELADUS_M2M_SECRET_ID (default enceladus/agent-m2m/client-secret),
+#      whose SecretString is {"client_id":"...","client_secret":"..."} (hydrated by the Ph1
+#      rotation Lambda). Requires AWS credentials with secretsmanager:GetSecretValue.
+#
+# Endpoint / scope (env, with gamma defaults):
+#   ENCELADUS_M2M_TOKEN_ENDPOINT   OAuth2 token endpoint (no default — must be set OR derivable)
+#   ENCELADUS_M2M_DOMAIN_PREFIX    Hosted-UI domain prefix (used to derive the endpoint)
+#   ENCELADUS_M2M_REGION           default us-west-2
+#   ENCELADUS_M2M_SCOPE            default enceladus-api/agent.standard
+#
+# Never prints the client_secret. Token is short-lived (60 min; see Ph1 AccessTokenValidity).
+
+set -euo pipefail
+
+OUTPUT_MODE="--headers-json"
+case "${1:-}" in
+  --headers-json|--token|--export) OUTPUT_MODE="$1" ;;
+  "") : ;;
+  *) echo "usage: $0 [--headers-json|--token|--export]" >&2; exit 2 ;;
+esac
+
+REGION="${ENCELADUS_M2M_REGION:-us-west-2}"
+SCOPE="${ENCELADUS_M2M_SCOPE:-enceladus-api/agent.standard}"
+SECRET_ID="${ENCELADUS_M2M_SECRET_ID:-enceladus/agent-m2m/client-secret}"
+
+PYTHON_BIN="${ENCELADUS_MCP_PYTHON_BIN:-$(command -v python3 || true)}"
+if [ -z "${PYTHON_BIN}" ]; then
+  echo "[ERROR] python3 is required (JSON parsing)." >&2
+  exit 1
+fi
+
+CLIENT_ID="${ENCELADUS_M2M_CLIENT_ID:-}"
+CLIENT_SECRET="${ENCELADUS_M2M_CLIENT_SECRET:-}"
+
+# Resolve credentials from Secrets Manager when not provided directly.
+if [ -z "${CLIENT_ID}" ] || [ -z "${CLIENT_SECRET}" ]; then
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "[ERROR] No ENCELADUS_M2M_CLIENT_ID/SECRET in env and AWS CLI not available to read ${SECRET_ID}." >&2
+    exit 1
+  fi
+  SECRET_JSON="$(aws secretsmanager get-secret-value \
+      --region "${REGION}" \
+      --secret-id "${SECRET_ID}" \
+      --query SecretString --output text 2>/dev/null || true)"
+  if [ -z "${SECRET_JSON}" ]; then
+    echo "[ERROR] Could not read Secrets Manager secret ${SECRET_ID} in ${REGION}." >&2
+    exit 1
+  fi
+  CLIENT_ID="$(printf '%s' "${SECRET_JSON}" | "${PYTHON_BIN}" -c 'import json,sys;print(json.load(sys.stdin).get("client_id",""))')"
+  CLIENT_SECRET="$(printf '%s' "${SECRET_JSON}" | "${PYTHON_BIN}" -c 'import json,sys;print(json.load(sys.stdin).get("client_secret",""))')"
+fi
+
+if [ -z "${CLIENT_ID}" ] || [ -z "${CLIENT_SECRET}" ]; then
+  echo "[ERROR] M2M client_id/client_secret unresolved (set ENCELADUS_M2M_CLIENT_ID/SECRET or populate ${SECRET_ID})." >&2
+  exit 1
+fi
+
+# Resolve the OAuth2 token endpoint.
+TOKEN_ENDPOINT="${ENCELADUS_M2M_TOKEN_ENDPOINT:-}"
+if [ -z "${TOKEN_ENDPOINT}" ]; then
+  if [ -n "${ENCELADUS_M2M_DOMAIN_PREFIX:-}" ]; then
+    TOKEN_ENDPOINT="https://${ENCELADUS_M2M_DOMAIN_PREFIX}.auth.${REGION}.amazoncognito.com/oauth2/token"
+  else
+    echo "[ERROR] Set ENCELADUS_M2M_TOKEN_ENDPOINT (or ENCELADUS_M2M_DOMAIN_PREFIX) — the agent-auth" >&2
+    echo "[ERROR] OAuth2 token endpoint is account-specific (see 08-agent-auth.yaml TokenEndpoint output)." >&2
+    exit 1
+  fi
+fi
+
+# client_credentials grant with client_secret_basic auth.
+RESPONSE="$(curl -sS -X POST "${TOKEN_ENDPOINT}" \
+  -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "scope=${SCOPE}" 2>/dev/null || true)"
+
+ACCESS_TOKEN="$(printf '%s' "${RESPONSE}" | "${PYTHON_BIN}" -c '
+import json, sys
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(obj.get("access_token", ""))
+')"
+
+if [ -z "${ACCESS_TOKEN}" ]; then
+  ERR="$(printf '%s' "${RESPONSE}" | "${PYTHON_BIN}" -c '
+import json, sys
+try:
+    obj = json.load(sys.stdin)
+    print(obj.get("error_description") or obj.get("error") or "")
+except Exception:
+    print("")
+')"
+  echo "[ERROR] client_credentials grant failed at ${TOKEN_ENDPOINT} (scope=${SCOPE}). ${ERR}" >&2
+  exit 1
+fi
+
+case "${OUTPUT_MODE}" in
+  --token)
+    printf '%s\n' "${ACCESS_TOKEN}"
+    ;;
+  --export)
+    printf "export ENCELADUS_M2M_BEARER='Bearer %s'\n" "${ACCESS_TOKEN}"
+    printf "export ENCELADUS_M2M_ACCESS_TOKEN='%s'\n" "${ACCESS_TOKEN}"
+    ;;
+  --headers-json|*)
+    ACCESS_TOKEN="${ACCESS_TOKEN}" "${PYTHON_BIN}" -c '
+import json, os
+print(json.dumps({"Authorization": "Bearer " + os.environ["ACCESS_TOKEN"]}))
+'
+    ;;
+esac

--- a/tools/enceladus-mcp-server/mcp.gamma-m2m.json
+++ b/tools/enceladus-mcp-server/mcp.gamma-m2m.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "ENC-FTR-074 Ph2 (ENC-TSK-I80) — gamma headless-agent MCP profile authenticated by a Cognito M2M client_credentials access token. The 'headersHelper' runs agent_m2m_headers_helper.sh, which performs the client_credentials grant against the agent-auth pool and emits {\"Authorization\":\"Bearer <fresh access_token>\"}. The static 'headers' block is a fallback for clients without headersHelper support: run `eval \"$(bash tools/enceladus-mcp-server/agent_m2m_headers_helper.sh --export)\"` first to populate ENCELADUS_M2M_BEARER. See AGENT_M2M_AUTH.md. v3-prod is FROZEN; this profile targets gamma only.",
+  "mcpServers": {
+    "enceladus-gamma": {
+      "type": "http",
+      "url": "https://enceladus-gamma.jreese.net/api/v1/coordination/mcp",
+      "headersHelper": {
+        "command": "bash",
+        "args": [
+          "tools/enceladus-mcp-server/agent_m2m_headers_helper.sh",
+          "--headers-json"
+        ]
+      },
+      "headers": {
+        "Authorization": "${env:ENCELADUS_M2M_BEARER}"
+      }
+    }
+  }
+}

--- a/tools/enceladus-mcp-server/routines/pending-updates-hourly.json
+++ b/tools/enceladus-mcp-server/routines/pending-updates-hourly.json
@@ -1,0 +1,40 @@
+{
+  "$comment": "ENC-FTR-074 Ph2 (ENC-TSK-I80) AC4 — declarative spec for the hourly Pending-Updates routine. Consumed by whichever scheduler wires it (cron / systemd timer / EventBridge Scheduler / Claude Code routine). The runner authenticates with a Cognito M2M token carrying the agent.standard scope and calls the governed Pending-Updates read on the gamma MCP gateway, which is admitted by the Ph2 REQUEST authorizer (Tier 1) and logged to CloudWatch.",
+  "routine": {
+    "name": "enceladus-pending-updates-hourly",
+    "description": "Governed hourly Pending Updates pull for project=enceladus, authenticated via Cognito M2M client_credentials (scope agent.standard).",
+    "schedule": {
+      "type": "cron",
+      "expression": "0 * * * *",
+      "timezone": "UTC",
+      "eventbridge_scheduler_expression": "cron(0 * * * ? *)"
+    },
+    "auth": {
+      "principal_type": "m2m",
+      "grant": "client_credentials",
+      "scope": "enceladus-api/agent.standard",
+      "tier": "standard",
+      "token_endpoint_env": "ENCELADUS_M2M_TOKEN_ENDPOINT",
+      "credentials_secret": "enceladus/agent-m2m/client-secret",
+      "headers_helper": "tools/enceladus-mcp-server/agent_m2m_headers_helper.sh"
+    },
+    "command": {
+      "executable": "bash",
+      "args": ["tools/enceladus-mcp-server/routines/run_pending_updates.sh"]
+    },
+    "target": {
+      "mcp_url": "https://enceladus-gamma.jreese.net/api/v1/coordination/mcp",
+      "tool": "search",
+      "action": "tracker.pending_updates",
+      "arguments": {"project_id": "enceladus"}
+    },
+    "evidence": {
+      "log_group_candidates": [
+        "/enceladus/mcp/server-gamma",
+        "/aws/lambda/devops-coordination-api-gamma",
+        "/aws/lambda/enceladus-agent-authorizer-gamma"
+      ],
+      "success_signal": "[SUCCESS] pending-updates routine completed (HTTP 200)"
+    }
+  }
+}

--- a/tools/enceladus-mcp-server/routines/run_pending_updates.sh
+++ b/tools/enceladus-mcp-server/routines/run_pending_updates.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# run_pending_updates.sh — ENC-FTR-074 Ph2 (ENC-TSK-I80) hourly Pending-Updates routine runner.
+#
+# Executes the governed "Pending Updates" read against the gamma Enceladus MCP gateway,
+# authenticated by a FRESH Cognito M2M access_token with the agent.standard scope (minted by
+# agent_m2m_headers_helper.sh via the client_credentials grant). Designed to be invoked on an
+# hourly schedule (cron / systemd timer / EventBridge-Scheduler→runner / Claude Code routine).
+# Each run authenticates through the Ph2 REQUEST authorizer (Tier 1 admits agent.standard) and
+# the call is recorded in the gamma MCP / coordination-api CloudWatch logs (AC4 evidence).
+#
+# Env (with gamma defaults):
+#   ENCELADUS_GAMMA_MCP_URL   default https://enceladus-gamma.jreese.net/api/v1/coordination/mcp
+#   ENCELADUS_M2M_SCOPE       forced to enceladus-api/agent.standard for this routine
+#   ENCELADUS_PROJECT_ID      default enceladus
+# Plus the credential/endpoint env consumed by agent_m2m_headers_helper.sh.
+#
+# Exit 0 on a successful governed response; non-zero otherwise (so the scheduler can alarm).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../agent_m2m_headers_helper.sh"
+
+MCP_URL="${ENCELADUS_GAMMA_MCP_URL:-https://enceladus-gamma.jreese.net/api/v1/coordination/mcp}"
+PROJECT_ID="${ENCELADUS_PROJECT_ID:-enceladus}"
+export ENCELADUS_M2M_SCOPE="enceladus-api/agent.standard"
+
+PYTHON_BIN="${ENCELADUS_MCP_PYTHON_BIN:-$(command -v python3 || true)}"
+if [ -z "${PYTHON_BIN}" ]; then
+  echo "[ERROR] python3 required." >&2
+  exit 1
+fi
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "[INFO] ${TS} pending-updates routine starting (scope=agent.standard, url=${MCP_URL})"
+
+# Mint a fresh M2M bearer token (agent.standard).
+ACCESS_TOKEN="$(bash "${HELPER}" --token)"
+if [ -z "${ACCESS_TOKEN}" ]; then
+  echo "[ERROR] Failed to mint M2M access_token." >&2
+  exit 1
+fi
+
+# Governed read: code-mode 'search' tool, action tracker.pending_updates.
+REQ_BODY="$("${PYTHON_BIN}" -c '
+import json, os
+print(json.dumps({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": "search",
+        "arguments": {
+            "action": "tracker.pending_updates",
+            "arguments": {"project_id": os.environ["PROJECT_ID"]},
+        },
+    },
+}))
+' PROJECT_ID="${PROJECT_ID}")"
+
+RESPONSE="$(curl -sS -w '\n%{http_code}' -X POST "${MCP_URL}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d "${REQ_BODY}" 2>/dev/null || true)"
+
+HTTP_CODE="$(printf '%s' "${RESPONSE}" | tail -1)"
+BODY="$(printf '%s' "${RESPONSE}" | sed '$d')"
+
+if [ "${HTTP_CODE}" = "200" ]; then
+  COUNT="$(printf '%s' "${BODY}" | "${PYTHON_BIN}" -c '
+import json, sys
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    print("unknown"); sys.exit(0)
+res = (obj.get("result") or {})
+# MCP content envelope or direct result.
+print("ok")
+' 2>/dev/null || echo "unknown")"
+  echo "[SUCCESS] $(date -u +%Y-%m-%dT%H:%M:%SZ) pending-updates routine completed (HTTP 200, ${COUNT})"
+  exit 0
+fi
+
+if [ "${HTTP_CODE}" = "401" ] || [ "${HTTP_CODE}" = "403" ]; then
+  echo "[ERROR] pending-updates routine denied (HTTP ${HTTP_CODE}). Token tier/scope or authorizer config." >&2
+  echo "${BODY}" >&2
+  exit 1
+fi
+
+echo "[ERROR] pending-updates routine failed (HTTP ${HTTP_CODE})." >&2
+echo "${BODY}" >&2
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ENC-TSK-I80 — FTR-074 Ph2: REQUEST-type Lambda authorizer + headersHelper + scope enforcement

**task_id:** ENC-TSK-I80
**Deploy target:** gamma (v4) ONLY — v3-prod is FROZEN (DOC-499FA089EC30). Base: `v4/main`. No deploy performed by this agent; the human owns merge + deploy + close-out.
**commit-complete-id:** `CCI-38bac76dd4bc4f44970b0747239b04fa`
**commit_sha:** `3e8100f998eb98898d1d61e07581de6ca5e8356b`
**governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`

### What this delivers
Builds on Ph1 (`ENC-TSK-I79`, merged) which stood up the dual-client agent-auth Cognito pool, the `enceladus-api` resource server scopes, and the V3_0 pre-token Lambda.

- **REQUEST-type Lambda authorizer** (`infrastructure/cloudformation/08-agent-auth.yaml`): `enceladus-agent-authorizer` discriminates three principal types — **internal-key** (`X-Coordination-Internal-Key` vs Secrets Manager), **human JWT** (`HumanUserPoolId`, Bearer or `enceladus_id_token` cookie), and **M2M scope token** (agent-auth pool, `enc:agent_tier` claim). Signature verified with a **pure-stdlib RS256** implementation against the Cognito JWKS — no PyJWT/cryptography, deliberately sidestepping the shared-layer `.so` ABI failure class (ENC-ISS-198 / ENC-LSN-020).
- **Governance-authority tier enforcement** `observe < standard < elevated < admin`: `agent.standard` denied on Tier 0 routes (403), admitted on Tier 1; GET reads need only `observe`.
- **`AWS::ApiGatewayV2::Authorizer`** (REQUEST, payload 2.0, simple responses, ttl 0) attached to the gamma HTTP API (ApiId imported from `<ApiStackName>-ApiId`), plus an echo backend and **Tier 1** (`POST /api/v1/agent/selftest/standard`) + **Tier 0** (`POST /api/v1/agent/selftest/admin`) self-test routes.
- **headersHelper + `.mcp.json`** (`tools/enceladus-mcp-server/`): `agent_m2m_headers_helper.sh` performs the Cognito **client_credentials** grant and injects `Authorization: Bearer <fresh access_token>`; `mcp.gamma-m2m.json` wires it for headless gamma sessions.
- **Hourly Pending-Updates routine**: `routines/run_pending_updates.sh` + `pending-updates-hourly.json` — authenticates with an `agent.standard` M2M token and calls `tracker.pending_updates` on the gamma MCP gateway.

### Acceptance criteria — code-complete; live evidence pending human gamma deploy
All four ACs require live gamma-runtime verification (`aws` calls / headless MCP run / CloudWatch), which is outside this code-mode agent's authority (no deploy). The artifacts that satisfy each on deploy are in place:

1. **AC1 — REQUEST authorizer discriminating 3 principal types**: authorizer Lambda + `AWS::ApiGatewayV2::Authorizer` added. Verify post-deploy: `aws apigatewayv2 get-authorizers --api-id <gamma-api-id>`.
2. **AC2 — headersHelper acquires fresh token via client_credentials**: `agent_m2m_headers_helper.sh` + `mcp.gamma-m2m.json`. Verify by running a governed MCP call from a headless session.
3. **AC3 — agent.standard rejected on Tier 0 (403), accepted on Tier 1**: Tier 0/Tier 1 self-test routes wired to the authorizer. Verify with the two `curl` checks in `tools/enceladus-mcp-server/AGENT_M2M_AUTH.md`.
4. **AC4 — hourly Pending-Updates routine via agent.standard M2M**: routine runner + spec. Wire to a scheduler; confirm one success in gamma CloudWatch.

### Validation performed in-session
- `cfn-lint infrastructure/cloudformation/08-agent-auth.yaml` — clean.
- Inline Lambda handlers `py_compile` — clean.
- `tests/infrastructure/test_agent_authorizer_ftr074.py` — **12/12 pass** (real RS256 verify + 3-principal discrimination + Tier0/Tier1 enforcement; vectors via PyJWT+cryptography, Lambda uses neither).
- `bash -n` + `shellcheck` on both scripts — clean; `.mcp.json` / routine JSON parse.

### connection_health (session init, governed via enceladus-mcp-prod)
```json
{"dynamodb": "ok", "s3": "ok", "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447", "checked_at": "2026-06-30T01:21:50Z", "server_version": "1.0.0", "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}, "graph_projection": {"name": "gds_standing_enceladus", "stale": false}}}
```

Session: `ENC-SES-00R` (cursor-cloud-agent / claude-opus-4-8).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-227c47a1-ea13-442e-8cb1-80ec91cf6010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-227c47a1-ea13-442e-8cb1-80ec91cf6010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

