### PR TITLE
ENC-TSK-J69: applyEscalatedMutation applier + launch mutation handlers (FTR-121 Ph2)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.01",
-  "updated_at": "2026-07-02T04:10:00Z",
-  "last_change_summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only).",
+  "version": "2026-07-02.02",
+  "updated_at": "2026-07-02T04:35:00Z",
+  "last_change_summary": "ENC-TSK-J69 (ENC-FTR-121 Ph2, DOC-5B888FCA43B8): applyEscalatedMutation applier - the single privileged code path applying io-approved escalations. applied_at idempotency guard + conditional approved->applying concurrency gate; both handler applies (deploy_arc_change preserving active checkouts; direct_state_override with escalation_waived sentinels, escalated_closure, verbatim field_values) execute one atomic UpdateItem on the target with escalation_provenance + [ESCALATION-APPLIED] worklog riding the same write (no-partial-write). applying->failed captures errors in result; corrective requests are new escalations. record.escalation.applied audit event. Also: escalation.list pseudo-id alias GET /{project}/escalation/list for explicit APIGW route tables (found in J68 gamma validation). Validators unchanged - no bypass flags.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6448,6 +6448,16 @@
             "format": "iso8601"
           },
           "definition": "Server-stamped on every mutation."
+        },
+        "escalation_provenance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-J69: append-only list of escalation IDs applied to a TARGET record (stamped on the target, not the escalation, inside the applier's atomic write together with the [ESCALATION-APPLIED] worklog entry carrying requesting session, approving human, before/after states, and waived fields). Artifact-Genesis: every override leaves an artifact."
         }
       },
       "dynamodb_key_schema": {
@@ -6481,11 +6491,20 @@
             "escalation_id": "ENC-ESC-NNN",
             "waived_at": "iso8601"
           },
-          "definition": "\u00a75.6: when direct_state_override lands a record in a state whose invariant fields are unsupplied, each such field is written with this sentinel rather than left null. Downstream consumers read 'known-absent by human decision', which is semantically distinct from 'never reached' or 'data loss'. Writer ships in Ph2 (ENC-TSK-J69)."
+          "definition": "Section 5.6: when direct_state_override lands a record in a state whose invariant fields are unsupplied, each such field is written with this sentinel rather than left null. Downstream consumers read 'known-absent by human decision', semantically distinct from 'never reached' or 'data loss'. LIVE as of ENC-TSK-J69: written by _apply_direct_state_override. Null-handling audit finding (2026-07-02): the deploy/closed evidence validators in tracker_mutation validate REQUEST transition_evidence, not stored record state, so sentinel-bearing records do not break them; the sentinel is a dict, making accidental string ops fail loudly and grep-ably rather than silently."
         },
         "escalated_closure": {
           "type": "boolean",
-          "definition": "Set true on any record closed via direct_state_override so ENC-FTR-118 empirical-runtime metrics and close-quality reporting can filter override closures out of organic-completion datasets. Writer ships in Ph2 (ENC-TSK-J69)."
+          "definition": "Set true on any record closed via direct_state_override so ENC-FTR-118 empirical-runtime metrics and close-quality reporting can filter override closures out of organic-completion datasets. LIVE as of ENC-TSK-J69 (written by _apply_direct_state_override; task closures also increment closed_count so DESIGNS-edge and subtask gates keep organic parity)."
+        }
+      },
+      "applier": {
+        "function": "applyEscalatedMutation (_handle_escalation_apply, tracker_mutation)",
+        "route": "POST /{projectId}/escalation/{escalationId}/apply (rides the registered {recordType}/{recordId}/{sub} route shape; tracker:write scope)",
+        "definition": "ENC-TSK-J69 (Ph2): the SINGLE privileged code path that may write transitions the normal FSM forbids (Tenet 2). Sequence per section 5.5: approved+applied_at-null guard (repeat/concurrent invocation no-ops); conditional approved->applying transition is the concurrency gate (ConditionExpression status=approved AND attribute_not_exists(applied_at)); fresh consistent target read; registry handler apply executes exactly ONE atomic UpdateItem on the target (provenance worklog + escalation_provenance append ride the same write, so a handler exception leaves the target untouched); applying->applied stamps applied_at + result; on failure applying->failed captures the error in result and a corrective request is a NEW escalation. Reachability: application requires status=approved, which only the Cognito-human approval route (Ph3/ENC-TSK-J70) can write - no MCP action, SCI token, or internal key maps to approve. Normal validators in _handle_update_field are untouched and carry no bypass flags. Emits record.escalation.applied to the enceladus.tracker audit event bus.",
+        "handler_applies": {
+          "deploy_arc_change": "rewrites transition_type (and checkout_transition_type when present, which recomputes arc-derived gate expectations) in place; checkout fields untouched so an active checkout survives.",
+          "direct_state_override": "writes target_status regardless of path legality; supplied field_values written verbatim; unsupplied required-for-state fields (from the transition-matrix gate contracts: committed->commit_sha, deploy-success->arc evidence key, closed->arc closed-evidence key, issue closed->evidence) get the escalation_waived sentinel; closures set escalated_closure=true and increment closed_count for tasks (organic-gate parity)."
         }
       }
     },
@@ -6502,7 +6521,7 @@
         },
         "escalation.list": {
           "type": "search_action",
-          "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first."
+          "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first. ENC-TSK-J69: the MCP server calls GET /{project}/escalation/list (pseudo-id alias riding the registered {recordType}/{recordId} API Gateway route) because explicit gamma-style route tables register no bare {recordType} collection path; 'list' can never collide with a server-minted ENC-ESC-* id."
         }
       }
     }
@@ -6578,6 +6597,11 @@
       "version": "2026-07-02.01",
       "task": "ENC-TSK-J68",
       "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
+    },
+    {
+      "version": "2026-07-02.02",
+      "task": "ENC-TSK-J69",
+      "summary": "ENC-TSK-J69 (ENC-FTR-121 Ph2, DOC-5B888FCA43B8): applyEscalatedMutation applier - the single privileged code path applying io-approved escalations. applied_at idempotency guard + conditional approved->applying concurrency gate; both handler applies (deploy_arc_change preserving active checkouts; direct_state_override with escalation_waived sentinels, escalated_closure, verbatim field_values) execute one atomic UpdateItem on the target with escalation_provenance + [ESCALATION-APPLIED] worklog riding the same write (no-partial-write). applying->failed captures errors in result; corrective requests are new escalations. record.escalation.applied audit event. Also: escalation.list pseudo-id alias GET /{project}/escalation/list for explicit APIGW route tables (found in J68 gamma validation). Validators unchanged - no bypass flags."
     }
   ]
 }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -62,6 +62,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from transition_type_matrix import (
     MATRIX_VERSION,
+    CLOSED_EVIDENCE,
     DEPLOY_SUCCESS_EVIDENCE,
     IMMUTABLE_TRANSITION_TYPES,
     STRICTNESS_RANK,
@@ -504,14 +505,226 @@ def _validate_direct_state_override_payload(payload: Dict, target_record_type: s
     return ""
 
 
+def _escalation_waivable_fields(target: Dict, target_status: str) -> list:
+    """Required-for-state fields the waiver sentinel covers (§5.6).
+
+    Derived from the canonical transition matrix gate contracts: the fields a
+    record landing in target_status would normally have to prove. Fields the
+    escalation payload supplies (or the record already carries) are written
+    verbatim; the rest get the escalation_waived sentinel — never silent null.
+    """
+    record_type = str(target.get("record_type") or "")
+    arc = str(target.get("transition_type") or "github_pr_deploy")
+    fields = []
+    if record_type == "task":
+        if target_status == "committed":
+            fields.append("commit_sha")
+        elif target_status == "deploy-success":
+            gate = DEPLOY_SUCCESS_EVIDENCE.get(arc)
+            if gate:
+                fields.append(gate["evidence_key"])
+        elif target_status == "closed":
+            gate = CLOSED_EVIDENCE.get(arc)
+            if gate:
+                fields.append(gate["evidence_key"])
+    elif record_type == "issue" and target_status == "closed":
+        fields.append("evidence")
+    return fields
+
+
+def _escalation_waiver_sentinel(escalation_id: str, now: str) -> Dict:
+    """§5.6 sentinel in DynamoDB attribute shape: known-absent by human decision."""
+    return {"M": {
+        "escalation_waived": {"BOOL": True},
+        "escalation_id": {"S": escalation_id},
+        "waived_at": {"S": now},
+    }}
+
+
+def _escalation_provenance_note(escalation: Dict, before: Dict, after: Dict,
+                                waived: list) -> str:
+    """Structured worklog description for the target record (§5.5 step 6)."""
+    requested_by = escalation.get("requested_by") or {}
+    approved_by = escalation.get("approved_by") or {}
+    approver = approved_by.get("email") or approved_by.get("sub") or "io"
+    return (
+        f"[ESCALATION-APPLIED] {escalation.get('item_id')} "
+        f"({escalation.get('mutation_type')}) "
+        f"requested_by={requested_by.get('session_id', 'unknown')} "
+        f"approved_by={approver} "
+        f"before={json.dumps(before, default=str)} "
+        f"after={json.dumps(after, default=str)} "
+        f"waived={json.dumps(waived)}"
+    )
+
+
+def _apply_deploy_arc_change(project_id: str, escalation: Dict, target: Dict) -> Dict:
+    """§5.3 handler 1 apply: rewrite the task's deploy arc in place.
+
+    Single atomic UpdateItem. Checkout fields are deliberately untouched — an
+    active checkout survives. checkout_transition_type (the arc snapshot the
+    checkout service gates against) is rewritten alongside transition_type
+    when present, which is what recomputes the remaining-lifecycle
+    expectations. The ENC-FTR-060 sealing validator in _handle_update_field
+    is NOT modified — this dedicated entry point applies io's approved
+    override with escalation provenance as a write precondition.
+    """
+    new_arc = str((escalation.get("payload") or {}).get("new_deploy_arc_type") or "").strip()
+    if new_arc not in VALID_TRANSITION_TYPES:
+        raise ValueError(f"payload.new_deploy_arc_type '{new_arc}' is not a legal arc type")
+    target_sk = f"{target.get('record_type')}#{target.get('item_id')}"
+    escalation_id = str(escalation.get("item_id") or "")
+    now = _now_z()
+    before = {
+        "transition_type": target.get("transition_type"),
+        "checkout_transition_type": target.get("checkout_transition_type"),
+        "checkout_state": target.get("checkout_state"),
+    }
+    after = {
+        "transition_type": new_arc,
+        "checkout_transition_type": new_arc if target.get("checkout_transition_type") else target.get("checkout_transition_type"),
+        "checkout_state": target.get("checkout_state"),
+    }
+    note = _escalation_provenance_note(escalation, before, after, [])
+
+    update_parts = [
+        "#tt = :arc",
+        "updated_at = :now",
+        "last_update_note = :note",
+        "sync_version = if_not_exists(sync_version, :zero) + :one",
+        "history = list_append(if_not_exists(history, :empty), :hentry)",
+        "escalation_provenance = list_append(if_not_exists(escalation_provenance, :empty), :esc)",
+    ]
+    names = {"#tt": "transition_type"}
+    values = {
+        ":arc": _ser_s(new_arc),
+        ":now": _ser_s(now),
+        ":note": _ser_s(f"Deploy arc changed via escalation {escalation_id}"),
+        ":zero": {"N": "0"},
+        ":one": {"N": "1"},
+        ":empty": {"L": []},
+        ":hentry": {"L": [{"M": {
+            "timestamp": _ser_s(now),
+            "status": _ser_s("worklog"),
+            "description": _ser_s(note),
+        }}]},
+        ":esc": {"L": [_ser_s(escalation_id)]},
+    }
+    if target.get("checkout_transition_type"):
+        update_parts.append("checkout_transition_type = :arc")
+
+    _get_ddb().update_item(
+        TableName=DYNAMODB_TABLE,
+        Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+        UpdateExpression="SET " + ", ".join(update_parts),
+        ConditionExpression="attribute_exists(record_id)",
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+    return {"before": before, "after": after, "waived_fields": []}
+
+
+def _apply_direct_state_override(project_id: str, escalation: Dict, target: Dict) -> Dict:
+    """§5.3 handler 2 apply: land the record in target_status regardless of
+    path legality, with supplied field_values verbatim and §5.6 waiver
+    sentinels on every unsupplied required-for-state field. Closures set
+    escalated_closure=true (ENC-FTR-118 metric filter) and, for tasks,
+    increment closed_count for organic-gate parity. Single atomic UpdateItem —
+    a handler exception leaves the target untouched (no-partial-write).
+    """
+    payload = escalation.get("payload") or {}
+    target_status = str(payload.get("target_status") or "").strip()
+    field_values = payload.get("field_values") or {}
+    if not target_status:
+        raise ValueError("payload.target_status is required")
+    record_type = str(target.get("record_type") or "")
+    if target_status not in _statuses_for_record_type(record_type):
+        raise ValueError(
+            f"target_status '{target_status}' is not dictionary-legal for {record_type}")
+
+    target_sk = f"{record_type}#{target.get('item_id')}"
+    escalation_id = str(escalation.get("item_id") or "")
+    now = _now_z()
+    before = {"status": target.get("status")}
+    waivable = _escalation_waivable_fields(target, target_status)
+    waived = [
+        field for field in waivable
+        if field not in field_values and not target.get(field)
+    ]
+    is_closure = target_status == _CLOSED_STATUS.get(record_type, "closed")
+    after = {"status": target_status, "field_values": sorted(field_values.keys()),
+             "escalated_closure": is_closure}
+    note = _escalation_provenance_note(escalation, before, after, waived)
+
+    update_parts = [
+        "#st = :target_status",
+        "updated_at = :now",
+        "last_update_note = :note",
+        "sync_version = if_not_exists(sync_version, :zero) + :one",
+        "history = list_append(if_not_exists(history, :empty), :hentry)",
+        "escalation_provenance = list_append(if_not_exists(escalation_provenance, :empty), :esc)",
+    ]
+    names = {"#st": "status"}
+    values = {
+        ":target_status": _ser_s(target_status),
+        ":now": _ser_s(now),
+        ":note": _ser_s(f"Status override to '{target_status}' via escalation {escalation_id}"),
+        ":zero": {"N": "0"},
+        ":one": {"N": "1"},
+        ":empty": {"L": []},
+        ":hentry": {"L": [{"M": {
+            "timestamp": _ser_s(now),
+            "status": _ser_s("worklog"),
+            "description": _ser_s(note),
+        }}]},
+        ":esc": {"L": [_ser_s(escalation_id)]},
+    }
+    for index, (field, value) in enumerate(sorted(field_values.items())):
+        name_key = f"#fv{index}"
+        value_key = f":fv{index}"
+        update_parts.append(f"{name_key} = {value_key}")
+        names[name_key] = str(field)
+        values[value_key] = _ser_value(value)
+    for index, field in enumerate(waived):
+        name_key = f"#wv{index}"
+        value_key = f":wv{index}"
+        update_parts.append(f"{name_key} = {value_key}")
+        names[name_key] = field
+        values[value_key] = _escalation_waiver_sentinel(escalation_id, now)
+    update_expression = "SET " + ", ".join(update_parts)
+    if is_closure:
+        update_parts.append("escalated_closure = :esc_closure")
+        values[":esc_closure"] = {"BOOL": True}
+        update_expression = "SET " + ", ".join(update_parts)
+        if record_type == "task":
+            update_expression += " ADD closed_count :one_count"
+            values[":one_count"] = {"N": "1"}
+
+    _get_ddb().update_item(
+        TableName=DYNAMODB_TABLE,
+        Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+        UpdateExpression=update_expression,
+        ConditionExpression="attribute_exists(record_id)",
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+    return {"before": before, "after": after, "waived_fields": waived}
+
+
 # §5.3 mutation handler registry (v4-shaped). Each handler grows three
-# functions across the feature: validate_payload (request time, this phase),
+# functions across the feature: validate_payload (request time, Ph1/ENC-TSK-J68),
 # render_diff (approval time, Ph3/ENC-TSK-J70), and apply (invoked ONLY by
 # applyEscalatedMutation after io approval, Ph2/ENC-TSK-J69). Adding a third
 # mutation type is a registry entry plus handler, not an architectural change.
 _ESCALATION_MUTATION_HANDLERS = {
-    "deploy_arc_change": {"validate_payload": _validate_deploy_arc_change_payload},
-    "direct_state_override": {"validate_payload": _validate_direct_state_override_payload},
+    "deploy_arc_change": {
+        "validate_payload": _validate_deploy_arc_change_payload,
+        "apply": _apply_deploy_arc_change,
+    },
+    "direct_state_override": {
+        "validate_payload": _validate_direct_state_override_payload,
+        "apply": _apply_direct_state_override,
+    },
 }
 
 
@@ -6851,6 +7064,212 @@ def _handle_escalation_list(project_id: str, query_params: Dict) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph2 / ENC-TSK-J69 — applyEscalatedMutation
+#
+# The SINGLE privileged code path that may write transitions the normal FSM
+# forbids (DOC-5B888FCA43B8 §5.5, Tenet 2). Reachable only through the
+# io-approval flow: the apply route no-ops unless the escalation is in
+# status=approved with applied_at unset, and status=approved is writable
+# ONLY by the Cognito-human approval route (Ph3/ENC-TSK-J70) — no MCP
+# action, SCI token, or internal key can approve. Validators in
+# _handle_update_field remain untouched and carry no bypass flags.
+# ---------------------------------------------------------------------------
+
+EVENT_DETAIL_TYPE_ESCALATION_APPLIED = "record.escalation.applied"
+
+
+def _escalation_fsm_transition(project_id: str, escalation_id: str,
+                               from_status: str, to_status: str, actor: str,
+                               detail: Optional[Dict] = None,
+                               extra_names: Optional[Dict] = None,
+                               extra_values: Optional[Dict] = None,
+                               extra_sets: Optional[list] = None,
+                               require_not_applied: bool = False) -> bool:
+    """Conditionally walk the escalation FSM one edge, appending the §11.2 event.
+
+    Returns False (without raising) when the ConditionExpression loses — the
+    concurrent-applier no-op path of the §5.5 idempotency contract.
+    """
+    if to_status not in _ESCALATION_FSM.get(from_status, set()):
+        raise ValueError(f"escalation FSM forbids {from_status}→{to_status}")
+    now = _now_z()
+    update_parts = [
+        "#st = :to_status",
+        "updated_at = :now",
+        "#ev = list_append(if_not_exists(#ev, :empty), :event)",
+    ] + (extra_sets or [])
+    names = {"#st": "status", "#ev": "events"}
+    names.update(extra_names or {})
+    values = {
+        ":to_status": _ser_s(to_status),
+        ":from_status": _ser_s(from_status),
+        ":now": _ser_s(now),
+        ":empty": {"L": []},
+        ":event": {"L": [_escalation_event(to_status, actor, detail=detail)]},
+    }
+    values.update(extra_values or {})
+    condition = "#st = :from_status"
+    if require_not_applied:
+        condition += " AND attribute_not_exists(applied_at)"
+    try:
+        _get_ddb().update_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ConditionExpression=condition,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _emit_escalation_applied_event(project_id: str, escalation: Dict,
+                                   result_detail: Dict) -> None:
+    """Best-effort audit-feed emission after a successful application."""
+    detail = {
+        "project_id": project_id,
+        "event": "escalation_applied",
+        "escalation_id": escalation.get("item_id"),
+        "target_record_id": escalation.get("target_record_id"),
+        "mutation_type": escalation.get("mutation_type"),
+        "requested_by": (escalation.get("requested_by") or {}).get("session_id"),
+        "approved_by": (escalation.get("approved_by") or {}).get("email")
+        or (escalation.get("approved_by") or {}).get("sub"),
+        "waived_fields": result_detail.get("waived_fields", []),
+        "applied_at": _now_z(),
+    }
+    try:
+        _get_events().put_events(Entries=[{
+            "Source": EVENT_SOURCE,
+            "DetailType": EVENT_DETAIL_TYPE_ESCALATION_APPLIED,
+            "Detail": json.dumps(detail, default=str),
+            "EventBusName": EVENT_BUS,
+        }])
+    except Exception as exc:
+        logger.error("escalation applied audit event emit failed: %s", exc)
+
+
+def _handle_escalation_apply(project_id: str, escalation_id: str, body: Dict) -> Dict:
+    """POST /{project}/escalation/{id}/apply — applyEscalatedMutation (§5.5).
+
+    Sequence: (1) approved + applied_at-null guard; (2) conditional
+    approved→applying transition (the concurrency gate — a losing racer
+    no-ops); (3) fresh target read; (4) expected_version drift was surfaced
+    at approval time, proceed on io's informed approval; (5) registry handler
+    apply — one atomic UpdateItem on the target; (6) provenance is stamped
+    inside that same write; (7) applying→applied with applied_at + result.
+    On handler exception: applying→failed with the error in result and no
+    partial target write.
+    """
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    actor = str((body.get("write_source") or {}).get("provider") or "system")
+    ddb = _get_ddb()
+    try:
+        raw = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation apply read failed: %s", exc)
+        return _error(500, "Database read failed.")
+    if not raw:
+        return _error(404, f"Escalation not found: {escalation_id}")
+
+    escalation = _escalation_public(raw)
+    status = escalation.get("status")
+    if escalation.get("applied_at") or status == "applied":
+        return _response(200, {
+            "success": True, "no_op": True, "escalation_id": escalation_id,
+            "status": "applied",
+            "reason": "applied_at already set — exactly-once guard (§5.5 step 1)",
+        })
+    if status != "approved":
+        return _error(409, (
+            f"Escalation {escalation_id} is '{status}', not 'approved'. "
+            "Only the Cognito-human approval flow can authorize application."
+        ))
+
+    handler = _ESCALATION_MUTATION_HANDLERS.get(str(escalation.get("mutation_type")))
+    if handler is None or "apply" not in handler:
+        return _error(500, f"No apply handler for mutation_type '{escalation.get('mutation_type')}'.")
+
+    # Concurrency gate: exactly one applier wins approved→applying.
+    if not _escalation_fsm_transition(
+        project_id, escalation_id, "approved", "applying", actor,
+        detail={"target_record_id": escalation.get("target_record_id")},
+        require_not_applied=True,
+    ):
+        return _response(200, {
+            "success": True, "no_op": True, "escalation_id": escalation_id,
+            "reason": "concurrent applier holds the applying transition",
+        })
+
+    now = _now_z()
+    target_type, target_sk, target_err = _parse_escalation_target(
+        str(escalation.get("target_record_id") or ""))
+    result_detail = None
+    failure = ""
+    if target_err:
+        failure = target_err
+    else:
+        try:
+            target_raw = ddb.get_item(
+                TableName=DYNAMODB_TABLE,
+                Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+                ConsistentRead=True,
+            ).get("Item")
+            if not target_raw:
+                failure = f"Target record not found: {escalation.get('target_record_id')}"
+            else:
+                result_detail = handler["apply"](project_id, escalation, _deser_item(target_raw))
+        except Exception as exc:
+            logger.error("escalation apply handler failed: %s", exc)
+            failure = f"{type(exc).__name__}: {exc}"
+
+    if failure:
+        _escalation_fsm_transition(
+            project_id, escalation_id, "applying", "failed", "system",
+            detail={"error": failure},
+            extra_sets=["#res = :result"],
+            extra_names={"#res": "result"},
+            extra_values={":result": _ser_value({"success": False, "error": failure})},
+        )
+        return _error(409, f"Escalation application failed (no partial write): {failure}")
+
+    _escalation_fsm_transition(
+        project_id, escalation_id, "applying", "applied", "system",
+        detail=result_detail,
+        extra_sets=["applied_at = :applied_at", "#res = :result"],
+        extra_names={"#res": "result"},
+        extra_values={
+            ":applied_at": _ser_s(now),
+            ":result": _ser_value({"success": True, **(result_detail or {})}),
+        },
+    )
+    _emit_escalation_applied_event(project_id, escalation, result_detail or {})
+    return _response(200, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": "applied",
+        "applied_at": now,
+        "result": result_detail,
+    })
+
+
+# ---------------------------------------------------------------------------
 # Path parsing & routing
 # ---------------------------------------------------------------------------
 
@@ -6860,7 +7279,8 @@ _RE_DEDUP_REVIEW = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-z0-9_-]+)/dedup-review$"
 )
 _RE_ESCALATION = re.compile(
-    r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/escalation(?:/(?P<id>[A-Za-z0-9_-]+))?$"
+    r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/escalation"
+    r"(?:/(?P<id>[A-Za-z0-9_-]+)(?:/(?P<sub>apply))?)?$"
 )
 _RE_RELATIONSHIP = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/relationship$"
@@ -6930,11 +7350,12 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         else:
             return _error(400, "Field 'op' must be 'propose', 'approve', or 'auto-merge'.")
 
-    # --- Route: escalations (ENC-FTR-121 Ph1 / ENC-TSK-J68) ---
+    # --- Route: escalations (ENC-FTR-121 Ph1+Ph2 / ENC-TSK-J68, ENC-TSK-J69) ---
     m_escalation = _RE_ESCALATION.match(path)
     if m_escalation:
         project_id = m_escalation.group("project")
         escalation_id = m_escalation.group("id")
+        escalation_sub = m_escalation.group("sub")
         claims, auth_err = _authenticate(
             event,
             ["tracker:read"] if method == "GET" else ["tracker:write"],
@@ -6944,13 +7365,27 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         project_err = _validate_project_exists(project_id)
         if project_err:
             return _error(404, project_err)
-        if method == "POST" and not escalation_id:
+        if method == "POST" and escalation_sub == "apply":
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except (ValueError, TypeError):
+                return _error(400, "Invalid JSON body.")
+            _normalize_write_source(body, claims)
+            return _handle_escalation_apply(project_id, escalation_id, body)
+        elif method == "POST" and not escalation_id:
             try:
                 body = json.loads(event.get("body") or "{}")
             except (ValueError, TypeError):
                 return _error(400, "Invalid JSON body.")
             _normalize_write_source(body, claims)
             return _handle_escalation_request(project_id, body)
+        elif method == "GET" and escalation_id == "list":
+            # Pseudo-id alias: gamma APIGW registers {recordType}/{recordId}
+            # but not the bare {recordType} collection path, so the list
+            # surface rides GET /{project}/escalation/list (ENC-TSK-J69;
+            # found during ENC-TSK-J68 gamma validation). "list" can never
+            # collide with a server-minted ENC-ESC-* id.
+            return _handle_escalation_list(project_id, query_params)
         elif method == "GET" and escalation_id:
             return _handle_escalation_get(project_id, escalation_id)
         elif method == "GET":

--- a/backend/lambda/tracker_mutation/test_escalation_applier_j69.py
+++ b/backend/lambda/tracker_mutation/test_escalation_applier_j69.py
@@ -1,0 +1,472 @@
+"""ENC-TSK-J69 (ENC-FTR-121 Ph2): applyEscalatedMutation applier tests.
+
+The applier is the single privileged code path allowed to write transitions
+the normal FSM forbids (DOC-5B888FCA43B8 Tenet 2) — the last line of defense,
+so it carries the feature's heaviest test weight: exactly-once semantics via
+the applied_at guard and the conditional approved→applying gate, the full
+approved→applying→applied|failed FSM walk with §11.2 events, checkout
+survival under deploy_arc_change, path-illegal direct_state_override
+(coding-complete→closed AND closed→pr), §5.6 escalation_waived sentinels,
+escalated_closure, provenance stamping, no-partial-write failure handling,
+and negative assertions that the normal validators acquired no bypass.
+"""
+import json
+import unittest
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+
+def _ccfe():
+    return ClientError(
+        {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem")
+
+
+def _escalation_item(status="approved", mutation_type="deploy_arc_change",
+                     payload=None, target="ENC-TSK-J10", applied_at=None):
+    if payload is None:
+        payload = {"new_deploy_arc_type": "code_only"}
+    item = {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": "escalation#ENC-ESC-001"},
+        "item_id": {"S": "ENC-ESC-001"},
+        "record_type": {"S": "escalation"},
+        "status": {"S": status},
+        "mutation_type": {"S": mutation_type},
+        "target_record_id": {"S": target},
+        "payload": {"S": json.dumps(payload)},
+        "justification": {"S": "test"},
+        "requested_by": {"M": {
+            "session_id": {"S": "ENC-SES-02F"},
+            "agent_type_id": {"S": "ENC-AGT-006"},
+            "sci_present": {"BOOL": False},
+        }},
+        "approved_by": {"M": {"email": {"S": "io@jreese.net"}, "sub": {"S": "abc-123"}}},
+        "events": {"L": []},
+        "created_at": {"S": "2026-07-02T04:00:00Z"},
+        "updated_at": {"S": "2026-07-02T04:00:00Z"},
+    }
+    if applied_at:
+        item["applied_at"] = {"S": applied_at}
+    return item
+
+
+def _target_task(status="in-progress", transition_type="github_pr_deploy",
+                 checked_out=True, record_id="ENC-TSK-J10"):
+    item = {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": f"task#{record_id}"},
+        "item_id": {"S": record_id},
+        "record_type": {"S": "task"},
+        "status": {"S": status},
+        "title": {"S": "target"},
+        "transition_type": {"S": transition_type},
+    }
+    if checked_out:
+        item["checkout_state"] = {"S": "checked_out"}
+        item["checked_out_by"] = {"S": "ENC-SES-02C"}
+        item["checked_out_at"] = {"S": "2026-07-02T03:00:00Z"}
+        item["active_agent_session_id"] = {"S": "ENC-SES-02C"}
+        item["checkout_transition_type"] = {"S": transition_type}
+    return item
+
+
+class _FakeDdb:
+    """Routes get_item by record_id; records every update_item call."""
+
+    def __init__(self, escalation=None, target=None,
+                 fail_first_update=False, fail_target_update=False):
+        self.escalation = escalation
+        self.target = target
+        self.updates = []
+        self._fail_first_update = fail_first_update
+        self._fail_target_update = fail_target_update
+        self.exceptions = mock.MagicMock()
+
+    def get_item(self, TableName=None, Key=None, **kwargs):
+        record_id = (Key or {}).get("record_id", {}).get("S", "")
+        if record_id.startswith("escalation#") and self.escalation is not None:
+            return {"Item": self.escalation}
+        if record_id.startswith(("task#", "issue#", "feature#")) and self.target is not None:
+            return {"Item": self.target}
+        return {}
+
+    def update_item(self, **kwargs):
+        record_id = kwargs.get("Key", {}).get("record_id", {}).get("S", "")
+        if self._fail_first_update and not self.updates:
+            self.updates.append(kwargs)
+            raise _ccfe()
+        if self._fail_target_update and not record_id.startswith("escalation#"):
+            self.updates.append(kwargs)
+            raise RuntimeError("forced target write failure")
+        self.updates.append(kwargs)
+        return {}
+
+    def escalation_updates(self):
+        return [u for u in self.updates
+                if u["Key"]["record_id"]["S"].startswith("escalation#")]
+
+    def target_updates(self):
+        return [u for u in self.updates
+                if not u["Key"]["record_id"]["S"].startswith("escalation#")]
+
+
+class _ApplierBase(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._patches = [
+            mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True),
+            mock.patch.object(lf, "_get_events", return_value=mock.MagicMock()),
+        ]
+        for patch in self._patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in self._patches:
+            patch.stop()
+
+    def _apply(self, ddb, body=None):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb):
+            return self.lf._handle_escalation_apply(
+                "enceladus", "ENC-ESC-001",
+                body or {"write_source": {"provider": "ENC-SES-02F"}})
+
+
+class TestApplierGuards(_ApplierBase):
+    def test_already_applied_no_ops_without_any_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(
+            status="applied", applied_at="2026-07-02T04:05:00Z"))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertTrue(body["no_op"])
+        self.assertEqual([], ddb.updates)
+
+    def test_applied_at_set_but_status_stale_still_no_ops(self):
+        ddb = _FakeDdb(escalation=_escalation_item(
+            status="applying", applied_at="2026-07-02T04:05:00Z"))
+        resp = self._apply(ddb)
+        self.assertTrue(json.loads(resp["body"])["no_op"])
+        self.assertEqual([], ddb.updates)
+
+    def test_requested_status_refused_409(self):
+        ddb = _FakeDdb(escalation=_escalation_item(status="requested"))
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        self.assertIn("not 'approved'", json.loads(resp["body"])["error"])
+        self.assertEqual([], ddb.updates)
+
+    def test_denied_status_refused_409(self):
+        ddb = _FakeDdb(escalation=_escalation_item(status="denied"))
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+    def test_missing_escalation_404(self):
+        ddb = _FakeDdb(escalation=None)
+        resp = self._apply(ddb)
+        self.assertEqual(404, resp["statusCode"])
+
+    def test_concurrent_applier_losing_race_no_ops(self):
+        ddb = _FakeDdb(escalation=_escalation_item(),
+                       target=_target_task(), fail_first_update=True)
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertTrue(body["no_op"])
+        self.assertIn("concurrent", body["reason"])
+        # Only the losing conditional write was attempted — target untouched.
+        self.assertEqual([], ddb.target_updates())
+
+    def test_double_sequential_apply_is_exactly_once(self):
+        first = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp1 = self._apply(first)
+        self.assertEqual(200, resp1["statusCode"])
+        self.assertEqual(1, len(first.target_updates()))
+        # Second invocation sees the applied state; must be a pure no-op.
+        second = _FakeDdb(escalation=_escalation_item(
+            status="applied", applied_at="2026-07-02T04:06:00Z"))
+        resp2 = self._apply(second)
+        self.assertTrue(json.loads(resp2["body"])["no_op"])
+        self.assertEqual([], second.updates)
+
+    def test_flag_off_503(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        with mock.patch.object(self.lf, "ENABLE_ESCALATION_PRIMITIVE", False):
+            resp = self._apply(ddb)
+        self.assertEqual(503, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+
+class TestApplierFsmWalk(_ApplierBase):
+    def test_success_walks_applying_then_applied_with_events(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual("applied", body["status"])
+        self.assertTrue(body["applied_at"])
+        esc_updates = ddb.escalation_updates()
+        self.assertEqual(2, len(esc_updates))
+        applying, applied = esc_updates
+        self.assertEqual({"S": "applying"},
+                         applying["ExpressionAttributeValues"][":to_status"])
+        self.assertIn("attribute_not_exists(applied_at)",
+                      applying["ConditionExpression"])
+        applying_event = applying["ExpressionAttributeValues"][":event"]["L"][0]["M"]
+        self.assertEqual("applying", applying_event["event_type"]["S"])
+        self.assertEqual({"S": "applied"},
+                         applied["ExpressionAttributeValues"][":to_status"])
+        self.assertIn("applied_at = :applied_at",
+                      applied["UpdateExpression"])
+        self.assertEqual("result",
+                         applied["ExpressionAttributeNames"]["#res"])
+        applied_event = applied["ExpressionAttributeValues"][":event"]["L"][0]["M"]
+        self.assertEqual("applied", applied_event["event_type"]["S"])
+
+    def test_missing_target_fails_escalation_with_error_result(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=None)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        esc_updates = ddb.escalation_updates()
+        self.assertEqual(2, len(esc_updates))
+        failed = esc_updates[1]
+        self.assertEqual({"S": "failed"},
+                         failed["ExpressionAttributeValues"][":to_status"])
+        result = failed["ExpressionAttributeValues"][":result"]
+        self.assertIn("not found", json.dumps(result))
+        self.assertEqual([], ddb.target_updates())
+
+    def test_handler_exception_fails_escalation_no_partial_target_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task(),
+                       fail_target_update=True)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        failed = ddb.escalation_updates()[1]
+        self.assertEqual({"S": "failed"},
+                         failed["ExpressionAttributeValues"][":to_status"])
+        result_json = json.dumps(failed["ExpressionAttributeValues"][":result"])
+        self.assertIn("forced target write failure", result_json)
+        # The single atomic target UpdateItem raised — nothing partial landed.
+        self.assertEqual(1, len(ddb.target_updates()))
+
+    def test_unknown_mutation_type_500_before_any_transition(self):
+        ddb = _FakeDdb(escalation=_escalation_item(mutation_type="mystery"))
+        resp = self._apply(ddb)
+        self.assertEqual(500, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+    def test_applied_emits_audit_event(self):
+        events_client = mock.MagicMock()
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        with mock.patch.object(self.lf, "_get_events", return_value=events_client):
+            resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        entry = events_client.put_events.call_args.kwargs["Entries"][0]
+        self.assertEqual("record.escalation.applied", entry["DetailType"])
+        detail = json.loads(entry["Detail"])
+        self.assertEqual("ENC-ESC-001", detail["escalation_id"])
+        self.assertEqual("io@jreese.net", detail["approved_by"])
+
+    def test_escalation_fsm_helper_refuses_illegal_edges(self):
+        with self.assertRaises(ValueError):
+            self.lf._escalation_fsm_transition(
+                "enceladus", "ENC-ESC-001", "requested", "applied", "system")
+
+
+class TestDeployArcChangeApply(_ApplierBase):
+    def test_arc_rewrite_preserves_active_checkout(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task(checked_out=True))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertEqual("transition_type",
+                         target_update["ExpressionAttributeNames"]["#tt"])
+        self.assertEqual({"S": "code_only"},
+                         target_update["ExpressionAttributeValues"][":arc"])
+        # checkout_transition_type recomputed alongside the arc...
+        self.assertIn("checkout_transition_type = :arc", expression)
+        # ...while checkout ownership fields are untouched (checkout survives).
+        for forbidden in ("checked_out_by", "checkout_state", "checked_out_at",
+                          "active_agent_session_id"):
+            self.assertNotIn(forbidden, expression)
+
+    def test_arc_rewrite_without_checkout_snapshot_skips_mirror(self):
+        ddb = _FakeDdb(escalation=_escalation_item(),
+                       target=_target_task(checked_out=False))
+        self._apply(ddb)
+        expression = ddb.target_updates()[0]["UpdateExpression"]
+        self.assertNotIn("checkout_transition_type", expression)
+
+    def test_provenance_rides_the_same_atomic_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        self._apply(ddb)
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertIn("escalation_provenance = list_append", expression)
+        self.assertIn("history = list_append", expression)
+        history_entry = target_update["ExpressionAttributeValues"][":hentry"]["L"][0]["M"]
+        note = history_entry["description"]["S"]
+        self.assertIn("[ESCALATION-APPLIED] ENC-ESC-001", note)
+        self.assertIn("requested_by=ENC-SES-02F", note)
+        self.assertIn("approved_by=io@jreese.net", note)
+        self.assertIn("before=", note)
+        self.assertIn("after=", note)
+        provenance = target_update["ExpressionAttributeValues"][":esc"]["L"]
+        self.assertEqual([{"S": "ENC-ESC-001"}], provenance)
+
+
+def _override_escalation(target_status, field_values=None, target="ENC-TSK-J10"):
+    payload = {"target_status": target_status}
+    if field_values is not None:
+        payload["field_values"] = field_values
+    return _escalation_item(mutation_type="direct_state_override",
+                            payload=payload, target=target)
+
+
+class TestDirectStateOverrideApply(_ApplierBase):
+    def test_coding_complete_to_closed_waives_and_flags_closure(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("closed"),
+            target=_target_task(status="coding-complete", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        result = json.loads(resp["body"])["result"]
+        self.assertEqual(["live_validation_evidence"], result["waived_fields"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        values = target_update["ExpressionAttributeValues"]
+        names = target_update["ExpressionAttributeNames"]
+        self.assertEqual({"S": "closed"}, values[":target_status"])
+        self.assertEqual("live_validation_evidence", names["#wv0"])
+        sentinel = values[":wv0"]["M"]
+        self.assertTrue(sentinel["escalation_waived"]["BOOL"])
+        self.assertEqual("ENC-ESC-001", sentinel["escalation_id"]["S"])
+        self.assertIn("waived_at", sentinel)
+        self.assertIn("escalated_closure = :esc_closure", expression)
+        self.assertTrue(values[":esc_closure"]["BOOL"])
+        self.assertIn("ADD closed_count :one_count", expression)
+
+    def test_closed_to_pr_path_illegal_transition_lands(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("pr"),
+            target=_target_task(status="closed", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        values = target_update["ExpressionAttributeValues"]
+        self.assertEqual({"S": "pr"}, values[":target_status"])
+        expression = target_update["UpdateExpression"]
+        self.assertNotIn("escalated_closure", expression)
+        self.assertNotIn("closed_count", expression)
+        self.assertNotIn("#wv0", expression)
+
+    def test_supplied_field_values_written_verbatim_not_waived(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation(
+                "closed", {"live_validation_evidence": "gamma smoke 200 OK"}),
+            target=_target_task(status="deploy-success", checked_out=False))
+        resp = self._apply(ddb)
+        result = json.loads(resp["body"])["result"]
+        self.assertEqual([], result["waived_fields"])
+        target_update = ddb.target_updates()[0]
+        names = target_update["ExpressionAttributeNames"]
+        values = target_update["ExpressionAttributeValues"]
+        self.assertEqual("live_validation_evidence", names["#fv0"])
+        self.assertEqual({"S": "gamma smoke 200 OK"}, values[":fv0"])
+
+    def test_deploy_success_waives_arc_specific_evidence_key(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("deploy-success"),
+            target=_target_task(status="pr", transition_type="web_deploy",
+                                checked_out=False))
+        self._apply(ddb)
+        names = ddb.target_updates()[0]["ExpressionAttributeNames"]
+        self.assertEqual("web_deploy_evidence", names["#wv0"])
+
+    def test_issue_closure_waives_evidence_without_closed_count(self):
+        issue = {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": "issue#ENC-ISS-441"},
+            "item_id": {"S": "ENC-ISS-441"},
+            "record_type": {"S": "issue"},
+            "status": {"S": "open"},
+        }
+        ddb = _FakeDdb(
+            escalation=_override_escalation("closed", target="ENC-ISS-441"),
+            target=issue)
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertEqual("evidence",
+                         target_update["ExpressionAttributeNames"]["#wv0"])
+        self.assertIn("escalated_closure", expression)
+        self.assertNotIn("closed_count", expression)
+
+    def test_works_on_closed_record_with_no_checkout(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation(
+                "deploy-success", {"deploy_evidence": {"id": 1, "conclusion": "success"}}),
+            target=_target_task(status="closed", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        self.assertEqual(1, len(ddb.target_updates()))
+
+
+class TestValidatorsUntouched(unittest.TestCase):
+    """AC-7: the normal FSM acquired no bypass — the applier is a separate path."""
+
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_normal_task_fsm_still_forbids_the_overridden_paths(self):
+        graph = self.lf._VALID_TRANSITIONS["task"]
+        self.assertNotIn("closed", graph)  # closed is terminal — no forward edges
+        self.assertNotIn("closed", graph["coding-complete"])  # no direct jump
+
+    def test_update_field_signature_carries_no_bypass_parameter(self):
+        import inspect
+        params = set(inspect.signature(self.lf._handle_update_field).parameters)
+        self.assertFalse(
+            {"escalation", "bypass", "override", "skip_validation"} & params,
+            "validator entry point must not grow bypass parameters")
+
+    def test_revert_transitions_unchanged(self):
+        self.assertEqual({"in-progress": {"open"}},
+                         self.lf._REVERT_TRANSITIONS["issue"])
+
+    def test_escalation_fsm_is_not_wired_into_normal_transitions(self):
+        for record_type_graph in self.lf._VALID_TRANSITIONS.values():
+            for status in record_type_graph:
+                self.assertNotIn(status, self.lf._ESCALATION_FSM.keys() - set())
+
+
+class TestApplyRouteRegex(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_apply_sub_path_matches(self):
+        match = self.lf._RE_ESCALATION.match(
+            "/api/v1/tracker/enceladus/escalation/ENC-ESC-001/apply")
+        self.assertIsNotNone(match)
+        self.assertEqual("ENC-ESC-001", match.group("id"))
+        self.assertEqual("apply", match.group("sub"))
+
+    def test_list_pseudo_id_matches_as_id(self):
+        match = self.lf._RE_ESCALATION.match("/enceladus/escalation/list")
+        self.assertIsNotNone(match)
+        self.assertEqual("list", match.group("id"))
+        self.assertIsNone(match.group("sub"))
+
+    def test_arbitrary_sub_does_not_match(self):
+        self.assertIsNone(self.lf._RE_ESCALATION.match(
+            "/enceladus/escalation/ENC-ESC-001/delete"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -6139,7 +6139,10 @@ async def _escalation_list(args: dict) -> list[TextContent]:
         "session_id": args.get("session_id"),
         "page_size": args.get("page_size"),
     }
-    resp = _tracker_api_request("GET", f"/{project_id}/escalation", query=query)
+    # ENC-TSK-J69: the "list" pseudo-id rides the API Gateway route
+    # GET /{projectId}/{recordType}/{recordId} — the bare collection path has
+    # no registered route on the explicit (gamma-style) route tables.
+    resp = _tracker_api_request("GET", f"/{project_id}/escalation/list", query=query)
     return _result_text(resp)
 
 


### PR DESCRIPTION
## ENC-TSK-J69 — FTR-121 Phase 2: the applier

The single privileged code path that may write lifecycle-forbidden transitions after io approval (DOC-5B888FCA43B8 §5.5, Tenet 2) under ENC-PLN-061 / ENC-FTR-121. Builds on #715 (Ph1).

### Scope
- **applyEscalatedMutation** (`_handle_escalation_apply`, `POST /{project}/escalation/{id}/apply`): `applied_at` idempotency guard (repeat invocation no-ops), conditional `approved→applying` transition as the concurrency gate (losing racer no-ops), fresh consistent target read, registry handler `apply` executing **one atomic UpdateItem** on the target, `applying→applied` stamping `applied_at`+`result`, `applying→failed` capturing the error with **no partial target write**. §11.2 events at every FSM edge. Reachability: application requires `status=approved`, writable only by the Ph3 Cognito-human approval route — no MCP action, SCI, or internal key can approve.
- **deploy_arc_change apply**: rewrites `transition_type` (and the `checkout_transition_type` snapshot when present — recomputing arc-derived gate expectations) in place; checkout ownership fields untouched, **active checkout survives** (test-proven).
- **direct_state_override apply**: lands `target_status` regardless of path legality (tests: coding-complete→closed AND closed→pr), `field_values` verbatim, **escalation_waived sentinels** on unsupplied required-for-state fields (derived from the canonical transition-matrix gate contracts), `escalated_closure=true` on closures (+`closed_count` for tasks — organic-gate parity).
- **Provenance** rides the same atomic write: `escalation_provenance` append + `[ESCALATION-APPLIED]` worklog (requesting session, approving human, before/after states, waived list). `record.escalation.applied` audit event (best-effort).
- **Validators untouched** — `_handle_update_field`, transition tables, close-eligibility, and checkout semantics unchanged; negative tests assert no bypass parameters exist.
- **escalation.list alias**: `GET /{project}/escalation/list` pseudo-id (gamma APIGW registers `{recordType}/{recordId}` but no bare collection route — found during J68 live validation); MCP `escalation_list` updated.
- **Dictionary → 2026-07-02.02**: applier semantics, `escalation_provenance` field, live waiver semantics + null-handling audit findings, list alias.
- **Tests**: 30 new (idempotency, FSM walk, failure isolation, checkout survival, waivers, provenance, validator-untouched negatives, route regex); tracker_mutation suite **308/308 green**.

### Null-handling audit (§10, recorded in task worklog)
Evidence validators validate REQUEST payloads, never stored record fields — sentinel-bearing records cannot flow through them; the sentinel is a typed map that fails loudly and grep-ably. No downstream fixes required.

CCI-effc3e036c3d4d8a85a1a08e7d0a6257

🤖 Generated with [Claude Code](https://claude.com/claude-code)