### PR TITLE
[ENC-TSK-J58] Wire DOCUMENTS_TABLE env var into coordination_api Lambda

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -189,6 +189,12 @@ Resources:
           COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
           TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          # ENC-TSK-J57: DocumentsTableRead/DocumentsTableCandidateDecisionWrite grant
+          # access to documents${EnvironmentSuffix}, but this env var was never wired
+          # up -- the code's os.environ.get("DOCUMENTS_TABLE", "documents") fallback
+          # silently pointed every environment at the unsuffixed prod table name,
+          # which gamma's IAM (correctly scoped to documents-gamma) then denied.
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           SSM_REGION: !Ref AWS::Region
           SECRETS_REGION: !Ref AWS::Region


### PR DESCRIPTION
## Summary
ENC-TSK-J57's gamma re-verification hit `AccessDeniedException`: `devops-coordination-api-gamma` tried `dynamodb:UpdateItem` on `documents` (prod, unsuffixed) instead of `documents-gamma`. `DocumentsTableRead`/`DocumentsTableCandidateDecisionWrite` IAM grants were correctly scoped to `documents${EnvironmentSuffix}`, but the matching `DOCUMENTS_TABLE` Lambda env var was never actually wired into `coordination_api`'s `Environment.Variables` block -- the Python fallback `os.environ.get("DOCUMENTS_TABLE", "documents")` silently pointed every environment at the unsuffixed prod table name. This was previously dead/latent because nothing in `coordination_api` read/wrote that table until the ENC-TSK-J46/J57 lesson-candidate work made it live.

- Adds `DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"` to the `coordination_api` Lambda's env block in `02-compute.yaml`. No code change.

CCI-f090d22c69014e15aec2dd1337b210ae

## Test plan
- [x] YAML structural parse of the modified template section
- [ ] Gamma re-verification once deployed: `devops-coordination-api-gamma` reads `DOCUMENTS_TABLE=documents-gamma`; lesson-candidate reject/approve succeed end-to-end without `AccessDeniedException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)