### PR TITLE
ENC-TSK-J30: env-drift auditor legacy consolidation + codify DEPLOY_TABLE (ISS-288 + storm) [v4/main]

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-06-30.14",
-  "updated_at": "2026-06-30T23:15:00Z",
+  "version": "2026-07-01.01",
+  "updated_at": "2026-07-01T12:50:00Z",
   "last_change_summary": "ENC-TSK-I92 (FTR-110 Ph1): graph_query_api hybrid retrieval gains a fifth, additive dispersion/corroboration Weber-law bonus signal layered on top of the existing 4-signal RRF fusion. Each candidate's per_node_fusion/_node_ entry gains k_corr (dispersion-constrained corroborator count -- near-duplicate records, pairwise cosine distance < 0.3, never count as corroborating each other), b_corr (B_corr = Weber_k * ln(1+k_corr)/ln(1+k_max), call-relative normalization, default Weber_k=0.3), final_score (fused_score + b_corr) and final_rank; nodes/per_node_fusion are now ordered by final_score rather than the pure-RRF fused_score (fused_score/fused_rank remain unmodified). Response gains corroboration_weber_k. No existing field renamed/removed; degrades to a no-op when no candidate carries an embedding. Version -> 2026-06-30.14. Prior change (.13) -- ENC-TSK-I98 (FTR-104 Ph1 AC-1/AC-2), the per-retrieval energy function E(x) additive 'energy' block; see that task's worklog for the full change summary.",
   "owners": [
     "enceladus-platform"

--- a/backend/lambda/env_drift_auditor/env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/env_parity_core.py
@@ -207,10 +207,57 @@ def find_signature_match(open_issues: Sequence[Dict[str, Any]], signature: str) 
     token = sig_token(signature)
     for issue in open_issues:
         if token in str(issue.get("title", "")):
-            bare = issue.get("item_id") or issue.get("id")
-            if not bare:
-                rid = str(issue.get("record_id", ""))
-                bare = rid.split("#", 1)[1] if "#" in rid else rid
+            bare = _bare_issue_id(issue)
+            if bare:
+                return bare
+    return None
+
+
+def _bare_issue_id(issue: Dict[str, Any]) -> Optional[str]:
+    """Prefer ``item_id`` (the bare ENC-ISS-NNN the ``/log`` route wants), else the
+    segment after ``#`` in ``record_id``."""
+    bare = issue.get("item_id") or issue.get("id")
+    if not bare:
+        rid = str(issue.get("record_id", ""))
+        bare = rid.split("#", 1)[1] if "#" in rid else rid
+    return bare or None
+
+
+def find_matching_drift_issue(
+    open_issues: Sequence[Dict[str, Any]],
+    signature: str,
+    fn_name: str,
+    missing_vars: Sequence[str],
+) -> Optional[str]:
+    """Find the ONE canonical open issue for a (lambda, missing-var-set) finding.
+
+    ENC-TSK-J30 hardening of the ENC-TSK-H10 dedup: the auditor also consolidates
+    LEGACY, pre-signature ``[auto-drift]`` issues. The 2026-06-18..21 storm filed one
+    tokenless P0 per run (ENC-ISS-319..381 for devops-deploy-intake / SQS_QUEUE_URL);
+    those titles carry no ``[sig:...]`` token, so ``find_signature_match`` never
+    matched them and they orphaned into a permanent open pile — a *new* signature
+    issue would then be a duplicate on top of the storm. Match order:
+      1. exact signature-token match (H10, tokenful issues); then
+      2. the deterministic ``[auto-drift] {fn} missing required env vars: {vars}``
+         title for the SAME fn + missing-var set (legacy / tokenless issues).
+    Guarantees one canonical record per (fn, var-set) rather than a re-storm.
+    """
+    matched = find_signature_match(open_issues, signature)
+    if matched:
+        return matched
+    want = frozenset(v for v in missing_vars if v)
+    if not want:
+        return None
+    prefix = f"[auto-drift] {fn_name} missing required env vars:"
+    for issue in open_issues:
+        title = str(issue.get("title", ""))
+        if not title.startswith(prefix):
+            continue
+        # the vars listed between the prefix and an optional trailing [sig:...] token
+        tail = title[len(prefix):].split("[sig:", 1)[0]
+        vars_in_title = frozenset(v.strip() for v in tail.split(",") if v.strip())
+        if vars_in_title == want:
+            bare = _bare_issue_id(issue)
             if bare:
                 return bare
     return None

--- a/backend/lambda/env_drift_auditor/lambda_function.py
+++ b/backend/lambda/env_drift_auditor/lambda_function.py
@@ -38,6 +38,7 @@ from env_parity_core import (
     classify_required,
     critical_vars,
     drift_signature,
+    find_matching_drift_issue,
     find_signature_match,
     sig_token,
 )
@@ -188,18 +189,22 @@ def _fetch_open_issues() -> List[Dict[str, Any]]:
     return issues
 
 
-def _find_existing_drift_issue(signature: str) -> Tuple[Optional[str], bool]:
-    """Return (matched_issue_id, query_ok) for an OPEN issue carrying ``signature``.
+def _find_existing_drift_issue(
+    signature: str, fn_name: str, missing_vars: List[str]
+) -> Tuple[Optional[str], bool]:
+    """Return (matched_issue_id, query_ok) for the canonical OPEN issue of this finding.
 
     query_ok=False means the lookup itself failed; the caller fails OPEN to filing so a
-    transient query error never silently drops a real finding (ENC-TSK-H10).
+    transient query error never silently drops a real finding (ENC-TSK-H10). ENC-TSK-J30:
+    matches the signature token first, then the legacy tokenless auto-drift title for the
+    same (fn, missing-var set), so a persistent finding stays ONE canonical record.
     """
     try:
         issues = _fetch_open_issues()
     except Exception:
         logger.exception("open-issue dedup query failed")
         return None, False
-    return find_signature_match(issues, signature), True
+    return find_matching_drift_issue(issues, signature, fn_name, missing_vars), True
 
 
 def _bump_drift_issue(issue_id: str, fn_name: str, run_id: str, now: str) -> Dict[str, Any]:
@@ -250,7 +255,7 @@ def _handle_drift_finding(fn_name: str, drift: List[Dict[str, Any]], run_id: str
         logger.info("DRY_RUN: would emit drift for %s (sig=%s) — %s", fn_name, signature, drift)
         return {"dry_run": True, "signature": signature}
 
-    existing_id, query_ok = _find_existing_drift_issue(signature)
+    existing_id, query_ok = _find_existing_drift_issue(signature, fn_name, missing_var_names)
     if existing_id:
         logger.info(
             "drift on %s already tracked by %s (sig=%s) — bumping, not re-filing",

--- a/backend/lambda/env_drift_auditor/test_env_parity_core.py
+++ b/backend/lambda/env_drift_auditor/test_env_parity_core.py
@@ -235,6 +235,31 @@ def test_auditor_idempotent_dedup_bumps_not_refiles():
     assert r2.get("deduped") is True
 
 
+def test_find_matching_drift_issue_consolidates_legacy_tokenless():
+    """ENC-TSK-J30: the matcher consolidates pre-signature (tokenless) auto-drift
+    issues for the same (fn, missing-var set), so a new run bumps the 2026-06 storm
+    issue instead of filing yet another duplicate on top of it."""
+    sig = core.drift_signature("devops-deploy-intake", ["SQS_QUEUE_URL"])
+    legacy = [{
+        "item_id": "ENC-ISS-319",
+        "title": "[auto-drift] devops-deploy-intake missing required env vars: SQS_QUEUE_URL",
+        "status": "open",
+    }]
+    # find_signature_match alone can't see a tokenless legacy issue...
+    assert core.find_signature_match(legacy, sig) is None
+    # ...but find_matching_drift_issue consolidates it by fn + var-set.
+    assert core.find_matching_drift_issue(legacy, sig, "devops-deploy-intake", ["SQS_QUEUE_URL"]) == "ENC-ISS-319"
+    # A different fn or a different missing-var set must NOT match.
+    assert core.find_matching_drift_issue(legacy, sig, "devops-other", ["SQS_QUEUE_URL"]) is None
+    assert core.find_matching_drift_issue(legacy, sig, "devops-deploy-intake", ["DEPLOY_TABLE"]) is None
+    # Signature-token issues still take precedence when both are present.
+    legacy.append({
+        "item_id": "ENC-ISS-T9",
+        "title": f"[auto-drift] devops-deploy-intake missing required env vars: SQS_QUEUE_URL {core.sig_token(sig)}",
+    })
+    assert core.find_matching_drift_issue(legacy, sig, "devops-deploy-intake", ["SQS_QUEUE_URL"]) == "ENC-ISS-T9"
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failures = 0

--- a/infrastructure/lambda-manifests/devops-github-integration.json
+++ b/infrastructure/lambda-manifests/devops-github-integration.json
@@ -9,6 +9,7 @@
     "environment": {
       "COGNITO_CLIENT_ID": "6q607dk3liirhtecgps7hifmlk",
       "COGNITO_USER_POOL_ID": "us-east-1_b2D0V3E1k",
+      "DEPLOY_TABLE": "devops-deployment-manager",
       "DYNAMODB_REGION": "us-west-2",
       "GITHUB_APP_ID": "",
       "GITHUB_INSTALLATION_ID": "",


### PR DESCRIPTION
ENC-TSK-J30 (A3 / ISS-288 + SQS_QUEUE_URL storm).

**Auditor UPSERT hardening:** the env-drift auditor already dedups by (lambda, missing-var) signature token (H10), but the 2026-06-18..21 storm filed one TOKENLESS P0 per run (ENC-ISS-319..381 for devops-deploy-intake / SQS_QUEUE_URL). Those legacy titles carry no [sig:] token, so find_signature_match never matched them — permanent orphans, and a fresh signature issue would duplicate on top. Adds find_matching_drift_issue: signature-token match first, then a fallback consolidating legacy auto-drift titles for the same fn+var-set → one canonical record per (fn,var-set), no re-storm. +unit test (18/18 pass).

**Codify DEPLOY_TABLE** in the devops-github-integration manifest (ISS-288). deploy-intake's SQS_QUEUE_URL is already codified in 02-compute via !ImportValue (H26); github-integration env is not touched by the Gen2 update-function-code path, so neither is re-stripped by its deploy path.

Live state verified: devops-deploy-intake has SQS_QUEUE_URL + COORDINATION_INTERNAL_API_KEY + DEPLOY_TABLE; devops-github-integration has DEPLOY_TABLE — both restores already present.

CCI-2f4fe890b5344be5a25da6f60351f50d