### PR TITLE
[ENC-TSK-J06] Fix ENC-ISS-454: move numpy/scipy to a dedicated Lambda layer

### DIFF
--- a/backend/lambda/graph_query_api/requirements.txt
+++ b/backend/lambda/graph_query_api/requirements.txt
@@ -1,7 +1,10 @@
 neo4j>=5.0,<6.0
 # ENC-TSK-I81 / ENC-FTR-088: graph_laplacian read action computes the induced-
 # subgraph Laplacian spectrum via scipy.sparse.linalg.eigsh on a scipy.sparse
-# CSR adjacency. numpy is scipy's hard dependency. Arch-correct manylinux2014
-# wheels are resolved by the _build.yml matrix (--platform/--only-binary).
-numpy>=1.26,<3.0
-scipy>=1.11,<2.0
+# CSR adjacency. numpy is scipy's hard dependency.
+#
+# ENC-TSK-J06 / ENC-ISS-454: numpy+scipy REMOVED from this per-function zip and
+# moved to the enceladus-graph-sci Lambda layer (see GraphSciLayerArnArm64 /
+# GraphSciLayerArnX86 in infrastructure/cloudformation/02-compute.yaml) — the
+# per-function zip alone was exceeding the 70MB direct UpdateFunctionCode
+# limit. Do not re-add numpy/scipy here; bump the layer instead.

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -121,6 +121,19 @@ Parameters:
     Type: String
     Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension-Arm64:147"
     Description: AppConfig Lambda extension layer ARN for arm64 (us-west-2). Pin to latest per AWS docs.
+  # ENC-TSK-J06 / ENC-ISS-454: numpy+scipy extracted from graph_query_api's per-function
+  # zip into a dedicated layer (graph_laplacian needs scipy.sparse.linalg.eigsh; numpy is
+  # scipy's hard dependency). The per-function zip alone was exceeding the 70MB direct
+  # UpdateFunctionCode limit. Kept separate from enceladus-shared (not needed by other
+  # functions) — same pattern as the AppConfig extension layer above.
+  GraphSciLayerArnArm64:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:356364570033:layer:enceladus-graph-sci:1"
+    Description: numpy+scipy layer for graph_query_api, arm64/python3.12 (gamma).
+  GraphSciLayerArnX86:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:356364570033:layer:enceladus-graph-sci:2"
+    Description: numpy+scipy layer for graph_query_api, x86_64/python3.11 (prod).
 
   # ENC-TSK-F63 AC-1: AppConfig IDs — populated after 06-feature-flags.yaml stack deploy.
   # Empty defaults disable AppConfig polling; appconfig_flags.flag() falls back to env_fallback.
@@ -1132,6 +1145,8 @@ Resources:
       Role: !GetAtt GraphQueryApiRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        # ENC-TSK-J06 / ENC-ISS-454: numpy+scipy moved here from requirements.txt.
+        - !If [IsGamma, !Ref GraphSciLayerArnArm64, !Ref GraphSciLayerArnX86]
         - !If
           - HasAppConfigLayer
           - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]


### PR DESCRIPTION
## Summary
Resolves ENC-ISS-454. `devops-graph-query-api-gamma`'s per-function deployment zip exceeded the 70MB direct `UpdateFunctionCode` limit because `numpy`+`scipy` (added for `graph_laplacian`, ENC-TSK-I81/FTR-088) were bundled inline via `requirements.txt`. Because the Gen2 pipeline deploys all ~30 gamma Lambdas in one GitHub Actions job, this single function's failure was blocking schema-valid `deploy_evidence` for every task on the shared pipeline — confirmed on ENC-TSK-H47/I91/I92/I98, none of which touch graph_query_api's own logic.

- Published `enceladus-graph-sci` Lambda layer: `:1` (arm64/python3.12, for gamma) and `:2` (x86_64/python3.11, for the eventual io-gated prod cutover).
- Wired into `GraphQueryApiFunction.Layers` in `02-compute.yaml`, `IsGamma`-conditional — same pattern already used for `SharedLayerArn`/the AppConfig extension layer.
- Removed `numpy`/`scipy` from `graph_query_api/requirements.txt`.

An earlier approach (switching `update-function-code` to `--s3-bucket/--s3-key`) was investigated and rejected: the artifact bucket is cross-region from the gamma Lambdas, and the gamma deploy role has no write access to stage a same-region copy without a new IAM grant. This layer approach needs no new IAM permissions.

## Verification
Replicated `_build.yml`'s exact packaging steps locally (rsync whole dir + `pip install --target` + zip): the real deployed zip drops from >70MB to **1.3MB**.

## Test plan
- [x] Full `graph_query_api` test directory: 213/213 pass (packaging-only change, no functional code touched)
- [x] CFN YAML parses; `GraphSciLayerArnArm64`/`GraphSciLayerArnX86` present in Parameters
- [ ] Live gamma deploy confirming the Gen2 job's overall conclusion is finally `success` — to be run by the orchestrating session after merge

CCI-0bd08ee0094d4042b3999c8634dc0e21

🤖 Generated with [Claude Code](https://claude.com/claude-code)