### PR TITLE
ENC-TSK-J89: fix escalation.watch MCP handler path (double-prefix 404)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-07-02.06",
-  "updated_at": "2026-07-02T08:49:00Z",
+  "version": "2026-07-02.07",
+  "updated_at": "2026-07-02T09:05:00Z",
   "last_change_summary": "ENC-TSK-J03 (ENC-FTR-108 Ph3): graph_query_api.adjacency first-page enrichment adds nullable flow_weight_entropy + flow_weight_edge_count (Shannon entropy over live Neo4j flow_weight distribution for comp-percolation-monitor nightly CloudWatch publish). GDS_PPR_WEIGHT_PROPERTY env (default flow_weight) documents PPR read-path weight selection.",
   "owners": [
     "enceladus-platform"
@@ -6546,7 +6546,7 @@
         },
         "escalation.watch": {
           "type": "coordination_action",
-          "definition": "ENC-TSK-J71: coordination(action=escalation.watch, arguments={session_id, since?, project_id?}) -> GET /api/v1/coordination/escalations/watch. Pass the returned next_cursor back as since. Registered behind ENABLE_ESCALATION_PRIMITIVE."
+          "definition": "ENC-TSK-J71: coordination(action=escalation.watch, arguments={session_id, since?, project_id?}) -> GET /api/v1/coordination/escalations/watch. Pass the returned next_cursor back as since. Registered behind ENABLE_ESCALATION_PRIMITIVE. ENC-TSK-J89 (2026-07-02.07): MCP handler fixed to call the coordination API with a base-relative path (/escalations/watch); the prior absolute path double-prefixed COORDINATION_API_BASE and 404d on gamma and prod."
         }
       }
     },

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -6163,8 +6163,10 @@ async def _escalation_watch(args: dict) -> list[TextContent]:
         "since": args.get("since"),
         "project_id": args.get("project_id"),
     }
+    # ENC-TSK-J89: path is RELATIVE to COORDINATION_API_BASE (which already ends
+    # in /api/v1/coordination) — the absolute form double-prefixed and 404'd.
     resp = _coordination_api_request(
-        "GET", "/api/v1/coordination/escalations/watch", query=query)
+        "GET", "/escalations/watch", query=query)
     return _result_text(resp)
 
 

--- a/tools/enceladus-mcp-server/test_escalation_watch_path_j89.py
+++ b/tools/enceladus-mcp-server/test_escalation_watch_path_j89.py
@@ -1,0 +1,68 @@
+"""ENC-TSK-J89: escalation.watch must call the coordination API with a path
+RELATIVE to COORDINATION_API_BASE.
+
+The base already ends in /api/v1/coordination; the original handler passed the
+absolute route and double-prefixed the URL, 404ing on both gamma and prod while
+every unit test mocked the helper. These tests pin the composed URL itself so a
+prefix regression can never be mock-blind again.
+"""
+import asyncio
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import uuid
+from unittest.mock import patch
+
+MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _load_server(**env):
+    module_name = f"enceladus_server_watch_path_{uuid.uuid4().hex}"
+    with patch.dict(os.environ, env, clear=False):
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+def test_watch_path_is_base_relative_and_never_double_prefixed():
+    server = _load_server(
+        ENCELADUS_COORDINATION_API_BASE="https://example.test/api/v1/coordination")
+    captured = {}
+
+    def fake_request(method, path="", payload=None, query=None):
+        base = server.COORDINATION_API_BASE.rstrip("/")
+        route = path if path.startswith("/") else (f"/{path}" if path else "")
+        captured["url"] = f"{base}{route}"
+        captured["path"] = path
+        return {"success": True, "events": [], "next_cursor": "e30"}
+
+    with patch.object(server, "_coordination_api_request", side_effect=fake_request):
+        result = _run(server._escalation_watch(
+            {"session_id": "ENC-SES-02F", "project_id": "enceladus"}))
+
+    assert captured["path"] == "/escalations/watch"
+    assert captured["url"] == (
+        "https://example.test/api/v1/coordination/escalations/watch")
+    assert "/api/v1/coordination/api/v1/coordination" not in captured["url"]
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+
+
+def test_watch_requires_session_id():
+    server = _load_server()
+    result = _run(server._escalation_watch({"project_id": "enceladus"}))
+    payload = json.loads(result[0].text)
+    assert "session_id" in payload.get("error", "")


### PR DESCRIPTION
## Summary
`_escalation_watch` in `tools/enceladus-mcp-server/server.py` passed the **absolute** route `/api/v1/coordination/escalations/watch` to `_coordination_api_request`, whose `COORDINATION_API_BASE` already ends in `/api/v1/coordination` — the composed URL double-prefixed and 404'd on **both gamma and prod**. Every sibling call site passes base-relative paths. The bug was mock-blind (J71 unit tests stub the helper) and E2E-blind (the Ph6 gamma E2E exercised watch via direct APIGW curl).

Discovered during ENC-TSK-J89 verification: prod `mcp.jreese.net` already serves `escalation.request/get/list` (J81's promote carried `mcp_code` via the ENC-TSK-I39 Gen2 inclusion) — `watch` was the only broken verb.

- One-line fix: base-relative `/escalations/watch`
- New `test_escalation_watch_path_j89.py`: pins the **composed URL** against a real base (2/2 pass) so the class can't regress mock-blind
- Dict gate: `governance_data_dictionary.json` 2026-07-02.06 → **.07** with the J89 note on the `escalation.watch` entry

Baseline: `test_code_mode.py` 7/8 — the 1 failure (embeddings registration) reproduces identically on pristine v4/main.

## Deploy
Merge → Gen2 gamma build/deploy (auto) → promote-gamma-to-prod-request pauses on the **v3-prod Environment** for io's click → prod `enceladus-mcp-code` swap → live watch verification through the prod connector.

## Tracker
ENC-TSK-J89

CCI-96167b5f8e41450ea824bb72e1df8f0f

🤖 Generated with [Claude Code](https://claude.com/claude-code)