### PR TITLE
ENC-TSK-J29: CloudFormationDeployRole capability contract (sqs+dynamodb+sns+iam:Attach) — ISS-453 [v4/main]

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -115,6 +115,12 @@ Resources:
                   - iam:DeleteRolePolicy
                   - iam:ListRolePolicies
                   - iam:ListAttachedRolePolicies
+                  # ENC-TSK-J29: 02-compute (x3) + 07-codedeploy (x1) declare
+                  # AWS::IAM::Role with ManagedPolicyArns; CFN calls Attach/Detach
+                  # on create/update. Was implicitDeny -> a new managed-policy role
+                  # would AccessDenied-rollback the whole stack (ISS-453 class).
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/devops-*"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/enceladus-*"
@@ -183,6 +189,68 @@ Resources:
                   - cloudwatch:TagResource
                   - cloudwatch:UntagResource
                 Resource: "*"
+
+              # ENC-TSK-J29 / ENC-ISS-453 — DATA-STACK (01-data.yaml) resource
+              # types. The role deploys 01-data (14 DynamoDB::Table, 6 SNS::Topic,
+              # 6 SQS::Queue) but the policy granted none of sqs/dynamodb/sns, so a
+              # NEW resource of these types (e.g. ConvergenceTelemetryDLQ) failed
+              # AccessDenied and rolled back the whole changeset. These were briefly
+              # unblocked by an out-of-band inline patch (enceladus-cfn-deploy-gamma-
+              # ddb-sns-v1, gamma-only); codified here as the durable capability
+              # contract, scoped to enceladus-*/devops-* (both prod and gamma).
+              - Sid: SqsQueueOps
+                Effect: Allow
+                Action:
+                  - sqs:CreateQueue
+                  - sqs:DeleteQueue
+                  - sqs:GetQueueAttributes
+                  - sqs:SetQueueAttributes
+                  - sqs:GetQueueUrl
+                  - sqs:ListQueueTags
+                  - sqs:TagQueue
+                  - sqs:UntagQueue
+                Resource:
+                  - !Sub "arn:aws:sqs:us-west-2:${AWS::AccountId}:enceladus-*"
+                  - !Sub "arn:aws:sqs:us-west-2:${AWS::AccountId}:devops-*"
+
+              - Sid: DynamoDBTableOps
+                Effect: Allow
+                Action:
+                  - dynamodb:CreateTable
+                  - dynamodb:DeleteTable
+                  - dynamodb:DescribeTable
+                  - dynamodb:UpdateTable
+                  - dynamodb:DescribeTimeToLive
+                  - dynamodb:UpdateTimeToLive
+                  - dynamodb:DescribeContinuousBackups
+                  - dynamodb:UpdateContinuousBackups
+                  - dynamodb:TagResource
+                  - dynamodb:UntagResource
+                  - dynamodb:ListTagsOfResource
+                Resource:
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/enceladus-*"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/devops-*"
+
+              - Sid: SnsTopicOps
+                Effect: Allow
+                Action:
+                  - sns:CreateTopic
+                  - sns:DeleteTopic
+                  - sns:GetTopicAttributes
+                  - sns:SetTopicAttributes
+                  - sns:Subscribe
+                  - sns:Unsubscribe
+                  - sns:GetSubscriptionAttributes
+                  - sns:SetSubscriptionAttributes
+                  - sns:ListSubscriptionsByTopic
+                  - sns:TagResource
+                  - sns:UntagResource
+                  - sns:ListTagsForResource
+                Resource:
+                  - !Sub "arn:aws:sns:us-west-2:${AWS::AccountId}:enceladus-*"
+                  - !Sub "arn:aws:sns:us-west-2:${AWS::AccountId}:devops-*"
+                  # us-west-1 governance-relay topics (enceladus-*-gamma)
+                  - !Sub "arn:aws:sns:us-west-1:${AWS::AccountId}:enceladus-*"
 
               # Read-only validation permissions required by CloudFormation
               # pre-deployment validation when new rules, pipes, and alarms are


### PR DESCRIPTION
ENC-TSK-J29 (A2 / ENC-ISS-453) — CloudFormationDeployRole capability contract.

The GitHub OIDC CFN deploy role (deploys 01-data/02-compute/03-api/05-monitoring/07-codedeploy) granted **no sqs/dynamodb/sns** actions, so a new 01-data resource (SQS::Queue ConvergenceTelemetryDLQ) failed AccessDenied and rolled back the whole changeset. Capability sweep also found **iam:AttachRolePolicy/DetachRolePolicy** missing (implicitDeny) — needed for the ManagedPolicyArns roles in 02-compute (x3) + 07-codedeploy (x1).

Codifies the full contract into 04-github-roles.yaml (SqsQueueOps + DynamoDBTableOps + SnsTopicOps + Attach/Detach), scoped enceladus-*/devops-* for both prod and gamma. These were briefly unblocked live by an out-of-band inline patch (enceladus-cfn-deploy-gamma-ddb-sns-v1, gamma-only) — this makes the IaC the source of truth so a future github-roles deploy cannot re-strip them.

Applied live this session via put-role-policy; verified with simulate-principal-policy (all allowed incl. prod scope: iam:AttachRolePolicy was implicitDeny -> allowed) and confirmed enceladus-data-gamma is UPDATE_COMPLETE with the DLQ live. CFN validate-template passes (CAPABILITY_NAMED_IAM).

CCI-d6edae0bc1944062abfdfcfe9e50437d