### PR TITLE
[ENC-TSK-H44] Pathway-telemetry S3 sink — main lane (prod apply pauses at v3-prod gate)

### DIFF
--- a/backend/lambda/env_drift_auditor/env_drift_registry.json
+++ b/backend/lambda/env_drift_auditor/env_drift_registry.json
@@ -16,7 +16,7 @@
       }
     },
     "provenance": "Deploy-critical vars and coverage gaps surfaced by the ENC-TSK-H15 coverage matrix (DOC-0C7E8AEF512E, ENC-PLN-048 Obj 1 child 1.1): COORDINATION_INTERNAL_API_KEY is deploy-critical on all 10 of its compute-stack consumers (it was the 2026-06-18 Sev-1 strip casualty, ENC-TSK-H04/H05); SQS_QUEUE_URL is deploy-critical on devops-deploy-intake (ENC-ISS-369, templated by ENC-TSK-H26). Out-of-band functions with no FunctionName in any CFN template (checkout_service, deploy_capability_auditor) are NOT added — they are not subject to the compute-stack strip (H15 waiver).",
-    "gamma_parity_provenance": "ENC-TSK-H54 (ENC-PLN-050 P0, feature ENC-FTR-062, gamma stack completion): the registry was keyed only by PROD function names, so a compute deploy rendered under EnvironmentSuffix=-gamma produced -gamma function names that matched NO registry entry — the pre-deploy gate (env_parity_gate.py L102 'has_registry_entry' skip) and the post-deploy auditor BOTH silently skipped every gamma function except the lone enceladus-mcp-code-gamma entry. That is exactly why gamma rotted unobserved for ~2.5 months (DOC-A07B553431FD). H54 mirrors each registry-governed prod function rendered in 02-compute.yaml to its <fn>-gamma twin so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy. Each gamma deploy-critical var was verified present+nonempty on the live gamma function before registration (no env_drift_auditor P0-storm risk; ENC-ISS-369 class). GDS_STANDING_PROJECTION_PREFIX is registered ADVISORY (not deploy-critical) on devops-graph-query-api-gamma because 02-compute.yaml L1047 gates it on IsProduction (!Ref Environment=production) → it resolves to AWS::NoValue on gamma BY DESIGN until ENC-TSK-H56 provisions on-demand AGA GDS-PPR for gamma; advisory makes the gap a persistent WARN (visible) without failing gamma deploys. PATHWAY_TELEMETRY_{BUCKET,PREFIX} mirror prod's advisory classification (owned by ENC-TSK-H44, unset on prod AND gamma). ENABLE_LESSON_PRIMITIVE drift (live-set on prod, unset on gamma) is intentionally NOT registered here: it is an out-of-band flag the template never sets, so it is not a template-parity/strip-class var — its codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig), not the FTR-102 template-side gate. devops-github-integration and prod enceladus-mcp-code are NOT rendered in 02-compute.yaml, so their gamma twins are out of this gate's scope."
+    "gamma_parity_provenance": "ENC-TSK-H54 (ENC-PLN-050 P0, feature ENC-FTR-062, gamma stack completion): the registry was keyed only by PROD function names, so a compute deploy rendered under EnvironmentSuffix=-gamma produced -gamma function names that matched NO registry entry — the pre-deploy gate (env_parity_gate.py L102 'has_registry_entry' skip) and the post-deploy auditor BOTH silently skipped every gamma function except the lone enceladus-mcp-code-gamma entry. That is exactly why gamma rotted unobserved for ~2.5 months (DOC-A07B553431FD). H54 mirrors each registry-governed prod function rendered in 02-compute.yaml to its <fn>-gamma twin so the existing FTR-102 machinery enforces gamma parity on every future gamma compute deploy. Each gamma deploy-critical var was verified present+nonempty on the live gamma function before registration (no env_drift_auditor P0-storm risk; ENC-ISS-369 class). GDS_STANDING_PROJECTION_PREFIX is registered ADVISORY (not deploy-critical) on devops-graph-query-api-gamma because 02-compute.yaml L1047 gates it on IsProduction (!Ref Environment=production) → it resolves to AWS::NoValue on gamma BY DESIGN until ENC-TSK-H56 provisions on-demand AGA GDS-PPR for gamma; advisory makes the gap a persistent WARN (visible) without failing gamma deploys. PATHWAY_TELEMETRY_{BUCKET,PREFIX} flipped advisory->deploy-critical by ENC-TSK-H44 in the same PR that templates them on GraphQueryApiFunction (both envs), so the env-parity gate now fails closed if a deploy would strip the FTR-082 AC-1 sink. ENABLE_LESSON_PRIMITIVE drift (live-set on prod, unset on gamma) is intentionally NOT registered here: it is an out-of-band flag the template never sets, so it is not a template-parity/strip-class var — its codification belongs to ENC-TSK-H16 / ENC-FTR-103 (AppConfig), not the FTR-102 template-side gate. devops-github-integration and prod enceladus-mcp-code are NOT rendered in 02-compute.yaml, so their gamma twins are out of this gate's scope."
   },
   "_policy": {
     "scan_interval": "hourly",
@@ -37,8 +37,8 @@
       "NEO4J_SECRET_NAME": "deploy-critical",
       "COGNITO_USER_POOL_ID": "deploy-critical",
       "COGNITO_CLIENT_ID": "deploy-critical",
-      "PATHWAY_TELEMETRY_BUCKET": "advisory",
-      "PATHWAY_TELEMETRY_PREFIX": "advisory"
+      "PATHWAY_TELEMETRY_BUCKET": "deploy-critical",
+      "PATHWAY_TELEMETRY_PREFIX": "deploy-critical"
     },
     "devops-github-integration": {
       "COORDINATION_INTERNAL_API_KEY": "deploy-critical",
@@ -155,8 +155,8 @@
       "NEO4J_SECRET_NAME": "deploy-critical",
       "COGNITO_USER_POOL_ID": "deploy-critical",
       "COGNITO_CLIENT_ID": "deploy-critical",
-      "PATHWAY_TELEMETRY_BUCKET": "advisory",
-      "PATHWAY_TELEMETRY_PREFIX": "advisory",
+      "PATHWAY_TELEMETRY_BUCKET": "deploy-critical",
+      "PATHWAY_TELEMETRY_PREFIX": "deploy-critical",
       "GDS_STANDING_PROJECTION_PREFIX": "advisory"
     },
     "devops-project-service-gamma": {

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1059,6 +1059,13 @@ Resources:
           # OR per-query gds.graph.project) is ever created; graph signal uses cypher_fallback.
           GDS_STANDING_PROJECTION_PREFIX: !Ref "AWS::NoValue"
           GDS_HARD_DISABLED: "1"
+          # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 sink. Setting
+          # the bucket activates the durable .jsonl append-log (the code degrades
+          # to CloudWatch when unset — ENC-TSK-H38); prefix is env-partitioned via
+          # S3EnvPrefix (prod "" / gamma "gamma/"). Registered deploy-critical in
+          # env_drift_registry.json so the env-parity gate protects them.
+          PATHWAY_TELEMETRY_BUCKET: !Ref S3Bucket
+          PATHWAY_TELEMETRY_PREFIX: !Sub "${S3EnvPrefix}pathway-telemetry"
       Tags:
         - Key: Project
           Value: enceladus
@@ -3160,6 +3167,20 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 append-log sink.
+        # The Lambda already emits envelopes and degrades to CloudWatch when
+        # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env
+        # vars on GraphQueryApiFunction turn the durable sink on. Write-only,
+        # prefix-scoped.
+        - PolicyName: PathwayTelemetrySinkWrite
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: PathwayTelemetryPutObject
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}pathway-telemetry/*"
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
Main-lane counterpart of #716 (cherry-pick, conflict-resolved to exclude v4-only I85 drift-telemetry context). Gamma is already live and verified: env vars deployed via the gated pipeline (run 28565151980, apply in v4-gamma), telemetry .jsonl objects landing under `gamma/pathway-telemetry/wave_id=.../`.

**Merging this fires the first real prod CFN plan under FTR-120**: the plan job will create a genuine change-set (GraphQueryApiRole + GraphQueryApiFunction Modify) and the apply job will **pause at the v3-prod Environment reviewer gate** — io approves or rejects at leisure; nothing mutates prod until then. Sequencing note: approve this prod CFN apply before/with the prod Lambda promote of env_drift_auditor (registry classification rides in that package).

CCI-ae1e6d3990ef46eeb299fae88f0a4243

🤖 Generated with [Claude Code](https://claude.com/claude-code)