### PR TITLE
[ENC-TSK-I92] FTR-110: Dispersion/Corroboration Weber-Law RRF term

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-06-30.13",
-  "updated_at": "2026-06-30T22:01:00Z",
-  "last_change_summary": "ENC-TSK-I98 (FTR-104 Ph1 AC-1/AC-2): graph_query_api.pathway_telemetry gains an additive 'energy' block (E(x) = E_vector + lambda_graph*E_PPR + lambda_kw*E_keyword per retrieval record, plus the lambda weights used); hybrid retrieval response gains retrieval_records[]/energy_lambda_weights. ppr_source_is_gds_pagerank flags whether E_PPR came from the FTR-101 gds_pagerank projection vs cypher_fallback. No existing field renamed/removed. Version -> 2026-06-30.13. Prior change (now on v4/main, .12) — ENC-TSK-J01 (FTR-108 Ph1, design-only); see that task's worklog for the full change summary.",
+  "version": "2026-06-30.14",
+  "updated_at": "2026-06-30T23:15:00Z",
+  "last_change_summary": "ENC-TSK-I92 (FTR-110 Ph1): graph_query_api hybrid retrieval gains a fifth, additive dispersion/corroboration Weber-law bonus signal layered on top of the existing 4-signal RRF fusion. Each candidate's per_node_fusion/_node_ entry gains k_corr (dispersion-constrained corroborator count -- near-duplicate records, pairwise cosine distance < 0.3, never count as corroborating each other), b_corr (B_corr = Weber_k * ln(1+k_corr)/ln(1+k_max), call-relative normalization, default Weber_k=0.3), final_score (fused_score + b_corr) and final_rank; nodes/per_node_fusion are now ordered by final_score rather than the pure-RRF fused_score (fused_score/fused_rank remain unmodified). Response gains corroboration_weber_k. No existing field renamed/removed; degrades to a no-op when no candidate carries an embedding. Version -> 2026-06-30.14. Prior change (.13) -- ENC-TSK-I98 (FTR-104 Ph1 AC-1/AC-2), the per-retrieval energy function E(x) additive 'energy' block; see that task's worklog for the full change summary.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/graph_query_api/corroboration.py
+++ b/backend/lambda/graph_query_api/corroboration.py
@@ -1,0 +1,340 @@
+"""Dispersion/Corroboration Weber-law bonus term (ENC-FTR-110 Ph1 / ENC-TSK-I92).
+
+Defines a fifth scoring signal layered on top of ``lambda_function._rrf_fuse``'s
+four-signal (vector/graph/keyword/PPR) Reciprocal Rank Fusion: a per-candidate
+**corroboration bonus** ``B_corr(x)`` that rewards a candidate for having other,
+*genuinely independent* records in the same result set that also point at it —
+while explicitly refusing credit for near-duplicate records propping each
+other up.
+
+Why a separate "dispersion constraint" is needed
+--------------------------------------------------
+Naively, "how many other results are similar to this one" is a cheap proxy for
+corroboration. But a cluster of near-identical records (e.g. five copies of the
+same Lesson re-embedded after minor edits) would inflate that count without
+adding any independent evidence — they are one opinion wearing five hats. This
+module instead counts **corroborators**: other records that are (a) similar
+enough to the candidate to support it, AND (b) pairwise distinct from every
+other counted corroborator (pairwise cosine distance >= ``DISPERSION_MIN_
+DISTANCE``). Two near-duplicates competing for the same corroborator slot only
+ever contribute one corroborator between them — see ``count_corroborators``.
+
+Term definitions
+-----------------
+  * ``k_corr(x)`` — the corroborator count for candidate x: the size of the
+    largest subset of "similar-to-x" records (cosine similarity to x >=
+    ``DEFAULT_SIMILARITY_THRESHOLD``) such that every pair within that subset
+    has pairwise cosine distance >= ``DISPERSION_MIN_DISTANCE`` (0.3). Computed
+    via a deterministic greedy packing (``count_corroborators``): candidates
+    similar to x are considered most-similar-to-x first, and a candidate is
+    accepted only if it is sufficiently dispersed (distance >= 0.3) from every
+    already-accepted corroborator. This is the practical, polynomial-time
+    reading of "pairwise distinct from each other" — an exact maximum
+    independent set is NP-hard in general, but result sets here are bounded
+    (``HYBRID_SIGNAL_TOP_N`` * fan-out, at most a few dozen candidates per
+    call), and the greedy packing is exact for the test scenarios this module
+    is built against (a single near-duplicate cluster, or a handful of
+    genuinely dispersed corroborators).
+  * ``B_corr(x) = Weber_k * ln(1 + k_corr(x)) / ln(1 + k_max)`` — a
+    Weber-Fechner-law-style logarithmic diminishing-returns curve: the jump
+    from 0 -> 1 corroborator matters far more than 5 -> 6. ``k_max`` is the
+    largest ``k_corr`` observed across the candidates fused in *this call*
+    (the same call-relative normalization convention ``energy_function`` uses
+    for ``E_PPR`` / ``E_keyword`` — see that module's docstring), so the best-
+    corroborated candidate in a given result set always receives the full
+    ``Weber_k`` bonus and ``k_max == 0`` (nobody in this call has any
+    corroboration) degrades to ``B_corr == 0.0`` for everyone rather than a
+    division by zero.
+
+This is a *bonus*, not an RRF term: it is not folded into the ``1/(k+rank)``
+reciprocal-rank sum ``_rrf_fuse`` computes (that sum is exercised by exact-value
+assertions in ``test_hybrid_retrieval.py`` and must not change), and it is not
+a penalty. ``lambda_function._query_hybrid`` adds it on top of each candidate's
+already-fused RRF ``fused_score`` to produce a ``final_score`` — see the
+"Wiring" banner in that function for the integration point. The hedge this
+buys (ENC-FTR-110 AC-4): a single high-RRF candidate with zero independent
+corroboration can be outranked, post-bonus, by a moderately-ranked candidate
+that several genuinely distinct records independently point at — exactly the
+spurious-attractor case this signal exists to dampen.
+
+Weber_k (configurable, AppConfig-backed)
+------------------------------------------
+``Weber_k`` is resolved at call time via ``load_weber_k()``, mirroring the
+AppConfig-with-env-var-fallback idiom already used by
+``backend/lambda/coordination_api/budget_hierarchy.py``
+(``_appconfig_budget_config`` / ``load_scale_budgets``) and
+``energy_function.load_lambda_weights``:
+
+  1. AppConfig ``corroboration-function`` configuration profile key
+     ``weber_k`` (via the AppConfig Lambda extension at ``localhost:2772``).
+  2. Environment variable ``CORROBORATION_WEBER_K``.
+  3. Hard-coded default ``DEFAULT_WEBER_K`` (0.3).
+
+This module is pure-Python and dependency-free (no numpy, no boto3 import at
+module load), matching the ``energy_function`` / ``drift_telemetry`` /
+``dedup_convergence`` precedent in this package, so it is importable in unit
+tests without AWS and bundles into the Lambda zip with no new dependency.
+
+OGTM (ENC-FTR-110 AC-5): this module is pure compute plus a config read, over
+candidate records ``lambda_function._query_hybrid`` has already fetched. It
+introduces NO new tracker record type, relational field, edge type, or graph
+node; performs NO Neo4j writes; and adds no new DDB table.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import urllib.error
+import urllib.request
+from typing import Dict, List, Optional, Sequence
+
+__all__ = [
+    "CORROBORATION_SCHEMA",
+    "DEFAULT_WEBER_K",
+    "DEFAULT_SIMILARITY_THRESHOLD",
+    "DISPERSION_MIN_DISTANCE",
+    "load_weber_k",
+    "cosine_similarity",
+    "cosine_distance",
+    "count_corroborators",
+    "compute_corroboration_counts",
+    "weber_bonus",
+    "compute_bonuses",
+]
+
+# Schema tag for the corroboration breakdown, additive-sibling to
+# energy_function.ENERGY_SCHEMA — surfaced for observability, not yet consumed
+# by any downstream telemetry contract.
+CORROBORATION_SCHEMA = "enceladus.retrieval.corroboration.v1"
+
+# Hard-coded fallback default for Weber_k (see module docstring).
+DEFAULT_WEBER_K: float = 0.3
+
+# "High vector similarity to it" floor (module docstring term 1): a record
+# below this cosine similarity to the candidate is not considered supporting
+# evidence at all, dispersion aside. Deliberately looser than dedup_
+# convergence.DEFAULT_COSINE_THRESHOLD (0.95, near-duplicate identity) — that
+# constant answers "is this the same record"; this one answers "is this
+# record independently pointing at the same answer," a lower bar.
+DEFAULT_SIMILARITY_THRESHOLD: float = 0.80
+
+# The dispersion constraint (ENC-FTR-110 AC-2): two records count as
+# corroborating each other only if their pairwise cosine distance is >= this
+# value. Fixed per the AC, not AppConfig-tunable like Weber_k.
+DISPERSION_MIN_DISTANCE: float = 0.3
+
+
+# ---------------------------------------------------------------------------
+# AppConfig-backed configurable Weber_k
+# ---------------------------------------------------------------------------
+
+def _appconfig_corroboration_config() -> Dict[str, object]:
+    """Best-effort read of the corroboration-function config from the
+    AppConfig Lambda extension (localhost:2772). Returns {} on any failure so
+    the caller falls back to the env var / hard-coded default. Mirrors
+    ``energy_function._appconfig_energy_config`` /
+    ``coordination_api.budget_hierarchy._appconfig_budget_config`` but
+    targets a dedicated ``corroboration-function`` configuration profile
+    (env-overridable)."""
+    port = os.environ.get("AWS_APPCONFIG_EXTENSION_HTTP_PORT", "2772")
+    app = os.environ.get("APPCONFIG_APPLICATION", "enceladus")
+    env = os.environ.get("APPCONFIG_ENVIRONMENT", "production")
+    cfg = os.environ.get("CORROBORATION_FUNCTION_APPCONFIG_CONFIGURATION", "corroboration-function")
+    url = f"http://localhost:{port}/applications/{app}/environments/{env}/configurations/{cfg}"
+    try:
+        with urllib.request.urlopen(url, timeout=1) as resp:  # noqa: S310 — localhost extension
+            data = json.loads(resp.read())
+        return data if isinstance(data, dict) else {}
+    except (urllib.error.URLError, OSError, ValueError):
+        return {}
+
+
+def load_weber_k() -> float:
+    """Resolve ``Weber_k`` at runtime.
+
+    Resolution order, highest precedence first:
+      1. AppConfig ``corroboration-function`` configuration profile key
+         ``weber_k``.
+      2. Environment variable ``CORROBORATION_WEBER_K``.
+      3. Hard-coded default (``DEFAULT_WEBER_K``).
+
+    Always returns a non-negative float so the caller never has to handle a
+    partial/invalid config.
+    """
+    appconfig = _appconfig_corroboration_config()
+    raw = appconfig.get("weber_k")
+    if raw is None:
+        raw = os.environ.get("CORROBORATION_WEBER_K")
+    try:
+        value = float(raw) if raw is not None else DEFAULT_WEBER_K
+    except (TypeError, ValueError):
+        value = DEFAULT_WEBER_K
+    if value < 0.0:
+        value = DEFAULT_WEBER_K
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Pairwise cosine similarity / distance (pure stdlib)
+# ---------------------------------------------------------------------------
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> Optional[float]:
+    """Cosine similarity between two equal-length vectors.
+
+    Returns ``None`` (rather than raising) on a dimension mismatch or a
+    zero-norm vector — both are "cannot compare" cases for a record missing or
+    carrying a degenerate embedding, and the caller (``count_corroborators``)
+    treats ``None`` as "not similar enough to corroborate," never as an error.
+    """
+    if not a or not b or len(a) != len(b):
+        return None
+    dot = sum(float(x) * float(y) for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(float(x) * float(x) for x in a))
+    norm_b = math.sqrt(sum(float(y) * float(y) for y in b))
+    if norm_a <= 0.0 or norm_b <= 0.0:
+        return None
+    sim = dot / (norm_a * norm_b)
+    # Clamp for floating-point overshoot beyond the mathematical [-1, 1] range.
+    return max(-1.0, min(1.0, sim))
+
+
+def cosine_distance(a: Sequence[float], b: Sequence[float]) -> Optional[float]:
+    """``1.0 - cosine_similarity(a, b)``; ``None`` propagates (see
+    ``cosine_similarity``)."""
+    sim = cosine_similarity(a, b)
+    if sim is None:
+        return None
+    return 1.0 - sim
+
+
+# ---------------------------------------------------------------------------
+# Corroborator counting (dispersion-constrained)
+# ---------------------------------------------------------------------------
+
+def count_corroborators(
+    candidate_id: str,
+    candidate_embedding: Optional[Sequence[float]],
+    pool: Dict[str, Sequence[float]],
+    *,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    dispersion_min_distance: float = DISPERSION_MIN_DISTANCE,
+) -> int:
+    """k_corr(candidate) — count of dispersion-constrained corroborators.
+
+    ``pool`` maps every OTHER candidate's record_id to its embedding (the
+    candidate itself must already be excluded by the caller — see
+    ``compute_corroboration_counts``). Returns 0 immediately if the candidate
+    has no usable embedding (ENC-FTR-110 AC-5 graceful degrade: a record with
+    no embedding gets no corroboration credit, never a crash).
+
+    Algorithm (deterministic greedy packing — see module docstring for why
+    this is the practical reading of "pairwise distinct from each other"):
+      1. Filter ``pool`` to records with cosine similarity to the candidate
+         >= ``similarity_threshold`` ("similar enough to support it").
+      2. Sort that similar pool by similarity to the candidate, descending
+         (ties broken by record_id for determinism), so the strongest
+         supporting evidence is considered first.
+      3. Walk the sorted list, greedily accepting a record as a corroborator
+         only if its cosine distance to EVERY already-accepted corroborator
+         is >= ``dispersion_min_distance``. A record that is a near-duplicate
+         of an already-accepted corroborator is skipped — it adds no
+         independent evidence (ENC-FTR-110 AC-2).
+    Returns the count of accepted corroborators.
+    """
+    if not candidate_embedding:
+        return 0
+
+    similar: List[tuple] = []
+    for rid, emb in pool.items():
+        if rid == candidate_id or not emb:
+            continue
+        sim = cosine_similarity(candidate_embedding, emb)
+        if sim is not None and sim >= similarity_threshold:
+            similar.append((sim, rid, emb))
+
+    # Most similar to the candidate first; record_id as a deterministic
+    # tie-breaker so the result never depends on dict/set iteration order.
+    similar.sort(key=lambda t: (-t[0], t[1]))
+
+    accepted: List[Sequence[float]] = []
+    for _sim, _rid, emb in similar:
+        if all(
+            (cosine_distance(emb, other) or 0.0) >= dispersion_min_distance
+            for other in accepted
+        ):
+            accepted.append(emb)
+
+    return len(accepted)
+
+
+def compute_corroboration_counts(
+    embeddings_by_rid: Dict[str, Sequence[float]],
+    *,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    dispersion_min_distance: float = DISPERSION_MIN_DISTANCE,
+) -> Dict[str, int]:
+    """k_corr for every candidate in ``embeddings_by_rid`` (one result set).
+
+    Records with no embedding are included in the output with k_corr == 0
+    (so callers can rely on every candidate id being present) but never
+    contribute to another candidate's corroborator count (excluded from the
+    similarity pool automatically — ``cosine_similarity`` returns ``None`` for
+    falsy/missing embeddings).
+    """
+    counts: Dict[str, int] = {}
+    for rid, emb in embeddings_by_rid.items():
+        counts[rid] = count_corroborators(
+            rid, emb, embeddings_by_rid,
+            similarity_threshold=similarity_threshold,
+            dispersion_min_distance=dispersion_min_distance,
+        )
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# B_corr(x) — the Weber-Fechner bonus
+# ---------------------------------------------------------------------------
+
+def weber_bonus(k_corr: int, k_max: int, weber_k: float = DEFAULT_WEBER_K) -> float:
+    """B_corr(x) = Weber_k * ln(1 + k_corr) / ln(1 + k_max).
+
+    Call-relative normalization (mirrors ``energy_function``'s E_PPR/
+    E_keyword convention): the best-corroborated candidate in this call's
+    result set (``k_corr == k_max``) always receives the full ``Weber_k``
+    bonus. When ``k_max <= 0`` (no candidate in this call has any
+    corroboration), the bonus is 0.0 for everyone rather than a division by
+    zero — there is nothing to normalize against.
+    """
+    if k_max is None or k_max <= 0 or k_corr is None or k_corr <= 0:
+        return 0.0
+    k_corr = max(0, int(k_corr))
+    k_max = max(0, int(k_max))
+    return weber_k * math.log1p(k_corr) / math.log1p(k_max)
+
+
+def compute_bonuses(
+    counts: Dict[str, int],
+    *,
+    weber_k: Optional[float] = None,
+) -> Dict[str, Dict[str, float]]:
+    """B_corr breakdown for every candidate in ``counts`` (one result set).
+
+    Returns ``{record_id: {"schema", "k_corr", "k_max", "weber_k", "b_corr"}}``
+    so a caller (or a unit test) can inspect the full provenance of each
+    bonus, not just its final value.
+    """
+    if weber_k is None:
+        weber_k = load_weber_k()
+    k_max = max(counts.values()) if counts else 0
+    out: Dict[str, Dict[str, float]] = {}
+    for rid, k_corr in counts.items():
+        out[rid] = {
+            "schema": CORROBORATION_SCHEMA,
+            "k_corr": k_corr,
+            "k_max": k_max,
+            "weber_k": weber_k,
+            "b_corr": weber_bonus(k_corr, k_max, weber_k),
+        }
+    return out

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -37,6 +37,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs
 
+import corroboration
 import dedup_convergence
 import energy_function
 
@@ -2018,7 +2019,8 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
 
     Response contract:
       {
-        "nodes":             [...ordered by fused score...],
+        "nodes":             [...ordered by final score (fused RRF score +
+                              ENC-TSK-I92 dispersion/corroboration bonus)...],
         "edges":             [],
         "paths":             [],
         "summary":           "Hybrid: N nodes (vector=V, graph=G, keyword=K)",
@@ -2027,8 +2029,17 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         "graph_algorithm":   "gds_pagerank" | "cypher_fallback" | "unavailable",
         "rrf_k":             60,
         "embedding_coverage_sample": {covered: N, total_ranked: N},
-        "per_node_fusion":   {record_id: {fused_rank, per_signal_ranks}}
+        "per_node_fusion":   {record_id: {fused_rank, per_signal_ranks, ...,
+                              k_corr, b_corr, final_score, final_rank}},
+        "corroboration_weber_k": 0.3,
       }
+
+    ENC-TSK-I92 (ENC-FTR-110 Ph1): each candidate's pure-RRF `fused_score`
+    (vector/graph/keyword/PPR fused via `_rrf_fuse`) is augmented with a fifth,
+    additive corroboration bonus B_corr — see the `corroboration` module and
+    the "ENC-TSK-I92" banner below — to produce `final_score`, which is what
+    `nodes`/`per_node_fusion` are actually ordered by. `fused_score`/
+    `fused_rank` remain the unmodified pure-RRF values throughout.
     """
     query_text = str(params.get("query", "")).strip()
     anchor_record_id = str(params.get("anchor_record_id", "")).strip()
@@ -2056,6 +2067,11 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
     # weights once per call (not once per candidate) so a single hybrid call
     # never re-probes AppConfig more than once.
     energy_lambda_graph, energy_lambda_kw = energy_function.load_lambda_weights()
+
+    # ENC-TSK-I92 (ENC-FTR-110 Ph1): resolve the corroboration Weber_k bonus
+    # weight once per call, same one-AppConfig-probe-per-call discipline as
+    # the energy lambda weights above.
+    corroboration_weber_k = corroboration.load_weber_k()
 
     # ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B — verify the cached Bolt
     # pool is live before dispatching to any of the three signal functions.
@@ -2201,6 +2217,10 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
             "energy_lambda_weights": {
                 "lambda_graph": energy_lambda_graph, "lambda_kw": energy_lambda_kw,
             },
+            # ENC-TSK-I92 (ENC-FTR-110 Ph1): the Weber_k bonus weight used for
+            # this call, surfaced even with zero candidates for observability
+            # parity with energy_lambda_weights above.
+            "corroboration_weber_k": corroboration_weber_k,
         }
 
     fused = _rrf_fuse(signals, k=RRF_K)
@@ -2238,6 +2258,52 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
             lambda_kw=energy_lambda_kw,
         )
 
+    # ENC-TSK-I92 (ENC-FTR-110 Ph1): dispersion/corroboration Weber-law bonus —
+    # a fifth scoring signal, layered on top of (not folded into) the 4-signal
+    # RRF sum above. For each candidate, count corroborators: other candidates
+    # in this SAME result set that are similar enough to it (cosine similarity
+    # >= corroboration.DEFAULT_SIMILARITY_THRESHOLD) AND pairwise dispersed
+    # from each other (cosine distance >= corroboration.DISPERSION_MIN_
+    # DISTANCE), so a cluster of near-duplicate records never counts as more
+    # than one independent corroborator (the "dispersion constraint" —
+    # corroboration.count_corroborators). B_corr is a bonus, not an RRF term:
+    # it is added on top of each candidate's already-fused RRF fused_score to
+    # produce final_score, and is never folded into _rrf_fuse's 1/(k+rank) sum
+    # — that sum is exact-value-asserted by test_hybrid_retrieval.py and must
+    # stay pure RRF. Degrades to a no-op (B_corr == 0.0 for everyone, final_
+    # score == fused_score) when no candidate in this call carries a usable
+    # embedding, so this is fully backward compatible with callers/tests that
+    # never populate the embedding property.
+    embeddings_by_rid = {
+        rid: node_by_rid[rid].get(_EMBEDDING_PROPERTY)
+        for rid in top_rids
+        if node_by_rid.get(rid) and node_by_rid[rid].get(_EMBEDDING_PROPERTY)
+    }
+    corroboration_counts = corroboration.compute_corroboration_counts(embeddings_by_rid)
+    corroboration_bonuses = corroboration.compute_bonuses(
+        corroboration_counts, weber_k=corroboration_weber_k,
+    )
+    for item in top_fused:
+        rid = item["record_id"]
+        bonus = corroboration_bonuses.get(rid)
+        item["k_corr"] = bonus["k_corr"] if bonus else 0
+        item["b_corr"] = bonus["b_corr"] if bonus else 0.0
+        item["final_score"] = item["fused_score"] + item["b_corr"]
+
+    # Re-rank by final_score (RRF fused_score + corroboration bonus), NOT
+    # fused_score alone, so a candidate several genuinely-distinct records
+    # independently corroborate can outrank a single high-RRF candidate with
+    # zero independent corroboration (ENC-FTR-110 AC-4 — the spurious-
+    # attractor hedge this signal exists to provide). fused_rank/fused_score
+    # above are left untouched (the pure-RRF values); only presentation order
+    # — and the node-level final_rank/final_score below — reflect the bonus.
+    # Python's sort is stable, so when every candidate's b_corr is 0.0 (no
+    # embeddings / no corroboration anywhere in this call) the RRF order from
+    # _rrf_fuse is preserved exactly.
+    top_fused.sort(key=lambda d: d["final_score"], reverse=True)
+    for idx, item in enumerate(top_fused, start=1):
+        item["final_rank"] = idx
+
     # Ordered list of nodes matching the fused ranking.
     nodes: List[Dict[str, Any]] = []
     embedding_covered = 0
@@ -2253,6 +2319,12 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         node["_fused_score"] = item["fused_score"]
         node["_per_signal_ranks"] = item["per_signal_ranks"]
         node["_retrieval_energy"] = energy_by_rid[rid]["retrieval_energy"]
+        # ENC-TSK-I92 (ENC-FTR-110 Ph1): corroboration count + Weber bonus +
+        # the bonus-adjusted final_score/final_rank (see banner above).
+        node["_corroboration_count"] = item["k_corr"]
+        node["_b_corr"] = item["b_corr"]
+        node["_final_score"] = item["final_score"]
+        node["_final_rank"] = item["final_rank"]
         if node.get(_EMBEDDING_PROPERTY):
             embedding_covered += 1
             # Drop the 256-float blob from the response to keep payloads small.
@@ -2262,6 +2334,10 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
             "fused_score": item["fused_score"],
             "per_signal_ranks": item["per_signal_ranks"],
             "retrieval_energy": energy_by_rid[rid]["retrieval_energy"],
+            "k_corr": item["k_corr"],
+            "b_corr": item["b_corr"],
+            "final_score": item["final_score"],
+            "final_rank": item["final_rank"],
         }
         nodes.append(node)
 
@@ -2348,6 +2424,10 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         "energy_lambda_weights": {
             "lambda_graph": energy_lambda_graph, "lambda_kw": energy_lambda_kw,
         },
+        # ENC-TSK-I92 (ENC-FTR-110 Ph1): Weber_k bonus weight used for this
+        # call's corroboration bonus (see per_node_fusion[*].b_corr/k_corr and
+        # nodes[*]._b_corr/_corroboration_count/_final_score/_final_rank).
+        "corroboration_weber_k": corroboration_weber_k,
     }
 
 

--- a/backend/lambda/graph_query_api/test_corroboration_ftr110.py
+++ b/backend/lambda/graph_query_api/test_corroboration_ftr110.py
@@ -1,0 +1,406 @@
+"""ENC-FTR-110 Phase 1 (ENC-TSK-I92) tests: dispersion/corroboration
+Weber-law bonus term.
+
+Exercises:
+  - corroboration.py pure math: cosine similarity/distance, the dispersion-
+    constrained corroborator count (AC-2: near-duplicates must not count as
+    corroborating each other), the Weber-Fechner B_corr formula (monotonic,
+    diminishing-returns, call-relative normalization), and the Weber_k
+    AppConfig -> env var -> default resolution order (mirrors
+    test_energy_function_ftr104.TestLambdaWeightResolution).
+  - Wiring into lambda_function._query_hybrid: per_node_fusion/nodes gain
+    k_corr/b_corr/final_score/final_rank, fused_score/fused_rank stay the
+    untouched pure-RRF values, and the AC-4 spurious-attractor hedge holds
+    end-to-end — a single zero-corroboration candidate with the best pure-RRF
+    score is outranked, by final_score, by a moderately-RRF-scored candidate
+    with two genuine (dispersed) corroborators.
+
+Pure unit tests — no live Neo4j/AWS/AppConfig. Mirrors the existing
+test_energy_function_ftr104.py / test_hybrid_retrieval.py mocking
+conventions in this package.
+"""
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import corroboration as cb  # noqa: E402
+import lambda_function as lf  # noqa: E402
+
+# --- Shared geometry fixtures (unit vectors in R^3, exact cosine values by
+# construction) --------------------------------------------------------------
+# B_CENTER and the two ~30-degree-off corroborators are mutually dispersed
+# (pairwise cosine distance 0.375 >= the 0.3 dispersion floor) while each
+# stays within the 0.80 similarity floor of B_CENTER.
+B_CENTER = [1.0, 0.0, 0.0]
+CORROBORATOR_1 = [0.8660254037844387, 0.5, 0.0]
+CORROBORATOR_2 = [0.8660254037844387, -0.25, 0.4330127018922194]
+# Orthogonal to B_CENTER and well outside the similarity floor of either
+# corroborator above -- a record with no genuine support.
+UNSUPPORTED = [0.0, 1.0, 0.0]
+# Two near-duplicates of each other (cosine sim 0.98 -> distance 0.02), both
+# "similar enough" to a candidate but NOT pairwise dispersed from each other.
+NEAR_DUP_1 = [1.0, 0.0]
+NEAR_DUP_2 = [0.98, math.sqrt(1.0 - 0.98 ** 2)]
+
+
+class TestCosineSimilarity(unittest.TestCase):
+    def test_identical_vectors(self):
+        self.assertAlmostEqual(cb.cosine_similarity([1.0, 0.0], [1.0, 0.0]), 1.0)
+
+    def test_orthogonal_vectors(self):
+        self.assertAlmostEqual(cb.cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0)
+
+    def test_opposite_vectors(self):
+        self.assertAlmostEqual(cb.cosine_similarity([1.0, 0.0], [-1.0, 0.0]), -1.0)
+
+    def test_near_duplicate_pair_is_point_98(self):
+        self.assertAlmostEqual(cb.cosine_similarity(NEAR_DUP_1, NEAR_DUP_2), 0.98, places=8)
+
+    def test_dimension_mismatch_returns_none(self):
+        self.assertIsNone(cb.cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0]))
+
+    def test_zero_vector_returns_none(self):
+        self.assertIsNone(cb.cosine_similarity([0.0, 0.0], [1.0, 0.0]))
+
+    def test_empty_vector_returns_none(self):
+        self.assertIsNone(cb.cosine_similarity([], []))
+
+    def test_cosine_distance_is_complement(self):
+        sim = cb.cosine_similarity(CORROBORATOR_1, CORROBORATOR_2)
+        dist = cb.cosine_distance(CORROBORATOR_1, CORROBORATOR_2)
+        self.assertAlmostEqual(sim + dist, 1.0)
+        self.assertAlmostEqual(dist, 0.375, places=8)
+
+    def test_cosine_distance_none_propagates(self):
+        self.assertIsNone(cb.cosine_distance([1.0, 0.0], [1.0, 0.0, 0.0]))
+
+
+class TestDispersionConstraint(unittest.TestCase):
+    """ENC-FTR-110 AC-2: near-duplicate records must not count as
+    corroborating each other."""
+
+    def test_near_duplicates_collapse_to_one_corroborator(self):
+        # Both NEAR_DUP_1 and NEAR_DUP_2 are highly similar to the candidate
+        # (identical to NEAR_DUP_1, 0.98 to NEAR_DUP_2) but only 0.02 apart
+        # from EACH OTHER -- well under the 0.3 dispersion floor. Only one of
+        # them may count.
+        candidate = list(NEAR_DUP_1)
+        pool = {"DUP_A": NEAR_DUP_1, "DUP_B": NEAR_DUP_2}
+        k_corr = cb.count_corroborators("CANDIDATE", candidate, pool)
+        self.assertEqual(k_corr, 1)
+
+    def test_two_corroborating_near_duplicates_alone_never_count_as_two(self):
+        """Direct AC-2 phrasing check: two near-duplicate records (cosine sim
+        0.98) must not BOTH count as corroborating a candidate similar to
+        both of them."""
+        candidate = [0.99, math.sqrt(1.0 - 0.99 ** 2)]  # similar to both dups
+        pool = {"DUP_A": NEAR_DUP_1, "DUP_B": NEAR_DUP_2}
+        k_corr = cb.count_corroborators("CANDIDATE", candidate, pool)
+        self.assertLess(k_corr, 2)
+        self.assertEqual(k_corr, 1)
+
+    def test_genuinely_dispersed_pair_both_count(self):
+        # CORROBORATOR_1/2 are both similar to B_CENTER (>=0.80) AND pairwise
+        # dispersed from each other (distance 0.375 >= 0.3) -- both count.
+        pool = {"C1": CORROBORATOR_1, "C2": CORROBORATOR_2}
+        k_corr = cb.count_corroborators("B", B_CENTER, pool)
+        self.assertEqual(k_corr, 2)
+
+    def test_below_similarity_floor_does_not_count(self):
+        pool = {"UNSUPPORTED": UNSUPPORTED}
+        k_corr = cb.count_corroborators("B", B_CENTER, pool)
+        self.assertEqual(k_corr, 0)
+
+    def test_excludes_self_from_pool(self):
+        pool = {"B": B_CENTER, "C1": CORROBORATOR_1}
+        k_corr = cb.count_corroborators("B", B_CENTER, pool)
+        # "B" must not corroborate itself even though it is keyed in the pool.
+        self.assertEqual(k_corr, 1)
+
+    def test_missing_candidate_embedding_is_zero(self):
+        pool = {"C1": CORROBORATOR_1, "C2": CORROBORATOR_2}
+        self.assertEqual(cb.count_corroborators("X", None, pool), 0)
+        self.assertEqual(cb.count_corroborators("X", [], pool), 0)
+
+    def test_pool_member_with_missing_embedding_skipped(self):
+        pool = {"C1": CORROBORATOR_1, "GHOST": None, "EMPTY": []}
+        k_corr = cb.count_corroborators("B", B_CENTER, pool)
+        self.assertEqual(k_corr, 1)
+
+    def test_deterministic_regardless_of_pool_iteration_order(self):
+        pool_a = {"C1": CORROBORATOR_1, "C2": CORROBORATOR_2}
+        pool_b = {"C2": CORROBORATOR_2, "C1": CORROBORATOR_1}
+        self.assertEqual(
+            cb.count_corroborators("B", B_CENTER, pool_a),
+            cb.count_corroborators("B", B_CENTER, pool_b),
+        )
+
+
+class TestComputeCorroborationCounts(unittest.TestCase):
+    def test_every_candidate_present_in_output(self):
+        embeddings = {"A": UNSUPPORTED, "B": B_CENTER, "C1": CORROBORATOR_1, "C2": CORROBORATOR_2}
+        counts = cb.compute_corroboration_counts(embeddings)
+        self.assertEqual(set(counts.keys()), set(embeddings.keys()))
+        self.assertEqual(counts["A"], 0)
+        self.assertEqual(counts["B"], 2)
+
+    def test_missing_embedding_yields_zero_but_is_present(self):
+        embeddings = {"A": None, "B": B_CENTER, "C1": CORROBORATOR_1}
+        counts = cb.compute_corroboration_counts(embeddings)
+        self.assertEqual(counts["A"], 0)
+
+    def test_empty_input(self):
+        self.assertEqual(cb.compute_corroboration_counts({}), {})
+
+
+class TestWeberBonusFormula(unittest.TestCase):
+    """B_corr(x) = Weber_k * ln(1 + k_corr) / ln(1 + k_max)."""
+
+    def test_best_corroborated_candidate_gets_full_weber_k(self):
+        self.assertAlmostEqual(cb.weber_bonus(5, 5, weber_k=0.3), 0.3)
+        self.assertAlmostEqual(cb.weber_bonus(1, 1, weber_k=0.3), 0.3)
+
+    def test_zero_corroboration_is_zero_bonus(self):
+        self.assertEqual(cb.weber_bonus(0, 5, weber_k=0.3), 0.0)
+
+    def test_zero_k_max_never_divides_by_zero(self):
+        self.assertEqual(cb.weber_bonus(0, 0, weber_k=0.3), 0.0)
+
+    def test_monotonic_in_k_corr(self):
+        # Holding k_max fixed, more corroboration never produces a lower bonus.
+        prev = -1.0
+        for k in range(0, 11):
+            bonus = cb.weber_bonus(k, 10, weber_k=0.3)
+            self.assertGreaterEqual(bonus, prev)
+            prev = bonus
+
+    def test_diminishing_returns_shape(self):
+        """Weber-Fechner: 0->1 corroborator matters more than 5->6."""
+        k_max = 20
+        delta_0_to_1 = cb.weber_bonus(1, k_max, 0.3) - cb.weber_bonus(0, k_max, 0.3)
+        delta_5_to_6 = cb.weber_bonus(6, k_max, 0.3) - cb.weber_bonus(5, k_max, 0.3)
+        self.assertGreater(delta_0_to_1, delta_5_to_6)
+
+    def test_worked_example(self):
+        # k_corr=2, k_max=2 (B is the best-corroborated candidate in its
+        # call) -> full Weber_k bonus, matching the AC-4 integration scenario.
+        self.assertAlmostEqual(cb.weber_bonus(2, 2, weber_k=0.3), 0.3)
+        # k_corr=1, k_max=2 -> partial, diminished bonus.
+        partial = cb.weber_bonus(1, 2, weber_k=0.3)
+        self.assertAlmostEqual(partial, 0.3 * math.log(2) / math.log(3))
+        self.assertLess(partial, 0.3)
+        self.assertGreater(partial, 0.0)
+
+
+class TestComputeBonuses(unittest.TestCase):
+    def test_shape_and_k_max_resolution(self):
+        counts = {"A": 0, "B": 2, "C1": 1, "C2": 1}
+        bonuses = cb.compute_bonuses(counts, weber_k=0.3)
+        self.assertEqual(set(bonuses.keys()), set(counts.keys()))
+        for rid, entry in bonuses.items():
+            self.assertEqual(entry["schema"], cb.CORROBORATION_SCHEMA)
+            self.assertEqual(entry["k_max"], 2)
+            self.assertEqual(entry["k_corr"], counts[rid])
+            self.assertEqual(entry["weber_k"], 0.3)
+        self.assertAlmostEqual(bonuses["A"]["b_corr"], 0.0)
+        self.assertAlmostEqual(bonuses["B"]["b_corr"], 0.3)
+
+    def test_empty_counts(self):
+        self.assertEqual(cb.compute_bonuses({}, weber_k=0.3), {})
+
+    def test_defaults_weber_k_when_omitted(self):
+        with mock.patch.object(cb, "load_weber_k", return_value=0.42):
+            bonuses = cb.compute_bonuses({"A": 1})
+        self.assertEqual(bonuses["A"]["weber_k"], 0.42)
+
+
+class TestWeberKResolution(unittest.TestCase):
+    """Mirrors test_energy_function_ftr104.TestLambdaWeightResolution for
+    Weber_k's AppConfig -> env var -> default resolution order."""
+
+    def test_defaults_when_unconfigured(self):
+        with mock.patch.object(cb, "_appconfig_corroboration_config", return_value={}):
+            with mock.patch.dict("os.environ", {}, clear=False):
+                import os
+                os.environ.pop("CORROBORATION_WEBER_K", None)
+                weber_k = cb.load_weber_k()
+        self.assertEqual(weber_k, cb.DEFAULT_WEBER_K)
+
+    def test_env_var_overrides_default(self):
+        with mock.patch.object(cb, "_appconfig_corroboration_config", return_value={}):
+            with mock.patch.dict("os.environ", {"CORROBORATION_WEBER_K": "0.5"}):
+                weber_k = cb.load_weber_k()
+        self.assertEqual(weber_k, 0.5)
+
+    def test_appconfig_overrides_env_var(self):
+        with mock.patch.object(cb, "_appconfig_corroboration_config", return_value={"weber_k": 0.77}):
+            with mock.patch.dict("os.environ", {"CORROBORATION_WEBER_K": "0.5"}):
+                weber_k = cb.load_weber_k()
+        self.assertEqual(weber_k, 0.77)
+
+    def test_malformed_env_var_falls_back_to_default(self):
+        with mock.patch.object(cb, "_appconfig_corroboration_config", return_value={}):
+            with mock.patch.dict("os.environ", {"CORROBORATION_WEBER_K": "not-a-number"}):
+                weber_k = cb.load_weber_k()
+        self.assertEqual(weber_k, cb.DEFAULT_WEBER_K)
+
+    def test_negative_weight_falls_back_to_default(self):
+        with mock.patch.object(cb, "_appconfig_corroboration_config", return_value={}):
+            with mock.patch.dict("os.environ", {"CORROBORATION_WEBER_K": "-1.0"}):
+                weber_k = cb.load_weber_k()
+        self.assertEqual(weber_k, cb.DEFAULT_WEBER_K)
+
+    def test_appconfig_extension_unreachable_degrades_to_empty(self):
+        """No localhost:2772 extension in a unit test -- must never raise."""
+        cfg = cb._appconfig_corroboration_config()
+        self.assertEqual(cfg, {})
+
+
+class TestOgtmByConstruction(unittest.TestCase):
+    """ENC-FTR-110 AC-5: pure compute + a config read. No new tracker record
+    type, relational field, edge type, graph node, DDB table, or Neo4j write."""
+
+    def test_no_aws_or_graph_imports(self):
+        source = Path(cb.__file__).read_text()
+        for forbidden in ("import boto3", "import neo4j", "dynamodb", "gds.", "CREATE (", "MERGE ("):
+            self.assertNotIn(forbidden, source)
+
+    def test_module_is_pure_functions_no_side_effecting_classes(self):
+        import inspect
+        for name in cb.__all__:
+            obj = getattr(cb, name)
+            if inspect.isfunction(obj):
+                continue
+            # Constants (floats/strings) are the only non-function exports.
+            self.assertIsInstance(obj, (int, float, str))
+
+
+class TestHybridCorroborationWiring(unittest.TestCase):
+    """Integration: lambda_function._query_hybrid wires B_corr into
+    final_score, and the AC-4 spurious-attractor hedge holds end-to-end.
+
+    Scenario: ENC-TSK-AAA is the #1 candidate on the (only) vector signal --
+    the single best, most "spurious-attractor"-shaped candidate -- but its
+    embedding ([0,1,0]) has zero genuine corroborators in this result set.
+    ENC-TSK-BBB ranks #2 on pure RRF, but its embedding ([1,0,0]) is
+    genuinely corroborated by two dispersed (pairwise distance 0.375 >= 0.3)
+    records also present in the result set. Despite AAA's strictly higher
+    fused_score, BBB's corroboration bonus must push it ahead on final_score.
+    """
+
+    def setUp(self):
+        self.weber_k = 0.3
+        patchers = [
+            mock.patch.object(lf, "_ensure_live_driver", side_effect=lambda d: d),
+            mock.patch.object(lf, "_compute_query_embedding", return_value=[0.1, 0.2, 0.3]),
+            mock.patch.object(
+                lf, "_hybrid_vector_ranks",
+                return_value=[
+                    {"record_id": "ENC-TSK-AAA", "score": 0.95, "rank": 1},
+                    {"record_id": "ENC-TSK-BBB", "score": 0.85, "rank": 2},
+                    {"record_id": "ENC-TSK-C01", "score": 0.50, "rank": 3},
+                    {"record_id": "ENC-TSK-C02", "score": 0.40, "rank": 4},
+                ],
+            ),
+            mock.patch.object(lf, "_hybrid_keyword_ranks", return_value=[]),
+            mock.patch.object(
+                lf, "_fetch_nodes_by_record_ids",
+                return_value={
+                    "ENC-TSK-AAA": {"record_id": "ENC-TSK-AAA", "_labels": ["Task"], "embedding": UNSUPPORTED},
+                    "ENC-TSK-BBB": {"record_id": "ENC-TSK-BBB", "_labels": ["Task"], "embedding": B_CENTER},
+                    "ENC-TSK-C01": {"record_id": "ENC-TSK-C01", "_labels": ["Task"], "embedding": CORROBORATOR_1},
+                    "ENC-TSK-C02": {"record_id": "ENC-TSK-C02", "_labels": ["Task"], "embedding": CORROBORATOR_2},
+                },
+            ),
+            mock.patch.object(lf, "_reconstruct_pathway_edges", return_value=([], [], [])),
+            mock.patch.object(cb, "load_weber_k", return_value=self.weber_k),
+        ]
+        self._emit_patch = mock.patch.object(lf, "_emit_pathway_telemetry")
+        self.mock_emit = self._emit_patch.start()
+        for p in patchers:
+            p.start()
+            self.addCleanup(p.stop)
+        self.addCleanup(self._emit_patch.stop)
+
+    def _run(self):
+        return lf._query_hybrid(
+            mock.MagicMock(), "enceladus",
+            {"query": "dispersion corroboration", "top_n": 20},
+        )
+
+    def test_corroboration_counts_match_dispersion_geometry(self):
+        result = self._run()
+        fusion = result["per_node_fusion"]
+        self.assertEqual(fusion["ENC-TSK-AAA"]["k_corr"], 0)
+        self.assertEqual(fusion["ENC-TSK-BBB"]["k_corr"], 2)
+
+    def test_fused_score_unaffected_by_corroboration(self):
+        """fused_score/fused_rank must remain the pure-RRF values: AAA is
+        rank 1 on the only signal, BBB is rank 2 -- AAA's fused_score must
+        stay strictly higher (the "very-high-RRF, zero-corroboration"
+        half of the AC-4 scenario)."""
+        result = self._run()
+        fusion = result["per_node_fusion"]
+        self.assertGreater(fusion["ENC-TSK-AAA"]["fused_score"], fusion["ENC-TSK-BBB"]["fused_score"])
+        self.assertEqual(fusion["ENC-TSK-AAA"]["fused_rank"], 1)
+
+    def test_ac4_spurious_attractor_hedge(self):
+        """The core AC-4 assertion: despite AAA's strictly higher fused_score,
+        BBB's two genuine corroborators flip the final_score ordering."""
+        result = self._run()
+        fusion = result["per_node_fusion"]
+        self.assertAlmostEqual(fusion["ENC-TSK-BBB"]["b_corr"], self.weber_k)
+        self.assertEqual(fusion["ENC-TSK-AAA"]["b_corr"], 0.0)
+        self.assertLess(
+            fusion["ENC-TSK-AAA"]["final_score"],
+            fusion["ENC-TSK-BBB"]["final_score"],
+        )
+        # And the presentation order (nodes / final_rank) reflects the hedge.
+        self.assertEqual(fusion["ENC-TSK-BBB"]["final_rank"], 1)
+        self.assertEqual(result["nodes"][0]["record_id"], "ENC-TSK-BBB")
+
+    def test_nodes_carry_corroboration_fields(self):
+        result = self._run()
+        node_bbb = next(n for n in result["nodes"] if n["record_id"] == "ENC-TSK-BBB")
+        self.assertEqual(node_bbb["_corroboration_count"], 2)
+        self.assertAlmostEqual(node_bbb["_b_corr"], self.weber_k)
+        self.assertAlmostEqual(node_bbb["_final_score"], node_bbb["_fused_score"] + self.weber_k)
+
+    def test_corroboration_weber_k_echoed_in_response(self):
+        result = self._run()
+        self.assertEqual(result["corroboration_weber_k"], self.weber_k)
+
+    def test_embedding_blob_still_stripped_from_response_nodes(self):
+        result = self._run()
+        for node in result["nodes"]:
+            self.assertNotIn("embedding", node)
+
+    def test_no_corroboration_is_a_no_op_when_embeddings_absent(self):
+        """Backward compatibility: when no candidate carries an embedding
+        (e.g. the pre-I92 mocking convention in test_energy_function_ftr104),
+        final_score must equal fused_score and ordering must be unchanged."""
+        with mock.patch.object(
+            lf, "_fetch_nodes_by_record_ids",
+            return_value={
+                "ENC-TSK-AAA": {"record_id": "ENC-TSK-AAA", "_labels": ["Task"]},
+                "ENC-TSK-BBB": {"record_id": "ENC-TSK-BBB", "_labels": ["Task"]},
+                "ENC-TSK-C01": {"record_id": "ENC-TSK-C01", "_labels": ["Task"]},
+                "ENC-TSK-C02": {"record_id": "ENC-TSK-C02", "_labels": ["Task"]},
+            },
+        ):
+            result = self._run()
+        fusion = result["per_node_fusion"]
+        for rid in fusion:
+            self.assertEqual(fusion[rid]["b_corr"], 0.0)
+            self.assertEqual(fusion[rid]["final_score"], fusion[rid]["fused_score"])
+        self.assertEqual(result["nodes"][0]["record_id"], "ENC-TSK-AAA")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a fifth scoring signal to graph_query_api's hybrid retrieval: B_corr(x) = Weber_k * ln(1+k_corr)/ln(1+k_max), a logarithmic diminishing-returns bonus for genuinely independent corroborating records (pairwise cosine distance >= 0.3 — near-duplicates don't count).
- Applied as a true post-fusion bonus (final_score = fused_score + b_corr); the candidate list is re-sorted by final_score so the bonus actually affects retrieval ordering, not just inert telemetry — confirmed backward-compatible no-op when no embeddings are present.
- `Weber_k` (default 0.3) is AppConfig-configurable, same idiom as ENC-TSK-I98's lambda weights.
- No new edge types, no new DDB tables, no new Neo4j writes, no new dependencies (pure-Python, mirrors `energy_function.py`'s structure).

## Note for reviewer
Result *ordering* changes whenever corroboration data exists (re-sort by final_score, not fused_score) — intentional, since the spurious-attractor hedge AC requires the bonus to actually suppress an uncorroborated outlier's rank, not just annotate it.

## Test plan
- [x] Full `graph_query_api` test directory: 213 passed, 8 subtests passed (169 pre-existing + 44 new), zero regressions
- [x] `py_compile`, governance-dictionary-sync, arch-parity checks all pass locally

CCI-ed539035cfda41e882d0a7d46662dd3f

🤖 Generated with [Claude Code](https://claude.com/claude-code)