### PR TITLE
ENC-TSK-J43: backport I38 agent-session HTTP routes to v4/main + credential_id binding

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -272,6 +272,19 @@ def mint_session_id(
     if not agent_type_id:
         raise ValueError("agent_type_id is required to mint a session")
 
+    # ENC-TSK-J43: when a session is bound to a credential, that credential must exist and
+    # be active at mint time. Binding to a missing/revoked credential is rejected so the
+    # revoke cascade's invariant holds (a live session's bound credential is always live).
+    if credential_id:
+        bound = get_credential(credential_id)
+        if bound is None:
+            raise ValueError(f"credential_id {credential_id!r} not found")
+        if bound.get("status") != "active":
+            raise ValueError(
+                f"credential_id {credential_id!r} is not active "
+                f"(status={bound.get('status')!r})"
+            )
+
     now = _now_z()
     resolved_claimed_at = claimed_at or (now if status == "claimed" else "")
 

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,40 +1,40 @@
 {
-  "version": "2026-07-01.03",
-  "updated_at": "2026-07-01T21:42:00Z",
-  "last_change_summary": "ENC-TSK-J41 (SEV-1 ENC-ISS-465 cost kill): graph_query_api adds GDS_HARD_DISABLED env gate that short-circuits _check_gds_available()->False (forces cypher_fallback; no Aura Graph Analytics session ever created). No new record schema/edge types introduced; env-gate only. 02-compute.yaml retires the standing GDS projection (prefix->AWS::NoValue, GDS_HARD_DISABLED=1, StandingProjectionRefreshSchedule State=DISABLED). Satisfies the Governance Dictionary Guard (graph_query_api lambda_function.py touched).",
+  "version": "2026-07-01.04",
+  "updated_at": "2026-07-01T21:59:00Z",
+  "last_change_summary": "ENC-TSK-J43: backported coordination.agent_session/coordination.agent_type entities + mcp_server.agent_actions entity (I38 HTTP routes, ported to v4/main gamma) and credential_id session-binding field.",
   "owners": [
     "enceladus-platform"
   ],
   "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
   "entities": {
     "tracker.dedup_auto_merge": {
-      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 \u00a7P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL \u2014 judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
       "fields": {
         "enable_dedup_auto_merge": {
           "type": "feature_flag",
-          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 \u00a74.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
           "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
         },
         "dedup_auto_merge_kill_switch": {
           "type": "feature_flag",
-          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} \u2014 auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 \u00a78).",
           "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
         },
         "precision_lcb_floor": {
           "type": "number",
           "default": 0.999,
-          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 \u00a74.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 \u2014 auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, \u00a74.4).",
           "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
         },
         "auto_walk_opt_out_latch": {
           "type": "behavior",
-          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
-          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge \u2014 un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source \u2014 PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required \u2014 the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
         },
         "audit_feed": {
           "type": "event",
           "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
-          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 \u00a710)."
         }
       }
     },
@@ -57,8 +57,8 @@
             "deployed",
             "superseded"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -110,8 +110,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -120,7 +120,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -146,14 +146,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -244,7 +244,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -254,12 +254,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -273,7 +273,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -289,7 +289,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -297,8 +297,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -343,7 +343,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -355,9 +355,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         },
         "auto_walk_opt_out": {
@@ -372,7 +372,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -421,7 +421,7 @@
             "closed",
             "superseded"
           ],
-          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
+          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
         },
         "priority": {
           "type": "enum",
@@ -487,7 +487,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -507,7 +507,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -704,7 +704,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
         }
       }
     },
@@ -740,7 +740,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -860,7 +860,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -885,7 +885,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -993,7 +993,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -1102,7 +1102,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -1131,7 +1131,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1239,7 +1239,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1371,7 +1371,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1397,7 +1397,7 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
           "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
@@ -1775,18 +1775,18 @@
           ],
           "default": "ci_triggered",
           "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
-          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field \u2014 including enceladus \u2014 are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier \u2014 never from evidence-field emptiness (DOC-078C57FC1BE6 \u00a77.2). seed value: enceladus = ci_triggered."
         }
       }
     },
     "lifecycle_service.arc_walker_walk": {
-      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 \u00a76.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (\u00a73.1/\u00a711): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) \u2014 distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the \u00a77.2 coding-complete trap).",
       "governing_feature": "ENC-FTR-111",
       "governing_task": "ENC-TSK-H85",
       "fields": {
         "feature_flag": {
           "type": "string",
-          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
+          "definition": "enable_arc_walker \u2014 independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 \u00a711).",
           "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
         },
         "phase1_legs": {
@@ -1796,19 +1796,19 @@
         },
         "idempotent_conditional_write": {
           "type": "object",
-          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly \u2014 no double-step, no lost update (DOC-078C57FC1BE6 \u00a78 idempotency / \u00a79 concurrent-advance mitigation)."
         },
         "safety_invariants": {
           "type": "object",
-          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity \u2014 a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning \u2014 if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
         },
         "write_source": {
           "type": "string",
-          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the \u00a713 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
         },
         "artifact_genesis": {
           "type": "string",
-          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 \u00a78/\u00a710): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
         }
       }
     },
@@ -2266,7 +2266,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2293,7 +2293,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2364,7 +2364,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2521,7 +2521,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2547,7 +2547,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2603,7 +2603,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2664,7 +2664,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2706,14 +2706,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -2742,7 +2742,7 @@
       }
     },
     "component_registry.component": {
-      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement — the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict — see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
       "fields": {
         "component_id": {
           "type": "string",
@@ -2781,7 +2781,7 @@
             "code_only",
             "no_code"
           ],
-          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement — see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
+          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement \u2014 see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
         },
         "required_transition_type": {
           "type": "string",
@@ -2800,9 +2800,9 @@
             "code_only": 2,
             "no_code": 3
           },
-          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field — not the legacy transition_type — and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
-          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent — same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
-          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) — raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
+          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field \u2014 not the legacy transition_type \u2014 and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
+          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent \u2014 same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
+          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) \u2014 raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
         },
         "description": {
           "type": "string",
@@ -2845,9 +2845,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -2880,11 +2880,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -2901,18 +2901,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -3014,7 +3014,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -3068,17 +3068,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -3096,7 +3096,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -3109,12 +3109,12 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
       "description": "Five-surface defense-in-depth contract for required_transition_type on component_registry.component (ENC-TSK-F50 / ENC-ISS-270). Mirrors the governance.ogtm pattern (ENC-FTR-066): every component record must carry required_transition_type, and every write path into the component registry validates its presence and type. Governance-intent source: DOC-240A67973B13 (AC-1 per-component review document).",
@@ -3250,12 +3250,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3278,7 +3278,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3572,7 +3572,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape \u2014 they do not abort the batch."
         }
       },
       "covered_lambdas": [
@@ -3909,7 +3909,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -3937,7 +3937,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -3950,7 +3950,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -3981,9 +3981,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -4091,7 +4091,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -4106,7 +4106,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -4369,7 +4369,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4399,7 +4399,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4416,12 +4416,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4454,23 +4454,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan → document. Attaches a document as reference material for the plan.",
+          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -4651,11 +4651,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -4688,7 +4688,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         },
         "orphan_purge_on_edge_removal": {
           "type": "string",
@@ -4743,7 +4743,7 @@
       }
     },
     "tracker.pathway_traversed": {
-      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection \u2014 graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation \u2014 tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability \u2014 graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
       "fields": {
         "edge_label": {
           "type": "string",
@@ -4751,11 +4751,11 @@
         },
         "relationship_type": {
           "type": "string",
-          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) \u2014 the lowercase tracker_mutation relationship_type keys."
         },
         "scoring_exclusion": {
           "type": "boolean",
-          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+          "definition": "true \u2014 excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
         },
         "ogtm_compliance": {
           "type": "object",
@@ -4764,7 +4764,7 @@
       }
     },
     "graph_query_api.pathway_telemetry": {
-      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response \u2014 this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
       "fields": {
         "request_params": {
           "type": "object",
@@ -4785,7 +4785,7 @@
       }
     },
     "graph_query_api.drift_telemetry": {
-      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub \u2014 the ENC-FTR-105 AC-8 wiring slot for a later task. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
       "fields": {
         "table": {
           "type": "string",
@@ -4806,7 +4806,7 @@
       }
     },
     "graph_query_api.vector_read": {
-      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector \u2014 the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
       "fields": {
         "offset": {
           "type": "integer",
@@ -4836,7 +4836,7 @@
       }
     },
     "graph_query_api.adjacency": {
-      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes \u2014 OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
       "fields": {
         "project_id": {
           "type": "string",
@@ -4909,7 +4909,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -4928,12 +4928,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md §13 Governance File Authority"
+          "reference": "agents.md \u00a713 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -4945,7 +4945,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -4972,7 +4972,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -4985,7 +4985,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -5019,7 +5019,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -5157,7 +5157,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5206,7 +5206,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -5227,7 +5227,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5322,7 +5322,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -5359,7 +5359,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -5426,12 +5426,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match — fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match \u2014 fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -5441,28 +5441,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",
@@ -5544,7 +5544,7 @@
       }
     },
     "deploy.parity_validator": {
-      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "description": "ENC-FTR-091 / ENC-TSK-F87 \u2014 v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
       "fields": {
         "function_name": {
           "type": "string",
@@ -5557,12 +5557,12 @@
         "detection_rules": {
           "type": "array",
           "item_type": "string",
-          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent \u2014 autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent \u2014 autonomous fix. ISS-279: enceladus-mcp-code-gamma missing \u2014 flag only. ISS-296: function_name_map gaps \u2014 flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas \u2014 flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api \u2014 flag only."
         },
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -5571,7 +5571,7 @@
       }
     },
     "auth.github_installation_token": {
-      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "description": "Response contract for GET /api/v1/auth/github-token \u2014 vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
       "fields": {
         "token": {
           "type": "string",
@@ -5592,7 +5592,7 @@
         },
         "env_fallback": {
           "type": "string",
-          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
         },
         "default": {
           "type": "boolean",
@@ -5605,12 +5605,12 @@
             "env_fallback",
             "default"
           ],
-          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
         }
       }
     },
     "monitoring.continuous_drift_audit": {
-      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
       "fields": {
         "trigger": {
           "type": "string",
@@ -5631,12 +5631,12 @@
         },
         "alert_channel": {
           "type": "string",
-          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
         }
       }
     },
     "monitoring.mentions_drift_audit": {
-      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 \u2014 Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
       "governing_feature": "ENC-FTR-098",
       "governing_task": "ENC-TSK-G43",
       "fields": {
@@ -5662,7 +5662,7 @@
         },
         "iam_scope": {
           "type": "string",
-          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design \u2014 ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
         }
       }
     },
@@ -5705,7 +5705,7 @@
       }
     },
     "telemetry.eligible_fields": {
-      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge.",
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only \u2014 it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge.",
       "governing_feature": "ENC-FTR-086",
       "governing_task": "ENC-TSK-I83",
       "design_source": "DOC-E3F5E025B3D9",
@@ -5722,7 +5722,7 @@
           "type": "string",
           "required": true,
           "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
-          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint \u2014 this is a policy answer, not a degraded failure."
         },
         "record_type": {
           "type": "string",
@@ -5829,15 +5829,15 @@
           "enum": [
             "governance-version-current"
           ],
-          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
+          "usage_guidance": "Partition key. Always 'governance-version-current' \u2014 single-item canonical record."
         },
         "governance_revision": {
           "type": "string",
-          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md \u00a713."
         },
         "governance_hash": {
           "type": "string",
-          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per \u00a74.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
         },
         "generation": {
           "type": "integer",
@@ -5862,7 +5862,7 @@
       }
     },
     "recompute_governance.event_handler": {
-      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes \u00a74.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
       "fields": {
         "trigger": {
           "type": "object",
@@ -5882,7 +5882,7 @@
         },
         "recursion_invariant": {
           "type": "object",
-          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject \u2014 prevents ObjectCreated loops."
         },
         "env_vars": {
           "type": "object",
@@ -5891,7 +5891,7 @@
       }
     },
     "coordination_api.governance_hash_resolution": {
-      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed \u2014 it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 \u00a72.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
       "fields": {
         "primary_source": {
           "type": "object",
@@ -5903,7 +5903,7 @@
         },
         "removed_fallback": {
           "type": "object",
-          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents \u2014 stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
         },
         "env_vars": {
           "type": "object",
@@ -5912,7 +5912,7 @@
       }
     },
     "coordination_api.session_init_intent_classifier": {
-      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized \u2014 same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced \u2014 predictions are returned inline (AC-4). Scope guard (AC-5): inference-only \u2014 intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
       "fields": {
         "routes": {
           "type": "object",
@@ -5953,11 +5953,11 @@
         },
         "tier_3_canonical_ddb": {
           "type": "object",
-          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely \u2014 valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
         },
         "tier_4_s3_catalog": {
           "type": "object",
-          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort \u2014 no longer the primary docstore path."
         },
         "env_vars": {
           "type": "object",
@@ -5966,7 +5966,7 @@
       }
     },
     "governance_drift_check.handler": {
-      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the \u00a74.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
       "fields": {
         "drift_metric": {
           "type": "object",
@@ -6015,7 +6015,7 @@
       "telemetry_eligible": true
     },
     "monitoring.dedup_convergence_probe": {
-      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
       "fields": {
         "signals": {
           "type": "array",
@@ -6032,8 +6032,8 @@
         },
         "walk_back_model_health": {
           "type": "object",
-          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
-          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 \u00a710). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (\u00a713/\u00a74.3), so the live walk-back rate is 0 / shadow until then."
         },
         "config_env_vars": {
           "type": "array",
@@ -6146,6 +6146,90 @@
         "type": "string",
         "definition": "agent-sessions rows may carry an OPTIONAL credential_id binding the session to the credential it authenticated with (written only when provided by mint_session_id, preserving the frozen SESSION_NODE_PROPERTIES value-identity shape for the credential-less path). revoke_credential's cascade reaps live sessions whose credential_id matches."
       }
+    },
+    "coordination.agent_session": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Session-allocation store (DynamoDB table agent-sessions${EnvironmentSuffix}) keyed by a server-minted ENC-SES-NNN; one row per governed agent session. Monotonic single-assignment: a minted, claimed, or retired id is never reissued (sessions retire, they do not recycle). v3 flat store; the property set is value-identical to the intended v4 session node so v4 promotion is a backfill, not a reshape (binding release gate, DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py) reusing tracker_mutation's discipline; callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-SES' sentinel row in the same table (excluded from v4 node backfill). The coordination(action=agent.*) MCP surface is ENC-TSK-I38; the active_agent_session_id value-swap is ENC-TSK-I40. Backported to v4/main gamma by ENC-TSK-J43 (I38 HTTP routes only existed on main/v3-prod prior). ENC-TSK-J43 / ENC-FTR-074 Ph3 additionally added the optional credential_id binding field so a session can be linked to an AgentCredential (coordination.agent_credential) for cascade-revocation and graph AUTHENTICATED_AS/OWNED_BY chain verification; streamed to graph_sync for :AgentSession node + AUTHENTICATED_AS/TRIGGERED_BY/MUTATED edges (see graph_sync.agent_identity_edges).",
+      "fields": {
+        "session_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-SES-NNN (partition key). base-36 monotonic sequence (ENC-FTR-056 discipline). Never caller-supplied (ENC-TSK-B99 ID Boundary Rule)."
+        },
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Foreign key to coordination.agent_type (ENC-AGT-NNN) -- the agent type this session is typed as."
+        },
+        "parent_session_id": {
+          "type": "string",
+          "definition": "ENC-SES-NNN of the dispatching parent session, or 'root' for a self-allocated (ad-hoc) session."
+        },
+        "runtime": {
+          "type": "string",
+          "definition": "Session runtime/surface descriptor (e.g. 'cc-desktop-opus48')."
+        },
+        "created_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC mint timestamp."
+        },
+        "claimed_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC claim timestamp; empty until claimed. A pre-allocated (dispatched) session stays 'allocated' with empty claimed_at until the child claims it (ENC-TSK-I38)."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "allocated",
+            "claimed",
+            "retired"
+          ],
+          "definition": "Session lifecycle. allocated -> claimed (allocated-to-claimed flip on claim) -> retired. A self-allocated session is minted directly as claimed. Append-only; retire never recycles the id. Also flipped to retired by a bound credential's revoke cascade (ENC-TSK-J43)."
+        },
+        "credential_id": {
+          "type": "string",
+          "definition": "ENC-TSK-J43 / ENC-FTR-074 Ph3. Optional foreign key to coordination.agent_credential. Written ONLY when the session is minted with a credential_id (validated active at mint time); omitted entirely -- not written as an empty string -- when no credential is bound, to preserve the frozen v4 SESSION_NODE_PROPERTIES shape (DOC-05C45B438FC1). Drives the graph AUTHENTICATED_AS edge target resolution alongside agent_type_id, and is the scan-filter key revoke_credential's cascade uses to find and retire bound sessions."
+        }
+      }
+    },
+    "coordination.agent_type": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Agent-type directory (DynamoDB table agent-types${EnvironmentSuffix}) keyed by a server-minted ENC-AGT-NNN; one durable row per surface-and-model tuple (e.g. Claude Desktop / Opus 4.8). Low-volume controlled vocabulary, not a per-session record. Property set value-identical to the intended v4 agent-type node (DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py); callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-AGT' sentinel row. Agent-type nodes are the retrieval-eligible half of the Agent ID model; selection telemetry (usage_count) supports cheapest-sufficient agent-type choice. Backported to v4/main gamma by ENC-TSK-J43.",
+      "fields": {
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-AGT-NNN (partition key). base-36 monotonic sequence. Never caller-supplied (ENC-TSK-B99)."
+        },
+        "surface": {
+          "type": "string",
+          "definition": "Agent surface (e.g. Claude Desktop, Claude Code Terminal, Cursor Cloud, Codex, Bedrock)."
+        },
+        "model": {
+          "type": "string",
+          "definition": "Model (e.g. Opus 4.8, Sonnet 4.6, Haiku 4.5)."
+        },
+        "cost_tier": {
+          "type": "string",
+          "definition": "Relative cost tier, used for the power-versus-cost agent-type selection decision."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "deprecated"
+          ],
+          "definition": "active, or deprecated when the underlying model is superseded."
+        },
+        "usage_count": {
+          "type": "integer",
+          "definition": "Server-incremented count of sessions of this agent type. Observed telemetry, not a hand-maintained fit assertion."
+        }
+      }
+    },
+    "mcp_server.agent_actions": {
+      "description": "ENC-TSK-I38, backported to v4/main gamma by ENC-TSK-J43. The coordination(action=agent.*) MCP tool surface: agent.register/agent.claim/agent.list/agent.retire proxy to POST/GET /api/v1/coordination/agents/sessions[/claim|/{id}/retire] on coordination_api; agent.type.list/agent.type.register proxy to GET/POST /api/v1/coordination/agents/types. All routes go through the real coordination_api Lambda over HTTPS (tools/enceladus-mcp-server/server.py _coordination_api_request) -- never fabricated/mocked. ENC-TSK-J43 additionally threads an optional credential_id through agent.register's payload build, forwarded only when the caller supplies it (fully backward compatible).",
+      "fields": {
+        "agent_register.credential_id": {
+          "type": "string",
+          "definition": "ENC-TSK-J43. Optional. When supplied, binds the minted session to an existing active AgentCredential (coordination.agent_credential); the underlying coordination_api call rejects (400) an unknown or non-active credential_id."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6153,12 +6237,12 @@
     {
       "version": "2026-06-27.05",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop \u2014 governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 \u00a74.3 hash). New entity: governance_drift_check.handler. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-27.01",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution — agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
+      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution \u2014 agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
     },
     {
       "version": "2026-06-21.02",
@@ -6173,12 +6257,12 @@
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",
-      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
     },
     {
       "version": "2026-06-27.03",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, §4.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, \u00a74.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-28.06",
@@ -6189,6 +6273,11 @@
       "version": "2026-07-01.02",
       "date": "2026-07-01",
       "summary": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-identity graph projection. Added entity graph_sync.agent_identity_edges (node projections + five typed edges: AUTHENTICATED_AS, OWNED_BY, DERIVED_FROM, TRIGGERED_BY, MUTATED) and entity coordination.agent_credential (agent-credentials store: credential_id, agent_identity_id, issued_at, status, revoked_at, revoked_reason, rotated_from + optional session credential_id binding). Edge labels registered byte-identically across graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178). All projection rides the existing DynamoDB Streams -> EventBridge Pipe -> SQS -> graph_sync path (no write amplification, no synchronous Neo4j on the hot path)."
+    },
+    {
+      "version": "2026-07-01.04",
+      "task": "ENC-TSK-J43",
+      "summary": "Backported I38 agent-session HTTP routes to v4/main + credential_id binding on coordination.agent_session."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -13209,6 +13209,145 @@ def _handle_agent_credential_revoke(credential_id: str, event: Dict[str, Any]) -
     return _response(200, {"success": True, **summary})
 
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-I38 — Agent identity handlers (agent.*) — ported to v4/main by ENC-TSK-J43
+# ---------------------------------------------------------------------------
+
+def _handle_agent_session_register(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """POST /api/v1/coordination/agents/sessions — mint a new ENC-SES-NNN session."""
+    body = _json_body(event) or {}
+    if body.get("session_id"):
+        return _error(400, "session_id must not be provided — ids are minted server-side (ENC-TSK-B99)", retryable=False)
+    agent_type_id = str(body.get("agent_type_id") or "").strip()
+    runtime = str(body.get("runtime") or "").strip()
+    parent_session_id = str(body.get("parent_session_id") or "root").strip()
+    status = str(body.get("status") or "allocated").strip()
+    # ENC-TSK-J43: optional credential binding (ENC-FTR-074 Ph3). Omitting it is fully
+    # backward-compatible — the session is minted credential-less exactly as before.
+    credential_id = str(body.get("credential_id") or "").strip()
+    if not agent_type_id:
+        return _error(400, "agent_type_id is required", retryable=False)
+    if not runtime:
+        return _error(400, "runtime is required", retryable=False)
+    if status not in _agent_id_alloc.SESSION_STATUSES:
+        return _error(400, f"status must be one of {list(_agent_id_alloc.SESSION_STATUSES)}", retryable=False)
+    try:
+        item = _agent_id_alloc.mint_session_id(
+            agent_type_id=agent_type_id,
+            runtime=runtime,
+            parent_session_id=parent_session_id,
+            status=status,
+            credential_id=credential_id,
+            caller_payload=body,
+        )
+    except _agent_id_alloc.CallerSuppliedIdError as exc:
+        return _error(400, str(exc), retryable=False)
+    except ValueError as exc:
+        # Invalid status or invalid/inactive credential_id (ENC-TSK-J43).
+        return _error(400, str(exc), retryable=False)
+    except _agent_id_alloc.IdAllocationError as exc:
+        logger.exception("[ERROR] mint_session_id failed: %s", exc)
+        return _error(500, "Failed to allocate session id — see Lambda logs")
+    return _response(201, {"session": item})
+
+
+def _handle_agent_session_claim(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """POST /api/v1/coordination/agents/sessions/claim — flip allocated → claimed."""
+    body = _json_body(event) or {}
+    session_id = str(body.get("session_id") or "").strip()
+    expected_agent_type_id = str(body.get("expected_agent_type_id") or "").strip() or None
+    if not session_id:
+        return _error(400, "session_id is required", retryable=False)
+    try:
+        item = _agent_id_alloc.claim_session(session_id, expected_agent_type_id=expected_agent_type_id)
+    except ValueError as exc:
+        return _error(400, str(exc), retryable=False)
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] claim_session failed: %s", exc)
+        return _error(500, "DynamoDB error during session claim")
+    return _response(200, {"session": item})
+
+
+def _handle_agent_session_list(event: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/agents/sessions — live session directory."""
+    params = event.get("queryStringParameters") or {}
+    status = str(params.get("status") or "").strip() or None
+    agent_type_id = str(params.get("agent_type_id") or "").strip() or None
+    if status and status not in _agent_id_alloc.SESSION_STATUSES:
+        return _error(400, f"status must be one of {list(_agent_id_alloc.SESSION_STATUSES)}", retryable=False)
+    try:
+        sessions = _agent_id_alloc.list_sessions(status=status, agent_type_id=agent_type_id)
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] list_sessions failed: %s", exc)
+        return _error(500, "Failed to list sessions")
+    return _response(200, {"sessions": sessions, "count": len(sessions)})
+
+
+def _handle_agent_session_retire(
+    session_id: str, event: Dict[str, Any], claims: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/agents/sessions/{id}/retire — graceful close."""
+    if not session_id:
+        return _error(400, "session_id is required", retryable=False)
+    try:
+        item = _agent_id_alloc.retire_session(session_id)
+    except ValueError as exc:
+        return _error(400, str(exc), retryable=False)
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] retire_session failed: %s", exc)
+        return _error(500, "DynamoDB error during session retire")
+    return _response(200, {"session": item})
+
+
+def _handle_agent_type_list(event: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/agents/types — agent-type directory."""
+    params = event.get("queryStringParameters") or {}
+    status = str(params.get("status") or "").strip() or None
+    if status and status not in _agent_id_alloc.AGENT_TYPE_STATUSES:
+        return _error(400, f"status must be one of {list(_agent_id_alloc.AGENT_TYPE_STATUSES)}", retryable=False)
+    try:
+        types = _agent_id_alloc.list_agent_types(status=status)
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] list_agent_types failed: %s", exc)
+        return _error(500, "Failed to list agent types")
+    return _response(200, {"agent_types": types, "count": len(types)})
+
+
+def _handle_agent_type_register(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """POST /api/v1/coordination/agents/types — idempotent agent-type registration."""
+    body = _json_body(event) or {}
+    if body.get("agent_type_id"):
+        return _error(400, "agent_type_id must not be provided — ids are minted server-side (ENC-TSK-B99)", retryable=False)
+    surface = str(body.get("surface") or "").strip()
+    model = str(body.get("model") or "").strip()
+    cost_tier = str(body.get("cost_tier") or "").strip()
+    if not surface:
+        return _error(400, "surface is required", retryable=False)
+    if not model:
+        return _error(400, "model is required", retryable=False)
+    if not cost_tier:
+        return _error(400, "cost_tier is required", retryable=False)
+    try:
+        existing = _agent_id_alloc.find_agent_type(surface=surface, model=model)
+        if existing:
+            return _response(200, {"agent_type": existing, "created": False})
+        item = _agent_id_alloc.mint_agent_type_id(
+            surface=surface,
+            model=model,
+            cost_tier=cost_tier,
+            caller_payload=body,
+        )
+    except _agent_id_alloc.CallerSuppliedIdError as exc:
+        return _error(400, str(exc), retryable=False)
+    except _agent_id_alloc.IdAllocationError as exc:
+        logger.exception("[ERROR] mint_agent_type_id failed: %s", exc)
+        return _error(500, "Failed to allocate agent type id — see Lambda logs")
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] agent_type register DDB error: %s", exc)
+        return _error(500, "DynamoDB error during agent type registration")
+    return _response(201, {"agent_type": item, "created": True})
+
+
 def _handle_auth_tokens_create(event: Dict[str, Any]) -> Dict[str, Any]:
     try:
         body = _json_body(event)
@@ -14211,6 +14350,35 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     )
     if method == "POST" and match_cred_revoke:
         return _handle_agent_credential_revoke(match_cred_revoke.group(1), event)
+
+    # --- ENC-TSK-I38: Agent identity routes (ported to v4/main by ENC-TSK-J43) ---
+
+    # GET /api/v1/coordination/agents/sessions
+    if method == "GET" and path == "/api/v1/coordination/agents/sessions":
+        return _handle_agent_session_list(event)
+
+    # POST /api/v1/coordination/agents/sessions
+    if method == "POST" and path == "/api/v1/coordination/agents/sessions":
+        return _handle_agent_session_register(event, claims or {})
+
+    # POST /api/v1/coordination/agents/sessions/claim
+    if method == "POST" and path == "/api/v1/coordination/agents/sessions/claim":
+        return _handle_agent_session_claim(event, claims or {})
+
+    # POST /api/v1/coordination/agents/sessions/{id}/retire
+    match_session_retire = re.fullmatch(
+        r"/api/v1/coordination/agents/sessions/([A-Za-z0-9_\-]+)/retire", path
+    )
+    if method == "POST" and match_session_retire:
+        return _handle_agent_session_retire(match_session_retire.group(1), event, claims or {})
+
+    # GET /api/v1/coordination/agents/types
+    if method == "GET" and path == "/api/v1/coordination/agents/types":
+        return _handle_agent_type_list(event)
+
+    # POST /api/v1/coordination/agents/types
+    if method == "POST" and path == "/api/v1/coordination/agents/types":
+        return _handle_agent_type_register(event, claims or {})
 
     # GET /api/v1/coordination/auth/tokens
     if method == "GET" and path == "/api/v1/coordination/auth/tokens":

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -641,6 +641,53 @@ class CredentialLifecycleTest(unittest.TestCase):
         self.assertEqual(alloc.get_credential(b["credential_id"])["status"], "revoked")
         self.assertLessEqual(len(summary["revoked_credentials"]), 2)
 
+    # -- ENC-TSK-J43: mint_session_id credential_id binding + validation ------
+    def test_mint_session_with_valid_credential_binds_field(self):
+        cred = alloc.issue_credential(agent_identity_id="ENC-AGT-001")
+        item = alloc.mint_session_id(
+            agent_type_id="ENC-AGT-001", runtime="cc-desktop",
+            status="claimed", credential_id=cred["credential_id"],
+        )
+        # The binding field is written under the exact name the revoke cascade reads.
+        self.assertEqual(item["credential_id"], cred["credential_id"])
+        persisted = alloc.get_session(item["session_id"])
+        self.assertEqual(persisted["credential_id"], cred["credential_id"])
+
+    def test_mint_session_with_missing_credential_raises(self):
+        with self.assertRaises(ValueError):
+            alloc.mint_session_id(
+                agent_type_id="ENC-AGT-001", runtime="cc-desktop",
+                credential_id="CRED-doesnotexist",
+            )
+
+    def test_mint_session_with_revoked_credential_raises(self):
+        cred = alloc.issue_credential(agent_identity_id="ENC-AGT-001")
+        alloc.revoke_credential(cred["credential_id"])
+        with self.assertRaises(ValueError):
+            alloc.mint_session_id(
+                agent_type_id="ENC-AGT-001", runtime="cc-desktop",
+                credential_id=cred["credential_id"],
+            )
+
+    def test_credential_less_session_omits_binding_field(self):
+        # Backward-compat: no credential_id => the frozen value-identity shape is preserved
+        # (credential_id is NOT written), matching SESSION_NODE_PROPERTIES exactly.
+        item = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="cc-desktop")
+        self.assertNotIn("credential_id", item)
+        self.assertEqual(set(item.keys()), {"session_id", *alloc.SESSION_NODE_PROPERTIES})
+
+    def test_revoke_cascade_finds_session_by_credential_id_field(self):
+        # Confirms the cascade reaps a live session bound via the SAME field name
+        # (`credential_id`) that mint_session_id writes.
+        cred = alloc.issue_credential(agent_identity_id="ENC-AGT-001")
+        sess = alloc.mint_session_id(
+            agent_type_id="ENC-AGT-001", runtime="cc-desktop",
+            status="claimed", credential_id=cred["credential_id"],
+        )
+        summary = alloc.revoke_credential(cred["credential_id"], "compromised")
+        self.assertIn(sess["session_id"], summary["retired_sessions"])
+        self.assertEqual(alloc.get_session(sess["session_id"])["status"], "retired")
+
     def test_list_credentials_filters(self):
         c1 = alloc.issue_credential(agent_identity_id="ENC-AGT-001")
         alloc.issue_credential(agent_identity_id="ENC-AGT-002")

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3341,7 +3341,8 @@ def _code_mode_tool_catalog() -> list[Tool]:
             name="coordination",
             description=(
                 "Compact coordination/orchestration surface for capabilities, request inspection, "
-                "dispatch-plan generation, and managed-session auth helpers."
+                "dispatch-plan generation, managed-session auth helpers, and agent identity actions "
+                "(ENC-FTR-117 / ENC-TSK-I38)."
             ),
             inputSchema={
                 "type": "object",
@@ -3349,8 +3350,11 @@ def _code_mode_tool_catalog() -> list[Tool]:
                     "action": {
                         "type": "string",
                         "description": (
-                            "Coordination action identifier such as capabilities.get, request.get, "
-                            "dispatch_plan.generate, dispatch_plan.dry_run, or auth.cognito_session."
+                            "Coordination action identifier. Orchestration: capabilities.get, "
+                            "request.get, dispatch_plan.generate, dispatch_plan.dry_run, "
+                            "auth.cognito_session. Agent identity (ENC-TSK-I38): agent.register, "
+                            "agent.claim, agent.list, agent.retire, agent.type.list, "
+                            "agent.type.register."
                         ),
                     },
                     "arguments": {
@@ -7603,6 +7607,13 @@ _COORDINATION_ACTIONS: Dict[str, Dict[str, Any]] = {
     # ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier.
     "session.classify_intent": {"tool": "coordination_classify_intent"},
     "session.intent_centroid_drift": {"tool": "coordination_intent_centroid_drift"},
+    # ENC-TSK-I38: Agent identity surface (ENC-FTR-117); ported to v4/main by ENC-TSK-J43.
+    "agent.register": {"tool": "agent_register"},
+    "agent.claim": {"tool": "agent_claim"},
+    "agent.list": {"tool": "agent_list"},
+    "agent.retire": {"tool": "agent_retire"},
+    "agent.type.list": {"tool": "agent_type_list"},
+    "agent.type.register": {"tool": "agent_type_register"},
 }
 
 _EXECUTE_ACTIONS: Dict[str, Dict[str, Any]] = {
@@ -9501,6 +9512,69 @@ async def _dispatch_plan_dry_run(args: dict) -> list[TextContent]:
 
 
 # -------------------------------------------------------------------
+# ENC-TSK-I38: Agent identity actions (agent.*) — ported to v4/main by ENC-TSK-J43
+# -------------------------------------------------------------------
+
+
+async def _agent_register(args: dict) -> list[TextContent]:
+    """Mint a new ENC-SES-NNN session (agent.register)."""
+    payload: Dict[str, Any] = {}
+    # ENC-TSK-J43: credential_id is an optional binding to an ENC-CRED credential; it is
+    # only forwarded when supplied, so omitting it is fully backward-compatible.
+    for key in ("agent_type_id", "runtime", "parent_session_id", "status", "credential_id"):
+        if args.get(key) is not None:
+            payload[key] = args[key]
+    result = _coordination_api_request("POST", "/agents/sessions", payload=payload)
+    return _result_text(result)
+
+
+async def _agent_claim(args: dict) -> list[TextContent]:
+    """Claim a pre-minted ENC-SES-NNN (allocated → claimed, agent.claim)."""
+    payload: Dict[str, Any] = {"session_id": args["session_id"]}
+    if args.get("expected_agent_type_id"):
+        payload["expected_agent_type_id"] = args["expected_agent_type_id"]
+    result = _coordination_api_request("POST", "/agents/sessions/claim", payload=payload)
+    return _result_text(result)
+
+
+async def _agent_list(args: dict) -> list[TextContent]:
+    """List live sessions from the ENC-SES directory (agent.list)."""
+    query: Dict[str, Any] = {}
+    if args.get("status"):
+        query["status"] = args["status"]
+    if args.get("agent_type_id"):
+        query["agent_type_id"] = args["agent_type_id"]
+    result = _coordination_api_request("GET", "/agents/sessions", query=query or None)
+    return _result_text(result)
+
+
+async def _agent_retire(args: dict) -> list[TextContent]:
+    """Retire an ENC-SES-NNN session (append-only, agent.retire)."""
+    session_id = urllib.parse.quote(str(args["session_id"]), safe="")
+    result = _coordination_api_request("POST", f"/agents/sessions/{session_id}/retire")
+    return _result_text(result)
+
+
+async def _agent_type_list(args: dict) -> list[TextContent]:
+    """List entries in the ENC-AGT agent-type directory (agent.type.list)."""
+    query: Dict[str, Any] = {}
+    if args.get("status"):
+        query["status"] = args["status"]
+    result = _coordination_api_request("GET", "/agents/types", query=query or None)
+    return _result_text(result)
+
+
+async def _agent_type_register(args: dict) -> list[TextContent]:
+    """Idempotently register an agent type in the ENC-AGT directory (agent.type.register)."""
+    payload: Dict[str, Any] = {}
+    for key in ("surface", "model", "cost_tier"):
+        if args.get(key) is not None:
+            payload[key] = args[key]
+    result = _coordination_api_request("POST", "/agents/types", payload=payload)
+    return _result_text(result)
+
+
+# -------------------------------------------------------------------
 # GitHub integration (ENC-FTR-021 Phase 2)
 # -------------------------------------------------------------------
 
@@ -10467,6 +10541,13 @@ _TOOL_HANDLERS = {
     "coordination_cognito_session": _coordination_cognito_session,
     "coordination_classify_intent": _coordination_classify_intent,
     "coordination_intent_centroid_drift": _coordination_intent_centroid_drift,
+    # ENC-TSK-I38: Agent identity actions (ported to v4/main by ENC-TSK-J43)
+    "agent_register": _agent_register,
+    "agent_claim": _agent_claim,
+    "agent_list": _agent_list,
+    "agent_retire": _agent_retire,
+    "agent_type_list": _agent_type_list,
+    "agent_type_register": _agent_type_register,
     "governance_update": _governance_update,
     "governance_hash": _governance_hash,
     "governance_get": _governance_get,


### PR DESCRIPTION
## Summary
- Ports ENC-TSK-I38's `agent.*` HTTP route layer (register/claim/list/retire sessions, list/register agent-types) from `main` to `v4/main` — gamma's coordination_api had the `mint_session_id()`/`claim_session()`/etc primitives (backported by ENC-TSK-J04) but no HTTP route to invoke them, so J04's AgentSession graph projection could never be exercised live on gamma.
- Adds optional `credential_id` binding to `mint_session_id` (validates the credential exists and is `active` before minting, raises otherwise) — threaded through the register handler and the MCP `agent.register` tool. Fully backward compatible: omitting it behaves identically to today's prod behavior.
- `credential_id` is written to the session item only when bound (not as an always-present empty string), preserving the frozen `SESSION_NODE_PROPERTIES` v4-node shape per DOC-05C45B438FC1 — locked in by a new test.

## Test plan
- [x] `coordination_api/test_agent_id_alloc.py`: 63 passed (5 new: valid binding, missing-credential rejection, revoked-credential rejection, credential-less backward-compat shape, cascade-by-credential_id confirmation)
- [x] `py_compile` clean on `lambda_function.py`, `agent_id_alloc.py`, `tools/enceladus-mcp-server/server.py`
- [ ] Live gamma E2E (credential → bound session → mutation → revoke → graph verification) — post-deploy step, will complete ENC-TSK-J04 AC-6

CCI-0330ccefdffb41f9b5df745d963099fe