### PR TITLE
ENC-TSK-J86: codify ENABLE_LESSON_PRIMITIVE on TrackerMutationFunction (v3-prod)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -239,6 +239,10 @@ Resources:
           # ENC-TSK-J80 / ENC-FTR-121 Ph5 backport: io's [ESCALATION] email rides
           # the existing feed-alerts topic (DOC-5B888FCA43B8 §5.8; empty = skip).
           ESCALATION_ALERTS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
+          # ENC-TSK-J86 / ENC-LSN-053: codify the flag's env_fallback so compute deploys
+          # stop stripping it out-of-band. appconfig_flags resolves AppConfig-first with
+          # default=False, so this fallback is load-bearing whenever AppConfig is unreachable.
+          ENABLE_LESSON_PRIMITIVE: "true"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]


### PR DESCRIPTION
## Summary
Caught during ENC-TSK-J80's pre-approval change-set review: the compute apply would strip the live-only `ENABLE_LESSON_PRIMITIVE=true` fallback from `devops-tracker-mutation-api` — the recurring ENC-LSN-053 strip class. AppConfig carries `enable_lesson_primitive: true` (deployment COMPLETE, extension layer attached), but `appconfig_flags.flag()` has `default=False`, so the env fallback is load-bearing during any AppConfig unavailability.

One line (+comment): codify the var on `TrackerMutationFunction` in `02-compute.yaml`, mirroring the F63 pattern on `EnceladusMcpCodeGammaFunction`. Ends the manual OOB restore dance.

## Validation
- Template YAML-parses
- Template-vs-live env key diff: **live-only (would-be-stripped) = NONE** on both `devops-coordination-api` and `devops-tracker-mutation-api`
- Stale strip-bearing run 28572125111 / change-set `ba692de0` cancelled
- Merge fires a fresh FTR-120 compute plan/apply carrying this + the ENC-TSK-J80 escalation deltas in one reviewed change-set

## Tracker
ENC-TSK-J86 (rider on ENC-TSK-J80 / ENC-FTR-121 Ph7a; registry-gap follow-up noted on ENC-ISS-467)

CCI-503de1328fb642c5be2ddbdb905bf6f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)