### PR TITLE
fix(ENC-TSK-J53): PWA gamma build TypeScript errors

### DIFF
--- a/frontend/ui/src/api/lessonCandidates.ts
+++ b/frontend/ui/src/api/lessonCandidates.ts
@@ -7,9 +7,8 @@ import { fetchWithAuth } from './client'
 const DOCUMENTS_BASE = '/api/v1/documents'
 const COORDINATION_BASE = '/api/v1/coordination'
 
-export interface LessonCandidate extends Document {
-  handoff_status?: string
-  description?: string
+export type LessonCandidate = Document & {
+  cluster_member_ids?: string[]
 }
 
 export interface LessonCandidateApproveBody {

--- a/frontend/ui/src/pages/LessonCandidatesPage.tsx
+++ b/frontend/ui/src/pages/LessonCandidatesPage.tsx
@@ -24,7 +24,7 @@ function defaultObservation(candidate: LessonCandidate): string {
 }
 
 function defaultInsight(candidate: LessonCandidate): string {
-  const members = (candidate as { cluster_member_ids?: string[] }).cluster_member_ids
+  const members = candidate.cluster_member_ids
   if (members?.length) {
     return `Recurring co-citation cluster across handoffs suggests a transferable pattern involving ${members.join(', ')}.`
   }
@@ -151,7 +151,7 @@ export function LessonCandidatesPage() {
   const [busyId, setBusyId] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
 
-  const { data: candidates = [], isLoading, isError, refetch } = useQuery({
+  const { data: candidates = [], isLoading, isError } = useQuery({
     queryKey: lessonCandidateKeys.pending(PROJECT_ID),
     queryFn: () => fetchPendingLessonCandidates(PROJECT_ID),
   })
@@ -228,7 +228,7 @@ export function LessonCandidatesPage() {
   })
 
   if (isLoading) return <LoadingState />
-  if (isError) return <ErrorState message="Failed to load lesson candidates." onRetry={refetch} />
+  if (isError) return <ErrorState message="Failed to load lesson candidates." />
 
   return (
     <div className="p-4 max-w-3xl mx-auto space-y-4">


### PR DESCRIPTION
CCI-4fe3fbac7c6d40448077e27238b610a8

## Summary
Hotfix for UI Gamma Deploy failure on #735 — fixes `tsc -b` errors in lesson-candidates module.

## Test plan
- [x] `npx tsc -b` in frontend/ui
- [x] `vitest run src/pages/LessonCandidatesPage.test.tsx`