### PR TITLE
[ENC-TSK-J64] v4/main port — Ph3 gated workflows + baseline + backstop-grant gate

### DIFF
--- a/.github/workflows/cfn-resource-import.yml
+++ b/.github/workflows/cfn-resource-import.yml
@@ -91,6 +91,8 @@ env:
 jobs:
   import:
     name: "${{ inputs.mode }} -> ${{ inputs.stack_name }}${{ inputs.preview_only && ' (preview)' || '' }}"
+    # ENC-TSK-J64 / ENC-FTR-120: stack imports/recoveries mutate CFN state — gamma-suffixed stacks flow via v4-gamma (ungated); everything else pauses on v3-prod.
+    environment: ${{ contains(inputs.stack_name, '-gamma') && 'v4-gamma' || 'v3-prod' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/governance-prod-backstop-grant.yml
+++ b/.github/workflows/governance-prod-backstop-grant.yml
@@ -44,6 +44,9 @@ env:
 jobs:
   apply:
     name: Apply prod governance-hash backstop (io-exception)
+    # ENC-TSK-J64 / ENC-FTR-120: prod IAM grant -- pauses on the v3-prod
+    # required-reviewer rule (layered under the doc-id consent input).
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-eventbridge-listrules-patch.yml
@@ -26,6 +26,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch CFN deploy role with events:ListRules
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-gamma-patch.yml
@@ -1,4 +1,4 @@
-name: IAM CFN Deploy Role — Gamma DDB/SNS Patch
+name: IAM CFN Deploy Role — Gamma DDB/SNS/SQS Patch
 
 on:
   workflow_dispatch:
@@ -16,6 +16,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch CFN deploy role with gamma DynamoDB and SNS permissions
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -28,10 +30,10 @@ jobs:
       - name: Verify caller identity
         run: aws sts get-caller-identity
 
-      - name: Apply inline policy — gamma DynamoDB + SNS bootstrap
+      - name: Apply inline policy — gamma DynamoDB + SNS + SQS bootstrap
         run: |
           set -euo pipefail
-          cat > /tmp/gamma-ddb-sns-policy.json <<'JSON'
+          cat > /tmp/gamma-ddb-sns-sqs-policy.json <<'JSON'
           {
             "Version": "2012-10-17",
             "Statement": [
@@ -66,9 +68,62 @@ jobs:
                   "sns:ListTagsForResource",
                   "sns:Subscribe",
                   "sns:Unsubscribe",
-                  "sns:GetSubscriptionAttributes"
+                  "sns:GetSubscriptionAttributes",
+                  "sns:ListSubscriptionsByTopic"
                 ],
                 "Resource": "arn:aws:sns:us-west-2:356364570033:enceladus-*-gamma"
+              },
+              {
+                "Sid": "GammaSQSBootstrap",
+                "Effect": "Allow",
+                "Action": [
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ListQueueTags",
+                  "sqs:CreateQueue",
+                  "sqs:SetQueueAttributes",
+                  "sqs:TagQueue",
+                  "sqs:UntagQueue"
+                ],
+                "Resource": "arn:aws:sqs:us-west-2:356364570033:devops-*-gamma*"
+              },
+              {
+                "Sid": "S3GovernanceBucketNotification",
+                "Effect": "Allow",
+                "Action": [
+                  "s3:GetBucketLocation",
+                  "s3:GetBucketNotification",
+                  "s3:PutBucketNotification",
+                  "s3:GetBucketNotificationConfiguration",
+                  "s3:PutBucketNotificationConfiguration"
+                ],
+                "Resource": "arn:aws:s3:::jreese-net"
+              },
+              {
+                "Sid": "LambdaGovernancePermission",
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:AddPermission",
+                  "lambda:RemovePermission",
+                  "lambda:GetPolicy"
+                ],
+                "Resource": "arn:aws:lambda:us-west-2:356364570033:function:devops-recompute-governance*"
+              },
+              {
+                "Sid": "SNSGovernanceRelayUSWest1",
+                "Effect": "Allow",
+                "Action": [
+                  "sns:CreateTopic",
+                  "sns:GetTopicAttributes",
+                  "sns:SetTopicAttributes",
+                  "sns:DeleteTopic",
+                  "sns:TagResource",
+                  "sns:Subscribe",
+                  "sns:Unsubscribe",
+                  "sns:GetSubscriptionAttributes",
+                  "sns:ListSubscriptionsByTopic"
+                ],
+                "Resource": "arn:aws:sns:us-west-1:356364570033:enceladus-*-gamma"
               }
             ]
           }
@@ -77,7 +132,7 @@ jobs:
           aws iam put-role-policy \
             --role-name "enceladus-cloudformation-deploy-github-role" \
             --policy-name "enceladus-cfn-deploy-gamma-ddb-sns-v1" \
-            --policy-document "file:///tmp/gamma-ddb-sns-policy.json"
+            --policy-document "file:///tmp/gamma-ddb-sns-sqs-policy.json"
 
       - name: Verify inline policy attached
         run: |

--- a/.github/workflows/iam-cloudformation-unblock.yml
+++ b/.github/workflows/iam-cloudformation-unblock.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch role policy for CloudFormation API deploy
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/iam-cognito-terminal-unblock.yml
+++ b/.github/workflows/iam-cognito-terminal-unblock.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   patch-role:
     name: Patch deploy role for Cognito terminal provisioning
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role objects) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ui-backend-deploy.yml
+++ b/.github/workflows/ui-backend-deploy.yml
@@ -51,6 +51,8 @@ env:
 jobs:
   deploy:
     name: Submit Backend UI Deployment
+    # ENC-TSK-J64 / ENC-FTR-120: the DPL submit below is the irrevocable prod trigger (the orchestrator deploys the queued request with no further gate), so this job pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -367,6 +367,11 @@ Resources:
                 token.actions.githubusercontent.com:sub:
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/main"
                   - !Sub "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/v4/*"
+                  # ENC-TSK-J64 / ENC-FTR-120: environment-scoped jobs (gated UI
+                  # prod lane + iam-* patch workflows assuming this role) emit
+                  # environment-form subs. Additive; ref subs retained.
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v3-prod"
+                  - !Sub "repo:${GitHubOrg}/${GitHubRepo}:environment:v4-gamma"
       Policies:
         # Split into original named policies to stay under IAM 10KB
         # per-policy limit (ENC-TSK-E32). Source: iam:GetRolePolicy dump

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -1,0 +1,40 @@
+{
+  "_doc": "ENC-TSK-J64 / ENC-FTR-120 prod-gate classification baseline. Every workflow under .github/workflows/ is classified for the FTR-120 invariant: no agent-reachable git operation mutates v3-prod without pausing on the v3-prod GitHub Environment required-reviewer gate. Consumed by the ENC-TSK-J65 prod-gate-coverage-guard, which FAILS CLOSED on any workflow absent from this file or classified prod-mutating without its mutating job carrying environment: v3-prod. Classes: prod-mutating (job can mutate v3-prod runtime/control-plane -> its mutating job MUST be v3-prod environment-scoped), gamma-only (mutates only -gamma resources / v4 lanes), conditional (environment chosen by expression from ref or inputs -> guard asserts the expression includes v3-prod for the prod path), already-gated (carries the environment natively), inert (no AWS mutation: guards, CI, git-only, read-only audits, docstore-only writes).",
+  "_schema": {
+    "version": "2026-07-02-j64",
+    "format": "workflows.<file> = {class, gated_jobs?, notes}",
+    "gated_jobs": "job ids whose environment key satisfies the invariant (v3-prod, v4-gamma, or a conditional expression covering both)"
+  },
+  "workflows": {
+    "_build.yml": {"class": "inert", "notes": "reusable build; artifact staging only, no runtime mutation"},
+    "_deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "environment: parametrized per target (v3-prod reviewer-gated, v4-gamma ungated); dedicated per-env OIDC roles (PR #407)"},
+    "build-lambda-artifacts.yml": {"class": "inert", "notes": "S3 artifact staging bucket writes only; no live function/stack mutation"},
+    "cfn-drift-audit.yml": {"class": "inert", "notes": "read-only drift audit"},
+    "cfn-resource-import.yml": {"class": "conditional", "gated_jobs": ["import"], "notes": "ENC-TSK-J64: environment chosen from inputs.stack_name (-gamma -> v4-gamma, else v3-prod)"},
+    "ci.yml": {"class": "inert", "notes": "lint/tests/guards"},
+    "cloudformation-agent-auth-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b); guard grace entry, must be gated before J63 closes"},
+    "cloudformation-api-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod)"},
+    "cloudformation-codedeploy-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
+    "cloudformation-compute-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref"},
+    "cloudformation-monitoring-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
+    "component-registry-guard.yml": {"class": "inert", "notes": "guard"},
+    "governance-dictionary-guard.yml": {"class": "inert", "notes": "guard"},
+    "governance-prod-backstop-grant.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; gated on the v4/main lane by ENC-TSK-J64's v4 port"},
+    "iam-cfn-deploy-role-eventbridge-listrules-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod (shared/global IAM role objects)"},
+    "iam-cfn-deploy-role-gamma-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"},
+    "iam-cloudformation-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
+    "iam-cognito-terminal-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
+    "iam-coordination-api-gamma-govversion-grant.yml": {"class": "gamma-only", "notes": "v4/main-only file; mutates devops-coordination-api-lambda-role-GAMMA policy only"},
+    "lambda-workflow-coverage-guard.yml": {"class": "inert", "notes": "guard"},
+    "mcp-api-boundary-guard.yml": {"class": "inert", "notes": "guard"},
+    "nightly-parity-audit.yml": {"class": "inert", "notes": "read-only audit"},
+    "oidc-trust-probe.yml": {"class": "already-gated", "gated_jobs": ["probe"], "notes": "read-only probe; environment: from input (v3-prod dispatches pause like any other)"},
+    "pr-commit-gate.yml": {"class": "inert", "notes": "gate validation, read-only"},
+    "promote-gamma-to-prod-request.yml": {"class": "inert", "notes": "relay: dispatches _deploy.yml whose v3-prod lane is environment-gated; performs no mutation itself"},
+    "secrets-guardrail.yml": {"class": "inert", "notes": "guard"},
+    "sync-architecture-doc.yml": {"class": "inert", "notes": "docstore document write via internal key; no runtime-infrastructure mutation — flagged for awareness, out of the v3-prod runtime invariant's scope"},
+    "sync-main-to-v4main.yml": {"class": "inert", "notes": "git-only forward-sync (currently disabled/fork-mode)"},
+    "ui-backend-deploy.yml": {"class": "prod-mutating", "gated_jobs": ["deploy"], "notes": "ENC-TSK-J64: environment: v3-prod — the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"},
+    "ui-gamma-deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "v4/main-only; environment: v4-gamma with dedicated GitHubActions-V4Gamma-DeployRole since inception"}
+  }
+}


### PR DESCRIPTION
v4/main counterpart of #719, plus gating the v4-only `governance-prod-backstop-grant.yml` (prod IAM grant → v3-prod environment pause, layered under its doc-id consent input). Keeps both branches' workflow lanes and the prod-gate baseline in sync.

CCI-618f09300e2643e4af28c63f0fcbf8fb

🤖 Generated with [Claude Code](https://claude.com/claude-code)