### PR TITLE
ENC-TSK-J27 fix: match imported gamma route logical ids [v4/main]

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -1754,10 +1754,11 @@ Resources:
 
   # ==================================================================
   # ENC-TSK-J27 / ENC-ISS-455 (gamma half): 65 live-only gamma routes
-  # adopted into enceladus-api-gamma via change-set IMPORT (batches j27-b1..b7),
-  # now codified Condition: IsGamma (prod excludes them) + DeletionPolicy: Retain.
+  # adopted into enceladus-api-gamma via change-set IMPORT (batches j27-b1..b7).
+  # Logical ids MATCH the imported stack resources so a deploy is a no-op.
+  # Condition: IsGamma (prod excludes) + DeletionPolicy: Retain.
   # ==================================================================
-  GammaImportedRoute001:
+  ImportedGammaRoute0101:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1766,7 +1767,7 @@ Resources:
       RouteKey: "DELETE /api/v1/coordination/auth/oauth-clients/{clientId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute002:
+  ImportedGammaRoute0102:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1775,7 +1776,7 @@ Resources:
       RouteKey: "DELETE /api/v1/coordination/auth/tokens/{tokenId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute003:
+  ImportedGammaRoute0103:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1784,7 +1785,7 @@ Resources:
       RouteKey: "GET /api/v1/coordination/auth/oauth-clients"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute004:
+  ImportedGammaRoute0104:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1793,7 +1794,7 @@ Resources:
       RouteKey: "GET /api/v1/coordination/auth/tokens"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute005:
+  ImportedGammaRoute0105:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1802,7 +1803,7 @@ Resources:
       RouteKey: "GET /api/v1/coordination/projects"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute006:
+  ImportedGammaRoute0106:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1811,7 +1812,7 @@ Resources:
       RouteKey: "GET /api/v1/coordination/projects/{projectId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute007:
+  ImportedGammaRoute0107:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1820,7 +1821,7 @@ Resources:
       RouteKey: "GET /api/v1/governance/dictionary"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute008:
+  ImportedGammaRoute0108:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1829,7 +1830,7 @@ Resources:
       RouteKey: "GET /api/v1/governance/hash"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute009:
+  ImportedGammaRoute0109:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1838,7 +1839,7 @@ Resources:
       RouteKey: "GET /api/v1/governance/{fileName+}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute010:
+  ImportedGammaRoute0110:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1847,7 +1848,7 @@ Resources:
       RouteKey: "GET /api/v1/health"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute011:
+  ImportedGammaRouteB0201:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1856,7 +1857,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/auth/refresh"
       Target: !Sub integrations/${AuthRefreshIntegration}
 
-  GammaImportedRoute012:
+  ImportedGammaRouteB0202:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1865,7 +1866,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/cognito/session"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute013:
+  ImportedGammaRouteB0203:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1874,7 +1875,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/oauth-clients"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute014:
+  ImportedGammaRouteB0204:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1883,7 +1884,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute015:
+  ImportedGammaRouteB0205:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1892,7 +1893,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/permissions"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute016:
+  ImportedGammaRouteB0206:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1901,7 +1902,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/usage"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute017:
+  ImportedGammaRouteB0207:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1910,7 +1911,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/permissions/{tokenId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute018:
+  ImportedGammaRouteB0208:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1919,7 +1920,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/tokens"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute019:
+  ImportedGammaRouteB0209:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1928,7 +1929,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/auth/tokens/{tokenId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute020:
+  ImportedGammaRouteB0210:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1937,7 +1938,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/capabilities"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute021:
+  ImportedGammaRouteB0301:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1946,7 +1947,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/mcp"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute022:
+  ImportedGammaRouteB0302:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1955,7 +1956,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/monitor"
       Target: !Sub integrations/${CoordinationMonitorIntegration}
 
-  GammaImportedRoute023:
+  ImportedGammaRouteB0303:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1964,7 +1965,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/projects"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute024:
+  ImportedGammaRouteB0304:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1973,7 +1974,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/projects/{projectId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute025:
+  ImportedGammaRouteB0305:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1982,7 +1983,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/requests"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute026:
+  ImportedGammaRouteB0306:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -1991,7 +1992,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/requests/{requestId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute027:
+  ImportedGammaRouteB0307:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2000,7 +2001,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/requests/{requestId}/callback"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute028:
+  ImportedGammaRouteB0308:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2009,7 +2010,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/coordination/requests/{requestId}/dispatch"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute029:
+  ImportedGammaRouteB0309:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2018,7 +2019,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/deploy/history/{projectId}"
       Target: !Sub integrations/${DeployIntakeIntegration}
 
-  GammaImportedRoute030:
+  ImportedGammaRouteB0310:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2027,7 +2028,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/deploy/state/{projectId}"
       Target: !Sub integrations/${DeployIntakeIntegration}
 
-  GammaImportedRoute031:
+  ImportedGammaRouteB0401:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2036,7 +2037,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/deploy/status/{specId}"
       Target: !Sub integrations/${DeployIntakeIntegration}
 
-  GammaImportedRoute032:
+  ImportedGammaRouteB0402:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2045,7 +2046,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/deploy/submit"
       Target: !Sub integrations/${DeployIntakeIntegration}
 
-  GammaImportedRoute033:
+  ImportedGammaRouteB0403:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2054,7 +2055,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/doc-prep/{projectName}"
       Target: !Sub integrations/${DocPrepIntegration}
 
-  GammaImportedRoute034:
+  ImportedGammaRouteB0404:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2063,7 +2064,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/documents"
       Target: !Sub integrations/${DocumentApiIntegration}
 
-  GammaImportedRoute035:
+  ImportedGammaRouteB0405:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2072,7 +2073,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/documents/{documentId}"
       Target: !Sub integrations/${DocumentApiIntegration}
 
-  GammaImportedRoute036:
+  ImportedGammaRouteB0406:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2081,7 +2082,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/feed"
       Target: !Sub integrations/${FeedQueryIntegration}
 
-  GammaImportedRoute037:
+  ImportedGammaRouteB0407:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2090,7 +2091,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/governance/dictionary"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute038:
+  ImportedGammaRouteB0408:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2099,7 +2100,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/governance/hash"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute039:
+  ImportedGammaRouteB0409:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2108,7 +2109,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/governance/{fileName+}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute040:
+  ImportedGammaRouteB0410:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2117,7 +2118,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/health"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute041:
+  ImportedGammaRouteB0501:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2126,7 +2127,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/projects"
       Target: !Sub integrations/${ProjectServiceIntegration}
 
-  GammaImportedRoute042:
+  ImportedGammaRouteB0502:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2135,7 +2136,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/projects/{projectName}"
       Target: !Sub integrations/${ProjectServiceIntegration}
 
-  GammaImportedRoute043:
+  ImportedGammaRouteB0503:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2144,7 +2145,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/reference/search"
       Target: !Sub integrations/${ReferenceSearchIntegration}
 
-  GammaImportedRoute044:
+  ImportedGammaRouteB0504:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2153,7 +2154,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/pending-updates"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute045:
+  ImportedGammaRouteB0505:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2162,7 +2163,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute046:
+  ImportedGammaRouteB0506:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2171,7 +2172,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/relationship"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute047:
+  ImportedGammaRouteB0507:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2180,7 +2181,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute048:
+  ImportedGammaRouteB0508:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2189,7 +2190,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute049:
+  ImportedGammaRouteB0509:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2198,7 +2199,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute050:
+  ImportedGammaRouteB0510:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2207,7 +2208,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute051:
+  ImportedGammaRouteB0601:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2216,7 +2217,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute052:
+  ImportedGammaRouteB0602:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2225,7 +2226,7 @@ Resources:
       RouteKey: "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/log"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute053:
+  ImportedGammaRouteB0603:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2234,7 +2235,7 @@ Resources:
       RouteKey: "OPTIONS /{projectId}/{recordType}/{recordId}"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
-  GammaImportedRoute054:
+  ImportedGammaRouteB0604:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2243,7 +2244,7 @@ Resources:
       RouteKey: "PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/permissions"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute055:
+  ImportedGammaRouteB0605:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2252,7 +2253,7 @@ Resources:
       RouteKey: "PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/usage"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute056:
+  ImportedGammaRouteB0606:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2261,7 +2262,7 @@ Resources:
       RouteKey: "PATCH /api/v1/coordination/auth/permissions/{tokenId}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute057:
+  ImportedGammaRouteB0607:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2270,7 +2271,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/auth/cognito/session"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute058:
+  ImportedGammaRouteB0608:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2279,7 +2280,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/auth/oauth-clients"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute059:
+  ImportedGammaRouteB0609:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2288,7 +2289,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/auth/tokens"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute060:
+  ImportedGammaRouteB0610:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2297,7 +2298,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/components/propose"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute061:
+  ImportedGammaRouteB0701:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2306,7 +2307,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/components/{componentId}/advance"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute062:
+  ImportedGammaRouteB0702:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2315,7 +2316,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/components/{componentId}/approve"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute063:
+  ImportedGammaRouteB0703:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2324,7 +2325,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/components/{componentId}/cloudwatch_event"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute064:
+  ImportedGammaRouteB0704:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain
@@ -2333,7 +2334,7 @@ Resources:
       RouteKey: "POST /api/v1/coordination/components/{componentId}/reject"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
-  GammaImportedRoute065:
+  ImportedGammaRouteB0705:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma
     DeletionPolicy: Retain


### PR DESCRIPTION
ENC-TSK-J27 fix (carrier ENC-TSK-J33) — correct the imported gamma route logical ids.

The initial J27 backport (#692/#693) used GammaImportedRoute* logical ids that did not match the stack's imported routes (ImportedGammaRoute0101../ImportedGammaRouteB..), so a gamma api deploy computed Add(AlreadyExists)+Delete and rolled back (routes survived via DeletionPolicy: Retain). This renames the 65 blocks to the stack's exact logical ids.

Verified via change-set preview against enceladus-api-gamma: 65 Modify, Replacement=False, Target RequiresRecreation=Never (in-place no-op adoption); assert_changeset_safe preview=PASS. audit_cfn_drift --environment gamma routes live_only=0.

CCI-5213f8e31db14b469168c58952ea66f3