### PR TITLE
[ENC-TSK-J65] v4/main port — prod-gate coverage guard + baseline correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
           python3 -m pip install --quiet pyyaml
           python3 tools/test_synthetic_strip_proof.py
 
+      # ENC-TSK-J65 / ENC-FTR-120: no agent-reachable git operation may mutate
+      # v3-prod without the environment reviewer gate. Fail-closed: unclassified
+      # workflows and ungated prod-mutating jobs fail CI here.
+      - name: Prod-gate coverage guard (ENC-TSK-J65)
+        run: |
+          set -euo pipefail
+          python3 tools/prod_gate_coverage_guard.py
+          python3 -m unittest tools.test_prod_gate_coverage_guard
+
   frontend-ui-tests:
     name: Frontend UI Tests
     runs-on: ubuntu-latest

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -6,35 +6,178 @@
     "gated_jobs": "job ids whose environment key satisfies the invariant (v3-prod, v4-gamma, or a conditional expression covering both)"
   },
   "workflows": {
-    "_build.yml": {"class": "inert", "notes": "reusable build; artifact staging only, no runtime mutation"},
-    "_deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "environment: parametrized per target (v3-prod reviewer-gated, v4-gamma ungated); dedicated per-env OIDC roles (PR #407)"},
-    "build-lambda-artifacts.yml": {"class": "inert", "notes": "S3 artifact staging bucket writes only; no live function/stack mutation"},
-    "cfn-drift-audit.yml": {"class": "inert", "notes": "read-only drift audit"},
-    "cfn-resource-import.yml": {"class": "conditional", "gated_jobs": ["import"], "notes": "ENC-TSK-J64: environment chosen from inputs.stack_name (-gamma -> v4-gamma, else v3-prod)"},
-    "ci.yml": {"class": "inert", "notes": "lint/tests/guards"},
-    "cloudformation-agent-auth-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b); guard grace entry, must be gated before J63 closes"},
-    "cloudformation-api-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod)"},
-    "cloudformation-codedeploy-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
-    "cloudformation-compute-stack-deploy.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref"},
-    "cloudformation-monitoring-stack-deploy.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "UNGATED — remediation owned by ENC-TSK-J63 (Ph2b)"},
-    "component-registry-guard.yml": {"class": "inert", "notes": "guard"},
-    "governance-dictionary-guard.yml": {"class": "inert", "notes": "guard"},
-    "governance-prod-backstop-grant.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; gated on the v4/main lane by ENC-TSK-J64's v4 port"},
-    "iam-cfn-deploy-role-eventbridge-listrules-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod (shared/global IAM role objects)"},
-    "iam-cfn-deploy-role-gamma-patch.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"},
-    "iam-cloudformation-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
-    "iam-cognito-terminal-unblock.yml": {"class": "prod-mutating", "gated_jobs": ["patch-role"], "notes": "ENC-TSK-J64: environment: v3-prod"},
-    "iam-coordination-api-gamma-govversion-grant.yml": {"class": "gamma-only", "notes": "v4/main-only file; mutates devops-coordination-api-lambda-role-GAMMA policy only"},
-    "lambda-workflow-coverage-guard.yml": {"class": "inert", "notes": "guard"},
-    "mcp-api-boundary-guard.yml": {"class": "inert", "notes": "guard"},
-    "nightly-parity-audit.yml": {"class": "inert", "notes": "read-only audit"},
-    "oidc-trust-probe.yml": {"class": "already-gated", "gated_jobs": ["probe"], "notes": "read-only probe; environment: from input (v3-prod dispatches pause like any other)"},
-    "pr-commit-gate.yml": {"class": "inert", "notes": "gate validation, read-only"},
-    "promote-gamma-to-prod-request.yml": {"class": "inert", "notes": "relay: dispatches _deploy.yml whose v3-prod lane is environment-gated; performs no mutation itself"},
-    "secrets-guardrail.yml": {"class": "inert", "notes": "guard"},
-    "sync-architecture-doc.yml": {"class": "inert", "notes": "docstore document write via internal key; no runtime-infrastructure mutation — flagged for awareness, out of the v3-prod runtime invariant's scope"},
-    "sync-main-to-v4main.yml": {"class": "inert", "notes": "git-only forward-sync (currently disabled/fork-mode)"},
-    "ui-backend-deploy.yml": {"class": "prod-mutating", "gated_jobs": ["deploy"], "notes": "ENC-TSK-J64: environment: v3-prod — the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"},
-    "ui-gamma-deploy.yml": {"class": "already-gated", "gated_jobs": ["deploy"], "notes": "v4/main-only; environment: v4-gamma with dedicated GitHubActions-V4Gamma-DeployRole since inception"}
+    "_build.yml": {
+      "class": "inert",
+      "notes": "reusable build; artifact staging only, no runtime mutation"
+    },
+    "_deploy.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "deploy"
+      ],
+      "notes": "environment: parametrized per target (v3-prod reviewer-gated, v4-gamma ungated); dedicated per-env OIDC roles (PR #407)"
+    },
+    "build-lambda-artifacts.yml": {
+      "class": "inert",
+      "notes": "S3 artifact staging bucket writes only; no live function/stack mutation"
+    },
+    "cfn-drift-audit.yml": {
+      "class": "inert",
+      "notes": "read-only drift audit"
+    },
+    "cfn-resource-import.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "import"
+      ],
+      "notes": "ENC-TSK-J64: environment chosen from inputs.stack_name (-gamma -> v4-gamma, else v3-prod)"
+    },
+    "ci.yml": {
+      "class": "inert",
+      "notes": "lint/tests/guards"
+    },
+    "cloudformation-agent-auth-stack-deploy.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [],
+      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b); guard grace entry, must be gated before J63 closes"
+    },
+    "cloudformation-api-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod)"
+    },
+    "cloudformation-codedeploy-stack-deploy.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [],
+      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b)"
+    },
+    "cloudformation-compute-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref"
+    },
+    "cloudformation-monitoring-stack-deploy.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [],
+      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b)"
+    },
+    "component-registry-guard.yml": {
+      "class": "inert",
+      "notes": "guard"
+    },
+    "governance-dictionary-guard.yml": {
+      "class": "inert",
+      "notes": "guard"
+    },
+    "governance-prod-backstop-grant.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; apply job gated environment: v3-prod by ENC-TSK-J64's v4 port (baseline entry corrected by the J65 guard's own first v4 run)."
+    },
+    "iam-cfn-deploy-role-eventbridge-listrules-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-J64: environment: v3-prod (shared/global IAM role objects)"
+    },
+    "iam-cfn-deploy-role-gamma-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
+    },
+    "iam-cloudformation-unblock.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-J64: environment: v3-prod"
+    },
+    "iam-cognito-terminal-unblock.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-J64: environment: v3-prod"
+    },
+    "iam-coordination-api-gamma-govversion-grant.yml": {
+      "class": "gamma-only",
+      "notes": "v4/main-only file; mutates devops-coordination-api-lambda-role-GAMMA policy only"
+    },
+    "lambda-workflow-coverage-guard.yml": {
+      "class": "inert",
+      "notes": "guard"
+    },
+    "mcp-api-boundary-guard.yml": {
+      "class": "inert",
+      "notes": "guard"
+    },
+    "nightly-parity-audit.yml": {
+      "class": "inert",
+      "notes": "read-only audit"
+    },
+    "oidc-trust-probe.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "probe"
+      ],
+      "notes": "read-only probe; environment: from input (v3-prod dispatches pause like any other)"
+    },
+    "pr-commit-gate.yml": {
+      "class": "inert",
+      "notes": "gate validation, read-only"
+    },
+    "promote-gamma-to-prod-request.yml": {
+      "class": "inert",
+      "notes": "relay: dispatches _deploy.yml whose v3-prod lane is environment-gated; performs no mutation itself"
+    },
+    "secrets-guardrail.yml": {
+      "class": "inert",
+      "notes": "guard"
+    },
+    "sync-architecture-doc.yml": {
+      "class": "inert",
+      "notes": "docstore document write via internal key; no runtime-infrastructure mutation \u2014 flagged for awareness, out of the v3-prod runtime invariant's scope"
+    },
+    "sync-main-to-v4main.yml": {
+      "class": "inert",
+      "notes": "git-only forward-sync (currently disabled/fork-mode)"
+    },
+    "ui-backend-deploy.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "deploy"
+      ],
+      "notes": "ENC-TSK-J64: environment: v3-prod \u2014 the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"
+    },
+    "ui-gamma-deploy.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "deploy"
+      ],
+      "notes": "v4/main-only; environment: v4-gamma with dedicated GitHubActions-V4Gamma-DeployRole since inception"
+    },
+    "ddb-add-deployment-manager-gsis.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "add-gsis"
+      ],
+      "notes": "ENC-TSK-J65: dispatch-only GSI addition on the prod deployment-manager table; environment: v3-prod. Caught by the guard's own first fail-closed run."
+    },
+    "s3-governance-notification-wire.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "wire-notification"
+      ],
+      "notes": "ENC-TSK-J65: environment chosen from environment_suffix input (-gamma -> v4-gamma, '' -> v3-prod). Caught by the guard's own first fail-closed run."
+    }
   }
 }

--- a/tools/prod_gate_coverage_guard.py
+++ b/tools/prod_gate_coverage_guard.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""ENC-TSK-J65 / ENC-FTR-120: prod-gate coverage guard.
+
+Enforces the FTR-120 invariant as a repo property: no agent-reachable git
+operation mutates v3-prod without pausing on the v3-prod GitHub Environment
+required-reviewer gate. Consumes tools/prod_gate_baseline.json (ENC-TSK-J64)
+and statically verifies the actual workflow YAML matches its classification.
+
+Fail-closed rules (any violation => exit 1, naming the file/job):
+  1. Every .github/workflows/*.yml file MUST appear in the baseline. An
+     unclassified workflow fails CI until someone classifies it.
+  2. class=prod-mutating: every job in gated_jobs must carry
+     environment: v3-prod verbatim in the workflow YAML.
+  3. class=prod-mutating with EMPTY gated_jobs: allowed only as a recorded
+     grace entry (notes mention ENC-TSK-J63). Grace entries must still exist
+     and still be ungated -- if one gained an environment, the baseline is
+     stale and must be updated (grace lists may not rot silently).
+  4. class=conditional: every job in gated_jobs must have an environment
+     expression whose text contains 'v3-prod' (the prod path must gate).
+  5. class=already-gated: every job in gated_jobs must have SOME environment
+     key (literal or expression).
+  6. Baseline entries whose workflow file does not exist on THIS branch are
+     skipped (main and v4/main carry branch-specific workflows) -- but a
+     baseline entry is required for every file that DOES exist (rule 1).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("::error::PyYAML is required (pip install pyyaml)")
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+BASELINE_PATH = REPO_ROOT / "tools" / "prod_gate_baseline.json"
+
+VALID_CLASSES = {"prod-mutating", "gamma-only", "conditional", "already-gated", "inert"}
+GRACE_MARKER = "ENC-TSK-J63"
+
+
+def load_workflow(path: Path) -> dict:
+    with open(path) as fh:
+        doc = yaml.safe_load(fh)
+    if not isinstance(doc, dict):
+        raise ValueError(f"{path.name}: not a mapping")
+    return doc
+
+
+def job_environment(job: dict):
+    """Return the environment value for a job: str, dict ({name: ...}), or None."""
+    env = job.get("environment")
+    if isinstance(env, dict):
+        return env.get("name")
+    return env
+
+
+def check(workflows_dir: Path = WORKFLOWS_DIR, baseline_path: Path = BASELINE_PATH) -> list[str]:
+    """Return a list of violation strings (empty == pass)."""
+    violations: list[str] = []
+
+    baseline = json.loads(baseline_path.read_text())
+    entries = baseline.get("workflows", {})
+
+    files = sorted(p.name for p in workflows_dir.glob("*.yml")) + sorted(
+        p.name for p in workflows_dir.glob("*.yaml")
+    )
+
+    # Rule 1: every present file must be classified.
+    for fname in files:
+        if fname not in entries:
+            violations.append(
+                f"{fname}: NOT in tools/prod_gate_baseline.json -- classify it "
+                f"(prod-mutating/gamma-only/conditional/already-gated/inert) before merging."
+            )
+
+    for fname, entry in entries.items():
+        wf_path = workflows_dir / fname
+        if not wf_path.exists():
+            continue  # rule 6: branch-specific workflow, entry applies where the file exists
+
+        cls = entry.get("class")
+        if cls not in VALID_CLASSES:
+            violations.append(f"{fname}: invalid class {cls!r} in baseline.")
+            continue
+
+        try:
+            doc = load_workflow(wf_path)
+        except Exception as exc:
+            violations.append(f"{fname}: unparseable workflow YAML ({exc}).")
+            continue
+
+        # PyYAML parses the bare `on:` trigger key as boolean True.
+        jobs = doc.get("jobs") or {}
+        gated_jobs = entry.get("gated_jobs") or []
+
+        for job_id in gated_jobs:
+            job = jobs.get(job_id)
+            if job is None:
+                violations.append(
+                    f"{fname}: baseline names gated job {job_id!r} which does not exist -- "
+                    f"update the baseline to match the workflow."
+                )
+                continue
+            env = job_environment(job)
+            if cls == "prod-mutating":
+                if env != "v3-prod":
+                    violations.append(
+                        f"{fname} job {job_id!r}: class=prod-mutating requires "
+                        f"environment: v3-prod, found {env!r}."
+                    )
+            elif cls == "conditional":
+                if not (isinstance(env, str) and "v3-prod" in env):
+                    violations.append(
+                        f"{fname} job {job_id!r}: class=conditional requires an environment "
+                        f"expression containing 'v3-prod', found {env!r}."
+                    )
+            elif cls == "already-gated":
+                if not env:
+                    violations.append(
+                        f"{fname} job {job_id!r}: class=already-gated but the job has no "
+                        f"environment key."
+                    )
+
+        if cls == "prod-mutating" and not gated_jobs:
+            notes = entry.get("notes", "")
+            if GRACE_MARKER not in notes:
+                violations.append(
+                    f"{fname}: class=prod-mutating with no gated_jobs and no {GRACE_MARKER} "
+                    f"grace marker -- gate its mutating job with environment: v3-prod."
+                )
+            else:
+                # Rule 3: grace entries may not rot -- if the workflow gained a gate,
+                # the baseline must be promoted (grace list must shrink, not linger).
+                any_env = any(job_environment(j) for j in jobs.values() if isinstance(j, dict))
+                if any_env:
+                    violations.append(
+                        f"{fname}: recorded as an ungated {GRACE_MARKER} grace entry but now "
+                        f"carries an environment -- promote its baseline entry (class/gated_jobs)."
+                    )
+
+    return violations
+
+
+def main() -> int:
+    violations = check()
+    if violations:
+        for v in violations:
+            print(f"::error::{v}")
+        print(f"[FAIL] prod-gate coverage guard: {len(violations)} violation(s).")
+        return 1
+    print("[SUCCESS] prod-gate coverage guard: every workflow classified; every prod lane gated or in recorded grace.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_prod_gate_coverage_guard.py
+++ b/tools/test_prod_gate_coverage_guard.py
@@ -1,0 +1,158 @@
+"""ENC-TSK-J65: tests for the prod-gate coverage guard.
+
+Happy path runs the guard against the REAL repo state (must be green -- that
+is itself the invariant). The negative tests build synthetic fixtures in a
+tempdir and prove the guard detects each violation class (the ENC-TSK-H22
+synthetic-strip-proof pattern): an ungated prod-mutating workflow, an
+unclassified workflow, and a rotted grace entry.
+
+Run: python3 -m unittest tools.test_prod_gate_coverage_guard -v
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.prod_gate_coverage_guard import check
+
+GATED_WF = """
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+"""
+
+UNGATED_WF = """
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+"""
+
+CONDITIONAL_WF = """
+on:
+  push:
+jobs:
+  apply:
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo apply
+"""
+
+
+class _Fixture:
+    def __init__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.workflows = root / "workflows"
+        self.workflows.mkdir()
+        self.baseline = root / "baseline.json"
+
+    def add_workflow(self, name, content):
+        (self.workflows / name).write_text(content)
+
+    def write_baseline(self, workflows):
+        self.baseline.write_text(json.dumps({"workflows": workflows}))
+
+    def check(self):
+        return check(workflows_dir=self.workflows, baseline_path=self.baseline)
+
+
+class HappyPathAgainstRealRepo(unittest.TestCase):
+    def test_real_repo_state_is_green(self):
+        violations = check()
+        self.assertEqual(violations, [], f"guard must be green on the shipped repo state: {violations}")
+
+
+class NegativeFixtures(unittest.TestCase):
+    def test_ungated_prod_mutating_workflow_fails(self):
+        fx = _Fixture()
+        fx.add_workflow("bad-deploy.yml", UNGATED_WF)
+        fx.write_baseline({
+            "bad-deploy.yml": {"class": "prod-mutating", "gated_jobs": ["deploy"], "notes": ""},
+        })
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("bad-deploy.yml", violations[0])
+        self.assertIn("environment: v3-prod", violations[0])
+
+    def test_unclassified_workflow_fails_closed(self):
+        fx = _Fixture()
+        fx.add_workflow("mystery.yml", GATED_WF)
+        fx.write_baseline({})
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("mystery.yml", violations[0])
+        self.assertIn("NOT in", violations[0])
+
+    def test_prod_mutating_empty_gated_jobs_without_grace_fails(self):
+        fx = _Fixture()
+        fx.add_workflow("naked.yml", UNGATED_WF)
+        fx.write_baseline({
+            "naked.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "no grace here"},
+        })
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("grace marker", violations[0])
+
+    def test_grace_entry_is_tolerated_while_ungated(self):
+        fx = _Fixture()
+        fx.add_workflow("pending.yml", UNGATED_WF)
+        fx.write_baseline({
+            "pending.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "owned by ENC-TSK-J63"},
+        })
+        self.assertEqual(fx.check(), [])
+
+    def test_rotted_grace_entry_fails(self):
+        # workflow gained a gate but the baseline still lists it as grace
+        fx = _Fixture()
+        fx.add_workflow("promoted.yml", GATED_WF)
+        fx.write_baseline({
+            "promoted.yml": {"class": "prod-mutating", "gated_jobs": [], "notes": "owned by ENC-TSK-J63"},
+        })
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("promote its baseline entry", violations[0])
+
+    def test_conditional_without_v3_prod_in_expression_fails(self):
+        fx = _Fixture()
+        fx.add_workflow("cond.yml", CONDITIONAL_WF.replace("v3-prod", "production"))
+        fx.write_baseline({
+            "cond.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": ""},
+        })
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("containing 'v3-prod'", violations[0])
+
+    def test_conditional_with_v3_prod_passes(self):
+        fx = _Fixture()
+        fx.add_workflow("cond.yml", CONDITIONAL_WF)
+        fx.write_baseline({
+            "cond.yml": {"class": "conditional", "gated_jobs": ["apply"], "notes": ""},
+        })
+        self.assertEqual(fx.check(), [])
+
+    def test_baseline_naming_missing_job_fails(self):
+        fx = _Fixture()
+        fx.add_workflow("drift.yml", GATED_WF)
+        fx.write_baseline({
+            "drift.yml": {"class": "prod-mutating", "gated_jobs": ["nonexistent"], "notes": ""},
+        })
+        violations = fx.check()
+        self.assertEqual(len(violations), 1)
+        self.assertIn("does not exist", violations[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
v4/main counterpart of #722. The guard's first v4 run immediately caught a real gap (governance-prod-backstop-grant gated in J64's v4 port but baseline entry stale — corrected). Guard + 9 tests green on this branch's workflow set.

CCI-61f3e28c91c14deab092a39fe0567c88

🤖 Generated with [Claude Code](https://claude.com/claude-code)