### PR TITLE
ENC-TSK-J82: backport PWA Escalations page to main (FTR-121 Ph7c)

### DIFF
--- a/frontend/ui/src/api/escalations.ts
+++ b/frontend/ui/src/api/escalations.ts
@@ -1,0 +1,121 @@
+import { fetchWithAuth } from './client'
+
+// ENC-FTR-121 Ph3 (ENC-TSK-J70): io's escalation approval queue
+// (DOC-5B888FCA43B8 §5.7). All calls ride the Cognito session cookie —
+// the backend structurally rejects non-human credentials.
+
+export interface EscalationDiff {
+  mutation_type: string
+  target_record_id?: string
+  target_missing?: boolean
+  field?: string
+  current?: unknown
+  requested?: unknown
+  field_values?: Record<string, { current: unknown; requested: unknown }>
+  target_snapshot?: {
+    title?: string
+    status?: string
+    transition_type?: string
+    checkout_state?: string
+    sync_version?: number | string
+    updated_at?: string
+  }
+  drift?: {
+    expected_version: string
+    current_sync_version: string
+    current_updated_at: string
+    detected: boolean
+  }
+}
+
+export interface EscalationItem {
+  item_id: string
+  project_id: string
+  status: string
+  mutation_type: string
+  target_record_id: string
+  justification: string
+  payload: Record<string, unknown>
+  requested_by?: { session_id?: string; agent_type_id?: string }
+  approved_by?: { sub?: string; email?: string }
+  guidance_note?: string
+  created_at: string
+  updated_at: string
+  applied_at?: string
+  diff?: EscalationDiff
+}
+
+export interface EscalationsFeedResponse {
+  success: boolean
+  project_id: string
+  pending: EscalationItem[]
+  terminal: EscalationItem[]
+  count: number
+}
+
+export interface EscalationDecisionResponse {
+  success: boolean
+  escalation_id: string
+  status: string
+  applied?: boolean
+  approved_by?: string
+  denied_by?: string
+  guidance_note?: string
+  apply_error?: string
+  retry?: string
+}
+
+export const escalationKeys = {
+  feed: (projectId: string) => ['escalations', 'feed', projectId] as const,
+}
+
+export async function fetchEscalations(
+  projectId = 'enceladus',
+): Promise<EscalationsFeedResponse> {
+  const res = await fetchWithAuth(
+    `/api/v1/coordination/escalations?project_id=${encodeURIComponent(projectId)}`,
+  )
+  if (!res.ok) throw new Error(`Failed to fetch escalations: ${res.status}`)
+  return res.json()
+}
+
+async function postDecision(
+  projectId: string,
+  escalationId: string,
+  decision: 'approve' | 'deny',
+  body?: Record<string, unknown>,
+): Promise<EscalationDecisionResponse> {
+  const res = await fetchWithAuth(
+    `/api/v1/coordination/escalations/${encodeURIComponent(projectId)}/${encodeURIComponent(escalationId)}/${decision}`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    },
+  )
+  const payload = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error(payload?.error || `Escalation ${decision} failed: ${res.status}`)
+  }
+  return payload
+}
+
+export function approveEscalation(
+  projectId: string,
+  escalationId: string,
+): Promise<EscalationDecisionResponse> {
+  return postDecision(projectId, escalationId, 'approve')
+}
+
+export function denyEscalation(
+  projectId: string,
+  escalationId: string,
+  guidanceNote?: string,
+): Promise<EscalationDecisionResponse> {
+  return postDecision(
+    projectId,
+    escalationId,
+    'deny',
+    guidanceNote ? { guidance_note: guidanceNote } : {},
+  )
+}

--- a/frontend/ui/src/components/layout/Header.tsx
+++ b/frontend/ui/src/components/layout/Header.tsx
@@ -17,6 +17,7 @@ const TITLES: Record<string, string> = {
   '/coordination/auth': 'Access Tokens',
   '/components': 'Component Registry',
   '/deployments': 'Deployment Manager',
+  '/escalations': 'Escalations',
 }
 
 function resolveTitle(pathname: string): string {
@@ -163,6 +164,15 @@ export function Header() {
                 className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
               >
                 Coordination Monitor
+              </button>
+              <button
+                onClick={() => {
+                  setMenuOpen(false)
+                  navigate('/escalations')
+                }}
+                className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700 active:bg-slate-600 transition-colors"
+              >
+                Escalations
               </button>
               <button
                 onClick={() => {

--- a/frontend/ui/src/lib/routes.tsx
+++ b/frontend/ui/src/lib/routes.tsx
@@ -78,6 +78,9 @@ const DeploymentManagerPage = lazy(() =>
     default: module.DeploymentManagerPage,
   })),
 )
+const EscalationsPage = lazy(() =>
+  import('../pages/EscalationsPage').then((module) => ({ default: module.EscalationsPage })),
+)
 
 function withSuspense(element: ReactNode) {
   return <Suspense fallback={<LoadingState />}>{element}</Suspense>
@@ -123,6 +126,7 @@ export const router = createBrowserRouter(
         { path: '/terminal/manage', element: withSuspense(<TerminalManagePage />) },
         { path: '/components', element: withSuspense(<ComponentRegistryPage />) },
         { path: '/deployments', element: withSuspense(<DeploymentManagerPage />) },
+        { path: '/escalations', element: withSuspense(<EscalationsPage />) },
         { path: '/coordination', element: withSuspense(<CoordinationPage />) },
         { path: '/coordination/auth', element: withSuspense(<AuthTokensPage />) },
         {

--- a/frontend/ui/src/pages/EscalationsPage.test.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * EscalationsPage tests — ENC-TSK-J70 / ENC-FTR-121 Ph3 (DOC-5B888FCA43B8 §5.7).
+ *
+ * Scope (AC-5, AC-7):
+ *   - Feed renders pending escalations newest-first with target id, mutation
+ *     type, requesting agent, justification, and the fresh diff.
+ *   - The drift warning renders prominently when diff.drift.detected.
+ *   - Approve / Deny / Deny-with-guidance wire to the API module.
+ *   - Terminal escalations render inside the collapsed History section.
+ *
+ * Mocks: the api/escalations module is stubbed at the import boundary so the
+ * page renders without the network; approval calls are asserted on the mock.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EscalationItem, EscalationsFeedResponse } from '../api/escalations'
+
+const { mockFetchEscalations, mockApprove, mockDeny } = vi.hoisted(() => ({
+  mockFetchEscalations: vi.fn(),
+  mockApprove: vi.fn(),
+  mockDeny: vi.fn(),
+}))
+
+vi.mock('../api/escalations', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/escalations')>()
+  return {
+    ...original,
+    fetchEscalations: mockFetchEscalations,
+    approveEscalation: mockApprove,
+    denyEscalation: mockDeny,
+  }
+})
+
+import { EscalationsPage } from './EscalationsPage'
+
+function pendingEscalation(overrides: Partial<EscalationItem> = {}): EscalationItem {
+  return {
+    item_id: 'ENC-ESC-001',
+    project_id: 'enceladus',
+    status: 'requested',
+    mutation_type: 'deploy_arc_change',
+    target_record_id: 'ENC-TSK-J10',
+    justification: 'Arc misclassified at create; no deployable artifact.',
+    payload: { new_deploy_arc_type: 'code_only' },
+    requested_by: { session_id: 'ENC-SES-02F' },
+    created_at: '2026-07-02T04:00:00Z',
+    updated_at: '2026-07-02T04:00:00Z',
+    diff: {
+      mutation_type: 'deploy_arc_change',
+      field: 'transition_type',
+      current: 'github_pr_deploy',
+      requested: 'code_only',
+      target_snapshot: {
+        title: 'Full CFN drift close-out',
+        status: 'in-progress',
+        transition_type: 'github_pr_deploy',
+        sync_version: 4,
+        updated_at: '2026-07-02T03:00:00Z',
+      },
+    },
+    ...overrides,
+  }
+}
+
+function feed(overrides: Partial<EscalationsFeedResponse> = {}): EscalationsFeedResponse {
+  return {
+    success: true,
+    project_id: 'enceladus',
+    pending: [pendingEscalation()],
+    terminal: [
+      pendingEscalation({
+        item_id: 'ENC-ESC-000',
+        status: 'denied_with_guidance',
+        guidance_note: 'Use a successor task instead.',
+        diff: undefined,
+      }),
+    ],
+    count: 2,
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return render(<EscalationsPage />, { wrapper })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetchEscalations.mockResolvedValue(feed())
+  mockApprove.mockResolvedValue({
+    success: true,
+    escalation_id: 'ENC-ESC-001',
+    status: 'applied',
+    applied: true,
+  })
+  mockDeny.mockResolvedValue({
+    success: true,
+    escalation_id: 'ENC-ESC-001',
+    status: 'denied',
+  })
+})
+
+describe('EscalationsPage', () => {
+  it('renders pending cards with target, mutation type, requester, justification, and diff', async () => {
+    renderPage()
+    const card = await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(within(card).getByText('ENC-TSK-J10')).toBeInTheDocument()
+    expect(within(card).getByText('deploy_arc_change')).toBeInTheDocument()
+    expect(within(card).getByText('ENC-SES-02F')).toBeInTheDocument()
+    expect(
+      within(card).getByText('Arc misclassified at create; no deployable artifact.'),
+    ).toBeInTheDocument()
+    const diff = within(card).getByTestId('escalation-diff')
+    expect(within(diff).getByText('github_pr_deploy')).toBeInTheDocument()
+    expect(within(diff).getByText('code_only')).toBeInTheDocument()
+  })
+
+  it('shows a prominent drift warning when expected_version mismatches', async () => {
+    mockFetchEscalations.mockResolvedValue(
+      feed({
+        pending: [
+          pendingEscalation({
+            diff: {
+              mutation_type: 'deploy_arc_change',
+              field: 'transition_type',
+              current: 'github_pr_deploy',
+              requested: 'code_only',
+              drift: {
+                expected_version: 'sync_version:3',
+                current_sync_version: '7',
+                current_updated_at: '2026-07-02T04:10:00Z',
+                detected: true,
+              },
+            },
+          }),
+        ],
+      }),
+    )
+    renderPage()
+    const warning = await screen.findByTestId('drift-warning')
+    expect(warning.textContent).toContain('drifted')
+    expect(warning.textContent).toContain('sync_version:3')
+  })
+
+  it('does not render a drift warning without drift', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(screen.queryByTestId('drift-warning')).toBeNull()
+  })
+
+  it('approve button calls approveEscalation with the escalation id', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(mockApprove).toHaveBeenCalledWith('enceladus', 'ENC-ESC-001')
+  })
+
+  it('deny button calls denyEscalation without a guidance note', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Deny' }))
+    expect(mockDeny).toHaveBeenCalledWith('enceladus', 'ENC-ESC-001', undefined)
+  })
+
+  it('deny-with-guidance sends the note', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Deny with guidance' }))
+    await userEvent.type(
+      screen.getByLabelText('Guidance note'),
+      'Open a successor task instead.',
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Send denial' }))
+    expect(mockDeny).toHaveBeenCalledWith(
+      'enceladus',
+      'ENC-ESC-001',
+      'Open a successor task instead.',
+    )
+  })
+
+  it('terminal escalations render in the collapsed History audit section', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    const history = screen.getByTestId('terminal-section')
+    expect(within(history).getByText('History (1)')).toBeInTheDocument()
+    expect(within(history).getByText('ENC-ESC-000')).toBeInTheDocument()
+    expect(within(history).getByText(/Use a successor task instead\./)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when nothing is pending', async () => {
+    mockFetchEscalations.mockResolvedValue(feed({ pending: [], terminal: [] }))
+    renderPage()
+    expect(await screen.findByText('No pending escalations.')).toBeInTheDocument()
+  })
+})

--- a/frontend/ui/src/pages/EscalationsPage.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  approveEscalation,
+  denyEscalation,
+  escalationKeys,
+  fetchEscalations,
+} from '../api/escalations'
+import type { EscalationDiff, EscalationItem } from '../api/escalations'
+import { LoadingState } from '../components/shared/LoadingState'
+import { ErrorState } from '../components/shared/ErrorState'
+import { EmptyState } from '../components/shared/EmptyState'
+
+// ENC-FTR-121 Ph3 (ENC-TSK-J70): io's Escalations approval queue
+// (DOC-5B888FCA43B8 §5.7). Pending cards render a FRESH current-vs-requested
+// diff (fetched at render time by the backend, never the cached request) with
+// a prominent drift warning when expected_version mismatches; io may still
+// approve (informed consent) or deny. Terminal escalations stay browsable in
+// a collapsed audit section.
+
+const PROJECT_ID = 'enceladus'
+
+const STATUS_COLORS: Record<string, string> = {
+  requested: 'bg-amber-500/20 text-amber-300',
+  approved: 'bg-sky-500/20 text-sky-300',
+  applying: 'bg-sky-500/20 text-sky-300',
+  applied: 'bg-emerald-500/20 text-emerald-300',
+  denied: 'bg-rose-500/20 text-rose-300',
+  denied_with_guidance: 'bg-rose-500/20 text-rose-300',
+  failed: 'bg-rose-600/30 text-rose-200',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[status] ?? 'bg-slate-600/40 text-slate-300'}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function DiffBlock({ diff }: { diff: EscalationDiff }) {
+  if (diff.target_missing) {
+    return <p className="text-sm text-rose-300">Target record no longer exists.</p>
+  }
+  return (
+    <div className="text-sm space-y-1" data-testid="escalation-diff">
+      <div className="flex items-center gap-2 font-mono">
+        <span className="text-slate-400">{diff.field}:</span>
+        <span className="text-rose-300 line-through">{String(diff.current ?? '—')}</span>
+        <span className="text-slate-500">→</span>
+        <span className="text-emerald-300">{String(diff.requested ?? '—')}</span>
+      </div>
+      {diff.field_values &&
+        Object.entries(diff.field_values).map(([field, delta]) => (
+          <div key={field} className="flex items-center gap-2 font-mono text-xs">
+            <span className="text-slate-400">{field}:</span>
+            <span className="text-rose-300 line-through">
+              {JSON.stringify(delta.current ?? null)}
+            </span>
+            <span className="text-slate-500">→</span>
+            <span className="text-emerald-300">{JSON.stringify(delta.requested)}</span>
+          </div>
+        ))}
+      {diff.target_snapshot && (
+        <p className="text-xs text-slate-500">
+          Live target: status={diff.target_snapshot.status} · arc=
+          {diff.target_snapshot.transition_type} · sync_version=
+          {String(diff.target_snapshot.sync_version ?? '—')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function PendingCard({
+  escalation,
+  onApprove,
+  onDeny,
+  busy,
+}: {
+  escalation: EscalationItem
+  onApprove: (id: string) => void
+  onDeny: (id: string, guidanceNote?: string) => void
+  busy: boolean
+}) {
+  const [showGuidance, setShowGuidance] = useState(false)
+  const [guidanceNote, setGuidanceNote] = useState('')
+  const drift = escalation.diff?.drift
+
+  return (
+    <div
+      className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3"
+      data-testid={`escalation-card-${escalation.item_id}`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm text-slate-200">{escalation.item_id}</span>
+          <StatusBadge status={escalation.status} />
+        </div>
+        <span className="text-xs text-slate-500">{escalation.created_at}</span>
+      </div>
+
+      <div className="text-sm text-slate-300">
+        <span className="font-mono text-sky-300">{escalation.target_record_id}</span>
+        {escalation.diff?.target_snapshot?.title && (
+          <span className="text-slate-400"> — {escalation.diff.target_snapshot.title}</span>
+        )}
+      </div>
+
+      <div className="text-xs text-slate-400">
+        <span className="font-medium text-slate-300">{escalation.mutation_type}</span>
+        {' · requested by '}
+        <span className="font-mono">{escalation.requested_by?.session_id ?? 'unknown'}</span>
+      </div>
+
+      {drift?.detected && (
+        <div
+          className="bg-amber-500/10 border border-amber-500/40 rounded px-3 py-2 text-xs text-amber-300"
+          data-testid="drift-warning"
+        >
+          ⚠ Target drifted since request: expected {drift.expected_version}, now
+          sync_version={drift.current_sync_version} (updated {drift.current_updated_at}).
+          Approving applies the cached mutation to the CURRENT record state.
+        </div>
+      )}
+
+      {escalation.diff && <DiffBlock diff={escalation.diff} />}
+
+      <p className="text-sm text-slate-300 bg-slate-900/60 rounded px-3 py-2">
+        {escalation.justification}
+      </p>
+
+      {showGuidance ? (
+        <div className="space-y-2">
+          <textarea
+            value={guidanceNote}
+            onChange={(e) => setGuidanceNote(e.target.value)}
+            placeholder="Guidance for the requesting agent…"
+            aria-label="Guidance note"
+            className="w-full bg-slate-900 border border-slate-700 rounded px-3 py-2 text-sm text-slate-200"
+            rows={2}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={() => onDeny(escalation.item_id, guidanceNote.trim() || undefined)}
+              disabled={busy}
+              className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
+            >
+              Send denial
+            </button>
+            <button
+              onClick={() => setShowGuidance(false)}
+              className="px-3 py-1.5 rounded bg-slate-700 text-sm text-slate-300"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <button
+            onClick={() => onApprove(escalation.item_id)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-emerald-600/80 hover:bg-emerald-600 text-sm text-white disabled:opacity-50"
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => onDeny(escalation.item_id)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
+          >
+            Deny
+          </button>
+          <button
+            onClick={() => setShowGuidance(true)}
+            disabled={busy}
+            className="px-3 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-sm text-slate-200"
+          >
+            Deny with guidance
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function EscalationsPage() {
+  const queryClient = useQueryClient()
+  const [actionError, setActionError] = useState('')
+  const [lastOutcome, setLastOutcome] = useState('')
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: escalationKeys.feed(PROJECT_ID),
+    queryFn: () => fetchEscalations(PROJECT_ID),
+    refetchInterval: 30_000,
+  })
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: escalationKeys.feed(PROJECT_ID) })
+
+  const approveMutation = useMutation({
+    mutationFn: (escalationId: string) => approveEscalation(PROJECT_ID, escalationId),
+    onSuccess: (result) => {
+      setActionError('')
+      setLastOutcome(
+        result.applied
+          ? `${result.escalation_id} approved and applied.`
+          : `${result.escalation_id} approved; apply pending${result.apply_error ? ` (${result.apply_error})` : ''}.`,
+      )
+      refresh()
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+
+  const denyMutation = useMutation({
+    mutationFn: ({ escalationId, guidanceNote }: { escalationId: string; guidanceNote?: string }) =>
+      denyEscalation(PROJECT_ID, escalationId, guidanceNote),
+    onSuccess: (result) => {
+      setActionError('')
+      setLastOutcome(`${result.escalation_id} ${result.status}.`)
+      refresh()
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+
+  if (isPending) return <LoadingState />
+  if (isError || !data) return <ErrorState />
+
+  const busy = approveMutation.isPending || denyMutation.isPending
+  const pending = data.pending ?? []
+  const terminal = data.terminal ?? []
+
+  return (
+    <div className="p-4 space-y-4">
+      <p className="text-xs text-slate-500">
+        Human-gated mutation overrides (ENC-FTR-121). Approval is non-delegable: decisions
+        here are the sole origin of override authorization.
+      </p>
+
+      {actionError && (
+        <div className="bg-rose-500/10 border border-rose-500/40 rounded px-3 py-2 text-sm text-rose-300">
+          {actionError}
+        </div>
+      )}
+      {lastOutcome && !actionError && (
+        <div className="bg-emerald-500/10 border border-emerald-500/40 rounded px-3 py-2 text-sm text-emerald-300">
+          {lastOutcome}
+        </div>
+      )}
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-300">
+          Pending ({pending.length})
+        </h2>
+        {pending.length === 0 ? (
+          <EmptyState message="No pending escalations." />
+        ) : (
+          pending.map((escalation) => (
+            <PendingCard
+              key={escalation.item_id}
+              escalation={escalation}
+              busy={busy}
+              onApprove={(id) => approveMutation.mutate(id)}
+              onDeny={(id, guidanceNote) => denyMutation.mutate({ escalationId: id, guidanceNote })}
+            />
+          ))
+        )}
+      </section>
+
+      <details className="group" data-testid="terminal-section">
+        <summary className="text-sm font-semibold text-slate-400 cursor-pointer select-none">
+          History ({terminal.length})
+        </summary>
+        <div className="mt-3 space-y-2">
+          {terminal.map((escalation) => (
+            <div
+              key={escalation.item_id}
+              className="bg-slate-800/60 border border-slate-700/60 rounded-lg px-4 py-3 text-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-slate-300">{escalation.item_id}</span>
+                  <StatusBadge status={escalation.status} />
+                </div>
+                <span className="text-xs text-slate-500">{escalation.updated_at}</span>
+              </div>
+              <p className="text-xs text-slate-400 mt-1">
+                {escalation.mutation_type} on{' '}
+                <span className="font-mono">{escalation.target_record_id}</span>
+                {escalation.approved_by?.email && ` · approved by ${escalation.approved_by.email}`}
+                {escalation.guidance_note && ` · guidance: ${escalation.guidance_note}`}
+              </p>
+            </div>
+          ))}
+        </div>
+      </details>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Surgical backport of the PWA Escalations surface from v4/main `a2459b6` ([PR #721](https://github.com/NX-2021-L/enceladus/pull/721)) to main — the last piece of the DOC-5B888FCA43B8 prod delivery, io-consented per DOC-B716E8FB10B6.

Exact cross-branch diff, +643 lines, 5 files:
- **New (byte-identical copies):** `api/escalations.ts`, `pages/EscalationsPage.tsx`, `pages/EscalationsPage.test.tsx`
- **Escalation-only hunks:** `lib/routes.tsx` (+4: lazy import + `/escalations` route), `components/layout/Header.tsx` (+10: TITLES entry + menu item)

Recon (3-agent workflow) verified zero non-escalation divergence in the shared files and all imports present on main (`fetchWithAuth`, shared `LoadingState/ErrorState/EmptyState` — identical cross-branch).

## Validation
- EscalationsPage tests: **8/8 pass**
- Full suite: 104/105 — the 1 failure is pre-existing on pristine main (`client.test.ts` fetchFeed cache-buster assertion, filed as ENC-ISS-468)
- Production build (`tsc -b && vite build`): **green**, `EscalationsPage-DQV_-Gu9.js` chunk emitted, buildspec-asserted DeploymentManagerPage chunk present

## Deploy
Merge fires `ui-backend-deploy`; its single job pauses on the **v3-prod Environment** before any step executes — io's approval is the trigger. Backend routes/Lambdas for the page are already live (ENC-TSK-J80/J81).

## Tracker
ENC-TSK-J82 (ENC-FTR-121 Ph7c / ENC-PLN-061)

CCI-d9eaca29739a40fa8870f0362011a4f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)