### PR TITLE
ENC-TSK-J13: fail-closed CFN resource-import/recovery workflow (autonomy enabler) [v4/main]

### DIFF
--- a/.github/workflows/cfn-resource-import.yml
+++ b/.github/workflows/cfn-resource-import.yml
@@ -1,0 +1,317 @@
+name: CFN Resource Import / Recovery (privileged, fail-closed)
+
+# ENC-TSK-J13 / DOC-AA5C7A37A103 — the AUTONOMY ENABLER for the ENC-TSK-J10 CFN
+# drift close-out wave. This privileged workflow assumes the CloudFormation role
+# and adopts out-of-band live resources into a stack via change-set IMPORT (or
+# recovers/creates the monitoring stacks). It has NO GitHub Environment reviewer
+# gate — the human review that normally guards a privileged CFN change is REPLACED,
+# for this wave, by the automated FAIL-CLOSED invariant checks below:
+#
+#   1. create-change-set (never a plain full-env deploy)
+#   2. tools/assert_changeset_safe.py — programmatic proof the change-set contains
+#      ONLY Import/no-op (import mode) or only non-destructive Add/Modify/Import
+#      (recover/create mode). ANY Remove / Replace / Conditional-replacement /
+#      Dynamic — or an unexpected Add/Modify in import mode — ABORTS before execute.
+#   3. tools/pre-deploy-health-gate.sh (ENC-PLN-020) must pass.
+#   4. Post-execute verification (describe-stack / get-routes / describe-rule).
+#
+# Only after ALL of 1–3 pass does execute-change-set run. preview_only=true stops
+# after the assertion and DELETES the change-set (no mutation) — use it to prove a
+# stack's next change-set is non-destructive (J16's six previews).
+#
+# Agent identity (enceladus-agent-cli) is read-only AWS + STS-AssumeRole-denied, so
+# this CI workflow is the ONLY autonomous privileged path (DOC-AA5C7A37A103). Do NOT
+# run `aws cloudformation deploy` / execute-change-set from an agent terminal.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "import = adopt OOB resources (IMPORT, assert Import-only). monitoring-recover = repair a degraded stack. monitoring-create = create/roll-forward a stack."
+        type: choice
+        options:
+          - import
+          - monitoring-recover
+          - monitoring-create
+        default: import
+        required: true
+      stack_name:
+        description: "Target CFN stack (enceladus-api, enceladus-compute, enceladus-monitoring, enceladus-monitoring-gamma, ...)."
+        type: string
+        required: true
+      template_file:
+        description: "Template path, repo-relative."
+        type: string
+        required: true
+        default: infrastructure/cloudformation/03-api.yaml
+      manifest_file:
+        description: "resources-to-import manifest, repo-relative. REQUIRED for import; supply on monitoring-recover to adopt an OOB resource; leave blank for a pure create/update."
+        type: string
+        required: false
+        default: ""
+      parameter_overrides:
+        description: "Space-separated Key=Value CFN parameters. If blank on IMPORT/UPDATE of an existing stack, current stack parameters are re-used (UsePreviousValue)."
+        type: string
+        required: false
+        default: ""
+      capabilities:
+        description: "CFN capabilities."
+        type: string
+        required: false
+        default: "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
+      preview_only:
+        description: "true = create the change-set, run the fail-closed assertion, then DELETE it without executing (no mutation)."
+        type: boolean
+        default: false
+      reason:
+        description: "Why this run is dispatched (audit trail)."
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-west-2
+  STAGING_BUCKET: enceladus-cfn-staging-us-west-2
+
+jobs:
+  import:
+    name: "${{ inputs.mode }} -> ${{ inputs.stack_name }}${{ inputs.preview_only && ' (preview)' || '' }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: cfn-resource-import-${{ inputs.stack_name }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify CloudFormation role secret is set
+        run: |
+          if [ -z "${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}" ]; then
+            echo "::error::AWS_CLOUDFORMATION_ROLE_TO_ASSUME secret is not set. Needs a role with cloudformation:*, apigateway:*, events:*, lambda:Get*, cloudwatch:*, s3 staging access."
+            exit 1
+          fi
+          echo "CF role secret present."
+
+      - name: Configure AWS credentials (OIDC privileged CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Self-check the fail-closed assertion tool
+        run: |
+          set -euo pipefail
+          echo "Verifying tools/assert_changeset_safe.py classifier before trusting it as the gate..."
+          python3 tools/assert_changeset_safe.py --self-check
+
+      - name: Resolve operation parameters
+        id: op
+        env:
+          MODE: ${{ inputs.mode }}
+          MANIFEST: ${{ inputs.manifest_file }}
+          TEMPLATE: ${{ inputs.template_file }}
+          STACK: ${{ inputs.stack_name }}
+        run: |
+          set -euo pipefail
+          # Derive change-set type + assertion mode from (mode, manifest presence).
+          cst=""; assert_mode=""; skip_drift="0"
+          case "${MODE}" in
+            import)
+              if [ -z "${MANIFEST}" ]; then echo "::error::import mode requires manifest_file"; exit 1; fi
+              cst="IMPORT"; assert_mode="import"; skip_drift="1" ;;
+            monitoring-recover)
+              if [ -n "${MANIFEST}" ]; then cst="IMPORT"; assert_mode="import"; skip_drift="1";
+              else cst="UPDATE"; assert_mode="recover"; fi ;;
+            monitoring-create)
+              if [ -n "${MANIFEST}" ]; then cst="IMPORT"; assert_mode="import"; skip_drift="1";
+              else cst="CREATE"; assert_mode="create"; fi ;;
+            *) echo "::error::unknown mode ${MODE}"; exit 1 ;;
+          esac
+          # Preflight: files exist
+          if [ ! -f "${TEMPLATE}" ]; then echo "::error::template not found: ${TEMPLATE}"; exit 1; fi
+          if [ -n "${MANIFEST}" ] && [ ! -f "${MANIFEST}" ]; then echo "::error::manifest not found: ${MANIFEST}"; exit 1; fi
+          # Change-set name: stack + run id (no Date.now available; run id is unique)
+          csn="j13imp-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "change_set_type=${cst}"
+            echo "assert_mode=${assert_mode}"
+            echo "skip_drift=${skip_drift}"
+            echo "change_set_name=${csn}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "mode=${MODE} -> change-set-type=${cst}, assert-mode=${assert_mode}, skip_drift=${skip_drift}, name=${csn}"
+
+      - name: Stage template to S3 (avoids 51KB inline template-body limit)
+        id: stage
+        run: |
+          set -euo pipefail
+          key="imports/${{ inputs.stack_name }}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.yaml"
+          aws s3 cp "${{ inputs.template_file }}" "s3://${STAGING_BUCKET}/${key}" --region "${AWS_REGION}"
+          echo "template_url=https://${STAGING_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${key}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build CFN parameters
+        id: params
+        env:
+          OVERRIDES: ${{ inputs.parameter_overrides }}
+          CST: ${{ steps.op.outputs.change_set_type }}
+          STACK: ${{ inputs.stack_name }}
+        run: |
+          set -euo pipefail
+          args=""
+          if [ -n "${OVERRIDES}" ]; then
+            for kv in ${OVERRIDES}; do
+              k="${kv%%=*}"; v="${kv#*=}"
+              args="${args} ParameterKey=${k},ParameterValue=${v}"
+            done
+          elif [ "${CST}" != "CREATE" ]; then
+            # Re-use the existing stack's parameters (UsePreviousValue) so an
+            # import/update never accidentally re-defaults a parameter.
+            keys=$(aws cloudformation describe-stacks --stack-name "${STACK}" --region "${AWS_REGION}" \
+              --query 'Stacks[0].Parameters[].ParameterKey' --output text 2>/dev/null || true)
+            for k in ${keys}; do
+              args="${args} ParameterKey=${k},UsePreviousValue=true"
+            done
+          fi
+          echo "parameters=${args}" >> "${GITHUB_OUTPUT}"
+          echo "parameters: ${args:-<none>}"
+
+      - name: Create change-set
+        id: create
+        env:
+          CST: ${{ steps.op.outputs.change_set_type }}
+          CSN: ${{ steps.op.outputs.change_set_name }}
+          TURL: ${{ steps.stage.outputs.template_url }}
+          PARAMS: ${{ steps.params.outputs.parameters }}
+        run: |
+          set -euo pipefail
+          extra=""
+          if [ -n "${{ inputs.manifest_file }}" ]; then
+            extra="--resources-to-import file://${{ inputs.manifest_file }}"
+          fi
+          pargs=""
+          if [ -n "${PARAMS}" ]; then pargs="--parameters ${PARAMS}"; fi
+          set -x
+          aws cloudformation create-change-set \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ inputs.stack_name }}" \
+            --change-set-name "${CSN}" \
+            --change-set-type "${CST}" \
+            --template-url "${TURL}" \
+            --capabilities ${{ inputs.capabilities }} \
+            ${pargs} ${extra} \
+            --description "ENC-TSK-J13 ${{ inputs.mode }}: ${{ inputs.reason }}"
+          set +x
+
+      - name: Wait for change-set creation (tolerate benign empty)
+        id: wait
+        env:
+          CSN: ${{ steps.op.outputs.change_set_name }}
+        run: |
+          set +e
+          aws cloudformation wait change-set-create-complete \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ inputs.stack_name }}" \
+            --change-set-name "${CSN}"
+          echo "wait-exit=$? (non-zero can be the benign 'no changes' case; the assertion step judges it)"
+
+      - name: Describe change-set
+        id: describe
+        env:
+          CSN: ${{ steps.op.outputs.change_set_name }}
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ inputs.stack_name }}" \
+            --change-set-name "${CSN}" \
+            --output json > /tmp/changeset.json
+          echo "=== change-set summary ==="
+          python3 -c "import json; d=json.load(open('/tmp/changeset.json')); print('Status:',d.get('Status'),'| StatusReason:',d.get('StatusReason','')); [print(' ',c['ResourceChange'].get('Action'), c['ResourceChange'].get('ResourceType'), c['ResourceChange'].get('LogicalResourceId'), 'Replacement=',c['ResourceChange'].get('Replacement')) for c in d.get('Changes',[])]"
+
+      - name: "FAIL-CLOSED GATE: assert change-set is Import/no-op only"
+        env:
+          AMODE: ${{ steps.op.outputs.assert_mode }}
+        run: |
+          set -euo pipefail
+          echo "Asserting change-set safety (mode=${AMODE}) — this REPLACES human review."
+          python3 tools/assert_changeset_safe.py --changeset-json /tmp/changeset.json --mode "${AMODE}"
+
+      - name: "Pre-deploy health gate (ENC-PLN-020)"
+        env:
+          HEALTH_GATE_SKIP_DRIFT: ${{ steps.op.outputs.skip_drift }}
+        run: |
+          set -euo pipefail
+          echo "HEALTH_GATE_SKIP_DRIFT=${HEALTH_GATE_SKIP_DRIFT} (1 = import context; assert_changeset_safe is the drift control)"
+          bash tools/pre-deploy-health-gate.sh \
+            --stack "${{ inputs.stack_name }}" \
+            --template "${{ inputs.template_file }}"
+
+      - name: "Preview only — delete change-set, do NOT execute"
+        if: ${{ inputs.preview_only }}
+        env:
+          CSN: ${{ steps.op.outputs.change_set_name }}
+        run: |
+          set -euo pipefail
+          echo "preview_only=true: change-set passed the fail-closed assertion + health gate; deleting without executing."
+          aws cloudformation delete-change-set \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ inputs.stack_name }}" \
+            --change-set-name "${CSN}" || true
+          echo "PREVIEW PASSED — the next change-set for ${{ inputs.stack_name }} is non-destructive."
+
+      - name: Execute change-set
+        if: ${{ !inputs.preview_only }}
+        env:
+          CSN: ${{ steps.op.outputs.change_set_name }}
+        run: |
+          set -euo pipefail
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ inputs.stack_name }}" \
+            --change-set-name "${CSN}"
+
+      - name: Wait for stack to reach a completed state
+        if: ${{ !inputs.preview_only }}
+        run: |
+          set +e
+          # IMPORT completes as IMPORT_COMPLETE; UPDATE/CREATE as *_COMPLETE.
+          aws cloudformation wait stack-import-complete --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" 2>/dev/null
+          aws cloudformation wait stack-update-complete --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" 2>/dev/null
+          aws cloudformation wait stack-create-complete --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" 2>/dev/null
+          status=$(aws cloudformation describe-stacks --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" --query 'Stacks[0].StackStatus' --output text)
+          echo "Final stack status: ${status}"
+          case "${status}" in
+            *ROLLBACK*|*FAILED*) echo "::error::stack ended in ${status}"; exit 1 ;;
+            *COMPLETE) echo "stack healthy: ${status}" ;;
+            *) echo "::error::unexpected status ${status}"; exit 1 ;;
+          esac
+
+      - name: Post-execute verification
+        if: ${{ !inputs.preview_only }}
+        run: |
+          set -euo pipefail
+          echo "=== stack state ==="
+          aws cloudformation describe-stacks --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" \
+            --query 'Stacks[0].{Name:StackName,Status:StackStatus,Updated:LastUpdatedTime}' --output table
+          echo "=== managed resource counts by type ==="
+          aws cloudformation list-stack-resources --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" \
+            --query 'StackResourceSummaries[].ResourceType' --output text | tr '\t' '\n' | sort | uniq -c || true
+
+      - name: Report stack events on failure
+        if: failure()
+        env:
+          CSN: ${{ steps.op.outputs.change_set_name }}
+        run: |
+          echo "=== change-set (if any) ==="
+          aws cloudformation describe-change-set --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" --change-set-name "${CSN}" --output json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print('Status',d.get('Status'),d.get('StatusReason',''))" 2>/dev/null || echo "(no change-set)"
+          echo "=== stack events (last 25) ==="
+          aws cloudformation describe-stack-events --region "${AWS_REGION}" --stack-name "${{ inputs.stack_name }}" \
+            --query 'StackEvents[:25].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"

--- a/tools/assert_changeset_safe.py
+++ b/tools/assert_changeset_safe.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""assert_changeset_safe.py — the fail-closed change-set safety assertion.
+
+ENC-TSK-J13 / DOC-AA5C7A37A103. This is the compensating control that REPLACES
+human review for the ENC-TSK-J10 CFN-drift close-out wave. The privileged import
+workflow (.github/workflows/cfn-resource-import.yml) calls this on the output of
+`aws cloudformation describe-change-set` BEFORE `execute-change-set`. If this
+script exits non-zero, the workflow aborts and NEVER executes the change-set.
+
+It answers one question: "Is this change-set safe to execute autonomously (no
+human in the loop)?" — where SAFE means it cannot delete, replace, or wedge a
+live resource on the frozen prod stacks (PLN-047 / ENC-TSK-1292 Sev1 class).
+
+Modes (matched to the wave's operations):
+
+  import   Adopt out-of-band live resources into a stack via change-set-type
+           IMPORT. The change-set MUST contain ONLY Action=Import. ANY Add,
+           Modify, Remove, Replace, or Dynamic aborts. (J14 route/rule imports.)
+
+  recover  Repair a degraded stack (UPDATE_ROLLBACK_COMPLETE) or roll a stack
+  create   forward. Adds of GENUINELY-NEW resources are allowed (CFN's own
+           EarlyValidation::ResourceExistenceCheck fails closed, non-destructively,
+           on an Add-of-EXISTING resource, so it cannot wedge/destroy); in-place
+           Modifies are allowed. Remove, Replace, and Conditional-replacement are
+           ALWAYS forbidden. (J15 monitoring recovery/create.)
+
+  preview  Same classification as recover/create but purely advisory — used by
+           the workflow's no-execute preview mode. Still exits non-zero on a
+           destructive change so a preview surfaces danger loudly.
+
+Destructive actions forbidden in EVERY mode: Remove; Replacement in {True,
+Conditional}; Action=Dynamic (cannot be proven safe offline).
+
+Usage:
+  assert_changeset_safe.py --changeset-json describe.json --mode import
+  assert_changeset_safe.py --self-check
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List, Tuple
+
+# Actions that CloudFormation reports on a ResourceChange.
+DESTRUCTIVE_ACTIONS = {"Remove"}
+UNSAFE_ACTIONS = {"Dynamic"}  # effect unknown at plan time -> never auto-execute
+
+
+def _classify_change(rc: dict, mode: str) -> Tuple[bool, str]:
+    """Return (ok, reason) for a single ResourceChange under ``mode``."""
+    action = rc.get("Action", "?")
+    logical = rc.get("LogicalResourceId", "?")
+    rtype = rc.get("ResourceType", "?")
+    replacement = rc.get("Replacement")  # "True" | "False" | "Conditional" | None
+    tag = f"{action} {rtype} {logical}"
+
+    # --- Universal fail-closed rules (all modes) ---
+    if action in DESTRUCTIVE_ACTIONS:
+        return False, f"FORBIDDEN delete of a live resource: {tag}"
+    if action in UNSAFE_ACTIONS:
+        return False, f"FORBIDDEN unprovable (Dynamic) change: {tag}"
+    if replacement in ("True", "Conditional"):
+        return False, f"FORBIDDEN replacement (Replacement={replacement}): {tag}"
+
+    # --- Mode-specific rules ---
+    if mode == "import":
+        if action != "Import":
+            return False, (
+                f"IMPORT change-set must contain ONLY Action=Import; found {tag}"
+            )
+        return True, f"OK import: {tag}"
+
+    # recover / create / preview
+    if action == "Import":
+        return True, f"OK import: {tag}"
+    if action == "Add":
+        # Add-of-EXISTING is blocked non-destructively by CFN EarlyValidation;
+        # Add-of-NEW is the intended create. Either way it cannot delete/replace.
+        return True, f"OK add (new-resource create; Add-of-existing self-blocks): {tag}"
+    if action == "Modify":
+        # Replacement already asserted False above -> in-place update, non-destructive.
+        return True, f"OK in-place modify (Replacement=False): {tag}"
+    return False, f"UNRECOGNIZED action, refusing: {tag}"
+
+
+def assert_safe(changeset: dict, mode: str) -> Tuple[bool, List[str]]:
+    changes = changeset.get("Changes", []) or []
+    lines: List[str] = []
+    ok_all = True
+
+    status = changeset.get("Status")
+    status_reason = changeset.get("StatusReason", "")
+    # A change-set that FAILED to create is not executable. The classic benign
+    # case is "no changes / no updates" -> for import that means nothing to
+    # import (suspicious -> fail); for create/recover an empty no-op is fine.
+    if status == "FAILED":
+        benign = "didn't contain changes" in status_reason or "No updates" in status_reason
+        if benign and mode != "import":
+            lines.append(f"[PASS] empty no-op change-set ({status_reason!r}); nothing to execute")
+            return True, lines
+        return False, [f"[FAIL] change-set Status=FAILED: {status_reason!r}"]
+
+    if not changes:
+        if mode == "import":
+            return False, ["[FAIL] import mode but change-set has ZERO Import actions"]
+        lines.append("[PASS] change-set has zero changes (no-op)")
+        return True, lines
+
+    for c in changes:
+        rc = c.get("ResourceChange", {})
+        ok, reason = _classify_change(rc, mode)
+        lines.append(("[ok] " if ok else "[FAIL] ") + reason)
+        ok_all = ok_all and ok
+
+    # Summary counts
+    from collections import Counter
+    counts = Counter(c.get("ResourceChange", {}).get("Action", "?") for c in changes)
+    lines.append(f"--- {len(changes)} change(s): {dict(counts)} | mode={mode} ---")
+    return ok_all, lines
+
+
+def _self_check() -> bool:
+    cases = [
+        # (name, changeset, mode, expect_ok)
+        ("pure import ok",
+         {"Changes": [{"ResourceChange": {"Action": "Import", "ResourceType": "AWS::ApiGatewayV2::Route", "LogicalResourceId": "R1"}}]},
+         "import", True),
+        ("import mode rejects Add",
+         {"Changes": [{"ResourceChange": {"Action": "Add", "ResourceType": "AWS::ApiGatewayV2::Route", "LogicalResourceId": "R2"}}]},
+         "import", False),
+        ("import mode rejects Modify",
+         {"Changes": [{"ResourceChange": {"Action": "Modify", "Replacement": "False", "LogicalResourceId": "R3"}}]},
+         "import", False),
+        ("any mode rejects Remove",
+         {"Changes": [{"ResourceChange": {"Action": "Remove", "LogicalResourceId": "R4"}}]},
+         "import", False),
+        ("recover rejects Remove",
+         {"Changes": [{"ResourceChange": {"Action": "Remove", "LogicalResourceId": "R5"}}]},
+         "recover", False),
+        ("recover rejects Replace(True)",
+         {"Changes": [{"ResourceChange": {"Action": "Modify", "Replacement": "True", "LogicalResourceId": "R6"}}]},
+         "recover", False),
+        ("recover rejects Conditional replacement",
+         {"Changes": [{"ResourceChange": {"Action": "Modify", "Replacement": "Conditional", "LogicalResourceId": "R7"}}]},
+         "recover", False),
+        ("recover allows Add(new)",
+         {"Changes": [{"ResourceChange": {"Action": "Add", "ResourceType": "AWS::Events::Rule", "LogicalResourceId": "R8"}}]},
+         "recover", True),
+        ("recover allows in-place Modify",
+         {"Changes": [{"ResourceChange": {"Action": "Modify", "Replacement": "False", "LogicalResourceId": "R9"}}]},
+         "recover", True),
+        ("recover allows Import",
+         {"Changes": [{"ResourceChange": {"Action": "Import", "LogicalResourceId": "R10"}}]},
+         "recover", True),
+        ("any mode rejects Dynamic",
+         {"Changes": [{"ResourceChange": {"Action": "Dynamic", "LogicalResourceId": "R11"}}]},
+         "recover", False),
+        ("import empty is fail",
+         {"Changes": []}, "import", False),
+        ("create empty is pass",
+         {"Changes": []}, "create", True),
+        ("failed benign no-op create pass",
+         {"Status": "FAILED", "StatusReason": "The submitted information didn't contain changes.", "Changes": []},
+         "create", True),
+        ("failed benign no-op import fail",
+         {"Status": "FAILED", "StatusReason": "The submitted information didn't contain changes.", "Changes": []},
+         "import", False),
+        ("mixed import+add in create passes",
+         {"Changes": [
+             {"ResourceChange": {"Action": "Import", "LogicalResourceId": "I1"}},
+             {"ResourceChange": {"Action": "Add", "LogicalResourceId": "A1"}},
+         ]}, "create", True),
+        ("mixed import+remove fails",
+         {"Changes": [
+             {"ResourceChange": {"Action": "Import", "LogicalResourceId": "I2"}},
+             {"ResourceChange": {"Action": "Remove", "LogicalResourceId": "D1"}},
+         ]}, "create", False),
+    ]
+    failures = 0
+    for name, cs, mode, expect in cases:
+        ok, _ = assert_safe(cs, mode)
+        status = "PASS" if ok == expect else "FAIL"
+        if ok != expect:
+            failures += 1
+        print(f"[{status}] {name}: got ok={ok} expect={expect}")
+    print(f"[self-check] {failures} failure(s)")
+    return failures == 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Fail-closed CFN change-set safety assertion (ENC-TSK-J13).")
+    ap.add_argument("--changeset-json", help="Path to `aws cloudformation describe-change-set` JSON output.")
+    ap.add_argument("--mode", choices=["import", "recover", "create", "preview"], default="import")
+    ap.add_argument("--self-check", action="store_true", help="Run offline classifier self-check and exit.")
+    args = ap.parse_args()
+
+    if args.self_check:
+        return 0 if _self_check() else 1
+
+    if not args.changeset_json:
+        print("[ERROR] --changeset-json is required (or use --self-check)", file=sys.stderr)
+        return 2
+    with open(args.changeset_json) as fh:
+        changeset = json.load(fh)
+
+    ok, lines = assert_safe(changeset, args.mode)
+    for ln in lines:
+        print(ln)
+    if ok:
+        print(f"[PASS] change-set is SAFE to execute autonomously (mode={args.mode}).")
+        return 0
+    print(f"[FAIL] change-set is UNSAFE — aborting fail-closed (mode={args.mode}). NOT executing.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -228,16 +228,27 @@ case "${STACK_NAME}" in
     *gamma*) DRIFT_ENV="gamma" ;;
 esac
 DRIFT_REPORT="/tmp/pre-deploy-drift-${TIMESTAMP}.json"
-echo "[CHECK 7/7] Validating no live CFN drift (environment=${DRIFT_ENV}, fail-on-drift)..."
 
-if python3 "${REPO_ROOT}/tools/audit_cfn_drift.py" \
-        --environment "${DRIFT_ENV}" \
-        --output-json "${DRIFT_REPORT}" \
-        --fail-on-drift; then
-    echo "[PASS] No CFN drift detected for ${DRIFT_ENV}"
+# ENC-TSK-J13: the CFN change-set IMPORT workflow (cfn-resource-import.yml) IS the
+# drift remediation — running Check 7 during an import would fail closed on the very
+# drift being adopted. For those operations the fail-closed change-set assertion
+# (tools/assert_changeset_safe.py, mode=import) is the compensating control instead,
+# so the import workflow sets HEALTH_GATE_SKIP_DRIFT=1. Default (unset) is unchanged:
+# a plain 'aws cloudformation deploy' still gets the full fail-on-drift guard.
+if [[ "${HEALTH_GATE_SKIP_DRIFT:-0}" == "1" ]]; then
+    echo "[CHECK 7/7] SKIPPED — HEALTH_GATE_SKIP_DRIFT=1 (change-set IMPORT context;"
+    echo "            assert_changeset_safe.py mode=import is the compensating control)."
 else
-    echo "[FAIL] CFN drift detected for ${DRIFT_ENV} — resolve before deploying (see ${DRIFT_REPORT}; ENC-ISS-455 / ENC-TSK-J12)"
-    ERRORS=$((ERRORS + 1))
+    echo "[CHECK 7/7] Validating no live CFN drift (environment=${DRIFT_ENV}, fail-on-drift)..."
+    if python3 "${REPO_ROOT}/tools/audit_cfn_drift.py" \
+            --environment "${DRIFT_ENV}" \
+            --output-json "${DRIFT_REPORT}" \
+            --fail-on-drift; then
+        echo "[PASS] No CFN drift detected for ${DRIFT_ENV}"
+    else
+        echo "[FAIL] CFN drift detected for ${DRIFT_ENV} — resolve before deploying (see ${DRIFT_REPORT}; ENC-ISS-455 / ENC-TSK-J12)"
+        ERRORS=$((ERRORS + 1))
+    fi
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## ENC-TSK-J13 (J10-B) — v4/main lane

Gamma-lane companion to #665 (main). Same three Channel-C files so the privileged import/recovery workflow is dispatchable against `v4/**` refs (J15 gamma monitoring recovery + gamma imports).

- `.github/workflows/cfn-resource-import.yml`, `tools/assert_changeset_safe.py`, `tools/pre-deploy-health-gate.sh` (opt-in `HEALTH_GATE_SKIP_DRIFT`, default unchanged).

Task **ENC-TSK-J13** (`no_code`, sealed — no CCI arc). Channel C, no push-deploy fires. Self-merged on green under the DOC-AA5C7A37A103 standing authorization. See #665 for full detail.

---
PR Commit Gate token (via io-authorized code_only carrier ENC-TSK-J17): CCI-5ac8979af156496780be52317060ad80
