### PR TITLE
ENC-TSK-J72: SNS [ESCALATION] notifications to io (FTR-121 Ph5)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.04",
-  "updated_at": "2026-07-02T06:00:00Z",
-  "last_change_summary": "ENC-TSK-J71 (ENC-FTR-121 Ph4, DOC-5B888FCA43B8): escalation.watch session-scoped cursor polling. Count-based opaque cursor (base64url JSON {escalation_id: events_consumed}) against the append-only events array - lossless under second-granular event timestamps where a timestamp cursor would drop same-second FSM edges; stable on empty polls; malformed cursors replay safely. Every poll refreshes the session's new last_activity_at heartbeat and the idle sweep's _idle_reference prefers it (listening agents survive the sweep; section 5.9 preferred formulation). MCP coordination action escalation.watch behind ENABLE_ESCALATION_PRIMITIVE; gamma APIGW route RouteEscalationsWatch. Polling guidance: 15-30s, backoff after two idle hours; polling only.",
+  "version": "2026-07-02.05",
+  "updated_at": "2026-07-02T06:10:00Z",
+  "last_change_summary": "ENC-TSK-J72 (ENC-FTR-121 Ph5, DOC-5B888FCA43B8): SNS [ESCALATION] notifications to io. Publishes on requested (post-write) and terminal applied/failed; failure-isolated (never fails the escalation write); reuses devops-feed-alerts{suffix} via ESCALATION_ALERTS_TOPIC_ARN env + PublishEscalationAlerts role grant (02-compute.yaml, gamma lane; prod via Ph7a). Sub-dollar budget; email subscription confirmation is an io residual for Ph8.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6516,6 +6516,9 @@
           "deploy_arc_change": "rewrites transition_type (and checkout_transition_type when present, which recomputes arc-derived gate expectations) in place; checkout fields untouched so an active checkout survives.",
           "direct_state_override": "writes target_status regardless of path legality; supplied field_values written verbatim; unsupplied required-for-state fields (from the transition-matrix gate contracts: committed->commit_sha, deploy-success->arc evidence key, closed->arc closed-evidence key, issue closed->evidence) get the escalation_waived sentinel; closures set escalated_closure=true and increment closed_count for tasks (organic-gate parity)."
         }
+      },
+      "notifications": {
+        "definition": "ENC-TSK-J72 (Ph5, section 5.8): tracker_mutation publishes an SNS notification with subject prefix [ESCALATION] on requested (after the durable item write) and on the terminal applied/failed transitions (closure telemetry). Topic: ESCALATION_ALERTS_TOPIC_ARN env, defaulting via CFN to the existing devops-feed-alerts{EnvironmentSuffix} topic (reuse - zero new infrastructure). FAILURE-ISOLATED by contract: an SNS error or unset ARN is logged and swallowed; notification can never fail the escalation write or the applier. Payload: escalation_id, target_record_id, mutation_type, requesting session, justification/result excerpt. Cost: tens of emails/month inside the SNS email free tier - combined feature incremental cost under one dollar per month. RESIDUAL (Ph8): the topic has no email subscription yet; io must subscribe + confirm to actually receive mail. IAM: PublishEscalationAlerts Sid on TrackerMutationRole (gamma via the compute stack; prod via Ph7a backport)."
       }
     },
     "mcp_server.escalation_actions": {
@@ -6649,6 +6652,11 @@
       "version": "2026-07-02.04",
       "task": "ENC-TSK-J71",
       "summary": "ENC-TSK-J71 (ENC-FTR-121 Ph4, DOC-5B888FCA43B8): escalation.watch session-scoped cursor polling. Count-based opaque cursor (base64url JSON {escalation_id: events_consumed}) against the append-only events array - lossless under second-granular event timestamps where a timestamp cursor would drop same-second FSM edges; stable on empty polls; malformed cursors replay safely. Every poll refreshes the session's new last_activity_at heartbeat and the idle sweep's _idle_reference prefers it (listening agents survive the sweep; section 5.9 preferred formulation). MCP coordination action escalation.watch behind ENABLE_ESCALATION_PRIMITIVE; gamma APIGW route RouteEscalationsWatch. Polling guidance: 15-30s, backoff after two idle hours; polling only."
+    },
+    {
+      "version": "2026-07-02.05",
+      "task": "ENC-TSK-J72",
+      "summary": "ENC-TSK-J72 (ENC-FTR-121 Ph5, DOC-5B888FCA43B8): SNS [ESCALATION] notifications to io. Publishes on requested (post-write) and terminal applied/failed; failure-isolated (never fails the escalation write); reuses devops-feed-alerts{suffix} via ESCALATION_ALERTS_TOPIC_ARN env + PublishEscalationAlerts role grant (02-compute.yaml, gamma lane; prod via Ph7a). Sub-dollar budget; email subscription confirmation is an io residual for Ph8."
     }
   ]
 }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -890,6 +890,10 @@ def _validate_pillar_scores(raw_pillar_scores, record_type="lesson"):
 # EventBridge event config for reopen notifications
 EVENT_BUS = os.environ.get("EVENT_BUS", "default")
 EVENT_SOURCE = "enceladus.tracker"
+# ENC-FTR-121 Ph5 / ENC-TSK-J72: SNS topic for io's escalation email (§5.8).
+# Reuses the existing devops-feed-alerts topic (subject-prefixed [ESCALATION]);
+# empty/unset ARN disables publishing (logged skip — never fails the write).
+ESCALATION_ALERTS_TOPIC_ARN = os.environ.get("ESCALATION_ALERTS_TOPIC_ARN", "")
 EVENT_DETAIL_TYPE_REOPENED = "record.status.reopened"
 # ENC-FTR-111 / ENC-TSK-H83: Artifact-Genesis telemetry for an auto_walk_opt_out latch
 # (feeds ENC-TSK-B66 / the T5 ARC_WALK telemetry consumer).
@@ -969,6 +973,48 @@ def _get_events():
     if _events_client is None:
         _events_client = boto3.client("events")
     return _events_client
+
+
+_sns_client = None
+
+
+def _get_sns():
+    global _sns_client
+    if _sns_client is None:
+        _sns_client = boto3.client("sns", region_name=DYNAMODB_REGION)
+    return _sns_client
+
+
+def _notify_escalation_event(kind: str, escalation_id: str, target_record_id: str,
+                             mutation_type: str, session_id: str, note: str = "") -> None:
+    """§5.8 io notification: best-effort SNS publish, failure-isolated by contract.
+
+    An SNS error (or an unset topic ARN) is logged and swallowed — notification
+    must never fail the escalation write. Subject is [ESCALATION]-prefixed for
+    inbox routing; expected volume is tens/month, inside the SNS email free
+    tier (sub-dollar budget).
+    """
+    if not ESCALATION_ALERTS_TOPIC_ARN:
+        logger.info("escalation notify skipped (%s %s): ESCALATION_ALERTS_TOPIC_ARN unset",
+                    kind, escalation_id)
+        return
+    try:
+        lines = [
+            f"Escalation {kind}: {escalation_id}",
+            f"Target: {target_record_id}",
+            f"Mutation: {mutation_type}",
+            f"Requested by: {session_id}",
+        ]
+        if note:
+            lines.append(f"Note: {note[:500]}")
+        lines.append("Review queue: PWA menu → Escalations")
+        _get_sns().publish(
+            TopicArn=ESCALATION_ALERTS_TOPIC_ARN,
+            Subject=f"[ESCALATION] {kind}: {escalation_id} ({mutation_type})"[:100],
+            Message="\n".join(lines),
+        )
+    except Exception as exc:  # noqa: BLE001 — §5.8 failure isolation
+        logger.error("escalation notify failed (%s %s): %s", kind, escalation_id, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -6957,6 +7003,12 @@ def _handle_escalation_request(project_id: str, body: Dict) -> Dict:
         logger.error("escalation put_item failed: %s", exc)
         return _error(500, "Database write failed while creating escalation.")
 
+    # ENC-TSK-J72 (§5.8): push io's email AFTER the durable write; never fails it.
+    _notify_escalation_event(
+        "requested", escalation_id, target_record_id, mutation_type,
+        session_id, note=justification,
+    )
+
     return _response(201, {
         "success": True,
         "escalation_id": escalation_id,
@@ -7247,6 +7299,15 @@ def _handle_escalation_apply(project_id: str, escalation_id: str, body: Dict) ->
             extra_names={"#res": "result"},
             extra_values={":result": _ser_value({"success": False, "error": failure})},
         )
+        # ENC-TSK-J72 (§5.8 optional terminal notification): closure telemetry
+        # for io without opening the PWA; same failure-isolation contract.
+        _notify_escalation_event(
+            "failed", escalation_id,
+            str(escalation.get("target_record_id") or ""),
+            str(escalation.get("mutation_type") or ""),
+            str((escalation.get("requested_by") or {}).get("session_id") or ""),
+            note=failure,
+        )
         return _error(409, f"Escalation application failed (no partial write): {failure}")
 
     _escalation_fsm_transition(
@@ -7260,6 +7321,14 @@ def _handle_escalation_apply(project_id: str, escalation_id: str, body: Dict) ->
         },
     )
     _emit_escalation_applied_event(project_id, escalation, result_detail or {})
+    # ENC-TSK-J72 (§5.8 optional terminal notification): applied closure telemetry.
+    _notify_escalation_event(
+        "applied", escalation_id,
+        str(escalation.get("target_record_id") or ""),
+        str(escalation.get("mutation_type") or ""),
+        str((escalation.get("requested_by") or {}).get("session_id") or ""),
+        note=json.dumps(result_detail or {}, default=str)[:300],
+    )
     return _response(200, {
         "success": True,
         "escalation_id": escalation_id,

--- a/backend/lambda/tracker_mutation/test_escalation_notify_j72.py
+++ b/backend/lambda/tracker_mutation/test_escalation_notify_j72.py
@@ -1,0 +1,116 @@
+"""ENC-TSK-J72 (ENC-FTR-121 Ph5): escalation SNS notification tests.
+
+Covers: exactly one [ESCALATION]-prefixed publish on a successful
+escalation.request (after the durable write, carrying escalation_id, target,
+mutation type, requesting session, and the justification excerpt); §5.8
+failure isolation (a raising SNS client never fails the request or applier);
+no publish on request-validation failures (nothing reached io's queue);
+terminal applied/failed notifications; and the unset-ARN skip path.
+"""
+import json
+import unittest
+from unittest import mock
+
+from test_escalation_j68 import _fake_ddb, _request_body, _TARGET_TASK_ITEM
+from test_escalation_applier_j69 import _FakeDdb, _escalation_item, _target_task
+
+
+class _NotifyBase(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._patches = [
+            mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True),
+            mock.patch.object(lf, "ESCALATION_ALERTS_TOPIC_ARN",
+                              "arn:aws:sns:us-west-2:1:devops-feed-alerts-test"),
+            mock.patch.object(lf, "_get_events", return_value=mock.MagicMock()),
+        ]
+        for patch in self._patches:
+            patch.start()
+        self.sns = mock.MagicMock()
+        self._sns_patch = mock.patch.object(self.lf, "_get_sns", return_value=self.sns)
+        self._sns_patch.start()
+
+    def tearDown(self):
+        self._sns_patch.stop()
+        for patch in self._patches:
+            patch.stop()
+
+
+class TestRequestNotification(_NotifyBase):
+    def _request(self, body, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb), \
+             mock.patch.object(self.lf, "_get_project_prefix", return_value="ENC"):
+            return self.lf._handle_escalation_request("enceladus", body)
+
+    def test_successful_request_publishes_exactly_one_escalation_email(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM, counter_next=7)
+        resp = self._request(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        self.assertEqual(1, self.sns.publish.call_count)
+        kwargs = self.sns.publish.call_args.kwargs
+        self.assertTrue(kwargs["Subject"].startswith("[ESCALATION] requested:"))
+        self.assertIn("deploy_arc_change", kwargs["Subject"])
+        message = kwargs["Message"]
+        escalation_id = json.loads(resp["body"])["escalation_id"]
+        self.assertIn(escalation_id, message)
+        self.assertIn("ENC-TSK-J10", message)
+        self.assertIn("ENC-SES-02F", message)
+        self.assertIn("Arc misclassified at create", message)
+        self.assertEqual(kwargs["TopicArn"],
+                         "arn:aws:sns:us-west-2:1:devops-feed-alerts-test")
+
+    def test_publish_happens_after_write_and_failure_never_fails_request(self):
+        self.sns.publish.side_effect = RuntimeError("SNS down")
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._request(_request_body(), ddb)
+        # The escalation write succeeded and the response is still 201.
+        self.assertEqual(201, resp["statusCode"])
+        self.assertEqual(1, ddb.put_item.call_count)
+
+    def test_validation_failure_publishes_nothing(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._request(_request_body(justification=""), ddb)
+        self.assertEqual(400, resp["statusCode"])
+        self.sns.publish.assert_not_called()
+
+    def test_unset_topic_arn_skips_publish_without_error(self):
+        with mock.patch.object(self.lf, "ESCALATION_ALERTS_TOPIC_ARN", ""):
+            ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+            resp = self._request(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        self.sns.publish.assert_not_called()
+
+
+class TestTerminalNotifications(_NotifyBase):
+    def _apply(self, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb):
+            return self.lf._handle_escalation_apply(
+                "enceladus", "ENC-ESC-001",
+                {"write_source": {"provider": "io:test"}})
+
+    def test_applied_sends_terminal_notification(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        subjects = [call.kwargs["Subject"] for call in self.sns.publish.call_args_list]
+        self.assertTrue(any(s.startswith("[ESCALATION] applied: ENC-ESC-001") for s in subjects))
+
+    def test_failed_sends_terminal_notification_with_error_note(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=None)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        kwargs = self.sns.publish.call_args.kwargs
+        self.assertTrue(kwargs["Subject"].startswith("[ESCALATION] failed: ENC-ESC-001"))
+        self.assertIn("not found", kwargs["Message"])
+
+    def test_terminal_publish_failure_does_not_break_applier(self):
+        self.sns.publish.side_effect = RuntimeError("SNS down")
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        self.assertEqual("applied", json.loads(resp["body"])["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -270,6 +270,9 @@ Resources:
           # ENC-TSK-H47: the lesson-scoring SNS topic tracker_mutation publishes to when
           # enable_scoring_service_extraction is ON. Inert until the (default-OFF) flag is flipped.
           LESSON_SCORING_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+          # ENC-TSK-J72 / ENC-FTR-121 Ph5: io's [ESCALATION] email rides the existing
+          # feed-alerts topic (§5.8 topic reuse; sub-dollar budget). Empty = publish skipped.
+          ESCALATION_ALERTS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
       Tags:
         - Key: Project
           Value: enceladus
@@ -2521,6 +2524,14 @@ Resources:
                   - sns:Publish
                 Resource:
                   - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+              # ENC-TSK-J72 / ENC-FTR-121 Ph5: escalation notifications to io
+              # ride the existing feed-alerts topic (DOC-5B888FCA43B8 §5.8).
+              - Sid: PublishEscalationAlerts
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
 
   # ENC-TSK-H46 / B63 Phase 2A — execution role for the Lifecycle Service. Read-only:
   # tracker table (subtask gate child lookups) + component-registry (STRICTNESS_RANK).


### PR DESCRIPTION
## ENC-TSK-J72 — FTR-121 Phase 5: the sub-dollar notification lane

DOC-5B888FCA43B8 §5.8 under ENC-PLN-061 / ENC-FTR-121.

- `_notify_escalation_event`: [ESCALATION]-prefixed SNS publish on **requested** (after the durable write; escalation_id, target, mutation type, requesting session, justification excerpt) and on the terminal **applied/failed** transitions (closure telemetry — the §5.8 optional notification implemented rather than deferred).
- **Failure-isolated by contract**: a raising SNS client or an unset topic ARN logs and skips — the escalation write and the applier never fail on notification failure (tests force both paths).
- **Topic reuse**: `ESCALATION_ALERTS_TOPIC_ARN` → `devops-feed-alerts${EnvironmentSuffix}` (existing live topic on prod+gamma; 05-monitoring carries no topics). CFN: env var + `PublishEscalationAlerts` grant on TrackerMutationRole — gamma lane; the prod-side grant rides Ph7a per the amended dual-target plan (AC-4 supersession worklogged on the task).
- **Cost**: <100 notifications/month vs the 1,000/month SNS email free tier — comfortably sub-dollar.
- **Residual for Ph8**: the topic has zero subscriptions; io must subscribe + confirm an email endpoint for delivery.
- Dictionary → `2026-07-02.05`; 7 new tests; tracker_mutation suite 315/315.

Per the amended ENC-PLN-061: halts at gamma deploy-success; ACs stamped after v3-prod UAT (Ph8).

CCI-2fe2ae9aad8f45d9b769bd6be9bbdf80

🤖 Generated with [Claude Code](https://claude.com/claude-code)