### PR TITLE
fix(deploy_orchestrator): check record_only before non-UI branch (ENC-ISS-452)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-28.02",
-  "updated_at": "2026-06-28T03:52:10Z",
-  "last_change_summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: agent-session TTL idle-sweep backstop. New coordination.agent_session_idle_sweep entity documents the scheduled EventBridge reaper (AgentSessionIdleSweepSchedule, rate(1 hour)) that flips sessions left allocated/claimed past AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS to 'retired' via the same append-only conditional UpdateItem as agent.retire — deliberately NOT DynamoDB native TTL, which would hard-delete and violate the append-only retire model from ENC-TSK-I38. Completes FTR-117 AC#8 (append-only storage + explicit agent.retire + idle-sweep backstop). Bump satisfies the path-triggered Governance Dictionary Guard on coordination_api lambda_function.py/config.py edits.",
+  "version": "2026-06-30.01",
+  "updated_at": "2026-06-30T03:30:00Z",
+  "last_change_summary": "ENC-ISS-452 (ENC-TSK-I96): Updated deploy.spec to document that record_only mode now applies to ALL deployment types (including lambda_update/non-UI). deploy_mode check moved before NON_UI branch in deploy_orchestrator so Gen2 _deploy.yml record_deploy submissions auto-finalize as DEP records. Updated deploy_mode usage_guidance accordingly.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1260,7 +1260,7 @@
             "record_only"
           ],
           "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
-          "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
+          "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. As of ENC-ISS-452, the record_only check runs BEFORE the NON_UI_SERVICE_GROUP_BY_TYPE branch, so lambda_update (and other non-UI types) also take the record_only path \u2014 _finalize_record_only() is called for any deployment_type when deploy_mode='record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
           "type": "object",
@@ -5750,7 +5750,7 @@
       }
     },
     "coordination.agent_session_idle_sweep": {
-      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8. Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose last lifecycle transition (claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent — already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge.",
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8. Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose last lifecycle transition (claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent \u2014 already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge.",
       "fields": {
         "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
           "type": "boolean",
@@ -5766,7 +5766,7 @@
         },
         "summary": {
           "type": "object",
-          "definition": "Return value (CloudWatch only — no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+          "definition": "Return value (CloudWatch only \u2014 no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
         }
       }
     },
@@ -5839,6 +5839,13 @@
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
   "change_log": [
     {
+      "version": "2026-06-30.01",
+      "date": "2026-06-30",
+      "summary": "ENC-ISS-452: record_only guard now applies to all deployment_types (lambda_update included). Updated deploy.spec.deploy_mode.usage_guidance.",
+      "task": "ENC-TSK-I96",
+      "issue": "ENC-ISS-452"
+    },
+    {
       "version": "2026-06-21.02",
       "date": "2026-06-21",
       "summary": "ENC-TSK-G45 + ENC-TSK-G12 (PR #483): Diataxis Reference rewrite of the top-20 code-mode tool descriptions + canonical typed handoff mandate schema (handoff_mandate.py, strict:true dispatch generator). server.py tool-surface change; version bump required by the CI governance-dictionary guard."
@@ -5866,7 +5873,7 @@
     {
       "version": "2026-06-28.02",
       "date": "2026-06-28",
-      "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip — NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
+      "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip \u2014 NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
     }
   ]
 }

--- a/backend/lambda/deploy_orchestrator/lambda_function.py
+++ b/backend/lambda/deploy_orchestrator/lambda_function.py
@@ -1285,6 +1285,52 @@ def _orchestrate_typed_batch(
     spec_id = f"SPEC-{_utc_now_compact()}"
     logger.info(f"[INFO] Spec ID: {spec_id}")
 
+    # --- Record-only mode: skip all execution for externally-deployed projects ---
+    # Check BEFORE the non-UI branch so lambda_update (and other non-UI types) also
+    # take the record-only path when deploy_mode='record_only'. Previously this check
+    # appeared after the non-UI branch exit, making it unreachable for those types.
+    # See ENC-ISS-452, ENC-ISS-102, ENC-ISS-103.
+    deploy_mode = _get_project_deploy_mode(project_id)
+    if deploy_mode == "record_only":
+        logger.info("[INFO] Record-only mode for %s — skipping execution", project_id)
+        config = _read_deploy_config(project_id)
+        current_version = _get_current_version(project_id, config)
+        new_version, change_type = _resolve_version(current_version, requests)
+        logger.info(
+            "[INFO] Version: %s → %s (%s) [record-only]",
+            current_version, new_version, change_type,
+        )
+        _write_spec(
+            project_id,
+            spec_id,
+            deployment_type=deployment_type,
+            deployment_category="ui",
+            previous_version=current_version,
+            resolved_version=new_version,
+            resolved_change_type=change_type,
+            included_request_ids=request_ids,
+            aggregated_changes=all_changes,
+            aggregated_release_summary=agg_summary,
+            integration_analysis=analysis,
+            all_related_record_ids=all_related,
+        )
+        _mark_requests(project_id, request_ids, "included", spec_id)
+        _finalize_record_only(
+            project_id,
+            spec_id,
+            current_version,
+            new_version,
+            change_type,
+            all_changes,
+            agg_summary,
+            request_ids,
+            all_related,
+        )
+        logger.info(
+            "[SUCCESS] Record-only deployment finalized: v%s (%s)", new_version, spec_id,
+        )
+        return
+
     if deployment_type in NON_UI_SERVICE_GROUP_BY_TYPE:
         valid, targets, errors = _validate_non_ui_requests(deployment_type, requests)
         if not valid:
@@ -1377,52 +1423,6 @@ def _orchestrate_typed_batch(
 
     if deployment_type not in UI_DEPLOYMENT_TYPES:
         logger.error("[ERROR] Unsupported deployment type '%s'", deployment_type)
-        return
-
-    # --- Record-only mode: skip CodeBuild for externally-deployed projects ---
-    # Projects with deploy_mode='record_only' deploy via their own CI/CD.
-    # We only need to track version + changelog. See ENC-ISS-102, ENC-ISS-103.
-    deploy_mode = _get_project_deploy_mode(project_id)
-    if deploy_mode == "record_only":
-        logger.info("[INFO] Record-only mode for %s — skipping CodeBuild", project_id)
-        config = _read_deploy_config(project_id)
-        current_version = _get_current_version(project_id, config)
-        new_version, change_type = _resolve_version(current_version, requests)
-        logger.info(
-            "[INFO] Version: %s → %s (%s) [record-only]",
-            current_version, new_version, change_type,
-        )
-
-        _write_spec(
-            project_id,
-            spec_id,
-            deployment_type=deployment_type,
-            deployment_category="ui",
-            previous_version=current_version,
-            resolved_version=new_version,
-            resolved_change_type=change_type,
-            included_request_ids=request_ids,
-            aggregated_changes=all_changes,
-            aggregated_release_summary=agg_summary,
-            integration_analysis=analysis,
-            all_related_record_ids=all_related,
-        )
-        _mark_requests(project_id, request_ids, "included", spec_id)
-
-        _finalize_record_only(
-            project_id,
-            spec_id,
-            current_version,
-            new_version,
-            change_type,
-            all_changes,
-            agg_summary,
-            request_ids,
-            all_related,
-        )
-        logger.info(
-            "[SUCCESS] Record-only deployment finalized: v%s (%s)", new_version, spec_id,
-        )
         return
 
     # UI deployment flow: read deploy config and run semver resolution + CodeBuild.


### PR DESCRIPTION
## Summary

- Moves `deploy_mode='record_only'` guard **before** `NON_UI_SERVICE_GROUP_BY_TYPE` branch in `deploy_orchestrator/lambda_function.py`
- Previously the guard was unreachable for `lambda_update` (and other non-UI types) because those branches `return` early at line 1376
- With the fix, Gen2 `_deploy.yml` `record_deploy` submissions auto-finalize as DEP records without manual DDB inserts

Fixes: ENC-ISS-452  
Task: ENC-TSK-I96

CCI-875a435ca57e4585ad1a75c5f50d68c1

## Test plan
- [ ] PR merges to `main` and `ui-backend-deploy.yml` deploys `devops-deploy-orchestrator` to prod
- [ ] Subsequent `_deploy.yml` run on `v4/main` produces a DEP record in `deploy.history` automatically