### PR TITLE
[ENC-TSK-J64] FTR-120 Ph3 — gate UI prod lane + iam-*/import workflows + prod-gate baseline

### DIFF
--- a/.github/workflows/cfn-resource-import.yml
+++ b/.github/workflows/cfn-resource-import.yml
@@ -91,6 +91,8 @@ env:
 jobs:
   import:
     name: "${{ inputs.mode }} -> ${{ inputs.stack_name }}${{ inputs.preview_only && ' (preview)' || '' }}"
+    # ENC-TSK-J64 / ENC-FTR-120: stack imports/recoveries mutate CFN state — gamma-suffixed stacks flow via v4-gamma (ungated); everything else pauses on v3-prod.
+    environment: ${{ contains(inputs.stack_name, '-gamma') && 'v4-gamma' || 'v3-prod' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
@@ -26,6 +26,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch CFN deploy role with events:ListRules
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch CFN deploy role with gamma DynamoDB and SNS permissions
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/iam-cloudformation-unblock.yml
+++ b/.github/workflows/iam-cloudformation-unblock.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch role policy for CloudFormation API deploy
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/iam-cognito-terminal-unblock.yml
+++ b/.github/workflows/iam-cognito-terminal-unblock.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch deploy role for Cognito terminal provisioning
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ui-backend-deploy.yml
+++ b/.github/workflows/ui-backend-deploy.yml
@@ -51,6 +51,8 @@ env:
 jobs:
   deploy:
     name: Submit Backend UI Deployment
+    # ENC-TSK-J64 / ENC-FTR-120: the DPL submit below is the irrevocable prod trigger (the orchestrator deploys the queued request with no further gate), so this job pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -65,7 +65,6 @@ Resources:
                   # the ref-based sub, so the gated CFN deploy lanes (plan/apply
                   # split, apply job runs inside the environment) need these.
                   # Additive: ref-based subs stay for ungated/legacy callers.
-                  # Deployed live 2026-07-02 via change-set enc-tsk-j61-oidc-env-subs.
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v3-prod"
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v4-gamma"
       Policies:
@@ -106,6 +105,9 @@ Resources:
                   # 2026-04-28 ApiDefaultStage CREATE_FAILED was an apigateway:TagResource
                   # AccessDenied (not CreateStage). Required for the deploy role to
                   # manage the gamma $default stage going forward.
+                  # (ENC-TSK-J61: restored on v4/main -- present live + on main, but
+                  # missing from this branch; a stack deploy from v4/main without it
+                  # would strip the live permission, the PLN-047 regression class.)
                   - apigateway:TagResource
                   - apigateway:UntagResource
                 Resource:
@@ -365,6 +367,11 @@ Resources:
                 token.actions.githubusercontent.com:sub:
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/v4/*"
+                  # ENC-TSK-J64 / ENC-FTR-120: environment-scoped jobs (gated UI
+                  # prod lane + iam-* patch workflows assuming this role) emit
+                  # environment-form subs. Additive; ref subs retained.
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v3-prod"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v4-gamma"
       Policies:
         # Split into original named policies to stay under IAM 10KB
         # per-policy limit (ENC-TSK-E32). Source: iam:GetRolePolicy dump
@@ -395,6 +402,16 @@ Resources:
                 Effect: Allow
                 Action: lambda:GetFunctionConfiguration
                 Resource: "*"
+              # Required by cfn-drift-audit.yml (ENC-TSK-I94 / ENC-ISS-442):
+              # audit_cfn_drift.py calls `aws events list-rules` to compare
+              # live EventBridge rules against CFN-declared rules. Backported to
+              # v4/main for parity with main (ENC-TSK-J08 / ENC-ISS-455) so the
+              # two branches' github-roles templates do not drift.
+              - Sid: CfnDriftAuditEventBridgeRead
+                Effect: Allow
+                Action:
+                  - events:ListRules
+                Resource: !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/*"
               - Sid: LambdaExecutionRoles
                 Effect: Allow
                 Action:
@@ -492,14 +509,6 @@ Resources:
                   - dynamodb:DescribeTable
                 Resource:
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/*-gamma"
-              # Required by cfn-drift-audit.yml (ENC-TSK-I94 / ENC-ISS-442):
-              # audit_cfn_drift.py calls `aws events list-rules` to compare
-              # live EventBridge rules against CFN-declared rules.
-              - Sid: CfnDriftAuditEventBridgeRead
-                Effect: Allow
-                Action:
-                  - events:ListRules
-                Resource: !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/*"
 
         - PolicyName: BackendDeployPolicy-LambdaArtifacts
           PolicyDocument:
@@ -625,6 +634,9 @@ Resources:
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/devops-project-tracker"
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects"
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents"
+                  # ENC-TSK-I28: deny-by-default — sole writer is RecomputeGovernanceRole (ENC-TSK-I27)
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version-gamma"
               - Sid: DenyGovernedS3Writes
                 Effect: Deny
                 Action:
@@ -761,6 +773,12 @@ Resources:
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
                   - lambda:ListVersionsByFunction
+                  # ENC-ISS-418: alias perms so _deploy.yml can advance/create the :live
+                  # alias on every v4-gamma deploy. Without these the direct-alias path
+                  # AccessDenied'd and gamma :live froze at v81 (published-but-not-served).
+                  - lambda:GetAlias
+                  - lambda:CreateAlias
+                  - lambda:UpdateAlias
                 Resource: "*"
               # S3 read for artifact version probing (belt-and-suspenders;
               # update-function-code fetches via Lambda service role, but

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -1,0 +1,40 @@
+{
+  "_doc": "ENC-TSK-J64 / ENC-FTR-120 prod-gate classification baseline. Every workflow under .github/workflows/ is classified for the FTR-120 invariant: no agent-reachable git operation mutates v3-prod without pausing on the v3-prod GitHub Environment required-reviewer gate. Consumed by the ENC-TSK-J65 prod-gate-coverage-guard, which FAILS CLOSED on any workflow absent from this file or classified prod-mutating without its mutating job carrying environment: v3-prod. Classes: prod-mutating (job can mutate v3-prod runtime/control-plane -> its mutating job MUST be v3-prod environment-scoped), gamma-only (mutates only -gamma resources / v4 lanes), conditional (environment chosen by expression from ref or inputs -> guard asserts the expression includes v3-prod for the prod path), already-gated (carries the environment natively), inert (no AWS mutation: guards, CI, git-only, read-only audits, docstore-only writes).",
+  "_schema": {
+    "version": "2026-07-02-j64",
+    "format": "workflows.<file> = {class, gated_jobs?, notes}",
+    "gated_jobs": "job ids whose environment key satisfies the invariant (v3-prod, v4-gamma, or a conditional expression covering both)"
+  },
+  "workflows": {
+    "_build.yml": {"class": "inert", "notes": "reusable build; artifact staging only, no runtime mutation"},
+    "_deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "environment: parametrized per target (v3-prod reviewer-gated, v4-gamma ungated); dedicated per-env OIDC roles (PR #407)"},
+    "build-lambda-artifacts.yml": {"class": "inert", "notes": "S3 artifact staging bucket writes only; no live function/stack mutation"},
+    "cfn-drift-audit.yml": {"class": "inert", "notes": "read-only drift audit"},
+    "cfn-resource-import.yml": {"class": "conditional", "gated_jobs": ["import"], "notes": "ENC-TSK-J64: environment chosen from inputs.stack_name (-gamma -> v4-gamma, else v3-prod)"},
+    "ci.yml": {"class": "inert", "notes": "lint/tests/guards"},
+    "cloudformation-agent-auth-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b); guard grace entry, must be gated before J63 closes"},
+    "cloudformation-api-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod)"},
+    "cloudformation-codedeploy-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
+    "cloudformation-compute-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref"},
+    "cloudformation-monitoring-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
+    "component-registry-guard.yml": {"class": "inert", "notes": "guard"},
+    "governance-dictionary-guard.yml": {"class": "inert", "notes": "guard"},
+    "governance-prod-backstop-grant.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; gated on the v4/main lane by ENC-TSK-J64's v4 port"},
+    "iam-cfn-deploy-role-eventbridge-listrules-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod (shared/global IAM role objects)"},
+    "iam-cfn-deploy-role-gamma-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"},
+    "iam-cloudformation-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
+    "iam-cognito-terminal-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
+    "iam-coordination-api-gamma-govversion-grant.yml": {"class": "gamma-only", "notes": "v4/main-only file; mutates devops-coordination-api-lambda-role-GAMMA policy only"},
+    "lambda-workflow-coverage-guard.yml": {"class": "inert", "notes": "guard"},
+    "mcp-api-boundary-guard.yml": {"class": "inert", "notes": "guard"},
+    "nightly-parity-audit.yml": {"class": "inert", "notes": "read-only audit"},
+    "oidc-trust-probe.yml": {"class": "already-gated", "gated_jobs": ["probe"], "notes": "read-only probe; environment: from input (v3-prod dispatches pause like any other)"},
+    "pr-commit-gate.yml": {"class": "inert", "notes": "gate validation, read-only"},
+    "promote-gamma-to-prod-request.yml": {"class": "inert", "notes": "relay: dispatches _deploy.yml whose v3-prod lane is environment-gated; performs no mutation itself"},
+    "secrets-guardrail.yml": {"class": "inert", "notes": "guard"},
+    "sync-architecture-doc.yml": {"class": "inert", "notes": "docstore document write via internal key; no runtime-infrastructure mutation — flagged for awareness, out of the v3-prod runtime invariant's scope"},
+    "sync-main-to-v4main.yml": {"class": "inert", "notes": "git-only forward-sync (currently disabled/fork-mode)"},
+    "ui-backend-deploy.yml": {"class": "prod-mutating", "gated_jobs": ["deploy"], "notes": "ENC-TSK-J64: environment: v3-prod — the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"},
+    "ui-gamma-deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "v4/main-only; environment: v4-gamma with dedicated GitHubActions-V4Gamma-DeployRole since inception"}
+  }
+}


### PR DESCRIPTION
## Summary
FTR-120 Ph3. Extends the v3-prod gate beyond CFN stack workflows (J62) to every remaining prod-mutating lane:
- **ui-backend-deploy.yml** (`deploy`): the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request ungated downstream) — job now pauses on v3-prod.
- **Four iam-\* patch workflows** (`patch-role`): live IAM mutations of shared role objects — v3-prod gated.
- **cfn-resource-import.yml** (`import`): conditional environment from `inputs.stack_name` (-gamma → ungated v4-gamma; else v3-prod).
- **tools/prod_gate_baseline.json**: machine-readable classification of all workflows — the J65 coverage guard's fail-closed seed. The 3 remaining ungated CFN workflows (agent-auth/codedeploy/monitoring) are recorded as J63-owned grace entries.
- `ui-gamma-deploy.yml` needed nothing (already `environment: v4-gamma` since inception).

Trust prerequisites already live (reviewed change-set `enc-tsk-j64-backend-role-env-subs-v3`, single BackendDeployRole Modify + direct update of the out-of-band UI role). Caught and avoided a PLN-047-class strip: main's stale 04-github-roles.yaml would have removed live I28/ISS-418 content — rebuilt to v4/main parity first.

CCI-618f09300e2643e4af28c63f0fcbf8fb

🤖 Generated with [Claude Code](https://claude.com/claude-code)