### PR TITLE
ENC-TSK-J21: Condition-scope imported prod API routes to IsProduction (GH #674) — v4/main

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -27,6 +27,7 @@ Parameters:
 
 Conditions:
   IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+  IsProduction: !Equals [!Ref EnvironmentSuffix, ""]
 
 Resources:
   # ---------------------------------------------------------------------------
@@ -901,6 +902,7 @@ Resources:
 
   RouteDeleteCoordinationAuthOauthClientsByClientId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -909,6 +911,7 @@ Resources:
 
   RouteDeleteCoordinationAuthTokensByTokenId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -917,6 +920,7 @@ Resources:
 
   RouteDeleteTrackerByProjectIdRelationship:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -925,6 +929,7 @@ Resources:
 
   RouteDeleteTrackerByProjectIdByRecordTypeByRecordIdCheckout:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -981,6 +986,7 @@ Resources:
 
   RouteGetCoordinationAuthOauthClients:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -989,6 +995,7 @@ Resources:
 
   RouteGetCoordinationAuthTokens:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -997,6 +1004,7 @@ Resources:
 
   RouteGetCoordinationProjects:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1005,6 +1013,7 @@ Resources:
 
   RouteGetCoordinationProjectsByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1029,6 +1038,7 @@ Resources:
 
   RouteGetGovernanceDictionary:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1037,6 +1047,7 @@ Resources:
 
   RouteGetGovernanceHash:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1045,6 +1056,7 @@ Resources:
 
   RouteGetGovernanceByFileName:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1053,6 +1065,7 @@ Resources:
 
   RouteGetHealth:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1061,6 +1074,7 @@ Resources:
 
   RouteGetTrackerPendingUpdates:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1069,6 +1083,7 @@ Resources:
 
   RouteGetTrackerByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1077,6 +1092,7 @@ Resources:
 
   RouteGetTrackerByProjectIdRelationship:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1085,6 +1101,7 @@ Resources:
 
   RouteGetTrackerByProjectIdByRecordTypeByRecordId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1093,6 +1110,7 @@ Resources:
 
   RouteOptAuthRefresh:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1141,6 +1159,7 @@ Resources:
 
   RouteOptCoordinationAuthCognitoSession:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1149,6 +1168,7 @@ Resources:
 
   RouteOptCoordinationAuthOauthClients:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1157,6 +1177,7 @@ Resources:
 
   RouteOptCoordinationAuthOauthClientsByClientId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1165,6 +1186,7 @@ Resources:
 
   RouteOptCoordinationAuthOauthClientsByClientIdPermissions:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1173,6 +1195,7 @@ Resources:
 
   RouteOptCoordinationAuthOauthClientsByClientIdUsage:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1181,6 +1204,7 @@ Resources:
 
   RouteOptCoordinationAuthPermissionsByTokenId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1189,6 +1213,7 @@ Resources:
 
   RouteOptCoordinationAuthTokens:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1197,6 +1222,7 @@ Resources:
 
   RouteOptCoordinationAuthTokensByTokenId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1205,6 +1231,7 @@ Resources:
 
   RouteOptCoordinationCapabilities:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1213,6 +1240,7 @@ Resources:
 
   RouteOptCoordinationMcp:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1221,6 +1249,7 @@ Resources:
 
   RouteOptCoordinationMonitor:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1229,6 +1258,7 @@ Resources:
 
   RouteOptCoordinationProjects:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1237,6 +1267,7 @@ Resources:
 
   RouteOptCoordinationProjectsByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1245,6 +1276,7 @@ Resources:
 
   RouteOptCoordinationRequests:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1253,6 +1285,7 @@ Resources:
 
   RouteOptCoordinationRequestsByRequestId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1261,6 +1294,7 @@ Resources:
 
   RouteOptCoordinationRequestsByRequestIdCallback:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1269,6 +1303,7 @@ Resources:
 
   RouteOptCoordinationRequestsByRequestIdDispatch:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1277,6 +1312,7 @@ Resources:
 
   RouteOptDeployHistoryByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1285,6 +1321,7 @@ Resources:
 
   RouteOptDeployStateByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1293,6 +1330,7 @@ Resources:
 
   RouteOptDeployStatusBySpecId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1301,6 +1339,7 @@ Resources:
 
   RouteOptDeploySubmit:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1309,6 +1348,7 @@ Resources:
 
   RouteOptDocPrepByProjectName:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1317,6 +1357,7 @@ Resources:
 
   RouteOptDocuments:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1325,6 +1366,7 @@ Resources:
 
   RouteOptDocumentsByDocumentId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1333,6 +1375,7 @@ Resources:
 
   RouteOptFeed:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1349,6 +1392,7 @@ Resources:
 
   RouteOptGovernanceDictionary:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1357,6 +1401,7 @@ Resources:
 
   RouteOptGovernanceHash:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1365,6 +1410,7 @@ Resources:
 
   RouteOptGovernanceByFileName:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1373,6 +1419,7 @@ Resources:
 
   RouteOptHealth:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1381,6 +1428,7 @@ Resources:
 
   RouteOptProjects:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1389,6 +1437,7 @@ Resources:
 
   RouteOptProjectsByProjectName:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1397,6 +1446,7 @@ Resources:
 
   RouteOptReferenceSearch:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1405,6 +1455,7 @@ Resources:
 
   RouteOptTrackerPendingUpdates:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1413,6 +1464,7 @@ Resources:
 
   RouteOptTrackerByProjectId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1421,6 +1473,7 @@ Resources:
 
   RouteOptTrackerByProjectIdRelationship:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1429,6 +1482,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordType:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1437,6 +1491,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordTypeByRecordId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1445,6 +1500,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1453,6 +1509,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordTypeByRecordIdCheckout:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1461,6 +1518,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordTypeByRecordIdExtend:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1469,6 +1527,7 @@ Resources:
 
   RouteOptTrackerByProjectIdByRecordTypeByRecordIdLog:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1477,6 +1536,7 @@ Resources:
 
   RouteOptByProjectIdByRecordTypeByRecordId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1485,6 +1545,7 @@ Resources:
 
   RoutePatchCoordinationAuthOauthClientsByClientIdPermissions:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1493,6 +1554,7 @@ Resources:
 
   RoutePatchCoordinationAuthOauthClientsByClientIdUsage:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1501,6 +1563,7 @@ Resources:
 
   RoutePatchCoordinationAuthPermissionsByTokenId:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1533,6 +1596,7 @@ Resources:
 
   RoutePostCoordinationAuthCognitoSession:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1541,6 +1605,7 @@ Resources:
 
   RoutePostCoordinationAuthOauthClients:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1549,6 +1614,7 @@ Resources:
 
   RoutePostCoordinationAuthTokens:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1557,6 +1623,7 @@ Resources:
 
   RoutePostCoordinationComponentsPropose:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1565,6 +1632,7 @@ Resources:
 
   RoutePostCoordinationComponentsByComponentIdAdvance:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1573,6 +1641,7 @@ Resources:
 
   RoutePostCoordinationComponentsByComponentIdApprove:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1581,6 +1650,7 @@ Resources:
 
   RoutePostCoordinationComponentsByComponentIdCloudwatchEvent:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1589,6 +1659,7 @@ Resources:
 
   RoutePostCoordinationComponentsByComponentIdReject:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1629,6 +1700,7 @@ Resources:
 
   RoutePostTrackerByProjectIdByRecordType:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1637,6 +1709,7 @@ Resources:
 
   RoutePostTrackerByProjectIdByRecordTypeByRecordIdAcceptanceEvidence:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1645,6 +1718,7 @@ Resources:
 
   RoutePostTrackerByProjectIdByRecordTypeByRecordIdCheckout:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1653,6 +1727,7 @@ Resources:
 
   RoutePostTrackerByProjectIdByRecordTypeByRecordIdExtend:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1661,6 +1736,7 @@ Resources:
 
   RoutePostTrackerByProjectIdByRecordTypeByRecordIdLog:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi
@@ -1669,6 +1745,7 @@ Resources:
 
   RoutePutGovernanceByFileName:
     Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
     DeletionPolicy: Retain
     Properties:
       ApiId: !Ref HttpApi


### PR DESCRIPTION
## ENC-TSK-J21 — Condition-scope imported prod API routes to `IsProduction` (GH #674) — v4/main lane

CCI-d72816347d7d450285641921ed8ddeb4

### What
v4/main counterpart of #677. Adds `Condition: IsProduction` to the **76** imported (`DeletionPolicy: Retain`) Route resources in `infrastructure/cloudformation/03-api.yaml` whose RouteKey already exists on the live `enceladus-api-gamma` API, so the shared template stops trying to CREATE duplicate routes on the gamma stack (API Gateway V2 409 ConflictException, GH #674). Defines `IsProduction: !Equals [!Ref EnvironmentSuffix, ""]`.

> The v4/main `03-api.yaml` diverges from main (has `RouteCursorWebhook`, lacks the agent-identity routes), but the #673-imported block and the 76-route live-collision set are **identical** to main's. Same 76 conditioned, same 22 + 3 integrations left deployable.

### This lane is the actual fix for #674
The failing deploy in #674 was `CloudFormation API Stack Deploy` on **v4/main** → `enceladus-api-gamma`. After this merge, `IsProduction=false` on gamma excludes the 76 duplicates → gamma reaches `UPDATE_COMPLETE` with zero 409s. Gamma stack tracks none of the 101 imported logical IDs → zero deletes.

### Per-route judgment (AC1)
- **76 conditioned** = every #673-imported route whose RouteKey is live on gamma (`get-routes` against `hi0dzmvqrc`). Supersedes #674's "23 confirmed" (only the 11 `*Gamma` logical twins); 65 more collide against live gamma routes lacking a `*Gamma` twin.
- **22 routes + 3 integrations** have no live gamma equivalent; `-gamma` backing Lambdas `Active` → left deployable on both.

Diff = +77 lines (76 `Condition` + 1 def), **zero deletions**.

Refs: GH #674, ENC-TSK-J19, DOC-AA5C7A37A103. Satisfies ENC-TSK-J19 AC-2 (v4/main api lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
