### PR TITLE
Revert "[ENC-TSK-J06] Fix ENC-ISS-454: move numpy/scipy to a dedicated Lambda layer"

### DIFF
--- a/backend/lambda/graph_query_api/requirements.txt
+++ b/backend/lambda/graph_query_api/requirements.txt
@@ -1,10 +1,7 @@
 neo4j>=5.0,<6.0
 # ENC-TSK-I81 / ENC-FTR-088: graph_laplacian read action computes the induced-
 # subgraph Laplacian spectrum via scipy.sparse.linalg.eigsh on a scipy.sparse
-# CSR adjacency. numpy is scipy's hard dependency.
-#
-# ENC-TSK-J06 / ENC-ISS-454: numpy+scipy REMOVED from this per-function zip and
-# moved to the enceladus-graph-sci Lambda layer (see GraphSciLayerArnArm64 /
-# GraphSciLayerArnX86 in infrastructure/cloudformation/02-compute.yaml) — the
-# per-function zip alone was exceeding the 70MB direct UpdateFunctionCode
-# limit. Do not re-add numpy/scipy here; bump the layer instead.
+# CSR adjacency. numpy is scipy's hard dependency. Arch-correct manylinux2014
+# wheels are resolved by the _build.yml matrix (--platform/--only-binary).
+numpy>=1.26,<3.0
+scipy>=1.11,<2.0

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -121,19 +121,6 @@ Parameters:
     Type: String
     Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension-Arm64:147"
     Description: AppConfig Lambda extension layer ARN for arm64 (us-west-2). Pin to latest per AWS docs.
-  # ENC-TSK-J06 / ENC-ISS-454: numpy+scipy extracted from graph_query_api's per-function
-  # zip into a dedicated layer (graph_laplacian needs scipy.sparse.linalg.eigsh; numpy is
-  # scipy's hard dependency). The per-function zip alone was exceeding the 70MB direct
-  # UpdateFunctionCode limit. Kept separate from enceladus-shared (not needed by other
-  # functions) — same pattern as the AppConfig extension layer above.
-  GraphSciLayerArnArm64:
-    Type: String
-    Default: "arn:aws:lambda:us-west-2:356364570033:layer:enceladus-graph-sci:1"
-    Description: numpy+scipy layer for graph_query_api, arm64/python3.12 (gamma).
-  GraphSciLayerArnX86:
-    Type: String
-    Default: "arn:aws:lambda:us-west-2:356364570033:layer:enceladus-graph-sci:2"
-    Description: numpy+scipy layer for graph_query_api, x86_64/python3.11 (prod).
 
   # ENC-TSK-F63 AC-1: AppConfig IDs — populated after 06-feature-flags.yaml stack deploy.
   # Empty defaults disable AppConfig polling; appconfig_flags.flag() falls back to env_fallback.
@@ -1145,8 +1132,6 @@ Resources:
       Role: !GetAtt GraphQueryApiRole.Arn
       Layers:
         - !Ref SharedLayerArn
-        # ENC-TSK-J06 / ENC-ISS-454: numpy+scipy moved here from requirements.txt.
-        - !If [IsGamma, !Ref GraphSciLayerArnArm64, !Ref GraphSciLayerArnX86]
         - !If
           - HasAppConfigLayer
           - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]


### PR DESCRIPTION
## Summary
Reverts #659 per io's explicit direction: coord-lead ENC-SES-01A's guidance on ENC-ISS-454 (switch `_deploy.yml`'s `update-function-code` to `--s3-bucket/--s3-key`, applied generally across functions) supersedes this session's layer-migration approach.

This is a clean `git revert` of f355ef1 — no conflicts, `graph_query_api` test suite still 213/213 green.

## For whoever implements the S3-reference approach
Logged in detail on ENC-ISS-454 and this task's worklog, but the short version: a plain `--s3-bucket/--s3-key` swap is not a drop-in fix as originally hypothesized —
1. AWS Lambda requires the code-reference S3 bucket to be in the **same region** as the function. Gamma Lambdas are `us-west-2`; the artifact bucket `jreese-net` is not (the existing `s3api get-object` call in `_deploy.yml` explicitly pins `--region us-east-1`).
2. `GitHubActions-V4Gamma-DeployRole` has **read-only** access scoped to `s3://jreese-net/lambda-artifacts/*` — no write access anywhere to stage a same-region copy.

Either plan for a same-region staging bucket + a new write grant, or a different mechanism.

CCI-b8570a0969bc47e8ad616ac0e1f050eb

🤖 Generated with [Claude Code](https://claude.com/claude-code)