### PR TITLE
ENC-TSK-H80: FTR-051 -- document markdown download control + serializer in PWA

### DIFF
--- a/frontend/ui/src/components/shared/DownloadMarkdownButton.test.tsx
+++ b/frontend/ui/src/components/shared/DownloadMarkdownButton.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DownloadMarkdownButton } from './DownloadMarkdownButton'
+import type { Document } from '../../types/feeds'
+
+function makeDoc(overrides: Partial<Document> = {}): Document {
+  return {
+    document_id: 'DOC-ABC123',
+    project_id: 'enceladus',
+    title: 'My Doc',
+    description: '',
+    file_name: 'my-doc.md',
+    content_type: 'text/markdown',
+    content_hash: 'abc',
+    size_bytes: 42,
+    keywords: [],
+    related_items: [],
+    status: 'active',
+    created_by: 'tester',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    content: '# Hello',
+    document_maturity_state: 'raw',
+    document_subtype: 'general',
+    ...overrides,
+  }
+}
+
+describe('DownloadMarkdownButton', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.fn>
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    createObjectURLSpy = vi.fn(() => 'blob:mock-url')
+    revokeObjectURLSpy = vi.fn()
+    // jsdom doesn't implement these.
+    // @ts-expect-error -- test stub
+    URL.createObjectURL = createObjectURLSpy
+    // @ts-expect-error -- test stub
+    URL.revokeObjectURL = revokeObjectURLSpy
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders with the expected tooltip and aria-label', () => {
+    render(<DownloadMarkdownButton document={makeDoc()} />)
+    const button = screen.getByRole('button', { name: 'Download markdown' })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('title', 'Download markdown')
+  })
+
+  it('triggers a blob download and shows the success state on click', () => {
+    const doc = makeDoc({ title: 'Design Doc: Phase 2' })
+    render(<DownloadMarkdownButton document={doc} />)
+
+    const button = screen.getByRole('button', { name: 'Download markdown' })
+    fireEvent.click(button)
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+    const blobArg = createObjectURLSpy.mock.calls[0]![0] as Blob
+    expect(blobArg).toBeInstanceOf(Blob)
+    expect(blobArg.type).toContain('text/markdown')
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url')
+
+    // success affordance mirrors CopyButton's local "copied" state pattern
+    expect(screen.getByRole('button', { name: 'Downloaded' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Downloaded' })).toHaveAttribute('title', 'Downloaded!')
+  })
+
+  it('sets the download filename from the document id and title slug', () => {
+    const doc = makeDoc({ document_id: 'DOC-XYZ789', title: 'Design Doc: Phase 2' })
+    const appendSpy = vi.spyOn(document.body, 'appendChild')
+
+    render(<DownloadMarkdownButton document={doc} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Download markdown' }))
+
+    const anchor = appendSpy.mock.calls
+      .map((call) => call[0])
+      .find((node): node is HTMLAnchorElement => node instanceof HTMLAnchorElement)
+    expect(anchor?.download).toBe('DOC-XYZ789-design-doc-phase-2.md')
+  })
+
+  it('does not fetch or mutate any external state — only serializes the passed-in document', () => {
+    const doc = makeDoc({ content: 'verbatim body' })
+    render(<DownloadMarkdownButton document={doc} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Download markdown' }))
+
+    // Blob content should reflect the doc object passed as a prop, proving
+    // no additional fetch/generation happened client-side.
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/ui/src/components/shared/DownloadMarkdownButton.tsx
+++ b/frontend/ui/src/components/shared/DownloadMarkdownButton.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react'
+import type { Document } from '../../types/feeds'
+import { documentMarkdownFileName, documentToMarkdown } from '../../lib/documentMarkdown'
+
+const DownloadIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+)
+
+interface DownloadMarkdownButtonProps {
+  document: Document
+  className?: string
+  size?: 'sm' | 'md'
+}
+
+/**
+ * ENC-FTR-051 — mounts alongside the ENC-FTR-038 CopyButton in the document
+ * detail page's control cluster. Mirrors its interaction contract exactly:
+ * same tooltip (`title`), same aria-label toggle pattern, same inline
+ * "success" affordance (no external toast system exists in this codebase —
+ * CopyButton's own local `copied` state IS the success notification
+ * pattern, so this component follows suit with a `downloaded` state).
+ */
+export function DownloadMarkdownButton({ document: doc, className = '', size = 'sm' }: DownloadMarkdownButtonProps) {
+  const [downloaded, setDownloaded] = useState(false)
+
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const markdown = documentToMarkdown(doc)
+      const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      const anchor = window.document.createElement('a')
+      anchor.href = url
+      anchor.download = documentMarkdownFileName(doc)
+      window.document.body.appendChild(anchor)
+      anchor.click()
+      window.document.body.removeChild(anchor)
+      URL.revokeObjectURL(url)
+
+      setDownloaded(true)
+      setTimeout(() => setDownloaded(false), 2000)
+    },
+    [doc],
+  )
+
+  const padding = size === 'sm' ? 'p-1' : 'p-1.5'
+
+  return (
+    <button
+      onClick={handleDownload}
+      className={`${padding} rounded transition-colors ${
+        downloaded
+          ? 'text-emerald-400'
+          : 'text-slate-500 hover:text-slate-300 active:text-slate-200'
+      } ${className}`}
+      title={downloaded ? 'Downloaded!' : 'Download markdown'}
+      aria-label={downloaded ? 'Downloaded' : 'Download markdown'}
+    >
+      {downloaded ? <CheckIcon /> : <DownloadIcon />}
+    </button>
+  )
+}

--- a/frontend/ui/src/lib/documentMarkdown.test.ts
+++ b/frontend/ui/src/lib/documentMarkdown.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import { documentMarkdownFileName, documentToMarkdown, slugifyTitle, yamlQuote } from './documentMarkdown'
+import type { Document } from '../types/feeds'
+
+function makeDoc(overrides: Partial<Document> = {}): Document {
+  return {
+    document_id: 'DOC-ABC123',
+    project_id: 'enceladus',
+    title: 'My Doc',
+    description: '',
+    file_name: 'my-doc.md',
+    content_type: 'text/markdown',
+    content_hash: 'abc',
+    size_bytes: 42,
+    keywords: [],
+    related_items: [],
+    status: 'active',
+    created_by: 'tester',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    content: '# Hello\n\nSome body text.',
+    document_maturity_state: 'raw',
+    document_subtype: 'general',
+    ...overrides,
+  }
+}
+
+describe('documentToMarkdown', () => {
+  it('includes a YAML frontmatter block with the expected fields', () => {
+    const doc = makeDoc()
+    const md = documentToMarkdown(doc, { now: () => new Date('2026-07-01T12:00:00.000Z') })
+
+    expect(md.startsWith('---\n')).toBe(true)
+    expect(md).toContain('document_id: DOC-ABC123')
+    expect(md).toContain('title: My Doc')
+    expect(md).toContain('document_subtype: general')
+    expect(md).toContain('status: active')
+    expect(md).toContain('document_maturity_state: raw')
+    expect(md).toContain('project_id: enceladus')
+    // exported_at contains colons, so yamlQuote wraps it in double quotes.
+    expect(md).toContain('exported_at: "2026-07-01T12:00:00.000Z"')
+  })
+
+  it('passes the content field through verbatim, including markdown special characters', () => {
+    const content = '# Title\n\n```js\nconst x = { a: 1 } // comment\n```\n\n> quote *em* **bold**\n\n- [ ] todo: item'
+    const doc = makeDoc({ content })
+    const md = documentToMarkdown(doc, { now: () => new Date('2026-07-01T12:00:00.000Z') })
+
+    expect(md.endsWith(content)).toBe(true)
+    // body must not be mutated/re-rendered
+    expect(md).toContain(content)
+  })
+
+  it('handles a missing content field gracefully', () => {
+    const doc = makeDoc({ content: undefined })
+    const md = documentToMarkdown(doc, { now: () => new Date('2026-07-01T12:00:00.000Z') })
+    expect(md.endsWith('---\n\n')).toBe(true)
+  })
+
+  it('generates exported_at at call time when no clock is injected', () => {
+    const doc = makeDoc()
+    const before = Date.now()
+    const md = documentToMarkdown(doc)
+    const after = Date.now()
+
+    const match = md.match(/exported_at: "?([^"\n]+?)"?\n/)
+    expect(match).not.toBeNull()
+    const parsed = new Date(match![1]!).getTime()
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+  })
+
+  it('quotes a title containing a colon so the frontmatter stays valid YAML', () => {
+    const doc = makeDoc({ title: 'Design Doc: Phase 2' })
+    const md = documentToMarkdown(doc, { now: () => new Date('2026-07-01T12:00:00.000Z') })
+    expect(md).toContain('title: "Design Doc: Phase 2"')
+  })
+
+  it('quotes and escapes a title containing double quotes', () => {
+    const doc = makeDoc({ title: 'The "Best" Doc' })
+    const md = documentToMarkdown(doc, { now: () => new Date('2026-07-01T12:00:00.000Z') })
+    expect(md).toContain('title: "The \\"Best\\" Doc"')
+  })
+})
+
+describe('yamlQuote', () => {
+  it('leaves plain scalars unquoted', () => {
+    expect(yamlQuote('active')).toBe('active')
+    expect(yamlQuote('DOC-ABC123')).toBe('DOC-ABC123')
+  })
+
+  it('quotes values containing a colon', () => {
+    expect(yamlQuote('a: b')).toBe('"a: b"')
+  })
+
+  it('quotes values containing a hash', () => {
+    expect(yamlQuote('note #1')).toBe('"note #1"')
+  })
+
+  it('quotes values with leading/trailing whitespace', () => {
+    expect(yamlQuote('  padded  ')).toBe('"  padded  "')
+  })
+
+  it('quotes the empty string', () => {
+    expect(yamlQuote('')).toBe('""')
+  })
+
+  it('quotes values starting with special YAML indicator characters', () => {
+    expect(yamlQuote('- item')).toBe('"- item"')
+    expect(yamlQuote('*anchor')).toBe('"*anchor"')
+  })
+
+  it('escapes embedded backslashes and quotes', () => {
+    expect(yamlQuote('back\\slash "quote"')).toBe('"back\\\\slash \\"quote\\""')
+  })
+})
+
+describe('slugifyTitle', () => {
+  it('lowercases and hyphenates the title', () => {
+    expect(slugifyTitle('My Great Doc!')).toBe('my-great-doc')
+  })
+
+  it('collapses repeated separators and trims leading/trailing hyphens', () => {
+    expect(slugifyTitle('  --Weird   Title--  ')).toBe('weird-title')
+  })
+})
+
+describe('documentMarkdownFileName', () => {
+  it('builds {DOC-ID}-{slug}.md', () => {
+    const doc = makeDoc({ document_id: 'DOC-XYZ789', title: 'Design Doc: Phase 2' })
+    expect(documentMarkdownFileName(doc)).toBe('DOC-XYZ789-design-doc-phase-2.md')
+  })
+
+  it('falls back to just the document id when title slugifies to empty', () => {
+    const doc = makeDoc({ document_id: 'DOC-XYZ789', title: '***' })
+    expect(documentMarkdownFileName(doc)).toBe('DOC-XYZ789.md')
+  })
+})

--- a/frontend/ui/src/lib/documentMarkdown.ts
+++ b/frontend/ui/src/lib/documentMarkdown.ts
@@ -1,0 +1,81 @@
+import type { Document } from '../types/feeds'
+
+/**
+ * ENC-FTR-051 — document markdown download.
+ *
+ * Serializes a loaded Document record into a standalone markdown file: a YAML
+ * frontmatter block containing the record's key metadata fields, followed by
+ * the raw (unmodified) markdown body from `document.content`.
+ */
+
+/**
+ * Quote a YAML scalar value only when necessary. Plain scalars are returned
+ * as-is; anything that could be misparsed by a YAML reader (colons, quotes,
+ * `#` comments, leading/trailing whitespace, or a leading special indicator
+ * character) is wrapped in a double-quoted YAML string with `\` and `"`
+ * escaped.
+ */
+export function yamlQuote(value: string): string {
+  const needsQuoting =
+    value === '' ||
+    value !== value.trim() ||
+    /[:#"'\n]/.test(value) ||
+    /^[-?:,[\]{}&*!|>%@`]/.test(value)
+
+  if (!needsQuoting) return value
+
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return `"${escaped}"`
+}
+
+function yamlField(key: string, value: string | undefined): string {
+  return `${key}: ${yamlQuote(value ?? '')}`
+}
+
+export interface DocumentMarkdownOptions {
+  /** Injectable clock for deterministic tests. Defaults to `new Date()`. */
+  now?: () => Date
+}
+
+/**
+ * Build the full markdown document (frontmatter + verbatim body) for a
+ * given loaded Document record.
+ */
+export function documentToMarkdown(doc: Document, options: DocumentMarkdownOptions = {}): string {
+  const now = options.now ? options.now() : new Date()
+  const exportedAt = now.toISOString()
+
+  const frontmatterLines = [
+    '---',
+    yamlField('document_id', doc.document_id),
+    yamlField('title', doc.title),
+    yamlField('document_subtype', doc.document_subtype),
+    yamlField('status', doc.status),
+    yamlField('document_maturity_state', doc.document_maturity_state),
+    yamlField('project_id', doc.project_id),
+    yamlField('exported_at', exportedAt),
+    '---',
+    '',
+    '',
+  ]
+
+  return frontmatterLines.join('\n') + (doc.content ?? '')
+}
+
+/**
+ * Build a filesystem-safe filename for the exported markdown: lowercase,
+ * non-alphanumeric runs collapsed to a single hyphen, trimmed of leading/
+ * trailing hyphens.
+ */
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function documentMarkdownFileName(doc: Document): string {
+  const slug = slugifyTitle(doc.title ?? '')
+  return slug ? `${doc.document_id}-${slug}.md` : `${doc.document_id}.md`
+}

--- a/frontend/ui/src/pages/DocumentDetailPage.tsx
+++ b/frontend/ui/src/pages/DocumentDetailPage.tsx
@@ -8,6 +8,7 @@ import { RecordNotFound } from '../components/shared/RecordNotFound'
 import { RecordFallbackError } from '../components/shared/RecordFallbackError'
 import { ErrorState } from '../components/shared/ErrorState'
 import { CopyButton } from '../components/shared/CopyButton'
+import { DownloadMarkdownButton } from '../components/shared/DownloadMarkdownButton'
 import { formatDate, timeAgo } from '../lib/formatters'
 import { HANDOFF_STATUS_COLORS, HANDOFF_STATUS_LABELS } from '../lib/constants'
 import { ProjectPrimaryDocumentsPage } from './ProjectPrimaryDocumentsPage'
@@ -89,7 +90,11 @@ export function DocumentDetailPage() {
         >
           {doc.project_id}
         </Link>
-        <span className="text-xs font-mono text-slate-500 mb-1 inline-flex items-center gap-1">{doc.document_id}<CopyButton text={doc.document_id} /></span>
+        <span className="text-xs font-mono text-slate-500 mb-1 inline-flex items-center gap-1">
+          {doc.document_id}
+          <CopyButton text={doc.document_id} />
+          <DownloadMarkdownButton document={doc} />
+        </span>
         <h1 className="text-lg font-semibold text-slate-100 mb-2">{doc.title}</h1>
         <div className="flex flex-wrap items-center gap-2 mb-2">
           <StatusChip status={doc.status} />

--- a/frontend/ui/src/types/feeds.ts
+++ b/frontend/ui/src/types/feeds.ts
@@ -313,6 +313,8 @@ export interface Document {
   updated_at: string
   version: number
   content?: string
+  // ENC-FTR-051: maturity lifecycle state (e.g. "raw", "reviewed").
+  document_maturity_state?: string
   // Handoff fields (ENC-FTR-061)
   document_subtype?: DocumentSubtype
   source_record_id?: string


### PR DESCRIPTION
## Summary
- Adds `documentToMarkdown()` (frontend/ui/src/lib/documentMarkdown.ts): prepends YAML frontmatter (document_id, title, document_subtype, status, document_maturity_state, project_id, exported_at) to the verbatim raw markdown `content` field -- no re-rendering.
- Adds `DownloadMarkdownButton`, mounted next to the existing FTR-038 `CopyButton` in the document detail page's control cluster, mirroring its interaction contract 1:1 (tooltip, aria-label, keyboard-activatable, inline success-state swap -- no toast library exists in this codebase, so both use the same pattern).
- Triggers a Blob download named `{DOC-ID}-{title-slug}.md` from the already-loaded document object -- no new fetch, no client-side ID generation (AC6).
- PWA-only change; no backend/lambda code touched (raw `content` field already exposed per ENC-TSK-H79).

## Test plan
- [x] `npx vitest run` (full suite): 117/118 pass. The 1 failure (`src/api/client.test.ts`, cache-busting timestamp assertion) is pre-existing on the clean `v4/main` baseline -- confirmed independently via `git stash` + re-run before this change was applied.
- [x] New tests: 21/21 pass (documentMarkdown.test.ts + DownloadMarkdownButton.test.tsx).
- [x] `npx tsc -b`: clean, no type errors.

ENC-TSK-H80 | CCI-cfaba9cbc5ce4dae8bcce9b925c7927a

🤖 Generated with [Claude Code](https://claude.com/claude-code)