### PR TITLE
[ENC-TSK-H44] FTR-082 AC-1 — pathway-telemetry S3 sink (IAM + env vars + registry flip)

### DIFF
--- a/backend/lambda/env_drift_auditor/env_drift_registry.json
+++ b/backend/lambda/env_drift_auditor/env_drift_registry.json
@@ -16,7 +16,7 @@
       }
     },
     "provenance": "Deploy-critical vars and coverage gaps surfaced by the ENC-TSK-H15 coverage matrix (DOC-0C7E8AEF512E, ENC-PLN-048 Obj 1 child 1.1): COORDINATION_INTERNAL_API_KEY is deploy-critical on all 10 of its compute-stack consumers (it was the 2026-06-18 Sev-1 strip casualty, ENC-TSK-H04/H05); SQS_QUEUE_URL is deploy-critical on devops-deploy-intake (ENC-ISS-369, templated by ENC-TSK-H26). Out-of-band functions with no FunctionName in any CFN template (checkout_service, deploy_capability_auditor) are NOT added — they are not subject to the compute-stack strip (H15 waiver).",
-    "gamma_parity_provenance": "ENC-TSK-H54 (ENC-PLN-050 P0, feature ENC-FTR-062, gamma stack completion): the registry was keyed only by PROD function names, so a compute deploy rendered under EnvironmentSuffix=-gamma produced -gamma function names that matched NO registry entry — the pre-deploy gate (env_parity_gate.py L102 'has_registry_entry' skip) and the post-deploy auditor BOTH silently skipped every gamma function except the lone enceladus-mcp-code-gamma entry. That is exactly why gamma rotted unobserved for ~2.5 months (DOC-A07B553431FD). H54 mirrors each registry-governed prod function rendered in 02-compute.yaml to its <fn>-gamma twin so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy. Each gamma deploy-critical var was verified present+nonempty on the live gamma function before registration (no env_drift_auditor P0-storm risk; ENC-ISS-369 class). GDS_STANDING_PROJECTION_PREFIX is registered ADVISORY (not deploy-critical) on devops-graph-query-api-gamma because 02-compute.yaml L1047 gates it on IsProduction (!Ref Environment=production) → it resolves to AWS::NoValue on gamma BY DESIGN until ENC-TSK-H56 provisions on-demand AGA GDS-PPR for gamma; advisory makes the gap a persistent WARN (visible) without failing gamma deploys. PATHWAY_TELEMETRY_{BUCKET,PREFIX} mirror prod's advisory classification (owned by ENC-TSK-H44, unset on prod AND gamma). ENABLE_LESSON_PRIMITIVE drift (live-set on prod, unset on gamma) is intentionally NOT registered here: it is an out-of-band flag the template never sets, so it is not a template-parity/strip-class var — its codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig), not the FTR-102 template-side gate. devops-github-integration and prod enceladus-mcp-code are NOT rendered in 02-compute.yaml, so their gamma twins are out of this gate's scope."
+    "gamma_parity_provenance": "ENC-TSK-H54 (ENC-PLN-050 P0, feature ENC-FTR-062, gamma stack completion): the registry was keyed only by PROD function names, so a compute deploy rendered under EnvironmentSuffix=-gamma produced -gamma function names that matched NO registry entry — the pre-deploy gate (env_parity_gate.py L102 'has_registry_entry' skip) and the post-deploy auditor BOTH silently skipped every gamma function except the lone enceladus-mcp-code-gamma entry. That is exactly why gamma rotted unobserved for ~2.5 months (DOC-A07B553431FD). H54 mirrors each registry-governed prod function rendered in 02-compute.yaml to its <fn>-gamma twin so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy. Each gamma deploy-critical var was verified present+nonempty on the live gamma function before registration (no env_drift_auditor P0-storm risk; ENC-ISS-369 class). GDS_STANDING_PROJECTION_PREFIX is registered ADVISORY (not deploy-critical) on devops-graph-query-api-gamma because 02-compute.yaml L1047 gates it on IsProduction (!Ref Environment=production) → it resolves to AWS::NoValue on gamma BY DESIGN until ENC-TSK-H56 provisions on-demand AGA GDS-PPR for gamma; advisory makes the gap a persistent WARN (visible) without failing gamma deploys. PATHWAY_TELEMETRY_{BUCKET,PREFIX} flipped advisory->deploy-critical by ENC-TSK-H44 in the same PR that templates them on GraphQueryApiFunction (both envs), so the env-parity gate now fails closed if a deploy would strip the FTR-082 AC-1 sink. ENABLE_LESSON_PRIMITIVE drift (live-set on prod, unset on gamma) is intentionally NOT registered here: it is an out-of-band flag the template never sets, so it is not a template-parity/strip-class var — its codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig), not the FTR-102 template-side gate. devops-github-integration and prod enceladus-mcp-code are NOT rendered in 02-compute.yaml, so their gamma twins are out of this gate's scope."
   },
   "_policy": {
     "scan_interval": "hourly",
@@ -37,8 +37,8 @@
       "NEO4J_SECRET_NAME": "deploy-critical",
       "COGNITO_USER_POOL_ID": "deploy-critical",
       "COGNITO_CLIENT_ID": "deploy-critical",
-      "PATHWAY_TELEMETRY_BUCKET": "advisory",
-      "PATHWAY_TELEMETRY_PREFIX": "advisory"
+      "PATHWAY_TELEMETRY_BUCKET": "deploy-critical",
+      "PATHWAY_TELEMETRY_PREFIX": "deploy-critical"
     },
     "devops-github-integration": {
       "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
@@ -155,8 +155,8 @@
       "NEO4J_SECRET_NAME": "deploy-critical",
       "COGNITO_USER_POOL_ID": "deploy-critical",
       "COGNITO_CLIENT_ID": "deploy-critical",
-      "PATHWAY_TELEMETRY_BUCKET": "advisory",
-      "PATHWAY_TELEMETRY_PREFIX": "advisory",
+      "PATHWAY_TELEMETRY_BUCKET": "deploy-critical",
+      "PATHWAY_TELEMETRY_PREFIX": "deploy-critical",
       "GDS_STANDING_PROJECTION_PREFIX": "advisory"
     },
     "devops-project-service-gamma": {

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1183,6 +1183,13 @@ Resources:
           # ENC-FTR-087 Phase 1 (ENC-TSK-I85): wave-close drift telemetry sink.
           # Codified here so a compute deploy never strips it (ENC-LSN-053 class).
           DRIFT_TELEMETRY_TABLE: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
+          # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 sink. Setting
+          # the bucket activates the durable .jsonl append-log (the code degrades
+          # to CloudWatch when unset — ENC-TSK-H38); prefix is env-partitioned via
+          # S3EnvPrefix (prod "" / gamma "gamma/"). Registered deploy-critical in
+          # env_drift_registry.json so the env-parity gate protects them.
+          PATHWAY_TELEMETRY_BUCKET: !Ref S3Bucket
+          PATHWAY_TELEMETRY_PREFIX: !Sub "${S3EnvPrefix}pathway-telemetry"
       Tags:
         - Key: Project
           Value: enceladus
@@ -4044,6 +4051,20 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}/index/*"
+        # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 append-log sink.
+        # The Lambda already emits envelopes and degrades to CloudWatch when
+        # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env
+        # vars on GraphQueryApiFunction turn the durable sink on. Write-only,
+        # prefix-scoped.
+        - PolicyName: PathwayTelemetrySinkWrite
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: PathwayTelemetryPutObject
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}pathway-telemetry/*"
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary
Turns on the durable S3 append-log sink for pathway telemetry (FTR-082 AC-1). The Lambda has emitted envelopes since ENC-TSK-H38, degrading to CloudWatch because `PATHWAY_TELEMETRY_BUCKET` was never set.
- `GraphQueryApiRole`: new `PathwayTelemetrySinkWrite` policy — `s3:PutObject` scoped to `${S3Bucket}/${S3EnvPrefix}pathway-telemetry/*` (write-only).
- `GraphQueryApiFunction` env: `PATHWAY_TELEMETRY_BUCKET` + `PATHWAY_TELEMETRY_PREFIX` (env-partitioned: `gamma/pathway-telemetry` vs `pathway-telemetry`).
- `env_drift_registry.json`: `PATHWAY_TELEMETRY_*` flipped advisory → deploy-critical in the same PR, so the env-parity gate fails closed if a future deploy would strip the sink.

**This is the first real template change through the ENC-TSK-J62 gated pipeline**: gamma applies via the reviewer-free `v4-gamma` environment; the main-lane port will pause at the `v3-prod` reviewer gate as a rejectable change-set (FTR-120 working as designed — also serves as J62's AC-3/AC-4 live evidence).

Sequencing note for the prod lane: the registry rides inside the env_drift_auditor Lambda package — approve the prod CFN apply before/with the prod Lambda promote to avoid a transient P0 drift issue.

CCI-ae1e6d3990ef46eeb299fae88f0a4243

## Test plan
- [x] Template + registry parse; diff surgical (26+/5-)
- [ ] Post-merge: gamma plan shows non-empty change-set summary; apply executes in v4-gamma ungated; live env vars + telemetry .jsonl under gamma/pathway-telemetry/ verified
- [ ] Main port: prod plan pauses at v3-prod gate (io approves/rejects at leisure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)