### PR TITLE
[ENC-TSK-J01] FTR-108 Ph1: Tero current-reinforcement contract (design only, no graph writes)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-30.11",
-  "updated_at": "2026-06-30T21:46:00Z",
-  "last_change_summary": "ENC-TSK-I91 (FTR-105 AC-7 spurious-attractor telemetry wiring). graph_query_api.drift_telemetry now computes spurious_attractor_rate from wave retrieval_records (no longer a permanent null stub); graph_query_api.adjacency surfaces a recent spurious_attractor_rate aggregate read off the existing enceladus-drift-telemetry GSI; comp-percolation-monitor's DDB row gains a nullable spurious_attractor_rate field sourced from that same adjacency response. No new edge types, no new Neo4j writes, no new AWS infrastructure. Version -> 2026-06-30.11. Prior change (now on v4/main, .10) — ENC-TSK-H47 (B63 Phase 2B, ENC-PLN-006 gamma): extracted lesson constitutional scoring into a new standalone backend/lambda/scoring_service Lambda, SNS-triggered and ASYNC, behind the enable_scoring_service_extraction AppConfig flag (default OFF); see that task's worklog for the full change summary.",
+  "version": "2026-06-30.12",
+  "updated_at": "2026-06-30T21:58:00Z",
+  "last_change_summary": "ENC-TSK-J01 (FTR-108 Ph1, design-only, no functional change): doc-comment cross-reference added to graph_query_api._build_pathway_telemetry_record noting that edge_participation[].edge_id (retrieval_outcome=='hit') is the confirmed Ph1 source of truth for the Tero current-reinforcement contract's flow(e,t) signal (design doc DOC-88A8F4835811). No schema/field/status changes. Version -> 2026-06-30.12. Prior change (now on v4/main, .11) — ENC-TSK-I91 (FTR-105 AC-7 spurious-attractor telemetry wiring); see that task's worklog for the full change summary.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -1933,7 +1933,14 @@ def _build_pathway_telemetry_record(*, wave_id, intent_signature, project_id,
                                     edge_participation, result_count, graph_algorithm,
                                     signal_availability) -> Dict[str, Any]:
     """Assemble the AC-1 raw telemetry record (also carries the AC-10 edge
-    participation list). This field set IS the ENC-FTR-108 AC-4 input contract."""
+    participation list). This field set IS the ENC-FTR-108 AC-4 input contract.
+
+    ENC-TSK-J01 (FTR-108 Ph1, design-only): edge_participation[].edge_id entries
+    with retrieval_outcome == "hit" are the Ph1 source of truth for "did edge e
+    participate in a successful retrieval this wave" -- the flow(e, t) signal in
+    the Tero current-reinforcement contract (DOC-88A8F4835811). No flow_weight
+    write path exists yet; that is Ph2, gated on an OGTM preflight not yet run.
+    """
     return {
         "schema": "enceladus.pathway.telemetry.v1",
         "wave_id": wave_id or "unassigned",


### PR DESCRIPTION
## Summary
- Design-only phase. Defines the Tero current-reinforcement law for edge `flow_weight`: `flow_weight(t+1) = flow_weight(t) + delta*flow - mu*flow_weight(t)`, with `delta=mu=0.2` defaults and full derivations (idle-decay half-life, fixed-point convergence). Published as DOC-88A8F4835811.
- Confirmed FTR-082's existing `edge_participation[].edge_id` (with `retrieval_outcome=="hit"`) already serves as the Ph1 source-of-truth for which edges participated in a successful retrieval — no new logging hook was needed.
- Only code change: a doc-comment cross-referencing the design doc on the existing `_build_pathway_telemetry_record` contract (no functional change).
- No Neo4j writes, no flow_weight write path — that's Ph2, gated on a not-yet-run OGTM preflight.

## Test plan
- [x] Full `graph_query_api` test directory: 140 passed, 8 subtests passed (no regression — doc-comment only)
- [x] `py_compile` clean

CCI-6444bb1f6e2b48ac8d9cfcc62aca43cb

🤖 Generated with [Claude Code](https://claude.com/claude-code)