### PR TITLE
ENC-TSK-J54: fix gamma PWA deploy path -- blank page bug

### DIFF
--- a/.github/workflows/ui-gamma-deploy.yml
+++ b/.github/workflows/ui-gamma-deploy.yml
@@ -16,7 +16,10 @@ permissions:
 env:
   AWS_REGION: us-west-2
   S3_BUCKET: jreese-net
-  S3_PREFIX: enceladus-gamma
+  # frontend/ui/vite.config.ts hardcodes base:'/enceladus/', so built assets
+  # reference /enceladus/... -- the S3 prefix must nest under enceladus/ to
+  # match, or the deployed app 404s on its own JS/CSS (blank page).
+  S3_PREFIX: enceladus-gamma/enceladus
   CLOUDFRONT_DISTRIBUTION_ID: E2CO2UXUONVQZH
 
 jobs:


### PR DESCRIPTION
## Summary
- io reported a blank white page at pwa-gamma.jreese.net despite 200 OK on the HTML shell.
- Root cause: `frontend/ui/vite.config.ts` hardcodes `base: '/enceladus/'`, so the built `index.html` references `/enceladus/assets/*.js`, but `ui-gamma-deploy.yml` (ENC-TSK-J51) synced `dist/` to the S3 bucket root -- all JS/CSS 404'd.
- Fix: `S3_PREFIX` changed from `enceladus-gamma` to `enceladus-gamma/enceladus`, matching the build's base path.
- Already live-fixed manually before this PR (rebuild + re-sync to the correct path + CloudFront `DefaultRootObject` -> `enceladus/index.html` + invalidation) and validated via curl -- this PR fixes the workflow so future automated deploys don't regress it.

## Test plan
- [x] Live curl validation (already applied manually, pre-PR): `https://pwa-gamma.jreese.net/` -> 200; all 13 referenced `/enceladus/assets/*.js`/`.css` paths -> 200 with correct `content-type: text/javascript`/`text/css`, real JS content (not an HTML 404 fallback).
- [ ] Post-merge: a live GH Actions run of the corrected workflow will confirm the automated path also lands correctly (same S3 destination the manual fix used).

ENC-TSK-J54 | CCI-2738d8bd87f44edeac14bd6ece161daa

🤖 Generated with [Claude Code](https://claude.com/claude-code)