### PR TITLE
ENC-TSK-J45: v3-prod GDS/AGA cost kill (ENC-ISS-465, DOC-B716E8FB10B6 Channel A)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.01",
-  "updated_at": "2026-07-01T12:50:00Z",
-  "last_change_summary": "ENC-ISS-452 (ENC-TSK-I96): Updated deploy.spec to document that record_only mode now applies to ALL deployment types (including lambda_update/non-UI). deploy_mode check moved before NON_UI branch in deploy_orchestrator so Gen2 _deploy.yml record_deploy submissions auto-finalize as DEP records. Updated deploy_mode usage_guidance accordingly.",
+  "version": "2026-07-01.02",
+  "updated_at": "2026-07-01T22:06:00Z",
+  "last_change_summary": "ENC-TSK-J41 v3-prod port (SEV-1 ENC-ISS-465 cost kill, via DOC-B716E8FB10B6 Channel A): graph_query_api adds GDS_HARD_DISABLED env gate (_check_gds_available->False; forces cypher_fallback, no Aura Graph Analytics session). 02-compute.yaml prefix->AWS::NoValue, GDS_HARD_DISABLED=1, StandingProjectionRefreshSchedule State=DISABLED. Env-gate only; no new record schema/edge types.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -153,6 +153,7 @@ _HEALTH_PROBE_TOKEN = "governance"
 # ('weight' today; flips to 'flow_weight' once ENC-FTR-108 writes adaptive
 # weights into the slot this projection initializes to 1.0).
 _GDS_STANDING_PROJECTION_PREFIX = os.environ.get("GDS_STANDING_PROJECTION_PREFIX", "").strip()
+_GDS_HARD_DISABLED = os.environ.get("GDS_HARD_DISABLED", "").strip().lower() in ("1", "true", "yes", "on")  # ENC-ISS-465/J41: hard-disable AGA/GDS -> cypher_fallback (kills Graph Analytics Serverless cost)
 _GDS_SESSION_MEMORY = os.environ.get("GDS_SESSION_MEMORY", "2GB").strip() or "2GB"
 _GDS_WEIGHT_PROPERTY = os.environ.get("GDS_WEIGHT_PROPERTY", "weight").strip() or "weight"
 _GDS_FLOW_WEIGHT_PROPERTY = "flow_weight"
@@ -709,6 +710,8 @@ def _check_gds_available(driver) -> bool:
 
     Returns True if CALL gds.list() succeeds; False otherwise. Never raises.
     """
+    if _GDS_HARD_DISABLED:
+        return False  # ENC-ISS-465/J41: force cypher_fallback; never create an AGA session
     import time as _time
     now = _time.time()
     if (
@@ -1175,6 +1178,8 @@ def _refresh_standing_projection(driver, project_id: str) -> Dict[str, Any]:
     slot (ENC-FTR-101 AC-5), then stamps a GdsProjectionMeta marker carrying the
     last-refresh epoch for staleness telemetry (AC-3). Never raises.
     """
+    if _GDS_HARD_DISABLED:
+        return {"refreshed": False, "reason": "GDS_HARD_DISABLED", "project_id": project_id}
     graph_name = _standing_projection_name(project_id)
     if not graph_name:
         return {"refreshed": False, "reason": "GDS_STANDING_PROJECTION_PREFIX unset", "project_id": project_id}

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1053,7 +1053,12 @@ Resources:
           # next compute deploy does not strip it (ENC-LSN-053 strip-class drift).
           # Prod-only: gamma uses a separate AuraDB and its compute deploy is blocked
           # (ENC-ISS-197), so the feature stays dormant there (AWS::NoValue omits the key).
-          GDS_STANDING_PROJECTION_PREFIX: !If [IsProduction, "gds_standing", !Ref "AWS::NoValue"]
+          # ENC-ISS-465 / ENC-TSK-J41 (SEV-1 cost kill): standing GDS projection retired.
+          # Prefix forced to AWS::NoValue (feature OFF) and GDS_HARD_DISABLED=1 short-circuits
+          # _check_gds_available()->False so NO Aura Graph Analytics session (standing warm-path
+          # OR per-query gds.graph.project) is ever created; graph signal uses cypher_fallback.
+          GDS_STANDING_PROJECTION_PREFIX: !Ref "AWS::NoValue"
+          GDS_HARD_DISABLED: "1"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1231,7 +1236,7 @@ Resources:
       Name: !Sub "enceladus-standing-projection-refresh${EnvironmentSuffix}"
       Description: "ENC-FTR-101 Option B: refresh the standing GDS projection for graph_query_api hybrid PPR."
       ScheduleExpression: rate(30 minutes)
-      State: ENABLED
+      State: DISABLED  # ENC-ISS-465/J41: 30-min AGA warmer retired (cost kill)
       Targets:
         - Arn: !GetAtt GraphQueryApiFunction.Arn
           Id: standing-projection-refresh


### PR DESCRIPTION
## v3-prod surgical deploy — ENC-ISS-465 / ENC-TSK-J45 (ports ENC-TSK-J41)

CCI-d7eca1214d0d43e2acc32c96bcb2583e

Authorized via **DOC-B716E8FB10B6** consent token (io). Kills the Neo4j **Graph Analytics Serverless** cost spike (~$258/mo; telemetry DOC-EBF5DAB8E1FC) on **v3-prod**.

### Channels (per DOC-B716E8FB10B6 Step 1)
- **Channel A — `02-compute.yaml`** (merge to `main` auto-fires the v3-prod compute-stack deploy, no reviewer gate): `GDS_STANDING_PROJECTION_PREFIX` → `AWS::NoValue`; add `GDS_HARD_DISABLED: "1"`; `StandingProjectionRefreshSchedule` `State: DISABLED`.
- **Channel B — `graph_query_api/lambda_function.py`**: `GDS_HARD_DISABLED` gate → `_check_gds_available()` returns `False` → `cypher_fallback`, no AGA session ever. Lands on main durably; prod Lambda code swap remains behind io's v3-prod Environment approval.

### Safety
**Pre-deploy health gate PASSED**: Lambda arch parity, shared-layer `:10`, env-parity (no critical strip), **no CFN drift** (5/5 EventBridge rules). No `AWS::EarlyValidation::ResourceExistenceCheck` import needed (ISS-197 closed; last main compute deploy J32 succeeded).

Graph degrades to Cypher proxy; vector+keyword and all DynamoDB-backed tracker reads/writes unaffected. Primary DB untouched. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)