### PR TITLE
ENC-TSK-J19: merge post-import CFN templates to v4/main (api routes + checkout-auto)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4403,6 +4403,32 @@ Resources:
           - mcp-session-id
         MaxAge: 86400
 
+  # ENC-TSK-J13 (ENC-ISS-455): enceladus-checkout-auto — the sole documented prod
+  # EventBridge orphan (created out-of-band via CLI for ENC-FTR-037). ADOPTED via
+  # `create-change-set --change-set-type IMPORT` (resource-import-checkout-auto.json)
+  # BEFORE any normal compute deploy. A plain deploy that ADDs this rule fails closed
+  # at AWS::Events::Rule "already exists" (the enceladus-monitoring UPDATE_ROLLBACK
+  # class); import first. Literal prod-only name (Condition: IsProduction) — no gamma
+  # sibling exists. DeletionPolicy/UpdateReplacePolicy: Retain so a stack op never
+  # deletes the live auto-checkout schedule. Properties mirror live EXACTLY for a
+  # clean Import/no-op change-set (rate(5 minutes), ENABLED, target the -auto Lambda).
+  # NOTE: the events->lambda AWS::Lambda::Permission is NOT importable and stays
+  # out-of-band (ENC-ISS-394 precedent); only the rule is adopted here.
+  # After import, J14 drops the audit's documented-exception for enceladus-checkout-auto.
+  CheckoutAutoScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: enceladus-checkout-auto
+      Description: "Auto-checkout Enceladus tasks after 15-minute window (ENC-FTR-037)"
+      ScheduleExpression: "rate(5 minutes)"
+      State: ENABLED
+      Targets:
+        - Id: checkout-auto-target
+          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-checkout-service-auto"
+
   # ENC-TSK-I27 / ENC-FTR-116 Wave 2: recompute-governance Lambda.
   # Triggered by S3 ObjectCreated on governance/live/*; writes canonical
   # governance-version DDB record. IAM sole-writer grant (I28).

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -847,6 +847,834 @@ Resources:
       RouteKey: OPTIONS /api/v1/tracker/graphsearch
       Target: !Sub integrations/${GraphQueryIntegration}
 
+  # ==================================================================
+  # ENC-TSK-J13 (ENC-ISS-455): out-of-band prod API surface adopted via
+  # change-set IMPORT (resource-import-api.json). 3 integrations + 98 routes.
+  # STAGED — do NOT plain-deploy before IMPORT (EarlyValidation wedge).
+  # All 98 routes classified KEEP-IMPORT (every one backs a live Lambda
+  # AWS_PROXY integration; zero stray/orphan routes).
+  # ==================================================================
+
+  GitHubProxyIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    DeletionPolicy: Retain
+    # ENC-TSK-J13: out-of-band integration (physical 0nmjqw3) adopted via change-set IMPORT.
+    # Duplicate-to-CFN note: GitHubIntegration/gwha2wd targets the same Lambda; live traffic uses this one.
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-github-integration${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  CheckoutApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    DeletionPolicy: Retain
+    # ENC-TSK-J13: out-of-band integration (physical oi4kfbn) adopted via change-set IMPORT.
+    # Duplicate-to-CFN note: CheckoutServiceIntegration/reizplt targets the same Lambda; live traffic uses this one.
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-checkout-service${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  ChangelogApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    DeletionPolicy: Retain
+    # ENC-TSK-J13: out-of-band integration (physical w6ey7lp) adopted via change-set IMPORT.
+    # Duplicate-to-CFN note: none (no CFN changelog integration existed) targets the same Lambda; live traffic uses this one.
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-changelog-api${EnvironmentSuffix}"
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  RouteDeleteCheckoutByProjectTaskByTaskIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/checkout/{project}/task/{taskId}/checkout
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteDeleteCoordinationAuthOauthClientsByClientId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/coordination/auth/oauth-clients/{clientId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteDeleteCoordinationAuthTokensByTokenId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/coordination/auth/tokens/{tokenId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteDeleteTrackerByProjectIdRelationship:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteDeleteTrackerByProjectIdByRecordTypeByRecordIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: DELETE /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteGetChangelogHistory:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/changelog/history
+      Target: !Sub integrations/${ChangelogApiIntegration}
+
+  RouteGetChangelogHistoryByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/changelog/history/{projectId}
+      Target: !Sub integrations/${ChangelogApiIntegration}
+
+  RouteGetChangelogVersionByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/changelog/version/{projectId}
+      Target: !Sub integrations/${ChangelogApiIntegration}
+
+  RouteGetChangelogVersions:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/changelog/versions
+      Target: !Sub integrations/${ChangelogApiIntegration}
+
+  RouteGetCheckoutValidateCommitCompleteByCciId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/checkout/validate/commit-complete/{cciId}
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteGetCheckoutByProjectTaskByTaskIdStatus:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/checkout/{project}/task/{taskId}/status
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteGetCoordinationAuthOauthClients:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/auth/oauth-clients
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetCoordinationAuthTokens:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/auth/tokens
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetCoordinationProjects:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/projects
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetCoordinationProjectsByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/projects/{projectId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetGithubCommitsValidate:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/github/commits/validate
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RouteGetGithubProjects:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/github/projects
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RouteGetGovernanceDictionary:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/governance/dictionary
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetGovernanceHash:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/governance/hash
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetGovernanceByFileName:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/governance/{fileName+}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetHealth:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/health
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteGetTrackerPendingUpdates:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/pending-updates
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteGetTrackerByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteGetTrackerByProjectIdRelationship:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteGetTrackerByProjectIdByRecordTypeByRecordId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/tracker/{projectId}/{recordType}/{recordId}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptAuthRefresh:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/auth/refresh
+      Target: !Sub integrations/${AuthRefreshIntegration}
+
+  RouteOptCheckoutValidateCommitCompleteByCciId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/checkout/validate/commit-complete/{cciId}
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteOptCheckoutByProjectTaskByTaskIdAdvance:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/checkout/{project}/task/{taskId}/advance
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteOptCheckoutByProjectTaskByTaskIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/checkout/{project}/task/{taskId}/checkout
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteOptCheckoutByProjectTaskByTaskIdLog:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/checkout/{project}/task/{taskId}/log
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteOptCheckoutByProjectTaskByTaskIdStatus:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/checkout/{project}/task/{taskId}/status
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RouteOptCoordinationAuthCognitoSession:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/cognito/session
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthOauthClients:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/oauth-clients
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthOauthClientsByClientId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthOauthClientsByClientIdPermissions:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/permissions
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthOauthClientsByClientIdUsage:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/usage
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthPermissionsByTokenId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/permissions/{tokenId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthTokens:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/tokens
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationAuthTokensByTokenId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/auth/tokens/{tokenId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationCapabilities:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/capabilities
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationMcp:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/mcp
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationMonitor:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/monitor
+      Target: !Sub integrations/${CoordinationMonitorIntegration}
+
+  RouteOptCoordinationProjects:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/projects
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationProjectsByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/projects/{projectId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationRequests:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/requests
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationRequestsByRequestId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/requests/{requestId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationRequestsByRequestIdCallback:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/requests/{requestId}/callback
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptCoordinationRequestsByRequestIdDispatch:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/coordination/requests/{requestId}/dispatch
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptDeployHistoryByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/deploy/history/{projectId}
+      Target: !Sub integrations/${DeployIntakeIntegration}
+
+  RouteOptDeployStateByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/deploy/state/{projectId}
+      Target: !Sub integrations/${DeployIntakeIntegration}
+
+  RouteOptDeployStatusBySpecId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/deploy/status/{specId}
+      Target: !Sub integrations/${DeployIntakeIntegration}
+
+  RouteOptDeploySubmit:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/deploy/submit
+      Target: !Sub integrations/${DeployIntakeIntegration}
+
+  RouteOptDocPrepByProjectName:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/doc-prep/{projectName}
+      Target: !Sub integrations/${DocPrepIntegration}
+
+  RouteOptDocuments:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/documents
+      Target: !Sub integrations/${DocumentApiIntegration}
+
+  RouteOptDocumentsByDocumentId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/documents/{documentId}
+      Target: !Sub integrations/${DocumentApiIntegration}
+
+  RouteOptFeed:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/feed
+      Target: !Sub integrations/${FeedQueryIntegration}
+
+  RouteOptGithubByProxy:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/github/{proxy+}
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RouteOptGovernanceDictionary:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/governance/dictionary
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptGovernanceHash:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/governance/hash
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptGovernanceByFileName:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/governance/{fileName+}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptHealth:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/health
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteOptProjects:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/projects
+      Target: !Sub integrations/${ProjectServiceIntegration}
+
+  RouteOptProjectsByProjectName:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/projects/{projectName}
+      Target: !Sub integrations/${ProjectServiceIntegration}
+
+  RouteOptReferenceSearch:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/reference/search
+      Target: !Sub integrations/${ReferenceSearchIntegration}
+
+  RouteOptTrackerPendingUpdates:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/pending-updates
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdRelationship:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/relationship
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordType:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordTypeByRecordId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordTypeByRecordIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordTypeByRecordIdExtend:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptTrackerByProjectIdByRecordTypeByRecordIdLog:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/log
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RouteOptByProjectIdByRecordTypeByRecordId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: OPTIONS /{projectId}/{recordType}/{recordId}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePatchCoordinationAuthOauthClientsByClientIdPermissions:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/permissions
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePatchCoordinationAuthOauthClientsByClientIdUsage:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/usage
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePatchCoordinationAuthPermissionsByTokenId:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: PATCH /api/v1/coordination/auth/permissions/{tokenId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCheckoutByProjectTaskByTaskIdAdvance:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/checkout/{project}/task/{taskId}/advance
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RoutePostCheckoutByProjectTaskByTaskIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/checkout/{project}/task/{taskId}/checkout
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RoutePostCheckoutByProjectTaskByTaskIdLog:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/checkout/{project}/task/{taskId}/log
+      Target: !Sub integrations/${CheckoutApiIntegration}
+
+  RoutePostCoordinationAuthCognitoSession:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/auth/cognito/session
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationAuthOauthClients:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/auth/oauth-clients
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationAuthTokens:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/auth/tokens
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationComponentsPropose:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/components/propose
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationComponentsByComponentIdAdvance:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/components/{componentId}/advance
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationComponentsByComponentIdApprove:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/components/{componentId}/approve
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationComponentsByComponentIdCloudwatchEvent:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/components/{componentId}/cloudwatch_event
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostCoordinationComponentsByComponentIdReject:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/components/{componentId}/reject
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RoutePostGithubDeployGammaSuccessByPrnumber:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/github/deploy/gamma-success/{pr_number}
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RoutePostGithubIssues:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/github/issues
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RoutePostGithubProjectsSync:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/github/projects/sync
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RoutePostGithubWebhook:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/github/webhook
+      Target: !Sub integrations/${GitHubProxyIntegration}
+
+  RoutePostTrackerByProjectIdByRecordType:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePostTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePostTrackerByProjectIdByRecordTypeByRecordIdCheckout:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePostTrackerByProjectIdByRecordTypeByRecordIdExtend:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePostTrackerByProjectIdByRecordTypeByRecordIdLog:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/log
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
+  RoutePutGovernanceByFileName:
+    Type: AWS::ApiGatewayV2::Route
+    DeletionPolicy: Retain
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: PUT /api/v1/governance/{fileName+}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint

--- a/infrastructure/cloudformation/resource-import-api.json
+++ b/infrastructure/cloudformation/resource-import-api.json
@@ -1,353 +1,810 @@
 [
   {
-    "ResourceType": "AWS::ApiGatewayV2::Api",
-    "LogicalResourceId": "HttpApi",
+    "ResourceType": "AWS::ApiGatewayV2::Integration",
+    "LogicalResourceId": "GitHubProxyIntegration",
     "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc"
+      "ApiId": "8nkzqkmxqc",
+      "IntegrationId": "0nmjqw3"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "CoordinationApiIntegration",
+    "LogicalResourceId": "CheckoutApiIntegration",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "kbvzvie"
+      "IntegrationId": "oi4kfbn"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "TrackerMutationIntegration",
+    "LogicalResourceId": "ChangelogApiIntegration",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "t0kta4k"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "DocumentApiIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "w68vrr1"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "ProjectServiceIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "vz2xmz7"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "FeedQueryIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "2jokxwl"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "CoordinationMonitorIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "9br2p3d"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "DeployIntakeIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "97dh84s"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "ReferenceSearchIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "f5j0912"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "DocPrepIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "es2dwuj"
-    }
-  },
-  {
-    "ResourceType": "AWS::ApiGatewayV2::Integration",
-    "LogicalResourceId": "AuthRefreshIntegration",
-    "ResourceIdentifier": {
-      "ApiId": "8nkzqkmxqc",
-      "IntegrationId": "7g2lg0h"
+      "IntegrationId": "w6ey7lp"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationCreate",
+    "LogicalResourceId": "RouteDeleteCheckoutByProjectTaskByTaskIdCheckout",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "9tn7hjo"
+      "RouteId": "2toxjyf"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationGet",
+    "LogicalResourceId": "RouteDeleteCoordinationAuthOauthClientsByClientId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "xrgxc19"
+      "RouteId": "inheu43"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationDispatch",
+    "LogicalResourceId": "RouteDeleteCoordinationAuthTokensByTokenId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "jgrn6uu"
+      "RouteId": "kinci5j"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationCallback",
+    "LogicalResourceId": "RouteDeleteTrackerByProjectIdRelationship",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "izqivn2"
+      "RouteId": "ca4fx7h"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationCapabilities",
+    "LogicalResourceId": "RouteDeleteTrackerByProjectIdByRecordTypeByRecordIdCheckout",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "kvgf3th"
+      "RouteId": "p4tphh2"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationMcpGet",
+    "LogicalResourceId": "RouteGetChangelogHistory",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "4yg74ho"
+      "RouteId": "za3nseq"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteCoordinationMcpPost",
+    "LogicalResourceId": "RouteGetChangelogHistoryByProjectId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "peyb8qc"
+      "RouteId": "syajmp4"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteTrackerMutationLegacy",
+    "LogicalResourceId": "RouteGetChangelogVersionByProjectId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "qk8jo5e"
+      "RouteId": "1ouvs37"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteTrackerMutationV1",
+    "LogicalResourceId": "RouteGetChangelogVersions",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "qeymb4h"
+      "RouteId": "neenwgu"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocumentsList",
+    "LogicalResourceId": "RouteGetCheckoutValidateCommitCompleteByCciId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "2o6ihsp"
+      "RouteId": "4bbbm5a"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocumentsGet",
+    "LogicalResourceId": "RouteGetCheckoutByProjectTaskByTaskIdStatus",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "cthvt85"
+      "RouteId": "00bia72"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocumentsSearch",
+    "LogicalResourceId": "RouteGetCoordinationAuthOauthClients",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "h169dol"
+      "RouteId": "tjw591r"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocumentsCreate",
+    "LogicalResourceId": "RouteGetCoordinationAuthTokens",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "ln0z2tg"
+      "RouteId": "swuaosp"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocumentsPatch",
+    "LogicalResourceId": "RouteGetCoordinationProjects",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "h8yl1jp"
+      "RouteId": "lcjiaue"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteProjectsList",
+    "LogicalResourceId": "RouteGetCoordinationProjectsByProjectId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "g6dvz97"
+      "RouteId": "6d6h9l5"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteProjectsGet",
+    "LogicalResourceId": "RouteGetGithubCommitsValidate",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "qog6e8a"
+      "RouteId": "87ua0yp"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteProjectsCreate",
+    "LogicalResourceId": "RouteGetGithubProjects",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "1hwa6q9"
+      "RouteId": "tfu100b"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteFeedQuery",
+    "LogicalResourceId": "RouteGetGovernanceDictionary",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "8aqd4uh"
+      "RouteId": "0ib1y82"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteMonitorList",
+    "LogicalResourceId": "RouteGetGovernanceHash",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "xtyrate"
+      "RouteId": "t52xj8f"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteMonitorGet",
+    "LogicalResourceId": "RouteGetGovernanceByFileName",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "dly5pju"
+      "RouteId": "z4rgal1"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDeploySubmit",
+    "LogicalResourceId": "RouteGetHealth",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "oybr8ft"
+      "RouteId": "k3frrz5"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDeployStatus",
+    "LogicalResourceId": "RouteGetTrackerPendingUpdates",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "j65o4bb"
+      "RouteId": "sqn8mvj"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDeployHistory",
+    "LogicalResourceId": "RouteGetTrackerByProjectId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "jcu41n1"
+      "RouteId": "4ircima"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDeployStateGet",
+    "LogicalResourceId": "RouteGetTrackerByProjectIdRelationship",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "rqw25bh"
+      "RouteId": "80fwtl5"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDeployStatePatch",
+    "LogicalResourceId": "RouteGetTrackerByProjectIdByRecordTypeByRecordId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "p4glilj"
+      "RouteId": "42i9gq9"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteReferenceSearch",
+    "LogicalResourceId": "RouteOptAuthRefresh",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "w5ktyu2"
+      "RouteId": "lf4wp3l"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteDocPrep",
+    "LogicalResourceId": "RouteOptCheckoutValidateCommitCompleteByCciId",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "e91bs4g"
+      "RouteId": "vioepoo"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteAuthRefresh",
+    "LogicalResourceId": "RouteOptCheckoutByProjectTaskByTaskIdAdvance",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "ur6y7wq"
+      "RouteId": "pvyzjff"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteComponentsAddEdge",
+    "LogicalResourceId": "RouteOptCheckoutByProjectTaskByTaskIdCheckout",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "r8yvurf"
+      "RouteId": "3ebw75q"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteComponentsRemoveEdge",
+    "LogicalResourceId": "RouteOptCheckoutByProjectTaskByTaskIdLog",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "bamcafm"
+      "RouteId": "5ywq81b"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteComponentsDeprecate",
+    "LogicalResourceId": "RouteOptCheckoutByProjectTaskByTaskIdStatus",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "n5o6ut9"
+      "RouteId": "ovy4wcg"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteComponentsRestore",
+    "LogicalResourceId": "RouteOptCoordinationAuthCognitoSession",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "4y52eem"
+      "RouteId": "1ejr5nh"
     }
   },
   {
     "ResourceType": "AWS::ApiGatewayV2::Route",
-    "LogicalResourceId": "RouteComponentsRevert",
+    "LogicalResourceId": "RouteOptCoordinationAuthOauthClients",
     "ResourceIdentifier": {
       "ApiId": "8nkzqkmxqc",
-      "RouteId": "wz9oprl"
+      "RouteId": "psl4n5i"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthOauthClientsByClientId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "tq4ge62"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthOauthClientsByClientIdPermissions",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "sssju36"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthOauthClientsByClientIdUsage",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "50rmr8b"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthPermissionsByTokenId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "kmmxug6"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthTokens",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "s0xlzpl"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationAuthTokensByTokenId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "2oji9is"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationCapabilities",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "9z55i5d"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationMcp",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "9fa7qy4"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationMonitor",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "2u37k27"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationProjects",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "yr0qnoc"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationProjectsByProjectId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "hft8nbm"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationRequests",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "6c7du4i"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationRequestsByRequestId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1d4rk9b"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationRequestsByRequestIdCallback",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "k6cvaqm"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptCoordinationRequestsByRequestIdDispatch",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "4z36392"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDeployHistoryByProjectId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "qxuwc84"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDeployStateByProjectId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "vuqbfze"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDeployStatusBySpecId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "wygehc0"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDeploySubmit",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "k6v8ylt"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDocPrepByProjectName",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "ve0e7yg"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDocuments",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "9s9is37"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptDocumentsByDocumentId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "xd2sc6h"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptFeed",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "djc9j03"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptGithubByProxy",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "476dn7a"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptGovernanceDictionary",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "xvb71eu"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptGovernanceHash",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "jgde38c"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptGovernanceByFileName",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "ho7ave1"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptHealth",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "gogzmv7"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptProjects",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "3j3s7d9"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptProjectsByProjectName",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "9v09vsm"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptReferenceSearch",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "vocz29v"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerPendingUpdates",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "teuj45p"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "mnsmb3q"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdRelationship",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "fwxuvfv"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordType",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "66ebh1j"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordTypeByRecordId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "qx7h1h4"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "k6b1vwc"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordTypeByRecordIdCheckout",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "v34kb3r"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordTypeByRecordIdExtend",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "2kupsqf"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptTrackerByProjectIdByRecordTypeByRecordIdLog",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "unkmfva"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RouteOptByProjectIdByRecordTypeByRecordId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1zx390i"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePatchCoordinationAuthOauthClientsByClientIdPermissions",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "llsv5m5"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePatchCoordinationAuthOauthClientsByClientIdUsage",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "2hrfx90"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePatchCoordinationAuthPermissionsByTokenId",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "a29r97r"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCheckoutByProjectTaskByTaskIdAdvance",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "yfulrth"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCheckoutByProjectTaskByTaskIdCheckout",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1osffkk"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCheckoutByProjectTaskByTaskIdLog",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "nkuflzf"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationAuthCognitoSession",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "08rcwqn"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationAuthOauthClients",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "tbubdpo"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationAuthTokens",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1km0lg2"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationComponentsPropose",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "18o1zwi"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationComponentsByComponentIdAdvance",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1u6lvv7"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationComponentsByComponentIdApprove",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "daa9o62"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationComponentsByComponentIdCloudwatchEvent",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "glgwnw8"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostCoordinationComponentsByComponentIdReject",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "ogdzuld"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostGithubDeployGammaSuccessByPrnumber",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "yi43nc0"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostGithubIssues",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "82n8beu"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostGithubProjectsSync",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "5ntletf"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostGithubWebhook",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "quqnmwo"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostTrackerByProjectIdByRecordType",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "i5d6cmh"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "co4bdks"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostTrackerByProjectIdByRecordTypeByRecordIdCheckout",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "gph0yo7"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostTrackerByProjectIdByRecordTypeByRecordIdExtend",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "1peer98"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePostTrackerByProjectIdByRecordTypeByRecordIdLog",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "nbyj0q6"
+    }
+  },
+  {
+    "ResourceType": "AWS::ApiGatewayV2::Route",
+    "LogicalResourceId": "RoutePutGovernanceByFileName",
+    "ResourceIdentifier": {
+      "ApiId": "8nkzqkmxqc",
+      "RouteId": "pk5h7l1"
     }
   }
 ]

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -237,21 +237,15 @@ _RULE_NAME_RE = re.compile(
 # CLI-only EventBridge rules: live and serving a real feature, but declared in
 # NEITHER branch's CFN templates (genuine out-of-band orphans, confirmed via
 # ENC-TSK-J07 grep of main + v4/main). Environment scoping (_in_environment)
-# already keeps gamma-managed rules from showing as prod drift, so the ONLY rule
-# that still needs an explicit exception is enceladus-checkout-auto — the
-# ENC-FTR-037 auto-checkout companion, created out-of-band alongside
-# enceladus-checkout-service-auto and never codified.
+# already keeps gamma-managed rules from showing as prod drift.
 #
-# Durable fix is a CloudFormation change-set IMPORT (the rule already exists, so
-# a plain stack update plans it as an Add and AWS::EarlyValidation::ResourceExistenceCheck
-# rejects the whole change set — the ENC-ISS-386 / ENC-TSK-H29 wedge). Import is a
-# privileged manual op tracked under ENC-ISS-455; until then this documented
-# exception keeps the daily audit from re-raising gh#635 noise. Stored as an
-# env-suffix-stripped BASE name (see _strip_env_suffix). Verified live + ENABLED
-# via `aws events describe-rule` on 2026-06-30.
-_EVENTBRIDGE_CLI_EXCEPTION_BASES = {
-    "enceladus-checkout-auto",  # ENC-FTR-037 auto-checkout companion, rate(5 minutes)
-}
+# enceladus-checkout-auto was the only entry here (ENC-FTR-037 auto-checkout
+# companion) and has been adopted into 02-compute.yaml via change-set IMPORT
+# (ENC-TSK-J14; CheckoutAutoScheduleRule, DeletionPolicy: Retain) — it is now
+# CFN-declared, so the exception is no longer needed (ENC-TSK-J19). Stored as
+# env-suffix-stripped BASE names (see _strip_env_suffix) should a future
+# out-of-band orphan need documenting again.
+_EVENTBRIDGE_CLI_EXCEPTION_BASES: Set[str] = set()
 
 
 def _strip_env_suffix(name: str) -> str:


### PR DESCRIPTION
## Summary
v4/main counterpart of #671 (main). Cherry-picks the same staged CFN import content onto v4/main's independently-diverged templates (clean auto-merge on 03-api.yaml; one conflict on 02-compute.yaml resolved by keeping both v4/main's `RecomputeGovernanceFunction` and the new `CheckoutAutoScheduleRule`).

- `infrastructure/cloudformation/03-api.yaml`: same 3 Integrations + 98 Routes as #671, `DeletionPolicy: Retain`.
- `infrastructure/cloudformation/02-compute.yaml`: `CheckoutAutoScheduleRule`, `Condition: IsProduction` — a no-op for gamma deploys (resource simply isn't created there), matters only if/when this template promotes to prod.
- `infrastructure/cloudformation/resource-import-api.json`, `tools/audit_cfn_drift.py`: same as #671.

**Gamma impact differs from prod's no-op**: unlike main (where these resources are already CFN-adopted via IMPORT, so the api-stack deploy is a clean no-op), gamma's live API never had these 98 routes at all. Pre-verified via `python3 tools/audit_cfn_drift.py --environment gamma` (read-only, `aws apigatewayv2 get-routes` against the live gamma API) before opening this PR: zero RouteKey collisions — none of the 93 newly-declared routes already exist live in gamma under a different declaration. So the gamma api-stack-deploy will do a genuine (but purely additive, non-destructive) `Add` of new routes/integrations extending gamma's API surface to match prod's, not an import or a no-op.

Expect the gamma compute-stack-deploy to hit the same pre-deploy-health-gate Check 7 IAM gap as #671 hit on main (`GitHubActions-V4Gamma-DeployRole` has no `events:*` permissions at all) — tracked in #672, out of scope for this code_only carrier.

## Test plan
- [x] `python3 -m pytest tests/tools/test_audit_cfn_drift.py -q` — 13 passed
- [x] YAML/JSON syntax validated for both templates + the import manifest post-merge-conflict-resolution
- [x] Read-only `audit_cfn_drift.py --environment gamma` pre-check: no route-key collisions between the new routes and gamma's live API
- [ ] Post-merge gamma stack-deploy runs (expect api: additive/green; compute: blocked on issue #672, non-destructive)

CCI-d0e5c52025094a68b08d4f05b8dc56d2

🤖 Generated with [Claude Code](https://claude.com/claude-code)