### PR TITLE
[ENC-TSK-I87] FTR-083 Ph2 — BHC alert ladder + drift monitor + emergency admission + ISS-265 closure

### DIFF
--- a/backend/lambda/coordination_api/budget_hierarchy.py
+++ b/backend/lambda/coordination_api/budget_hierarchy.py
@@ -1,0 +1,306 @@
+"""budget_hierarchy.py — Budget Hierarchy Controller (ENC-FTR-083 Phase 1, ENC-TSK-I86).
+
+Implements the Budget Hierarchy Controller primitive described in
+DOC-C6584044BEEB (Primitive 2 + Definition 5), grounded in the two governed
+research artifacts:
+
+  * DOC-18D2337D7E1F (ENC-TSK-F11) — RG fixed points of the budget recurrence,
+    Banach-iteration solver, super-stability on the interior triple.
+  * DOC-1E5E505CB51A (ENC-TSK-F15) — coupled information-bottleneck scheduling,
+    logarithmic cognitive-temperature (beta) schedule anchored at beta_0 = 8.0.
+
+Acceptance criteria implemented here (ENC-TSK-I86):
+
+  * AC-1: Four canonical scale budgets (session / wave / project / corpus),
+    readable by coordination_api at runtime from AppConfig (with env-var
+    override and hard-coded F11 fixed-point-tuple defaults as the fallback).
+  * AC-2: Banach-iteration solver over the top-down RG budget recurrence that
+    converges in <= 1 effective pass on the interior regime.
+  * AC-3: Logarithmic beta-schedule with beta_0 = 8.0.
+  * AC-5: ``log_session_budget_allocation`` emits the per-session budget
+    allocation at DEBUG level; called from coordination_api session init.
+
+OGTM (AC-4): this module is pure compute + a config read. It introduces NO new
+tracker record type, relational field, edge type, or graph node, and does not
+touch graph_sync. It depends only on the Python standard library so it adds no
+deployment dependency and is importable in unit tests without AWS.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import urllib.error
+import urllib.request
+from typing import Dict, List, Sequence, Tuple
+
+__all__ = [
+    "SCALES",
+    "DEFAULT_SCALE_BUDGETS_TOKENS",
+    "DEFAULT_BETA_0",
+    "DEFAULT_SOLVER_CALIBRATION",
+    "load_scale_budgets",
+    "beta_schedule",
+    "beta_for_budget",
+    "beta_tuple",
+    "local_optimum",
+    "recurrence_step",
+    "find_fixed_point",
+    "l2_norm_delta",
+    "log_session_budget_allocation",
+]
+
+# ---------------------------------------------------------------------------
+# Canonical scales (top-down nesting: session ⊂ wave ⊂ project ⊂ corpus)
+# ---------------------------------------------------------------------------
+SCALES: Tuple[str, str, str, str] = ("session", "wave", "project", "corpus")
+
+# AC-1: four canonical per-scale token budgets. These are the F11
+# fixed-point-tuple defaults restated in token units for the v4 admission
+# controller (ENC-TSK-I86 acceptance contract). They are the fallback the
+# runtime resolver returns when neither AppConfig nor env vars provide an
+# override, so coordination_api always has a readable budget vector.
+DEFAULT_SCALE_BUDGETS_TOKENS: Dict[str, int] = {
+    "session": 200_000,
+    "wave": 50_000,
+    "project": 500_000,
+    "corpus": 2_000_000,
+}
+
+# AC-3: session-scale sharpness anchor for the logarithmic beta-schedule.
+DEFAULT_BETA_0: float = 8.0
+
+# Logarithmic cooling coefficient for the step-indexed beta-schedule. Calibrated
+# so the schedule descends from beta_0 = 8.0 at the session anchor (t = 0) to
+# ~3.33 at the t = 10 reference depth, matching the F15 logarithmic profile
+# (DOC-1E5E505CB51A): beta(10) = 8 / (1 + 0.585 * ln(11)) ≈ 3.329.
+_LOG_BETA_DECAY: float = 0.585
+
+# AC-2: default solver calibration anchored to the DOC-18D2337D7E1F reference
+# point (16 TB mature-state corpus). Index order matches SCALES
+# (0=session, 1=wave, 2=project, 3=corpus). This calibration sits in the
+# interior regime, where the recurrence is super-stable and converges in one
+# top-down pass.
+DEFAULT_SOLVER_CALIBRATION: Dict[str, object] = {
+    "s": [1.50, 1.30, 1.15, 1.05],          # Zipf-Mandelbrot intent exponents
+    "T": [1.0, 1.5, 2.0, 2.5],              # cognitive temperatures per scale
+    "c": [1.0, 0.5, 0.25, 0.125],           # per-node cost
+    "lam": [1.0e-4, 5.0e-5, 2.0e-5, 1.0e-5],  # cost-penalty coefficients
+    "k_anchor": 2.0e8,                       # corpus hot-tier node-count anchor
+}
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — runtime-readable four-scale budget config
+# ---------------------------------------------------------------------------
+def _appconfig_budget_config() -> Dict[str, object]:
+    """Best-effort read of the budget-hierarchy config from the AppConfig
+    Lambda extension (localhost:2772). Returns {} on any failure so the caller
+    falls back to env vars / hard-coded defaults. Mirrors the resolution
+    pattern of enceladus_shared.appconfig_flags but targets a dedicated
+    ``budget-hierarchy`` configuration profile (env-overridable)."""
+    port = os.environ.get("AWS_APPCONFIG_EXTENSION_HTTP_PORT", "2772")
+    app = os.environ.get("APPCONFIG_APPLICATION", "enceladus")
+    env = os.environ.get("APPCONFIG_ENVIRONMENT", "production")
+    cfg = os.environ.get("BUDGET_HIERARCHY_APPCONFIG_CONFIGURATION", "budget-hierarchy")
+    url = f"http://localhost:{port}/applications/{app}/environments/{env}/configurations/{cfg}"
+    try:
+        with urllib.request.urlopen(url, timeout=1) as resp:  # noqa: S310 — localhost extension
+            data = json.loads(resp.read())
+        return data if isinstance(data, dict) else {}
+    except (urllib.error.URLError, OSError, ValueError):
+        return {}
+
+
+def load_scale_budgets() -> Dict[str, int]:
+    """Resolve the four-scale token budget vector at runtime.
+
+    Resolution order, per scale, highest precedence first:
+      1. AppConfig ``budget-hierarchy`` profile key ``budget_<scale>_tokens``.
+      2. Environment variable ``BUDGET_<SCALE>_TOKENS``.
+      3. Hard-coded F11 fixed-point-tuple default (DEFAULT_SCALE_BUDGETS_TOKENS).
+
+    Always returns a complete, positive budget for every canonical scale so the
+    caller never has to handle a partial config.
+    """
+    appconfig = _appconfig_budget_config()
+    budgets: Dict[str, int] = {}
+    for scale in SCALES:
+        raw = appconfig.get(f"budget_{scale}_tokens")
+        if raw is None:
+            raw = os.environ.get(f"BUDGET_{scale.upper()}_TOKENS")
+        try:
+            value = int(raw) if raw is not None else DEFAULT_SCALE_BUDGETS_TOKENS[scale]
+        except (TypeError, ValueError):
+            value = DEFAULT_SCALE_BUDGETS_TOKENS[scale]
+        if value <= 0:
+            value = DEFAULT_SCALE_BUDGETS_TOKENS[scale]
+        budgets[scale] = value
+    return budgets
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — logarithmic beta-schedule (cognitive-temperature / retrieval-sharpness)
+# ---------------------------------------------------------------------------
+def beta_schedule(t: float, beta_0: float = DEFAULT_BETA_0) -> float:
+    """Step-indexed logarithmic beta-schedule.
+
+    beta(t) = beta_0 / (1 + _LOG_BETA_DECAY * ln(1 + t))
+
+    Monotonically decreasing in t (hotter / more exploratory as scope widens).
+    beta(0) = beta_0 (= 8.0 by default); beta(10) ≈ 3.33 — the F15 reference
+    cooling depth.
+    """
+    if t < 0:
+        raise ValueError("beta-schedule step t must be non-negative")
+    return beta_0 / (1.0 + _LOG_BETA_DECAY * math.log1p(t))
+
+
+def beta_for_budget(b_n: float, b_session: float, beta_0: float = DEFAULT_BETA_0) -> float:
+    """Canonical budget-ratio beta from F15 (DOC-1E5E505CB51A):
+
+    beta_n = beta_0 / ln((B_n / B_session) + e - 1)
+
+    At the session scale (B_n == B_session) the ratio is 1 and the denominator
+    is ln(e) = 1, so beta_session == beta_0.
+    """
+    if b_session <= 0:
+        raise ValueError("session budget must be positive")
+    ratio = float(b_n) / float(b_session)
+    return beta_0 / math.log(ratio + math.e - 1.0)
+
+
+def beta_tuple(budgets: Dict[str, int], beta_0: float = DEFAULT_BETA_0) -> Dict[str, float]:
+    """Per-scale cognitive-temperature tuple derived from the budget vector via
+    the canonical F15 budget-ratio schedule."""
+    b_session = budgets["session"]
+    return {scale: beta_for_budget(budgets[scale], b_session, beta_0) for scale in SCALES}
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Banach-iteration fixed-point solver over the RG budget recurrence
+# ---------------------------------------------------------------------------
+def _stationarity(k: float, s: float, T: float, c: float, lam: float) -> float:
+    """dF/dk of the free-energy objective (DOC-18D2337D7E1F eq. star):
+
+    (s - 1) * k^{-s} + T / k - lam * c
+
+    Strictly monotone decreasing in k, so it has at most one positive root.
+    """
+    return (s - 1.0) * k ** (-s) + T / k - lam * c
+
+
+def local_optimum(
+    s: float, T: float, c: float, lam: float, k_max: float,
+    tol: float = 1e-9, max_iter: int = 200,
+) -> Tuple[float, bool]:
+    """Unconstrained scale-n free-energy optimum, clipped to the parent ceiling.
+
+    Returns ``(k_star, binding)``. If the stationarity derivative is still
+    positive at the parent ceiling the child saturates it (binding regime);
+    otherwise the unique interior root is found by bisection (the pure-Python
+    stand-in for scipy.optimize.brentq, O(log 1/eps) per scale, no third-party
+    dependency).
+    """
+    if _stationarity(k_max, s, T, c, lam) > 0:
+        return k_max, True
+
+    lo, hi = 1.0, float(k_max)
+    f_lo = _stationarity(lo, s, T, c, lam)
+    mid = 0.5 * (lo + hi)
+    for _ in range(max_iter):
+        mid = 0.5 * (lo + hi)
+        f_mid = _stationarity(mid, s, T, c, lam)
+        if abs(f_mid) < 1e-12 or (hi - lo) < tol * max(1.0, mid):
+            break
+        if (f_lo > 0) == (f_mid > 0):
+            lo, f_lo = mid, f_mid
+        else:
+            hi = mid
+    return mid, False
+
+
+def recurrence_step(
+    k: Sequence[float],
+    s: Sequence[float],
+    T: Sequence[float],
+    c: Sequence[float],
+    lam: Sequence[float],
+    k_anchor: float,
+) -> List[float]:
+    """One application of the top-down RG recurrence operator.
+
+    The corpus anchor (index 3) is pinned; each interior child is solved
+    against its immediate parent ceiling, coarse-to-fine (project, wave,
+    session). The recurrence is triangular, which is what makes it converge in
+    a single effective pass.
+    """
+    k_new = [float(x) for x in k]
+    k_new[3] = float(k_anchor)
+    for n in (2, 1, 0):
+        k_new[n], _ = local_optimum(s[n], T[n], c[n], lam[n], k_new[n + 1])
+    return k_new
+
+
+def l2_norm_delta(a: Sequence[float], b: Sequence[float]) -> float:
+    """Euclidean norm of (a - b)."""
+    return math.sqrt(sum((float(a[i]) - float(b[i])) ** 2 for i in range(len(a))))
+
+
+def find_fixed_point(
+    s: Sequence[float],
+    T: Sequence[float],
+    c: Sequence[float],
+    lam: Sequence[float],
+    k_anchor: float,
+    max_iter: int = 50,
+    tol: float = 1e-9,
+) -> Tuple[List[float], int]:
+    """Banach iteration of the top-down recurrence from the all-anchor seed.
+
+    Returns ``(k_star, iterations)``. On the interior regime the interior block
+    of the recurrence Jacobian is nilpotent (spectral radius 0), so the fixed
+    point is reached after one top-down solve pass; the convergence check then
+    confirms it on the following pass.
+    """
+    k = [float(k_anchor)] * 4
+    iterations = 0
+    for it in range(max_iter):
+        k_new = recurrence_step(k, s, T, c, lam, k_anchor)
+        iterations = it + 1
+        rel = max(abs((k_new[i] - k[i]) / max(abs(k[i]), 1.0)) for i in range(4))
+        if rel < tol:
+            return k_new, iterations
+        k = k_new
+    return k, iterations
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — session-init budget allocation logging
+# ---------------------------------------------------------------------------
+def log_session_budget_allocation(
+    logger,
+    *,
+    request_id: str = "",
+    project_id: str = "",
+    beta_0: float = DEFAULT_BETA_0,
+) -> Dict[str, object]:
+    """Emit the per-session budget allocation at DEBUG and return it.
+
+    Called from coordination_api on every session init (coordination request
+    intake). Resolves the runtime four-scale budget vector (AC-1) and the
+    per-scale cognitive-temperature tuple (AC-3) and logs them. Best-effort:
+    callers should not let a logging failure break session init.
+    """
+    budgets = load_scale_budgets()
+    betas = beta_tuple(budgets, beta_0)
+    logger.debug(
+        "[BUDGET] session-init allocation request_id=%s project_id=%s "
+        "scales_tokens=%s beta_0=%.4f betas=%s",
+        request_id,
+        project_id,
+        budgets,
+        beta_0,
+        {scale: round(value, 4) for scale, value in betas.items()},
+    )
+    return {"scales_tokens": budgets, "beta_0": beta_0, "betas": betas}

--- a/backend/lambda/coordination_api/budget_hierarchy.py
+++ b/backend/lambda/coordination_api/budget_hierarchy.py
@@ -1,4 +1,15 @@
-"""budget_hierarchy.py — Budget Hierarchy Controller (ENC-FTR-083 Phase 1, ENC-TSK-I86).
+"""budget_hierarchy.py — Budget Hierarchy Controller (ENC-FTR-083).
+
+Phase 1 (ENC-TSK-I86): four-scale budget config + Banach RG-recurrence solver +
+logarithmic beta-schedule + session-init allocation logging.
+
+Phase 2 (ENC-TSK-I87, AC-4..AC-7): operational control surface layered on the
+Phase 1 admission math — five-level corpus alert ladder wired to SNS, a
+wave-close drift monitor, an emergency mid-wave admission path that writes a
+wave-budget-extension record to the enceladus-drift-telemetry sink, and
+corpus-scale token-usage telemetry emitted as the CloudWatch metric
+Enceladus/BudgetController/CorpusTokenUsage (ENC-ISS-265 closure evidence). See
+the "Phase 2" banner below for the per-AC mapping.
 
 Implements the Budget Hierarchy Controller primitive described in
 DOC-C6584044BEEB (Primitive 2 + Definition 5), grounded in the two governed
@@ -30,9 +41,11 @@ from __future__ import annotations
 import json
 import math
 import os
+import time
+import uuid
 import urllib.error
 import urllib.request
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 __all__ = [
     "SCALES",
@@ -48,6 +61,22 @@ __all__ = [
     "find_fixed_point",
     "l2_norm_delta",
     "log_session_budget_allocation",
+    # --- Phase 2 (ENC-TSK-I87) ---
+    "ALERT_LADDER",
+    "ALERT_LEVELS",
+    "MIN_PUBLISH_RANK",
+    "DRIFT_INF_NORM_THRESHOLD",
+    "CLOUDWATCH_NAMESPACE",
+    "CORPUS_TOKEN_USAGE_METRIC",
+    "DEFAULT_DRIFT_TELEMETRY_TABLE",
+    "classify_alert_level",
+    "corpus_utilization",
+    "inf_norm_delta",
+    "publish_corpus_alert",
+    "emit_corpus_token_usage_metric",
+    "evaluate_corpus_budget",
+    "WaveBudgetDriftMonitor",
+    "emergency_wave_admission",
 ]
 
 # ---------------------------------------------------------------------------
@@ -304,3 +333,473 @@ def log_session_budget_allocation(
         {scale: round(value, 4) for scale, value in betas.items()},
     )
     return {"scales_tokens": budgets, "beta_0": beta_0, "betas": betas}
+
+
+# ===========================================================================
+# Phase 2 (ENC-FTR-083 AC-4..AC-7, ENC-TSK-I87)
+#
+# Builds the operational control surface on top of the Phase 1 admission math:
+#   * AC-4: five-level corpus-budget alert ladder wired to SNS.
+#   * AC-5: wave-close drift monitor that triggers recalibration on
+#     ||s_new - s_old||_inf > 0.1.
+#   * AC-6: emergency mid-wave admission with a wave-budget-extension record
+#     written to the enceladus-drift-telemetry sink.
+#   * AC-7 / ENC-ISS-265: corpus-scale token-usage telemetry emitted as the
+#     CloudWatch metric Enceladus/BudgetController/CorpusTokenUsage, measured
+#     against the PPR-informed hot-tier baseline.
+#
+# OGTM (ENC-FTR-066): every primitive here is pure compute plus best-effort
+# emission to existing AWS telemetry surfaces (SNS / CloudWatch / a DynamoDB
+# telemetry sink). It introduces NO new tracker record type, relational field,
+# graph node, or edge type, and never touches graph_sync — so it adds no new
+# ontology edge to keep traversable. boto3 is imported lazily and every emit is
+# wrapped so a missing client, missing topic/table, or transient AWS failure
+# degrades to a structured CloudWatch log line and never raises into the
+# caller's request path (mirrors the graph_query_api.pathway_telemetry S3->log
+# degradation contract).
+# ===========================================================================
+
+# AC-4: five-level alert ladder. Each rung is (level_name, utilization_floor).
+# Ordered ascending by floor; classification returns the highest rung whose
+# floor the corpus utilization has crossed. A utilization of 0.72 crosses the
+# NOTICE floor (0.70) but not WARNING (0.85), so it classifies as NOTICE.
+ALERT_LADDER: Tuple[Tuple[str, float], ...] = (
+    ("NORMAL", 0.50),
+    ("NOTICE", 0.70),
+    ("WARNING", 0.85),
+    ("CRITICAL", 0.95),
+    ("FRAGMENTED", 1.00),
+)
+
+# Level-name -> rank (0 == NORMAL, 4 == FRAGMENTED). Higher rank == more severe.
+ALERT_LEVELS: Dict[str, int] = {name: rank for rank, (name, _floor) in enumerate(ALERT_LADDER)}
+
+# Minimum rank that warrants an SNS publish. NORMAL (rank 0, 50-70% utilization)
+# is healthy headroom and is logged only; NOTICE (rank 1) and above publish.
+MIN_PUBLISH_RANK: int = ALERT_LEVELS["NOTICE"]
+
+# AC-5: wave-close drift recalibration threshold on the infinity-norm of the
+# delta between two consecutive wave-close budget (utilization) vectors. The
+# trigger is strict greater-than, so a delta of exactly 0.10 does NOT recalibrate
+# while 0.12 does.
+DRIFT_INF_NORM_THRESHOLD: float = 0.10
+
+# AC-7 / ENC-ISS-265: corpus token-usage CloudWatch metric coordinates.
+CLOUDWATCH_NAMESPACE: str = "Enceladus/BudgetController"
+CORPUS_TOKEN_USAGE_METRIC: str = "CorpusTokenUsage"
+
+# AC-6: DynamoDB telemetry sink for wave-budget-extension records.
+DEFAULT_DRIFT_TELEMETRY_TABLE: str = "enceladus-drift-telemetry"
+
+
+def _aws_region() -> Optional[str]:
+    return os.environ.get("DYNAMODB_REGION") or os.environ.get("AWS_REGION")
+
+
+def _boto3_client(service: str):
+    """Lazily build a boto3 client. boto3 is always present in the Lambda
+    runtime; importing it lazily keeps this module importable in a plain
+    unit-test environment (where clients are injected instead)."""
+    import boto3  # noqa: PLC0415 — lazy import so unit tests need no boto3
+
+    return boto3.client(service, region_name=_aws_region())
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — five-level corpus-budget alert ladder wired to SNS
+# ---------------------------------------------------------------------------
+def corpus_utilization(used_tokens: float, budgets: Optional[Dict[str, int]] = None) -> float:
+    """Fraction of the corpus token budget consumed (>= 0.0; may exceed 1.0)."""
+    if budgets is None:
+        budgets = load_scale_budgets()
+    corpus_budget = float(budgets["corpus"])
+    if corpus_budget <= 0:
+        raise ValueError("corpus budget must be positive")
+    return max(0.0, float(used_tokens) / corpus_budget)
+
+
+def classify_alert_level(utilization: float) -> Optional[Dict[str, object]]:
+    """Map a corpus utilization fraction onto the five-level alert ladder.
+
+    Returns ``{"level", "rank", "floor", "utilization"}`` for the highest rung
+    whose floor the utilization has crossed, or ``None`` when utilization is
+    below the NORMAL floor (healthy, sub-50% — nothing to report).
+    """
+    matched: Optional[Tuple[str, float, int]] = None
+    for rank, (name, floor) in enumerate(ALERT_LADDER):
+        if utilization >= floor:
+            matched = (name, floor, rank)
+        else:
+            break
+    if matched is None:
+        return None
+    name, floor, rank = matched
+    return {"level": name, "rank": rank, "floor": floor, "utilization": float(utilization)}
+
+
+def publish_corpus_alert(
+    level: Dict[str, object],
+    *,
+    used_tokens: float,
+    budgets: Dict[str, int],
+    logger,
+    sns_client=None,
+    topic_arn: Optional[str] = None,
+    project_id: str = "",
+    request_id: str = "",
+) -> Dict[str, object]:
+    """Publish a corpus-budget alert to SNS (best-effort) and always log it.
+
+    The structured ``[BUDGET][ALERT]`` log line is the CloudWatch-Logs evidence
+    surface for AC-4 (verifiable on a test invocation even when no SNS topic is
+    configured). The SNS publish is fired only when the rung rank is at or above
+    MIN_PUBLISH_RANK (NOTICE) and a topic ARN is resolvable; any failure is
+    logged and swallowed.
+    """
+    payload = {
+        "event_type": "budget.corpus_alert",
+        "level": level["level"],
+        "rank": level["rank"],
+        "floor": level["floor"],
+        "utilization": round(float(level["utilization"]), 6),
+        "corpus_used_tokens": int(used_tokens),
+        "corpus_budget_tokens": int(budgets["corpus"]),
+        "project_id": project_id,
+        "request_id": request_id,
+    }
+    # AC-4 CloudWatch-Logs evidence line (always emitted).
+    logger.info("[BUDGET][ALERT] %s", json.dumps(payload, sort_keys=True))
+
+    published = False
+    message_id = ""
+    if int(level["rank"]) < MIN_PUBLISH_RANK:
+        return {**payload, "published": published, "sns_message_id": message_id}
+
+    arn = topic_arn or os.environ.get("BUDGET_ALERT_SNS_TOPIC_ARN") or os.environ.get(
+        "DEAD_LETTER_SNS_TOPIC_ARN", ""
+    )
+    if not arn:
+        logger.info(
+            "[BUDGET][ALERT] no SNS topic configured (BUDGET_ALERT_SNS_TOPIC_ARN); "
+            "level=%s logged only",
+            level["level"],
+        )
+        return {**payload, "published": published, "sns_message_id": message_id}
+
+    try:
+        client = sns_client or _boto3_client("sns")
+        resp = client.publish(
+            TopicArn=arn,
+            Subject=f"Budget {level['level']}: corpus at {payload['utilization']:.0%}",
+            Message=json.dumps(payload, sort_keys=True),
+        )
+        published = True
+        message_id = str(resp.get("MessageId", "")) if isinstance(resp, dict) else ""
+    except Exception as exc:  # noqa: BLE001 — alerting must never break the caller
+        logger.warning("[BUDGET][ALERT] SNS publish failed level=%s: %s", level["level"], exc)
+    return {**payload, "published": published, "sns_message_id": message_id}
+
+
+# ---------------------------------------------------------------------------
+# AC-7 / ENC-ISS-265 — corpus token-usage CloudWatch metric
+# ---------------------------------------------------------------------------
+def emit_corpus_token_usage_metric(
+    used_tokens: float,
+    *,
+    logger,
+    budgets: Optional[Dict[str, int]] = None,
+    ppr_baseline_tokens: Optional[float] = None,
+    cloudwatch_client=None,
+    project_id: str = "",
+) -> Dict[str, object]:
+    """Emit the corpus token-usage telemetry to CloudWatch (best-effort).
+
+    Publishes the metric ``Enceladus/BudgetController/CorpusTokenUsage`` (unit:
+    Count == tokens) plus, when a PPR-informed hot-tier baseline is supplied (or
+    resolvable from ``BUDGET_CORPUS_PPR_BASELINE_TOKENS``), the ratio metric
+    ``CorpusTokenUsageVsBaseline`` (used / baseline). This is the ENC-ISS-265
+    closure evidence: corpus-scale usage measured against the PPR-informed
+    baseline rather than assumed. Always logs the values for CloudWatch-Logs
+    confirmation; the put_metric_data call is swallowed on failure.
+    """
+    if budgets is None:
+        budgets = load_scale_budgets()
+    if ppr_baseline_tokens is None:
+        raw = os.environ.get("BUDGET_CORPUS_PPR_BASELINE_TOKENS")
+        try:
+            ppr_baseline_tokens = float(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            ppr_baseline_tokens = None
+
+    util = corpus_utilization(used_tokens, budgets)
+    vs_baseline: Optional[float] = None
+    if ppr_baseline_tokens and ppr_baseline_tokens > 0:
+        vs_baseline = float(used_tokens) / float(ppr_baseline_tokens)
+
+    record = {
+        "metric_namespace": CLOUDWATCH_NAMESPACE,
+        "metric_name": CORPUS_TOKEN_USAGE_METRIC,
+        "corpus_used_tokens": int(used_tokens),
+        "corpus_budget_tokens": int(budgets["corpus"]),
+        "corpus_utilization": round(util, 6),
+        "ppr_baseline_tokens": int(ppr_baseline_tokens) if ppr_baseline_tokens else None,
+        "used_vs_ppr_baseline": round(vs_baseline, 6) if vs_baseline is not None else None,
+        "project_id": project_id,
+    }
+    logger.info("[BUDGET][CORPUS-TELEMETRY] %s", json.dumps(record, sort_keys=True))
+
+    metric_data: List[Dict[str, object]] = [
+        {
+            "MetricName": CORPUS_TOKEN_USAGE_METRIC,
+            "Value": float(used_tokens),
+            "Unit": "Count",
+            "Dimensions": [{"Name": "ProjectId", "Value": project_id or "enceladus"}],
+        }
+    ]
+    if vs_baseline is not None:
+        metric_data.append(
+            {
+                "MetricName": "CorpusTokenUsageVsBaseline",
+                "Value": float(vs_baseline),
+                "Unit": "None",
+                "Dimensions": [{"Name": "ProjectId", "Value": project_id or "enceladus"}],
+            }
+        )
+
+    emitted = False
+    try:
+        client = cloudwatch_client or _boto3_client("cloudwatch")
+        client.put_metric_data(Namespace=CLOUDWATCH_NAMESPACE, MetricData=metric_data)
+        emitted = True
+    except Exception as exc:  # noqa: BLE001 — telemetry must never break the caller
+        logger.warning("[BUDGET][CORPUS-TELEMETRY] put_metric_data failed: %s", exc)
+    return {**record, "emitted": emitted}
+
+
+def evaluate_corpus_budget(
+    logger,
+    *,
+    used_tokens: Optional[float] = None,
+    budgets: Optional[Dict[str, int]] = None,
+    sns_client=None,
+    cloudwatch_client=None,
+    topic_arn: Optional[str] = None,
+    ppr_baseline_tokens: Optional[float] = None,
+    emit_metric: bool = True,
+    project_id: str = "",
+    request_id: str = "",
+) -> Optional[Dict[str, object]]:
+    """End-to-end corpus-budget evaluation: classify -> alert -> telemetry.
+
+    ``used_tokens`` may be passed explicitly (the recommended path) or resolved
+    from the ``BUDGET_CORPUS_USED_TOKENS`` env / AppConfig signal so the same
+    code path is exercisable by a direct test invocation. Returns ``None`` (a
+    no-op) when no corpus-usage signal is available, so wiring this into
+    session-init is safe and silent in the common case.
+    """
+    if budgets is None:
+        budgets = load_scale_budgets()
+    if used_tokens is None:
+        appconfig = _appconfig_budget_config()
+        raw = appconfig.get("corpus_used_tokens")
+        if raw is None:
+            raw = os.environ.get("BUDGET_CORPUS_USED_TOKENS")
+        try:
+            used_tokens = float(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            used_tokens = None
+    if used_tokens is None:
+        return None
+
+    util = corpus_utilization(used_tokens, budgets)
+    level = classify_alert_level(util)
+    alert_result: Optional[Dict[str, object]] = None
+    if level is not None:
+        alert_result = publish_corpus_alert(
+            level,
+            used_tokens=used_tokens,
+            budgets=budgets,
+            logger=logger,
+            sns_client=sns_client,
+            topic_arn=topic_arn,
+            project_id=project_id,
+            request_id=request_id,
+        )
+
+    telemetry_result: Optional[Dict[str, object]] = None
+    if emit_metric:
+        telemetry_result = emit_corpus_token_usage_metric(
+            used_tokens,
+            logger=logger,
+            budgets=budgets,
+            ppr_baseline_tokens=ppr_baseline_tokens,
+            cloudwatch_client=cloudwatch_client,
+            project_id=project_id,
+        )
+
+    return {
+        "corpus_used_tokens": int(used_tokens),
+        "corpus_utilization": round(util, 6),
+        "level": level,
+        "alert": alert_result,
+        "telemetry": telemetry_result,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — wave-close budget-drift monitor
+# ---------------------------------------------------------------------------
+def inf_norm_delta(a: Sequence[float], b: Sequence[float]) -> float:
+    """Infinity-norm (max absolute component) of (a - b)."""
+    if len(a) != len(b):
+        raise ValueError("vectors must have equal length for the infinity-norm delta")
+    return max(abs(float(a[i]) - float(b[i])) for i in range(len(a))) if a else 0.0
+
+
+class WaveBudgetDriftMonitor:
+    """Tracks consecutive wave-close budget (utilization) vectors and flags a
+    recalibration when the infinity-norm of the delta between two consecutive
+    vectors exceeds DRIFT_INF_NORM_THRESHOLD (default 0.1, strict greater-than).
+
+    Stateless across waves except for the single previous vector it retains, so
+    a Lambda can keep one instance per warm container or reconstruct it from the
+    last-persisted wave-close vector.
+    """
+
+    def __init__(self, threshold: float = DRIFT_INF_NORM_THRESHOLD, logger=None) -> None:
+        self.threshold = float(threshold)
+        self.logger = logger
+        self._previous: Optional[List[float]] = None
+
+    def observe_wave_close(
+        self, budget_vector: Sequence[float], *, wave_id: str = ""
+    ) -> Dict[str, object]:
+        """Record a wave-close budget vector and report whether recalibration
+        is triggered relative to the immediately preceding wave-close vector.
+
+        On the first observation there is no predecessor, so ``recalibrate`` is
+        False and ``drift`` is None. When recalibration triggers, a structured
+        ``[BUDGET][DRIFT]`` recalibration log entry is emitted (AC-5 evidence).
+        """
+        current = [float(x) for x in budget_vector]
+        result: Dict[str, object] = {
+            "wave_id": wave_id,
+            "vector": current,
+            "previous": self._previous,
+            "drift": None,
+            "threshold": self.threshold,
+            "recalibrate": False,
+        }
+        if self._previous is not None:
+            drift = inf_norm_delta(current, self._previous)
+            recalibrate = drift > self.threshold
+            result["drift"] = round(drift, 6)
+            result["recalibrate"] = recalibrate
+            if recalibrate and self.logger is not None:
+                self.logger.warning(
+                    "[BUDGET][DRIFT] recalibration triggered wave_id=%s "
+                    "inf_norm=%.6f threshold=%.6f prev=%s curr=%s",
+                    wave_id,
+                    drift,
+                    self.threshold,
+                    self._previous,
+                    current,
+                )
+        self._previous = current
+        return result
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — emergency mid-wave admission (wave-budget extension)
+# ---------------------------------------------------------------------------
+def emergency_wave_admission(
+    *,
+    logger,
+    session_id: str,
+    wave_id: str,
+    requested_tokens: int,
+    wave_used_tokens: int,
+    wave_budget_tokens: Optional[int] = None,
+    reason: str = "cache_miss",
+    extension_factor: float = 0.25,
+    budgets: Optional[Dict[str, int]] = None,
+    dynamodb_client=None,
+    table_name: Optional[str] = None,
+    project_id: str = "",
+) -> Dict[str, object]:
+    """Grant a temporary wave-budget extension for a forced mid-wave cache-miss
+    and write a wave-budget-extension record to the drift-telemetry sink.
+
+    A forced cache-miss mid-wave can push ``wave_used + requested`` past the
+    wave budget; rather than hard-rejecting (which would strand an in-flight
+    wave), the controller grants a bounded extension (``extension_factor`` of
+    the wave budget, at least the overflow) and records it. The record is
+    written to the ``enceladus-drift-telemetry`` DynamoDB table when configured;
+    otherwise it degrades to a structured ``[BUDGET][EMERGENCY-ADMISSION]``
+    CloudWatch log line. Always returns the extension record.
+    """
+    if budgets is None:
+        budgets = load_scale_budgets()
+    if wave_budget_tokens is None:
+        wave_budget_tokens = int(budgets["wave"])
+
+    projected = int(wave_used_tokens) + int(requested_tokens)
+    overflow = max(0, projected - int(wave_budget_tokens))
+    floor_extension = int(math.ceil(extension_factor * float(wave_budget_tokens)))
+    granted_extension = max(overflow, floor_extension) if overflow > 0 else 0
+    extended_budget = int(wave_budget_tokens) + granted_extension
+
+    record = {
+        "telemetry_id": str(uuid.uuid4()),
+        "record_type": "wave_budget_extension",
+        "schema": "enceladus.budget.wave_extension.v1",
+        "session_id": session_id,
+        "wave_id": wave_id,
+        "project_id": project_id or "enceladus",
+        "reason": reason,
+        "requested_tokens": int(requested_tokens),
+        "wave_used_tokens": int(wave_used_tokens),
+        "wave_budget_tokens": int(wave_budget_tokens),
+        "overflow_tokens": int(overflow),
+        "granted_extension_tokens": int(granted_extension),
+        "extended_wave_budget_tokens": int(extended_budget),
+        "admitted": True,
+        "ts": int(time.time()),
+    }
+
+    table = table_name or os.environ.get("DRIFT_TELEMETRY_TABLE", DEFAULT_DRIFT_TELEMETRY_TABLE)
+    persisted = False
+    if table:
+        try:
+            client = dynamodb_client or _boto3_client("dynamodb")
+            client.put_item(TableName=table, Item=_to_dynamodb_item(record))
+            persisted = True
+        except Exception as exc:  # noqa: BLE001 — admission must never break mid-wave
+            logger.warning(
+                "[BUDGET][EMERGENCY-ADMISSION] drift-telemetry write failed wave_id=%s: %s",
+                wave_id,
+                exc,
+            )
+    # Always log (CloudWatch-Logs evidence + degraded sink when table absent).
+    logger.warning(
+        "[BUDGET][EMERGENCY-ADMISSION] %s",
+        json.dumps({**record, "persisted": persisted, "table": table}, sort_keys=True),
+    )
+    return {**record, "persisted": persisted, "table": table}
+
+
+def _to_dynamodb_item(record: Dict[str, object]) -> Dict[str, Dict[str, str]]:
+    """Marshal a flat record into the DynamoDB low-level attribute-value shape.
+
+    Only the scalar types this module emits (str / int / bool) are handled."""
+    item: Dict[str, Dict[str, str]] = {}
+    for key, value in record.items():
+        if isinstance(value, bool):
+            item[key] = {"BOOL": value}
+        elif isinstance(value, int):
+            item[key] = {"N": str(value)}
+        elif value is None:
+            item[key] = {"NULL": True}
+        else:
+            item[key] = {"S": str(value)}
+    return item

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-30.06",
-  "updated_at": "2026-06-30T02:45:00Z",
-  "last_change_summary": "ENC-TSK-I84 (FTR-096 Ph1 memory consolidation). Adds monitoring.memory_consolidation. Version -> 2026-06-30.06.",
+  "version": "2026-06-30.08",
+  "updated_at": "2026-06-30T02:50:00Z",
+  "last_change_summary": "ENC-TSK-I87 FTR-083 Ph2 BHC alert. Version -> 2026-06-30.08.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5970,6 +5970,11 @@
       "telemetry_eligible": false
     },
     "monitoring.memory_consolidation": {
+      "description": "See source task.",
+      "source": "ENC-TSK",
+      "telemetry_eligible": false
+    },
+    "coordination_api.bhc_alert": {
       "description": "See source task.",
       "source": "ENC-TSK",
       "telemetry_eligible": false

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -86,11 +86,11 @@ try:
 except Exception:
     _CERT_BUNDLE = None
 
-# Budget Hierarchy Controller (ENC-FTR-083 Ph1 / ENC-TSK-I86). Imported with the
-# same defensive fallback as mcp_client so a flat-file Lambda package and a
-# package-relative import both resolve.
+# Budget Hierarchy Controller (ENC-FTR-083 Ph1 / ENC-TSK-I86; Ph2 / ENC-TSK-I87).
+# Imported with the same defensive fallback as mcp_client so a flat-file Lambda
+# package and a package-relative import both resolve.
 try:
-    from budget_hierarchy import log_session_budget_allocation
+    from budget_hierarchy import log_session_budget_allocation, evaluate_corpus_budget
 except ModuleNotFoundError:
     _BHC_MODULE_PATH = pathlib.Path(__file__).with_name("budget_hierarchy.py")
     _BHC_SPEC = importlib.util.spec_from_file_location("coordination_budget_hierarchy", _BHC_MODULE_PATH)
@@ -99,6 +99,7 @@ except ModuleNotFoundError:
     _BHC_MODULE = importlib.util.module_from_spec(_BHC_SPEC)
     _BHC_SPEC.loader.exec_module(_BHC_MODULE)
     log_session_budget_allocation = _BHC_MODULE.log_session_budget_allocation
+    evaluate_corpus_budget = _BHC_MODULE.evaluate_corpus_budget
 
 
 def _normalize_api_keys(*raw_values: str) -> tuple[str, ...]:
@@ -10938,6 +10939,17 @@ def _handle_create_request(event: Dict[str, Any], claims: Dict[str, Any]) -> Dic
         log_session_budget_allocation(logger, request_id=request_id, project_id=project_id)
     except Exception:  # noqa: BLE001 — budget telemetry must never break session init
         logger.debug("budget allocation logging skipped (non-fatal)", exc_info=True)
+
+    # ENC-FTR-083 Ph2 (ENC-TSK-I87) — corpus-budget alert ladder + corpus
+    # token-usage telemetry. No-op unless a corpus-usage signal is configured
+    # (BUDGET_CORPUS_USED_TOKENS env / AppConfig), so this stays silent in the
+    # common case; when present it classifies the five-level ladder, publishes
+    # NOTICE+ alerts to SNS, and emits the CorpusTokenUsage CloudWatch metric.
+    # Best-effort: never let budget telemetry break request intake.
+    try:
+        evaluate_corpus_budget(logger, request_id=request_id, project_id=project_id)
+    except Exception:  # noqa: BLE001 — budget telemetry must never break session init
+        logger.debug("corpus budget evaluation skipped (non-fatal)", exc_info=True)
 
     if decomposition.get("feature_id"):
         _append_tracker_history(

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -86,6 +86,20 @@ try:
 except Exception:
     _CERT_BUNDLE = None
 
+# Budget Hierarchy Controller (ENC-FTR-083 Ph1 / ENC-TSK-I86). Imported with the
+# same defensive fallback as mcp_client so a flat-file Lambda package and a
+# package-relative import both resolve.
+try:
+    from budget_hierarchy import log_session_budget_allocation
+except ModuleNotFoundError:
+    _BHC_MODULE_PATH = pathlib.Path(__file__).with_name("budget_hierarchy.py")
+    _BHC_SPEC = importlib.util.spec_from_file_location("coordination_budget_hierarchy", _BHC_MODULE_PATH)
+    if _BHC_SPEC is None or _BHC_SPEC.loader is None:
+        raise
+    _BHC_MODULE = importlib.util.module_from_spec(_BHC_SPEC)
+    _BHC_SPEC.loader.exec_module(_BHC_MODULE)
+    log_session_budget_allocation = _BHC_MODULE.log_session_budget_allocation
+
 
 def _normalize_api_keys(*raw_values: str) -> tuple[str, ...]:
     """Return deduplicated, non-empty key values from scalar/csv env sources."""
@@ -10915,6 +10929,15 @@ def _handle_create_request(event: Dict[str, Any], claims: Dict[str, Any]) -> Dic
             return _error(409, "Coordination request ID collision; retry")
         logger.exception("put request failed")
         return _error(500, f"Failed persisting coordination request: {exc}")
+
+    # ENC-FTR-083 Ph1 (ENC-TSK-I86) — Budget Hierarchy Controller. Log the
+    # per-session budget allocation (four-scale token budgets + cognitive
+    # temperature tuple) at DEBUG on every session init. Best-effort: never let
+    # budget logging break request intake.
+    try:
+        log_session_budget_allocation(logger, request_id=request_id, project_id=project_id)
+    except Exception:  # noqa: BLE001 — budget telemetry must never break session init
+        logger.debug("budget allocation logging skipped (non-fatal)", exc_info=True)
 
     if decomposition.get("feature_id"):
         _append_tracker_history(

--- a/backend/lambda/coordination_api/test_budget_hierarchy.py
+++ b/backend/lambda/coordination_api/test_budget_hierarchy.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Budget Hierarchy Controller (ENC-FTR-083 Ph1 / ENC-TSK-I86).
+
+Covers the three core acceptance criteria:
+  * AC-1: four-scale budget config is readable at runtime with canonical defaults.
+  * AC-2: Banach-iteration solver converges in <= 1 pass (norm(s_new - s_old) < 1e-6).
+  * AC-3: logarithmic beta-schedule with beta_0 = 8.0 hits ~8.0 at t=0 and ~3.33 at t=10.
+
+Pure-stdlib unittest so it runs under both ``python -m unittest`` and pytest
+without any AWS or third-party dependency.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import budget_hierarchy as bhc  # noqa: E402
+
+
+class TestScaleBudgetConfig(unittest.TestCase):
+    """AC-1: four canonical scale budgets, readable at runtime."""
+
+    def test_default_budgets_present_for_all_scales(self):
+        budgets = bhc.load_scale_budgets()
+        self.assertEqual(set(budgets), set(bhc.SCALES))
+        # Canonical ENC-TSK-I86 token budgets.
+        self.assertEqual(budgets["session"], 200_000)
+        self.assertEqual(budgets["wave"], 50_000)
+        self.assertEqual(budgets["project"], 500_000)
+        self.assertEqual(budgets["corpus"], 2_000_000)
+
+    def test_env_override(self):
+        os.environ["BUDGET_SESSION_TOKENS"] = "123456"
+        try:
+            budgets = bhc.load_scale_budgets()
+            self.assertEqual(budgets["session"], 123_456)
+        finally:
+            del os.environ["BUDGET_SESSION_TOKENS"]
+
+    def test_invalid_override_falls_back_to_default(self):
+        os.environ["BUDGET_CORPUS_TOKENS"] = "not-a-number"
+        try:
+            budgets = bhc.load_scale_budgets()
+            self.assertEqual(budgets["corpus"], 2_000_000)
+        finally:
+            del os.environ["BUDGET_CORPUS_TOKENS"]
+
+
+class TestBanachSolver(unittest.TestCase):
+    """AC-2: solver converges in <= 1 iteration on the interior 4-scale vector."""
+
+    def setUp(self):
+        cal = bhc.DEFAULT_SOLVER_CALIBRATION
+        self.s = cal["s"]
+        self.T = cal["T"]
+        self.c = cal["c"]
+        self.lam = cal["lam"]
+        self.k_anchor = cal["k_anchor"]
+
+    def test_converges_after_one_pass(self):
+        # Seed every scale at the corpus anchor, then take two passes.
+        seed = [self.k_anchor] * 4
+        s_old = bhc.recurrence_step(seed, self.s, self.T, self.c, self.lam, self.k_anchor)
+        s_new = bhc.recurrence_step(s_old, self.s, self.T, self.c, self.lam, self.k_anchor)
+        delta = bhc.l2_norm_delta(s_new, s_old)
+        # AC-2: ||s_new - s_old|| < 1e-6 after pass 1.
+        self.assertLess(delta, 1e-6, f"solver not converged after one pass: delta={delta}")
+
+    def test_find_fixed_point_one_effective_pass(self):
+        k_star, iterations = bhc.find_fixed_point(
+            self.s, self.T, self.c, self.lam, self.k_anchor
+        )
+        # Converges almost immediately (one solve pass + one confirmation pass).
+        self.assertLessEqual(iterations, 2)
+        # Corpus anchor is preserved by the recurrence.
+        self.assertAlmostEqual(k_star[3], self.k_anchor, delta=1.0)
+        # Interior modes are nested and strictly below their parents.
+        self.assertLess(k_star[0], k_star[1])
+        self.assertLess(k_star[1], k_star[2])
+        self.assertLess(k_star[2], k_star[3])
+
+    def test_fixed_point_is_stable_under_reapplication(self):
+        k_star, _ = bhc.find_fixed_point(
+            self.s, self.T, self.c, self.lam, self.k_anchor
+        )
+        k_again = bhc.recurrence_step(k_star, self.s, self.T, self.c, self.lam, self.k_anchor)
+        self.assertLess(bhc.l2_norm_delta(k_again, k_star), 1e-6)
+
+
+class TestLogarithmicBetaSchedule(unittest.TestCase):
+    """AC-3: logarithmic beta-schedule, beta_0 = 8.0."""
+
+    def test_beta_at_zero_is_anchor(self):
+        self.assertAlmostEqual(bhc.beta_schedule(0), 8.0, delta=0.01)
+
+    def test_beta_at_ten(self):
+        self.assertAlmostEqual(bhc.beta_schedule(10), 3.33, delta=0.01)
+
+    def test_beta_monotonically_decreasing(self):
+        prev = bhc.beta_schedule(0)
+        for t in range(1, 21):
+            cur = bhc.beta_schedule(t)
+            self.assertLess(cur, prev)
+            prev = cur
+
+    def test_negative_step_rejected(self):
+        with self.assertRaises(ValueError):
+            bhc.beta_schedule(-1)
+
+    def test_budget_ratio_beta_session_anchor(self):
+        # Canonical F15 budget-ratio schedule: session ratio == 1 -> beta_0.
+        self.assertAlmostEqual(bhc.beta_for_budget(200_000, 200_000), 8.0, delta=1e-9)
+
+
+class TestSessionBudgetLogging(unittest.TestCase):
+    """AC-5: session-init allocation logging is best-effort and structured."""
+
+    def test_log_session_budget_allocation_returns_allocation(self):
+        class _CapturingLogger:
+            def __init__(self):
+                self.records = []
+
+            def debug(self, *args, **kwargs):
+                self.records.append((args, kwargs))
+
+        logger = _CapturingLogger()
+        result = bhc.log_session_budget_allocation(
+            logger, request_id="REQ-1", project_id="enceladus"
+        )
+        self.assertEqual(set(result["scales_tokens"]), set(bhc.SCALES))
+        self.assertAlmostEqual(result["beta_0"], 8.0)
+        self.assertEqual(set(result["betas"]), set(bhc.SCALES))
+        self.assertTrue(logger.records, "expected a DEBUG log record to be emitted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_budget_hierarchy_ph2.py
+++ b/backend/lambda/coordination_api/test_budget_hierarchy_ph2.py
@@ -1,0 +1,353 @@
+"""Unit tests for the Budget Hierarchy Controller Phase 2 (ENC-FTR-083 / ENC-TSK-I87).
+
+Covers the Phase 2 acceptance criteria:
+  * AC-4: five-level alert ladder (NORMAL/NOTICE/WARNING/CRITICAL/FRAGMENTED at
+    50/70/85/95/100%) — corpus utilization of 0.72 classifies as NOTICE and
+    triggers exactly one SNS publish carrying that level.
+  * AC-5: two consecutive wave-close budget vectors whose infinity-norm delta is
+    0.12 (> 0.1) trigger a recalibration log entry.
+  * AC-6: a forced mid-wave cache-miss produces a wave-budget-extension record
+    written to the enceladus-drift-telemetry sink (DynamoDB put_item).
+  * AC-7 / ENC-ISS-265: corpus token-usage telemetry is emitted as the
+    Enceladus/BudgetController/CorpusTokenUsage CloudWatch metric, measured
+    against the PPR-informed baseline.
+
+Pure-stdlib unittest with injected fake AWS clients so it runs under both
+``python -m unittest`` and pytest with no boto3 / AWS dependency.
+"""
+import json
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import budget_hierarchy as bhc  # noqa: E402
+
+
+class _CapturingLogger:
+    """Minimal logger stand-in that records formatted messages by level."""
+
+    def __init__(self):
+        self.info_records = []
+        self.warning_records = []
+        self.debug_records = []
+
+    def _fmt(self, args):
+        if not args:
+            return ""
+        msg = args[0]
+        params = args[1:]
+        try:
+            return msg % params if params else msg
+        except (TypeError, ValueError):
+            return " ".join(str(a) for a in args)
+
+    def info(self, *args, **kwargs):
+        self.info_records.append(self._fmt(args))
+
+    def warning(self, *args, **kwargs):
+        self.warning_records.append(self._fmt(args))
+
+    def debug(self, *args, **kwargs):
+        self.debug_records.append(self._fmt(args))
+
+
+class _FakeSns:
+    def __init__(self):
+        self.calls = []
+
+    def publish(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"MessageId": "msg-test-1"}
+
+
+class _FakeCloudWatch:
+    def __init__(self):
+        self.calls = []
+
+    def put_metric_data(self, **kwargs):
+        self.calls.append(kwargs)
+        return {}
+
+
+class _FakeDynamo:
+    def __init__(self):
+        self.items = []
+
+    def put_item(self, **kwargs):
+        self.items.append(kwargs)
+        return {}
+
+
+class TestAlertLadder(unittest.TestCase):
+    """AC-4: five-level alert ladder + SNS publish."""
+
+    def test_ladder_has_five_canonical_levels(self):
+        names = [name for name, _floor in bhc.ALERT_LADDER]
+        self.assertEqual(names, ["NORMAL", "NOTICE", "WARNING", "CRITICAL", "FRAGMENTED"])
+        floors = [floor for _name, floor in bhc.ALERT_LADDER]
+        self.assertEqual(floors, [0.50, 0.70, 0.85, 0.95, 1.00])
+
+    def test_classify_levels_at_each_boundary(self):
+        self.assertIsNone(bhc.classify_alert_level(0.49))
+        self.assertEqual(bhc.classify_alert_level(0.50)["level"], "NORMAL")
+        self.assertEqual(bhc.classify_alert_level(0.72)["level"], "NOTICE")
+        self.assertEqual(bhc.classify_alert_level(0.85)["level"], "WARNING")
+        self.assertEqual(bhc.classify_alert_level(0.96)["level"], "CRITICAL")
+        self.assertEqual(bhc.classify_alert_level(1.0)["level"], "FRAGMENTED")
+        self.assertEqual(bhc.classify_alert_level(1.5)["level"], "FRAGMENTED")
+
+    def test_corpus_at_72pct_classifies_notice(self):
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        used = int(0.72 * budgets["corpus"])  # 1_440_000
+        util = bhc.corpus_utilization(used, budgets)
+        self.assertAlmostEqual(util, 0.72, places=6)
+        level = bhc.classify_alert_level(util)
+        self.assertEqual(level["level"], "NOTICE")
+        self.assertEqual(level["rank"], bhc.ALERT_LEVELS["NOTICE"])
+
+    def test_notice_triggers_single_sns_publish_with_level(self):
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        used = 1_440_000  # 72%
+        logger = _CapturingLogger()
+        sns = _FakeSns()
+        level = bhc.classify_alert_level(bhc.corpus_utilization(used, budgets))
+        result = bhc.publish_corpus_alert(
+            level,
+            used_tokens=used,
+            budgets=budgets,
+            logger=logger,
+            sns_client=sns,
+            topic_arn="arn:aws:sns:us-west-2:111122223333:enceladus-budget-alerts",
+        )
+        self.assertTrue(result["published"])
+        self.assertEqual(len(sns.calls), 1)
+        published = json.loads(sns.calls[0]["Message"])
+        self.assertEqual(published["level"], "NOTICE")
+        self.assertEqual(published["event_type"], "budget.corpus_alert")
+        # AC-4 CloudWatch-Logs evidence line present.
+        self.assertTrue(any("[BUDGET][ALERT]" in r for r in logger.info_records))
+
+    def test_normal_level_logs_but_does_not_publish(self):
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        used = 1_200_000  # 60% -> NORMAL
+        logger = _CapturingLogger()
+        sns = _FakeSns()
+        level = bhc.classify_alert_level(bhc.corpus_utilization(used, budgets))
+        self.assertEqual(level["level"], "NORMAL")
+        result = bhc.publish_corpus_alert(
+            level, used_tokens=used, budgets=budgets, logger=logger,
+            sns_client=sns, topic_arn="arn:aws:sns:us-west-2:111122223333:t",
+        )
+        self.assertFalse(result["published"])
+        self.assertEqual(len(sns.calls), 0)
+
+    def test_publish_failure_is_swallowed(self):
+        class _BoomSns:
+            def publish(self, **kwargs):
+                raise RuntimeError("SNS down")
+
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        logger = _CapturingLogger()
+        level = bhc.classify_alert_level(0.9)  # WARNING
+        result = bhc.publish_corpus_alert(
+            level, used_tokens=1_800_000, budgets=budgets, logger=logger,
+            sns_client=_BoomSns(), topic_arn="arn:aws:sns:us-west-2:111122223333:t",
+        )
+        self.assertFalse(result["published"])
+        self.assertTrue(any("SNS publish failed" in r for r in logger.warning_records))
+
+
+class TestDriftMonitor(unittest.TestCase):
+    """AC-5: wave-close drift monitor triggers recalibration at inf-norm > 0.1."""
+
+    def test_inf_norm_delta(self):
+        self.assertAlmostEqual(bhc.inf_norm_delta([0.1, 0.2, 0.3], [0.1, 0.2, 0.42]), 0.12, places=6)
+
+    def test_consecutive_drift_of_0_12_triggers_recalibration(self):
+        logger = _CapturingLogger()
+        monitor = bhc.WaveBudgetDriftMonitor(logger=logger)
+        first = monitor.observe_wave_close([0.40, 0.50, 0.30, 0.60], wave_id="w1")
+        self.assertFalse(first["recalibrate"])
+        self.assertIsNone(first["drift"])
+        # Second vector differs by exactly 0.12 in the infinity norm.
+        second = monitor.observe_wave_close([0.40, 0.62, 0.30, 0.60], wave_id="w2")
+        self.assertAlmostEqual(second["drift"], 0.12, places=6)
+        self.assertTrue(second["recalibrate"])
+        # AC-5 recalibration log entry asserted.
+        self.assertTrue(
+            any("[BUDGET][DRIFT] recalibration triggered" in r for r in logger.warning_records),
+            "expected a recalibration log entry",
+        )
+
+    def test_drift_at_threshold_does_not_trigger(self):
+        logger = _CapturingLogger()
+        monitor = bhc.WaveBudgetDriftMonitor(logger=logger)
+        monitor.observe_wave_close([0.10, 0.10, 0.10, 0.10], wave_id="w1")
+        result = monitor.observe_wave_close([0.20, 0.10, 0.10, 0.10], wave_id="w2")
+        # Exactly 0.10 is NOT strictly greater than the 0.10 threshold.
+        self.assertAlmostEqual(result["drift"], 0.10, places=6)
+        self.assertFalse(result["recalibrate"])
+        self.assertFalse(
+            any("[BUDGET][DRIFT] recalibration triggered" in r for r in logger.warning_records)
+        )
+
+    def test_small_drift_no_recalibration(self):
+        logger = _CapturingLogger()
+        monitor = bhc.WaveBudgetDriftMonitor(logger=logger)
+        monitor.observe_wave_close([0.40, 0.50, 0.30, 0.60])
+        result = monitor.observe_wave_close([0.41, 0.51, 0.31, 0.61])
+        self.assertLess(result["drift"], bhc.DRIFT_INF_NORM_THRESHOLD)
+        self.assertFalse(result["recalibrate"])
+
+
+class TestEmergencyAdmission(unittest.TestCase):
+    """AC-6: emergency mid-wave admission writes a wave-budget-extension record."""
+
+    def test_cache_miss_overflow_grants_extension_and_persists(self):
+        logger = _CapturingLogger()
+        dynamo = _FakeDynamo()
+        record = bhc.emergency_wave_admission(
+            logger=logger,
+            session_id="ENC-SES-TEST",
+            wave_id="wave-7",
+            requested_tokens=8_000,
+            wave_used_tokens=48_000,
+            wave_budget_tokens=50_000,
+            reason="cache_miss",
+            dynamodb_client=dynamo,
+            table_name="enceladus-drift-telemetry",
+        )
+        # 48k + 8k = 56k projected vs 50k budget -> 6k overflow; extension >= overflow.
+        self.assertEqual(record["overflow_tokens"], 6_000)
+        self.assertGreaterEqual(record["granted_extension_tokens"], 6_000)
+        self.assertEqual(
+            record["extended_wave_budget_tokens"],
+            50_000 + record["granted_extension_tokens"],
+        )
+        self.assertEqual(record["record_type"], "wave_budget_extension")
+        self.assertTrue(record["admitted"])
+        self.assertTrue(record["persisted"])
+        # One DynamoDB write to the drift-telemetry sink.
+        self.assertEqual(len(dynamo.items), 1)
+        self.assertEqual(dynamo.items[0]["TableName"], "enceladus-drift-telemetry")
+        item = dynamo.items[0]["Item"]
+        self.assertEqual(item["record_type"]["S"], "wave_budget_extension")
+        self.assertEqual(item["wave_id"]["S"], "wave-7")
+        self.assertIn("telemetry_id", item)
+
+    def test_degrades_to_log_when_dynamo_write_fails(self):
+        class _BoomDynamo:
+            def put_item(self, **kwargs):
+                raise RuntimeError("table missing")
+
+        logger = _CapturingLogger()
+        record = bhc.emergency_wave_admission(
+            logger=logger,
+            session_id="ENC-SES-TEST",
+            wave_id="wave-9",
+            requested_tokens=5_000,
+            wave_used_tokens=49_000,
+            wave_budget_tokens=50_000,
+            dynamodb_client=_BoomDynamo(),
+            table_name="enceladus-drift-telemetry",
+        )
+        self.assertFalse(record["persisted"])
+        # The extension record is still returned and logged (degraded sink).
+        self.assertTrue(record["admitted"])
+        self.assertTrue(
+            any("[BUDGET][EMERGENCY-ADMISSION]" in r for r in logger.warning_records)
+        )
+
+
+class TestCorpusTelemetry(unittest.TestCase):
+    """AC-7 / ENC-ISS-265: corpus token-usage CloudWatch metric vs PPR baseline."""
+
+    def test_emits_corpus_token_usage_metric(self):
+        logger = _CapturingLogger()
+        cw = _FakeCloudWatch()
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        result = bhc.emit_corpus_token_usage_metric(
+            1_440_000,
+            logger=logger,
+            budgets=budgets,
+            ppr_baseline_tokens=1_200_000,
+            cloudwatch_client=cw,
+            project_id="enceladus",
+        )
+        self.assertTrue(result["emitted"])
+        self.assertEqual(len(cw.calls), 1)
+        call = cw.calls[0]
+        self.assertEqual(call["Namespace"], "Enceladus/BudgetController")
+        metric_names = {m["MetricName"] for m in call["MetricData"]}
+        self.assertIn("CorpusTokenUsage", metric_names)
+        # PPR-informed baseline ratio also emitted (1_440_000 / 1_200_000 = 1.2).
+        self.assertIn("CorpusTokenUsageVsBaseline", metric_names)
+        self.assertAlmostEqual(result["used_vs_ppr_baseline"], 1.2, places=6)
+        self.assertTrue(
+            any("[BUDGET][CORPUS-TELEMETRY]" in r for r in logger.info_records)
+        )
+
+    def test_metric_without_baseline_emits_single_series(self):
+        logger = _CapturingLogger()
+        cw = _FakeCloudWatch()
+        budgets = {"session": 200_000, "wave": 50_000, "project": 500_000, "corpus": 2_000_000}
+        result = bhc.emit_corpus_token_usage_metric(
+            1_000_000, logger=logger, budgets=budgets, cloudwatch_client=cw,
+        )
+        self.assertTrue(result["emitted"])
+        metric_names = {m["MetricName"] for m in cw.calls[0]["MetricData"]}
+        self.assertEqual(metric_names, {"CorpusTokenUsage"})
+        self.assertIsNone(result["used_vs_ppr_baseline"])
+
+
+class TestEvaluateCorpusBudget(unittest.TestCase):
+    """The end-to-end orchestrator wired into session-init."""
+
+    def test_returns_none_without_usage_signal(self):
+        logger = _CapturingLogger()
+        # Ensure no env signal leaks in.
+        os.environ.pop("BUDGET_CORPUS_USED_TOKENS", None)
+        result = bhc.evaluate_corpus_budget(logger, sns_client=_FakeSns(), cloudwatch_client=_FakeCloudWatch())
+        self.assertIsNone(result)
+
+    def test_full_path_classifies_publishes_and_emits(self):
+        logger = _CapturingLogger()
+        sns = _FakeSns()
+        cw = _FakeCloudWatch()
+        result = bhc.evaluate_corpus_budget(
+            logger,
+            used_tokens=1_440_000,  # 72% of 2M default corpus budget
+            sns_client=sns,
+            cloudwatch_client=cw,
+            topic_arn="arn:aws:sns:us-west-2:111122223333:enceladus-budget-alerts",
+            ppr_baseline_tokens=1_200_000,
+            project_id="enceladus",
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["level"]["level"], "NOTICE")
+        self.assertTrue(result["alert"]["published"])
+        self.assertEqual(len(sns.calls), 1)
+        self.assertEqual(len(cw.calls), 1)
+
+    def test_reads_used_tokens_from_env(self):
+        logger = _CapturingLogger()
+        sns = _FakeSns()
+        cw = _FakeCloudWatch()
+        os.environ["BUDGET_CORPUS_USED_TOKENS"] = "1440000"
+        try:
+            result = bhc.evaluate_corpus_budget(
+                logger, sns_client=sns, cloudwatch_client=cw,
+                topic_arn="arn:aws:sns:us-west-2:111122223333:t",
+            )
+        finally:
+            del os.environ["BUDGET_CORPUS_USED_TOKENS"]
+        self.assertIsNotNone(result)
+        self.assertEqual(result["level"]["level"], "NOTICE")
+
+
+if __name__ == "__main__":
+    logging.disable(logging.CRITICAL)
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of the Budget Hierarchy Controller (ENC-FTR-083), layering the operational
control surface on top of the Phase 1 admission math in
`backend/lambda/coordination_api/budget_hierarchy.py`. All emits are best-effort and
degrade to structured CloudWatch log lines (mirroring the `graph_query_api.pathway_telemetry`
S3→log degradation contract), so the change is deploy-safe even before the supporting
infra exists.

- **task_id:** `ENC-TSK-I87`
- **commit-complete-id (CCI):** `CCI-b1f1022b1b5249d8a0dcba3a20e38f5a`
- **commit_sha:** `aa685c9247555a8ffa766486f9de890817878707`
- **governance_hash:** `22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447`
- **Deploy target:** `v4/main` (gamma). No deploy performed; human owns merge + deploy + close-out.

> **Stacked on ENC-TSK-I86 (Ph1).** Ph1 is not yet merged into `v4/main`; its commit
> (`budget_hierarchy.py` + the session-init wiring) is cherry-picked as the parent of this
> change so the PR builds coherently. **Merge ENC-TSK-I86 first**, then this PR rebases
> cleanly onto `v4/main`.

## Acceptance criteria

| AC | Description | Status |
|----|-------------|--------|
| 1 | Five-level alert ladder wired to SNS; corpus budget at 72% triggers NOTICE SNS publish — verified via CloudWatch Logs on test invocation | **Code + unit test complete.** Ladder NORMAL/NOTICE/WARNING/CRITICAL/FRAGMENTED at 50/70/85/95/100%; `classify_alert_level(0.72) == NOTICE`; `[BUDGET][ALERT]` log line always emitted + SNS publish for NOTICE+. CloudWatch-Logs verification on a deployed test invocation is human-owned (post-deploy). |
| 2 | Drift monitor: two consecutive wave-close budget vectors with `‖diff‖_inf = 0.12` trigger recalibration log entry — unit test asserts | **Fully satisfied.** `WaveBudgetDriftMonitor` fires at `‖·‖_inf > 0.1` (strict); `test_consecutive_drift_of_0_12_triggers_recalibration` asserts the `[BUDGET][DRIFT] recalibration triggered` entry. |
| 3 | Emergency admission path: forced cache-miss mid-wave results in wave budget extension record in `enceladus-drift-telemetry` — E2E on gamma | **Code + unit test complete.** `emergency_wave_admission()` grants a bounded extension and writes a `wave_budget_extension` record via DynamoDB `put_item`; degrades to a `[BUDGET][EMERGENCY-ADMISSION]` log line when the table is absent. Gamma E2E is human-owned (requires table + IAM, see prerequisites). |
| 4 | ENC-ISS-265 closed with corpus-scale telemetry measured against PPR-informed baseline confirmed in CloudWatch metric `Enceladus/BudgetController/CorpusTokenUsage` | **Code + unit test complete.** `emit_corpus_token_usage_metric()` publishes `Enceladus/BudgetController/CorpusTokenUsage` + `CorpusTokenUsageVsBaseline` (vs `BUDGET_CORPUS_PPR_BASELINE_TOKENS`). ENC-ISS-265 is already `closed` in the tracker (2026-06-17); metric confirmation is post-deploy + human-owned. Task is **not** advanced past `committed`. |

## Changes

- `backend/lambda/coordination_api/budget_hierarchy.py` — Phase 2 API: `ALERT_LADDER`,
  `classify_alert_level`, `corpus_utilization`, `publish_corpus_alert`,
  `emit_corpus_token_usage_metric`, `evaluate_corpus_budget`, `inf_norm_delta`,
  `WaveBudgetDriftMonitor`, `emergency_wave_admission`.
- `backend/lambda/coordination_api/lambda_function.py` — wire `evaluate_corpus_budget`
  into `_handle_create_request` (session init), best-effort, no-op unless
  `BUDGET_CORPUS_USED_TOKENS` is configured.
- `backend/lambda/coordination_api/test_budget_hierarchy_ph2.py` — 17 new unittest cases
  (29 total with Ph1), all green via `python -m unittest`.

## OGTM (ENC-FTR-066)

Pure compute + best-effort emission to existing AWS telemetry surfaces (SNS / CloudWatch /
a DynamoDB telemetry sink). No new tracker record type, relational field, graph node, or
edge type; `graph_sync` untouched — no new ontology edge to keep traversable.

## Deploy prerequisites (no_code / infra follow-up — comp-cloudformation, human-owned)

The runtime degrades to CloudWatch logs without these, but the AC1/AC3/AC4 deployed
verifications on gamma require:

- **SNS:** an alert topic + grant `sns:Publish` on it to the coordination_api role; set
  `BUDGET_ALERT_SNS_TOPIC_ARN` (falls back to `DEAD_LETTER_SNS_TOPIC_ARN`).
- **CloudWatch:** grant `cloudwatch:PutMetricData` scoped to namespace
  `Enceladus/BudgetController` on the coordination_api role.
- **DynamoDB:** provision the `enceladus-drift-telemetry` table (PK `telemetry_id`) and
  grant `dynamodb:PutItem`; set `DRIFT_TELEMETRY_TABLE`.
- **Config signals (optional):** `BUDGET_CORPUS_USED_TOKENS`,
  `BUDGET_CORPUS_PPR_BASELINE_TOKENS`.

## Evidence

`system.connection_health` (session init, via enceladus-mcp-prod):

```json
{"dynamodb": "ok", "s3": "ok", "governance_hash": "22a7195bb6799011ae57438f9409e654d4eabbb22f885c50263b1f3a70cde447", "checked_at": "2026-06-30T01:22:11Z", "server_version": "1.0.0", "graph_index": {"status": "healthy", "signals": {"vector": true, "graph": true, "keyword": true}, "graph_projection": {"name": "gds_standing_enceladus", "exists": true, "stale": false}}}
```

Unit tests:

```
Ran 29 tests in 0.031s
OK
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0504e8df-876d-4c65-8177-1cd9c1346cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0504e8df-876d-4c65-8177-1cd9c1346cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

