### PR TITLE
[ENC-TSK-J63] Plan/apply split for monitoring + codedeploy CFN workflows

### DIFF
--- a/.github/workflows/cloudformation-codedeploy-stack-deploy.yml
+++ b/.github/workflows/cloudformation-codedeploy-stack-deploy.yml
@@ -7,13 +7,18 @@ name: CloudFormation CodeDeploy Stack Deploy
 # alarms, Lambda live aliases, and per-function DeploymentGroups for canary
 # traffic shifting in v3-prod.
 #
+# ENC-TSK-J63 / ENC-FTR-120: plan/apply split with a GitHub Environment gate
+# (the ENC-TSK-J62 pattern). This stack is PROD-ONLY (no gamma counterpart),
+# so the apply job is always environment: v3-prod — a merge to main PAUSES
+# as a reviewable, rejectable request instead of deploying prod directly.
+# Change-set creation uses `aws cloudformation deploy --no-execute-changeset`
+# deliberately: it preserves deploy's parameter-override semantics (unlisted
+# params reuse the stack's stored values), which the ENC-LSN-053 NoEcho
+# strip-class guards depend on.
+#
 # Prerequisites (set as GitHub Actions secrets):
 #   AWS_CLOUDFORMATION_ROLE_TO_ASSUME — ARN of a role with cloudformation:*,
 #     codedeploy:*, lambda:*, iam:*, cloudwatch:* permissions.
-#
-# After this stack is deployed, the first _deploy.yml run will update aliases
-# from $LATEST bootstrap to a specific published version and then use CodeDeploy
-# for subsequent canary traffic shifts (Linear10PercentEvery10Minutes for prod).
 
 on:
   push:
@@ -55,6 +60,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: cloudformation-codedeploy-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   TEMPLATE_FILE: infrastructure/cloudformation/07-codedeploy.yaml
@@ -63,13 +72,14 @@ env:
   DEFAULT_CANARY_PREFERENCE: Linear10PercentEvery10Minutes
 
 jobs:
-  deploy:
-    name: Deploy CodeDeploy CloudFormation stack
+  plan:
+    name: Plan CodeDeploy stack change-set
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    concurrency:
-      group: cloudformation-codedeploy-stack-deploy-${{ github.ref_name }}
-      cancel-in-progress: false
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
 
     steps:
       - name: Checkout
@@ -114,8 +124,28 @@ jobs:
 
           echo "Stack: ${stack_name}  Compute: ${compute_stack_name}  Canary: ${canary_preference}"
 
-      - name: Deploy CodeDeploy stack (07-codedeploy)
-        id: deploy
+      - name: Pre-check stack state (fail closed on stuck stack)
+        run: |
+          set -euo pipefail
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${stack_name}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          echo "Stack status: ${status}"
+          case "${status}" in
+            DOES_NOT_EXIST|CREATE_COMPLETE|UPDATE_COMPLETE|UPDATE_ROLLBACK_COMPLETE)
+              echo "Stack state permits change-set creation."
+              ;;
+            *)
+              echo "::error::Prod stack ${stack_name} is in ${status} — change-sets cannot be created against it. Remediate the stack manually (e.g. continue-update-rollback) before planning."
+              exit 1
+              ;;
+          esac
+
+      - name: Create CodeDeploy stack change-set (no execute)
+        id: changeset
         run: |
           set -euo pipefail
 
@@ -125,13 +155,88 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --no-execute-changeset \
             --s3-bucket enceladus-cfn-staging-us-west-2 \
             --s3-prefix 07-codedeploy/ \
             --parameter-overrides \
               Environment=production \
               EnvironmentSuffix="" \
               ComputeStackName="${{ steps.params.outputs.compute_stack_name }}" \
-              CanaryPreference="${{ steps.params.outputs.canary_preference }}"
+              CanaryPreference="${{ steps.params.outputs.canary_preference }}" 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## CodeDeploy stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## CodeDeploy stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply CodeDeploy stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: this stack is prod-only, so the apply lane always pauses on
+    # the v3-prod required-reviewer rule (io) as a rejectable request.
+    environment: v3-prod
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
 
       - name: Report stack events on failure
         if: failure() && steps.deploy.conclusion == 'failure'
@@ -139,7 +244,7 @@ jobs:
           echo "=== Stack events (last 20) ==="
           aws cloudformation describe-stack-events \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
             --output table || echo "(describe-stack-events unavailable)"
 
@@ -148,17 +253,17 @@ jobs:
           set -euo pipefail
           status=$(aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].StackStatus' \
             --output text)
           echo "Stack status: ${status}"
           if [ "${status}" != "UPDATE_COMPLETE" ] && [ "${status}" != "CREATE_COMPLETE" ]; then
-            echo "::error::Stack ${{ steps.params.outputs.stack_name }} is in unexpected state: ${status}"
+            echo "::error::Stack ${{ needs.plan.outputs.stack_name }} is in unexpected state: ${status}"
             exit 1
           fi
           aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
             --output table
 

--- a/.github/workflows/cloudformation-monitoring-stack-deploy.yml
+++ b/.github/workflows/cloudformation-monitoring-stack-deploy.yml
@@ -1,5 +1,16 @@
 name: CloudFormation Monitoring Stack Deploy
 
+# ENC-TSK-J63 / ENC-FTR-120: plan/apply split with a GitHub Environment gate
+# (the ENC-TSK-J62 pattern). The plan job creates (but does not execute) the
+# change-set and writes its resource-level summary to the job summary. The
+# apply job runs inside a GitHub Environment — v3-prod (required reviewer: io)
+# for main, v4-gamma (no reviewer) for v4/** — so a merge to main PAUSES as a
+# reviewable, rejectable request instead of deploying prod directly.
+# Change-set creation uses `aws cloudformation deploy --no-execute-changeset`
+# deliberately: it preserves deploy's parameter-override semantics (unlisted
+# params reuse the stack's stored values), which the ENC-LSN-053 NoEcho
+# strip-class guards depend on.
+
 on:
   push:
     branches:
@@ -25,6 +36,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: cloudformation-monitoring-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   TEMPLATE_FILE: infrastructure/cloudformation/05-monitoring.yaml
@@ -32,13 +47,14 @@ env:
   DEFAULT_STACK_NAME: enceladus-monitoring
 
 jobs:
-  deploy:
-    name: Deploy Monitoring CloudFormation stack
+  plan:
+    name: Plan Monitoring stack change-set
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    concurrency:
-      group: cloudformation-monitoring-stack-deploy-${{ github.ref_name }}
-      cancel-in-progress: false
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
 
     steps:
       - name: Checkout
@@ -60,7 +76,7 @@ jobs:
           stack_name="${{ github.event.inputs.stack_name || env.DEFAULT_STACK_NAME }}${ENVIRONMENT_SUFFIX}"
           echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
 
-      - name: Clean up ROLLBACK_COMPLETE stack if present
+      - name: Clean up ROLLBACK_COMPLETE stack if present (gamma self-heal, prod fail-closed)
         run: |
           set -euo pipefail
           stack_name="${{ steps.params.outputs.stack_name }}"
@@ -70,35 +86,127 @@ jobs:
             --query 'Stacks[0].StackStatus' \
             --output text 2>/dev/null || echo "DOES_NOT_EXIST")
           if [ "${status}" = "ROLLBACK_COMPLETE" ]; then
-            echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy"
-            aws cloudformation delete-stack \
-              --region "${AWS_REGION}" \
-              --stack-name "${stack_name}"
-            aws cloudformation wait stack-delete-complete \
-              --region "${AWS_REGION}" \
-              --stack-name "${stack_name}"
-            echo "Stack deleted successfully"
+            if [ "${ENVIRONMENT_SUFFIX}" = "-gamma" ]; then
+              echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy (gamma self-heal)"
+              aws cloudformation delete-stack \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              aws cloudformation wait stack-delete-complete \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              echo "Stack deleted successfully"
+            else
+              echo "::error::Prod stack ${stack_name} is in ROLLBACK_COMPLETE — refusing to auto-delete a prod stack; remediate manually."
+              exit 1
+            fi
           fi
 
-      - name: Deploy Monitoring stack (05-monitoring)
+      - name: Create Monitoring stack change-set (no execute)
+        id: changeset
         run: |
           set -euo pipefail
+
           aws cloudformation deploy \
             --region "${AWS_REGION}" \
             --stack-name "${{ steps.params.outputs.stack_name }}" \
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
+            --no-execute-changeset \
             --s3-bucket enceladus-cfn-staging-us-west-2 \
             --s3-prefix 05-monitoring/ \
             --parameter-overrides \
-              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}"
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" 2>&1 | tee /tmp/plan.log
 
-      - name: Verify deployed stack state
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Monitoring stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## Monitoring stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply Monitoring stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          echo "=== Stack events (last 20) ==="
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"
+
+      - name: Report deployed stack state
         run: |
           set -euo pipefail
           aws cloudformation describe-stacks \
             --region "${AWS_REGION}" \
-            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
             --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
             --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -37,9 +37,11 @@
       "notes": "lint/tests/guards"
     },
     "cloudformation-agent-auth-stack-deploy.yml": {
-      "class": "prod-mutating",
-      "gated_jobs": [],
-      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b); guard grace entry, must be gated before J63 closes"
+      "class": "already-gated",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "v4/main-only file; gamma-only by construction (guard-gamma-only job refuses non-gamma, v3-prod FROZEN per DOC-499FA089EC30); ENC-TSK-J63 plan/apply split with apply environment: v4-gamma"
     },
     "cloudformation-api-stack-deploy.yml": {
       "class": "conditional",
@@ -50,8 +52,10 @@
     },
     "cloudformation-codedeploy-stack-deploy.yml": {
       "class": "prod-mutating",
-      "gated_jobs": [],
-      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b)"
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-J63 plan/apply split; prod-only stack so apply is always environment: v3-prod; plan fails closed on stuck stack states"
     },
     "cloudformation-compute-stack-deploy.yml": {
       "class": "conditional",
@@ -61,9 +65,11 @@
       "notes": "ENC-TSK-J62 plan/apply split; apply environment by ref"
     },
     "cloudformation-monitoring-stack-deploy.yml": {
-      "class": "prod-mutating",
-      "gated_jobs": [],
-      "notes": "UNGATED \u2014 remediation owned by ENC-TSK-J63 (Ph2b)"
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-J63 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
     },
     "component-registry-guard.yml": {
       "class": "inert",
@@ -75,8 +81,10 @@
     },
     "governance-prod-backstop-grant.yml": {
       "class": "prod-mutating",
-      "gated_jobs": [],
-      "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; gated on the v4/main lane by ENC-TSK-J64's v4 port"
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "v4/main-only file; dispatch-only IAM grant with doc-id consent input; apply job gated environment: v3-prod by ENC-TSK-J64's v4 port (baseline entry corrected by the J65 guard's own first v4 run)."
     },
     "iam-cfn-deploy-role-eventbridge-listrules-patch.yml": {
       "class": "prod-mutating",


### PR DESCRIPTION
FTR-120 Ph2b: rolls the J62 plan/apply + environment-gate pattern to the remaining CFN lanes.

- **monitoring**: conditional apply environment (v4/** → v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is now gamma-self-heal / prod-fail-closed
- **codedeploy**: prod-only stack — apply is always `environment: v3-prod`; plan pre-checks stack state and fails closed on stuck states (live stack is currently UPDATE_ROLLBACK_FAILED, pre-existing)
- **baseline**: J63 grace entries promoted to final classes; guard green with zero remaining grace entries on this branch

NOTE FOR io: merging this PR triggers push runs of both workflows (their own file paths are triggers). Both prod apply lanes will pause at the v3-prod gate as rejectable requests — codedeploy's plan will fail closed on the stuck stack before reaching apply. This is the AC-4 pause evidence.

CCI-67f855a2641d458d886f8f6b07266a26

🤖 Generated with [Claude Code](https://claude.com/claude-code)