### PR TITLE
ENC-TSK-J44: fix record-type synthesis misclassifying credential-bound sessions

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.04",
-  "updated_at": "2026-07-01T21:59:00Z",
-  "last_change_summary": "ENC-TSK-J43: backported coordination.agent_session/coordination.agent_type entities + mcp_server.agent_actions entity (I38 HTTP routes, ported to v4/main gamma) and credential_id session-binding field.",
+  "version": "2026-07-01.05",
+  "updated_at": "2026-07-01T22:10:00Z",
+  "last_change_summary": "ENC-TSK-J44: fixed graph_sync record-type synthesis probe order (session_id before credential_id) to prevent credential-bound sessions from corrupting the credential's Neo4j node.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6086,7 +6086,7 @@
       }
     },
     "graph_sync.agent_identity_edges": {
-      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent identity/session/credential graph projection. Three DynamoDB stores (agent-types -> :AgentIdentity, agent-sessions -> :AgentSession, agent-credentials -> :AgentCredential) each carry a NEW_AND_OLD_IMAGES DynamoDB Stream wired through a dedicated EventBridge Pipe (AgentSessionsToGraphPipe / AgentTypesToGraphPipe / AgentCredentialsToGraphPipe) into the SAME devops-graph-sync-queue.fifo consumed by graph_sync -- no synchronous Neo4j write exists anywhere on the auth/mutation hot path (coordination_api and agent_id_alloc import no neo4j driver). The stores carry no record_type column, so graph_sync._normalize_record_for_graph synthesizes record_type (agent_identity/agent_session/agent_credential) and record_id from the id field. _upsert_agent_node MERGEs the node by its id; _reconcile_agent_edges and the generic _project_mutated_edge hook MERGE five typed edges. Counter# sentinel rows are excluded. OGTM (ENC-FTR-066) compliance: all five edge labels are registered byte-identically in graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178 drift guard) so they are traversable via tracker.graphsearch. The labels are emitted directly from the agent-store streams (NOT via the ENC-FTR-049 relationship-record path). E2E gamma tracker.graphsearch validation is a post-deploy manual/CI step (deferred to after this code merges + deploys to v4-gamma).",
+      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent identity/session/credential graph projection. Three DynamoDB stores (agent-types -> :AgentIdentity, agent-sessions -> :AgentSession, agent-credentials -> :AgentCredential) each carry a NEW_AND_OLD_IMAGES DynamoDB Stream wired through a dedicated EventBridge Pipe (AgentSessionsToGraphPipe / AgentTypesToGraphPipe / AgentCredentialsToGraphPipe) into the SAME devops-graph-sync-queue.fifo consumed by graph_sync -- no synchronous Neo4j write exists anywhere on the auth/mutation hot path (coordination_api and agent_id_alloc import no neo4j driver). The stores carry no record_type column, so graph_sync._normalize_record_for_graph synthesizes record_type (agent_identity/agent_session/agent_credential) and record_id from the id field. _upsert_agent_node MERGEs the node by its id; _reconcile_agent_edges and the generic _project_mutated_edge hook MERGE five typed edges. Counter# sentinel rows are excluded. OGTM (ENC-FTR-066) compliance: all five edge labels are registered byte-identically in graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178 drift guard) so they are traversable via tracker.graphsearch. The labels are emitted directly from the agent-store streams (NOT via the ENC-FTR-049 relationship-record path). E2E gamma tracker.graphsearch validation is a post-deploy manual/CI step (deferred to after this code merges + deploys to v4-gamma). ENC-TSK-J44 (2026-07-01): fixed a record-type synthesis bug where the id-field probe order (in _normalize_record_for_graph) checked credential_id before session_id -- since J43 added an optional credential_id FK onto agent-session rows, a credential-bound session was misclassified as agent_credential and its properties were MERGEd onto the real credential's node, corrupting shared fields (e.g. status). Probe order corrected to check each type's own PK (session_id) before any field it may merely carry as an FK.",
       "fields": {
         "node_labels": {
           "type": "object",
@@ -6278,6 +6278,11 @@
       "version": "2026-07-01.04",
       "task": "ENC-TSK-J43",
       "summary": "Backported I38 agent-session HTTP routes to v4/main + credential_id binding on coordination.agent_session."
+    },
+    {
+      "version": "2026-07-01.05",
+      "task": "ENC-TSK-J44",
+      "summary": "Fixed graph_sync._normalize_record_for_graph probe order bug (credential-bound sessions misclassified as agent_credential)."
     }
   ]
 }

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -156,12 +156,19 @@ def _normalize_record_for_graph(record: Dict[str, Any]) -> Dict[str, Any]:
 
     # ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-identity stores carry no record_type column and
     # key on their own id field. Synthesize record_type + record_id from the id field so
-    # the graph dispatch can route them. Order matters: sessions AND credentials also carry
-    # agent_type_id / agent_identity_id, so probe the most-specific key first.
+    # the graph dispatch can route them. Order matters: probe each type's OWN partition-key
+    # field before any foreign-key field another type might also carry. ENC-TSK-J43 added an
+    # optional credential_id FK onto agent-session rows, so session_id (a session's own PK)
+    # MUST be probed before credential_id (a session row now has both) -- checking
+    # credential_id first misclassified every credential-bound session as an agent_credential
+    # record, corrupting the real credential's Neo4j node via SET n += $props on shared field
+    # names (e.g. status). Credential rows have no session_id, so this ordering is safe for
+    # them; agent-type rows have neither session_id nor credential_id, so they fall through
+    # correctly regardless of position.
     if not record_type:
         for id_field, synthetic_type in (
-            ("credential_id", "agent_credential"),
             ("session_id", "agent_session"),
+            ("credential_id", "agent_credential"),
             ("agent_type_id", "agent_identity"),
         ):
             id_val = str(normalized.get(id_field) or "").strip()

--- a/backend/lambda/graph_sync/test_agent_identity_projection_j04.py
+++ b/backend/lambda/graph_sync/test_agent_identity_projection_j04.py
@@ -77,6 +77,21 @@ class TestNormalizeSynthesizesRecordType(_CypherCaptureMixin, unittest.TestCase)
         )
         self.assertEqual(sess["record_type"], "agent_session")
 
+    def test_credential_bound_session_synthesized_as_session_not_credential(self):
+        # ENC-TSK-J43 regression: a session bound to a credential carries BOTH session_id
+        # and credential_id. Must resolve as agent_session (its own PK), not agent_credential
+        # (a mere FK on the row) -- misclassifying it would MERGE the session's properties
+        # onto the real credential's Neo4j node under the shared credential_id record_id,
+        # corrupting fields like status via SET n += $props.
+        out = self.lf._normalize_record_for_graph({
+            "session_id": "ENC-SES-001",
+            "agent_type_id": "ENC-AGT-005",
+            "credential_id": "CRED-a535fc10c7844268a7a4980af9067b1d",
+            "status": "retired",
+        })
+        self.assertEqual(out["record_type"], "agent_session")
+        self.assertEqual(out["record_id"], "ENC-SES-001")
+
 
 class TestEdgeLabelRegistration(_CypherCaptureMixin, unittest.TestCase):
     NEW = {


### PR DESCRIPTION
## Summary
- Fixes a real, live-confirmed data-corruption bug found while verifying ENC-TSK-J43: `graph_sync`'s `_normalize_record_for_graph` probed `credential_id` before `session_id` when synthesizing `record_type` for id-only DynamoDB rows.
- ENC-TSK-J43 added an optional `credential_id` FK onto agent-session rows, so a credential-bound session now carries both its own PK (`session_id`) and a foreign key (`credential_id`). Probing `credential_id` first misclassified every such session as `agent_credential`, and its properties got `MERGE`d onto the real credential's Neo4j node (`SET n += $props`), silently overwriting shared fields like `status`.
- Fix: probe `session_id` before `credential_id` (each type's own PK checked before any field it might merely carry as an FK).

## Test plan
- [x] New regression test `test_credential_bound_session_synthesized_as_session_not_credential`
- [x] Full `graph_sync` suite: 42 passed
- [ ] Fresh live gamma E2E re-run post-deploy (new credential + session) to confirm correct classification

CCI-63264048c1af44e0ba046aaae202e400