### PR TITLE
ENC-TSK-J87: codify ENABLE_LESSON_PRIMITIVE on TrackerMutationFunction (gamma twin of J86)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -273,6 +273,11 @@ Resources:
           # ENC-TSK-J72 / ENC-FTR-121 Ph5: io's [ESCALATION] email rides the existing
           # feed-alerts topic (§5.8 topic reuse; sub-dollar budget). Empty = publish skipped.
           ESCALATION_ALERTS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
+          # ENC-TSK-J87 (gamma twin of ENC-TSK-J86 / ENC-LSN-053): codify the flag's
+          # env_fallback so compute deploys stop stripping it out-of-band. appconfig_flags
+          # resolves AppConfig-first with default=False, so this fallback is load-bearing
+          # whenever AppConfig is unreachable.
+          ENABLE_LESSON_PRIMITIVE: "true"
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary
Gamma twin of ENC-TSK-J86 (main [PR #731](https://github.com/NX-2021-L/enceladus/pull/731)): `devops-tracker-mutation-api-gamma` already lost the `ENABLE_LESSON_PRIMITIVE` env fallback to a prior compute deploy (ENC-LSN-053 class). Gamma lessons currently work only because gamma AppConfig (`fhhcl7m`) carries `enable_lesson_primitive: true`; `appconfig_flags` `default=False` makes the env fallback load-bearing during AppConfig unavailability. One line (+comment) codifies it on `TrackerMutationFunction` in v4/main's `02-compute.yaml`.

## Validation
- Template YAML-parses
- Pre-merge gamma strip check: **live-only = NONE** on both `devops-coordination-api-gamma` and `devops-tracker-mutation-api-gamma`; only template-new = the intended var
- Merge auto-fires the gamma compute CFN deploy (ungated); expected change-set: TrackerMutationFunction env Modify + Dynamic GetAtt ripples only

## Tracker
ENC-TSK-J87 (related: ENC-TSK-J86, ENC-ISS-467, ENC-PLN-061)

CCI-b1f65d6cc03c4593ae60a704ff732317

🤖 Generated with [Claude Code](https://claude.com/claude-code)