### PR TITLE
ENC-TSK-J26: reconcile 05-monitoring DeletionPolicy:Retain to imported live stacks (main)

### DIFF
--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -27,6 +27,7 @@ Resources:
   # ---------------------------------------------------------------------------
   ProdHealthMonitorRole:
     Type: AWS::IAM::Role
+    DeletionPolicy: Retain
     Properties:
       RoleName: !Sub "enceladus-prod-health-monitor-role${EnvironmentSuffix}"
       AssumeRolePolicyDocument:
@@ -144,6 +145,7 @@ Resources:
 
   EnvDriftAuditorScheduleRule:
     Type: AWS::Events::Rule
+    DeletionPolicy: Retain
     Properties:
       Name: !Sub "devops-env-drift-auditor-hourly${EnvironmentSuffix}"
       Description: Triggers env drift auditor Lambda hourly at :07 past the hour


### PR DESCRIPTION
ENC-TSK-J26 (code_only carrier for ENC-TSK-J15 / ENC-ISS-456).

Reconciles infrastructure/cloudformation/05-monitoring.yaml to the now-imported live monitoring stacks: adds `DeletionPolicy: Retain` to `ProdHealthMonitorRole` and `EnvDriftAuditorScheduleRule` (adopted out-of-band via change-set IMPORT in the io-dev-admin terminal per DOC-C45EA94DDDE8). Prevents a future deploy from resetting the import-time Retain policy.

**Non-destructive** (verified via change-set preview): the resulting prod monitoring deploy cleanly Adds ParityDriftDailyScheduleRule + ParityDriftDailyInvokePermission + EnvDriftAuditorInvokePermission (targets verified live, none pre-exist) + applies DeletionPolicy metadata; ProdHealthMonitorFunction Modify is Role-ref only (RequiresRecreation=Never) — NO Code stomp. No Add-of-existing / Delete-of-live / Replace.

CCI-055393fd99b04e18921ff78514b8fe3c