### PR TITLE
fix(cfn-drift): resolve_api_id honors --environment for gamma (ENC-TSK-J12 follow-up, gamma lane)

### DIFF
--- a/tests/tools/test_audit_cfn_drift.py
+++ b/tests/tools/test_audit_cfn_drift.py
@@ -218,6 +218,21 @@ def test_resolve_api_id_single_match(monkeypatch, mod):
     assert mod.resolve_api_id("enceladus-") == "only1"
 
 
+def test_resolve_api_id_prefers_gamma_sibling_for_gamma_environment(monkeypatch, mod):
+    """ENC-TSK-J12: without this, a gamma audit dispatch silently resolved to
+    PROD's ApiId (the default prod-preferring behavior), comparing
+    gamma-declared routes against prod's live routes."""
+    apis = {
+        "Items": [
+            {"Name": "devops-tracker-api", "ApiId": "prod123"},
+            {"Name": "devops-tracker-api-gamma", "ApiId": "gamma456"},
+        ]
+    }
+    monkeypatch.setattr(mod, "_aws_json", lambda cmd: apis)
+    assert mod.resolve_api_id("enceladus-", "gamma") == "gamma456"
+    assert mod.resolve_api_id("enceladus-", "prod") == "prod123"
+
+
 def test_audit_no_drift(tmp_path, monkeypatch, mod):
     _write_cfn_template(
         tmp_path,

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -78,7 +78,16 @@ def _is_env_sibling(name: str) -> bool:
     return any(name.endswith(suffix) for suffix in _ENV_SUFFIXES)
 
 
-def resolve_api_id(stack_prefix: str) -> str:
+def resolve_api_id(stack_prefix: str, environment: str = "prod") -> str:
+    """Resolve the ApiGatewayV2 API to audit, matching ``environment``.
+
+    ENC-TSK-J12: previously this always dropped every env-suffixed sibling
+    and returned the production ApiId, regardless of ``environment`` — a
+    gamma audit would silently compare gamma-declared routes against PROD's
+    live routes. Now prefers the -gamma sibling when environment == "gamma"
+    (still dropping every OTHER env-suffixed sibling, e.g. -beta/-staging),
+    and keeps the original prod-preferring behavior otherwise (ENC-TSK-H36).
+    """
     data = _aws_json([
         "aws", "apigatewayv2", "get-apis",
         "--max-results", "500",
@@ -95,6 +104,15 @@ def resolve_api_id(stack_prefix: str) -> str:
             f"pass --api-id explicitly."
         )
     if len(candidates) > 1:
+        if environment == "gamma":
+            gamma = [c for c in candidates if c.get("Name", "").endswith("-gamma")]
+            if len(gamma) == 1:
+                return gamma[0]["ApiId"]
+            names = [c["Name"] for c in (gamma or candidates)]
+            raise RuntimeError(
+                f"Multiple API Gateway v2 APIs match environment=gamma: {names}. "
+                f"Pass --api-id explicitly."
+            )
         # Prefer production APIs by dropping env-suffixed siblings. If exactly
         # one production candidate remains the ambiguity is resolved.
         prod = [c for c in candidates if not _is_env_sibling(c.get("Name", ""))]
@@ -440,7 +458,7 @@ def main() -> int:
     if args.self_check:
         return 0 if _self_check() else 1
 
-    api_id = args.api_id or resolve_api_id(args.stack_prefix)
+    api_id = args.api_id or resolve_api_id(args.stack_prefix, args.environment)
 
     report = audit(api_id, args.cfn_glob, args.event_rule_prefix, args.environment)
     report["_api_id"] = api_id


### PR DESCRIPTION
## Summary
Gamma-lane counterpart of #663 (cherry-pick of f2ddc17). Fixes `resolve_api_id` to prefer the `-gamma` ApiGatewayV2 sibling when `--environment gamma` is passed — previously it always resolved to prod's ApiId (8nkzqkmxqc) regardless of environment, discovered while validating #662's gamma dispatch.

CCI-f7116712805f42c99597164388f30859

## Test plan
- [x] `pytest tests/tools/test_audit_cfn_drift.py` — 13/13 pass
- [x] `python3 tools/audit_cfn_drift.py --self-check` — pass
- [ ] Post-merge: re-dispatch `cfn-drift-audit.yml` on v4/main (environment=gamma) and confirm `_api_id: hi0dzmvqrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)