### PR TITLE
fix(cfn-drift): Condition-aware audit + fail-on-drift regression guard (ENC-TSK-J12, gamma lane)

### DIFF
--- a/.github/workflows/cfn-drift-audit.yml
+++ b/.github/workflows/cfn-drift-audit.yml
@@ -18,6 +18,25 @@ on:
         type: string
         required: false
         default: ""
+      environment:
+        description: >-
+          Which environment's live resources to audit against the
+          checked-out branch's templates (prod=main, gamma=v4/main).
+          ENC-TSK-J12: also scopes Condition-gated (IsProduction/IsGamma)
+          declared resources.
+        type: choice
+        options: ["prod", "gamma"]
+        required: false
+        default: "prod"
+      fail_on_drift:
+        description: >-
+          Fail this run if drift is detected. Use for a blocking
+          regression-guard dispatch (e.g. before merging a CFN template
+          change); leave false for the routine informational report
+          (ENC-TSK-J12).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -43,17 +62,20 @@ jobs:
         id: audit
         run: |
           set -euo pipefail
+          ENVIRONMENT="${{ inputs.environment || 'prod' }}"
           if [[ -n "${{ inputs.api_id }}" ]]; then
             python3 tools/audit_cfn_drift.py \
               --api-id "${{ inputs.api_id }}" \
+              --environment "${ENVIRONMENT}" \
               --output-json /tmp/cfn-drift-report.json \
               || true
           else
             python3 tools/audit_cfn_drift.py \
+              --environment "${ENVIRONMENT}" \
               --output-json /tmp/cfn-drift-report.json \
               || true
           fi
-          echo "=== Drift Report ==="
+          echo "=== Drift Report (environment=${ENVIRONMENT}) ==="
           # The audit invocations above are guarded with `|| true` so that a
           # detected-drift exit code does not abort the step. But a hard crash
           # (e.g. resolve_api_id ambiguity) leaves no report behind. Surface
@@ -75,6 +97,16 @@ jobs:
           print('true' if drift else 'false')
           ")
           echo "any_drift=${any_drift}" >> "$GITHUB_OUTPUT"
+
+          # ENC-TSK-J12 regression guard: dispatch with fail_on_drift=true to
+          # use this run as a blocking gate (e.g. to validate a lane after a
+          # Channel C/A merge) rather than the default informational report.
+          # `inputs.fail_on_drift` is unset (empty) on schedule-triggered runs,
+          # so the daily cron never fails from this check.
+          if [[ "${{ inputs.fail_on_drift }}" == "true" && "${any_drift}" == "true" ]]; then
+            echo "::error::Drift detected on environment=${ENVIRONMENT} and fail_on_drift=true — failing this run as a regression-guard gate."
+            exit 1
+          fi
 
       - name: Upload drift report artifact
         if: always()

--- a/tests/tools/test_audit_cfn_drift.py
+++ b/tests/tools/test_audit_cfn_drift.py
@@ -1,13 +1,13 @@
 """Regression tests for tools/audit_cfn_drift.py.
 
-ENC-TSK-E67. Covers the CFN parsing path (no AWS calls) and the delta
-computation shape.
+ENC-TSK-E67 / ENC-TSK-J08 / ENC-TSK-J12. Covers the CFN parsing path (no AWS
+calls), Condition-aware (IsProduction/IsGamma) declared-side scoping, and the
+delta computation shape.
 """
 
 from __future__ import annotations
 
 import importlib.util
-import json
 import sys
 from pathlib import Path
 
@@ -27,18 +27,25 @@ def mod():
     return m
 
 
-def _write_cfn_template(tmp_path: Path, routes: list[str], rules: list[str]) -> Path:
+def _write_cfn_template(tmp_path: Path, routes=(), rules=()) -> Path:
+    """routes/rules: iterable of (key_or_name,) or (key_or_name, condition)."""
     body = ["AWSTemplateFormatVersion: '2010-09-09'", "Resources:"]
-    for i, rk in enumerate(routes):
+    for i, entry in enumerate(routes):
+        rk, condition = (entry, None) if isinstance(entry, str) else entry
         body.append(f"  Route{i}:")
         body.append("    Type: AWS::ApiGatewayV2::Route")
+        if condition:
+            body.append(f"    Condition: {condition}")
         body.append("    Properties:")
         body.append("      ApiId: !Ref HttpApi")
         body.append(f"      RouteKey: {rk}")
         body.append("      Target: !Sub integrations/${X}")
-    for i, name in enumerate(rules):
+    for i, entry in enumerate(rules):
+        name, condition = (entry, None) if isinstance(entry, str) else entry
         body.append(f"  Rule{i}:")
         body.append("    Type: AWS::Events::Rule")
+        if condition:
+            body.append(f"    Condition: {condition}")
         body.append("    Properties:")
         body.append(f"      Name: {name}")
         body.append("      ScheduleExpression: rate(24 hours)")
@@ -55,7 +62,6 @@ def test_declared_routes_extracts_all_route_keys(tmp_path, mod):
             "POST /api/v1/bar/{id}",
             "PATCH /api/v1/baz",
         ],
-        rules=[],
     )
     found = mod.declared_routes(str(tmp_path / "*.yaml"))
     assert found == {
@@ -68,14 +74,63 @@ def test_declared_routes_extracts_all_route_keys(tmp_path, mod):
 def test_declared_eventbridge_rules_parses_name(tmp_path, mod):
     _write_cfn_template(
         tmp_path,
-        routes=[],
         rules=[
             "enceladus-auditor-schedule",
             "enceladus-health-probe",
         ],
     )
-    found = mod.declared_eventbridge_rules(str(tmp_path / "*.yaml"))
+    found = mod.declared_eventbridge_rules(str(tmp_path / "*.yaml"), "enceladus-")
     assert found == {"enceladus-auditor-schedule", "enceladus-health-probe"}
+
+
+def test_declared_routes_isgamma_scoped_to_gamma_environment(tmp_path, mod):
+    """ENC-TSK-J12 / ENC-ISS-455: a Condition: IsGamma route only materializes
+    in the gamma stack; it must not count as declared on a prod audit (else it
+    reads as cfn_only drift the moment the route is added — the 16-route
+    false-positive class)."""
+    _write_cfn_template(
+        tmp_path,
+        routes=[
+            "GET /api/v1/always",
+            ("POST /api/v1/gamma-only", "IsGamma"),
+        ],
+    )
+    glob_pattern = str(tmp_path / "*.yaml")
+    prod = mod.declared_routes(glob_pattern, "prod")
+    gamma = mod.declared_routes(glob_pattern, "gamma")
+    assert prod == {"GET /api/v1/always"}
+    assert gamma == {"GET /api/v1/always", "POST /api/v1/gamma-only"}
+
+
+def test_declared_eventbridge_rules_isproduction_scoped_to_prod_environment(tmp_path, mod):
+    """ENC-TSK-J12 / ENC-ISS-455: a Condition: IsProduction rule (e.g.
+    enceladus-standing-projection-refresh) only exists in the prod stack; it
+    must not count as declared on a gamma audit."""
+    _write_cfn_template(
+        tmp_path,
+        rules=[
+            "enceladus-always-rule",
+            ("enceladus-prod-only-rule", "IsProduction"),
+        ],
+    )
+    glob_pattern = str(tmp_path / "*.yaml")
+    prod = mod.declared_eventbridge_rules(glob_pattern, "enceladus-", "prod")
+    gamma = mod.declared_eventbridge_rules(glob_pattern, "enceladus-", "gamma")
+    assert prod == {"enceladus-always-rule", "enceladus-prod-only-rule"}
+    assert gamma == {"enceladus-always-rule"}
+
+
+def test_unconditioned_and_unknown_condition_always_declared(tmp_path, mod):
+    """A resource with no Condition, or one gated by a condition name this
+    tool doesn't understand, keeps the pre-J12 always-declared behavior rather
+    than being silently dropped."""
+    _write_cfn_template(
+        tmp_path,
+        routes=[("GET /api/v1/weird", "SomeOtherCondition")],
+    )
+    glob_pattern = str(tmp_path / "*.yaml")
+    assert mod.declared_routes(glob_pattern, "prod") == {"GET /api/v1/weird"}
+    assert mod.declared_routes(glob_pattern, "gamma") == {"GET /api/v1/weird"}
 
 
 def test_audit_report_has_expected_shape(tmp_path, monkeypatch, mod):
@@ -88,7 +143,7 @@ def test_audit_report_has_expected_shape(tmp_path, monkeypatch, mod):
     def fake_live_routes(api_id):
         return {"GET /api/v1/foo", "DELETE /api/v1/extra"}
 
-    def fake_live_rules(prefix):
+    def fake_live_rules(prefix, environment="prod"):
         return {"enceladus-auditor-schedule", "enceladus-extra-rule"}
 
     monkeypatch.setattr(mod, "live_apigw_routes", fake_live_routes)
@@ -104,6 +159,30 @@ def test_audit_report_has_expected_shape(tmp_path, monkeypatch, mod):
     assert report["apigw_routes"]["cfn_only"] == ["POST /api/v1/bar"]
     assert report["eventbridge_rules"]["live_only"] == ["enceladus-extra-rule"]
     assert report["eventbridge_rules"]["cfn_only"] == []
+
+
+def test_audit_isgamma_route_is_not_prod_drift(tmp_path, monkeypatch, mod):
+    """End-to-end: an IsGamma route that is live in gamma but declared with a
+    Condition must not appear as cfn_only drift on a prod-environment audit
+    (it was never supposed to exist in prod)."""
+    _write_cfn_template(
+        tmp_path,
+        routes=[
+            "GET /api/v1/always",
+            ("POST /api/v1/gamma-only", "IsGamma"),
+        ],
+    )
+    monkeypatch.setattr(mod, "live_apigw_routes", lambda api_id: {"GET /api/v1/always"})
+    monkeypatch.setattr(mod, "live_eventbridge_rules", lambda p, environment="prod": set())
+
+    report = mod.audit(
+        api_id="abc123",
+        cfn_glob=str(tmp_path / "*.yaml"),
+        event_rule_prefix="enceladus-",
+        environment="prod",
+    )
+    assert report["apigw_routes"]["cfn_only"] == []
+    assert report["apigw_routes"]["live_only"] == []
 
 
 def test_resolve_api_id_drops_gamma_sibling(monkeypatch, mod):
@@ -146,7 +225,9 @@ def test_audit_no_drift(tmp_path, monkeypatch, mod):
         rules=["enceladus-auditor-schedule"],
     )
     monkeypatch.setattr(mod, "live_apigw_routes", lambda api_id: {"GET /api/v1/foo"})
-    monkeypatch.setattr(mod, "live_eventbridge_rules", lambda p: {"enceladus-auditor-schedule"})
+    monkeypatch.setattr(
+        mod, "live_eventbridge_rules", lambda p, environment="prod": {"enceladus-auditor-schedule"}
+    )
 
     report = mod.audit(
         api_id="abc123",
@@ -157,3 +238,9 @@ def test_audit_no_drift(tmp_path, monkeypatch, mod):
     for section in ("apigw_routes", "eventbridge_rules"):
         assert report[section]["live_only"] == []
         assert report[section]["cfn_only"] == []
+
+
+def test_self_check_passes(mod):
+    """The tool's own offline self-check (ENC-TSK-J12) must pass; this pins
+    it as a real regression signal rather than a script that always exits 0."""
+    assert mod._self_check() is True

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -25,12 +25,18 @@ Modes:
                                starts with this prefix (default: enceladus-)
   --cfn-glob <pattern>         Glob of CFN template files to parse
                                (default: infrastructure/cloudformation/*.yaml)
+  --environment <prod|gamma>   Which environment's live resources to audit
+                               against the checked-out branch's templates.
+                               Also scopes which Condition-gated (IsProduction/
+                               IsGamma) resources count as declared (ENC-TSK-J12).
   --output-json <path>         Write JSON drift report for CI consumption
   --fail-on-drift              Exit 1 if any drift is detected
+  --self-check                 Run an offline sanity check of the
+                               Condition-aware parser (no AWS calls) and exit
 
 The YAML parser handles CFN intrinsic tags (!Ref, !Sub, etc.) without
-requiring cfn-lint. Only the fields we care about (route keys) are
-extracted, so the parser is deliberately minimal.
+requiring cfn-lint. Only the fields we care about (route keys, rule names,
+Condition) are extracted, so the parser is deliberately minimal.
 """
 
 from __future__ import annotations
@@ -107,16 +113,63 @@ _ROUTEKEY_RE = re.compile(
     re.MULTILINE,
 )
 
+# ENC-TSK-J12 / ENC-ISS-455: every top-level CFN resource is a `  <Name>:`
+# line (2-space indent) followed by its body until the next such line. This
+# generic block splitter lets us read each resource's own `Type:` and
+# `Condition:` fields instead of scanning RouteKey/Name lines flat across the
+# whole file with no idea which resource (or Condition) they belong to.
+_RESOURCE_BLOCK_RE = re.compile(r"^  (?P<name>\w+):\n(?P<body>(?:(?!^  \w+:).*\n)*)", re.MULTILINE)
+_TYPE_RE = re.compile(r"^\s*Type:\s*(?P<type>[\w:]+)\s*$", re.MULTILINE)
+_CONDITION_RE = re.compile(r"^\s*Condition:\s*(?P<cond>\w+)\s*$", re.MULTILINE)
 
-def declared_routes(cfn_glob: str) -> Set[str]:
+
+def _iter_resources(text: str):
+    """Yield (name, type, condition, body) for every top-level CFN resource."""
+    for m in _RESOURCE_BLOCK_RE.finditer(text):
+        body = m.group("body")
+        type_m = _TYPE_RE.search(body)
+        if not type_m:
+            continue
+        cond_m = _CONDITION_RE.search(body)
+        yield m.group("name"), type_m.group("type"), (cond_m.group("cond") if cond_m else None), body
+
+
+def _condition_declared_for_environment(condition: str | None, environment: str) -> bool:
+    """Does a Condition-gated resource actually materialize for ``environment``?
+
+    ENC-TSK-J12 / ENC-ISS-455: a CFN Condition decides, at deploy time, whether
+    a resource is created at all. `Condition: IsGamma` resources exist ONLY in
+    the gamma stack (EnvironmentSuffix != ""); `Condition: IsProduction`
+    resources exist ONLY in the production stack (Environment == "production").
+    Treating every declared resource as always-declared (the pre-J12 behavior)
+    makes every such resource look like drift in the OTHER environment — the
+    16 IsGamma routes / enceladus-standing-projection-refresh false positives.
+    Any other (or absent) condition is treated as always-declared, matching
+    prior behavior, since we don't know its semantics.
+    """
+    if condition == "IsGamma":
+        return environment == "gamma"
+    if condition == "IsProduction":
+        return environment == "prod"
+    return True
+
+
+def declared_routes(cfn_glob: str, environment: str = "prod") -> Set[str]:
     """Extract RouteKey values from every AWS::ApiGatewayV2::Route resource
-    in the matched CFN templates. Uses a regex scoped to RouteKey lines so
-    we don't need to handle full CFN intrinsic parsing.
+    in the matched CFN templates that is actually declared for ``environment``
+    (see _condition_declared_for_environment).
     """
     keys: Set[str] = set()
     for path in sorted(glob.glob(cfn_glob)):
         text = Path(path).read_text()
-        for m in _ROUTEKEY_RE.finditer(text):
+        for _name, rtype, condition, body in _iter_resources(text):
+            if rtype != "AWS::ApiGatewayV2::Route":
+                continue
+            if not _condition_declared_for_environment(condition, environment):
+                continue
+            m = _ROUTEKEY_RE.search(body)
+            if not m:
+                continue
             key = m.group("key").strip()
             if key:
                 keys.add(key)
@@ -153,9 +206,6 @@ def live_eventbridge_rules(name_prefix: str, environment: str = "prod") -> Set[s
     }
 
 
-_EVENTBRIDGE_RULE_RE = re.compile(
-    r"Type:\s*AWS::Events::Rule[\s\S]*?(?=Type:\s*AWS::|\Z)"
-)
 # ENC-TSK-J08 / ENC-ISS-455: the name class must include the characters used by
 # `!Sub "<base>${EnvironmentSuffix}"` (the form EVERY rule in 02-compute.yaml /
 # 05-monitoring.yaml uses). The previous class `[A-Za-z0-9_.-]+` could not match
@@ -213,8 +263,11 @@ def _resolve_declared_name(raw: str) -> str | None:
     return _strip_env_suffix(base)
 
 
-def declared_eventbridge_rules(cfn_glob: str, name_prefix: str) -> Set[str]:
-    """CFN-declared EventBridge rule BASE names, scoped to ``name_prefix``.
+def declared_eventbridge_rules(cfn_glob: str, name_prefix: str, environment: str = "prod") -> Set[str]:
+    """CFN-declared EventBridge rule BASE names, scoped to ``name_prefix`` and
+    filtered to whatever is actually declared for ``environment`` (ENC-TSK-J12;
+    see _condition_declared_for_environment — e.g. StandingProjectionRefreshSchedule
+    is Condition: IsProduction and must not appear as cfn_only drift on gamma).
 
     Scoping to the same prefix the live query uses keeps the comparison
     apples-to-apples: without it, fixing the !Sub bug would surface every
@@ -224,8 +277,12 @@ def declared_eventbridge_rules(cfn_glob: str, name_prefix: str) -> Set[str]:
     bases: Set[str] = set()
     for path in sorted(glob.glob(cfn_glob)):
         text = Path(path).read_text()
-        for block in _EVENTBRIDGE_RULE_RE.findall(text):
-            m = _RULE_NAME_RE.search(block)
+        for _name, rtype, condition, body in _iter_resources(text):
+            if rtype != "AWS::Events::Rule":
+                continue
+            if not _condition_declared_for_environment(condition, environment):
+                continue
+            m = _RULE_NAME_RE.search(body)
             if not m:
                 continue
             base = _resolve_declared_name(m.group("name"))
@@ -240,7 +297,7 @@ def audit(
     event_rule_prefix: str,
     environment: str = "prod",
 ) -> Dict[str, Dict[str, List[str]]]:
-    declared_rt = declared_routes(cfn_glob)
+    declared_rt = declared_routes(cfn_glob, environment)
     live_rt = live_apigw_routes(api_id)
 
     # ENC-TSK-J08: EventBridge comparison is done on environment-suffix-stripped
@@ -248,8 +305,11 @@ def audit(
     # environment (see _in_environment) so gamma rules are not compared against
     # prod (main) templates. declared_ev_bases is prefix-scoped to match the live
     # query; the documented CLI-only exception is removed from the live side so
-    # the daily audit does not re-raise gh#635.
-    declared_ev_bases = declared_eventbridge_rules(cfn_glob, event_rule_prefix)
+    # the daily audit does not re-raise gh#635. ENC-TSK-J12: both declared_rt and
+    # declared_ev_bases are also Condition-scoped to `environment` so IsGamma/
+    # IsProduction-gated resources only count as declared where they actually
+    # deploy.
+    declared_ev_bases = declared_eventbridge_rules(cfn_glob, event_rule_prefix, environment)
     live_ev = live_eventbridge_rules(event_rule_prefix, environment)
     live_ev_bases = {_strip_env_suffix(n) for n in live_ev}
     exceptions = sorted(
@@ -279,8 +339,80 @@ def audit(
     }
 
 
+def _self_check() -> bool:
+    """Offline sanity check of the Condition-aware parsing logic.
+
+    ENC-TSK-J12: no AWS calls, no real CFN templates — writes synthetic
+    templates to a temp dir and asserts declared_routes/declared_eventbridge_rules
+    scope IsGamma/IsProduction resources to the right --environment. Intended
+    as a fast pre-flight (e.g. inside tools/pre-deploy-health-gate.sh) that
+    catches a broken parser before spending an AWS round-trip on the live
+    --fail-on-drift check.
+    """
+    import tempfile
+
+    failures: List[str] = []
+
+    def check(label: str, condition: bool) -> None:
+        print(f"[{'PASS' if condition else 'FAIL'}] {label}")
+        if not condition:
+            failures.append(label)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        template = Path(tmp) / "self-check.yaml"
+        template.write_text(
+            "AWSTemplateFormatVersion: '2010-09-09'\n"
+            "Resources:\n"
+            "  RouteAlways:\n"
+            "    Type: AWS::ApiGatewayV2::Route\n"
+            "    Properties:\n"
+            "      RouteKey: GET /always\n"
+            "  RouteGammaOnly:\n"
+            "    Type: AWS::ApiGatewayV2::Route\n"
+            "    Condition: IsGamma\n"
+            "    Properties:\n"
+            "      RouteKey: GET /gamma-only\n"
+            "  RuleProdOnly:\n"
+            "    Type: AWS::Events::Rule\n"
+            "    Condition: IsProduction\n"
+            "    Properties:\n"
+            "      Name: !Sub \"enceladus-prod-only${EnvironmentSuffix}\"\n"
+        )
+        glob_pattern = str(Path(tmp) / "*.yaml")
+
+        prod_routes = declared_routes(glob_pattern, "prod")
+        gamma_routes = declared_routes(glob_pattern, "gamma")
+        check(
+            "IsGamma route excluded from prod-declared set",
+            "GET /gamma-only" not in prod_routes and "GET /always" in prod_routes,
+        )
+        check(
+            "IsGamma route included in gamma-declared set",
+            "GET /gamma-only" in gamma_routes and "GET /always" in gamma_routes,
+        )
+
+        prod_rules = declared_eventbridge_rules(glob_pattern, "enceladus-", "prod")
+        gamma_rules = declared_eventbridge_rules(glob_pattern, "enceladus-", "gamma")
+        check(
+            "IsProduction rule included in prod-declared set",
+            "enceladus-prod-only" in prod_rules,
+        )
+        check(
+            "IsProduction rule excluded from gamma-declared set",
+            "enceladus-prod-only" not in gamma_rules,
+        )
+
+    print(f"[{'PASS' if not failures else 'FAIL'}] self-check: {len(failures)} failure(s)")
+    return not failures
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--self-check",
+        action="store_true",
+        help="Run an offline sanity check of the Condition-aware parser (no AWS calls) and exit.",
+    )
     ap.add_argument("--api-id", default=None)
     ap.add_argument("--stack-prefix", default="enceladus-")
     ap.add_argument(
@@ -304,6 +436,9 @@ def main() -> int:
     ap.add_argument("--output-json", default=None)
     ap.add_argument("--fail-on-drift", action="store_true")
     args = ap.parse_args()
+
+    if args.self_check:
+        return 0 if _self_check() else 1
 
     api_id = args.api_id or resolve_api_id(args.stack_prefix)
 

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -17,11 +17,17 @@
 #   4. Validates deploy scripts have no hardcoded runtime defaults
 #   5. Validates enceladus-shared layer is pinned to canonical (verify_shared_layer_version.py)
 #   6. Validates env-var parity — no out-of-band vars the deploy would strip (env_parity_gate.py)
+#   7. Validates no live CFN drift (fail-on-drift; audit_cfn_drift.py) before touching the stack
 #   ...and warns operator about direct deploy risks
 #
 # Part of ENC-PLN-020 (Production Deploy Hardening) / ENC-FTR-068.
 # ENC-TSK-H24: Check 5 added — the enceladus-shared :7-vs-:10 layer-version parity gate.
 # ENC-PLN-048 / ENC-FTR-102: Check 6 added — env-var parity gate (H17 resolver + H18 fail-closed).
+# ENC-TSK-J12 / ENC-ISS-455: Check 7 added — CFN drift regression guard. Adding or
+# adopting an out-of-band-existing resource via a plain deploy fails
+# AWS::EarlyValidation::ResourceExistenceCheck and wedges the stack (R1/R2 in
+# DOC-AA5C7A37A103); this check fails the gate closed while unresolved live
+# drift exists, until the change-set IMPORT reconciliation (ENC-TSK-J14) lands.
 
 set -euo pipefail
 
@@ -83,7 +89,7 @@ ERRORS=0
 SNAPSHOT_FILE="/tmp/pre-deploy-snapshot-${TIMESTAMP}.json"
 
 # --- Check 1: Capture Lambda snapshot ---
-echo "[CHECK 1/6] Capturing current Lambda state snapshot..."
+echo "[CHECK 1/7] Capturing current Lambda state snapshot..."
 
 if [[ ! -f "${MANIFEST}" ]]; then
     echo "[ERROR] Lambda workflow manifest not found: ${MANIFEST}"
@@ -128,7 +134,7 @@ fi
 
 # --- Check 2: Validate IsGamma conditionals ---
 echo ""
-echo "[CHECK 2/6] Validating CFN template architecture parity..."
+echo "[CHECK 2/7] Validating CFN template architecture parity..."
 
 if python3 "${REPO_ROOT}/tools/verify_lambda_arch_parity.py"; then
     echo "[PASS] CFN template uses IsGamma conditionals correctly"
@@ -139,7 +145,7 @@ fi
 
 # --- Check 3: Validate EnvironmentSuffix parameter ---
 echo ""
-echo "[CHECK 3/6] Validating EnvironmentSuffix parameter in template..."
+echo "[CHECK 3/7] Validating EnvironmentSuffix parameter in template..."
 
 if grep -q "EnvironmentSuffix" "${TEMPLATE_FILE}"; then
     echo "[PASS] Template contains EnvironmentSuffix parameter"
@@ -150,7 +156,7 @@ fi
 
 # --- Check 4: Validate deploy scripts ---
 echo ""
-echo "[CHECK 4/6] Validating deploy scripts via manifest..."
+echo "[CHECK 4/7] Validating deploy scripts via manifest..."
 
 # This is already done by verify_lambda_arch_parity.py, but we add a specific
 # check for hardcoded RUNTIME/ARCHITECTURE defaults without conditionals
@@ -165,7 +171,7 @@ fi
 
 # --- Check 5: Validate enceladus-shared layer-version parity (ENC-TSK-H24) ---
 echo ""
-echo "[CHECK 5/6] Validating enceladus-shared layer-version pin (:7-vs-:10 gate)..."
+echo "[CHECK 5/7] Validating enceladus-shared layer-version pin (:7-vs-:10 gate)..."
 
 # Static checks (template Default + workflow --parameter-overrides override) are
 # fail-closed (no AWS creds needed). ENC-TSK-H28 added the workflow-override check that
@@ -192,7 +198,7 @@ fi
 # advisory classification are the single source in env_drift_registry.json;
 # tools/env_parity_waivers.json carries only risk-accepted failure suppressions.
 echo ""
-echo "[CHECK 6/6] Validating env-var parity (no out-of-band vars the deploy would strip)..."
+echo "[CHECK 6/7] Validating env-var parity (no out-of-band vars the deploy would strip)..."
 
 # Infer EnvironmentSuffix from the stack name so gamma stacks resolve their -gamma env.
 PARITY_PARAMS=()
@@ -206,6 +212,31 @@ if python3 "${REPO_ROOT}/tools/env_parity_gate.py" \
     echo "[PASS] All deploy-critical env vars are present in the template-resolved env"
 else
     echo "[FAIL] Env parity gate found deploy-critical vars the deploy would strip (see above)"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# --- Check 7: Validate no live CFN drift (ENC-TSK-J12 / ENC-ISS-455) ---
+# A plain deploy that ADDs or adopts a resource already existing out-of-band
+# fails AWS::EarlyValidation::ResourceExistenceCheck and wedges the stack
+# (R1/R2, DOC-AA5C7A37A103). Fail the gate closed while unresolved live drift
+# exists on the stack's environment; this is expected to (correctly) fail
+# on the API stack until the change-set IMPORT reconciliation (ENC-TSK-J14)
+# lands. Infer environment from the stack name, same as Check 6.
+echo ""
+DRIFT_ENV="prod"
+case "${STACK_NAME}" in
+    *gamma*) DRIFT_ENV="gamma" ;;
+esac
+DRIFT_REPORT="/tmp/pre-deploy-drift-${TIMESTAMP}.json"
+echo "[CHECK 7/7] Validating no live CFN drift (environment=${DRIFT_ENV}, fail-on-drift)..."
+
+if python3 "${REPO_ROOT}/tools/audit_cfn_drift.py" \
+        --environment "${DRIFT_ENV}" \
+        --output-json "${DRIFT_REPORT}" \
+        --fail-on-drift; then
+    echo "[PASS] No CFN drift detected for ${DRIFT_ENV}"
+else
+    echo "[FAIL] CFN drift detected for ${DRIFT_ENV} — resolve before deploying (see ${DRIFT_REPORT}; ENC-ISS-455 / ENC-TSK-J12)"
     ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Summary
Gamma-lane counterpart of #661 (cherry-pick of 5fe279a, identical baseline on v4/main). Same change:
- `audit_cfn_drift.py` Condition-aware declared-side scoping (IsGamma/IsProduction), fixing the 16 IsGamma-route + `enceladus-standing-projection-refresh` false positives (ENC-ISS-455).
- Fixed + extended `tests/tools/test_audit_cfn_drift.py` regression suite, added offline `--self-check` harness.
- `cfn-drift-audit.yml` gains `environment`/`fail_on_drift` dispatch inputs.
- `pre-deploy-health-gate.sh` gains Check 7/7 fail-on-drift gate.

Channel C per DOC-B716E8FB10B6 — tools/workflow files only, no CFN stack deploy fires from this merge.

CCI-f7116712805f42c99597164388f30859

## Test plan
- [x] `pytest tests/tools/test_audit_cfn_drift.py` — 12/12 pass (verified against v4/main baseline)
- [x] `python3 tools/audit_cfn_drift.py --self-check` — pass
- [ ] Post-merge: dispatch `cfn-drift-audit.yml` on v4/main (environment=gamma, fail_on_drift=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)