### PR TITLE
fix(record_deploy): remove invalid target_arn from deploy submit body

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -732,7 +732,6 @@ jobs:
               "submitted_by": "gha-deploy-pipeline",
               "non_ui_config": {
                   "service_group": "lambda",
-                  "target_arn": os.environ['DEPLOY_ROLE_ARN'],
               },
               "governance_hash": os.environ['GOVERNANCE_HASH'],
           }))


### PR DESCRIPTION
Removes non_ui_config.target_arn (was the IAM deploy role ARN, which fails validation when service_group=lambda). The deploy submit API requires target_arn to match arn:aws:lambda: prefix or be absent.