### PR TITLE
[ENC-TSK-J57] Fix ENC-TSK-J46 lesson-candidate decision write (gamma E2E finding)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.06",
-  "updated_at": "2026-07-02T02:00:00Z",
-  "last_change_summary": "ENC-TSK-J46: lesson-candidate curation surface (list filter + io-gated approve/reject with LEARNED_FROM provenance).",
+  "version": "2026-07-01.07",
+  "updated_at": "2026-07-02T02:20:00Z",
+  "last_change_summary": "ENC-TSK-J46 fix: lesson-candidate approve/reject now finalize via a direct DynamoDB write, not document_api's PATCH (whose internal-key auth was indistinguishable from the MCP server's agent-facing relay, which silently reopened the io-gate).",
   "owners": [
     "enceladus-platform"
   ],
@@ -6310,6 +6310,10 @@
             "min_length": 10
           },
           "definition": "Human-readable reason appended (append-only) to the candidate document content when marking it stale."
+        },
+        "decision_write_mechanism": {
+          "type": "string",
+          "definition": "Approve/reject finalize the candidate's handoff_status via a direct DynamoDB UpdateItem against the documents table (DocumentsTableCandidateDecisionWrite IAM statement, 02-compute.yaml), atomically conditioned on document_subtype='lesson-candidate' AND handoff_status='pending', and append a structured {status,note,by,at} entry to decision_log via list_append. This is NOT proxied through document_api's PATCH: that endpoint authenticates internal-key callers identically whether the caller is coordination_api (already Cognito-verified at its own HTTP layer) or the MCP server relaying a bare agent session's documents.patch call -- routing through it would silently readmit the exact autonomous-promotion path AC4 forbids. A ConditionalCheckFailedException (candidate already decided by a concurrent request) surfaces as HTTP 409."
         }
       }
     }
@@ -6370,6 +6374,11 @@
       "version": "2026-07-01.06",
       "task": "ENC-TSK-J46",
       "summary": "Added document.lesson-candidate and coordination.lesson_candidates entities: candidate list filter (document_api handoff_status query param) and io-gated approve/reject (coordination_api, Cognito-only), approve creates a governed ENC-LSN via the tracker.create_lesson validation surface with evidence_chain provenance back to the candidate."
+    },
+    {
+      "version": "2026-07-01.07",
+      "task": "ENC-TSK-J46",
+      "summary": "Fixed a gamma E2E finding: lesson-candidate approve/reject were calling document_api's PATCH via the shared internal-key service credential, which document_api's Cognito-only gate for candidate transitions correctly rejected (that credential is indistinguishable from the MCP server's agent-facing documents.patch path). Replaced with a direct, atomically-conditioned DynamoDB write plus an append-only decision_log, gated solely by coordination_api's own Cognito check. Added DocumentsTableCandidateDecisionWrite (dynamodb:UpdateItem) to CoordinationApiRole."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -8934,6 +8934,47 @@ def _create_lesson_record(
     raise RuntimeError("Failed allocating lesson record id after retries")
 
 
+def _finalize_lesson_candidate_decision(
+    document_id: str, new_handoff_status: str, decider: str, note: str
+) -> None:
+    """Atomically transition a lesson-candidate's handoff_status and append a
+    structured decision_log entry, directly against DOCUMENTS_TABLE.
+
+    Written directly (DocumentsTableCandidateDecisionWrite in 02-compute.yaml)
+    rather than proxied through document_api's PATCH: that endpoint's
+    internal-key auth is shared with the MCP server's agent-facing
+    documents.patch relay, so it cannot distinguish an already-Cognito-verified
+    coordination_api call from a bare agent session -- routing through it would
+    silently reopen the exact autonomous-promotion hole AC4 forbids. Writing
+    here keeps the Cognito gate solely at this Lambda's own HTTP layer (checked
+    by the caller before this function runs), where it is actually enforceable.
+    Raises botocore.exceptions.ClientError (ConditionalCheckFailedException) if
+    the candidate is no longer pending (race with a concurrent decision).
+    """
+    ddb = _get_ddb()
+    now = _now_z()
+    entry = [{"status": new_handoff_status, "note": note, "by": decider, "at": now}]
+    ddb.update_item(
+        TableName=DOCUMENTS_TABLE,
+        Key={"document_id": _serialize(document_id)},
+        UpdateExpression=(
+            "SET handoff_status = :new, updated_at = :now, "
+            "decision_log = list_append(if_not_exists(decision_log, :empty), :entry)"
+        ),
+        ConditionExpression=(
+            "attribute_exists(document_id) AND document_subtype = :subtype AND handoff_status = :pending"
+        ),
+        ExpressionAttributeValues={
+            ":new": _serialize(new_handoff_status),
+            ":now": _serialize(now),
+            ":empty": _serialize([]),
+            ":entry": _serialize(entry),
+            ":subtype": _serialize("lesson-candidate"),
+            ":pending": _serialize("pending"),
+        },
+    )
+
+
 def _handle_lesson_candidate_approve(
     document_id: str, event: Dict[str, Any], claims: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -9018,22 +9059,24 @@ def _handle_lesson_candidate_approve(
 
     approved_by = _resolve_decider_identity(claims)
     now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-    patch_resp = _invoke_document_api(
-        "PATCH",
-        document_id,
-        {
-            "handoff_status": "approved",
-            "append_content": (
-                f"---\nApproved by {approved_by} at {now}. Promoted to {lesson_id} "
-                f"(ENC-TSK-J46 lesson-candidate curation)."
-            ),
-        },
-    )
-    if patch_resp.get("_status_code") not in (200, 201):
-        logger.warning(
-            "lesson_candidate_approve: %s created but candidate patch failed: %s",
-            lesson_id, patch_resp,
+    try:
+        _finalize_lesson_candidate_decision(
+            document_id,
+            "approved",
+            approved_by,
+            f"Promoted to {lesson_id} (ENC-TSK-J46 lesson-candidate curation).",
         )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.warning(
+                "lesson_candidate_approve: %s created but candidate %s was decided "
+                "concurrently -- candidate handoff_status left unchanged.",
+                lesson_id, document_id,
+            )
+        else:
+            logger.exception(
+                "lesson_candidate_approve: %s created but candidate patch failed", lesson_id
+            )
 
     return _response(
         200,
@@ -9054,8 +9097,9 @@ def _handle_lesson_candidate_reject(
     """POST /api/v1/coordination/lesson-candidates/{documentId}/reject
 
     ENC-TSK-J46 / ENC-FTR-096 Ph2. Marks a pending lesson-candidate document
-    handoff_status='stale' with an appended rejection note — the candidate is
-    never deleted (append-only discipline). Cognito session required.
+    handoff_status='stale' and appends the rejection reason to its append-only
+    decision_log (list_append; the document itself is never deleted or
+    overwritten). Cognito session required.
     """
     if not _is_cognito_session(claims):
         return _error(
@@ -9086,19 +9130,16 @@ def _handle_lesson_candidate_reject(
 
     rejected_by = _resolve_decider_identity(claims)
     now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-    patch_resp = _invoke_document_api(
-        "PATCH",
-        document_id,
-        {
-            "handoff_status": "stale",
-            "append_content": f"---\nRejected by {rejected_by} at {now}. Reason: {rejection_reason}",
-        },
-    )
-    if patch_resp.get("_status_code") not in (200, 201):
-        return _error(
-            502,
-            f"Candidate document patch failed (status={patch_resp.get('_status_code')}): {patch_resp}",
-        )
+    try:
+        _finalize_lesson_candidate_decision(document_id, "stale", rejected_by, rejection_reason)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return _error(
+                409,
+                f"Lesson candidate '{document_id}' was decided concurrently by another request.",
+            )
+        logger.exception("lesson_candidate_reject: candidate write failed")
+        return _error(500, f"Failed to reject lesson candidate: {exc}")
 
     return _response(
         200,

--- a/backend/lambda/coordination_api/test_lesson_candidate_curation.py
+++ b/backend/lambda/coordination_api/test_lesson_candidate_curation.py
@@ -3,12 +3,16 @@
 Validates:
 - Cognito-only enforcement (403 for internal-key sessions) on both approve and reject.
 - Approve requires observation/insight/pillar_scores; creates a lesson record with
-  evidence_chain including the candidate document_id, then patches the candidate to
-  handoff_status='approved'.
-- Reject requires rejection_reason >= 10 chars; patches the candidate to
-  handoff_status='stale' with an appended note (append-only, never deleted).
+  evidence_chain including the candidate document_id, then finalizes the candidate
+  to handoff_status='approved' via a direct DynamoDB write (NOT document_api's PATCH
+  -- that endpoint's internal-key auth is shared with the MCP server's agent-facing
+  documents.patch relay, so it can't distinguish this already-Cognito-verified call
+  from a bare agent session; see _finalize_lesson_candidate_decision).
+- Reject requires rejection_reason >= 10 chars; finalizes the candidate to
+  handoff_status='stale' with the reason appended to its decision_log (append-only,
+  never deleted).
 - 404 when the candidate document is missing; 400 when it isn't a lesson-candidate;
-  409 when it isn't pending (already decided).
+  409 when it isn't pending (already decided), including the concurrent-decision race.
 """
 
 import importlib.util
@@ -113,22 +117,15 @@ class LessonCandidateApproveTests(unittest.TestCase):
             )
         self.assertEqual(resp["statusCode"], 400)
 
-    def test_happy_path_creates_lesson_and_patches_candidate(self):
-        calls = []
-
-        def fake_invoke(method, document_id, body=None):
-            calls.append((method, document_id, body))
-            if method == "GET":
-                return PENDING_CANDIDATE
-            return {"_status_code": 200}
-
-        with mock.patch.object(coordination_lambda, "_invoke_document_api", side_effect=fake_invoke), \
+    def test_happy_path_creates_lesson_and_finalizes_candidate(self):
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=PENDING_CANDIDATE), \
              mock.patch.object(
                  coordination_lambda,
                  "_load_project_meta",
                  return_value=coordination_lambda.ProjectMeta(project_id="enceladus", prefix="ENC"),
              ), \
-             mock.patch.object(coordination_lambda, "_create_lesson_record", return_value="ENC-LSN-042") as create_mock:
+             mock.patch.object(coordination_lambda, "_create_lesson_record", return_value="ENC-LSN-042") as create_mock, \
+             mock.patch.object(coordination_lambda, "_finalize_lesson_candidate_decision") as finalize_mock:
             resp = coordination_lambda._handle_lesson_candidate_approve(
                 "DOC-CANDIDATE01",
                 _event({
@@ -149,13 +146,13 @@ class LessonCandidateApproveTests(unittest.TestCase):
         evidence_chain = create_args[5]
         self.assertIn("DOC-CANDIDATE01", evidence_chain)
 
-        # The candidate document must be patched to approved with an append-only note.
-        patch_calls = [c for c in calls if c[0] == "PATCH"]
-        self.assertEqual(len(patch_calls), 1)
-        _, patched_doc_id, patch_body = patch_calls[0]
-        self.assertEqual(patched_doc_id, "DOC-CANDIDATE01")
-        self.assertEqual(patch_body["handoff_status"], "approved")
-        self.assertIn("append_content", patch_body)
+        # The candidate must be finalized to approved via the direct-write path
+        # (never via document_api's shared-internal-key PATCH -- see
+        # _finalize_lesson_candidate_decision's docstring for why).
+        finalize_mock.assert_called_once()
+        finalize_args = finalize_mock.call_args.args
+        self.assertEqual(finalize_args[0], "DOC-CANDIDATE01")
+        self.assertEqual(finalize_args[1], "approved")
 
 
 class LessonCandidateRejectTests(unittest.TestCase):
@@ -188,16 +185,9 @@ class LessonCandidateRejectTests(unittest.TestCase):
             )
         self.assertEqual(resp["statusCode"], 409)
 
-    def test_happy_path_marks_stale_with_append_only_note(self):
-        calls = []
-
-        def fake_invoke(method, document_id, body=None):
-            calls.append((method, document_id, body))
-            if method == "GET":
-                return PENDING_CANDIDATE
-            return {"_status_code": 200}
-
-        with mock.patch.object(coordination_lambda, "_invoke_document_api", side_effect=fake_invoke):
+    def test_happy_path_marks_stale_via_direct_write(self):
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=PENDING_CANDIDATE), \
+             mock.patch.object(coordination_lambda, "_finalize_lesson_candidate_decision") as finalize_mock:
             resp = coordination_lambda._handle_lesson_candidate_reject(
                 "DOC-CANDIDATE01",
                 _event({"rejection_reason": "Cluster is coincidental, not a real pattern."}),
@@ -208,13 +198,27 @@ class LessonCandidateRejectTests(unittest.TestCase):
         body = json.loads(resp["body"])
         self.assertEqual(body["handoff_status"], "stale")
 
-        patch_calls = [c for c in calls if c[0] == "PATCH"]
-        self.assertEqual(len(patch_calls), 1)
-        _, patched_doc_id, patch_body = patch_calls[0]
-        self.assertEqual(patched_doc_id, "DOC-CANDIDATE01")
-        self.assertEqual(patch_body["handoff_status"], "stale")
-        self.assertIn("append_content", patch_body)
-        self.assertNotIn("content", patch_body)  # never overwrites, only appends
+        finalize_mock.assert_called_once_with(
+            "DOC-CANDIDATE01", "stale", "lead@example.com",
+            "Cluster is coincidental, not a real pattern.",
+        )
+
+    def test_concurrent_decision_race_returns_409(self):
+        class _CCFE(Exception):
+            pass
+
+        error_response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+        with mock.patch.object(coordination_lambda, "_invoke_document_api", return_value=PENDING_CANDIDATE), \
+             mock.patch.object(
+                 coordination_lambda, "_finalize_lesson_candidate_decision",
+                 side_effect=coordination_lambda.ClientError(error_response, "UpdateItem"),
+             ):
+            resp = coordination_lambda._handle_lesson_candidate_reject(
+                "DOC-CANDIDATE01",
+                _event({"rejection_reason": "Cluster is coincidental, not a real pattern."}),
+                COGNITO_CLAIMS,
+            )
+        self.assertEqual(resp["statusCode"], 409)
 
 
 if __name__ == "__main__":

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2253,6 +2253,18 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              # ENC-TSK-J46 / ENC-FTR-096 Ph2: lesson-candidate approve/reject writes the
+              # curation decision directly (documents.patch's internal-key auth is shared
+              # with the MCP server's agent-facing path, so it cannot distinguish an
+              # already-Cognito-verified coordination_api relay from a bare agent call --
+              # direct-write here keeps the Cognito gate solely at coordination_api's own
+              # HTTP layer, where it is actually enforceable).
+              - Sid: DocumentsTableCandidateDecisionWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
               - Sid: ComponentRegistryTableAccess
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
Gamma E2E validation of ENC-TSK-J46 (merged in #705, deployed to gamma) found a real bug: `coordination_api`'s lesson-candidate approve/reject handlers finalized the decision by calling `document_api`'s PATCH using the shared internal-key service credential. That credential is indistinguishable from the MCP server's agent-facing `documents.patch` relay, so `document_api`'s Cognito-only gate for candidate transitions (correctly) rejected it -- a real Cognito-authenticated reject call returned `502` because its own downstream PATCH got `403`.

- `coordination_api` now finalizes lesson-candidate decisions via a direct, atomically-conditioned `dynamodb:UpdateItem` against the documents table (`ConditionExpression` on `document_subtype='lesson-candidate' AND handoff_status='pending'`), gated solely by `coordination_api`'s own `_is_cognito_session` check -- the only place the real caller identity is actually known.
- The decision note is appended to a structured, append-only `decision_log` list (`list_append`) instead of freeform markdown content -- also drops the need to touch `document_api`'s S3/compliance pipeline for this path.
- `02-compute.yaml`: new `DocumentsTableCandidateDecisionWrite` IAM statement (`dynamodb:UpdateItem` on the `documents` table only) on `CoordinationApiRole`.
- `governance_data_dictionary.json` bumped to `2026-07-01.07`.

This is tracked under a small linked task (ENC-TSK-J57) because ENC-TSK-J46 itself can't re-enter its lifecycle from `deploy-success` for a fresh CCI -- the checkout-service `transition_type_matrix` for `github_pr_deploy` rejects `coding-updates` even though the `tracker.task` governance dictionary documents it as the re-entry arc. Flagged as a governance drift in ENC-TSK-J46's worklog.

CCI-0a8c2f6881564fee8d4ce80d48113461

## Test plan
- [x] `pytest backend/lambda/coordination_api/test_lesson_candidate_curation.py` -- 13 passed (including a new concurrent-decision-race test)
- [x] Full `coordination_api` suite re-run clean (530 passed / 2 pre-existing unrelated skips)
- [x] Re-verify on gamma once deployed: Cognito-session reject/approve against the same seeded candidates that reproduced the 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)