### PR TITLE
ENC-TSK-J80: backport FTR-121 escalation CFN surface to v3-prod (routes + env + IAM)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -182,6 +182,9 @@ Resources:
           CORS_ORIGIN: !Ref CorsOrigin
           ENCELADUS_MCP_INTERFACE_MODE: code
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
+          # ENC-TSK-J80 / ENC-FTR-121 Ph3 backport: applyEscalatedMutation lives in
+          # tracker_mutation; the Cognito approval flow invokes it directly.
+          TRACKER_MUTATION_LAMBDA_NAME: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
           # ENC-TSK-I37 / ENC-FTR-117: Agent ID v3 identity stores (server-side allocator path)
           AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
@@ -233,6 +236,9 @@ Resources:
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          # ENC-TSK-J80 / ENC-FTR-121 Ph5 backport: io's [ESCALATION] email rides
+          # the existing feed-alerts topic (DOC-5B888FCA43B8 §5.8; empty = skip).
+          ESCALATION_ALERTS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
@@ -1610,6 +1616,17 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              # ENC-TSK-J80 / ENC-FTR-121 Ph3 backport: the Cognito-gated escalation
+              # approval flow drives applyEscalatedMutation in tracker_mutation via
+              # direct Lambda invoke — the only reachable entry to the single
+              # privileged apply path (DOC-5B888FCA43B8 §6).
+              - Sid: InvokeTrackerMutationEscalationApply
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}:*"
               - Sid: ProjectsTableRead
                 Effect: Allow
                 Action:
@@ -1814,6 +1831,18 @@ Resources:
                   - appconfig:GetLatestConfiguration
                   - appconfig:StartConfigurationSession
                 Resource: "*"
+        # ENC-TSK-J80 / ENC-FTR-121 Ph5 backport: escalation notifications to io
+        # ride the existing feed-alerts topic (DOC-5B888FCA43B8 §5.8).
+        - PolicyName: escalation-alerts-publish
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: PublishEscalationAlerts
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
 
   DocumentApiRole:
     Type: AWS::IAM::Role

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -2221,6 +2221,52 @@ Resources:
       RouteKey: "PUT /api/v1/governance/{fileName+}"
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-J80 / ENC-FTR-121: Escalations approval surface backport to v3-prod
+  # (DOC-5B888FCA43B8, io-consented under DOC-B716E8FB10B6). Clean ADDs — no
+  # escalation routes exist on the prod gateway. GET feed + Cognito-gated
+  # approve/deny + agent watch polling on coordination_api; the tracker apply
+  # route is the HTTP lane to applyEscalatedMutation (idempotent; actionable
+  # only while an escalation is io-approved and unapplied).
+  RouteEscalationsFeed:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/escalations"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteEscalationsWatch:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/escalations/watch"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteEscalationsApprove:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteEscalationsDeny:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteTrackerEscalationApply:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsProduction
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply"
+      Target: !Sub integrations/${TrackerMutationIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint


### PR DESCRIPTION
## Summary
Pure-ADD backport of the FTR-121 escalations approval surface (DOC-5B888FCA43B8) from v4/main to main, io-consented under DOC-B716E8FB10B6 Channel A. Merge creates PAUSED plan/apply change-set requests on the api and compute stacks (ENC-FTR-120); io's v3-prod Environment approvals execute them.

- **03-api.yaml**: 5 `Condition: IsProduction` routes — escalations feed/watch/approve/deny → CoordinationApiIntegration; tracker `{recordType}/{recordId}/apply` → TrackerMutationIntegration
- **02-compute.yaml**: `TRACKER_MUTATION_LAMBDA_NAME` env + `InvokeTrackerMutationEscalationApply` grant on CoordinationApi{Function,Role}; `ESCALATION_ALERTS_TOPIC_ARN` env + `escalation-alerts-publish` sns:Publish policy on TrackerMutation{Function,Role}

## Validation
- pre-deploy-health-gate.sh **7/7 PASS on both stacks** from a clean origin/main worktree (@d2f5112)
- Drift audit from this branch: `live_only=[]`, `cfn_only` = exactly the 5 intended routes (pure-ADD manifest; PLN-047 condition proven). Check 7 pure-ADD false-fail filed as ENC-ISS-467
- Backend code already promoted to v3-prod (ENC-TSK-J81, run 28569244521) — routes land on live handlers
- Dict gate not triggered (CFN-only paths)

## Tracker
ENC-TSK-J80 (ENC-FTR-121 Ph7a / ENC-PLN-061)

CCI-a411734788a74005bbb0d575d486598f

🤖 Generated with [Claude Code](https://claude.com/claude-code)