### PR TITLE
fix(record_deploy): provide valid Lambda ARN for non_ui_config.target_arn

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -732,6 +732,7 @@ jobs:
               "submitted_by": "gha-deploy-pipeline",
               "non_ui_config": {
                   "service_group": "lambda",
+                  "target_arn": f"arn:aws:lambda:us-west-2:356364570033:function:devops-tracker-mutation-api{'-gamma' if 'gamma' in env else ''}",
               },
               "governance_hash": os.environ['GOVERNANCE_HASH'],
           }))


### PR DESCRIPTION
The deploy submit API requires non_ui_config.target_arn to be an arn:aws:lambda: prefix when service_group=lambda. Uses devops-tracker-mutation-api-gamma as the canonical representative function.