### PR TITLE
ENC-TSK-J26: reconcile 05-monitoring DeletionPolicy:Retain to imported live stacks (v4/main)

### DIFF
--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -27,6 +27,7 @@ Resources:
   # ---------------------------------------------------------------------------
   ProdHealthMonitorRole:
     Type: AWS::IAM::Role
+    DeletionPolicy: Retain
     Properties:
       RoleName: !Sub "enceladus-prod-health-monitor-role${EnvironmentSuffix}"
       AssumeRolePolicyDocument:
@@ -144,6 +145,7 @@ Resources:
 
   EnvDriftAuditorScheduleRule:
     Type: AWS::Events::Rule
+    DeletionPolicy: Retain
     Properties:
       Name: !Sub "devops-env-drift-auditor-hourly${EnvironmentSuffix}"
       Description: Triggers env drift auditor Lambda hourly at :07 past the hour


### PR DESCRIPTION
ENC-TSK-J26 (code_only carrier for ENC-TSK-J15 / ENC-ISS-456), gamma lane.

Reconciles infrastructure/cloudformation/05-monitoring.yaml on v4/main to the now-imported live enceladus-monitoring-gamma stack: adds `DeletionPolicy: Retain` to `ProdHealthMonitorRole` and `EnvDriftAuditorScheduleRule`.

**Non-destructive**: enceladus-monitoring-gamma is already at full parity (created via change-set IMPORT of the OOB Role+Function, then full-template UPDATE materialized the schedule rule + alarms + parity/env-drift rules; ENC-ISS-456 symptom cleared — enceladus-health-probe-schedule-gamma now ENABLED). The v4/main monitoring deploy is an in-place no-op (Modify Replacement=False + benign Lambda::Permission Conditional). No Add-of-existing / Delete-of-live / Replace.

CCI-055393fd99b04e18921ff78514b8fe3c