### PR TITLE
[ENC-TSK-J61] FTR-120 Ph1 — OIDC environment-sub trust extension + trust probe

### DIFF
--- a/.github/workflows/oidc-trust-probe.yml
+++ b/.github/workflows/oidc-trust-probe.yml
@@ -1,0 +1,62 @@
+name: OIDC Trust Probe
+
+# ENC-TSK-J61 / ENC-FTR-120: on-demand proof that an environment-scoped job's
+# OIDC token (sub=repo:...:environment:<name>) can assume the CFN deploy role
+# after the trust-policy extension. Read-only: decodes its own token's claims
+# and calls sts get-caller-identity. Dispatch with the environment to probe;
+# v3-prod dispatches pause on the required-reviewer gate like any other
+# v3-prod job, which is itself part of what this workflow proves.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "GitHub Environment whose OIDC sub to probe"
+        type: choice
+        options: [v4-gamma, v3-prod]
+        required: true
+        default: v4-gamma
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  probe:
+    name: Probe ${{ inputs.target_environment }} OIDC trust
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ inputs.target_environment }}
+
+    steps:
+      - name: Decode own OIDC token claims
+        run: |
+          set -euo pipefail
+          token=$(curl -sS -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | jq -r '.value')
+          payload=$(printf '%s' "$token" | python3 -c "
+          import base64, json, sys
+          seg = sys.stdin.read().split('.')[1]
+          seg += '=' * (-len(seg) % 4)
+          claims = json.loads(base64.urlsafe_b64decode(seg))
+          print(json.dumps({k: claims.get(k) for k in ('sub', 'environment', 'ref', 'aud')}))
+          ")
+          echo "claims: $payload"
+          {
+            echo "## OIDC Trust Probe — ${{ inputs.target_environment }}"
+            echo '```json'
+            echo "$payload"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Assume CFN deploy role via environment-scoped token
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::356364570033:role/enceladus-cloudformation-deploy-github-role
+          aws-region: us-west-2
+
+      - name: Verify assumed identity
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity
+          echo "role assumption via environment-scoped sub: OK" >> "$GITHUB_STEP_SUMMARY"

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -60,6 +60,13 @@ Resources:
                 token.actions.githubusercontent.com:sub:
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/v4/*"
+                  # ENC-TSK-J61 / ENC-FTR-120: a job that declares a GitHub
+                  # Environment emits sub=repo:...:environment:<name> instead of
+                  # the ref-based sub, so the gated CFN deploy lanes (plan/apply
+                  # split, apply job runs inside the environment) need these.
+                  # Additive: ref-based subs stay for ungated/legacy callers.
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v3-prod"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v4-gamma"
       Policies:
         - PolicyName: CloudFormationDeployPolicy
           PolicyDocument:
@@ -94,6 +101,15 @@ Resources:
                   - apigateway:PUT
                   - apigateway:PATCH
                   - apigateway:DELETE
+                  # ENC-TSK-H64: CFn tags stages with stack tags on create; the
+                  # 2026-04-28 ApiDefaultStage CREATE_FAILED was an apigateway:TagResource
+                  # AccessDenied (not CreateStage). Required for the deploy role to
+                  # manage the gamma $default stage going forward.
+                  # (ENC-TSK-J61: restored on v4/main -- present live + on main, but
+                  # missing from this branch; a stack deploy from v4/main without it
+                  # would strip the live permission, the PLN-047 regression class.)
+                  - apigateway:TagResource
+                  - apigateway:UntagResource
                 Resource:
                   - !Sub "arn:aws:apigateway:us-west-2::/*"
 


### PR DESCRIPTION
## Summary
FTR-120 Ph1 (design: DOC-8E7ECA9BB044). Prerequisite for gating the CFN prod lanes: a job that declares a GitHub Environment emits `sub=repo:...:environment:<name>`, which the CFN deploy role's ref-only trust policy would reject.

- Adds `environment:v3-prod` / `environment:v4-gamma` subs to `CloudFormationDeployRole`'s trust policy (additive; ref subs retained).
- **Empirical grounding**: repo OIDC sub customization is `use_default=true`; the Gen2 Lambda lane already proves the environment-sub pattern live via dedicated roles (`GitHubActions-V4Gamma-DeployRole`/`V3Prod`, PR #407) — so `BackendDeployRole` needs no extension and the UI role defers to Ph3.
- Restores the ENC-TSK-H64 `apigateway:TagResource/UntagResource` grant (live + on main, missing from v4/main — deploying without it would strip a live permission, PLN-047 class).
- Adds `oidc-trust-probe.yml`: on-demand read-only proof (token-claim dump + `sts get-caller-identity` under `environment: v4-gamma`).

Stack already deployed via reviewed change-set `enc-tsk-j61-oidc-env-subs` (3 in-place Modifies, no replacements) under io's a priori product-lead authorization for FTR-120; live trust policy verified via `aws iam get-role`.

CCI-aea0a895399f405f98037829e053b85f

## Test plan
- [x] Template + workflow YAML parse
- [x] Template diff vs v4/main additive-only (4 lines)
- [x] Change-set reviewed before execution; live IAM verified after
- [ ] Post-merge: dispatch oidc-trust-probe.yml (v4-gamma) — proves environment-scoped assumption end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)