### PR TITLE
[ENC-TSK-H81] Markdown-download tests + wire frontend CI + fix stale assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,30 @@ jobs:
           set -euo pipefail
           python3 -m pip install --quiet pyyaml
           python3 tools/test_synthetic_strip_proof.py
+
+  frontend-ui-tests:
+    name: Frontend UI Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend/ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ENC-TSK-H81 (ENC-FTR-051 AC3): documentMarkdown/DownloadMarkdownButton
+      # tests run here; this job is the "comp-enceladus-pwa CI suite" the AC refers to.
+      - name: Run tests
+        run: npm test

--- a/frontend/ui/src/api/client.test.ts
+++ b/frontend/ui/src/api/client.test.ts
@@ -47,7 +47,9 @@ describe('client api helpers', () => {
     expect(data.tasks).toEqual([])
 
     const [url] = fetchMock.mock.calls[0] as [string]
-    expect(url).toBe('/mobile/v1/tasks.json')
+    // fetchFeed appends a cache-busting `_t` query param (Date.now()), so match
+    // the path prefix rather than an exact URL.
+    expect(url.startsWith('/mobile/v1/tasks.json?_t=')).toBe(true)
   })
 
   it('probeSession throws when probe endpoint is non-2xx', async () => {

--- a/frontend/ui/src/components/shared/DownloadMarkdownButton.test.tsx
+++ b/frontend/ui/src/components/shared/DownloadMarkdownButton.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DownloadMarkdownButton } from './DownloadMarkdownButton'
 import type { Document } from '../../types/feeds'
@@ -94,6 +95,30 @@ describe('DownloadMarkdownButton', () => {
 
     // Blob content should reflect the doc object passed as a prop, proving
     // no additional fetch/generation happened client-side.
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is keyboard-activatable: Tab focuses the control and Enter triggers the download (ENC-FTR-051 AC5)', async () => {
+    const user = userEvent.setup()
+    render(<DownloadMarkdownButton document={makeDoc()} />)
+
+    await user.tab()
+    const button = screen.getByRole('button', { name: 'Download markdown' })
+    expect(button).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: 'Downloaded' })).toBeInTheDocument()
+  })
+
+  it('is keyboard-activatable via Space as well as Enter', async () => {
+    const user = userEvent.setup()
+    render(<DownloadMarkdownButton document={makeDoc()} />)
+
+    await user.tab()
+    await user.keyboard(' ')
+
     expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- ENC-FTR-051's golden-file serializer test (`documentMarkdown.test.ts`) and Blob-download/aria/toast interaction test (`DownloadMarkdownButton.test.tsx`) already existed from ENC-TSK-H80 (#702), but AC5's "keyboard-activatable" contract had no explicit coverage. Added Tab+Enter and Tab+Space interaction tests using `@testing-library/user-event`.
- AC3 ("tests run in the comp-enceladus-pwa CI suite") was unsatisfiable as written: no workflow ran `npm test` for `frontend/ui` at all. Added a `frontend-ui-tests` job to `ci.yml` (`npm ci` + `npm test`).
- Running the full suite for the first time surfaced one pre-existing, deterministically-failing assertion in `client.test.ts` -- `fetchFeed` appends a cache-busting `_t` query param (matching the sibling `probeSession` test's pattern) but its own test still asserted an exact URL match with no param. Fixed to match `probeSession`'s `startsWith()` pattern.

CCI-9241b889a69440489df098f760720585

## Test plan
- [x] `npx vitest run` in `frontend/ui` -- 120/120 tests pass (19 files)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the changed test file
- [x] New `ci.yml` job YAML-parses correctly; will run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)