### PR TITLE
ENC-TSK-J71: escalation.watch polling + session-activity rule (FTR-121 Ph4)

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -496,18 +496,61 @@ def retire_session(session_id: str) -> Dict[str, Any]:
     return updated
 
 
+def touch_session_activity(session_id: str) -> bool:
+    """Refresh a live session's ``last_activity_at`` heartbeat (ENC-TSK-J71).
+
+    DOC-5B888FCA43B8 §5.9 / ENC-ISS-441: a listening agent polling
+    ``escalation.watch`` performs only reads and would otherwise be idle-retired
+    mid-wait. Each watch poll calls this to advance the heartbeat the idle
+    sweep measures against (see ``_idle_reference``). Best-effort by contract:
+    a missing or already-retired session returns False rather than failing the
+    poll — the watch response reports ``session_touched`` so the caller can
+    notice its session died. The 10-minute unclaim TTL is unaffected (that
+    path reads ``created_at`` on allocated sessions only).
+    """
+    if not session_id:
+        return False
+
+    ddb = _get_ddb()
+    try:
+        ddb.update_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": _serialize(session_id)},
+            UpdateExpression="SET last_activity_at = :now",
+            ConditionExpression="attribute_exists(session_id) AND (#st = :allocated OR #st = :claimed)",
+            ExpressionAttributeNames={"#st": "status"},
+            ExpressionAttributeValues={
+                ":now": _serialize(dt.datetime.now(dt.timezone.utc).strftime(_TS_FORMAT)),
+                ":allocated": _serialize("allocated"),
+                ":claimed": _serialize("claimed"),
+            },
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Idle-sweep backstop — ENC-TSK-I71 (ENC-FTR-117 AC#8)
 # ---------------------------------------------------------------------------
 
 def _idle_reference(item: Mapping[str, Any]) -> str:
-    """Return the timestamp marking a session's last lifecycle transition.
+    """Return the timestamp marking a session's most recent activity.
 
-    For a claimed session that is ``claimed_at``; for an allocated (never-claimed) session
-    it is ``created_at``. There is no separate heartbeat attribute, so the most recent
-    lifecycle event stands in as the clock against which idleness is measured.
+    ENC-TSK-J71 (DOC-5B888FCA43B8 §5.9): ``last_activity_at`` — the heartbeat
+    advanced by every ``escalation.watch`` poll — takes precedence when present,
+    so a listening agent waiting on io's approval is not idle-retired. Sessions
+    that never polled fall back to the last lifecycle transition: ``claimed_at``
+    for claimed sessions, else ``created_at``.
     """
-    return str(item.get("claimed_at") or item.get("created_at") or "")
+    return str(
+        item.get("last_activity_at")
+        or item.get("claimed_at")
+        or item.get("created_at")
+        or ""
+    )
 
 
 def sweep_idle_sessions(

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.03",
-  "updated_at": "2026-07-02T04:50:00Z",
-  "last_change_summary": "ENC-TSK-J70 (ENC-FTR-121 Ph3, DOC-5B888FCA43B8): Cognito approval API + PWA Escalations page. coordination.escalations entity: Cognito-human-only feed/approve/deny routes (403 for internal-key/SCI/managed-token; no MCP action), requested->approved|denied|denied_with_guidance decision writes with race guards, approve drives applyEscalatedMutation via Lambda invoke with a fail-soft approved-but-unapplied path, section-5.7 render_diff with drift flag computed from the live target at render time. PWA: hamburger menu item + /escalations page (pending cards with diff + drift warning, approve/deny/deny-with-guidance, collapsed History audit section). APIGW routes gamma-only in 03-api.yaml; TRACKER_MUTATION_LAMBDA_NAME env + InvokeTrackerMutationEscalationApply role grant in 02-compute.yaml.",
+  "version": "2026-07-02.04",
+  "updated_at": "2026-07-02T06:00:00Z",
+  "last_change_summary": "ENC-TSK-J71 (ENC-FTR-121 Ph4, DOC-5B888FCA43B8): escalation.watch session-scoped cursor polling. Count-based opaque cursor (base64url JSON {escalation_id: events_consumed}) against the append-only events array - lossless under second-granular event timestamps where a timestamp cursor would drop same-second FSM edges; stable on empty polls; malformed cursors replay safely. Every poll refreshes the session's new last_activity_at heartbeat and the idle sweep's _idle_reference prefers it (listening agents survive the sweep; section 5.9 preferred formulation). MCP coordination action escalation.watch behind ENABLE_ESCALATION_PRIMITIVE; gamma APIGW route RouteEscalationsWatch. Polling guidance: 15-30s, backoff after two idle hours; polling only.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6186,6 +6186,16 @@
         "credential_id": {
           "type": "string",
           "definition": "ENC-TSK-J43 / ENC-FTR-074 Ph3. Optional foreign key to coordination.agent_credential. Written ONLY when the session is minted with a credential_id (validated active at mint time); omitted entirely -- not written as an empty string -- when no credential is bound, to preserve the frozen v4 SESSION_NODE_PROPERTIES shape (DOC-05C45B438FC1). Drives the graph AUTHENTICATED_AS edge target resolution alongside agent_type_id, and is the scan-filter key revoke_credential's cascade uses to find and retire bound sessions."
+        },
+        "last_activity_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-J71 (DOC-5B888FCA43B8 section 5.9 / ENC-ISS-441): heartbeat refreshed by every escalation.watch poll (agent_id_alloc.touch_session_activity - conditional on the session being live; retired/missing sessions return session_touched=false rather than failing the poll). The idle sweep's _idle_reference now prefers last_activity_at over claimed_at/created_at, so a listening agent waiting on io's approval is not idle-retired. The 10-minute unclaim TTL is unaffected."
         }
       }
     },
@@ -6522,6 +6532,10 @@
         "escalation.list": {
           "type": "search_action",
           "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first. ENC-TSK-J69: the MCP server calls GET /{project}/escalation/list (pseudo-id alias riding the registered {recordType}/{recordId} API Gateway route) because explicit gamma-style route tables register no bare {recordType} collection path; 'list' can never collide with a server-minted ENC-ESC-* id."
+        },
+        "escalation.watch": {
+          "type": "coordination_action",
+          "definition": "ENC-TSK-J71: coordination(action=escalation.watch, arguments={session_id, since?, project_id?}) -> GET /api/v1/coordination/escalations/watch. Pass the returned next_cursor back as since. Registered behind ENABLE_ESCALATION_PRIMITIVE."
         }
       }
     },
@@ -6539,6 +6553,10 @@
         "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny": {
           "type": "route",
           "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied."
+        },
+        "GET /api/v1/coordination/escalations/watch": {
+          "type": "route",
+          "definition": "ENC-TSK-J71 (Ph4, section 5.4 + 5.9): session-scoped cursor polling - the listening AGENT's side of the loop (read scope; agent credentials are the intended callers; approval stays Cognito-only). Query params: session_id (required, ENC-SES-*), since (opaque cursor), project_id (default enceladus). Returns every section-11.2 lifecycle event newer than the cursor across all escalations the session originated (guidance_note rides denied_with_guidance events), plus next_cursor and session_touched. CURSOR SEMANTICS: base64url(JSON {escalation_id: events_consumed}) counting against the append-only events array - event timestamps are second-granular and FSM edges (applying->applied) land inside one second, so a timestamp cursor would drop same-second events; the count cursor is lossless, exactly-once, and stable on empty polls. Malformed/absent cursors replay from the start (events are facts; replay is safe). Every poll refreshes the session's last_activity_at heartbeat. POLLING GUIDANCE (section 5.8): 15-30s interval, exponential backoff after two idle hours; transport is polling ONLY (no WebSocket/SSE by design)."
         }
       },
       "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
@@ -6626,6 +6644,11 @@
       "version": "2026-07-02.03",
       "task": "ENC-TSK-J70",
       "summary": "ENC-TSK-J70 (ENC-FTR-121 Ph3, DOC-5B888FCA43B8): Cognito approval API + PWA Escalations page. coordination.escalations entity: Cognito-human-only feed/approve/deny routes (403 for internal-key/SCI/managed-token; no MCP action), requested->approved|denied|denied_with_guidance decision writes with race guards, approve drives applyEscalatedMutation via Lambda invoke with a fail-soft approved-but-unapplied path, section-5.7 render_diff with drift flag computed from the live target at render time. PWA: hamburger menu item + /escalations page (pending cards with diff + drift warning, approve/deny/deny-with-guidance, collapsed History audit section). APIGW routes gamma-only in 03-api.yaml; TRACKER_MUTATION_LAMBDA_NAME env + InvokeTrackerMutationEscalationApply role grant in 02-compute.yaml."
+    },
+    {
+      "version": "2026-07-02.04",
+      "task": "ENC-TSK-J71",
+      "summary": "ENC-TSK-J71 (ENC-FTR-121 Ph4, DOC-5B888FCA43B8): escalation.watch session-scoped cursor polling. Count-based opaque cursor (base64url JSON {escalation_id: events_consumed}) against the append-only events array - lossless under second-granular event timestamps where a timestamp cursor would drop same-second FSM edges; stable on empty polls; malformed cursors replay safely. Every poll refreshes the session's new last_activity_at heartbeat and the idle sweep's _idle_reference prefers it (listening agents survive the sweep; section 5.9 preferred formulation). MCP coordination action escalation.watch behind ENABLE_ESCALATION_PRIMITIVE; gamma APIGW route RouteEscalationsWatch. Polling guidance: 15-30s, backoff after two idle hours; polling only."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -37,6 +37,7 @@ import ssl
 import time
 import uuid
 import urllib.error
+import base64
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -9357,6 +9358,121 @@ def _handle_escalation_decision(
     })
 
 
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph4 / ENC-TSK-J71 — escalation.watch cursor polling (§5.4, §5.9)
+# ---------------------------------------------------------------------------
+
+
+def _decode_watch_cursor(raw: str) -> Dict[str, int]:
+    """Decode the opaque watch cursor: base64url(JSON {escalation_id: events_consumed}).
+
+    Event timestamps are second-granular and FSM edges (applying→applied) land
+    inside one second, so a timestamp cursor would drop same-second events.
+    The cursor instead counts consumed events per escalation against the
+    append-only events array — lossless and stable on empty polls. Garbage or
+    absent cursors decode to {} (full replay; events are facts, replay is safe).
+    """
+    if not raw:
+        return {}
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(raw.encode("ascii")).decode("utf-8"))
+        if not isinstance(decoded, dict):
+            return {}
+        return {str(k): int(v) for k, v in decoded.items() if int(v) >= 0}
+    except Exception:  # noqa: BLE001 — any malformed cursor means full replay
+        return {}
+
+
+def _encode_watch_cursor(counts: Dict[str, int]) -> str:
+    return base64.urlsafe_b64encode(
+        json.dumps(counts, sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+
+
+def _handle_escalation_watch(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/escalations/watch — session-scoped event polling.
+
+    Returns escalation lifecycle events newer than the supplied cursor across
+    every escalation the calling session originated, and refreshes the
+    session's last_activity_at heartbeat (§5.9) so a listening agent survives
+    the idle sweep while waiting on io. Read-scoped: agent credentials are the
+    intended callers (this is the agent side of the loop; approval stays
+    Cognito-only). Recommended polling: 15-30s with exponential backoff after
+    two idle hours (§5.8).
+    """
+    params = event.get("queryStringParameters") or {}
+    session_id = str(params.get("session_id") or "").strip()
+    if not session_id:
+        return _error(400, "Query parameter 'session_id' is required (ENC-SES-*).")
+    project_id = str(params.get("project_id") or "enceladus").strip()
+    cursor_counts = _decode_watch_cursor(str(params.get("since") or "").strip())
+
+    ddb = _get_ddb()
+    query_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
+        "FilterExpression": "requested_by.session_id = :sid",
+        "ExpressionAttributeValues": {
+            ":pid": _serialize(project_id),
+            ":prefix": _serialize("escalation#"),
+            ":sid": _serialize(session_id),
+        },
+    }
+    escalations = []
+    try:
+        while True:
+            page = ddb.query(**query_kwargs)
+            escalations.extend(_deserialize(raw) for raw in page.get("Items", []))
+            last_key = page.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            query_kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalation watch query failed: %s", exc)
+        return _error(500, "Failed to read escalations for watch.")
+
+    new_events = []
+    next_counts = dict(cursor_counts)
+    for escalation in escalations:
+        escalation_id = str(escalation.get("item_id") or "")
+        events = escalation.get("events") or []
+        consumed = cursor_counts.get(escalation_id, 0)
+        for entry in events[consumed:]:
+            if not isinstance(entry, dict):
+                continue
+            emitted = {
+                "escalation_id": escalation_id,
+                "escalation_status": escalation.get("status"),
+                "target_record_id": escalation.get("target_record_id"),
+                "event_type": entry.get("event_type"),
+                "at": entry.get("at"),
+                "actor": entry.get("actor"),
+            }
+            if entry.get("detail") is not None:
+                emitted["detail"] = entry.get("detail")
+            if entry.get("guidance_note"):
+                emitted["guidance_note"] = entry.get("guidance_note")
+            new_events.append(emitted)
+        next_counts[escalation_id] = len(events)
+
+    new_events.sort(key=lambda item: (str(item.get("at") or ""), str(item["escalation_id"])))
+    session_touched = False
+    try:
+        session_touched = _agent_id_alloc.touch_session_activity(session_id)
+    except Exception as exc:  # noqa: BLE001 — heartbeat failure must not fail the poll
+        logger.error("watch heartbeat touch failed for %s: %s", session_id, exc)
+
+    return _response(200, {
+        "success": True,
+        "session_id": session_id,
+        "project_id": project_id,
+        "events": new_events,
+        "count": len(new_events),
+        "next_cursor": _encode_watch_cursor(next_counts),
+        "session_touched": session_touched,
+    })
+
+
 def _handle_lesson_candidate_approve(
     document_id: str, event: Dict[str, Any], claims: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -15051,6 +15167,11 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if decision == "approve":
             return _handle_lesson_candidate_approve(candidate_doc_id, event, claims or {})
         return _handle_lesson_candidate_reject(candidate_doc_id, event, claims or {})
+
+    # ENC-FTR-121 Ph4 (ENC-TSK-J71): session-scoped escalation event polling —
+    # the AGENT side of the loop (approval stays Cognito-only).
+    if method == "GET" and path == "/api/v1/coordination/escalations/watch":
+        return _handle_escalation_watch(event, claims or {})
 
     # ENC-FTR-121 Ph3 (ENC-TSK-J70): Escalations — io approval queue + decisions
     # (DOC-5B888FCA43B8 §5.7). Cognito-gated inside the handlers; no agent path.

--- a/backend/lambda/coordination_api/test_escalation_watch_j71.py
+++ b/backend/lambda/coordination_api/test_escalation_watch_j71.py
@@ -1,0 +1,228 @@
+"""ENC-TSK-J71 (ENC-FTR-121 Ph4): escalation.watch polling tests.
+
+Covers the count-based opaque cursor (first poll full replay, incremental
+polls return only unconsumed events, multi-escalation interleaving in a
+merged at-sorted stream, stability on empty polls, malformed-cursor safe
+replay), §11.2 event shape passthrough with guidance_note only on
+denied_with_guidance, session scoping (the DDB filter targets
+requested_by.session_id), the §5.9 last_activity_at heartbeat
+(touch_session_activity conditional write + _idle_reference precedence), and
+the agent-callable auth posture (no Cognito gate — internal-key claims work).
+"""
+import base64
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
+import importlib.util
+
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda_j71",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = coordination_lambda
+_SPEC.loader.exec_module(coordination_lambda)
+
+import agent_id_alloc
+
+INTERNAL_CLAIMS = {"auth_mode": "internal-key"}
+
+
+def _event_entry(event_type, at, actor="ENC-SES-02F", guidance_note=None):
+    entry = {"event_type": event_type, "at": at, "actor": actor}
+    if guidance_note:
+        entry["guidance_note"] = guidance_note
+    return entry
+
+
+def _escalation(escalation_id, status, events, session_id="ENC-SES-02F"):
+    return {
+        "project_id": "enceladus",
+        "record_id": f"escalation#{escalation_id}",
+        "item_id": escalation_id,
+        "record_type": "escalation",
+        "status": status,
+        "mutation_type": "deploy_arc_change",
+        "target_record_id": "ENC-TSK-J10",
+        "requested_by": {"session_id": session_id},
+        "events": events,
+        "created_at": "2026-07-02T04:00:00Z",
+        "updated_at": "2026-07-02T04:10:00Z",
+    }
+
+
+def _serialized(item):
+    return {k: coordination_lambda._serialize(v) for k, v in item.items()}
+
+
+def _cursor(counts):
+    return base64.urlsafe_b64encode(json.dumps(counts).encode()).decode()
+
+
+def _watch(escalations, params, touched=True):
+    fake = mock.MagicMock()
+    fake.query.return_value = {"Items": [_serialized(e) for e in escalations]}
+    with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake), \
+         mock.patch.object(coordination_lambda._agent_id_alloc, "touch_session_activity",
+                           return_value=touched) as touch:
+        resp = coordination_lambda._handle_escalation_watch(
+            {"queryStringParameters": params}, INTERNAL_CLAIMS)
+    return resp, fake, touch
+
+
+class TestWatchCursor(unittest.TestCase):
+    def test_first_poll_replays_all_events_and_returns_full_cursor(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("approved", "2026-07-02T04:05:00Z", actor="cognito-sub"),
+        ]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "approved", events)],
+                            {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+        self.assertEqual(["requested", "approved"],
+                         [e["event_type"] for e in body["events"]])
+        decoded = json.loads(base64.urlsafe_b64decode(body["next_cursor"]))
+        self.assertEqual({"ENC-ESC-001": 2}, decoded)
+
+    def test_incremental_poll_returns_only_unconsumed_events(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("approved", "2026-07-02T04:05:00Z"),
+            _event_entry("applying", "2026-07-02T04:05:30Z"),
+            _event_entry("applied", "2026-07-02T04:05:30Z"),  # same second as applying
+        ]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "applied", events)],
+                            {"session_id": "ENC-SES-02F",
+                             "since": _cursor({"ENC-ESC-001": 2})})
+        body = json.loads(resp["body"])
+        # Both same-second events delivered — the count cursor cannot drop them.
+        self.assertEqual(["applying", "applied"],
+                         [e["event_type"] for e in body["events"]])
+
+    def test_empty_poll_returns_stable_cursor_and_no_events(self):
+        events = [_event_entry("requested", "2026-07-02T04:00:00Z")]
+        cursor = _cursor({"ENC-ESC-001": 1})
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "requested", events)],
+                            {"session_id": "ENC-SES-02F", "since": cursor})
+        body = json.loads(resp["body"])
+        self.assertEqual(0, body["count"])
+        self.assertEqual(json.loads(base64.urlsafe_b64decode(cursor)),
+                         json.loads(base64.urlsafe_b64decode(body["next_cursor"])))
+
+    def test_multi_escalation_events_merge_sorted_by_time(self):
+        first = _escalation("ENC-ESC-001", "applied", [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("applied", "2026-07-02T04:09:00Z"),
+        ])
+        second = _escalation("ENC-ESC-002", "denied_with_guidance", [
+            _event_entry("requested", "2026-07-02T04:03:00Z"),
+            _event_entry("denied_with_guidance", "2026-07-02T04:06:00Z",
+                         guidance_note="Use a successor task."),
+        ])
+        resp, _, _ = _watch([first, second], {"session_id": "ENC-SES-02F"})
+        body = json.loads(resp["body"])
+        self.assertEqual(
+            [("ENC-ESC-001", "requested"), ("ENC-ESC-002", "requested"),
+             ("ENC-ESC-002", "denied_with_guidance"), ("ENC-ESC-001", "applied")],
+            [(e["escalation_id"], e["event_type"]) for e in body["events"]])
+
+    def test_malformed_cursor_replays_from_start(self):
+        events = [_event_entry("requested", "2026-07-02T04:00:00Z")]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "requested", events)],
+                            {"session_id": "ENC-SES-02F", "since": "!!!not-a-cursor!!!"})
+        body = json.loads(resp["body"])
+        self.assertEqual(1, body["count"])
+
+
+class TestWatchSemantics(unittest.TestCase):
+    def test_guidance_note_present_only_on_denied_with_guidance(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("denied_with_guidance", "2026-07-02T04:06:00Z",
+                         guidance_note="Fix the arc first."),
+        ]
+        resp, _, _ = _watch(
+            [_escalation("ENC-ESC-001", "denied_with_guidance", events)],
+            {"session_id": "ENC-SES-02F"})
+        body = json.loads(resp["body"])
+        requested, denied = body["events"]
+        self.assertNotIn("guidance_note", requested)
+        self.assertEqual("Fix the arc first.", denied["guidance_note"])
+
+    def test_query_filters_to_the_calling_session(self):
+        resp, fake, _ = _watch([], {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertEqual("requested_by.session_id = :sid", kwargs["FilterExpression"])
+        self.assertEqual({"S": "ENC-SES-02F"},
+                         kwargs["ExpressionAttributeValues"][":sid"])
+
+    def test_missing_session_id_400(self):
+        resp, fake, _ = _watch([], {})
+        self.assertEqual(400, resp["statusCode"])
+        fake.query.assert_not_called()
+
+    def test_internal_key_claims_are_allowed(self):
+        # The watch surface is the AGENT side of the loop — no Cognito gate.
+        resp, _, _ = _watch([], {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+
+    def test_poll_touches_session_and_reports_result(self):
+        resp, _, touch = _watch([], {"session_id": "ENC-SES-02F"}, touched=True)
+        touch.assert_called_once_with("ENC-SES-02F")
+        self.assertTrue(json.loads(resp["body"])["session_touched"])
+
+    def test_retired_session_reports_untouched_but_poll_succeeds(self):
+        resp, _, _ = _watch([], {"session_id": "ENC-SES-0FF"}, touched=False)
+        body = json.loads(resp["body"])
+        self.assertEqual(200, resp["statusCode"])
+        self.assertFalse(body["session_touched"])
+
+
+class TestSessionActivity(unittest.TestCase):
+    def test_touch_writes_last_activity_at_conditionally(self):
+        fake = mock.MagicMock()
+        with mock.patch.object(agent_id_alloc, "_get_ddb", return_value=fake):
+            self.assertTrue(agent_id_alloc.touch_session_activity("ENC-SES-02F"))
+        kwargs = fake.update_item.call_args.kwargs
+        self.assertEqual("SET last_activity_at = :now", kwargs["UpdateExpression"])
+        self.assertIn("#st = :allocated OR #st = :claimed",
+                      kwargs["ConditionExpression"])
+
+    def test_touch_returns_false_for_dead_session(self):
+        from botocore.exceptions import ClientError
+        fake = mock.MagicMock()
+        fake.update_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem")
+        with mock.patch.object(agent_id_alloc, "_get_ddb", return_value=fake):
+            self.assertFalse(agent_id_alloc.touch_session_activity("ENC-SES-0FF"))
+
+    def test_touch_empty_session_id_is_noop_false(self):
+        self.assertFalse(agent_id_alloc.touch_session_activity(""))
+
+    def test_idle_reference_prefers_last_activity_at(self):
+        item = {"created_at": "2026-07-01T00:00:00Z",
+                "claimed_at": "2026-07-01T01:00:00Z",
+                "last_activity_at": "2026-07-02T05:00:00Z"}
+        self.assertEqual("2026-07-02T05:00:00Z", agent_id_alloc._idle_reference(item))
+
+    def test_idle_reference_falls_back_to_lifecycle_timestamps(self):
+        self.assertEqual(
+            "2026-07-01T01:00:00Z",
+            agent_id_alloc._idle_reference(
+                {"created_at": "2026-07-01T00:00:00Z",
+                 "claimed_at": "2026-07-01T01:00:00Z"}))
+        self.assertEqual(
+            "2026-07-01T00:00:00Z",
+            agent_id_alloc._idle_reference({"created_at": "2026-07-01T00:00:00Z"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -2374,6 +2374,15 @@ Resources:
       RouteKey: "GET /api/v1/coordination/escalations"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-J71 / ENC-FTR-121 Ph4: session-scoped escalation event polling.
+  RouteEscalationsWatch:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/escalations/watch"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
   RouteEscalationsApprove:
     Type: AWS::ApiGatewayV2::Route
     Condition: IsGamma

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -6146,6 +6146,28 @@ async def _escalation_list(args: dict) -> list[TextContent]:
     return _result_text(resp)
 
 
+async def _escalation_watch(args: dict) -> list[TextContent]:
+    """ENC-TSK-J71 (Ph4): cursor-based escalation event polling.
+
+    Streams §11.2 lifecycle events for every escalation the calling session
+    originated and refreshes the session's last_activity_at heartbeat so a
+    listening agent survives the idle sweep (§5.9). Pass the returned
+    next_cursor back as `since`. Recommended cadence: 15-30s, exponential
+    backoff after two idle hours (§5.8).
+    """
+    session_id = str(args.get("session_id") or "").strip()
+    if not session_id:
+        return _result_text({"error": "Field 'session_id' is required (ENC-SES-*)."})
+    query = {
+        "session_id": session_id,
+        "since": args.get("since"),
+        "project_id": args.get("project_id"),
+    }
+    resp = _coordination_api_request(
+        "GET", "/api/v1/coordination/escalations/watch", query=query)
+    return _result_text(resp)
+
+
 # --- Acceptance Criteria Evidence Handshake (§7.1.1) ---
 
 
@@ -7732,6 +7754,11 @@ if ENABLE_ESCALATION_PRIMITIVE:
     }
     _SEARCH_ACTIONS["escalation.list"] = {
         "tool": "escalation_list",
+    }
+    # ENC-TSK-J71 (Ph4): session-scoped cursor polling — the listening agent's
+    # side of the loop (§5.4 coordination surface, §5.9 activity rule).
+    _COORDINATION_ACTIONS["escalation.watch"] = {
+        "tool": "escalation_watch",
     }
 
 # ENC-FTR-052: Conditionally register lesson actions behind feature flag
@@ -10646,6 +10673,8 @@ _TOOL_HANDLERS = {
     "escalation_request": _escalation_request,
     "escalation_get": _escalation_get,
     "escalation_list": _escalation_list,
+    # ENC-FTR-121 / ENC-TSK-J71: session-scoped event polling
+    "escalation_watch": _escalation_watch,
     # ENC-FTR-047: Graph search
     "tracker_graphsearch": _tracker_graphsearch,
     # ENC-FTR-089 / ENC-TSK-I89: admin-scoped raw-embedding egress


### PR DESCRIPTION
## ENC-TSK-J71 — FTR-121 Phase 4: the listening agent's side of the loop

DOC-5B888FCA43B8 §5.4 + §5.9 under ENC-PLN-061 / ENC-FTR-121. Builds on #715/#718/#721.

- **`GET /api/v1/coordination/escalations/watch`** — session-scoped cursor polling across every escalation the calling session originated; §11.2 events with `guidance_note` riding `denied_with_guidance`; **agent-callable** (approval remains Cognito-only).
- **Count-based opaque cursor** (`base64url({escalation_id: events_consumed})`) against the append-only events array — event timestamps are second-granular and `applying→applied` share a second, so a timestamp cursor would drop events; the count cursor is lossless, exactly-once, stable on empty polls, and malformed cursors replay safely.
- **§5.9 / ENC-ISS-441**: new `agent_id_alloc.touch_session_activity` writes `last_activity_at` (conditional on live status; dead sessions report `session_touched=false` without failing the poll); `_idle_reference` now prefers `last_activity_at` so listening agents survive the idle sweep. The 10-minute unclaim TTL is untouched.
- **MCP**: `coordination(action=escalation.watch)` behind `ENABLE_ESCALATION_PRIMITIVE`.
- **CFN**: `RouteEscalationsWatch` (IsGamma) in 03-api.yaml.
- **Dictionary → 2026-07-02.04** (watch route + cursor semantics + `coordination.agent_session.last_activity_at` + 15-30s polling guidance).
- **Tests**: 16 new; coordination discovery 576 tests with zero new failures vs the clean baseline.

Per the amended ENC-PLN-061 (io directive): this task halts at gamma deploy-success; ACs are stamped only after UAT on live v3 prod (Ph8).

CCI-f1aed3eac9244e328700bb3fc72a5343

🤖 Generated with [Claude Code](https://claude.com/claude-code)