### PR TITLE
[ENC-TSK-J46] FTR-096 Ph2 -- lesson-candidate curation surface

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.05",
-  "updated_at": "2026-07-01T22:10:00Z",
-  "last_change_summary": "ENC-TSK-J44: fixed graph_sync record-type synthesis probe order (session_id before credential_id) to prevent credential-bound sessions from corrupting the credential's Neo4j node.",
+  "version": "2026-07-01.06",
+  "updated_at": "2026-07-02T02:00:00Z",
+  "last_change_summary": "ENC-TSK-J46: lesson-candidate curation surface (list filter + io-gated approve/reject with LEARNED_FROM provenance).",
   "owners": [
     "enceladus-platform"
   ],
@@ -3291,7 +3291,7 @@
       }
     },
     "tracker.graphsearch": {
-      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges — never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges \u2014 never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
       "fields": {
         "search_type": {
           "type": "enum",
@@ -6230,6 +6230,88 @@
           "definition": "ENC-TSK-J43. Optional. When supplied, binds the minted session to an existing active AgentCredential (coordination.agent_credential); the underlying coordination_api call rejects (400) an unknown or non-active credential_id."
         }
       }
+    },
+    "document.lesson-candidate": {
+      "description": "Lesson-candidate document subtype (ENC-FTR-096). Drafted directly to DynamoDB by the memory_consolidation Lambda (ENC-TSK-I84) from recurring co-citation clusters -- NOT created via document_api PUT, so it is absent from the document_subtype allow-list enforced there. Curated (approved/rejected) via ENC-TSK-J46: coordination_api POST /api/v1/coordination/lesson-candidates/{documentId}/approve|reject, both Cognito-gated.",
+      "fields": {
+        "document_subtype": {
+          "type": "string",
+          "literal_value": "lesson-candidate",
+          "definition": "Fixed subtype value for candidate documents. Written directly by memory_consolidation Lambda; document_api's PUT/PATCH document_subtype allow-list does not include it (candidates are never created or re-subtyped through that surface)."
+        },
+        "handoff_status": {
+          "type": "enum",
+          "enum": [
+            "pending",
+            "approved",
+            "stale"
+          ],
+          "transitions": {
+            "pending": [
+              "approved",
+              "stale"
+            ],
+            "approved": [],
+            "stale": []
+          },
+          "definition": "Curation-state field, reusing the handoff_status attribute name (document_api CANDIDATE_STATUSES / CANDIDATE_STATUS_TRANSITIONS, ENC-TSK-J46). 'approved' is only a legal value for lesson-candidate documents -- handoff documents keep their own {pending,claimed,completed,stale} vocabulary.",
+          "write_authority": "document_api Lambda PATCH. Transitions to 'approved' or 'stale' require a Cognito-authenticated session (document_api._is_cognito_session); an internal-key (agent) session is rejected with 403. This is the enforced io-gate: no agent session can promote or reject a lesson candidate autonomously.",
+          "usage_guidance": "List pending candidates via documents.list(document_subtype='lesson-candidate', handoff_status='pending', sort='created_at'). Approve/reject through coordination_api's lesson-candidates routes (see coordination.lesson_candidates), not a raw PATCH -- approval also creates the governed ENC-LSN record."
+        },
+        "related_items": {
+          "type": "array",
+          "definition": "Source Handoff document IDs the candidate's co-citation cluster was drawn from (ENC-TSK-I84 AC-3)."
+        },
+        "cluster_member_ids": {
+          "type": "array",
+          "definition": "Tracker record IDs that recur together as the co-citation cluster underlying this candidate."
+        },
+        "frequency_count": {
+          "type": "number",
+          "definition": "Count of distinct Handoff documents in which the cluster co-cited within the lookback window."
+        }
+      }
+    },
+    "coordination.lesson_candidates": {
+      "description": "ENC-TSK-J46 / ENC-FTR-096 Ph2: coordination_api HTTP surface that promotes or rejects a pending lesson-candidate document. Approve creates a governed ENC-LSN record via the same validation as tracker.create_lesson (observation/insight/evidence_chain/provenance/pillar_scores), stamping the candidate's document_id into evidence_chain (LEARNED_FROM provenance at graph_sync), then marks the candidate handoff_status='approved'. Reject marks handoff_status='stale' with an appended rejection note -- the candidate document is never deleted (append-only discipline).",
+      "fields": {
+        "route": {
+          "type": "string",
+          "enum": [
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/approve",
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/reject"
+          ],
+          "definition": "Both routes require a Cognito-authenticated session (_is_cognito_session); an internal-key (agent) session receives 403. Gamma-only (Condition: IsGamma in 03-api.yaml) per DOC-499FA089EC30 -- v3-prod is frozen pending the io-gated cutover."
+        },
+        "approve.body.observation": {
+          "type": "string",
+          "required": true,
+          "definition": "What was observed in the candidate data. Required on the created lesson (ENC-FTR-052); immutable after creation."
+        },
+        "approve.body.insight": {
+          "type": "string",
+          "required": true,
+          "definition": "What was learned from the observation. Required on the created lesson."
+        },
+        "approve.body.pillar_scores": {
+          "type": "object",
+          "required": true,
+          "definition": "efficiency, human_protection, intention, alignment, each a number in [0.0, 1.0] (ENC-FTR-054). Validated identically to tracker_mutation's create-lesson check."
+        },
+        "approve.body.evidence_chain": {
+          "type": "array",
+          "required": false,
+          "definition": "Optional additional evidence record IDs. The candidate document_id is always prepended automatically -- this is what stamps LEARNED_FROM provenance back to the candidate."
+        },
+        "reject.body.rejection_reason": {
+          "type": "string",
+          "required": true,
+          "constraints": {
+            "min_length": 10
+          },
+          "definition": "Human-readable reason appended (append-only) to the candidate document content when marking it stale."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6283,6 +6365,11 @@
       "version": "2026-07-01.05",
       "task": "ENC-TSK-J44",
       "summary": "Fixed graph_sync._normalize_record_for_graph probe order bug (credential-bound sessions misclassified as agent_credential)."
+    },
+    {
+      "version": "2026-07-01.06",
+      "task": "ENC-TSK-J46",
+      "summary": "Added document.lesson-candidate and coordination.lesson_candidates entities: candidate list filter (document_api handoff_status query param) and io-gated approve/reject (coordination_api, Cognito-only), approve creates a governed ENC-LSN via the tracker.create_lesson validation surface with evidence_chain provenance back to the candidate."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -531,6 +531,7 @@ _DEFAULT_STATUS = {
     "issue": "open",
     "feature": "planned",
     "plan": "drafted",
+    "lesson": "draft",
 }
 
 
@@ -8830,6 +8831,288 @@ def _handle_components_reject(
     )
 
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-J46 / ENC-FTR-096 Ph2: lesson-candidate curation (approve/reject)
+# ---------------------------------------------------------------------------
+
+_LESSON_REQUIRED_PILLARS = {"efficiency", "human_protection", "intention", "alignment"}
+_LESSON_VALID_PROVENANCE = ("agent", "human", "mining", "system")
+
+
+def _validate_lesson_pillar_scores(raw: Any) -> Tuple[Optional[Dict[str, float]], Optional[str]]:
+    """Validate a pillar_scores payload, mirroring tracker_mutation's ENC-FTR-054 check."""
+    if not isinstance(raw, dict):
+        return None, (
+            "pillar_scores is required: an object with efficiency, human_protection, "
+            "intention, alignment, each a number in [0.0, 1.0]."
+        )
+    missing = _LESSON_REQUIRED_PILLARS - set(raw.keys())
+    if missing:
+        return None, f"pillar_scores missing required keys: {sorted(missing)}."
+    parsed: Dict[str, float] = {}
+    for pillar in _LESSON_REQUIRED_PILLARS:
+        try:
+            val = float(raw[pillar])
+        except (TypeError, ValueError):
+            return None, f"pillar_scores.{pillar} must be a number in [0.0, 1.0]. Got: {raw[pillar]!r}"
+        if not (0.0 <= val <= 1.0):
+            return None, f"pillar_scores.{pillar} must be in [0.0, 1.0]. Got: {val}"
+        parsed[pillar] = val
+    return parsed, None
+
+
+def _create_lesson_record(
+    project_id: str,
+    prefix: str,
+    title: str,
+    observation: str,
+    insight: str,
+    evidence_chain: List[str],
+    pillar_scores: Dict[str, float],
+    *,
+    provenance: str = "human",
+    category: Optional[str] = None,
+    confidence: Optional[float] = None,
+    description: Optional[str] = None,
+) -> str:
+    """Create a governed ENC-LSN record directly against TRACKER_TABLE.
+
+    Mirrors tracker_mutation's ENC-FTR-052 tracker.create_lesson validation
+    (observation/insight/evidence_chain/provenance/pillar_scores) so a lesson
+    created here is indistinguishable from one created through that surface.
+    evidence_chain entries become LEARNED_FROM edges at graph_sync time
+    (backend/lambda/graph_sync/lambda_function.py), so passing the source
+    lesson-candidate document_id there is what stamps its provenance.
+    """
+    ddb = _get_ddb()
+    now = _now_z()
+    for _ in range(5):
+        seq = _next_tracker_sequence(project_id, "lesson")
+        record_id = _build_record_id(prefix, "lesson", seq)
+        item: Dict[str, Any] = {
+            "project_id": project_id,
+            "record_id": f"lesson#{record_id}",
+            "record_type": "lesson",
+            "item_id": record_id,
+            "title": title,
+            "description": description or "",
+            "observation": observation,
+            "insight": insight,
+            "evidence_chain": evidence_chain,
+            "provenance": provenance,
+            "pillar_scores": pillar_scores,
+            "status": _DEFAULT_STATUS["lesson"],
+            "created_at": now,
+            "updated_at": now,
+            "sync_version": 1,
+            "last_update_note": "Created via coordination API: lesson-candidate approval (ENC-TSK-J46)",
+            "history": [
+                {
+                    "timestamp": now,
+                    "status": "created",
+                    "description": f"Created via coordination API: {title}",
+                }
+            ],
+        }
+        if category:
+            item["category"] = category
+        if confidence is not None:
+            item["confidence"] = float(confidence)
+
+        try:
+            ddb.put_item(
+                TableName=TRACKER_TABLE,
+                Item={k: _serialize(v) for k, v in item.items()},
+                ConditionExpression="attribute_not_exists(record_id)",
+            )
+            return record_id
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                continue
+            raise
+
+    raise RuntimeError("Failed allocating lesson record id after retries")
+
+
+def _handle_lesson_candidate_approve(
+    document_id: str, event: Dict[str, Any], claims: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/lesson-candidates/{documentId}/approve
+
+    ENC-TSK-J46 / ENC-FTR-096 Ph2. Promotes a pending lesson-candidate document
+    (drafted by the I84 memory_consolidation Lambda) to a governed ENC-LSN
+    record via the same creation surface as tracker.create_lesson, stamping the
+    candidate document_id into evidence_chain for LEARNED_FROM provenance, then
+    marks the candidate handoff_status='approved'. Cognito session required —
+    no agent session may promote a lesson candidate autonomously.
+    """
+    if not _is_cognito_session(claims):
+        return _error(
+            403,
+            "Approving a lesson candidate requires Cognito authentication (PWA session only).",
+        )
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return _error(400, "Invalid JSON body")
+
+    candidate = _invoke_document_api("GET", document_id)
+    if candidate.get("_status_code") != 200:
+        return _error(404, f"Lesson candidate '{document_id}' not found or unreadable.")
+    if candidate.get("document_subtype") != "lesson-candidate":
+        return _error(400, f"Document '{document_id}' is not a lesson-candidate.")
+    if candidate.get("handoff_status") != "pending":
+        return _error(
+            409,
+            f"Lesson candidate '{document_id}' is not pending (handoff_status="
+            f"{candidate.get('handoff_status')!r}); it may already have been decided.",
+        )
+
+    title = str(body.get("title") or candidate.get("title") or "").strip()
+    observation = str(body.get("observation") or "").strip()
+    insight = str(body.get("insight") or "").strip()
+    if not title:
+        return _error(400, "title is required (candidate title was empty).")
+    if not observation:
+        return _error(400, "observation is required: what was observed in the candidate data.")
+    if not insight:
+        return _error(400, "insight is required: what was learned from the observation.")
+
+    pillar_scores, pillar_err = _validate_lesson_pillar_scores(body.get("pillar_scores"))
+    if pillar_err:
+        return _error(400, pillar_err)
+
+    provenance = str(body.get("provenance") or "human").strip()
+    if provenance not in _LESSON_VALID_PROVENANCE:
+        return _error(400, f"Invalid provenance '{provenance}'. Allowed: {list(_LESSON_VALID_PROVENANCE)}")
+
+    evidence_chain = [document_id]
+    extra_evidence = body.get("evidence_chain")
+    if isinstance(extra_evidence, list):
+        evidence_chain.extend(str(e).strip() for e in extra_evidence if str(e).strip())
+
+    project_id = str(candidate.get("project_id") or GOVERNANCE_PROJECT_ID)
+    try:
+        meta = _load_project_meta(project_id)
+    except (ValueError, RuntimeError) as exc:
+        return _error(400, str(exc))
+
+    try:
+        lesson_id = _create_lesson_record(
+            project_id,
+            meta.prefix,
+            title,
+            observation,
+            insight,
+            evidence_chain,
+            pillar_scores,
+            provenance=provenance,
+            category=body.get("category"),
+            confidence=body.get("confidence"),
+            description=body.get("description"),
+        )
+    except ClientError as exc:
+        logger.exception("lesson_candidate_approve: lesson create failed")
+        return _error(500, f"Failed to create lesson record: {exc}")
+
+    approved_by = _resolve_decider_identity(claims)
+    now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    patch_resp = _invoke_document_api(
+        "PATCH",
+        document_id,
+        {
+            "handoff_status": "approved",
+            "append_content": (
+                f"---\nApproved by {approved_by} at {now}. Promoted to {lesson_id} "
+                f"(ENC-TSK-J46 lesson-candidate curation)."
+            ),
+        },
+    )
+    if patch_resp.get("_status_code") not in (200, 201):
+        logger.warning(
+            "lesson_candidate_approve: %s created but candidate patch failed: %s",
+            lesson_id, patch_resp,
+        )
+
+    return _response(
+        200,
+        {
+            "success": True,
+            "document_id": document_id,
+            "lesson_id": lesson_id,
+            "handoff_status": "approved",
+            "approved_by": approved_by,
+            "approved_at": now,
+        },
+    )
+
+
+def _handle_lesson_candidate_reject(
+    document_id: str, event: Dict[str, Any], claims: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/lesson-candidates/{documentId}/reject
+
+    ENC-TSK-J46 / ENC-FTR-096 Ph2. Marks a pending lesson-candidate document
+    handoff_status='stale' with an appended rejection note — the candidate is
+    never deleted (append-only discipline). Cognito session required.
+    """
+    if not _is_cognito_session(claims):
+        return _error(
+            403,
+            "Rejecting a lesson candidate requires Cognito authentication (PWA session only).",
+        )
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return _error(400, "Invalid JSON body")
+
+    rejection_reason = str(body.get("rejection_reason") or "").strip()
+    if len(rejection_reason) < 10:
+        return _error(400, "rejection_reason is required and must be at least 10 characters")
+
+    candidate = _invoke_document_api("GET", document_id)
+    if candidate.get("_status_code") != 200:
+        return _error(404, f"Lesson candidate '{document_id}' not found or unreadable.")
+    if candidate.get("document_subtype") != "lesson-candidate":
+        return _error(400, f"Document '{document_id}' is not a lesson-candidate.")
+    if candidate.get("handoff_status") != "pending":
+        return _error(
+            409,
+            f"Lesson candidate '{document_id}' is not pending (handoff_status="
+            f"{candidate.get('handoff_status')!r}); it may already have been decided.",
+        )
+
+    rejected_by = _resolve_decider_identity(claims)
+    now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    patch_resp = _invoke_document_api(
+        "PATCH",
+        document_id,
+        {
+            "handoff_status": "stale",
+            "append_content": f"---\nRejected by {rejected_by} at {now}. Reason: {rejection_reason}",
+        },
+    )
+    if patch_resp.get("_status_code") not in (200, 201):
+        return _error(
+            502,
+            f"Candidate document patch failed (status={patch_resp.get('_status_code')}): {patch_resp}",
+        )
+
+    return _response(
+        200,
+        {
+            "success": True,
+            "document_id": document_id,
+            "handoff_status": "stale",
+            "rejected_by": rejected_by,
+            "rejected_at": now,
+            "rejection_reason": rejection_reason,
+        },
+    )
+
+
 def _handle_components_cloudwatch_event(
     component_id: str, event: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -12719,6 +13002,62 @@ def _cursor_create_document_via_api(payload: Dict[str, Any]) -> Dict[str, Any]:
     return inner
 
 
+def _invoke_document_api(
+    method: str, document_id: str, body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """GET/PATCH a single document via the SAME internal Lambda-invoke mechanism as
+    _cursor_create_document_via_api, generalized past PUT. Used by the ENC-TSK-J46
+    lesson-candidate approve/reject handlers to read and update the candidate
+    document without direct DynamoDB/S3 access to the document store.
+    """
+    fn_name = DOCUMENT_API_LAMBDA_NAME
+    if not fn_name:
+        raise RuntimeError("DOCUMENT_API_LAMBDA_NAME not configured")
+
+    path = f"/api/v1/documents/{document_id}"
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    internal_key = (COORDINATION_INTERNAL_API_KEY or "").strip()
+    if internal_key:
+        headers["X-Coordination-Internal-Key"] = internal_key
+
+    invoke_event = {
+        "version": "2.0",
+        "routeKey": f"{method.upper()} {path}",
+        "rawPath": path,
+        "requestContext": {"http": {"method": method.upper(), "path": path}},
+        "httpMethod": method.upper(),
+        "headers": headers,
+        "isBase64Encoded": False,
+        "body": json.dumps(body) if body is not None else None,
+    }
+
+    resp = _get_lambda_client().invoke(
+        FunctionName=fn_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(invoke_event).encode("utf-8"),
+    )
+    raw = resp.get("Payload")
+    payload_text = raw.read().decode("utf-8") if raw is not None else ""
+    envelope = json.loads(payload_text) if payload_text else {}
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"document API invoke error: {envelope}")
+
+    status_code = int(envelope.get("statusCode") or 0)
+    inner_raw = envelope.get("body")
+    inner: Dict[str, Any] = {}
+    if isinstance(inner_raw, str) and inner_raw:
+        try:
+            inner = json.loads(inner_raw)
+        except json.JSONDecodeError:
+            inner = {}
+    elif isinstance(inner_raw, dict):
+        inner = inner_raw
+    inner["_status_code"] = status_code
+    return inner
+
+
 def _cursor_create_issue(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Create a tracker issue via the SAME internal mechanism existing handlers use.
 
@@ -14277,6 +14616,18 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if decision == "approve":
             return _handle_components_approve(comp_id, event, claims or {})
         return _handle_components_reject(comp_id, event, claims or {})
+
+    # POST /api/v1/coordination/lesson-candidates/{documentId}/approve|reject
+    # (ENC-TSK-J46 / ENC-FTR-096 Ph2). Cognito-gated inside the handlers.
+    match_candidate_decision = re.fullmatch(
+        r"/api/v1/coordination/lesson-candidates/([A-Za-z0-9_\-]+)/(approve|reject)", path
+    )
+    if method == "POST" and match_candidate_decision:
+        candidate_doc_id = match_candidate_decision.group(1)
+        decision = match_candidate_decision.group(2)
+        if decision == "approve":
+            return _handle_lesson_candidate_approve(candidate_doc_id, event, claims or {})
+        return _handle_lesson_candidate_reject(candidate_doc_id, event, claims or {})
 
     # POST /api/v1/coordination/components/{componentId}/{action} where action is
     # one of the ENC-FTR-076 v2 / ENC-TSK-F40 state-machine actions.

--- a/backend/lambda/coordination_api/test_lesson_candidate_curation.py
+++ b/backend/lambda/coordination_api/test_lesson_candidate_curation.py
@@ -1,0 +1,221 @@
+"""Tests for coordination_api lesson-candidate approve/reject (ENC-TSK-J46 / ENC-FTR-096 Ph2).
+
+Validates:
+- Cognito-only enforcement (403 for internal-key sessions) on both approve and reject.
+- Approve requires observation/insight/pillar_scores; creates a lesson record with
+  evidence_chain including the candidate document_id, then patches the candidate to
+  handoff_status='approved'.
+- Reject requires rejection_reason >= 10 chars; patches the candidate to
+  handoff_status='stale' with an appended note (append-only, never deleted).
+- 404 when the candidate document is missing; 400 when it isn't a lesson-candidate;
+  409 when it isn't pending (already decided).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda_lesson_candidate",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = coordination_lambda
+_SPEC.loader.exec_module(coordination_lambda)
+
+
+COGNITO_CLAIMS = {
+    "auth_mode": "cognito",
+    "sub": "user-sub-123",
+    "email": "lead@example.com",
+    "cognito:username": "lead",
+}
+INTERNAL_CLAIMS = {"auth_mode": "internal-key", "sub": "agent"}
+
+PILLAR_SCORES = {
+    "efficiency": 0.8,
+    "human_protection": 0.9,
+    "intention": 0.7,
+    "alignment": 0.8,
+}
+
+PENDING_CANDIDATE = {
+    "_status_code": 200,
+    "document_id": "DOC-CANDIDATE01",
+    "project_id": "enceladus",
+    "title": "LESSON-CANDIDATE -- recurring co-citation cluster",
+    "document_subtype": "lesson-candidate",
+    "handoff_status": "pending",
+}
+
+
+def _event(body):
+    return {"httpMethod": "POST", "body": json.dumps(body or {})}
+
+
+class LessonCandidateApproveTests(unittest.TestCase):
+    def test_internal_key_returns_403(self):
+        resp = coordination_lambda._handle_lesson_candidate_approve(
+            "DOC-CANDIDATE01", _event({}), INTERNAL_CLAIMS
+        )
+        self.assertEqual(resp["statusCode"], 403)
+
+    def test_missing_candidate_returns_404(self):
+        with mock.patch.object(
+            coordination_lambda, "_invoke_document_api", return_value={"_status_code": 404}
+        ):
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-MISSING", _event({}), COGNITO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_wrong_subtype_returns_400(self):
+        wrong = dict(PENDING_CANDIDATE, document_subtype="doc")
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=wrong):
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-CANDIDATE01", _event({}), COGNITO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_already_decided_returns_409(self):
+        decided = dict(PENDING_CANDIDATE, handoff_status="approved")
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=decided):
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-CANDIDATE01", _event({}), COGNITO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 409)
+
+    def test_missing_observation_returns_400(self):
+        with mock.patch.object(
+            coordination_lambda, "_invoke_document_api", return_value=PENDING_CANDIDATE
+        ):
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-CANDIDATE01",
+                _event({"insight": "x", "pillar_scores": PILLAR_SCORES}),
+                COGNITO_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_missing_pillar_scores_returns_400(self):
+        with mock.patch.object(
+            coordination_lambda, "_invoke_document_api", return_value=PENDING_CANDIDATE
+        ):
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-CANDIDATE01",
+                _event({"observation": "o", "insight": "i"}),
+                COGNITO_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_happy_path_creates_lesson_and_patches_candidate(self):
+        calls = []
+
+        def fake_invoke(method, document_id, body=None):
+            calls.append((method, document_id, body))
+            if method == "GET":
+                return PENDING_CANDIDATE
+            return {"_status_code": 200}
+
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", side_effect=fake_invoke), \
+             mock.patch.object(
+                 coordination_lambda,
+                 "_load_project_meta",
+                 return_value=coordination_lambda.ProjectMeta(project_id="enceladus", prefix="ENC"),
+             ), \
+             mock.patch.object(coordination_lambda, "_create_lesson_record", return_value="ENC-LSN-042") as create_mock:
+            resp = coordination_lambda._handle_lesson_candidate_approve(
+                "DOC-CANDIDATE01",
+                _event({
+                    "observation": "Records recur together across handoffs.",
+                    "insight": "This signals a transferable workflow pattern.",
+                    "pillar_scores": PILLAR_SCORES,
+                }),
+                COGNITO_CLAIMS,
+            )
+
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["lesson_id"], "ENC-LSN-042")
+        self.assertEqual(body["handoff_status"], "approved")
+
+        # evidence_chain must include the candidate document_id (provenance anchor).
+        create_args = create_mock.call_args.args
+        evidence_chain = create_args[5]
+        self.assertIn("DOC-CANDIDATE01", evidence_chain)
+
+        # The candidate document must be patched to approved with an append-only note.
+        patch_calls = [c for c in calls if c[0] == "PATCH"]
+        self.assertEqual(len(patch_calls), 1)
+        _, patched_doc_id, patch_body = patch_calls[0]
+        self.assertEqual(patched_doc_id, "DOC-CANDIDATE01")
+        self.assertEqual(patch_body["handoff_status"], "approved")
+        self.assertIn("append_content", patch_body)
+
+
+class LessonCandidateRejectTests(unittest.TestCase):
+    def test_internal_key_returns_403(self):
+        resp = coordination_lambda._handle_lesson_candidate_reject(
+            "DOC-CANDIDATE01", _event({"rejection_reason": "not useful pattern"}), INTERNAL_CLAIMS
+        )
+        self.assertEqual(resp["statusCode"], 403)
+
+    def test_short_reason_returns_400(self):
+        resp = coordination_lambda._handle_lesson_candidate_reject(
+            "DOC-CANDIDATE01", _event({"rejection_reason": "meh"}), COGNITO_CLAIMS
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_missing_candidate_returns_404(self):
+        with mock.patch.object(
+            coordination_lambda, "_invoke_document_api", return_value={"_status_code": 404}
+        ):
+            resp = coordination_lambda._handle_lesson_candidate_reject(
+                "DOC-MISSING", _event({"rejection_reason": "not useful pattern"}), COGNITO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 404)
+
+    def test_already_decided_returns_409(self):
+        decided = dict(PENDING_CANDIDATE, handoff_status="stale")
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=decided):
+            resp = coordination_lambda._handle_lesson_candidate_reject(
+                "DOC-CANDIDATE01", _event({"rejection_reason": "not useful pattern"}), COGNITO_CLAIMS
+            )
+        self.assertEqual(resp["statusCode"], 409)
+
+    def test_happy_path_marks_stale_with_append_only_note(self):
+        calls = []
+
+        def fake_invoke(method, document_id, body=None):
+            calls.append((method, document_id, body))
+            if method == "GET":
+                return PENDING_CANDIDATE
+            return {"_status_code": 200}
+
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", side_effect=fake_invoke):
+            resp = coordination_lambda._handle_lesson_candidate_reject(
+                "DOC-CANDIDATE01",
+                _event({"rejection_reason": "Cluster is coincidental, not a real pattern."}),
+                COGNITO_CLAIMS,
+            )
+
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["handoff_status"], "stale")
+
+        patch_calls = [c for c in calls if c[0] == "PATCH"]
+        self.assertEqual(len(patch_calls), 1)
+        _, patched_doc_id, patch_body = patch_calls[0]
+        self.assertEqual(patched_doc_id, "DOC-CANDIDATE01")
+        self.assertEqual(patch_body["handoff_status"], "stale")
+        self.assertIn("append_content", patch_body)
+        self.assertNotIn("content", patch_body)  # never overwrites, only appends
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -162,6 +162,20 @@ HANDOFF_STATUS_TRANSITIONS = {
 }
 HANDOFF_REQUIRED_FIELDS = {"source_record_id"}  # required when subtype=handoff
 
+# ENC-TSK-J46 / ENC-FTR-096 Ph2: lesson-candidate documents (drafted by the I84
+# memory_consolidation Lambda, written directly via DynamoDB) reuse the
+# handoff_status attribute as their curation-state field. "approved" is only
+# valid for this subtype -- handoff documents keep their own vocabulary above.
+CANDIDATE_STATUSES = {"pending", "approved", "stale"}
+CANDIDATE_STATUS_TRANSITIONS = {
+    "pending": {"approved", "stale"},
+    "approved": set(),
+    "stale": set(),
+}
+# Curation-state transitions that constitute promoting/rejecting a lesson
+# candidate must come from an io-Cognito PWA session -- never an agent session.
+CANDIDATE_GATED_TRANSITIONS = {"approved", "stale"}
+
 # ---------------------------------------------------------------------------
 # COE (correction-of-errors) document schema (ENC-FTR-077)
 # ---------------------------------------------------------------------------
@@ -540,6 +554,12 @@ def _authenticate(event: Dict, required_scopes: Optional[List[str]] = None) -> T
     except ValueError as exc:
         logger.warning("auth failed: %s", exc)
         return None, _error(401, str(exc))
+
+
+def _is_cognito_session(claims: Dict[str, Any]) -> bool:
+    """Return True if the request was authenticated via a Cognito JWT cookie (not internal key)."""
+    mode = str((claims or {}).get("auth_mode") or "").strip().lower()
+    return mode not in ("internal-key", "managed-token")
 
 
 # ---------------------------------------------------------------------------
@@ -2161,7 +2181,19 @@ def _list_by_project(qs: Dict) -> Dict:
     if maturity_filter:
         docs = [d for d in docs if d.get("document_maturity_state", "") == maturity_filter]
 
-    docs.sort(key=lambda d: d.get("updated_at", "") or "", reverse=True)
+    # ENC-TSK-J46 / ENC-FTR-096 Ph2: handoff_status filter (also covers the
+    # lesson-candidate curation-state field, which reuses this attribute).
+    handoff_status_filter = qs.get("handoff_status", "").strip().lower()
+    if handoff_status_filter:
+        docs = [d for d in docs if d.get("handoff_status", "") == handoff_status_filter]
+
+    # ENC-TSK-J46: candidate curation lists sort oldest-drafted-first so the
+    # queue is worked in draft order; every other list keeps the existing
+    # most-recently-updated-first ordering.
+    if qs.get("sort", "").strip().lower() == "created_at":
+        docs.sort(key=lambda d: d.get("created_at", "") or "")
+    else:
+        docs.sort(key=lambda d: d.get("updated_at", "") or "", reverse=True)
     sliced = docs[:PAGE_SIZE]
     return _response(
         200,
@@ -2409,16 +2441,26 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
         expr_parts.append("document_maturity_state = :dms")
         attr_values[":dms"] = {"S": dms}
 
-    # Handoff status transitions (ENC-FTR-061)
+    # Handoff status transitions (ENC-FTR-061); lesson-candidate curation-state
+    # transitions (ENC-TSK-J46 / ENC-FTR-096 Ph2) reuse the same attribute.
     current_subtype = existing.get("document_subtype", {}).get("S", "general")
     if "handoff_status" in body:
-        if current_subtype != "handoff":
-            return _error(400, "Cannot set handoff_status on a non-handoff document.")
+        is_candidate = current_subtype == "lesson-candidate"
+        if current_subtype != "handoff" and not is_candidate:
+            return _error(400, "Cannot set handoff_status on a document of this subtype.")
+        valid_statuses = CANDIDATE_STATUSES if is_candidate else HANDOFF_STATUSES
+        transitions = CANDIDATE_STATUS_TRANSITIONS if is_candidate else HANDOFF_STATUS_TRANSITIONS
         new_handoff_status = str(body["handoff_status"]).strip().lower()
-        if new_handoff_status not in HANDOFF_STATUSES:
-            return _error(400, f"Invalid handoff_status '{new_handoff_status}'. Must be one of: {', '.join(sorted(HANDOFF_STATUSES))}")
+        if is_candidate and new_handoff_status in CANDIDATE_GATED_TRANSITIONS and not _is_cognito_session(claims):
+            return _error(
+                403,
+                "Approving or rejecting a lesson candidate requires Cognito authentication "
+                "(PWA session only) -- no agent session may promote a lesson candidate autonomously.",
+            )
+        if new_handoff_status not in valid_statuses:
+            return _error(400, f"Invalid handoff_status '{new_handoff_status}'. Must be one of: {', '.join(sorted(valid_statuses))}")
         current_handoff_status = existing.get("handoff_status", {}).get("S", "pending")
-        allowed = HANDOFF_STATUS_TRANSITIONS.get(current_handoff_status, set())
+        allowed = transitions.get(current_handoff_status, set())
         if new_handoff_status != current_handoff_status and new_handoff_status not in allowed:
             return _error(
                 400,

--- a/backend/lambda/document_api/test_lesson_candidate_curation.py
+++ b/backend/lambda/document_api/test_lesson_candidate_curation.py
@@ -1,0 +1,144 @@
+"""Tests for document_api lesson-candidate curation-state support (ENC-TSK-J46 / ENC-FTR-096 Ph2).
+
+Validates:
+- _list_by_project honors the handoff_status filter (also usable for candidate
+  curation-state) and the created_at sort used by candidate queues.
+- PATCH handoff_status on a lesson-candidate document requires Cognito auth for
+  the gated transitions (pending -> approved / stale); an internal-key (agent)
+  session gets 403.
+- Valid pending -> approved / pending -> stale transitions succeed for a Cognito
+  session; invalid values / transitions are rejected.
+- handoff_status remains blocked on non-handoff, non-lesson-candidate subtypes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "document_api_lesson_candidate",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+document_api = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(document_api)
+
+
+COGNITO_CLAIMS = {"auth_mode": "cognito", "sub": "user-sub", "email": "lead@example.com"}
+INTERNAL_CLAIMS = {"auth_mode": "internal-key", "sub": "internal-key"}
+
+
+def _event(body):
+    return {"body": json.dumps(body)}
+
+
+def _candidate_item(handoff_status="pending"):
+    return {
+        "document_id": {"S": "DOC-CANDIDATE01"},
+        "project_id": {"S": "enceladus"},
+        "document_subtype": {"S": "lesson-candidate"},
+        "handoff_status": {"S": handoff_status},
+        "version": {"N": "1"},
+    }
+
+
+class ListByProjectFilterTests(unittest.TestCase):
+    @patch.object(document_api, "_get_ddb")
+    def test_handoff_status_filter(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.scan.return_value = {
+            "Items": [
+                _candidate_item("pending"),
+                dict(_candidate_item("approved"), document_id={"S": "DOC-CANDIDATE02"}),
+            ]
+        }
+        resp = document_api._list_by_project(
+            {"project": "enceladus", "handoff_status": "pending"}
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["documents"][0]["document_id"], "DOC-CANDIDATE01")
+
+    @patch.object(document_api, "_get_ddb")
+    def test_created_at_sort(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        older = dict(_candidate_item(), document_id={"S": "DOC-OLD"}, created_at={"S": "2026-01-01T00:00:00Z"})
+        newer = dict(_candidate_item(), document_id={"S": "DOC-NEW"}, created_at={"S": "2026-06-01T00:00:00Z"})
+        fake_ddb.scan.return_value = {"Items": [newer, older]}
+        resp = document_api._list_by_project(
+            {"project": "enceladus", "document_subtype": "lesson-candidate", "sort": "created_at"}
+        )
+        body = json.loads(resp["body"])
+        self.assertEqual([d["document_id"] for d in body["documents"]], ["DOC-OLD", "DOC-NEW"])
+
+
+class LessonCandidatePatchGateTests(unittest.TestCase):
+    @patch.object(document_api, "_authenticate", return_value=(INTERNAL_CLAIMS, None))
+    @patch.object(document_api, "_get_ddb")
+    def test_internal_key_cannot_approve(self, mock_ddb, _auth):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _candidate_item("pending")}
+        resp = document_api._handle_patch(
+            _event({"handoff_status": "approved"}), INTERNAL_CLAIMS, "DOC-CANDIDATE01"
+        )
+        self.assertEqual(resp["statusCode"], 403)
+
+    @patch.object(document_api, "_get_ddb")
+    def test_cognito_can_reject_to_stale(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _candidate_item("pending")}
+
+        with patch.object(document_api, "_get_content", return_value="body"), \
+             patch.object(document_api, "_upload_content", return_value=("s3key", "hash", 4)):
+            resp = document_api._handle_patch(
+                _event({"handoff_status": "stale", "append_content": "Rejected: not useful."}),
+                COGNITO_CLAIMS,
+                "DOC-CANDIDATE01",
+            )
+        self.assertEqual(resp["statusCode"], 200)
+
+    @patch.object(document_api, "_get_ddb")
+    def test_invalid_status_value_rejected(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _candidate_item("pending")}
+        resp = document_api._handle_patch(
+            _event({"handoff_status": "bogus"}), COGNITO_CLAIMS, "DOC-CANDIDATE01"
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    @patch.object(document_api, "_get_ddb")
+    def test_terminal_state_cannot_be_re_decided(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _candidate_item("approved")}
+        resp = document_api._handle_patch(
+            _event({"handoff_status": "stale"}), COGNITO_CLAIMS, "DOC-CANDIDATE01"
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    @patch.object(document_api, "_get_ddb")
+    def test_handoff_status_blocked_on_other_subtypes(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        other = dict(_candidate_item("pending"), document_subtype={"S": "doc"})
+        fake_ddb.get_item.return_value = {"Item": other}
+        resp = document_api._handle_patch(
+            _event({"handoff_status": "approved"}), COGNITO_CLAIMS, "DOC-CANDIDATE01"
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -2343,6 +2343,24 @@ Resources:
       RouteKey: "PUT /api/v1/governance/{fileName+}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-J46 / ENC-FTR-096 Ph2: lesson-candidate curation (gamma-only per
+  # DOC-499FA089EC30 -- v3-prod is frozen pending the io-gated cutover).
+  RouteLessonCandidatesApprove:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/lesson-candidates/{documentId}/approve"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteLessonCandidatesReject:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/lesson-candidates/{documentId}/reject"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -6152,7 +6152,15 @@ async def _documents_list(args: dict) -> list[TextContent]:
     project_id = args["project_id"]
     page_size = int(args.get("page_size", 25))
     cursor = args.get("cursor")
-    resp = _document_api_request("GET", query={"project": project_id})
+    query: Dict[str, Any] = {"project": project_id}
+    # ENC-TSK-J46 / ENC-FTR-096 Ph2: thread through document_subtype /
+    # handoff_status filters (the latter also covers the lesson-candidate
+    # curation-state field) and the created_at sort used by candidate queues.
+    for passthrough_key in ("document_subtype", "handoff_status", "maturity_state", "sort"):
+        value = args.get(passthrough_key)
+        if value:
+            query[passthrough_key] = value
+    resp = _document_api_request("GET", query=query)
     if isinstance(resp, dict) and resp.get("error"):
         return _result_text(resp)
     # Response is typically {"documents": [...]} or a list


### PR DESCRIPTION
## Summary
- Adds the lesson-candidate curation surface (ENC-FTR-096 Ph2): candidates drafted by the I84 memory_consolidation Lambda were previously invisible -- nothing listed, approved, or rejected them.
- `document_api`: `handoff_status` query filter on `documents.list` (also the candidate curation-state field) + `created_at` sort; extends the `handoff_status` PATCH gate to `lesson-candidate` documents with their own `{pending -> approved|stale}` transitions, Cognito-only for the gated transitions (403 for agent/internal-key sessions).
- `coordination_api`: new Cognito-gated `POST /api/v1/coordination/lesson-candidates/{documentId}/approve|reject` routes (mirrors the existing component approve/reject pattern). Approve creates a governed `ENC-LSN` record via the same validation as `tracker.create_lesson` (observation/insight/evidence_chain/provenance/pillar_scores), stamping the candidate's `document_id` into `evidence_chain` so `graph_sync` derives the `LEARNED_FROM` provenance edge, then marks the candidate `approved`. Reject marks it `stale` with an appended note -- never deleted (append-only).
- MCP server: threads `document_subtype`/`handoff_status`/`maturity_state`/`sort` through `documents.list` so the candidate queue is agent-readable (listing only -- promotion stays io-gated).
- `03-api.yaml`: two new gamma-only routes (`Condition: IsGamma`) per DOC-499FA089EC30 (v3-prod frozen pending io cutover).
- `governance_data_dictionary.json`: `document.lesson-candidate` + `coordination.lesson_candidates` entities, version bumped to `2026-07-01.06`.

CCI-334da0c0b1274295b95096f8c21a9c8d

## Test plan
- [x] `pytest backend/lambda/document_api/test_lesson_candidate_curation.py` -- 7 passed
- [x] `pytest backend/lambda/coordination_api/test_lesson_candidate_curation.py` -- 12 passed
- [x] Full `document_api` + `coordination_api` suites re-run clean (2 pre-existing unrelated failures in `test_component_opacity.py`, confirmed present on `origin/v4/main` before this change too)
- [x] `tools/check_governance_dictionary_sync.py` passes for this diff
- [ ] E2E on gamma once deployed: seed a candidate via I84, list it, reject it (verify `stale`), seed another, approve it (verify `ENC-LSN` created with `LEARNED_FROM` provenance) -- per task AC-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)