### PR TITLE
feat(ENC-TSK-J03): flow-weighted PPR read path + flow_weight_entropy metric

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.05",
-  "updated_at": "2026-07-02T06:10:00Z",
-  "last_change_summary": "ENC-TSK-J72 (ENC-FTR-121 Ph5, DOC-5B888FCA43B8): SNS [ESCALATION] notifications to io. Publishes on requested (post-write) and terminal applied/failed; failure-isolated (never fails the escalation write); reuses devops-feed-alerts{suffix} via ESCALATION_ALERTS_TOPIC_ARN env + PublishEscalationAlerts role grant (02-compute.yaml, gamma lane; prod via Ph7a). Sub-dollar budget; email subscription confirmation is an io residual for Ph8.",
+  "version": "2026-07-02.06",
+  "updated_at": "2026-07-02T08:49:00Z",
+  "last_change_summary": "ENC-TSK-J03 (ENC-FTR-108 Ph3): graph_query_api.adjacency first-page enrichment adds nullable flow_weight_entropy + flow_weight_edge_count (Shannon entropy over live Neo4j flow_weight distribution for comp-percolation-monitor nightly CloudWatch publish). GDS_PPR_WEIGHT_PROPERTY env (default flow_weight) documents PPR read-path weight selection.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4888,6 +4888,14 @@
         "next_offset": {
           "type": "integer",
           "definition": "Response field: offset to pass on the next call when has_more is true; null otherwise."
+        },
+        "flow_weight_entropy": {
+          "type": "number",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03 / ENC-FTR-108 AC-5): normalized Shannon entropy [0,1] over the live flow_weight distribution across all project relationships. Null when enrichment fails or graph_query_api predates J03."
+        },
+        "flow_weight_edge_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03): count of relationships sampled for flow_weight_entropy. Companion to flow_weight_entropy."
         }
       }
     },

--- a/backend/lambda/graph_query_api/flow_weight_entropy.py
+++ b/backend/lambda/graph_query_api/flow_weight_entropy.py
@@ -1,0 +1,71 @@
+"""ENC-FTR-108 Ph3 (ENC-TSK-J03) — Shannon entropy over flow_weight distribution.
+
+Computed nightly from live Neo4j relationship properties; a decreasing trend
+indicates convergence toward usage geometry (FTR-108 AC-5).
+"""
+from __future__ import annotations
+
+import math
+from typing import Iterable, List, Sequence
+
+
+def shannon_entropy(weights: Sequence[float], *, bins: int = 0) -> float:
+    """Normalized Shannon entropy H in [0, 1] over non-negative weights.
+
+    When *bins* > 0, weights are histogram-binned first (stabilizes entropy
+  against near-duplicate floats). With bins=0 (default), treats each weight as
+    its own category after rounding to 6 decimal places.
+    """
+    if not weights:
+        return 0.0
+    vals = [max(0.0, float(w)) for w in weights]
+    total = sum(vals)
+    if total <= 0:
+        return 0.0
+
+    if bins and bins > 1:
+        lo, hi = min(vals), max(vals)
+        if hi <= lo:
+            return 0.0
+        width = (hi - lo) / bins
+        counts = [0] * bins
+        for v in vals:
+            idx = min(bins - 1, int((v - lo) / width))
+            counts[idx] += 1
+        probs = [c / len(vals) for c in counts if c > 0]
+    else:
+        rounded = [round(v, 6) for v in vals]
+        freq: dict[float, int] = {}
+        for v in rounded:
+            freq[v] = freq.get(v, 0) + 1
+        n = len(rounded)
+        probs = [c / n for c in freq.values()]
+
+    h = -sum(p * math.log(p) for p in probs if p > 0)
+    k = len(probs)
+    if k <= 1:
+        return 0.0
+    return h / math.log(k)
+
+
+def fetch_flow_weights_cypher() -> str:
+    """Cypher fragment returning one row per relationship flow_weight."""
+    return (
+        "MATCH (a)-[r]-(b) "
+        "WHERE a.project_id = $project_id AND b.project_id = $project_id "
+        "AND NOT 'Project' IN labels(a) AND NOT 'Project' IN labels(b) "
+        "AND coalesce(a.is_placeholder, false) = false "
+        "AND coalesce(b.is_placeholder, false) = false "
+        "AND a.record_id IS NOT NULL AND b.record_id IS NOT NULL "
+        "RETURN coalesce(r.flow_weight, 1.0) AS fw"
+    )
+
+
+def compute_from_session(session, project_id: str) -> dict:
+    """Query Neo4j and return {entropy, edge_count, sample_size}."""
+    rows = session.run(fetch_flow_weights_cypher(), project_id=project_id)
+    weights: List[float] = [float(r["fw"]) for r in rows]
+    return {
+        "flow_weight_entropy": shannon_entropy(weights),
+        "flow_weight_edge_count": len(weights),
+    }

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -213,6 +213,11 @@ _GDS_HARD_DISABLED = os.environ.get("GDS_HARD_DISABLED", "").strip().lower() in 
 _GDS_SESSION_MEMORY = os.environ.get("GDS_SESSION_MEMORY", "2GB").strip() or "2GB"
 _GDS_WEIGHT_PROPERTY = os.environ.get("GDS_WEIGHT_PROPERTY", "weight").strip() or "weight"
 _GDS_FLOW_WEIGHT_PROPERTY = "flow_weight"
+# ENC-TSK-J03: PPR/PageRank reads flow_weight (not static type weight) when set.
+_GDS_PPR_WEIGHT_PROPERTY = (
+    os.environ.get("GDS_PPR_WEIGHT_PROPERTY", _GDS_FLOW_WEIGHT_PROPERTY).strip()
+    or _GDS_FLOW_WEIGHT_PROPERTY
+)
 _GDS_PROJECTION_META_LABEL = "GdsProjectionMeta"
 try:
     _GDS_PROJECTION_MAX_AGE_S = int(os.environ.get("GDS_PROJECTION_MAX_AGE_S", "3600"))
@@ -1259,7 +1264,7 @@ def _hybrid_graph_ranks_gds(
                     $name,
                     src,
                     tgt,
-                    {{relationshipProperties: {{weight: {weight_case_sql}}}}},
+                    {{relationshipProperties: {{weight: {weight_case_sql}, {_GDS_FLOW_WEIGHT_PROPERTY}: coalesce(r.{_GDS_FLOW_WEIGHT_PROPERTY}, 1.0)}}}},
                     {{memory: '2GB'}}
                 ) AS g
                 RETURN g.graphName
@@ -1292,7 +1297,7 @@ def _hybrid_graph_ranks_gds(
                         sourceNodes: [$anchorId],
                         dampingFactor: $damping,
                         maxIterations: $maxIter,
-                        relationshipWeightProperty: 'weight'
+                        relationshipWeightProperty: $weightProp
                     }
                 )
                 YIELD nodeId, score
@@ -1304,6 +1309,7 @@ def _hybrid_graph_ranks_gds(
                 anchorId=anchor_rec["nodeId"],
                 damping=PPR_DAMPING_FACTOR,
                 maxIter=PPR_MAX_ITERATIONS,
+                weightProp=_GDS_PPR_WEIGHT_PROPERTY,
                 limit=top_n,
             )
             node_rows: List[tuple] = [(r.get("nodeId"), float(r.get("score") or 0.0)) for r in stream_result]
@@ -1379,7 +1385,8 @@ def _hybrid_graph_ranks_cypher_fallback(
         f"AND neighbor.project_id = $project_id "
         f"AND neighbor.record_id <> $rid "
         f"WITH neighbor, path, "
-        f"  reduce(s = 0.0, rel IN relationships(path) | s + {weight_case_sql}) "
+        f"  reduce(s = 0.0, rel IN relationships(path) | "
+        f"    s + ({weight_case_sql}) * coalesce(rel.{_GDS_FLOW_WEIGHT_PROPERTY}, 1.0)) "
         f"  * ({decay} ^ length(path)) AS path_score "
         f"WITH neighbor.record_id AS rid, sum(path_score) AS score "
         f"RETURN rid, score ORDER BY score DESC LIMIT $limit"
@@ -1490,7 +1497,7 @@ def _hybrid_graph_ranks_gds_warm(
                 anchorId=anchor_rec["nodeId"],
                 damping=PPR_DAMPING_FACTOR,
                 maxIter=PPR_MAX_ITERATIONS,
-                weightProp=_GDS_WEIGHT_PROPERTY,
+                weightProp=_GDS_PPR_WEIGHT_PROPERTY,
                 limit=top_n,
             )
             node_rows = [(r.get("nodeId"), float(r.get("score") or 0.0)) for r in stream_result]
@@ -1532,8 +1539,9 @@ def _refresh_standing_projection(driver, project_id: str) -> Dict[str, Any]:
     — never from the request path — so the FlightRuntimeException
     'already a job running' same-graph-name race (DOC-D4CB8048798B, Concurrency
     Hazards) cannot occur. Drops any prior projection of the same name, projects
-    the project's nodes/edges with BOTH a per-type 'weight' and a flow_weight=1.0
-    slot (ENC-FTR-101 AC-5), then stamps a GdsProjectionMeta marker carrying the
+    the project's nodes/edges with BOTH a per-type 'weight' and a flow_weight
+    property read from each relationship (ENC-TSK-J03 / FTR-108 Ph3), then stamps
+    a GdsProjectionMeta marker carrying the
     last-refresh epoch for staleness telemetry (AC-3). Never raises.
     """
     if _GDS_HARD_DISABLED:
@@ -1568,7 +1576,7 @@ def _refresh_standing_projection(driver, project_id: str) -> Dict[str, Any]:
                     $name,
                     src,
                     tgt,
-                    {{relationshipProperties: {{weight: {weight_case_sql}, {_GDS_FLOW_WEIGHT_PROPERTY}: 1.0}}}},
+                    {{relationshipProperties: {{weight: {weight_case_sql}, {_GDS_FLOW_WEIGHT_PROPERTY}: coalesce(r.{_GDS_FLOW_WEIGHT_PROPERTY}, 1.0)}}}},
                     {{memory: $memory}}
                 ) AS g
                 RETURN g.graphName AS graphName, g.nodeCount AS nodeCount, g.relationshipCount AS relationshipCount
@@ -2574,6 +2582,17 @@ def _query_adjacency(driver, project_id: str, params: Dict) -> Dict:
         result["node_count"] = node_count
         result["edge_count"] = edge_count
         result["spurious_attractor_rate"] = _recent_spurious_attractor_rate(project_id)
+        try:
+            import flow_weight_entropy as _fwe
+            with driver.session() as entropy_session:
+                entropy_info = _fwe.compute_from_session(entropy_session, project_id)
+            result.update(entropy_info)
+        except Exception:  # noqa: BLE001 — enrichment must never break adjacency reads
+            logger.warning(
+                "[WARNING] flow_weight_entropy enrichment failed project_id=%s",
+                project_id,
+                exc_info=True,
+            )
     return result
 # ---------------------------------------------------------------------------
 # ENC-FTR-095 / ENC-TSK-I90: Sheaf Laplacian H1 inconsistency detection

--- a/backend/lambda/graph_query_api/test_flow_weight_ppr_j03.py
+++ b/backend/lambda/graph_query_api/test_flow_weight_ppr_j03.py
@@ -1,0 +1,52 @@
+"""ENC-TSK-J03 — flow_weight PPR read path + entropy metric tests."""
+from __future__ import annotations
+
+import math
+import unittest
+from unittest.mock import MagicMock, patch
+
+import flow_weight_entropy as fwe
+
+
+class TestShannonEntropy(unittest.TestCase):
+    def test_diverse_weights_higher_entropy_than_degenerate(self):
+        diverse = fwe.shannon_entropy([1.0, 2.0, 3.0, 4.0])
+        degenerate = fwe.shannon_entropy([5.0, 5.0, 5.0, 5.0])
+        self.assertGreater(diverse, degenerate)
+
+    def test_single_weight_zero_entropy(self):
+        self.assertEqual(fwe.shannon_entropy([5.0, 5.0, 5.0]), 0.0)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(fwe.shannon_entropy([]), 0.0)
+
+
+class TestCypherFallbackFlowWeight(unittest.TestCase):
+    def test_cypher_includes_flow_weight_multiplier(self):
+        import lambda_function as lf
+
+        cypher_frag = (
+            f"coalesce(rel.{lf._GDS_FLOW_WEIGHT_PROPERTY}, 1.0)"
+        )
+        # Inspect source by calling with a mock driver that captures the query.
+        driver = MagicMock()
+        session = MagicMock()
+        driver.session.return_value.__enter__.return_value = session
+        session.run.return_value = []
+
+        lf._hybrid_graph_ranks_cypher_fallback(
+            driver, "enceladus", "ENC-PLN-006", 5,
+        )
+        query = session.run.call_args[0][0]
+        self.assertIn(cypher_frag, query)
+
+
+class TestPprWeightProperty(unittest.TestCase):
+    def test_default_ppr_weight_is_flow_weight(self):
+        import lambda_function as lf
+
+        self.assertEqual(lf._GDS_PPR_WEIGHT_PROPERTY, lf._GDS_FLOW_WEIGHT_PROPERTY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/percolation_monitor/lambda_function.py
+++ b/backend/lambda/percolation_monitor/lambda_function.py
@@ -110,8 +110,8 @@ def _graphsearch(params: Dict[str, Any]) -> Dict[str, Any]:
     return body
 
 
-def _fetch_graph() -> Tuple[int, List[Tuple[str, str]], Optional[float]]:
-    """Page the adjacency export; return (node_count, edge_list, spurious_attractor_rate).
+def _fetch_graph() -> Tuple[int, List[Tuple[str, str]], Optional[float], Optional[float]]:
+    """Page the adjacency export; return (node_count, edge_list, spurious_attractor_rate, flow_weight_entropy).
 
     node_count is the total number of governed nodes (including isolated ones),
     so LCC ratios and degree means are taken relative to the whole graph.
@@ -125,10 +125,14 @@ def _fetch_graph() -> Tuple[int, List[Tuple[str, str]], Optional[float]]:
     Lambda's role). None when the key is absent (an older graph_query_api
     deploy that predates ENC-TSK-I91) or when graph_query_api itself had no
     recent rate to report -- both degrade silently, never raising.
+
+    flow_weight_entropy (ENC-FTR-108 AC-5 / ENC-TSK-J03) is likewise read from
+    the first adjacency page when graph_query_api provides it; None otherwise.
     """
     edges: List[Tuple[str, str]] = []
     node_count = 0
     spurious_attractor_rate: Optional[float] = None
+    flow_weight_entropy: Optional[float] = None
     offset = 0
     for page_idx in range(_MAX_PAGES):
         body = _graphsearch({
@@ -141,6 +145,8 @@ def _fetch_graph() -> Tuple[int, List[Tuple[str, str]], Optional[float]]:
             node_count = int(body.get("node_count", 0) or 0)
             raw_rate = body.get("spurious_attractor_rate")
             spurious_attractor_rate = float(raw_rate) if raw_rate is not None else None
+            raw_entropy = body.get("flow_weight_entropy")
+            flow_weight_entropy = float(raw_entropy) if raw_entropy is not None else None
         for e in body.get("edges", []):
             s, t = e.get("s"), e.get("t")
             if s and t and s != t:
@@ -152,10 +158,10 @@ def _fetch_graph() -> Tuple[int, List[Tuple[str, str]], Optional[float]]:
     else:
         logger.warning("[WARNING] adjacency pagination hit _MAX_PAGES=%d ceiling", _MAX_PAGES)
     logger.info(
-        "[INFO] Graph read: node_count=%d edge_count=%d spurious_attractor_rate=%s",
-        node_count, len(edges), spurious_attractor_rate,
+        "[INFO] Graph read: node_count=%d edge_count=%d spurious_attractor_rate=%s flow_weight_entropy=%s",
+        node_count, len(edges), spurious_attractor_rate, flow_weight_entropy,
     )
-    return node_count, edges, spurious_attractor_rate
+    return node_count, edges, spurious_attractor_rate, flow_weight_entropy
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +294,12 @@ def _write_ddb(row: Dict[str, Any]) -> None:
     logger.info("[SUCCESS] Wrote percolation telemetry row pk=%s to %s", row.get("pk"), PERCOLATION_TABLE)
 
 
-def _publish_cloudwatch(analytical_pc: float, empirical_pc: float, mean_degree: float) -> None:
+def _publish_cloudwatch(
+    analytical_pc: float,
+    empirical_pc: float,
+    mean_degree: float,
+    flow_weight_entropy: Optional[float] = None,
+) -> None:
     cw = boto3.client("cloudwatch", region_name=REGION)
     now = datetime.now(timezone.utc)
     dims = [{"Name": "ProjectId", "Value": PROJECT_ID}]
@@ -297,10 +308,18 @@ def _publish_cloudwatch(analytical_pc: float, empirical_pc: float, mean_degree: 
         {"MetricName": "empirical_pc", "Value": float(empirical_pc), "Unit": "None", "Timestamp": now, "Dimensions": dims},
         {"MetricName": "mean_degree", "Value": float(mean_degree), "Unit": "None", "Timestamp": now, "Dimensions": dims},
     ]
+    if flow_weight_entropy is not None:
+        metric_data.append({
+            "MetricName": "flow_weight_entropy",
+            "Value": float(flow_weight_entropy),
+            "Unit": "None",
+            "Timestamp": now,
+            "Dimensions": dims,
+        })
     cw.put_metric_data(Namespace=CLOUDWATCH_NAMESPACE, MetricData=metric_data)
     logger.info(
-        "[SUCCESS] Published Enceladus/Percolation metrics: analytical_pc=%.5f empirical_pc=%.5f mean_degree=%.4f",
-        analytical_pc, empirical_pc, mean_degree,
+        "[SUCCESS] Published Enceladus/Percolation metrics: analytical_pc=%.5f empirical_pc=%.5f mean_degree=%.4f flow_weight_entropy=%s",
+        analytical_pc, empirical_pc, mean_degree, flow_weight_entropy,
     )
 
 
@@ -313,7 +332,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     started = time.time()
 
     try:
-        node_count, edges, spurious_attractor_rate = _fetch_graph()
+        node_count, edges, spurious_attractor_rate, flow_weight_entropy = _fetch_graph()
         stats = _degree_stats(node_count, edges)
         analytical_pc = stats["analytical_pc"]
         mean_degree = stats["mean_degree"]
@@ -343,6 +362,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             # _fetch_graph). None on an older graph_query_api deploy or when
             # no recent drift-telemetry record carries a non-null rate.
             "spurious_attractor_rate": spurious_attractor_rate,
+            "flow_weight_entropy": flow_weight_entropy,
             "mc_trials": MC_TRIALS,
             "mc_num_p": MC_NUM_P,
             "sweep_p": [round(p, 6) for p in p_grid],
@@ -360,7 +380,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         row["analytical_pc_in_range"] = analytical_in_range
 
         _write_ddb(row)
-        _publish_cloudwatch(analytical_pc, empirical_pc, mean_degree)
+        _publish_cloudwatch(analytical_pc, empirical_pc, mean_degree, flow_weight_entropy)
 
         logger.info(
             "[END] node_count=%d edge_count=%d analytical_pc=%.5f empirical_pc=%.5f in %dms",

--- a/backend/lambda/percolation_monitor/test_percolation.py
+++ b/backend/lambda/percolation_monitor/test_percolation.py
@@ -121,7 +121,7 @@ class FetchGraphSpuriousAttractorRateTest(unittest.TestCase):
         with mock.patch.object(pm, "_graphsearch", return_value=self._single_page_body(
             {"spurious_attractor_rate": 0.37}
         )):
-            node_count, edges, rate = pm._fetch_graph()
+            node_count, edges, rate, _entropy = pm._fetch_graph()
         self.assertEqual(node_count, 2)
         self.assertEqual(edges, [("A", "B")])
         self.assertAlmostEqual(rate, 0.37)
@@ -130,14 +130,14 @@ class FetchGraphSpuriousAttractorRateTest(unittest.TestCase):
         """Backward compatibility: an older graph_query_api deploy that
         predates ENC-TSK-I91 simply omits the key."""
         with mock.patch.object(pm, "_graphsearch", return_value=self._single_page_body()):
-            _node_count, _edges, rate = pm._fetch_graph()
+            _node_count, _edges, rate, _entropy = pm._fetch_graph()
         self.assertIsNone(rate)
 
     def test_rate_is_none_when_explicitly_null(self):
         with mock.patch.object(pm, "_graphsearch", return_value=self._single_page_body(
             {"spurious_attractor_rate": None}
         )):
-            _node_count, _edges, rate = pm._fetch_graph()
+            _node_count, _edges, rate, _entropy = pm._fetch_graph()
         self.assertIsNone(rate)
 
     def test_rate_taken_from_first_page_only(self):
@@ -148,7 +148,7 @@ class FetchGraphSpuriousAttractorRateTest(unittest.TestCase):
             "has_more": False,
         }
         with mock.patch.object(pm, "_graphsearch", side_effect=[first, second]):
-            node_count, edges, rate = pm._fetch_graph()
+            node_count, edges, rate, _entropy = pm._fetch_graph()
         self.assertEqual(node_count, 2)
         self.assertEqual(edges, [("A", "B"), ("B", "C")])
         self.assertAlmostEqual(rate, 0.6)


### PR DESCRIPTION
## Summary
- Wire `flow_weight` into GDS standing projection, warm/per-query PageRank (`GDS_PPR_WEIGHT_PROPERTY`), and cypher_fallback hop scoring
- Add `flow_weight_entropy` Shannon entropy module; enrich adjacency first page; publish nightly via comp-percolation-monitor CloudWatch
- Governance dictionary v2026-07-02.06: adjacency `flow_weight_entropy` + `flow_weight_edge_count` response fields

## Test plan
- [x] `pytest backend/lambda/graph_query_api/test_flow_weight_ppr_j03.py` (5 pass)
- [x] `pytest backend/lambda/percolation_monitor/test_percolation.py` (12 pass)
- [ ] Gamma deploy + verify `flow_weight_entropy` metric in Enceladus/Percolation namespace after nightly run

CCI-6eb07dab2acf4ed39d6c5e63c9ef6451

ENC-TSK-J03 | ENC-FTR-108 Ph3 | gamma-only