### PR TITLE
[ENC-TSK-J61] Codify OIDC environment subs on main + register trust probe

### DIFF
--- a/.github/workflows/oidc-trust-probe.yml
+++ b/.github/workflows/oidc-trust-probe.yml
@@ -1,0 +1,62 @@
+name: OIDC Trust Probe
+
+# ENC-TSK-J61 / ENC-FTR-120: on-demand proof that an environment-scoped job's
+# OIDC token (sub=repo:...:environment:<name>) can assume the CFN deploy role
+# after the trust-policy extension. Read-only: decodes its own token's claims
+# and calls sts get-caller-identity. Dispatch with the environment to probe;
+# v3-prod dispatches pause on the required-reviewer gate like any other
+# v3-prod job, which is itself part of what this workflow proves.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "GitHub Environment whose OIDC sub to probe"
+        type: choice
+        options: [v4-gamma, v3-prod]
+        required: true
+        default: v4-gamma
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  probe:
+    name: Probe ${{ inputs.target_environment }} OIDC trust
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ inputs.target_environment }}
+
+    steps:
+      - name: Decode own OIDC token claims
+        run: |
+          set -euo pipefail
+          token=$(curl -sS -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | jq -r '.value')
+          payload=$(printf '%s' "$token" | python3 -c "
+          import base64, json, sys
+          seg = sys.stdin.read().split('.')[1]
+          seg += '=' * (-len(seg) % 4)
+          claims = json.loads(base64.urlsafe_b64decode(seg))
+          print(json.dumps({k: claims.get(k) for k in ('sub', 'environment', 'ref', 'aud')}))
+          ")
+          echo "claims: $payload"
+          {
+            echo "## OIDC Trust Probe — ${{ inputs.target_environment }}"
+            echo '```json'
+            echo "$payload"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Assume CFN deploy role via environment-scoped token
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::356364570033:role/enceladus-cloudformation-deploy-github-role
+          aws-region: us-west-2
+
+      - name: Verify assumed identity
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity
+          echo "role assumption via environment-scoped sub: OK" >> "$GITHUB_STEP_SUMMARY"

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -60,6 +60,14 @@ Resources:
                 token.actions.githubusercontent.com:sub:
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/v4/*"
+                  # ENC-TSK-J61 / ENC-FTR-120: a job that declares a GitHub
+                  # Environment emits sub=repo:...:environment:<name> instead of
+                  # the ref-based sub, so the gated CFN deploy lanes (plan/apply
+                  # split, apply job runs inside the environment) need these.
+                  # Additive: ref-based subs stay for ungated/legacy callers.
+                  # Deployed live 2026-07-02 via change-set enc-tsk-j61-oidc-env-subs.
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v3-prod"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v4-gamma"
       Policies:
         - PolicyName: CloudFormationDeployPolicy
           PolicyDocument:


### PR DESCRIPTION
Main-lane counterpart of #711. The enceladus-github-roles stack is already live with the environment-scoped trust subs (reviewed change-set `enc-tsk-j61-oidc-env-subs`, executed under io's a priori product-lead authorization for FTR-120); this keeps main's template consistent with the deployed stack and registers `oidc-trust-probe.yml` on the default branch so it becomes dispatchable. 04-github-roles.yaml fires no push-deploy on main (DOC-B716E8FB10B6 Channel C) — codification only.

CCI-aea0a895399f405f98037829e053b85f

🤖 Generated with [Claude Code](https://claude.com/claude-code)