### PR TITLE
ENC-TSK-J32 (J31/ISS-462): env-aware gamma AppConfig IDs + mcp-code-gamma hardcode [main]

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -200,6 +200,16 @@ jobs:
           # canonical :10 ARN here forces the param so the heal moves live; the H24 gate
           # (tools/verify_shared_layer_version.py) asserts this override stays == the canonical pin.
 
+          # ENC-TSK-J31 / ENC-ISS-462: env-aware AppConfig IDs so the gamma stack reads its OWN
+          # feature-flags (enceladus-feature-flags-gamma) instead of prod's. Previously both prod
+          # AND gamma deploys passed the prod IDs (5t3sqte/bnwj3lj), so gamma/UAT silently resolved
+          # prod feature flags. Prod: 5t3sqte/bnwj3lj; gamma: fhhcl7m/zecfu42.
+          if [ "${ENVIRONMENT_SUFFIX}" = "-gamma" ]; then
+            APPCFG_APP="fhhcl7m"; APPCFG_ENV="zecfu42"
+          else
+            APPCFG_APP="5t3sqte"; APPCFG_ENV="bnwj3lj"
+          fi
+
           aws cloudformation deploy \
             --region "${AWS_REGION}" \
             --stack-name "${{ steps.params.outputs.stack_name }}" \
@@ -211,8 +221,8 @@ jobs:
             --parameter-overrides \
               DataStackName="${{ steps.params.outputs.data_stack_name }}" \
               CoordinationInternalApiKey="${{ secrets.COORDINATION_INTERNAL_API_KEY }}" \
-              AppConfigApplicationId="5t3sqte" \
-              AppConfigEnvironmentId="bnwj3lj" \
+              AppConfigApplicationId="${APPCFG_APP}" \
+              AppConfigEnvironmentId="${APPCFG_ENV}" \
               EnceladusCognitoClientSecret="${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}" \
               SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10"
 

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3443,8 +3443,12 @@ Resources:
           ENABLE_LESSON_PRIMITIVE: "true"
           ENABLE_TYPED_RELATIONSHIPS: "true"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
-          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
-          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          # ENC-TSK-J31 / ENC-ISS-462: this function is a GAMMA function but is prod-stack-owned
+          # (Condition: IsProduction, H29/ISS-386 name-collision guard), so it inherits the PROD
+          # stack's AppConfigApplicationId param. Hardcode the GAMMA AppConfig ids so a prod compute
+          # deploy sets it to read gamma feature-flags (enceladus-feature-flags-gamma), not prod's.
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, "fhhcl7m", !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, "zecfu42", !Ref "AWS::NoValue"]
           APPCONFIG_CONFIGURATION: feature-flags
       Tags:
         - Key: Project


### PR DESCRIPTION
J31-carrier (ENC-TSK-J32) for ENC-TSK-J31 / ENC-ISS-462 durable codification.

(1) cloudformation-compute-stack-deploy.yml: select AppConfig IDs by ENVIRONMENT_SUFFIX so the gamma compute deploy passes the new gamma AppConfig (fhhcl7m/zecfu42) instead of prod's (5t3sqte/bnwj3lj). (2) 02-compute.yaml: hardcode gamma AppConfig on the prod-stack-owned enceladus-mcp-code-gamma (Condition:IsProduction) so a prod deploy sets it to gamma feature-flags.

Live already done this session: enceladus-feature-flags-gamma stack (App fhhcl7m / Env zecfu42) created + config deployed; all 27 live gamma Lambdas repointed + verified resolving gamma config; prod AppConfig (5t3sqte/bnwj3lj) untouched. This codifies it so the next compute deploy cannot reset gamma to prod.

NOTE: merging triggers the compute-stack-deploy workflow (its own file + 02-compute are trigger paths) -> gamma compute deploy (v4/main, applies gamma AppConfig) + prod compute deploy (main, prod AppConfig unchanged, mcp-code-gamma -> gamma). Both gated by FTR-102 env-parity + pre-deploy health gate.

CCI-e2b2ff742cc845a58ecbdedf69ae600a