### PR TITLE
[ENC-TSK-J62] FTR-120 Ph2a — plan/apply split + environment gates on compute + api CFN workflows

### DIFF
--- a/.github/workflows/cloudformation-api-stack-deploy.yml
+++ b/.github/workflows/cloudformation-api-stack-deploy.yml
@@ -1,5 +1,16 @@
 name: CloudFormation API Stack Deploy
 
+# ENC-TSK-J62 / ENC-FTR-120: plan/apply split with a GitHub Environment gate.
+# The plan job creates (but does not execute) the change-set and writes its
+# resource-level summary to the job summary. The apply job runs inside a
+# GitHub Environment — v3-prod (required reviewer: io) for main, v4-gamma
+# (no reviewer) for v4/** — so a merge to main PAUSES as a reviewable,
+# rejectable request instead of deploying prod directly (the 1292/J08 class).
+# Change-set creation uses `aws cloudformation deploy --no-execute-changeset`
+# deliberately: it preserves deploy's parameter-override semantics (unlisted
+# params reuse the stack's stored values), which the ENC-LSN-053 NoEcho
+# strip-class guards depend on.
+
 on:
   push:
     branches:
@@ -36,6 +47,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: cloudformation-api-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   TEMPLATE_FILE: infrastructure/cloudformation/03-api.yaml
@@ -45,13 +60,14 @@ env:
   DEFAULT_API_NAME: devops-tracker-api
 
 jobs:
-  deploy:
-    name: Deploy API CloudFormation stack
+  plan:
+    name: Plan API stack change-set
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    concurrency:
-      group: cloudformation-api-stack-deploy-${{ github.ref_name }}
-      cancel-in-progress: false
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
 
     steps:
       - name: Checkout
@@ -93,8 +109,8 @@ jobs:
             echo "api_name=${api_name}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Deploy API stack (03-api)
-        id: deploy
+      - name: Create API stack change-set (no execute)
+        id: changeset
         run: |
           set -euo pipefail
 
@@ -104,11 +120,86 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --no-execute-changeset \
             --s3-bucket enceladus-cfn-staging-us-west-2 \
             --s3-prefix 03-api/ \
             --parameter-overrides \
               ComputeStackName="${{ steps.params.outputs.compute_stack_name }}" \
-              ApiName="${{ steps.params.outputs.api_name }}"
+              ApiName="${{ steps.params.outputs.api_name }}" 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## API stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## API stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply API stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
 
       - name: Report stack events on failure
         if: failure() && steps.deploy.conclusion == 'failure'
@@ -116,7 +207,7 @@ jobs:
           echo "=== Stack events (last 20) ==="
           aws cloudformation describe-stack-events \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
             --output table || echo "(describe-stack-events unavailable)"
 
@@ -125,6 +216,6 @@ jobs:
           set -euo pipefail
           aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
             --output table

--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -1,5 +1,25 @@
 name: CloudFormation Compute Stack Deploy
 
+# ENC-TSK-J62 / ENC-FTR-120: plan/apply split with a GitHub Environment gate.
+# The plan job runs every read-only guard (orphan-Lambda guard, pre-deploy
+# health gate, NoEcho strip-class guards) and creates — but does not execute —
+# the 01-data and 02-compute change-sets, writing their resource summaries to
+# the job summary. The apply job runs inside a GitHub Environment: v3-prod
+# (required reviewer: io) for main, v4-gamma (no reviewer) for v4/**. A merge
+# to main therefore PAUSES as a reviewable, rejectable request instead of
+# deploying prod directly (the 1292/J08 class).
+#
+# Change-set creation uses `aws cloudformation deploy --no-execute-changeset`
+# deliberately: it preserves deploy's parameter-override semantics (unlisted
+# params reuse the stack's stored values), which the ENC-LSN-053 NoEcho
+# strip-class guards depend on.
+#
+# Known constraint: the 02-compute change-set is created before the 01-data
+# change-set applies, so a change that ADDS a new cross-stack export consumed
+# by 02-compute in the same merge fails at plan (missing export). Remediation:
+# land/dispatch the data-stack change first, then re-run. Pre-cutover both
+# stacks are fully deployed, so this is a rare, loud, safe failure mode.
+
 on:
   push:
     branches:
@@ -31,6 +51,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: cloudformation-compute-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   TEMPLATE_FILE: infrastructure/cloudformation/02-compute.yaml
@@ -39,13 +63,17 @@ env:
   DEFAULT_DATA_STACK_NAME: enceladus-data
 
 jobs:
-  deploy:
-    name: Deploy Compute CloudFormation stack
+  plan:
+    name: Plan Data + Compute change-sets
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    concurrency:
-      group: cloudformation-compute-stack-deploy-${{ github.ref_name }}
-      cancel-in-progress: false
+    timeout-minutes: 30
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      data_stack_name: ${{ steps.params.outputs.data_stack_name }}
+      data_has_changes: ${{ steps.data_changeset.outputs.has_changes }}
+      data_changeset_arn: ${{ steps.data_changeset.outputs.changeset_arn }}
+      compute_has_changes: ${{ steps.compute_changeset.outputs.has_changes }}
+      compute_changeset_arn: ${{ steps.compute_changeset.outputs.changeset_arn }}
 
     steps:
       - name: Checkout
@@ -136,20 +164,15 @@ jobs:
 
       - name: Pre-deploy health gate (ENC-FTR-102 env parity + ENC-PLN-020 — ENC-TSK-H20)
         # ENC-TSK-H20 / ENC-PLN-048 Obj 3: run the sanctioned pre-deploy health gate
-        # BEFORE `aws cloudformation deploy`, so a deploy that would strip a deploy-critical
-        # env var (the H05/H09/ENC-ISS-369 strip class) fails THIS job and the deploy step
-        # never runs. Check 6 of the script is the FTR-102 env-parity gate
-        # (tools/env_parity_gate.py), registry-driven via env_drift_registry.json (ENC-TSK-H16).
-        # Closes the ENC-TSK-H05 AC-9 residual: tools/pre-deploy-health-gate.sh existed but was
-        # only referenced in coordination handoff templates, never wired into this workflow.
+        # BEFORE change-set creation, so a deploy that would strip a deploy-critical
+        # env var (the H05/H09/ENC-ISS-369 strip class) fails THIS job and no
+        # change-set reaches the approval gate. Check 6 of the script is the FTR-102
+        # env-parity gate (tools/env_parity_gate.py), registry-driven via
+        # env_drift_registry.json (ENC-TSK-H16).
         #
         # AC2 (resolved-env parity reflects the actual deploy): --stack passes the SAME resolved
-        # stack name the deploy step uses (steps.params.outputs.stack_name), so the gate resolves
-        # the template under the identical EnvironmentSuffix (prod="" / gamma="-gamma"). The
-        # deploy's other --parameter-overrides supply NoEcho *values* (CoordinationInternalApiKey,
-        # EnceladusCognitoClientSecret, SharedLayerArn, AppConfig*) — !Ref values that do not
-        # change which env-var KEYS the parity gate evaluates; the empty-value strip class they
-        # guard against is covered by the deploy step's own inline NoEcho guards + Check 5.
+        # stack name the change-set uses (steps.params.outputs.stack_name), so the gate resolves
+        # the template under the identical EnvironmentSuffix (prod="" / gamma="-gamma").
         # No `continue-on-error`: a non-zero exit is fail-closed and blocks the deploy.
         run: |
           set -euo pipefail
@@ -158,22 +181,29 @@ jobs:
             --template "${TEMPLATE_FILE}" \
             --region "${AWS_REGION}"
 
-      - name: Clean up orphaned data-stack resources (pre-deploy idempotency guard)
+      - name: Handle orphaned data-stack resources (pre-changeset idempotency guard)
         run: |
           set -euo pipefail
           # When a previous 01-data CFN update creates resources then rolls back with
-          # DeletionPolicy:Retain, those resources are left untracked by the stack.
-          # The next deploy fails at changeset creation (AWS::EarlyValidation::ResourceExistenceCheck)
-          # because the resource exists but is not managed by the stack.
-          # This step deletes any such orphaned resources before the deploy so CFN can CREATE them.
+          # DeletionPolicy:Retain, those resources are left untracked by the stack and the
+          # next change-set fails AWS::EarlyValidation::ResourceExistenceCheck.
+          #
+          # ENC-TSK-J62 / ENC-FTR-120 posture change: on GAMMA this step self-heals by
+          # deleting the orphaned debris (as before). On PROD it now FAILS CLOSED and
+          # names the orphans instead of deleting prod resources from an ungated plan
+          # job — strictly safer than the pre-J62 behavior, where this deletion ran
+          # ungated on every main merge. Prod orphans need an explicit import or a
+          # deliberate manual cleanup (DOC-B716E8FB10B6 hard-stop class).
           stack_name="${{ steps.params.outputs.data_stack_name }}"
-          account="356364570033"
           region="${AWS_REGION}"
           suffix="${ENVIRONMENT_SUFFIX}"
+          is_gamma="false"
+          [ "${suffix}" = "-gamma" ] && is_gamma="true"
+          prod_orphans=()
 
           # --- SNS topics ---
           candidate_topics=(
-            "arn:aws:sns:${region}:${account}:enceladus-component-registry-events${suffix}"
+            "arn:aws:sns:${region}:356364570033:enceladus-component-registry-events${suffix}"
           )
           tracked_sns=$(aws cloudformation list-stack-resources \
             --stack-name "${stack_name}" --region "${region}" \
@@ -182,9 +212,13 @@ jobs:
           for arn in "${candidate_topics[@]}"; do
             if echo "${tracked_sns}" | grep -qF "${arn}"; then
               echo "SNS topic tracked by stack, skipping: ${arn}"
-            else
-              echo "Deleting orphaned SNS topic: ${arn}"
-              aws sns delete-topic --topic-arn "${arn}" --region "${region}" 2>/dev/null || true
+            elif aws sns get-topic-attributes --topic-arn "${arn}" --region "${region}" >/dev/null 2>&1; then
+              if [ "${is_gamma}" = "true" ]; then
+                echo "Deleting orphaned SNS topic: ${arn}"
+                aws sns delete-topic --topic-arn "${arn}" --region "${region}" 2>/dev/null || true
+              else
+                prod_orphans+=("SNS ${arn}")
+              fi
             fi
           done
 
@@ -201,55 +235,91 @@ jobs:
           for table in "${candidate_tables[@]}"; do
             if echo "${tracked_tables}" | grep -qF "${table}"; then
               echo "DynamoDB table tracked by stack, skipping: ${table}"
+              continue
+            fi
+            table_status=$(aws dynamodb describe-table --table-name "${table}" \
+              --region "${region}" \
+              --query "Table.TableStatus" --output text 2>/dev/null || echo "NOT_FOUND")
+            if [ "${table_status}" = "NOT_FOUND" ]; then
+              echo "Table does not exist: ${table} — nothing to do"
+              continue
+            fi
+            if [ "${is_gamma}" != "true" ]; then
+              prod_orphans+=("DynamoDB ${table}")
+              continue
+            fi
+            protect=$(aws dynamodb describe-table --table-name "${table}" \
+              --region "${region}" \
+              --query "Table.DeletionProtectionEnabled" --output text 2>/dev/null || echo "false")
+            if [ "${protect}" = "True" ] || [ "${protect}" = "true" ]; then
+              echo "::warning::Table ${table} has DeletionProtection=true — skipping delete, manual import required"
             else
-              # Only delete if the table actually exists and DeletionProtection is off
-              status=$(aws dynamodb describe-table --table-name "${table}" \
-                --region "${region}" \
-                --query "Table.TableStatus" --output text 2>/dev/null || echo "NOT_FOUND")
-              if [ "${status}" = "NOT_FOUND" ]; then
-                echo "Table does not exist: ${table} — nothing to delete"
-              else
-                protect=$(aws dynamodb describe-table --table-name "${table}" \
-                  --region "${region}" \
-                  --query "Table.DeletionProtectionEnabled" --output text 2>/dev/null || echo "false")
-                if [ "${protect}" = "True" ] || [ "${protect}" = "true" ]; then
-                  echo "::warning::Table ${table} has DeletionProtection=true — skipping delete, manual import required"
-                else
-                  echo "Deleting orphaned DynamoDB table: ${table} (status=${status})"
-                  aws dynamodb delete-table --table-name "${table}" --region "${region}" 2>&1 || true
-                  # Wait for table to be deleted before proceeding
-                  aws dynamodb wait table-not-exists --table-name "${table}" --region "${region}" 2>/dev/null || true
-                  echo "Table ${table} deleted."
-                fi
-              fi
+              echo "Deleting orphaned DynamoDB table: ${table} (status=${table_status})"
+              aws dynamodb delete-table --table-name "${table}" --region "${region}" 2>&1 || true
+              aws dynamodb wait table-not-exists --table-name "${table}" --region "${region}" 2>/dev/null || true
+              echo "Table ${table} deleted."
             fi
           done
 
-      - name: Deploy Data stack (01-data)
+          if [ "${#prod_orphans[@]}" -gt 0 ]; then
+            echo "::error::Orphaned prod data-stack resource(s) detected (live but not stack-managed):"
+            printf '::error::  - %s\n' "${prod_orphans[@]}"
+            echo "::error::Refusing to auto-delete prod resources from the plan job. Import them into ${stack_name} or clean up deliberately (DOC-B716E8FB10B6 hard-stop class), then re-run."
+            exit 1
+          fi
+
+      - name: Create Data stack change-set (01-data, no execute)
+        id: data_changeset
         run: |
           set -euo pipefail
-          # Deploy the data stack first so cross-stack exports (e.g. GovernanceVersionTableArn)
-          # exist before 02-compute is deployed. Uses previous values for all params not
-          # overridden here; EnvironmentSuffix and Environment are derived from the branch.
-          environment="${ENVIRONMENT_SUFFIX:+-gamma}"
-          environment="${environment:-production}"
-          # ENVIRONMENT_SUFFIX is "-gamma" or "". 'production' when empty.
           [ -n "${ENVIRONMENT_SUFFIX}" ] && environment="gamma" || environment="production"
+
           aws cloudformation deploy \
             --region "${AWS_REGION}" \
             --stack-name "${{ steps.params.outputs.data_stack_name }}" \
             --template-file infrastructure/cloudformation/01-data.yaml \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --no-execute-changeset \
             --s3-bucket enceladus-cfn-staging-us-west-2 \
             --s3-prefix 01-data/ \
             --parameter-overrides \
               EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" \
               Environment="${environment}" \
-              DynamoDBRegion="${AWS_REGION}"
+              DynamoDBRegion="${AWS_REGION}" 2>&1 | tee /tmp/plan-data.log
 
-      - name: Deploy Compute stack (02-compute)
-        id: deploy
+          if grep -q "No changes to deploy" /tmp/plan-data.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Data stack plan — ${{ steps.params.outputs.data_stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan-data.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Data change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Data stack plan — ${{ steps.params.outputs.data_stack_name }}"
+            echo ""
+            echo "Change-set: \`${changeset_arn}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${changeset_arn}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create Compute stack change-set (02-compute, no execute)
+        id: compute_changeset
         run: |
           set -euo pipefail
 
@@ -307,6 +377,7 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --no-execute-changeset \
             --s3-bucket enceladus-cfn-staging-us-west-2 \
             --s3-prefix 02-compute/ \
             --parameter-overrides \
@@ -316,41 +387,115 @@ jobs:
               AppConfigEnvironmentId="${APPCFG_ENV}" \
               EnceladusCognitoClientSecret="${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}" \
               SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10" \
-              CursorWebhookSecret="${{ secrets.CURSOR_WEBHOOK_SECRET }}"
+              CursorWebhookSecret="${{ secrets.CURSOR_WEBHOOK_SECRET }}" 2>&1 | tee /tmp/plan-compute.log
               # ADE Component C (ENC-FTR-118): pass the Cursor webhook HMAC secret as a NoEcho
               # param so `aws cloudformation deploy` does not reuse/zero it (same value-strip class
               # as ENC-LSN-053). No hard empty-guard here on purpose: an unset secret resolves to
               # "" and the handler fails CLOSED (rejects all webhooks) — secure default — so an
-              # un-set secret never wedges unrelated gamma compute deploys. Set the GitHub Actions
-              # secret CURSOR_WEBHOOK_SECRET (= the value configured in Cursor's webhook settings)
-              # before relying on the /api/v1/cursor/webhook route.
+              # un-set secret never wedges unrelated gamma compute deploys.
+
+          if grep -q "No changes to deploy" /tmp/plan-compute.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Compute stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan-compute.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Compute change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Compute stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${changeset_arn}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${changeset_arn}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply Data + Compute change-sets
+    needs: plan
+    if: needs.plan.outputs.data_has_changes == 'true' || needs.plan.outputs.compute_has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute Data stack change-set
+        id: deploy_data
+        if: needs.plan.outputs.data_has_changes == 'true'
+        run: |
+          set -euo pipefail
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.data_changeset_arn }}"
+          aws cloudformation wait stack-update-complete \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.data_stack_name }}"
+
+      - name: Execute Compute stack change-set
+        id: deploy
+        if: needs.plan.outputs.compute_has_changes == 'true'
+        run: |
+          set -euo pipefail
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.compute_changeset_arn }}"
+          aws cloudformation wait stack-update-complete \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}"
 
       - name: Report stack events on failure
-        if: failure() && steps.deploy.conclusion == 'failure'
+        if: failure()
         run: |
-          echo "=== Stack events (last 20) ==="
-          aws cloudformation describe-stack-events \
-            --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
-            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
-            --output table || echo "(describe-stack-events unavailable)"
+          for s in "${{ needs.plan.outputs.data_stack_name }}" "${{ needs.plan.outputs.stack_name }}"; do
+            echo "=== Stack events (last 20) — ${s} ==="
+            aws cloudformation describe-stack-events \
+              --region "${AWS_REGION}" \
+              --stack-name "${s}" \
+              --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+              --output table || echo "(describe-stack-events unavailable)"
+          done
 
       - name: Verify deployed stack state
         run: |
           set -euo pipefail
-          status=$(aws cloudformation describe-stacks \
+          stack_state=$(aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].StackStatus' \
             --output text)
-          echo "Stack status: ${status}"
-          if [ "${status}" != "UPDATE_COMPLETE" ] && [ "${status}" != "CREATE_COMPLETE" ]; then
-            echo "::error::Stack ${{ steps.params.outputs.stack_name }} is in unexpected state: ${status}"
+          echo "Stack status: ${stack_state}"
+          if [ "${stack_state}" != "UPDATE_COMPLETE" ] && [ "${stack_state}" != "CREATE_COMPLETE" ]; then
+            echo "::error::Stack ${{ needs.plan.outputs.stack_name }} is in unexpected state: ${stack_state}"
             exit 1
           fi
           aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
             --output table
 


### PR DESCRIPTION
## Summary
FTR-120 Ph2a (design DOC-8E7ECA9BB044 D1+D2, prerequisite ENC-TSK-J61 closed). Splits the two highest-traffic CFN workflows into:
- **plan** (ungated): all existing read-only guards + change-set creation via `aws cloudformation deploy --no-execute-changeset` (preserves the parameter-reuse semantics the ENC-LSN-053 NoEcho strip-class guards depend on); writes the resource-level Add/Modify/Remove summary to the job summary for the approval screen.
- **apply** (gated): `environment: v3-prod` (required reviewer: io) on main; `environment: v4-gamma` (no reviewer) on v4/**. Executes only the reviewed change-set. Merge-to-main now pauses as a rejectable request — the 1292/J08 ungated-prod-CFN class is closed on these two workflows.

Safety posture change: the orphaned data-stack-resource cleanup still self-heals on gamma, but on prod now **fails closed** naming the orphans, instead of deleting prod resources from an ungated job (strictly safer than pre-J62).

No-change merges skip apply entirely (no empty approval requests). Concurrency stays per-ref so pending prod approvals can't block gamma.

CCI-68008b16891842dfae807042321dc554

## Test plan
- [x] Both workflows YAML-parse; job graph verified (plan ungated → apply environment-scoped, needs+if wiring)
- [ ] This merge itself fires both workflows on v4/main (gamma lane) — live validation of the ungated gamma path
- [ ] Main-lane port follows for the prod gate to become real (workflows must exist on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)