### PR TITLE
ENC-TSK-J70: Cognito approval API + PWA Escalations page (FTR-121 Ph3)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.02",
-  "updated_at": "2026-07-02T04:35:00Z",
-  "last_change_summary": "ENC-TSK-J69 (ENC-FTR-121 Ph2, DOC-5B888FCA43B8): applyEscalatedMutation applier - the single privileged code path applying io-approved escalations. applied_at idempotency guard + conditional approved->applying concurrency gate; both handler applies (deploy_arc_change preserving active checkouts; direct_state_override with escalation_waived sentinels, escalated_closure, verbatim field_values) execute one atomic UpdateItem on the target with escalation_provenance + [ESCALATION-APPLIED] worklog riding the same write (no-partial-write). applying->failed captures errors in result; corrective requests are new escalations. record.escalation.applied audit event. Also: escalation.list pseudo-id alias GET /{project}/escalation/list for explicit APIGW route tables (found in J68 gamma validation). Validators unchanged - no bypass flags.",
+  "version": "2026-07-02.03",
+  "updated_at": "2026-07-02T04:50:00Z",
+  "last_change_summary": "ENC-TSK-J70 (ENC-FTR-121 Ph3, DOC-5B888FCA43B8): Cognito approval API + PWA Escalations page. coordination.escalations entity: Cognito-human-only feed/approve/deny routes (403 for internal-key/SCI/managed-token; no MCP action), requested->approved|denied|denied_with_guidance decision writes with race guards, approve drives applyEscalatedMutation via Lambda invoke with a fail-soft approved-but-unapplied path, section-5.7 render_diff with drift flag computed from the live target at render time. PWA: hamburger menu item + /escalations page (pending cards with diff + drift warning, approve/deny/deny-with-guidance, collapsed History audit section). APIGW routes gamma-only in 03-api.yaml; TRACKER_MUTATION_LAMBDA_NAME env + InvokeTrackerMutationEscalationApply role grant in 02-compute.yaml.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6524,6 +6524,25 @@
           "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first. ENC-TSK-J69: the MCP server calls GET /{project}/escalation/list (pseudo-id alias riding the registered {recordType}/{recordId} API Gateway route) because explicit gamma-style route tables register no bare {recordType} collection path; 'list' can never collide with a server-minted ENC-ESC-* id."
         }
       }
+    },
+    "coordination.escalations": {
+      "description": "ENC-FTR-121 Ph3 (ENC-TSK-J70, DOC-5B888FCA43B8 sections 5.7 + 6): io's escalation approval surface on coordination_api - the SOLE origin of override authorization in the platform. Every route verifies a genuine Cognito human session server-side per call (_is_cognito_session); internal-key, SCI, and managed-token credentials are structurally rejected with 403. No MCP action maps to approve or deny. Approve stamps approved_by {sub, email}, walks requested->approved under a ConditionExpression race guard, and drives applyEscalatedMutation (ENC-TSK-J69) in tracker_mutation via direct Lambda invoke (TRACKER_MUTATION_LAMBDA_NAME + X-Coordination-Internal-Key); the approval is durable even if the applier invoke fails (fail-soft: the escalation stays approved and the idempotent apply route can be re-driven - the agent never resubmits the cached mutation). Deny walks requested->denied, or requested->denied_with_guidance when a guidance_note is supplied; the note is stored on the item AND rides the denial event so watch polling (Ph4) delivers it to the agent.",
+      "fields": {
+        "GET /api/v1/coordination/escalations": {
+          "type": "route",
+          "definition": "io approval queue feed. Query params: project_id (default enceladus), status. Pending (requested) escalations carry a fresh section-5.7 render_diff computed from the LIVE target record at render time - never the cached request - including a drift object {expected_version, current_sync_version, current_updated_at, detected} when expected_version was supplied. Terminal escalations return in a separate array for the collapsed audit section. Cognito-only."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve": {
+          "type": "route",
+          "definition": "Non-delegable approve: requested->approved + approved_by + event, then drives the applier. Returns applied:true|false with apply_result or apply_error+retry."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny": {
+          "type": "route",
+          "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied."
+        }
+      },
+      "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
+      "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6602,6 +6621,11 @@
       "version": "2026-07-02.02",
       "task": "ENC-TSK-J69",
       "summary": "ENC-TSK-J69 (ENC-FTR-121 Ph2, DOC-5B888FCA43B8): applyEscalatedMutation applier - the single privileged code path applying io-approved escalations. applied_at idempotency guard + conditional approved->applying concurrency gate; both handler applies (deploy_arc_change preserving active checkouts; direct_state_override with escalation_waived sentinels, escalated_closure, verbatim field_values) execute one atomic UpdateItem on the target with escalation_provenance + [ESCALATION-APPLIED] worklog riding the same write (no-partial-write). applying->failed captures errors in result; corrective requests are new escalations. record.escalation.applied audit event. Also: escalation.list pseudo-id alias GET /{project}/escalation/list for explicit APIGW route tables (found in J68 gamma validation). Validators unchanged - no bypass flags."
+    },
+    {
+      "version": "2026-07-02.03",
+      "task": "ENC-TSK-J70",
+      "summary": "ENC-TSK-J70 (ENC-FTR-121 Ph3, DOC-5B888FCA43B8): Cognito approval API + PWA Escalations page. coordination.escalations entity: Cognito-human-only feed/approve/deny routes (403 for internal-key/SCI/managed-token; no MCP action), requested->approved|denied|denied_with_guidance decision writes with race guards, approve drives applyEscalatedMutation via Lambda invoke with a fail-soft approved-but-unapplied path, section-5.7 render_diff with drift flag computed from the live target at render time. PWA: hamburger menu item + /escalations page (pending cards with diff + drift warning, approve/deny/deny-with-guidance, collapsed History audit section). APIGW routes gamma-only in 03-api.yaml; TRACKER_MUTATION_LAMBDA_NAME env + InvokeTrackerMutationEscalationApply role grant in 02-compute.yaml."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -171,6 +171,13 @@ GOVERNANCE_PROJECT_ID = os.environ.get("GOVERNANCE_PROJECT_ID", "devops")
 GOVERNANCE_KEYWORD = os.environ.get("GOVERNANCE_KEYWORD", "governance-file")
 # ENC-TSK-729: push-on-write sync — Lambda name for async document store refresh
 DOCUMENT_API_LAMBDA_NAME = os.environ.get("DOCUMENT_API_LAMBDA_NAME", "devops-document-api")
+# ENC-FTR-121 Ph3 (ENC-TSK-J70): tracker_mutation Lambda hosting applyEscalatedMutation.
+# Default derives the environment suffix so a code deploy that races the CFN env
+# addition still targets the same environment's tracker mutation function.
+TRACKER_MUTATION_LAMBDA_NAME = os.environ.get(
+    "TRACKER_MUTATION_LAMBDA_NAME",
+    f"devops-tracker-mutation-api{os.environ.get('ENVIRONMENT_SUFFIX', '')}",
+)
 # ADE Component C: shared secret used to verify Cursor Cloud Agents completion
 # webhook signatures (HMAC-SHA256 over the raw body). Sourced via SSM/Secrets
 # param in CFN (see infrastructure/cloudformation/02-compute.yaml). Empty default
@@ -8978,6 +8985,378 @@ def _finalize_lesson_candidate_decision(
     )
 
 
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph3 / ENC-TSK-J70 — Escalations approval surface (DOC-5B888FCA43B8
+# §5.7 + §6). Approval is non-delegable by construction: every route here
+# verifies a genuine Cognito human session server-side; internal-key, SCI, and
+# managed-token credentials are structurally rejected (403). No MCP action maps
+# to approve/deny. Approve is the ONLY reachable entry to applyEscalatedMutation
+# (tracker_mutation) because status=approved is written nowhere else.
+# ---------------------------------------------------------------------------
+
+_ESCALATION_TARGET_SEGMENTS = {"TSK": "task", "ISS": "issue", "FTR": "feature"}
+
+
+def _invoke_tracker_mutation_api(
+    method: str, path: str, body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Invoke the tracker_mutation Lambda via the same internal Lambda-invoke
+    mechanism as _invoke_document_api. Used by the escalation approval flow to
+    drive applyEscalatedMutation (ENC-TSK-J69) after io approval.
+    """
+    fn_name = TRACKER_MUTATION_LAMBDA_NAME
+    if not fn_name:
+        raise RuntimeError("TRACKER_MUTATION_LAMBDA_NAME not configured")
+
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    internal_key = (COORDINATION_INTERNAL_API_KEY or "").strip()
+    if internal_key:
+        headers["X-Coordination-Internal-Key"] = internal_key
+
+    invoke_event = {
+        "version": "2.0",
+        "routeKey": f"{method.upper()} {path}",
+        "rawPath": path,
+        "requestContext": {"http": {"method": method.upper(), "path": path}},
+        "httpMethod": method.upper(),
+        "headers": headers,
+        "isBase64Encoded": False,
+        "body": json.dumps(body) if body is not None else None,
+    }
+
+    resp = _get_lambda_client().invoke(
+        FunctionName=fn_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(invoke_event).encode("utf-8"),
+    )
+    raw = resp.get("Payload")
+    payload_text = raw.read().decode("utf-8") if raw is not None else ""
+    envelope = json.loads(payload_text) if payload_text else {}
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"tracker mutation invoke error: {envelope}")
+
+    status_code = int(envelope.get("statusCode") or 0)
+    inner_raw = envelope.get("body")
+    inner: Dict[str, Any] = {}
+    if isinstance(inner_raw, str) and inner_raw:
+        try:
+            inner = json.loads(inner_raw)
+        except json.JSONDecodeError:
+            inner = {}
+    elif isinstance(inner_raw, dict):
+        inner = inner_raw
+    inner["_status_code"] = status_code
+    return inner
+
+
+def _escalation_payload_dict(escalation: Dict[str, Any]) -> Dict[str, Any]:
+    """The escalation payload is stored as a JSON string on the item."""
+    raw = escalation.get("payload")
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            return {}
+    return {}
+
+
+def _read_escalation_item(project_id: str, escalation_id: str) -> Optional[Dict[str, Any]]:
+    resp = _get_ddb().get_item(
+        TableName=TRACKER_TABLE,
+        Key={
+            "project_id": _serialize(project_id),
+            "record_id": _serialize(f"escalation#{escalation_id}"),
+        },
+        ConsistentRead=True,
+    )
+    raw = resp.get("Item")
+    return _deserialize(raw) if raw else None
+
+
+def _read_escalation_target(project_id: str, target_record_id: str) -> Optional[Dict[str, Any]]:
+    parts = str(target_record_id or "").split("-")
+    record_type = _ESCALATION_TARGET_SEGMENTS.get(parts[1].upper()) if len(parts) >= 3 else None
+    if not record_type:
+        return None
+    resp = _get_ddb().get_item(
+        TableName=TRACKER_TABLE,
+        Key={
+            "project_id": _serialize(project_id),
+            "record_id": _serialize(f"{record_type}#{target_record_id}"),
+        },
+        ConsistentRead=True,
+    )
+    raw = resp.get("Item")
+    return _deserialize(raw) if raw else None
+
+
+def _render_escalation_diff(
+    escalation: Dict[str, Any], target: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """§5.7 render_diff: fresh current-versus-requested delta computed at render
+    time from the LIVE target record — never from the cached request — with an
+    explicit drift flag when expected_version mismatches.
+    """
+    payload = _escalation_payload_dict(escalation)
+    mutation_type = str(escalation.get("mutation_type") or "")
+    diff: Dict[str, Any] = {
+        "mutation_type": mutation_type,
+        "target_record_id": escalation.get("target_record_id"),
+    }
+    if target is None:
+        diff["target_missing"] = True
+        return diff
+
+    if mutation_type == "deploy_arc_change":
+        diff["field"] = "transition_type"
+        diff["current"] = target.get("transition_type")
+        diff["requested"] = payload.get("new_deploy_arc_type")
+    elif mutation_type == "direct_state_override":
+        diff["field"] = "status"
+        diff["current"] = target.get("status")
+        diff["requested"] = payload.get("target_status")
+        field_values = payload.get("field_values")
+        if isinstance(field_values, dict) and field_values:
+            diff["field_values"] = {
+                field: {"current": target.get(field), "requested": requested}
+                for field, requested in field_values.items()
+            }
+
+    diff["target_snapshot"] = {
+        "title": target.get("title"),
+        "status": target.get("status"),
+        "transition_type": target.get("transition_type"),
+        "checkout_state": target.get("checkout_state"),
+        "sync_version": target.get("sync_version"),
+        "updated_at": target.get("updated_at"),
+    }
+    expected_version = str(escalation.get("expected_version") or "").strip()
+    if expected_version:
+        current_markers = {
+            str(target.get("sync_version") or ""),
+            str(target.get("updated_at") or ""),
+            f"sync_version:{target.get('sync_version')}",
+        }
+        diff["drift"] = {
+            "expected_version": expected_version,
+            "current_sync_version": str(target.get("sync_version") or ""),
+            "current_updated_at": str(target.get("updated_at") or ""),
+            "detected": expected_version not in current_markers,
+        }
+    return diff
+
+
+def _handle_escalations_feed(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/escalations — io's approval queue (§5.7).
+
+    Pending escalations carry a fresh diff + drift flag; terminal escalations
+    remain browsable for audit. Cognito-only: this is the human queue view.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, "The escalations queue requires a Cognito session (PWA, human-only).")
+
+    params = event.get("queryStringParameters") or {}
+    project_id = str(params.get("project_id") or "enceladus").strip()
+    status_filter = str(params.get("status") or "").strip()
+
+    ddb = _get_ddb()
+    query_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
+        "ExpressionAttributeValues": {
+            ":pid": _serialize(project_id),
+            ":prefix": _serialize("escalation#"),
+        },
+    }
+    if status_filter:
+        query_kwargs["FilterExpression"] = "#st = :status_filter"
+        query_kwargs["ExpressionAttributeNames"] = {"#st": "status"}
+        query_kwargs["ExpressionAttributeValues"][":status_filter"] = _serialize(status_filter)
+
+    escalations = []
+    try:
+        while True:
+            page = ddb.query(**query_kwargs)
+            escalations.extend(_deserialize(raw) for raw in page.get("Items", []))
+            last_key = page.get("LastEvaluatedKey")
+            if not last_key or len(escalations) >= 200:
+                break
+            query_kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalations feed query failed: %s", exc)
+        return _error(500, "Failed to read escalations.")
+
+    for escalation in escalations:
+        escalation["payload"] = _escalation_payload_dict(escalation)
+        if escalation.get("status") == "requested":
+            target = _read_escalation_target(
+                project_id, str(escalation.get("target_record_id") or ""))
+            escalation["diff"] = _render_escalation_diff(escalation, target)
+
+    escalations.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
+    pending = [e for e in escalations if e.get("status") == "requested"]
+    terminal = [e for e in escalations if e.get("status") != "requested"]
+    return _response(200, {
+        "success": True,
+        "project_id": project_id,
+        "pending": pending,
+        "terminal": terminal,
+        "count": len(escalations),
+    })
+
+
+def _record_escalation_decision(
+    project_id: str, escalation_id: str, new_status: str, actor: str,
+    approved_by: Optional[Dict[str, str]] = None, guidance_note: str = "",
+) -> bool:
+    """Conditionally walk requested→{approved|denied|denied_with_guidance},
+    appending the §11.2 event. Returns False when the race guard loses.
+    """
+    now = _now_z()
+    event_entry: Dict[str, Any] = {"event_type": new_status, "at": now, "actor": actor}
+    if guidance_note:
+        event_entry["guidance_note"] = guidance_note
+    update_parts = [
+        "#st = :new_status",
+        "updated_at = :now",
+        "#ev = list_append(if_not_exists(#ev, :empty), :event)",
+    ]
+    names = {"#st": "status", "#ev": "events"}
+    values: Dict[str, Any] = {
+        ":new_status": _serialize(new_status),
+        ":requested": _serialize("requested"),
+        ":now": _serialize(now),
+        ":empty": _serialize([]),
+        ":event": _serialize([event_entry]),
+    }
+    if approved_by is not None:
+        update_parts.append("approved_by = :approved_by")
+        values[":approved_by"] = _serialize(approved_by)
+    if guidance_note:
+        update_parts.append("guidance_note = :guidance_note")
+        values[":guidance_note"] = _serialize(guidance_note)
+    try:
+        _get_ddb().update_item(
+            TableName=TRACKER_TABLE,
+            Key={
+                "project_id": _serialize(project_id),
+                "record_id": _serialize(f"escalation#{escalation_id}"),
+            },
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ConditionExpression="attribute_exists(record_id) AND #st = :requested",
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except Exception as exc:
+        code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        if code == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _handle_escalation_decision(
+    project_id: str, escalation_id: str, decision: str,
+    event: Dict[str, Any], claims: Dict[str, Any],
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve|deny.
+
+    Non-delegable (§6): Cognito human session only. Approve stamps approved_by
+    and drives applyEscalatedMutation; if the applier invoke fails, the
+    approval remains durable (status=approved) and the idempotent apply route
+    can be re-driven — the agent never resubmits the mutation.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, (
+            "Escalation approval/denial requires a Cognito session (human-only). "
+            "Agent, SCI, and internal-key credentials are structurally rejected."
+        ))
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except (ValueError, TypeError):
+        body = {}
+
+    escalation = _read_escalation_item(project_id, escalation_id)
+    if escalation is None:
+        return _error(404, f"Escalation not found: {escalation_id}")
+    current_status = str(escalation.get("status") or "")
+    if current_status != "requested":
+        return _error(409, (
+            f"Escalation {escalation_id} is '{current_status}'; only 'requested' "
+            "escalations can be decided."
+        ))
+
+    decider = _resolve_decider_identity(claims)
+    actor = str(claims.get("sub") or decider)
+
+    if decision == "approve":
+        approved_by = {
+            "sub": str(claims.get("sub") or ""),
+            "email": str(claims.get("email") or ""),
+        }
+        if not _record_escalation_decision(
+            project_id, escalation_id, "approved", actor, approved_by=approved_by,
+        ):
+            return _error(409, "Escalation was decided concurrently; refresh the queue.")
+
+        apply_result: Dict[str, Any] = {}
+        apply_error = ""
+        try:
+            apply_result = _invoke_tracker_mutation_api(
+                "POST",
+                f"/api/v1/tracker/{project_id}/escalation/{escalation_id}/apply",
+                body={"write_source": {"provider": f"io:{decider}", "channel": "coordination_api"}},
+            )
+            status_code = int(apply_result.get("_status_code") or 0)
+            if status_code >= 400:
+                apply_error = str(apply_result.get("error") or f"apply returned HTTP {status_code}")
+        except Exception as exc:
+            logger.error("escalation apply invoke failed: %s", exc)
+            apply_error = str(exc)
+
+        if apply_error:
+            return _response(200, {
+                "success": True,
+                "escalation_id": escalation_id,
+                "status": "approved",
+                "applied": False,
+                "approved_by": decider,
+                "apply_error": apply_error,
+                "retry": (
+                    f"POST /api/v1/tracker/{project_id}/escalation/{escalation_id}/apply "
+                    "(idempotent; applies only while status=approved and applied_at unset)"
+                ),
+            })
+        return _response(200, {
+            "success": True,
+            "escalation_id": escalation_id,
+            "status": str(apply_result.get("status") or "applied"),
+            "applied": str(apply_result.get("status") or "applied") == "applied",
+            "approved_by": decider,
+            "apply_result": apply_result.get("result"),
+        })
+
+    guidance_note = str(body.get("guidance_note") or "").strip()
+    new_status = "denied_with_guidance" if guidance_note else "denied"
+    if not _record_escalation_decision(
+        project_id, escalation_id, new_status, actor, guidance_note=guidance_note,
+    ):
+        return _error(409, "Escalation was decided concurrently; refresh the queue.")
+    return _response(200, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": new_status,
+        "denied_by": decider,
+        "guidance_note": guidance_note,
+    })
+
+
 def _handle_lesson_candidate_approve(
     document_id: str, event: Dict[str, Any], claims: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -14672,6 +15051,22 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if decision == "approve":
             return _handle_lesson_candidate_approve(candidate_doc_id, event, claims or {})
         return _handle_lesson_candidate_reject(candidate_doc_id, event, claims or {})
+
+    # ENC-FTR-121 Ph3 (ENC-TSK-J70): Escalations — io approval queue + decisions
+    # (DOC-5B888FCA43B8 §5.7). Cognito-gated inside the handlers; no agent path.
+    if method == "GET" and path == "/api/v1/coordination/escalations":
+        return _handle_escalations_feed(event, claims or {})
+    match_escalation_decision = re.fullmatch(
+        r"/api/v1/coordination/escalations/([a-z0-9_\-]+)/([A-Za-z0-9\-]+)/(approve|deny)", path
+    )
+    if method == "POST" and match_escalation_decision:
+        return _handle_escalation_decision(
+            match_escalation_decision.group(1),
+            match_escalation_decision.group(2),
+            match_escalation_decision.group(3),
+            event,
+            claims or {},
+        )
 
     # POST /api/v1/coordination/components/{componentId}/{action} where action is
     # one of the ENC-FTR-076 v2 / ENC-TSK-F40 state-machine actions.

--- a/backend/lambda/coordination_api/test_escalation_decision_j70.py
+++ b/backend/lambda/coordination_api/test_escalation_decision_j70.py
@@ -1,0 +1,296 @@
+"""ENC-TSK-J70 (ENC-FTR-121 Ph3): escalation approval surface tests.
+
+Covers the §6 non-delegable approval invariant (internal-key / managed-token
+credentials get 403 on every escalation route — mirroring ENC-TSK-J57's
+test_internal_key_returns_403), the requested→approved|denied|
+denied_with_guidance decision writes with their race guard, approve driving
+the ENC-TSK-J69 applier (with the fail-soft approved-but-unapplied path), and
+the §5.7 render_diff fresh-delta + drift-flag semantics.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
+import importlib.util
+
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda_j70",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = coordination_lambda
+_SPEC.loader.exec_module(coordination_lambda)
+
+INTERNAL_CLAIMS = {"auth_mode": "internal-key"}
+MANAGED_CLAIMS = {"auth_mode": "managed-token"}
+COGNITO_CLAIMS = {
+    "auth_mode": "cognito",
+    "sub": "abc-123",
+    "email": "io@jreese.net",
+    "cognito:username": "io",
+}
+
+
+class _CCFE(Exception):
+    def __init__(self):
+        super().__init__("conditional check failed")
+        self.response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+
+
+def _escalation_item(status="requested", mutation_type="deploy_arc_change",
+                     payload=None, expected_version=""):
+    if payload is None:
+        payload = {"new_deploy_arc_type": "code_only"}
+    item = {
+        "project_id": "enceladus",
+        "record_id": "escalation#ENC-ESC-001",
+        "item_id": "ENC-ESC-001",
+        "record_type": "escalation",
+        "status": status,
+        "mutation_type": mutation_type,
+        "target_record_id": "ENC-TSK-J10",
+        "payload": json.dumps(payload),
+        "justification": "test",
+        "requested_by": {"session_id": "ENC-SES-02F"},
+        "created_at": "2026-07-02T04:00:00Z",
+        "updated_at": "2026-07-02T04:00:00Z",
+        "events": [],
+    }
+    if expected_version:
+        item["expected_version"] = expected_version
+    return item
+
+
+def _target_item(status="in-progress", transition_type="github_pr_deploy", sync_version=4):
+    return {
+        "project_id": "enceladus",
+        "record_id": "task#ENC-TSK-J10",
+        "item_id": "ENC-TSK-J10",
+        "record_type": "task",
+        "title": "target task",
+        "status": status,
+        "transition_type": transition_type,
+        "sync_version": sync_version,
+        "updated_at": "2026-07-02T03:00:00Z",
+    }
+
+
+def _serialized(item):
+    return {k: coordination_lambda._serialize(v) for k, v in item.items()}
+
+
+def _fake_ddb(escalation=None, target=None, decision_raises=None):
+    fake = mock.MagicMock()
+
+    def _get_item(TableName=None, Key=None, **kwargs):
+        record_id = (Key or {}).get("record_id", {}).get("S", "")
+        if record_id.startswith("escalation#") and escalation is not None:
+            return {"Item": _serialized(escalation)}
+        if record_id.startswith("task#") and target is not None:
+            return {"Item": _serialized(target)}
+        return {}
+
+    fake.get_item.side_effect = _get_item
+    if decision_raises is not None:
+        fake.update_item.side_effect = decision_raises
+    return fake
+
+
+def _decision_event(body=None):
+    return {"body": json.dumps(body or {}), "queryStringParameters": None}
+
+
+class TestNonDelegableGate(unittest.TestCase):
+    def test_internal_key_gets_403_on_all_escalation_routes(self):
+        for claims in (INTERNAL_CLAIMS, MANAGED_CLAIMS):
+            feed = coordination_lambda._handle_escalations_feed({"queryStringParameters": {}}, claims)
+            self.assertEqual(403, feed["statusCode"])
+            for decision in ("approve", "deny"):
+                resp = coordination_lambda._handle_escalation_decision(
+                    "enceladus", "ENC-ESC-001", decision, _decision_event(), claims)
+                self.assertEqual(403, resp["statusCode"])
+                self.assertIn("human-only", json.loads(resp["body"])["error"])
+
+
+class TestEscalationDecisions(unittest.TestCase):
+    def _decide(self, decision, ddb, body=None, apply_result=None, apply_raises=None):
+        patches = [mock.patch.object(coordination_lambda, "_get_ddb", return_value=ddb)]
+        invoke = mock.MagicMock()
+        if apply_raises is not None:
+            invoke.side_effect = apply_raises
+        else:
+            invoke.return_value = apply_result or {
+                "success": True, "status": "applied",
+                "result": {"before": {}, "after": {}}, "_status_code": 200,
+            }
+        patches.append(mock.patch.object(
+            coordination_lambda, "_invoke_tracker_mutation_api", invoke))
+        with patches[0], patches[1]:
+            resp = coordination_lambda._handle_escalation_decision(
+                "enceladus", "ENC-ESC-001", decision,
+                _decision_event(body), COGNITO_CLAIMS)
+        return resp, ddb, invoke
+
+    def test_approve_happy_path_stamps_identity_and_applies(self):
+        resp, ddb, invoke = self._decide(
+            "approve", _fake_ddb(escalation=_escalation_item()))
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertTrue(body["applied"])
+        self.assertEqual("applied", body["status"])
+        self.assertEqual("io@jreese.net", body["approved_by"])
+
+        update = ddb.update_item.call_args.kwargs
+        self.assertIn("#st = :requested", update["ConditionExpression"])
+        values = update["ExpressionAttributeValues"]
+        self.assertEqual("approved", values[":new_status"]["S"])
+        approved_by = values[":approved_by"]["M"]
+        self.assertEqual("abc-123", approved_by["sub"]["S"])
+        self.assertEqual("io@jreese.net", approved_by["email"]["S"])
+        event_entry = values[":event"]["L"][0]["M"]
+        self.assertEqual("approved", event_entry["event_type"]["S"])
+
+        invoke.assert_called_once()
+        args = invoke.call_args.args
+        self.assertEqual("POST", args[0])
+        self.assertEqual("/api/v1/tracker/enceladus/escalation/ENC-ESC-001/apply", args[1])
+
+    def test_approve_with_apply_failure_is_fail_soft(self):
+        resp, _, _ = self._decide(
+            "approve", _fake_ddb(escalation=_escalation_item()),
+            apply_raises=RuntimeError("AccessDenied on lambda:InvokeFunction"))
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual("approved", body["status"])
+        self.assertFalse(body["applied"])
+        self.assertIn("AccessDenied", body["apply_error"])
+        self.assertIn("/apply", body["retry"])
+
+    def test_approve_with_apply_http_error_reports_error(self):
+        resp, _, _ = self._decide(
+            "approve", _fake_ddb(escalation=_escalation_item()),
+            apply_result={"success": False, "error": "escalation is 'denied'", "_status_code": 409})
+        body = json.loads(resp["body"])
+        self.assertFalse(body["applied"])
+        self.assertIn("denied", body["apply_error"])
+
+    def test_deny_without_note_is_denied(self):
+        resp, ddb, invoke = self._decide(
+            "deny", _fake_ddb(escalation=_escalation_item()))
+        body = json.loads(resp["body"])
+        self.assertEqual("denied", body["status"])
+        self.assertEqual("io@jreese.net", body["denied_by"])
+        invoke.assert_not_called()
+        values = ddb.update_item.call_args.kwargs["ExpressionAttributeValues"]
+        self.assertEqual("denied", values[":new_status"]["S"])
+        self.assertNotIn(":guidance_note", values)
+
+    def test_deny_with_note_is_denied_with_guidance(self):
+        resp, ddb, _ = self._decide(
+            "deny", _fake_ddb(escalation=_escalation_item()),
+            body={"guidance_note": "Open a successor task instead."})
+        body = json.loads(resp["body"])
+        self.assertEqual("denied_with_guidance", body["status"])
+        self.assertEqual("Open a successor task instead.", body["guidance_note"])
+        update = ddb.update_item.call_args.kwargs
+        values = update["ExpressionAttributeValues"]
+        self.assertEqual("denied_with_guidance", values[":new_status"]["S"])
+        event_entry = values[":event"]["L"][0]["M"]
+        self.assertEqual(
+            "Open a successor task instead.", event_entry["guidance_note"]["S"])
+
+    def test_non_requested_escalation_409(self):
+        resp, ddb, invoke = self._decide(
+            "approve", _fake_ddb(escalation=_escalation_item(status="applied")))
+        self.assertEqual(409, resp["statusCode"])
+        ddb.update_item.assert_not_called()
+        invoke.assert_not_called()
+
+    def test_missing_escalation_404(self):
+        resp, _, _ = self._decide("approve", _fake_ddb(escalation=None))
+        self.assertEqual(404, resp["statusCode"])
+
+    def test_concurrent_decision_race_409(self):
+        resp, _, invoke = self._decide(
+            "approve",
+            _fake_ddb(escalation=_escalation_item(), decision_raises=_CCFE()))
+        self.assertEqual(409, resp["statusCode"])
+        self.assertIn("concurrently", json.loads(resp["body"])["error"])
+        invoke.assert_not_called()
+
+
+class TestRenderDiff(unittest.TestCase):
+    def test_arc_change_diff_from_live_target(self):
+        diff = coordination_lambda._render_escalation_diff(
+            _escalation_item(), _target_item())
+        self.assertEqual("transition_type", diff["field"])
+        self.assertEqual("github_pr_deploy", diff["current"])
+        self.assertEqual("code_only", diff["requested"])
+        self.assertEqual("in-progress", diff["target_snapshot"]["status"])
+        self.assertNotIn("drift", diff)
+
+    def test_override_diff_includes_field_values_delta(self):
+        escalation = _escalation_item(
+            mutation_type="direct_state_override",
+            payload={"target_status": "closed",
+                     "field_values": {"live_validation_evidence": "gamma ok"}})
+        diff = coordination_lambda._render_escalation_diff(escalation, _target_item())
+        self.assertEqual("status", diff["field"])
+        self.assertEqual("closed", diff["requested"])
+        self.assertEqual(
+            "gamma ok", diff["field_values"]["live_validation_evidence"]["requested"])
+
+    def test_drift_detected_when_expected_version_mismatches(self):
+        escalation = _escalation_item(expected_version="sync_version:2")
+        diff = coordination_lambda._render_escalation_diff(
+            escalation, _target_item(sync_version=7))
+        self.assertTrue(diff["drift"]["detected"])
+        self.assertEqual("7", diff["drift"]["current_sync_version"])
+
+    def test_drift_not_detected_when_expected_version_matches(self):
+        escalation = _escalation_item(expected_version="sync_version:4")
+        diff = coordination_lambda._render_escalation_diff(
+            escalation, _target_item(sync_version=4))
+        self.assertFalse(diff["drift"]["detected"])
+
+    def test_missing_target_flagged(self):
+        diff = coordination_lambda._render_escalation_diff(_escalation_item(), None)
+        self.assertTrue(diff["target_missing"])
+
+
+class TestEscalationsFeed(unittest.TestCase):
+    def test_feed_attaches_fresh_diff_to_pending_and_splits_terminal(self):
+        pending = _escalation_item()
+        terminal = _escalation_item()
+        terminal = dict(terminal, item_id="ENC-ESC-000",
+                        record_id="escalation#ENC-ESC-000", status="denied",
+                        created_at="2026-07-01T00:00:00Z")
+        fake = mock.MagicMock()
+        fake.query.return_value = {
+            "Items": [_serialized(pending), _serialized(terminal)]}
+
+        def _get_item(TableName=None, Key=None, **kwargs):
+            record_id = (Key or {}).get("record_id", {}).get("S", "")
+            if record_id.startswith("task#"):
+                return {"Item": _serialized(_target_item())}
+            return {}
+
+        fake.get_item.side_effect = _get_item
+        with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
+            resp = coordination_lambda._handle_escalations_feed(
+                {"queryStringParameters": {"project_id": "enceladus"}}, COGNITO_CLAIMS)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual(1, len(body["pending"]))
+        self.assertEqual(1, len(body["terminal"]))
+        self.assertEqual("ENC-ESC-001", body["pending"][0]["item_id"])
+        self.assertEqual("code_only", body["pending"][0]["diff"]["requested"])
+        self.assertNotIn("diff", body["terminal"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/ui/src/api/escalations.ts
+++ b/frontend/ui/src/api/escalations.ts
@@ -1,0 +1,121 @@
+import { fetchWithAuth } from './client'
+
+// ENC-FTR-121 Ph3 (ENC-TSK-J70): io's escalation approval queue
+// (DOC-5B888FCA43B8 §5.7). All calls ride the Cognito session cookie —
+// the backend structurally rejects non-human credentials.
+
+export interface EscalationDiff {
+  mutation_type: string
+  target_record_id?: string
+  target_missing?: boolean
+  field?: string
+  current?: unknown
+  requested?: unknown
+  field_values?: Record<string, { current: unknown; requested: unknown }>
+  target_snapshot?: {
+    title?: string
+    status?: string
+    transition_type?: string
+    checkout_state?: string
+    sync_version?: number | string
+    updated_at?: string
+  }
+  drift?: {
+    expected_version: string
+    current_sync_version: string
+    current_updated_at: string
+    detected: boolean
+  }
+}
+
+export interface EscalationItem {
+  item_id: string
+  project_id: string
+  status: string
+  mutation_type: string
+  target_record_id: string
+  justification: string
+  payload: Record<string, unknown>
+  requested_by?: { session_id?: string; agent_type_id?: string }
+  approved_by?: { sub?: string; email?: string }
+  guidance_note?: string
+  created_at: string
+  updated_at: string
+  applied_at?: string
+  diff?: EscalationDiff
+}
+
+export interface EscalationsFeedResponse {
+  success: boolean
+  project_id: string
+  pending: EscalationItem[]
+  terminal: EscalationItem[]
+  count: number
+}
+
+export interface EscalationDecisionResponse {
+  success: boolean
+  escalation_id: string
+  status: string
+  applied?: boolean
+  approved_by?: string
+  denied_by?: string
+  guidance_note?: string
+  apply_error?: string
+  retry?: string
+}
+
+export const escalationKeys = {
+  feed: (projectId: string) => ['escalations', 'feed', projectId] as const,
+}
+
+export async function fetchEscalations(
+  projectId = 'enceladus',
+): Promise<EscalationsFeedResponse> {
+  const res = await fetchWithAuth(
+    `/api/v1/coordination/escalations?project_id=${encodeURIComponent(projectId)}`,
+  )
+  if (!res.ok) throw new Error(`Failed to fetch escalations: ${res.status}`)
+  return res.json()
+}
+
+async function postDecision(
+  projectId: string,
+  escalationId: string,
+  decision: 'approve' | 'deny',
+  body?: Record<string, unknown>,
+): Promise<EscalationDecisionResponse> {
+  const res = await fetchWithAuth(
+    `/api/v1/coordination/escalations/${encodeURIComponent(projectId)}/${encodeURIComponent(escalationId)}/${decision}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    },
+  )
+  const payload = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error(payload?.error || `Escalation ${decision} failed: ${res.status}`)
+  }
+  return payload
+}
+
+export function approveEscalation(
+  projectId: string,
+  escalationId: string,
+): Promise<EscalationDecisionResponse> {
+  return postDecision(projectId, escalationId, 'approve')
+}
+
+export function denyEscalation(
+  projectId: string,
+  escalationId: string,
+  guidanceNote?: string,
+): Promise<EscalationDecisionResponse> {
+  return postDecision(
+    projectId,
+    escalationId,
+    'deny',
+    guidanceNote ? { guidance_note: guidanceNote } : {},
+  )
+}

--- a/frontend/ui/src/components/layout/Header.tsx
+++ b/frontend/ui/src/components/layout/Header.tsx
@@ -17,6 +17,7 @@ const TITLES: Record<string, string> = {
   '/coordination/auth': 'Access Tokens',
   '/components': 'Component Registry',
   '/deployments': 'Deployment Manager',
+  '/escalations': 'Escalations',
 }
 
 function resolveTitle(pathname: string): string {
@@ -163,6 +164,15 @@ export function Header() {
                 className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
               >
                 Coordination Monitor
+              </button>
+              <button
+                onClick={() => {
+                  setMenuOpen(false)
+                  navigate('/escalations')
+                }}
+                className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
+              >
+                Escalations
               </button>
               <button
                 onClick={() => {

--- a/frontend/ui/src/lib/routes.tsx
+++ b/frontend/ui/src/lib/routes.tsx
@@ -78,6 +78,9 @@ const DeploymentManagerPage = lazy(() =>
     default: module.DeploymentManagerPage,
   })),
 )
+const EscalationsPage = lazy(() =>
+  import('../pages/EscalationsPage').then((module) => ({ default: module.EscalationsPage })),
+)
 
 function withSuspense(element: ReactNode) {
   return <Suspense fallback={<LoadingState />}>{element}</Suspense>
@@ -123,6 +126,7 @@ export const router = createBrowserRouter(
         { path: '/terminal/manage', element: withSuspense(<TerminalManagePage />) },
         { path: '/components', element: withSuspense(<ComponentRegistryPage />) },
         { path: '/deployments', element: withSuspense(<DeploymentManagerPage />) },
+        { path: '/escalations', element: withSuspense(<EscalationsPage />) },
         { path: '/coordination', element: withSuspense(<CoordinationPage />) },
         { path: '/coordination/auth', element: withSuspense(<AuthTokensPage />) },
         {

--- a/frontend/ui/src/pages/EscalationsPage.test.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * EscalationsPage tests — ENC-TSK-J70 / ENC-FTR-121 Ph3 (DOC-5B888FCA43B8 §5.7).
+ *
+ * Scope (AC-5, AC-7):
+ *   - Feed renders pending escalations newest-first with target id, mutation
+ *     type, requesting agent, justification, and the fresh diff.
+ *   - The drift warning renders prominently when diff.drift.detected.
+ *   - Approve / Deny / Deny-with-guidance wire to the API module.
+ *   - Terminal escalations render inside the collapsed History section.
+ *
+ * Mocks: the api/escalations module is stubbed at the import boundary so the
+ * page renders without the network; approval calls are asserted on the mock.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EscalationItem, EscalationsFeedResponse } from '../api/escalations'
+
+const { mockFetchEscalations, mockApprove, mockDeny } = vi.hoisted(() => ({
+  mockFetchEscalations: vi.fn(),
+  mockApprove: vi.fn(),
+  mockDeny: vi.fn(),
+}))
+
+vi.mock('../api/escalations', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/escalations')>()
+  return {
+    ...original,
+    fetchEscalations: mockFetchEscalations,
+    approveEscalation: mockApprove,
+    denyEscalation: mockDeny,
+  }
+})
+
+import { EscalationsPage } from './EscalationsPage'
+
+function pendingEscalation(overrides: Partial<EscalationItem> = {}): EscalationItem {
+  return {
+    item_id: 'ENC-ESC-001',
+    project_id: 'enceladus',
+    status: 'requested',
+    mutation_type: 'deploy_arc_change',
+    target_record_id: 'ENC-TSK-J10',
+    justification: 'Arc misclassified at create; no deployable artifact.',
+    payload: { new_deploy_arc_type: 'code_only' },
+    requested_by: { session_id: 'ENC-SES-02F' },
+    created_at: '2026-07-02T04:00:00Z',
+    updated_at: '2026-07-02T04:00:00Z',
+    diff: {
+      mutation_type: 'deploy_arc_change',
+      field: 'transition_type',
+      current: 'github_pr_deploy',
+      requested: 'code_only',
+      target_snapshot: {
+        title: 'Full CFN drift close-out',
+        status: 'in-progress',
+        transition_type: 'github_pr_deploy',
+        sync_version: 4,
+        updated_at: '2026-07-02T03:00:00Z',
+      },
+    },
+    ...overrides,
+  }
+}
+
+function feed(overrides: Partial<EscalationsFeedResponse> = {}): EscalationsFeedResponse {
+  return {
+    success: true,
+    project_id: 'enceladus',
+    pending: [pendingEscalation()],
+    terminal: [
+      pendingEscalation({
+        item_id: 'ENC-ESC-000',
+        status: 'denied_with_guidance',
+        guidance_note: 'Use a successor task instead.',
+        diff: undefined,
+      }),
+    ],
+    count: 2,
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return render(<EscalationsPage />, { wrapper })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetchEscalations.mockResolvedValue(feed())
+  mockApprove.mockResolvedValue({
+    success: true,
+    escalation_id: 'ENC-ESC-001',
+    status: 'applied',
+    applied: true,
+  })
+  mockDeny.mockResolvedValue({
+    success: true,
+    escalation_id: 'ENC-ESC-001',
+    status: 'denied',
+  })
+})
+
+describe('EscalationsPage', () => {
+  it('renders pending cards with target, mutation type, requester, justification, and diff', async () => {
+    renderPage()
+    const card = await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(within(card).getByText('ENC-TSK-J10')).toBeInTheDocument()
+    expect(within(card).getByText('deploy_arc_change')).toBeInTheDocument()
+    expect(within(card).getByText('ENC-SES-02F')).toBeInTheDocument()
+    expect(
+      within(card).getByText('Arc misclassified at create; no deployable artifact.'),
+    ).toBeInTheDocument()
+    const diff = within(card).getByTestId('escalation-diff')
+    expect(within(diff).getByText('github_pr_deploy')).toBeInTheDocument()
+    expect(within(diff).getByText('code_only')).toBeInTheDocument()
+  })
+
+  it('shows a prominent drift warning when expected_version mismatches', async () => {
+    mockFetchEscalations.mockResolvedValue(
+      feed({
+        pending: [
+          pendingEscalation({
+            diff: {
+              mutation_type: 'deploy_arc_change',
+              field: 'transition_type',
+              current: 'github_pr_deploy',
+              requested: 'code_only',
+              drift: {
+                expected_version: 'sync_version:3',
+                current_sync_version: '7',
+                current_updated_at: '2026-07-02T04:10:00Z',
+                detected: true,
+              },
+            },
+          }),
+        ],
+      }),
+    )
+    renderPage()
+    const warning = await screen.findByTestId('drift-warning')
+    expect(warning.textContent).toContain('drifted')
+    expect(warning.textContent).toContain('sync_version:3')
+  })
+
+  it('does not render a drift warning without drift', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(screen.queryByTestId('drift-warning')).toBeNull()
+  })
+
+  it('approve button calls approveEscalation with the escalation id', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(mockApprove).toHaveBeenCalledWith('enceladus', 'ENC-ESC-001')
+  })
+
+  it('deny button calls denyEscalation without a guidance note', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Deny' }))
+    expect(mockDeny).toHaveBeenCalledWith('enceladus', 'ENC-ESC-001', undefined)
+  })
+
+  it('deny-with-guidance sends the note', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Deny with guidance' }))
+    await userEvent.type(
+      screen.getByLabelText('Guidance note'),
+      'Open a successor task instead.',
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Send denial' }))
+    expect(mockDeny).toHaveBeenCalledWith(
+      'enceladus',
+      'ENC-ESC-001',
+      'Open a successor task instead.',
+    )
+  })
+
+  it('terminal escalations render in the collapsed History audit section', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    const history = screen.getByTestId('terminal-section')
+    expect(within(history).getByText('History (1)')).toBeInTheDocument()
+    expect(within(history).getByText('ENC-ESC-000')).toBeInTheDocument()
+    expect(within(history).getByText(/Use a successor task instead\./)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when nothing is pending', async () => {
+    mockFetchEscalations.mockResolvedValue(feed({ pending: [], terminal: [] }))
+    renderPage()
+    expect(await screen.findByText('No pending escalations.')).toBeInTheDocument()
+  })
+})

--- a/frontend/ui/src/pages/EscalationsPage.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  approveEscalation,
+  denyEscalation,
+  escalationKeys,
+  fetchEscalations,
+} from '../api/escalations'
+import type { EscalationDiff, EscalationItem } from '../api/escalations'
+import { LoadingState } from '../components/shared/LoadingState'
+import { ErrorState } from '../components/shared/ErrorState'
+import { EmptyState } from '../components/shared/EmptyState'
+
+// ENC-FTR-121 Ph3 (ENC-TSK-J70): io's Escalations approval queue
+// (DOC-5B888FCA43B8 §5.7). Pending cards render a FRESH current-vs-requested
+// diff (fetched at render time by the backend, never the cached request) with
+// a prominent drift warning when expected_version mismatches; io may still
+// approve (informed consent) or deny. Terminal escalations stay browsable in
+// a collapsed audit section.
+
+const PROJECT_ID = 'enceladus'
+
+const STATUS_COLORS: Record<string, string> = {
+  requested: 'bg-amber-500/20 text-amber-300',
+  approved: 'bg-sky-500/20 text-sky-300',
+  applying: 'bg-sky-500/20 text-sky-300',
+  applied: 'bg-emerald-500/20 text-emerald-300',
+  denied: 'bg-rose-500/20 text-rose-300',
+  denied_with_guidance: 'bg-rose-500/20 text-rose-300',
+  failed: 'bg-rose-600/30 text-rose-200',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[status] ?? 'bg-slate-600/40 text-slate-300'}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function DiffBlock({ diff }: { diff: EscalationDiff }) {
+  if (diff.target_missing) {
+    return <p className="text-sm text-rose-300">Target record no longer exists.</p>
+  }
+  return (
+    <div className="text-sm space-y-1" data-testid="escalation-diff">
+      <div className="flex items-center gap-2 font-mono">
+        <span className="text-slate-400">{diff.field}:</span>
+        <span className="text-rose-300 line-through">{String(diff.current ?? '—')}</span>
+        <span className="text-slate-500">→</span>
+        <span className="text-emerald-300">{String(diff.requested ?? '—')}</span>
+      </div>
+      {diff.field_values &&
+        Object.entries(diff.field_values).map(([field, delta]) => (
+          <div key={field} className="flex items-center gap-2 font-mono text-xs">
+            <span className="text-slate-400">{field}:</span>
+            <span className="text-rose-300 line-through">
+              {JSON.stringify(delta.current ?? null)}
+            </span>
+            <span className="text-slate-500">→</span>
+            <span className="text-emerald-300">{JSON.stringify(delta.requested)}</span>
+          </div>
+        ))}
+      {diff.target_snapshot && (
+        <p className="text-xs text-slate-500">
+          Live target: status={diff.target_snapshot.status} · arc=
+          {diff.target_snapshot.transition_type} · sync_version=
+          {String(diff.target_snapshot.sync_version ?? '—')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function PendingCard({
+  escalation,
+  onApprove,
+  onDeny,
+  busy,
+}: {
+  escalation: EscalationItem
+  onApprove: (id: string) => void
+  onDeny: (id: string, guidanceNote?: string) => void
+  busy: boolean
+}) {
+  const [showGuidance, setShowGuidance] = useState(false)
+  const [guidanceNote, setGuidanceNote] = useState('')
+  const drift = escalation.diff?.drift
+
+  return (
+    <div
+      className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3"
+      data-testid={`escalation-card-${escalation.item_id}`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm text-slate-200">{escalation.item_id}</span>
+          <StatusBadge status={escalation.status} />
+        </div>
+        <span className="text-xs text-slate-500">{escalation.created_at}</span>
+      </div>
+
+      <div className="text-sm text-slate-300">
+        <span className="font-mono text-sky-300">{escalation.target_record_id}</span>
+        {escalation.diff?.target_snapshot?.title && (
+          <span className="text-slate-400"> — {escalation.diff.target_snapshot.title}</span>
+        )}
+      </div>
+
+      <div className="text-xs text-slate-400">
+        <span className="font-medium text-slate-300">{escalation.mutation_type}</span>
+        {' · requested by '}
+        <span className="font-mono">{escalation.requested_by?.session_id ?? 'unknown'}</span>
+      </div>
+
+      {drift?.detected && (
+        <div
+          className="bg-amber-500/10 border border-amber-500/40 rounded px-3 py-2 text-xs text-amber-300"
+          data-testid="drift-warning"
+        >
+          ⚠ Target drifted since request: expected {drift.expected_version}, now
+          sync_version={drift.current_sync_version} (updated {drift.current_updated_at}).
+          Approving applies the cached mutation to the CURRENT record state.
+        </div>
+      )}
+
+      {escalation.diff && <DiffBlock diff={escalation.diff} />}
+
+      <p className="text-sm text-slate-300 bg-slate-900/60 rounded px-3 py-2">
+        {escalation.justification}
+      </p>
+
+      {showGuidance ? (
+        <div className="space-y-2">
+          <textarea
+            value={guidanceNote}
+            onChange={(e) => setGuidanceNote(e.target.value)}
+            placeholder="Guidance for the requesting agent…"
+            aria-label="Guidance note"
+            className="w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-200"
+            rows={2}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={() => onDeny(escalation.item_id, guidanceNote.trim() || undefined)}
+              disabled={busy}
+              className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
+            >
+              Send denial
+            </button>
+            <button
+              onClick={() => setShowGuidance(false)}
+              className="px-3 py-1.5 rounded bg-slate-700 text-sm text-slate-300"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <button
+            onClick={() => onApprove(escalation.item_id)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-emerald-600/80 hover:bg-emerald-600 text-sm text-white disabled:opacity-50"
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => onDeny(escalation.item_id)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
+          >
+            Deny
+          </button>
+          <button
+            onClick={() => setShowGuidance(true)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-sm text-slate-200"
+          >
+            Deny with guidance
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function EscalationsPage() {
+  const queryClient = useQueryClient()
+  const [actionError, setActionError] = useState('')
+  const [lastOutcome, setLastOutcome] = useState('')
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: escalationKeys.feed(PROJECT_ID),
+    queryFn: () => fetchEscalations(PROJECT_ID),
+    refetchInterval: 30_000,
+  })
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: escalationKeys.feed(PROJECT_ID) })
+
+  const approveMutation = useMutation({
+    mutationFn: (escalationId: string) => approveEscalation(PROJECT_ID, escalationId),
+    onSuccess: (result) => {
+      setActionError('')
+      setLastOutcome(
+        result.applied
+          ? `${result.escalation_id} approved and applied.`
+          : `${result.escalation_id} approved; apply pending${result.apply_error ? ` (${result.apply_error})` : ''}.`,
+      )
+      refresh()
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+
+  const denyMutation = useMutation({
+    mutationFn: ({ escalationId, guidanceNote }: { escalationId: string; guidanceNote?: string }) =>
+      denyEscalation(PROJECT_ID, escalationId, guidanceNote),
+    onSuccess: (result) => {
+      setActionError('')
+      setLastOutcome(`${result.escalation_id} ${result.status}.`)
+      refresh()
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+
+  if (isPending) return <LoadingState />
+  if (isError || !data) return <ErrorState />
+
+  const busy = approveMutation.isPending || denyMutation.isPending
+  const pending = data.pending ?? []
+  const terminal = data.terminal ?? []
+
+  return (
+    <div className="p-4 space-y-4">
+      <p className="text-xs text-slate-500">
+        Human-gated mutation overrides (ENC-FTR-121). Approval is non-delegable: decisions
+        here are the sole origin of override authorization.
+      </p>
+
+      {actionError && (
+        <div className="bg-rose-500/10 border border-rose-500/40 rounded px-3 py-2 text-sm text-rose-300">
+          {actionError}
+        </div>
+      )}
+      {lastOutcome && !actionError && (
+        <div className="bg-emerald-500/10 border border-emerald-500/40 rounded px-3 py-2 text-sm text-emerald-300">
+          {lastOutcome}
+        </div>
+      )}
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-300">
+          Pending ({pending.length})
+        </h2>
+        {pending.length === 0 ? (
+          <EmptyState message="No pending escalations." />
+        ) : (
+          pending.map((escalation) => (
+            <PendingCard
+              key={escalation.item_id}
+              escalation={escalation}
+              busy={busy}
+              onApprove={(id) => approveMutation.mutate(id)}
+              onDeny={(id, guidanceNote) => denyMutation.mutate({ escalationId: id, guidanceNote })}
+            />
+          ))
+        )}
+      </section>
+
+      <details className="group" data-testid="terminal-section">
+        <summary className="text-sm font-semibold text-slate-400 cursor-pointer select-none">
+          History ({terminal.length})
+        </summary>
+        <div className="mt-3 space-y-2">
+          {terminal.map((escalation) => (
+            <div
+              key={escalation.item_id}
+              className="bg-slate-800/60 border border-slate-700/60 rounded-lg px-4 py-3 text-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-slate-300">{escalation.item_id}</span>
+                  <StatusBadge status={escalation.status} />
+                </div>
+                <span className="text-xs text-slate-500">{escalation.updated_at}</span>
+              </div>
+              <p className="text-xs text-slate-400 mt-1">
+                {escalation.mutation_type} on{' '}
+                <span className="font-mono">{escalation.target_record_id}</span>
+                {escalation.approved_by?.email && ` · approved by ${escalation.approved_by.email}`}
+                {escalation.guidance_note && ` · guidance: ${escalation.guidance_note}`}
+              </p>
+            </div>
+          ))}
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -201,6 +201,9 @@ Resources:
           CORS_ORIGIN: !Ref CorsOrigin
           ENCELADUS_MCP_INTERFACE_MODE: code
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
+          # ENC-TSK-J70 / ENC-FTR-121 Ph3: applyEscalatedMutation lives in
+          # tracker_mutation; the Cognito approval flow invokes it directly.
+          TRACKER_MUTATION_LAMBDA_NAME: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
           # ADE Component C: Cursor webhook HMAC verification secret (POST /api/v1/cursor/webhook)
           CURSOR_WEBHOOK_SECRET: !Ref CursorWebhookSecret
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
@@ -2278,6 +2281,17 @@ Resources:
                   - dynamodb:UpdateItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+              # ENC-TSK-J70 / ENC-FTR-121 Ph3: the Cognito-gated escalation
+              # approval flow drives applyEscalatedMutation (ENC-TSK-J69) in
+              # tracker_mutation via direct Lambda invoke -- the only reachable
+              # entry to the single privileged apply path (DOC-5B888FCA43B8 §6).
+              - Sid: InvokeTrackerMutationEscalationApply
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}:*"
               - Sid: ComponentRegistryTableAccess
                 Effect: Allow
                 Action:

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -2361,6 +2361,43 @@ Resources:
       RouteKey: "POST /api/v1/coordination/lesson-candidates/{documentId}/reject"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-J70 / ENC-FTR-121 Ph3: Escalations approval surface (gamma-only per
+  # DOC-499FA089EC30 -- v3-prod promotion is io-gated per DOC-B716E8FB10B6).
+  # GET feed + Cognito-gated approve/deny on coordination_api; the tracker apply
+  # route is the HTTP lane to applyEscalatedMutation (ENC-TSK-J69) -- idempotent,
+  # only actionable while the escalation is io-approved and unapplied.
+  RouteEscalationsFeed:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/escalations"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteEscalationsApprove:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteEscalationsDeny:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteTrackerEscalationApply:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply"
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint


### PR DESCRIPTION
## ENC-TSK-J70 — FTR-121 Phase 3: io's override-authorization surface

DOC-5B888FCA43B8 §5.7 + §6 under ENC-PLN-061 / ENC-FTR-121. Builds on #715 (entity) and #718 (applier).

### Backend (coordination_api)
- `GET /api/v1/coordination/escalations` — io's approval queue. Pending items carry a **fresh §5.7 render_diff** computed from the LIVE target at render time (never the cached request), with a drift object when `expected_version` mismatches. Terminal items return separately for the audit section.
- `POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve|deny` — **non-delegable by construction**: `_is_cognito_session` rejects internal-key/SCI/managed-token with 403 on every route (J57 precedent); no MCP action maps to approve/deny.
- Approve: `requested→approved` + `approved_by{sub,email}` under a ConditionExpression race guard, then drives `applyEscalatedMutation` (#718) via Lambda invoke. **Fail-soft**: the approval is durable even if the invoke fails — the idempotent apply route can be re-driven; the agent never resubmits.
- Deny: `denied` / `denied_with_guidance` with the note on the item AND the event (Ph4 watch delivers it).

### CFN (gamma lane; `v4-gamma` env verified — no reviewers, applies automatic)
- `03-api.yaml`: +4 `IsGamma` routes — escalations feed/approve/deny → CoordinationApiIntegration; `POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply` → TrackerMutationIntegration (HTTP lane to the idempotent applier).
- `02-compute.yaml`: `TRACKER_MUTATION_LAMBDA_NAME` env + `InvokeTrackerMutationEscalationApply` grant on CoordinationApiRole.

### PWA
- Escalations item in the hamburger menu + `/escalations` page: pending cards (target id/title, mutation type, requesting session, justification, diff, **prominent drift warning** that still permits informed approve/deny), Approve / Deny / Deny-with-guidance, collapsed History audit section.

### Governance + tests
- Dictionary → `2026-07-02.03` (+`coordination.escalations`).
- 15 backend tests (403 gates, decision writes, race, fail-soft, diff/drift) + 8 page tests; frontend 128/128; build clean; zero new failures vs the clean v4/main discovery baseline.

CCI-7d7fc46e32c24a9d8e3aa2f1be4578b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)