### PR TITLE
ENC-TSK-J53: FTR-096 Ph3 — Lesson-candidate curation PWA

### DIFF
--- a/frontend/ui/src/api/lessonCandidates.ts
+++ b/frontend/ui/src/api/lessonCandidates.ts
@@ -1,0 +1,90 @@
+import type { Document } from '../types/feeds'
+import { fetchWithAuth } from './client'
+
+// ENC-TSK-J53 / ENC-FTR-096 Ph3: io-gated lesson-candidate curation queue.
+// List via document_api filters (J46); approve/reject via coordination_api (Cognito only).
+
+const DOCUMENTS_BASE = '/api/v1/documents'
+const COORDINATION_BASE = '/api/v1/coordination'
+
+export interface LessonCandidate extends Document {
+  handoff_status?: string
+  description?: string
+}
+
+export interface LessonCandidateApproveBody {
+  title: string
+  observation: string
+  insight: string
+  provenance?: string
+}
+
+export interface LessonCandidateApproveResponse {
+  success: boolean
+  document_id: string
+  lesson_id: string
+  handoff_status: string
+}
+
+export interface LessonCandidateRejectResponse {
+  success: boolean
+  document_id: string
+  handoff_status: string
+}
+
+export const lessonCandidateKeys = {
+  pending: (projectId: string) => ['lesson-candidates', 'pending', projectId] as const,
+}
+
+export async function fetchPendingLessonCandidates(
+  projectId = 'enceladus',
+): Promise<LessonCandidate[]> {
+  const qs = new URLSearchParams({
+    project: projectId,
+    document_subtype: 'lesson-candidate',
+    handoff_status: 'pending',
+    sort: 'created_at',
+  })
+  const res = await fetchWithAuth(`${DOCUMENTS_BASE}?${qs.toString()}`)
+  if (!res.ok) throw new Error(`Failed to fetch lesson candidates: ${res.status}`)
+  const data = await res.json()
+  return data.documents ?? []
+}
+
+export async function approveLessonCandidate(
+  documentId: string,
+  body: LessonCandidateApproveBody,
+): Promise<LessonCandidateApproveResponse> {
+  const res = await fetchWithAuth(
+    `${COORDINATION_BASE}/lesson-candidates/${encodeURIComponent(documentId)}/approve`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  )
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.error || err.message || `Approve failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function rejectLessonCandidate(
+  documentId: string,
+  rejectionReason: string,
+): Promise<LessonCandidateRejectResponse> {
+  const res = await fetchWithAuth(
+    `${COORDINATION_BASE}/lesson-candidates/${encodeURIComponent(documentId)}/reject`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rejection_reason: rejectionReason }),
+    },
+  )
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.error || err.message || `Reject failed: ${res.status}`)
+  }
+  return res.json()
+}

--- a/frontend/ui/src/components/layout/Header.tsx
+++ b/frontend/ui/src/components/layout/Header.tsx
@@ -18,6 +18,7 @@ const TITLES: Record<string, string> = {
   '/components': 'Component Registry',
   '/deployments': 'Deployment Manager',
   '/escalations': 'Escalations',
+  '/lesson-candidates': 'Lesson Candidates',
 }
 
 function resolveTitle(pathname: string): string {
@@ -173,6 +174,15 @@ export function Header() {
                 className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
               >
                 Escalations
+              </button>
+              <button
+                onClick={() => {
+                  setMenuOpen(false)
+                  navigate('/lesson-candidates')
+                }}
+                className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
+              >
+                Lesson Candidates
               </button>
               <button
                 onClick={() => {

--- a/frontend/ui/src/lib/routes.tsx
+++ b/frontend/ui/src/lib/routes.tsx
@@ -81,6 +81,11 @@ const DeploymentManagerPage = lazy(() =>
 const EscalationsPage = lazy(() =>
   import('../pages/EscalationsPage').then((module) => ({ default: module.EscalationsPage })),
 )
+const LessonCandidatesPage = lazy(() =>
+  import('../pages/LessonCandidatesPage').then((module) => ({
+    default: module.LessonCandidatesPage,
+  })),
+)
 
 function withSuspense(element: ReactNode) {
   return <Suspense fallback={<LoadingState />}>{element}</Suspense>
@@ -127,6 +132,7 @@ export const router = createBrowserRouter(
         { path: '/components', element: withSuspense(<ComponentRegistryPage />) },
         { path: '/deployments', element: withSuspense(<DeploymentManagerPage />) },
         { path: '/escalations', element: withSuspense(<EscalationsPage />) },
+        { path: '/lesson-candidates', element: withSuspense(<LessonCandidatesPage />) },
         { path: '/coordination', element: withSuspense(<CoordinationPage />) },
         { path: '/coordination/auth', element: withSuspense(<AuthTokensPage />) },
         {

--- a/frontend/ui/src/pages/LessonCandidatesPage.test.tsx
+++ b/frontend/ui/src/pages/LessonCandidatesPage.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * LessonCandidatesPage tests — ENC-TSK-J53 / ENC-FTR-096 Ph3.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LessonCandidate } from '../api/lessonCandidates'
+
+const { mockFetchPending, mockApprove, mockReject } = vi.hoisted(() => ({
+  mockFetchPending: vi.fn(),
+  mockApprove: vi.fn(),
+  mockReject: vi.fn(),
+}))
+
+vi.mock('../api/lessonCandidates', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/lessonCandidates')>()
+  return {
+    ...original,
+    fetchPendingLessonCandidates: mockFetchPending,
+    approveLessonCandidate: mockApprove,
+    rejectLessonCandidate: mockReject,
+  }
+})
+
+import { LessonCandidatesPage } from './LessonCandidatesPage'
+
+function candidate(overrides: Partial<LessonCandidate> = {}): LessonCandidate {
+  return {
+    document_id: 'DOC-CAND-001',
+    project_id: 'enceladus',
+    title: 'LESSON-CANDIDATE — recurring cluster',
+    description: 'Auto-drafted lesson candidate pending io review.',
+    file_name: 'doc.md',
+    content_type: 'text/markdown',
+    content_hash: 'abc',
+    size_bytes: 100,
+    keywords: ['lesson-candidate'],
+    related_items: ['DOC-HANDOFF-001'],
+    status: 'active',
+    created_by: 'system',
+    created_at: '2026-07-02T06:00:00Z',
+    updated_at: '2026-07-02T06:00:00Z',
+    version: 1,
+    handoff_status: 'pending',
+    cluster_member_ids: ['ENC-TSK-A01', 'ENC-TSK-B02'],
+    ...overrides,
+  } as LessonCandidate
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  )
+  return render(<LessonCandidatesPage />, { wrapper })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetchPending.mockResolvedValue([candidate()])
+  mockApprove.mockResolvedValue({
+    success: true,
+    document_id: 'DOC-CAND-001',
+    lesson_id: 'ENC-LSN-999',
+    handoff_status: 'completed',
+  })
+  mockReject.mockResolvedValue({
+    success: true,
+    document_id: 'DOC-CAND-001',
+    handoff_status: 'stale',
+  })
+})
+
+describe('LessonCandidatesPage', () => {
+  it('renders pending candidates with control-cluster approve/reject', async () => {
+    renderPage()
+    const card = await screen.findByTestId('candidate-card-DOC-CAND-001')
+    expect(within(card).getByText('DOC-CAND-001')).toBeInTheDocument()
+    expect(within(card).getByTestId('control-cluster')).toBeInTheDocument()
+    expect(within(card).getByRole('button', { name: /approve/i })).toBeInTheDocument()
+    expect(within(card).getByRole('button', { name: /^reject$/i })).toBeInTheDocument()
+  })
+
+  it('calls approve API with edited fields', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const card = await screen.findByTestId('candidate-card-DOC-CAND-001')
+    await user.click(within(card).getByRole('button', { name: /approve/i }))
+    expect(mockApprove).toHaveBeenCalledWith('DOC-CAND-001', {
+      title: 'LESSON-CANDIDATE — recurring cluster',
+      observation: 'Auto-drafted lesson candidate pending io review.',
+      insight: expect.stringContaining('ENC-TSK-A01'),
+      provenance: 'human',
+    })
+  })
+
+  it('calls reject API after reason entry', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const card = await screen.findByTestId('candidate-card-DOC-CAND-001')
+    await user.click(within(card).getByRole('button', { name: /^reject$/i }))
+    await user.type(
+      within(card).getByRole('textbox', { name: /rejection reason/i }),
+      'Not actionable pattern for gamma.',
+    )
+    await user.click(within(card).getByRole('button', { name: /confirm reject/i }))
+    expect(mockReject).toHaveBeenCalledWith(
+      'DOC-CAND-001',
+      'Not actionable pattern for gamma.',
+    )
+  })
+
+  it('shows empty state when no pending candidates', async () => {
+    mockFetchPending.mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByText(/no pending lesson candidates/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/ui/src/pages/LessonCandidatesPage.tsx
+++ b/frontend/ui/src/pages/LessonCandidatesPage.tsx
@@ -1,0 +1,269 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  approveLessonCandidate,
+  fetchPendingLessonCandidates,
+  lessonCandidateKeys,
+  rejectLessonCandidate,
+  type LessonCandidate,
+} from '../api/lessonCandidates'
+import { LoadingState } from '../components/shared/LoadingState'
+import { ErrorState } from '../components/shared/ErrorState'
+import { EmptyState } from '../components/shared/EmptyState'
+
+// ENC-TSK-J53 / ENC-FTR-096 Ph3: Lesson-candidate curation queue (FTR-038 control-cluster).
+
+const PROJECT_ID = 'enceladus'
+
+function defaultObservation(candidate: LessonCandidate): string {
+  return (
+    candidate.description?.trim() ||
+    `Lesson candidate ${candidate.document_id} drafted by memory consolidation (pending io review).`
+  )
+}
+
+function defaultInsight(candidate: LessonCandidate): string {
+  const members = (candidate as { cluster_member_ids?: string[] }).cluster_member_ids
+  if (members?.length) {
+    return `Recurring co-citation cluster across handoffs suggests a transferable pattern involving ${members.join(', ')}.`
+  }
+  return 'Promote this auto-drafted candidate into governed semantic memory after io review.'
+}
+
+function CandidateCard({
+  candidate,
+  onApprove,
+  onReject,
+  busyId,
+}: {
+  candidate: LessonCandidate
+  onApprove: (id: string, title: string, observation: string, insight: string) => void
+  onReject: (id: string, reason: string) => void
+  busyId: string | null
+}) {
+  const [title, setTitle] = useState(candidate.title ?? '')
+  const [observation, setObservation] = useState(() => defaultObservation(candidate))
+  const [insight, setInsight] = useState(() => defaultInsight(candidate))
+  const [showReject, setShowReject] = useState(false)
+  const [rejectReason, setRejectReason] = useState('')
+  const busy = busyId === candidate.document_id
+
+  return (
+    <div
+      className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3"
+      data-testid={`candidate-card-${candidate.document_id}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          to={`/documents/${candidate.document_id}`}
+          className="font-mono text-sm text-sky-300 hover:text-sky-200"
+        >
+          {candidate.document_id}
+        </Link>
+        <span className="text-xs text-amber-300 bg-amber-500/10 px-2 py-0.5 rounded">
+          pending
+        </span>
+      </div>
+
+      <div className="space-y-2 text-sm">
+        <label className="block text-xs text-slate-400">Title</label>
+        <input
+          className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-100"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          disabled={busy}
+        />
+        <label className="block text-xs text-slate-400">Observation</label>
+        <textarea
+          className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-100 min-h-[72px]"
+          value={observation}
+          onChange={(e) => setObservation(e.target.value)}
+          disabled={busy}
+        />
+        <label className="block text-xs text-slate-400">Insight</label>
+        <textarea
+          className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-100 min-h-[72px]"
+          value={insight}
+          onChange={(e) => setInsight(e.target.value)}
+          disabled={busy}
+        />
+      </div>
+
+      {showReject ? (
+        <div className="space-y-2 border-t border-slate-700 pt-3">
+          <label htmlFor={`reject-${candidate.document_id}`} className="block text-xs text-slate-400">
+            Rejection reason (min 10 chars)
+          </label>
+          <textarea
+            id={`reject-${candidate.document_id}`}
+            aria-label="Rejection reason"
+            className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-100 min-h-[60px]"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            disabled={busy}
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={busy || rejectReason.trim().length < 10}
+              onClick={() => onReject(candidate.document_id, rejectReason.trim())}
+              className="px-3 py-1.5 rounded text-sm bg-rose-600 hover:bg-rose-500 disabled:opacity-50 text-white"
+            >
+              Confirm reject
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setShowReject(false)}
+              className="px-3 py-1.5 rounded text-sm bg-slate-700 hover:bg-slate-600 text-slate-200"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2 pt-1" data-testid="control-cluster">
+          <button
+            type="button"
+            disabled={busy || !title.trim() || !observation.trim() || !insight.trim()}
+            onClick={() => onApprove(candidate.document_id, title.trim(), observation.trim(), insight.trim())}
+            className="px-3 py-1.5 rounded text-sm bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white"
+          >
+            Approve → Lesson
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setShowReject(true)}
+            className="px-3 py-1.5 rounded text-sm bg-slate-700 hover:bg-slate-600 text-slate-200"
+          >
+            Reject
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function LessonCandidatesPage() {
+  const queryClient = useQueryClient()
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const { data: candidates = [], isLoading, isError, refetch } = useQuery({
+    queryKey: lessonCandidateKeys.pending(PROJECT_ID),
+    queryFn: () => fetchPendingLessonCandidates(PROJECT_ID),
+  })
+
+  const approveMutation = useMutation({
+    mutationFn: ({
+      documentId,
+      title,
+      observation,
+      insight,
+    }: {
+      documentId: string
+      title: string
+      observation: string
+      insight: string
+    }) =>
+      approveLessonCandidate(documentId, {
+        title,
+        observation,
+        insight,
+        provenance: 'human',
+      }),
+    onMutate: async ({ documentId }) => {
+      setBusyId(documentId)
+      setActionError(null)
+      await queryClient.cancelQueries({ queryKey: lessonCandidateKeys.pending(PROJECT_ID) })
+      const previous = queryClient.getQueryData<LessonCandidate[]>(
+        lessonCandidateKeys.pending(PROJECT_ID),
+      )
+      queryClient.setQueryData<LessonCandidate[]>(
+        lessonCandidateKeys.pending(PROJECT_ID),
+        (old = []) => old.filter((c) => c.document_id !== documentId),
+      )
+      return { previous }
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(lessonCandidateKeys.pending(PROJECT_ID), context.previous)
+      }
+      setActionError(err instanceof Error ? err.message : 'Approve failed')
+    },
+    onSettled: () => {
+      setBusyId(null)
+      void queryClient.invalidateQueries({ queryKey: lessonCandidateKeys.pending(PROJECT_ID) })
+    },
+  })
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ documentId, reason }: { documentId: string; reason: string }) =>
+      rejectLessonCandidate(documentId, reason),
+    onMutate: async ({ documentId }) => {
+      setBusyId(documentId)
+      setActionError(null)
+      await queryClient.cancelQueries({ queryKey: lessonCandidateKeys.pending(PROJECT_ID) })
+      const previous = queryClient.getQueryData<LessonCandidate[]>(
+        lessonCandidateKeys.pending(PROJECT_ID),
+      )
+      queryClient.setQueryData<LessonCandidate[]>(
+        lessonCandidateKeys.pending(PROJECT_ID),
+        (old = []) => old.filter((c) => c.document_id !== documentId),
+      )
+      return { previous }
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(lessonCandidateKeys.pending(PROJECT_ID), context.previous)
+      }
+      setActionError(err instanceof Error ? err.message : 'Reject failed')
+    },
+    onSettled: () => {
+      setBusyId(null)
+      void queryClient.invalidateQueries({ queryKey: lessonCandidateKeys.pending(PROJECT_ID) })
+    },
+  })
+
+  if (isLoading) return <LoadingState />
+  if (isError) return <ErrorState message="Failed to load lesson candidates." onRetry={refetch} />
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-lg font-semibold text-slate-100">Lesson Candidates</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          Approve or reject memory-consolidation drafts (ENC-FTR-096). Cognito session required.
+        </p>
+      </div>
+
+      {actionError && (
+        <div className="text-sm text-rose-300 bg-rose-900/20 border border-rose-500/30 rounded px-3 py-2">
+          {actionError}
+        </div>
+      )}
+
+      {candidates.length === 0 ? (
+        <EmptyState message="No pending lesson candidates." />
+      ) : (
+        <div className="space-y-4">
+          {candidates.map((candidate) => (
+            <CandidateCard
+              key={candidate.document_id}
+              candidate={candidate}
+              busyId={busyId}
+              onApprove={(documentId, title, observation, insight) =>
+                approveMutation.mutate({ documentId, title, observation, insight })
+              }
+              onReject={(documentId, reason) =>
+                rejectMutation.mutate({ documentId, reason })
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
CCI-9f9c489bdb6043d4896bf5b2f231fe9b

## Summary
- Adds `/lesson-candidates` PWA view listing pending `lesson-candidate` documents
- Approve/reject wired to J46 coordination endpoints with Cognito-gated mutations
- FTR-038 control-cluster UX with optimistic list updates and rollback on error
- Route + header menu entry; unit tests for queue rendering and actions

## Test plan
- [x] `vitest run src/pages/LessonCandidatesPage.test.tsx`
- [ ] Gamma UI deploy + E2E: seed candidate → approve → LSN provenance link