### PR TITLE
ENC-TSK-J41: codify GDS/AGA hard-disable to kill Graph Analytics Serverless cost (ENC-ISS-465)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.02",
-  "updated_at": "2026-07-01T18:30:00Z",
-  "last_change_summary": "ENC-TSK-J04 (FTR-074 Ph3): agent identity/session/credential Neo4j graph projection. New entities graph_sync.agent_identity_edges (OGTM write-up: :AgentIdentity/:AgentSession/:AgentCredential nodes + five typed edges AUTHENTICATED_AS/OWNED_BY/DERIVED_FROM/TRIGGERED_BY/MUTATED, registered byte-identically in graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES per ENC-ISS-178) and coordination.agent_credential (new agent-credentials table fields + lifecycle). Satisfies the Governance Dictionary Guard (config.py / graph_sync + graph_query_api lambda_function.py touched in the same change).",
+  "version": "2026-07-01.03",
+  "updated_at": "2026-07-01T21:42:00Z",
+  "last_change_summary": "ENC-TSK-J41 (SEV-1 ENC-ISS-465 cost kill): graph_query_api adds GDS_HARD_DISABLED env gate that short-circuits _check_gds_available()->False (forces cypher_fallback; no Aura Graph Analytics session ever created). No new record schema/edge types introduced; env-gate only. 02-compute.yaml retires the standing GDS projection (prefix->AWS::NoValue, GDS_HARD_DISABLED=1, StandingProjectionRefreshSchedule State=DISABLED). Satisfies the Governance Dictionary Guard (graph_query_api lambda_function.py touched).",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -209,6 +209,7 @@ _HEALTH_PROBE_TOKEN = "governance"
 # ('weight' today; flips to 'flow_weight' once ENC-FTR-108 writes adaptive
 # weights into the slot this projection initializes to 1.0).
 _GDS_STANDING_PROJECTION_PREFIX = os.environ.get("GDS_STANDING_PROJECTION_PREFIX", "").strip()
+_GDS_HARD_DISABLED = os.environ.get("GDS_HARD_DISABLED", "").strip().lower() in ("1", "true", "yes", "on")  # ENC-ISS-465/J41: hard-disable AGA/GDS -> cypher_fallback (kills Graph Analytics Serverless cost)
 _GDS_SESSION_MEMORY = os.environ.get("GDS_SESSION_MEMORY", "2GB").strip() or "2GB"
 _GDS_WEIGHT_PROPERTY = os.environ.get("GDS_WEIGHT_PROPERTY", "weight").strip() or "weight"
 _GDS_FLOW_WEIGHT_PROPERTY = "flow_weight"
@@ -1087,6 +1088,8 @@ def _check_gds_available(driver) -> bool:
 
     Returns True if CALL gds.list() succeeds; False otherwise. Never raises.
     """
+    if _GDS_HARD_DISABLED:
+        return False  # ENC-ISS-465/J41: force cypher_fallback; never create an AGA session
     import time as _time
     now = _time.time()
     if (
@@ -1533,6 +1536,8 @@ def _refresh_standing_projection(driver, project_id: str) -> Dict[str, Any]:
     slot (ENC-FTR-101 AC-5), then stamps a GdsProjectionMeta marker carrying the
     last-refresh epoch for staleness telemetry (AC-3). Never raises.
     """
+    if _GDS_HARD_DISABLED:
+        return {"refreshed": False, "reason": "GDS_HARD_DISABLED", "project_id": project_id}
     graph_name = _standing_projection_name(project_id)
     if not graph_name:
         return {"refreshed": False, "reason": "GDS_STANDING_PROJECTION_PREFIX unset", "project_id": project_id}

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1168,7 +1168,12 @@ Resources:
           # next compute deploy does not strip it (ENC-LSN-053 strip-class drift).
           # Prod-only: gamma uses a separate AuraDB and its compute deploy is blocked
           # (ENC-ISS-197), so the feature stays dormant there (AWS::NoValue omits the key).
-          GDS_STANDING_PROJECTION_PREFIX: !If [IsProduction, "gds_standing", !Ref "AWS::NoValue"]
+          # ENC-ISS-465 / ENC-TSK-J41 (SEV-1 cost kill): standing GDS projection retired.
+          # Prefix forced to AWS::NoValue (feature OFF) and GDS_HARD_DISABLED=1 short-circuits
+          # _check_gds_available()->False so NO Aura Graph Analytics session (standing warm-path
+          # OR per-query gds.graph.project) is ever created; graph signal uses cypher_fallback.
+          GDS_STANDING_PROJECTION_PREFIX: !Ref "AWS::NoValue"
+          GDS_HARD_DISABLED: "1"
           # ENC-FTR-087 Phase 1 (ENC-TSK-I85): wave-close drift telemetry sink.
           # Codified here so a compute deploy never strips it (ENC-LSN-053 class).
           DRIFT_TELEMETRY_TABLE: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
@@ -1734,7 +1739,7 @@ Resources:
       Name: !Sub "enceladus-standing-projection-refresh${EnvironmentSuffix}"
       Description: "ENC-FTR-101 Option B: refresh the standing GDS projection for graph_query_api hybrid PPR."
       ScheduleExpression: rate(30 minutes)
-      State: ENABLED
+      State: DISABLED  # ENC-ISS-465/J41: 30-min AGA warmer retired (cost kill)
       Targets:
         - Arn: !GetAtt GraphQueryApiFunction.Arn
           Id: standing-projection-refresh


### PR DESCRIPTION
## SEV-1 cost remediation — ENC-ISS-465 / ENC-TSK-J41

CCI-207e529ed9c8420a9ad7611ccee4a27b

### Problem
Neo4j Aura **Graph Analytics Serverless** (AGA Sessions) drove a ~$258/mo spike (invoice ZKLRZSUK-0003; telemetry **DOC-EBF5DAB8E1FC**: 674 sessions, prod instance `2447873d`, Apr 135 → May 0 → Jun 548). Root cause **ENC-FTR-101** standing GDS projection + per-query PPR (`gds.graph.project {memory:'2GB'}`) in `graph_query_api`.

Emergency manual mitigation was applied 2026-07-01 (prod warmer disabled, standing projection dropped, env+code hotfixed on prod+gamma) but is **ephemeral** — a CFN deploy (`enceladus-cloudformation-deploy-github-role`) reverted gamma env at 21:26:35Z. This PR **codifies the kill** so future deploys can't restore the cost.

### Changes
- **`graph_query_api/lambda_function.py`**: add `GDS_HARD_DISABLED` env gate. `_check_gds_available()` returns `False` when set → forces `cypher_fallback`, so neither the standing warm-path nor the per-query `gds.graph.project` ever creates an AGA session. `_refresh_standing_projection` no-ops.
- **`02-compute.yaml`**: `GDS_STANDING_PROJECTION_PREFIX` → `AWS::NoValue`; add `GDS_HARD_DISABLED: "1"`; `StandingProjectionRefreshSchedule` `State: DISABLED` (retire the 30-min warmer).

### Blast radius
Anchored hybrid retrieval degrades PPR → Cypher graph proxy (documented graceful fallback, FTR-101 AC-3 / ENC-TSK-G98). Vector + keyword unaffected. Primary DB untouched. **Reversible**: unset `GDS_HARD_DISABLED` / re-enable the rule.

### Scope note
Base `v4/main` → deploys to **gamma**. Prod is the separate frozen io-gated cutover; prod manual mitigation holds until then. PLN-006 Phase-1 (FTR-101) impact + exhaustive COE tracked as follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)