### PR TITLE
ENC-TSK-J51: gamma PWA deploy pipeline (unblocks H80 AC6 + UAT)

### DIFF
--- a/.github/workflows/ui-gamma-deploy.yml
+++ b/.github/workflows/ui-gamma-deploy.yml
@@ -1,0 +1,73 @@
+name: UI Gamma Deploy
+
+on:
+  push:
+    branches:
+      - v4/main
+    paths:
+      - "frontend/ui/**"
+      - ".github/workflows/ui-gamma-deploy.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-west-2
+  S3_BUCKET: jreese-net
+  S3_PREFIX: enceladus-gamma
+  CLOUDFRONT_DISTRIBUTION_ID: E2CO2UXUONVQZH
+
+jobs:
+  deploy:
+    name: Build + Deploy PWA to gamma
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: v4-gamma
+    concurrency:
+      group: ui-gamma-deploy
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: frontend/ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure AWS credentials (OIDC, v4-gamma environment)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::356364570033:role/GitHubActions-V4Gamma-DeployRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Sync build output to S3
+        run: |
+          aws s3 sync dist/ "s3://${S3_BUCKET}/${S3_PREFIX}/" --delete \
+            --cache-control "max-age=0,s-maxage=300" \
+            --exclude "assets/*" --exclude "workbox-*"
+          aws s3 sync dist/assets/ "s3://${S3_BUCKET}/${S3_PREFIX}/assets/" --delete \
+            --cache-control "max-age=31536000,immutable"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ui-gamma-deploy.yml`: builds `frontend/ui` and syncs `dist/` to `s3://jreese-net/enceladus-gamma/` on push to `v4/main` under `frontend/ui/**`, then invalidates the new gamma CloudFront distribution.
- New infra (provisioned out-of-band via `io-dev-admin`, session-authorized, mirrors the existing unmanaged prod CloudFront setup):
  - CloudFront distribution `E2CO2UXUONVQZH` (`d2mbwo2hsn2pfx.cloudfront.net`) with `/api/v1/*` behaviors proxied to the gamma tracker API (`hi0dzmvqrc`), mirroring prod's behavior list exactly.
  - S3 bucket policy: additive statement on `jreese-net`, scoped to `enceladus-gamma/*` + this distribution's ARN only -- existing statements untouched.
  - IAM: new inline policy `V4GammaPWADeployPolicy` on the existing `GitHubActions-V4Gamma-DeployRole` (already OIDC-trusted for the `v4-gamma` GH environment), scoped to S3 write on `enceladus-gamma/*` and CloudFront invalidation on this one distribution only.
  - ACM cert requested for `pwa-gamma.jreese.net` (DNS validation pending -- io needs to add the CNAME in Cloudflare); distribution serves on its default `*.cloudfront.net` domain until that lands.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` -- workflow YAML valid.
- [ ] Live smoke test after merge: confirm `https://d2mbwo2hsn2pfx.cloudfront.net/` returns 200 and an `/api/v1/*` page round-trips to the gamma tracker API (will run once merged and the workflow fires).

ENC-TSK-J51 | CCI-d86d4b83a8c04e8e860021a3e3af691a

🤖 Generated with [Claude Code](https://claude.com/claude-code)