### PR TITLE
fix(deploy_orchestrator): guard record_only before non-UI execution (ENC-ISS-452)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-27.04",
-  "updated_at": "2026-06-27T14:00:00Z",
-  "last_change_summary": "ENC-TSK-I27 / ENC-FTR-116 Wave 2: added governance.version_record (canonical DDB record schema for devops-recompute-governance Lambda) and recompute_governance.event_handler (S3-triggered Lambda contract: trigger, canonical file set, dedup, CAS guard, recursion invariant, env vars). Required by governance-dictionary-guard for backend/lambda/recompute_governance/lambda_function.py addition.",
+  "version": "2026-06-30.01",
+  "updated_at": "2026-06-30T05:00:00Z",
+  "last_change_summary": "ENC-TSK-I97 / ENC-ISS-452: version bump for deploy_orchestrator/lambda_function.py fix (record_only guard before NON_UI_SERVICE_GROUP_BY_TYPE branch). No new entities added; bump required by Governance Dictionary Guard.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/deploy_orchestrator/lambda_function.py
+++ b/backend/lambda/deploy_orchestrator/lambda_function.py
@@ -1286,6 +1286,52 @@ def _orchestrate_typed_batch(
     logger.info(f"[INFO] Spec ID: {spec_id}")
 
     if deployment_type in NON_UI_SERVICE_GROUP_BY_TYPE:
+        # ENC-ISS-452: guard record_only before inline validation/execution so lambda_update
+        # REQs from Gen2 record_deploy produce a DEP record instead of a status=failed SPEC.
+        deploy_mode = _get_project_deploy_mode(project_id)
+        if deploy_mode == "record_only":
+            logger.info(
+                "[INFO] Record-only mode for %s (%s) — skipping non-UI execution",
+                project_id, deployment_type,
+            )
+            config = _read_deploy_config(project_id)
+            current_version = _get_current_version(project_id, config)
+            new_version, change_type = _resolve_version(current_version, requests)
+            logger.info(
+                "[INFO] Version: %s → %s (%s) [record-only]",
+                current_version, new_version, change_type,
+            )
+            _write_spec(
+                project_id,
+                spec_id,
+                deployment_type=deployment_type,
+                deployment_category="non_ui",
+                previous_version=current_version,
+                resolved_version=new_version,
+                resolved_change_type=change_type,
+                included_request_ids=request_ids,
+                aggregated_changes=all_changes,
+                aggregated_release_summary=agg_summary,
+                integration_analysis=analysis,
+                all_related_record_ids=all_related,
+            )
+            _mark_requests(project_id, request_ids, "included", spec_id)
+            _finalize_record_only(
+                project_id,
+                spec_id,
+                current_version,
+                new_version,
+                change_type,
+                all_changes,
+                agg_summary,
+                request_ids,
+                all_related,
+            )
+            logger.info(
+                "[SUCCESS] Record-only non-UI deployment finalized: v%s (%s)", new_version, spec_id,
+            )
+            return
+
         valid, targets, errors = _validate_non_ui_requests(deployment_type, requests)
         if not valid:
             logger.error("[ERROR] Non-UI validation failed for %s", deployment_type)


### PR DESCRIPTION
## Summary

- Adds `deploy_mode='record_only'` guard inside `NON_UI_SERVICE_GROUP_BY_TYPE` branch of `deploy_orchestrator/lambda_function.py`, before `_validate_non_ui_requests`
- When `record_only`, calls `_finalize_record_only` directly and returns — creates a DEP record instead of a `status=failed` SPEC
- Fixes REQ→DEP auto-promotion breakage for Gen2 `lambda_update` deploys

Fixes: ENC-ISS-452

## Test plan

- [ ] Deploy to v3 prod enceladus-deploy-orchestrator via surgical update-function-code
- [ ] Merge a PR to v4/main — confirm record_deploy job REQ produces DEP (status=deployed), not SPEC (status=failed)
- [ ] Confirm `deploy.history` auto-populates without manual DDB inserts

ENC-TSK-I97 | CCI-d9fe770c0b814114a847f1cc3108be15