### PR TITLE
ENC-TSK-J68: Escalations entity + escalation.request/get/list surface (FTR-121 Ph1)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.08",
-  "updated_at": "2026-07-02T02:45:00Z",
-  "last_change_summary": "ENC-TSK-J59 fix: _create_lesson_record now converts pillar_scores/confidence to Decimal before DynamoDB put_item -- boto3's TypeSerializer rejects native float Number values, which crashed the lesson-candidate approve path with a 500 on gamma.",
+  "version": "2026-07-02.01",
+  "updated_at": "2026-07-02T04:10:00Z",
+  "last_change_summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only).",
   "owners": [
     "enceladus-platform"
   ],
@@ -6316,6 +6316,195 @@
           "definition": "Approve/reject finalize the candidate's handoff_status via a direct DynamoDB UpdateItem against the documents table (DocumentsTableCandidateDecisionWrite IAM statement, 02-compute.yaml), atomically conditioned on document_subtype='lesson-candidate' AND handoff_status='pending', and append a structured {status,note,by,at} entry to decision_log via list_append. This is NOT proxied through document_api's PATCH: that endpoint authenticates internal-key callers identically whether the caller is coordination_api (already Cognito-verified at its own HTTP layer) or the MCP server relaying a bare agent session's documents.patch call -- routing through it would silently readmit the exact autonomous-promotion path AC4 forbids. A ConditionalCheckFailedException (candidate already decided by a concurrent request) surfaces as HTTP 409. ENC-TSK-J59: pillar_scores and confidence are converted to Decimal (via Decimal(str(v)) to avoid binary-float precision drift) before the lesson record's put_item -- boto3's TypeSerializer raises TypeError on native float Number values."
         }
       }
+    },
+    "tracker.escalation": {
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "fields": {
+        "escalation_id": {
+          "type": "string",
+          "constraints": {
+            "format": "{PREFIX}-ESC-{SEQ}",
+            "immutable": true
+          },
+          "definition": "Server-minted escalation ID (e.g. ENC-ESC-001).",
+          "usage_guidance": "Minted by tracker_mutation's atomic-counter ID authority via the 'escalation' entry in _TRACKER_TYPE_SUFFIX. ID Boundary Rule holds without exception: no client predicts, computes, or scans for the next ID."
+        },
+        "target_record_id": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "The tracker record the requested mutation targets.",
+          "usage_guidance": "Must be an existing task (TSK), issue (ISS), or feature (FTR) record. Validated for existence at request time with a consistent read."
+        },
+        "mutation_type": {
+          "type": "enum",
+          "enum": [
+            "deploy_arc_change",
+            "direct_state_override"
+          ],
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+        },
+        "payload": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Mutation-type-specific payload, validated by the handler's validate_payload at request time.",
+          "usage_guidance": "Stored as a JSON document on the item; malformed payloads fail fast at request time and never reach io's queue."
+        },
+        "justification": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "definition": "Required free-text rationale from the requesting agent, shown to io on the PWA approval card."
+        },
+        "expected_version": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Optional target-record version or content hash captured at request time.",
+          "usage_guidance": "When supplied and the target has drifted by approval time, the PWA shows a drift warning; io may still approve (informed consent) or deny."
+        },
+        "requested_by": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Requesting agent identity: {session_id (ENC-SES-*, required), agent_type_id (ENC-AGT-*), sci_present (bool)}.",
+          "usage_guidance": "session_id is required (server-minted ENC-SES id; ENC-FTR-117). SCI-bearing sessions stamp sci_present=true once ENC-ISS-441 ships."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "requested",
+            "approved",
+            "denied",
+            "denied_with_guidance",
+            "applying",
+            "applied",
+            "failed"
+          ],
+          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
+          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+        },
+        "events": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
+        },
+        "guidance_note": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "io's free-text course-correction note on deny-with-guidance; travels back to the agent in the event stream."
+        },
+        "approved_by": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Cognito sub + email of the approving human. Null until approval.",
+          "usage_guidance": "Written only by the Cognito-gated approval route (Ph3/ENC-TSK-J70). Structurally unwritable by agent credentials."
+        },
+        "applied_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "required": false
+          },
+          "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
+        },
+        "result": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Applier outcome object (success detail or captured error on failed). Null until terminal."
+        },
+        "created_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "immutable": true
+          },
+          "definition": "Server-stamped at request time."
+        },
+        "updated_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "definition": "Server-stamped on every mutation."
+        }
+      },
+      "dynamodb_key_schema": {
+        "pk": "project_id",
+        "sk_pattern": "escalation#{escalation_id}",
+        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "record_id_format": "{PREFIX}-ESC-{SEQ}",
+        "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
+      },
+      "mutation_rules": {
+        "escalation_id": "IMMUTABLE (server-minted)",
+        "target_record_id": "IMMUTABLE after create",
+        "mutation_type": "IMMUTABLE after create",
+        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
+        "events": "APPEND_ONLY (list_append only)",
+        "approved_by": "Written only by the Cognito human approval route",
+        "applied_at": "Written exactly once by applyEscalatedMutation"
+      },
+      "required_fields": [
+        "target_record_id",
+        "mutation_type",
+        "payload",
+        "justification",
+        "requested_by"
+      ],
+      "waiver_semantics": {
+        "escalation_waived_sentinel": {
+          "shape": {
+            "escalation_waived": true,
+            "escalation_id": "ENC-ESC-NNN",
+            "waived_at": "iso8601"
+          },
+          "definition": "\u00a75.6: when direct_state_override lands a record in a state whose invariant fields are unsupplied, each such field is written with this sentinel rather than left null. Downstream consumers read 'known-absent by human decision', which is semantically distinct from 'never reached' or 'data loss'. Writer ships in Ph2 (ENC-TSK-J69)."
+        },
+        "escalated_closure": {
+          "type": "boolean",
+          "definition": "Set true on any record closed via direct_state_override so ENC-FTR-118 empirical-runtime metrics and close-quality reporting can filter override closures out of organic-completion datasets. Writer ships in Ph2 (ENC-TSK-J69)."
+        }
+      }
+    },
+    "mcp_server.escalation_actions": {
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "fields": {
+        "escalation.request": {
+          "type": "execute_action",
+          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+        },
+        "escalation.get": {
+          "type": "search_action",
+          "definition": "Return the full escalation item by escalation_id (project_id required)."
+        },
+        "escalation.list": {
+          "type": "search_action",
+          "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6384,6 +6573,11 @@
       "version": "2026-07-01.08",
       "task": "ENC-TSK-J59",
       "summary": "Fixed a second gamma E2E finding: approving a lesson candidate 500'd because _create_lesson_record passed pillar_scores/confidence as native Python floats into DynamoDB put_item -- boto3's TypeSerializer requires Decimal for Number attributes. Converted via Decimal(str(v)). Added a dedicated serialization regression test that exercises the real put_item path (no mocking of _serialize) so this class of bug fails in CI, not just in gamma."
+    },
+    {
+      "version": "2026-07-02.01",
+      "task": "ENC-TSK-J68",
+      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
     }
   ]
 }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -319,8 +319,8 @@ def _publish_lesson_scoring_request(project_id: str, record_id: str, item_id: st
 _RECORD_TYPES = {"task", "issue", "feature", "lesson", "plan", "generation"}
 _CLOSED_STATUS = {"task": "closed", "issue": "closed", "feature": "completed", "lesson": "archived", "plan": "complete", "generation": "archived"}
 _DEFAULT_STATUS = {"task": "open", "issue": "open", "feature": "planned", "lesson": "draft", "plan": "drafted", "generation": "drafted"}
-_TRACKER_TYPE_SUFFIX = {"task": "TSK", "issue": "ISS", "feature": "FTR", "lesson": "LSN", "plan": "PLN", "generation": "GEN"}
-_ID_SEGMENT_TO_TYPE = {"TSK": "task", "ISS": "issue", "FTR": "feature", "LSN": "lesson", "PLN": "plan", "GEN": "generation"}
+_TRACKER_TYPE_SUFFIX = {"task": "TSK", "issue": "ISS", "feature": "FTR", "lesson": "LSN", "plan": "PLN", "generation": "GEN", "escalation": "ESC"}
+_ID_SEGMENT_TO_TYPE = {"TSK": "task", "ISS": "issue", "FTR": "feature", "LSN": "lesson", "PLN": "plan", "GEN": "generation", "ESC": "escalation"}
 
 # Category validation per record type
 _VALID_CATEGORIES = {
@@ -409,6 +409,111 @@ _REVERT_TRANSITIONS = {
         "started": {"incomplete"},
     },
 }
+
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 / ENC-TSK-J68 — Escalations: Human-Gated Mutation Override
+# Surface (DOC-5B888FCA43B8), Phase 1: entity + request/read surface.
+#
+# Escalation items live in the EXISTING tracker table (record_id =
+# "escalation#ENC-ESC-…"; no new table or GSI — Channel B purity). They are
+# deliberately NOT a member of _RECORD_TYPES: the generic record CRUD,
+# checkout, lifecycle, and tracker.set surfaces cannot touch them. The
+# escalation FSM below is enforced normally — escalations are not themselves
+# escalatable (§5.2). ENC-ESC IDs are minted by _next_record_id via the
+# "escalation" entry in _TRACKER_TYPE_SUFFIX (ID Boundary Rule holds).
+# ---------------------------------------------------------------------------
+ENABLE_ESCALATION_PRIMITIVE = _appconfig_flag(
+    "enable_escalation_primitive",
+    env_fallback="ENABLE_ESCALATION_PRIMITIVE",
+    default=True,
+)
+
+# §5.2 escalation status lifecycle. `failed` is terminal: a corrective
+# request is a NEW escalation (exactly-once semantics stay trivial).
+_ESCALATION_FSM = {
+    "requested": {"approved", "denied", "denied_with_guidance"},
+    "approved": {"applying"},
+    "applying": {"applied", "failed"},
+    "denied": set(),
+    "denied_with_guidance": set(),
+    "applied": set(),
+    "failed": set(),
+}
+_ESCALATION_STATUSES = set(_ESCALATION_FSM.keys())
+_ESCALATION_TARGET_TYPES = {"task", "issue", "feature"}
+
+
+def _statuses_for_record_type(record_type: str) -> set:
+    """Full dictionary-legal status universe for a record type.
+
+    Derived from the normal transition graph (keys ∪ targets) plus the
+    create-time default and the ENC-FTR-115 `superseded` alt-terminal.
+    Used by direct_state_override validation, which checks status LEGALITY
+    only — path legality is deliberately unchecked (§5.3): the path is
+    precisely what io's approval overrides.
+    """
+    graph = _VALID_TRANSITIONS.get(record_type, {})
+    statuses = set(graph.keys())
+    for targets in graph.values():
+        statuses |= set(targets)
+    default_status = _DEFAULT_STATUS.get(record_type)
+    if default_status:
+        statuses.add(default_status)
+    if record_type in ("task", "issue", "lesson"):
+        statuses.add("superseded")
+    return statuses
+
+
+def _validate_deploy_arc_change_payload(payload: Dict, target_record_type: str) -> str:
+    """§5.3 handler 1: request-time validation for deploy_arc_change."""
+    if target_record_type != "task":
+        return (
+            "deploy_arc_change targets must be task records; "
+            f"'{target_record_type}' records have no deploy arc."
+        )
+    new_arc = str(payload.get("new_deploy_arc_type") or "").strip()
+    if not new_arc:
+        return "Field 'payload.new_deploy_arc_type' is required for deploy_arc_change."
+    if new_arc not in VALID_TRANSITION_TYPES:
+        return (
+            f"Invalid new_deploy_arc_type '{new_arc}'. "
+            f"Allowed: {sorted(VALID_TRANSITION_TYPES)}"
+        )
+    return ""
+
+
+def _validate_direct_state_override_payload(payload: Dict, target_record_type: str) -> str:
+    """§5.3 handler 2: request-time validation for direct_state_override.
+
+    Confirms target_status is dictionary-legal for the record type. Path
+    legality is deliberately NOT checked here — that is what io approval
+    overrides.
+    """
+    target_status = str(payload.get("target_status") or "").strip()
+    if not target_status:
+        return "Field 'payload.target_status' is required for direct_state_override."
+    legal = _statuses_for_record_type(target_record_type)
+    if target_status not in legal:
+        return (
+            f"Invalid target_status '{target_status}' for record type "
+            f"'{target_record_type}'. Allowed: {sorted(legal)}"
+        )
+    field_values = payload.get("field_values")
+    if field_values is not None and not isinstance(field_values, dict):
+        return "Field 'payload.field_values' must be an object when supplied."
+    return ""
+
+
+# §5.3 mutation handler registry (v4-shaped). Each handler grows three
+# functions across the feature: validate_payload (request time, this phase),
+# render_diff (approval time, Ph3/ENC-TSK-J70), and apply (invoked ONLY by
+# applyEscalatedMutation after io approval, Ph2/ENC-TSK-J69). Adding a third
+# mutation type is a registry entry plus handler, not an architectural change.
+_ESCALATION_MUTATION_HANDLERS = {
+    "deploy_arc_change": {"validate_payload": _validate_deploy_arc_change_payload},
+    "direct_state_override": {"validate_payload": _validate_direct_state_override_payload},
+}
+
 
 # ENC-FTR-076 / ENC-TSK-E08: Component lifecycle transitions.
 # Components are registered in the component-registry table (separate from
@@ -6467,6 +6572,285 @@ def _handle_dedup_auto_merge(project_id: str, body: Dict, claims: Optional[Dict]
 
 
 # ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph1 / ENC-TSK-J68 — escalation request/read handlers
+# ---------------------------------------------------------------------------
+
+def _parse_escalation_target(target_record_id: str):
+    """Resolve (record_type, sort_key, error) for an escalation target ID.
+
+    Target IDs look like PREFIX-SEG-SEQ (e.g. ENC-TSK-J68); SEG resolves the
+    record type via _ID_SEGMENT_TO_TYPE and must be an escalatable type.
+    """
+    parts = str(target_record_id or "").strip().split("-")
+    if len(parts) < 3:
+        return None, None, (
+            "Field 'target_record_id' must look like PREFIX-SEG-SEQ "
+            "(e.g. ENC-TSK-123)."
+        )
+    segment = parts[1].upper()
+    record_type = _ID_SEGMENT_TO_TYPE.get(segment)
+    if record_type is None or record_type not in _ESCALATION_TARGET_TYPES:
+        return None, None, (
+            f"target_record_id type '{segment}' is not escalatable. "
+            "Allowed: task (TSK), issue (ISS), feature (FTR)."
+        )
+    return record_type, f"{record_type}#{target_record_id}", ""
+
+
+def _escalation_event(event_type: str, actor: str, detail: Optional[Dict] = None,
+                      guidance_note: str = "") -> Dict:
+    """Build one §11.2 event object in DynamoDB attribute shape (append-only)."""
+    event_attrs = {
+        "event_type": _ser_s(event_type),
+        "at": _ser_s(_now_z()),
+        "actor": _ser_s(actor or "system"),
+    }
+    if detail:
+        event_attrs["detail"] = _ser_s(json.dumps(detail, default=str))
+    if guidance_note:
+        event_attrs["guidance_note"] = _ser_s(guidance_note)
+    return {"M": event_attrs}
+
+
+def _escalation_public(item: Dict) -> Dict:
+    """Deserialize an escalation item for API responses (payload back to JSON)."""
+    record = _deser_item(item)
+    raw_payload = record.get("payload")
+    if isinstance(raw_payload, str):
+        try:
+            record["payload"] = json.loads(raw_payload)
+        except (ValueError, TypeError):
+            pass
+    for event in record.get("events") or []:
+        raw_detail = event.get("detail") if isinstance(event, dict) else None
+        if isinstance(raw_detail, str):
+            try:
+                event["detail"] = json.loads(raw_detail)
+            except (ValueError, TypeError):
+                pass
+    return record
+
+
+def _handle_escalation_request(project_id: str, body: Dict) -> Dict:
+    """POST /{project}/escalation — governed escalation.request (§5.4).
+
+    Validates the §11.1 envelope via the mutation-handler registry, mints an
+    ENC-ESC id server-side, writes the item with status=requested, and appends
+    the `requested` event. Malformed requests fail fast and write NOTHING —
+    they never reach io's queue.
+    """
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    target_record_id = str(body.get("target_record_id") or "").strip()
+    mutation_type = str(body.get("mutation_type") or "").strip()
+    payload = body.get("payload")
+    justification = str(body.get("justification") or "").strip()
+    expected_version = str(body.get("expected_version") or "").strip()
+
+    if not target_record_id:
+        return _error(400, "Field 'target_record_id' is required.")
+    handler = _ESCALATION_MUTATION_HANDLERS.get(mutation_type)
+    if handler is None:
+        return _error(
+            400,
+            f"Unknown mutation_type '{mutation_type}'. "
+            f"Allowed: {sorted(_ESCALATION_MUTATION_HANDLERS)}.",
+        )
+    if not isinstance(payload, dict) or not payload:
+        return _error(400, "Field 'payload' is required and must be a non-empty object.")
+    if not justification:
+        return _error(400, "Field 'justification' is required (free-text rationale for io).")
+
+    target_type, target_sk, target_err = _parse_escalation_target(target_record_id)
+    if target_err:
+        return _error(400, target_err)
+
+    requested_by_raw = body.get("requested_by")
+    requested_by = requested_by_raw if isinstance(requested_by_raw, dict) else {}
+    session_id = str(
+        requested_by.get("session_id")
+        or (body.get("write_source") or {}).get("provider")
+        or ""
+    ).strip()
+    if not session_id:
+        return _error(
+            400,
+            "Field 'requested_by.session_id' is required "
+            "(server-minted ENC-SES session id).",
+        )
+    agent_type_id = str(requested_by.get("agent_type_id") or "").strip()
+    sci_present = bool(requested_by.get("sci_present", False))
+
+    validation_error = handler["validate_payload"](payload, target_type)
+    if validation_error:
+        return _error(400, validation_error)
+
+    # Target must exist — read fresh, never trust the caller's snapshot.
+    ddb = _get_ddb()
+    try:
+        target_item = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation target read failed: %s", exc)
+        return _error(500, "Database read failed while validating target record.")
+    if not target_item:
+        return _error(404, f"Target record not found: {target_record_id}")
+
+    prefix = _get_project_prefix(project_id)
+    if not prefix:
+        return _error(404, f"Project '{project_id}' not found or has no prefix.")
+
+    escalation_id = _next_record_id(project_id, prefix, "escalation")
+    now = _now_z()
+    item = {
+        "project_id": _ser_s(project_id),
+        "record_id": _ser_s(f"escalation#{escalation_id}"),
+        "item_id": _ser_s(escalation_id),
+        "record_type": _ser_s("escalation"),
+        "target_record_id": _ser_s(target_record_id),
+        "target_record_type": _ser_s(target_type),
+        "mutation_type": _ser_s(mutation_type),
+        "payload": _ser_s(json.dumps(payload, default=str)),
+        "justification": _ser_s(justification),
+        "requested_by": {"M": {
+            "session_id": _ser_s(session_id),
+            "agent_type_id": _ser_s(agent_type_id),
+            "sci_present": {"BOOL": sci_present},
+        }},
+        "status": _ser_s("requested"),
+        "events": {"L": [_escalation_event(
+            "requested",
+            session_id,
+            detail={"mutation_type": mutation_type, "target_record_id": target_record_id},
+        )]},
+        "created_at": _ser_s(now),
+        "updated_at": _ser_s(now),
+        "write_source": _build_write_source(body),
+    }
+    if expected_version:
+        item["expected_version"] = _ser_s(expected_version)
+
+    try:
+        ddb.put_item(
+            TableName=DYNAMODB_TABLE,
+            Item=item,
+            ConditionExpression="attribute_not_exists(record_id)",
+        )
+    except Exception as exc:
+        logger.error("escalation put_item failed: %s", exc)
+        return _error(500, "Database write failed while creating escalation.")
+
+    return _response(201, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": "requested",
+        "target_record_id": target_record_id,
+        "target_record_type": target_type,
+        "mutation_type": mutation_type,
+        "created_at": now,
+    })
+
+
+def _handle_escalation_get(project_id: str, escalation_id: str) -> Dict:
+    """GET /{project}/escalation/{id} — full escalation item (§5.4)."""
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+    ddb = _get_ddb()
+    try:
+        item = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation get_item failed: %s", exc)
+        return _error(500, "Database read failed.")
+    if not item:
+        return _error(404, f"Escalation not found: {escalation_id}")
+    return _response(200, {"success": True, "escalation": _escalation_public(item)})
+
+
+def _handle_escalation_list(project_id: str, query_params: Dict) -> Dict:
+    """GET /{project}/escalation — list with status/target/session filters (§5.4)."""
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    status_filter = str(query_params.get("status") or "").strip()
+    target_filter = str(query_params.get("target_record_id") or "").strip()
+    session_filter = str(query_params.get("session_id") or "").strip()
+    if status_filter and status_filter not in _ESCALATION_STATUSES:
+        return _error(
+            400,
+            f"Invalid status filter '{status_filter}'. "
+            f"Allowed: {sorted(_ESCALATION_STATUSES)}",
+        )
+    try:
+        page_size = max(1, min(int(query_params.get("page_size", "50")), 200))
+    except (TypeError, ValueError):
+        page_size = 50
+
+    ddb = _get_ddb()
+    key_values = {
+        ":pid": _ser_s(project_id),
+        ":esc_prefix": _ser_s("escalation#"),
+    }
+    filter_clauses = []
+    expression_names = {}
+    if status_filter:
+        filter_clauses.append("#st = :status_filter")
+        expression_names["#st"] = "status"
+        key_values[":status_filter"] = _ser_s(status_filter)
+    if target_filter:
+        filter_clauses.append("target_record_id = :target_filter")
+        key_values[":target_filter"] = _ser_s(target_filter)
+    if session_filter:
+        filter_clauses.append("requested_by.session_id = :session_filter")
+        key_values[":session_filter"] = _ser_s(session_filter)
+
+    kwargs = {
+        "TableName": DYNAMODB_TABLE,
+        "KeyConditionExpression": (
+            "project_id = :pid AND begins_with(record_id, :esc_prefix)"
+        ),
+        "ExpressionAttributeValues": key_values,
+    }
+    if filter_clauses:
+        kwargs["FilterExpression"] = " AND ".join(filter_clauses)
+    if expression_names:
+        kwargs["ExpressionAttributeNames"] = expression_names
+
+    escalations = []
+    try:
+        while True:
+            resp = ddb.query(**kwargs)
+            escalations.extend(
+                _escalation_public(raw) for raw in resp.get("Items", [])
+            )
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key or len(escalations) >= page_size:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalation list query failed: %s", exc)
+        return _error(500, "Database query failed.")
+
+    escalations.sort(key=lambda esc: esc.get("created_at", ""), reverse=True)
+    escalations = escalations[:page_size]
+    return _response(200, {
+        "success": True,
+        "escalations": escalations,
+        "count": len(escalations),
+    })
+
+
+# ---------------------------------------------------------------------------
 # Path parsing & routing
 # ---------------------------------------------------------------------------
 
@@ -6474,6 +6858,9 @@ def _handle_dedup_auto_merge(project_id: str, body: Dict, claims: Optional[Dict]
 _RE_PENDING_UPDATES = re.compile(r"^(?:/api/v1/tracker)?/pending-updates$")
 _RE_DEDUP_REVIEW = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-z0-9_-]+)/dedup-review$"
+)
+_RE_ESCALATION = re.compile(
+    r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/escalation(?:/(?P<id>[A-Za-z0-9_-]+))?$"
 )
 _RE_RELATIONSHIP = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/relationship$"
@@ -6542,6 +6929,33 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
             return _handle_dedup_auto_merge(project_id, body, claims)
         else:
             return _error(400, "Field 'op' must be 'propose', 'approve', or 'auto-merge'.")
+
+    # --- Route: escalations (ENC-FTR-121 Ph1 / ENC-TSK-J68) ---
+    m_escalation = _RE_ESCALATION.match(path)
+    if m_escalation:
+        project_id = m_escalation.group("project")
+        escalation_id = m_escalation.group("id")
+        claims, auth_err = _authenticate(
+            event,
+            ["tracker:read"] if method == "GET" else ["tracker:write"],
+        )
+        if auth_err:
+            return auth_err
+        project_err = _validate_project_exists(project_id)
+        if project_err:
+            return _error(404, project_err)
+        if method == "POST" and not escalation_id:
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except (ValueError, TypeError):
+                return _error(400, "Invalid JSON body.")
+            _normalize_write_source(body, claims)
+            return _handle_escalation_request(project_id, body)
+        elif method == "GET" and escalation_id:
+            return _handle_escalation_get(project_id, escalation_id)
+        elif method == "GET":
+            return _handle_escalation_list(project_id, query_params)
+        return _error(405, f"Method {method} not allowed on /escalation.")
 
     # --- Route: typed relationship edges (ENC-FTR-049) ---
     m_rel = _RE_RELATIONSHIP.match(path)

--- a/backend/lambda/tracker_mutation/test_escalation_j68.py
+++ b/backend/lambda/tracker_mutation/test_escalation_j68.py
@@ -1,0 +1,401 @@
+"""ENC-TSK-J68 (ENC-FTR-121 Ph1): Escalations entity + request/read surface tests.
+
+Covers, in the established tracker_mutation house style (no DDB round-trip):
+the mutation-handler registry validate_payload contracts (deploy_arc_change
+arc-type legality + task-only targets; direct_state_override status legality
+with path legality DELIBERATELY unchecked — that is what io approval
+overrides), the request handler's fail-fast envelope validation (malformed
+requests write NOTHING), server-side ENC-ESC minting through the existing
+atomic-counter ID authority, the `requested` event append shape (§11.2),
+get/list read paths with status/target/session filters, and the route regex.
+
+The applier (applyEscalatedMutation), waiver sentinels, and escalated_closure
+land in Ph2 (ENC-TSK-J69) with their own test weight.
+"""
+import json
+import unittest
+from unittest import mock
+
+
+def _fake_ddb(target_item=None, counter_next=7):
+    """MagicMock DDB serving the target read, the mint counter, and put capture.
+
+    get_item routes on the record_id key: counter#escalation returns a live
+    counter (so _next_record_id skips the seed scan); anything else returns
+    target_item (or nothing).
+    """
+    fake = mock.MagicMock()
+
+    def _get_item(TableName=None, Key=None, **kwargs):
+        record_id = (Key or {}).get("record_id", {}).get("S", "")
+        if record_id.startswith("counter#"):
+            return {"Item": {"next_num": {"N": str(counter_next - 1)}}}
+        if target_item is not None:
+            return {"Item": target_item}
+        return {}
+
+    fake.get_item.side_effect = _get_item
+    fake.update_item.return_value = {"Attributes": {"next_num": {"N": str(counter_next)}}}
+    return fake
+
+
+def _request_body(**overrides):
+    body = {
+        "target_record_id": "ENC-TSK-J10",
+        "mutation_type": "deploy_arc_change",
+        "payload": {"new_deploy_arc_type": "code_only"},
+        "justification": "Arc misclassified at create; task ships no deployable artifact.",
+        "requested_by": {"session_id": "ENC-SES-02F", "agent_type_id": "ENC-AGT-006"},
+    }
+    body.update(overrides)
+    return body
+
+
+_TARGET_TASK_ITEM = {
+    "project_id": {"S": "enceladus"},
+    "record_id": {"S": "task#ENC-TSK-J10"},
+    "item_id": {"S": "ENC-TSK-J10"},
+    "record_type": {"S": "task"},
+    "status": {"S": "open"},
+    "title": {"S": "target"},
+}
+
+
+class TestStatusUniverse(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_task_universe_includes_full_arc_and_superseded(self):
+        statuses = self.lf._statuses_for_record_type("task")
+        for expected in ("open", "in-progress", "coding-complete", "committed",
+                         "pr", "merged-main", "deploy-init", "deploy-success",
+                         "closed", "coding-updates", "superseded"):
+            self.assertIn(expected, statuses)
+
+    def test_issue_universe(self):
+        statuses = self.lf._statuses_for_record_type("issue")
+        self.assertEqual({"open", "in-progress", "closed", "superseded"}, statuses)
+
+    def test_feature_universe_has_no_superseded(self):
+        statuses = self.lf._statuses_for_record_type("feature")
+        self.assertIn("production", statuses)
+        self.assertNotIn("superseded", statuses)
+
+
+class TestDeployArcChangeValidation(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.validate = lf._ESCALATION_MUTATION_HANDLERS["deploy_arc_change"]["validate_payload"]
+
+    def test_legal_arc_on_task_passes(self):
+        self.assertEqual("", self.validate({"new_deploy_arc_type": "code_only"}, "task"))
+
+    def test_non_task_target_rejected(self):
+        err = self.validate({"new_deploy_arc_type": "code_only"}, "issue")
+        self.assertIn("task records", err)
+
+    def test_missing_arc_rejected(self):
+        self.assertIn("new_deploy_arc_type", self.validate({}, "task"))
+
+    def test_illegal_arc_rejected(self):
+        err = self.validate({"new_deploy_arc_type": "carrier_pigeon"}, "task")
+        self.assertIn("carrier_pigeon", err)
+        self.assertIn("github_pr_deploy", err)
+
+
+class TestDirectStateOverrideValidation(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.validate = lf._ESCALATION_MUTATION_HANDLERS["direct_state_override"]["validate_payload"]
+
+    def test_path_illegal_but_dictionary_legal_status_passes(self):
+        # closed -> pr is path-illegal in the normal FSM; the validator must
+        # accept it (status legality only) — path is what io approval overrides.
+        self.assertEqual("", self.validate({"target_status": "pr"}, "task"))
+
+    def test_terminal_closure_status_passes(self):
+        self.assertEqual("", self.validate({"target_status": "closed"}, "task"))
+
+    def test_superseded_passes_for_task(self):
+        self.assertEqual("", self.validate({"target_status": "superseded"}, "task"))
+
+    def test_status_from_wrong_type_universe_rejected(self):
+        err = self.validate({"target_status": "deploy-success"}, "issue")
+        self.assertIn("deploy-success", err)
+
+    def test_missing_target_status_rejected(self):
+        self.assertIn("target_status", self.validate({}, "task"))
+
+    def test_non_dict_field_values_rejected(self):
+        err = self.validate({"target_status": "closed", "field_values": "oops"}, "task")
+        self.assertIn("field_values", err)
+
+    def test_dict_field_values_passes(self):
+        payload = {"target_status": "closed", "field_values": {"live_validation_evidence": "gamma smoke ok"}}
+        self.assertEqual("", self.validate(payload, "task"))
+
+
+class TestTargetParse(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_task_issue_feature_targets_resolve(self):
+        for record_id, expected_type in (("ENC-TSK-J10", "task"), ("ENC-ISS-441", "issue"), ("ENC-FTR-121", "feature")):
+            record_type, sort_key, err = self.lf._parse_escalation_target(record_id)
+            self.assertEqual("", err)
+            self.assertEqual(expected_type, record_type)
+            self.assertEqual(f"{expected_type}#{record_id}", sort_key)
+
+    def test_lesson_target_rejected(self):
+        _, _, err = self.lf._parse_escalation_target("ENC-LSN-039")
+        self.assertIn("not escalatable", err)
+
+    def test_malformed_id_rejected(self):
+        _, _, err = self.lf._parse_escalation_target("garbage")
+        self.assertIn("PREFIX-SEG-SEQ", err)
+
+
+class TestEscalationRequest(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _run(self, body, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb), \
+             mock.patch.object(self.lf, "_get_project_prefix", return_value="ENC"):
+            return self.lf._handle_escalation_request("enceladus", body)
+
+    def test_happy_path_mints_and_writes_requested_item(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM, counter_next=7)
+        resp = self._run(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        payload = json.loads(resp["body"])
+        self.assertTrue(payload["success"])
+        self.assertEqual("requested", payload["status"])
+        self.assertRegex(payload["escalation_id"], r"^ENC-ESC-[A-Z0-9]{3}$")
+
+        self.assertEqual(1, ddb.put_item.call_count)
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual(f"escalation#{payload['escalation_id']}", item["record_id"]["S"])
+        self.assertEqual("escalation", item["record_type"]["S"])
+        self.assertEqual("requested", item["status"]["S"])
+        self.assertEqual("ENC-SES-02F", item["requested_by"]["M"]["session_id"]["S"])
+        self.assertFalse(item["requested_by"]["M"]["sci_present"]["BOOL"])
+        events = item["events"]["L"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("requested", events[0]["M"]["event_type"]["S"])
+        self.assertEqual("ENC-SES-02F", events[0]["M"]["actor"]["S"])
+        stored_payload = json.loads(item["payload"]["S"])
+        self.assertEqual("code_only", stored_payload["new_deploy_arc_type"])
+
+    def test_expected_version_persisted_when_supplied(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._run(_request_body(expected_version="sync_version:4"), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual("sync_version:4", item["expected_version"]["S"])
+
+    def test_session_falls_back_to_write_source_provider(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        body = _request_body(requested_by=None,
+                             write_source={"provider": "ENC-SES-02F", "channel": "mcp_server"})
+        resp = self._run(body, ddb)
+        self.assertEqual(201, resp["statusCode"])
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual("ENC-SES-02F", item["requested_by"]["M"]["session_id"]["S"])
+
+    def _assert_rejected_without_write(self, body, status, fragment, target_item=_TARGET_TASK_ITEM):
+        ddb = _fake_ddb(target_item=target_item)
+        resp = self._run(body, ddb)
+        self.assertEqual(status, resp["statusCode"])
+        self.assertIn(fragment, json.loads(resp["body"])["error"])
+        ddb.put_item.assert_not_called()
+
+    def test_unknown_mutation_type_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(mutation_type="delete_everything"), 400, "delete_everything")
+
+    def test_missing_justification_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(justification=""), 400, "justification")
+
+    def test_missing_payload_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(payload=None), 400, "payload")
+
+    def test_missing_target_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(target_record_id=""), 400, "target_record_id")
+
+    def test_missing_session_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(requested_by={}), 400, "session_id")
+
+    def test_invalid_payload_for_handler_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(payload={"new_deploy_arc_type": "bogus"}), 400, "bogus")
+
+    def test_nonexistent_target_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(), 404, "not found", target_item=None)
+
+    def test_arc_change_on_issue_target_rejected_without_write(self):
+        body = _request_body(target_record_id="ENC-ISS-441")
+        self._assert_rejected_without_write(body, 400, "task records")
+
+    def test_flag_off_returns_503(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        with mock.patch.object(self.lf, "ENABLE_ESCALATION_PRIMITIVE", False):
+            resp = self._run(_request_body(), ddb)
+        self.assertEqual(503, resp["statusCode"])
+        ddb.put_item.assert_not_called()
+
+
+class TestEscalationGet(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def test_found_returns_deserialized_escalation_with_parsed_payload(self):
+        item = {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": "escalation#ENC-ESC-001"},
+            "item_id": {"S": "ENC-ESC-001"},
+            "record_type": {"S": "escalation"},
+            "status": {"S": "requested"},
+            "payload": {"S": json.dumps({"target_status": "closed"})},
+            "events": {"L": [{"M": {
+                "event_type": {"S": "requested"},
+                "at": {"S": "2026-07-02T04:00:00Z"},
+                "actor": {"S": "ENC-SES-02F"},
+                "detail": {"S": json.dumps({"mutation_type": "direct_state_override"})},
+            }}]},
+        }
+        fake = mock.MagicMock()
+        fake.get_item.return_value = {"Item": item}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_get("enceladus", "ENC-ESC-001")
+        self.assertEqual(200, resp["statusCode"])
+        escalation = json.loads(resp["body"])["escalation"]
+        self.assertEqual({"target_status": "closed"}, escalation["payload"])
+        self.assertEqual("direct_state_override", escalation["events"][0]["detail"]["mutation_type"])
+        key = fake.get_item.call_args.kwargs["Key"]
+        self.assertEqual("escalation#ENC-ESC-001", key["record_id"]["S"])
+
+    def test_missing_returns_404(self):
+        fake = mock.MagicMock()
+        fake.get_item.return_value = {}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_get("enceladus", "ENC-ESC-999")
+        self.assertEqual(404, resp["statusCode"])
+
+
+class TestEscalationList(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _item(self, esc_id, created_at):
+        return {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": f"escalation#{esc_id}"},
+            "item_id": {"S": esc_id},
+            "record_type": {"S": "escalation"},
+            "status": {"S": "requested"},
+            "payload": {"S": "{}"},
+            "created_at": {"S": created_at},
+        }
+
+    def _run(self, query_params, items):
+        fake = mock.MagicMock()
+        fake.query.return_value = {"Items": items}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_list("enceladus", query_params)
+        return resp, fake
+
+    def test_unfiltered_list_sorts_newest_first(self):
+        items = [self._item("ENC-ESC-001", "2026-07-02T01:00:00Z"),
+                 self._item("ENC-ESC-002", "2026-07-02T03:00:00Z")]
+        resp, fake = self._run({}, items)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+        self.assertEqual("ENC-ESC-002", body["escalations"][0]["item_id"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("begins_with(record_id, :esc_prefix)", kwargs["KeyConditionExpression"])
+        self.assertNotIn("FilterExpression", kwargs)
+
+    def test_status_filter_lands_in_filter_expression(self):
+        resp, fake = self._run({"status": "requested"}, [])
+        self.assertEqual(200, resp["statusCode"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("#st = :status_filter", kwargs["FilterExpression"])
+        self.assertEqual({"#st": "status"}, kwargs["ExpressionAttributeNames"])
+        self.assertEqual({"S": "requested"}, kwargs["ExpressionAttributeValues"][":status_filter"])
+
+    def test_target_and_session_filters_compose(self):
+        resp, fake = self._run(
+            {"target_record_id": "ENC-TSK-J10", "session_id": "ENC-SES-02F"}, [])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("target_record_id = :target_filter", kwargs["FilterExpression"])
+        self.assertIn("requested_by.session_id = :session_filter", kwargs["FilterExpression"])
+        self.assertIn(" AND ", kwargs["FilterExpression"])
+
+    def test_invalid_status_filter_rejected(self):
+        resp, fake = self._run({"status": "pending"}, [])
+        self.assertEqual(400, resp["statusCode"])
+        fake.query.assert_not_called()
+
+    def test_page_size_clamped(self):
+        items = [self._item(f"ENC-ESC-{i:03d}", f"2026-07-02T0{i}:00:00Z") for i in range(1, 4)]
+        resp, _ = self._run({"page_size": "2"}, items)
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+
+
+class TestEscalationRoute(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_regex_matches_collection_and_item_paths(self):
+        for path, expected_id in (
+            ("/api/v1/tracker/enceladus/escalation", None),
+            ("/enceladus/escalation", None),
+            ("/api/v1/tracker/enceladus/escalation/ENC-ESC-001", "ENC-ESC-001"),
+        ):
+            match = self.lf._RE_ESCALATION.match(path)
+            self.assertIsNotNone(match, path)
+            self.assertEqual("enceladus", match.group("project"))
+            self.assertEqual(expected_id, match.group("id"))
+
+    def test_regex_does_not_swallow_other_routes(self):
+        self.assertIsNone(self.lf._RE_ESCALATION.match("/enceladus/task"))
+        self.assertIsNone(self.lf._RE_ESCALATION.match("/enceladus/task/ENC-TSK-J10"))
+
+    def test_escalation_never_joined_generic_record_types(self):
+        # Guard: escalations must stay OUT of the generic CRUD surface.
+        self.assertNotIn("escalation", self.lf._RECORD_TYPES)
+        self.assertEqual("ESC", self.lf._TRACKER_TYPE_SUFFIX["escalation"])
+        self.assertEqual("escalation", self.lf._ID_SEGMENT_TO_TYPE["ESC"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -234,6 +234,10 @@ ENABLE_LESSON_PRIMITIVE = _appconfig_flag("enable_lesson_primitive", env_fallbac
 ENABLE_HANDOFF_PRIMITIVE = _appconfig_flag("enable_handoff_primitive", env_fallback="ENABLE_HANDOFF_PRIMITIVE")
 # ENC-FTR-076 / ENC-TSK-E08
 ENABLE_COMPONENT_PROPOSAL = _appconfig_flag("enable_component_proposal", env_fallback="ENABLE_COMPONENT_PROPOSAL")
+# ENC-FTR-121 / ENC-TSK-J68: Escalations — human-gated mutation override surface
+# (DOC-5B888FCA43B8). Default ON: the request/read surface is inert unless
+# called and carries no privileged write path (the applier is io-approval-gated).
+ENABLE_ESCALATION_PRIMITIVE = _appconfig_flag("enable_escalation_primitive", env_fallback="ENABLE_ESCALATION_PRIMITIVE", default=True)
 
 TRACKER_API_INTERNAL_API_KEY = os.environ.get(
     "ENCELADUS_TRACKER_API_INTERNAL_API_KEY",
@@ -6084,6 +6088,61 @@ async def _tracker_create(args: dict) -> list[TextContent]:
     resp = _tracker_api_request("POST", f"/{project_id}/{record_type}", payload=payload)
     return _result_text(resp)
 
+
+# --- ENC-FTR-121 / ENC-TSK-J68: Escalations request/read surface ------------
+# escalation.request proposes a lifecycle-forbidden mutation for io approval.
+# The backend validates the envelope via its mutation-handler registry and
+# mints the ENC-ESC id server-side (ID Boundary Rule). approve/deny have NO
+# MCP surface by design — they exist only behind the Cognito human path (§6).
+
+
+async def _escalation_request(args: dict) -> list[TextContent]:
+    governance_error = _require_governance_hash(args)
+    if governance_error:
+        return _result_text({"error": governance_error})
+
+    project_id = args["project_id"]
+    payload: Dict[str, Any] = {
+        "target_record_id": args.get("target_record_id", ""),
+        "mutation_type": args.get("mutation_type", ""),
+        "payload": args.get("payload"),
+        "justification": args.get("justification", ""),
+        "governance_hash": args.get("governance_hash", ""),
+    }
+    for optional_key in ("expected_version", "requested_by", "provider",
+                         "coordination_request_id", "dispatch_id"):
+        if args.get(optional_key) is not None:
+            payload[optional_key] = args[optional_key]
+
+    resp = _tracker_api_request("POST", f"/{project_id}/escalation", payload=payload)
+    return _result_text(resp)
+
+
+async def _escalation_get(args: dict) -> list[TextContent]:
+    project_id = args.get("project_id", "")
+    escalation_id = str(args.get("escalation_id", "")).strip()
+    if not escalation_id:
+        return _result_text({"error": "Field 'escalation_id' is required."})
+    if not project_id:
+        return _result_text({"error": "Field 'project_id' is required."})
+    resp = _tracker_api_request("GET", f"/{project_id}/escalation/{escalation_id}")
+    return _result_text(resp)
+
+
+async def _escalation_list(args: dict) -> list[TextContent]:
+    project_id = args.get("project_id", "")
+    if not project_id:
+        return _result_text({"error": "Field 'project_id' is required."})
+    query = {
+        "status": args.get("status"),
+        "target_record_id": args.get("target_record_id"),
+        "session_id": args.get("session_id"),
+        "page_size": args.get("page_size"),
+    }
+    resp = _tracker_api_request("GET", f"/{project_id}/escalation", query=query)
+    return _result_text(resp)
+
+
 # --- Acceptance Criteria Evidence Handshake (§7.1.1) ---
 
 
@@ -7656,6 +7715,20 @@ if ENABLE_TYPED_RELATIONSHIPS:
     }
     _SEARCH_ACTIONS["tracker.list_relationships"] = {
         "tool": "tracker_list_relationships",
+    }
+
+# ENC-FTR-121 / ENC-TSK-J68: Escalations — governed request/read surface.
+# escalation.request proposes a lifecycle-forbidden mutation for io approval;
+# approve/deny deliberately have NO MCP action (Cognito human path only, §6).
+if ENABLE_ESCALATION_PRIMITIVE:
+    _EXECUTE_ACTIONS["escalation.request"] = {
+        "tool": "escalation_request", "requires_governance_hash": True,
+    }
+    _SEARCH_ACTIONS["escalation.get"] = {
+        "tool": "escalation_get",
+    }
+    _SEARCH_ACTIONS["escalation.list"] = {
+        "tool": "escalation_list",
     }
 
 # ENC-FTR-052: Conditionally register lesson actions behind feature flag
@@ -10566,6 +10639,10 @@ _TOOL_HANDLERS = {
     "github_create_issue": _github_create_issue,
     "github_projects_sync": _github_projects_sync,
     "github_projects_list": _github_projects_list,
+    # ENC-FTR-121 / ENC-TSK-J68: Escalations request/read surface
+    "escalation_request": _escalation_request,
+    "escalation_get": _escalation_get,
+    "escalation_list": _escalation_list,
     # ENC-FTR-047: Graph search
     "tracker_graphsearch": _tracker_graphsearch,
     # ENC-FTR-089 / ENC-TSK-I89: admin-scoped raw-embedding egress


### PR DESCRIPTION
## ENC-TSK-J68 — FTR-121 Phase 1: Escalation entity + request/read surface

Implements Phase 1 of DOC-5B888FCA43B8 (Escalations: Human-Gated Mutation Override Surface) under ENC-PLN-061 / ENC-FTR-121.

### Scope
- **tracker_mutation**: escalation item type in the existing tracker table (`escalation#ENC-ESC-*` sort key — no new table, GSI, or CloudFormation diff; Channel B purity), ENC-ESC server-side minting via the existing atomic-counter ID authority, seven-state escalation FSM (§5.2), mutation-handler registry (§5.3) with request-time `validate_payload` for `deploy_arc_change` (dictionary-legal arc, task targets only) and `direct_state_override` (status legality checked; **path legality deliberately NOT** — that is what io approval overrides), and `/{project}/escalation` POST/GET routes with fail-fast envelope validation (malformed requests write nothing).
- **Isolation invariant**: escalations stay OUT of `_RECORD_TYPES` — generic CRUD/checkout/tracker.set cannot touch them; escalations are not themselves escalatable (guarded by test).
- **MCP server route map**: `escalation.request` (execute, governance-hash-gated), `escalation.get` / `escalation.list` (search), behind `ENABLE_ESCALATION_PRIMITIVE` (default ON). approve/deny have **no MCP action by design** — override authorization exists only behind the Cognito human path (§6).
- **Dictionary**: `governance_data_dictionary.json` → `2026-07-02.01` adds `tracker.escalation` + `mcp_server.escalation_actions`.
- **Tests**: 39 new unit tests (`test_escalation_j68.py`); full tracker_mutation suite 278/278 green locally.

### Deploy notes
- Backend routes go live with the gamma compute deploy on merge.
- The live MCP server (mcp.jreese.net) deploys out-of-band (ENC-TSK-J11 class) — the repo route map lands here; live exposure of the three actions follows the next MCP server deploy. Recorded in the task worklog.

CCI-3db4098e119d4873bb1a5e12936c2b37

🤖 Generated with [Claude Code](https://claude.com/claude-code)