### PR TITLE
fix(cfn-drift): fail-safe on AccessDenied + grant events:ListRules to CFN deploy role (GH#672) [v4/main]

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
@@ -1,0 +1,72 @@
+name: IAM CFN Deploy Role — EventBridge ListRules Patch
+
+# ENC-TSK-J22 / GH#672: CloudFormationDeployRole (enceladus-cloudformation-deploy-github-role)
+# has events:DescribeRule but never events:ListRules, so tools/audit_cfn_drift.py's
+# `aws events list-rules` call (pre-deploy-health-gate.sh Check 7) fails AccessDenied
+# on every compute/api/monitoring stack-deploy. The durable fix lands the grant in
+# infrastructure/cloudformation/04-github-roles.yaml (mirroring BackendDeployRole's
+# CfnDriftAuditEventBridgeRead grant, ENC-ISS-442/ENC-TSK-I94); 04-github-roles has no
+# push-deploy, so this one-off dispatchable patch (matching the
+# iam-cloudformation-unblock.yml / iam-cfn-deploy-role-gamma-patch.yml pattern) applies
+# the same statement live immediately, ahead of the next full github-roles stack deploy.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Unblock GH#672 / ENC-TSK-J22 — grant events:ListRules to CloudFormationDeployRole for pre-deploy-health-gate.sh Check 7"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with events:ListRules
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — events:ListRules
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          cat > /tmp/cfn-deploy-role-eventbridge-listrules.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "CfnDriftAuditEventBridgeRead",
+                "Effect": "Allow",
+                "Action": [
+                  "events:ListRules"
+                ],
+                "Resource": "arn:aws:events:us-west-2:${ACCOUNT_ID}:rule/*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-eventbridge-listrules-v1" \
+            --policy-document "file:///tmp/cfn-deploy-role-eventbridge-listrules.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-eventbridge-listrules-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -196,6 +196,19 @@ Resources:
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/enceladus-*"
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/on-project-json-sync*"
 
+              # Required by pre-deploy-health-gate.sh Check 7 (ENC-TSK-J12 /
+              # ENC-ISS-455): audit_cfn_drift.py calls `aws events list-rules`
+              # to compare live EventBridge rules against CFN-declared rules.
+              # Mirrors BackendDeployRole's CfnDriftAuditEventBridgeRead grant
+              # (ENC-TSK-I94 / ENC-ISS-442). GH#672 / ENC-TSK-J22: without this,
+              # the health gate's drift check crashed with AccessDenied on
+              # every compute/api/monitoring push-deploy.
+              - Sid: CfnDriftAuditEventBridgeRead
+                Effect: Allow
+                Action:
+                  - events:ListRules
+                Resource: !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/*"
+
               - Sid: PipesValidationReadOnly
                 Effect: Allow
                 Action:

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -30,7 +30,10 @@ Modes:
                                Also scopes which Condition-gated (IsProduction/
                                IsGamma) resources count as declared (ENC-TSK-J12).
   --output-json <path>         Write JSON drift report for CI consumption
-  --fail-on-drift              Exit 1 if any drift is detected
+  --fail-on-drift              Exit 1 if real drift is detected. Exit 2 (not 1) if any
+                               category could not be evaluated because a live AWS read
+                               was denied (AccessDenied) — a permission gap is flagged as
+                               'inconclusive', never reported as drift (ENC-TSK-J22 / GH#672).
   --self-check                 Run an offline sanity check of the
                                Condition-aware parser (no AWS calls) and exit
 
@@ -51,9 +54,33 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
 
+class LiveReadAccessDenied(RuntimeError):
+    """A live AWS read was denied by IAM — a permission gap, not CFN drift.
+
+    ENC-TSK-J22 / GH#672: CloudFormationDeployRole lacked events:ListRules, so
+    `aws events list-rules` raised an uncaught CalledProcessError that crashed
+    this script; pre-deploy-health-gate.sh Check 7 then mis-reported the crash
+    as "[FAIL] CFN drift detected". Raising this dedicated exception lets
+    callers distinguish "we don't have permission to check" from "we checked
+    and found drift" and surface the former as inconclusive instead.
+    """
+
+    def __init__(self, action: str, detail: str):
+        self.action = action
+        self.detail = detail
+        super().__init__(f"AccessDenied calling `{action}`: {detail}")
+
+
 def _aws_json(cmd: List[str]) -> object:
-    out = subprocess.check_output(cmd, text=True)
-    return json.loads(out) if out.strip() else None
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        if "AccessDenied" in stderr:
+            raise LiveReadAccessDenied(action=" ".join(cmd), detail=stderr)
+        raise subprocess.CalledProcessError(
+            proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
+        )
+    return json.loads(proc.stdout) if proc.stdout.strip() else None
 
 
 def live_apigw_routes(api_id: str) -> Set[str]:
@@ -303,14 +330,47 @@ def declared_eventbridge_rules(cfn_glob: str, name_prefix: str, environment: str
     return bases
 
 
+def _inconclusive_section(declared_count: int, reason: str, **extra: List[str]) -> Dict[str, object]:
+    section: Dict[str, object] = {
+        "inconclusive": True,
+        "inconclusive_reason": reason,
+        "live_count": None,
+        "declared_count": declared_count,
+        "live_only": [],
+        "cfn_only": [],
+    }
+    section.update(extra)
+    return section
+
+
 def audit(
-    api_id: str,
+    api_id: str | None,
     cfn_glob: str,
     event_rule_prefix: str,
     environment: str = "prod",
-) -> Dict[str, Dict[str, List[str]]]:
+    api_id_inconclusive: str | None = None,
+) -> Dict[str, Dict[str, object]]:
     declared_rt = declared_routes(cfn_glob, environment)
-    live_rt = live_apigw_routes(api_id)
+
+    # ENC-TSK-J22 / GH#672: a live-read AccessDenied (e.g. CloudFormationDeployRole
+    # lacking events:ListRules) is a permission gap, not evidence of drift. Each
+    # category is evaluated independently so one denied category doesn't crash
+    # the whole audit or masquerade as "drift detected" for the others.
+    if api_id_inconclusive:
+        apigw_section = _inconclusive_section(len(declared_rt), api_id_inconclusive)
+    else:
+        try:
+            live_rt = live_apigw_routes(api_id)
+        except LiveReadAccessDenied as e:
+            apigw_section = _inconclusive_section(len(declared_rt), str(e))
+        else:
+            apigw_section = {
+                "inconclusive": False,
+                "live_count": len(live_rt),
+                "declared_count": len(declared_rt),
+                "live_only": sorted(live_rt - declared_rt),
+                "cfn_only": sorted(declared_rt - live_rt),
+            }
 
     # ENC-TSK-J08: EventBridge comparison is done on environment-suffix-stripped
     # base names (see _strip_env_suffix), with the live set scoped to the audited
@@ -322,32 +382,36 @@ def audit(
     # IsProduction-gated resources only count as declared where they actually
     # deploy.
     declared_ev_bases = declared_eventbridge_rules(cfn_glob, event_rule_prefix, environment)
-    live_ev = live_eventbridge_rules(event_rule_prefix, environment)
-    live_ev_bases = {_strip_env_suffix(n) for n in live_ev}
-    exceptions = sorted(
-        n for n in live_ev
-        if _strip_env_suffix(n) in _EVENTBRIDGE_CLI_EXCEPTION_BASES
-    )
-    live_only = sorted(
-        n for n in live_ev
-        if _strip_env_suffix(n) not in declared_ev_bases
-        and _strip_env_suffix(n) not in _EVENTBRIDGE_CLI_EXCEPTION_BASES
-    )
-    cfn_only = sorted(b for b in declared_ev_bases if b not in live_ev_bases)
-    return {
-        "apigw_routes": {
-            "live_count": len(live_rt),
-            "declared_count": len(declared_rt),
-            "live_only": sorted(live_rt - declared_rt),
-            "cfn_only": sorted(declared_rt - live_rt),
-        },
-        "eventbridge_rules": {
+    try:
+        live_ev = live_eventbridge_rules(event_rule_prefix, environment)
+    except LiveReadAccessDenied as e:
+        eventbridge_section = _inconclusive_section(
+            len(declared_ev_bases), str(e), documented_exceptions=[]
+        )
+    else:
+        live_ev_bases = {_strip_env_suffix(n) for n in live_ev}
+        exceptions = sorted(
+            n for n in live_ev
+            if _strip_env_suffix(n) in _EVENTBRIDGE_CLI_EXCEPTION_BASES
+        )
+        live_only = sorted(
+            n for n in live_ev
+            if _strip_env_suffix(n) not in declared_ev_bases
+            and _strip_env_suffix(n) not in _EVENTBRIDGE_CLI_EXCEPTION_BASES
+        )
+        cfn_only = sorted(b for b in declared_ev_bases if b not in live_ev_bases)
+        eventbridge_section = {
+            "inconclusive": False,
             "live_count": len(live_ev),
             "declared_count": len(declared_ev_bases),
             "live_only": live_only,
             "cfn_only": cfn_only,
             "documented_exceptions": exceptions,
-        },
+        }
+
+    return {
+        "apigw_routes": apigw_section,
+        "eventbridge_rules": eventbridge_section,
     }
 
 
@@ -452,9 +516,21 @@ def main() -> int:
     if args.self_check:
         return 0 if _self_check() else 1
 
-    api_id = args.api_id or resolve_api_id(args.stack_prefix, args.environment)
+    api_id = args.api_id
+    api_id_inconclusive = None
+    if api_id is None:
+        try:
+            api_id = resolve_api_id(args.stack_prefix, args.environment)
+        except LiveReadAccessDenied as e:
+            api_id_inconclusive = str(e)
 
-    report = audit(api_id, args.cfn_glob, args.event_rule_prefix, args.environment)
+    report = audit(
+        api_id,
+        args.cfn_glob,
+        args.event_rule_prefix,
+        args.environment,
+        api_id_inconclusive=api_id_inconclusive,
+    )
     report["_api_id"] = api_id
     report["_cfn_glob"] = args.cfn_glob
     report["_environment"] = args.environment
@@ -465,12 +541,26 @@ def main() -> int:
     if args.output_json:
         Path(args.output_json).write_text(payload)
 
+    inconclusive_sections = [
+        section for section in ("apigw_routes", "eventbridge_rules")
+        if report[section].get("inconclusive")
+    ]
+    for section in inconclusive_sections:
+        print(
+            f"[INCONCLUSIVE] {section}: {report[section]['inconclusive_reason']} "
+            "-- this is a permission gap, not drift. Flagging rather than "
+            "failing closed as 'CFN drift detected' (ENC-TSK-J22 / GH#672)."
+        )
+
     any_drift = any(
-        report[section]["live_only"] or report[section]["cfn_only"]
+        not report[section].get("inconclusive")
+        and (report[section]["live_only"] or report[section]["cfn_only"])
         for section in ("apigw_routes", "eventbridge_rules")
     )
     if args.fail_on_drift and any_drift:
         return 1
+    if inconclusive_sections:
+        return 2
     return 0
 
 

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -245,7 +245,21 @@ else
             --output-json "${DRIFT_REPORT}" \
             --fail-on-drift; then
         echo "[PASS] No CFN drift detected for ${DRIFT_ENV}"
+        DRIFT_RC=0
     else
+        DRIFT_RC=$?
+    fi
+
+    # ENC-TSK-J22 / GH#672: audit_cfn_drift.py exits 2 (not 1) when a live AWS
+    # read was denied (e.g. CloudFormationDeployRole missing events:ListRules) —
+    # a permission gap, not evidence of drift. Treat exit 2 as flagged-but-
+    # non-fatal so the gate doesn't false-fail on a role's missing read grant;
+    # exit 1 (real drift) still fails the gate closed as before.
+    if [[ "${DRIFT_RC:-0}" -eq 2 ]]; then
+        echo "[WARN] CFN drift audit INCONCLUSIVE for ${DRIFT_ENV} — a live-read permission"
+        echo "       gap (e.g. missing events:ListRules) prevented full evaluation. Flagged,"
+        echo "       NOT treated as drift; gate not failed (see ${DRIFT_REPORT}; GH #672)."
+    elif [[ "${DRIFT_RC:-0}" -ne 0 ]]; then
         echo "[FAIL] CFN drift detected for ${DRIFT_ENV} — resolve before deploying (see ${DRIFT_REPORT}; ENC-ISS-455 / ENC-TSK-J12)"
         ERRORS=$((ERRORS + 1))
     fi


### PR DESCRIPTION
## Summary
Cherry-pick of the main-lane fix (PR #675, commit b89219f) onto v4/main — same fix applies to both lanes since `CloudFormationDeployRole`'s OIDC trust and the pre-deploy-health-gate script are shared.

- `tools/audit_cfn_drift.py`: AccessDenied on a live AWS read is now surfaced as `inconclusive` (exit 2) per-category instead of crashing or being reported as drift.
- `tools/pre-deploy-health-gate.sh` Check 7: exit 2 is a non-fatal `[WARN]`, not a gate failure.
- `infrastructure/cloudformation/04-github-roles.yaml`: `events:ListRules` added to `CloudFormationDeployRole` (verified this file's `BackendDeployRole` already has the equivalent grant at a different line in this branch's copy — no duplication).
- New dispatchable one-off patch workflow `iam-cfn-deploy-role-eventbridge-listrules-patch.yml`.

Related to #672 (closed via the main-lane PR). ENC-TSK-J22.

CCI-e06bb154b5ae4fe695f7a073aa9fe112

## Test plan
- [x] Clean cherry-pick (`git cherry-pick` auto-merged with no conflicts).
- [x] `python3 tools/audit_cfn_drift.py --self-check` passes.
- [x] `bash -n tools/pre-deploy-health-gate.sh` passes.
- [x] Confirmed exactly one `CfnDriftAuditEventBridgeRead` Sid under `CloudFormationDeployRole` (no duplicate with `BackendDeployRole`'s pre-existing grant).