### PR TITLE
ENC-TSK-J60: fix gamma PWA login redirecting to prod

### DIFF
--- a/frontend/ui/src/lib/constants.ts
+++ b/frontend/ui/src/lib/constants.ts
@@ -8,7 +8,12 @@ export const ENABLE_REFRESH_LINK = true
 export const COGNITO_DOMAIN =
   'https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com'
 export const COGNITO_CLIENT_ID = '6q607dk3liirhtecgps7hifmlk'
-export const COGNITO_REDIRECT_URI = 'https://jreese.net/enceladus/callback'
+// Computed from the current origin (not hardcoded to prod) so the OAuth
+// flow returns to whichever domain served the page -- prod, gamma, or any
+// future environment. Each domain's callback URL must also be registered
+// on the Cognito App Client (see enceladus-auth-edge-gamma for gamma's
+// server-side token exchange, which independently derives the same value).
+export const COGNITO_REDIRECT_URI = `${window.location.origin}/enceladus/callback`
 export const COGNITO_SCOPES = 'openid email profile'
 
 export const STATUS_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- io reported: after clicking Sign In on pwa-gamma.jreese.net, Cognito redirected back to **prod** jreese.net/enceladus instead of staying on gamma.
- Root cause: `COGNITO_REDIRECT_URI` was hardcoded to `https://jreese.net/enceladus/callback` in `constants.ts`, used to build the Cognito `/oauth2/authorize` URL regardless of which domain served the page.
- Fix: `COGNITO_REDIRECT_URI` now computed as `` `${window.location.origin}/enceladus/callback` `` -- correct on prod, gamma, and any future domain.
- Companion server-side infra (already live, out-of-band, **does not touch prod's `enceladus-auth-edge` Lambda**): a new, fully separate `enceladus-auth-edge-gamma` Lambda@Edge function on a new `/enceladus/callback*` cache behavior on the gamma CloudFront distribution handles the OAuth code->token exchange with a Host-derived (allowlisted) redirect_uri; `pwa-gamma.jreese.net` and the CloudFront default domain were added as additional Callback URLs on the shared Cognito App Client (existing prod/claude.ai URLs untouched).

## Test plan
- [x] `npm run build`: succeeds.
- [x] `npx vitest run`: 120/120 pass, no regressions.
- [ ] Post-merge live verification: Sign-In button's constructed authorize URL uses the gamma redirect_uri; `/enceladus/callback` (no code) returns 400 from the new Lambda@Edge function.

ENC-TSK-J60 | CCI-3d3ef6f1e89a46ba85b44a4c1d17d0fe

🤖 Generated with [Claude Code](https://claude.com/claude-code)