### PR TITLE
[ENC-TSK-J91] ISS-441 Ph1 — backport I71 agent-session idle-sweep to v4/main

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.08",
-  "updated_at": "2026-07-02T09:10:00Z",
-  "last_change_summary": "ENC-TSK-J90: graph_query_api gains action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave), the missing wave-aggregation producer for compute_spurious_attractor_rate's retrieval_records[] -- see graph_query_api.drift_telemetry entity for detail.",
+  "version": "2026-07-02.09",
+  "updated_at": "2026-07-02T09:30:00Z",
+  "last_change_summary": "ENC-TSK-J91 (ENC-ISS-441 Ph1): I71 agent-session idle-sweep backported to v4/main - _handle_agent_session_idle_sweep + EventBridge dispatch in coordination_api, AgentSessionIdleSweepSchedule rule + permission + env vars in 02-compute.yaml (v4). New entity coordination.agent_session_idle_sweep documenting the v4 idle-reference precedence (last_activity_at > claimed_at > created_at). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
   "owners": [
     "enceladus-platform"
   ],
@@ -6572,6 +6572,27 @@
       },
       "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
       "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
+    },
+    "coordination.agent_session_idle_sweep": {
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep.",
+      "fields": {
+        "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits and reaps nothing."
+        },
+        "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS": {
+          "type": "integer",
+          "definition": "Env var (config.py), default 86400 (24h) at J91 backport time. A live session whose idle reference is older than this is reaped. Operator-configurable per ENC-TSK-I71 AC#2; ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default to 7200 (2h)."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator. Fixed value 'agent_session_idle_sweep' routes lambda_handler to the sweep. Optional idle_threshold_seconds and dry_run keys in the Input override the configured defaults for an ad-hoc invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only - no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6665,6 +6686,11 @@
       "version": "2026-07-02.05",
       "task": "ENC-TSK-J72",
       "summary": "ENC-TSK-J72 (ENC-FTR-121 Ph5, DOC-5B888FCA43B8): SNS [ESCALATION] notifications to io. Publishes on requested (post-write) and terminal applied/failed; failure-isolated (never fails the escalation write); reuses devops-feed-alerts{suffix} via ESCALATION_ALERTS_TOPIC_ARN env + PublishEscalationAlerts role grant (02-compute.yaml, gamma lane; prod via Ph7a). Sub-dollar budget; email subscription confirmation is an io residual for Ph8."
+    },
+    {
+      "version": "2026-07-02.09",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J91 (ENC-ISS-441 Ph1): I71 agent-session idle-sweep backported to v4/main - _handle_agent_session_idle_sweep + EventBridge dispatch in coordination_api, AgentSessionIdleSweepSchedule rule + permission + env vars in 02-compute.yaml (v4). New entity coordination.agent_session_idle_sweep documenting the v4 idle-reference precedence (last_activity_at > claimed_at > created_at). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -372,6 +372,12 @@ CALLBACK_SQS_QUEUE_URL = os.environ.get("CALLBACK_SQS_QUEUE_URL", "")
 CALLBACK_EVENT_SOURCE = os.environ.get("CALLBACK_EVENT_SOURCE", "enceladus.coordination")
 CALLBACK_EVENT_DETAIL_TYPE = os.environ.get("CALLBACK_EVENT_DETAIL_TYPE", "coordination.callback")
 FEED_SUBSCRIPTIONS_TABLE = os.environ.get("FEED_SUBSCRIPTIONS_TABLE", "feed-subscriptions")
+# ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91: master enable flag for
+# the scheduled agent-session idle-sweep. Threshold default lives in config.py and is the
+# default of agent_id_alloc.sweep_idle_sessions; only the enable flag is read here.
+AGENT_SESSIONS_IDLE_SWEEP_ENABLED = (
+    os.environ.get("AGENT_SESSIONS_IDLE_SWEEP_ENABLED", "true").lower() == "true"
+)
 # ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier config.
 GRAPH_QUERY_API_URL = os.environ.get("GRAPH_QUERY_API_URL", "").strip()
 DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
@@ -15040,6 +15046,44 @@ def _handle_session_init_intent_drift(
     )
 
 
+def _handle_agent_session_idle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Scheduled backstop reaper for abandoned agent sessions (ENC-TSK-I71 / ENC-FTR-117 AC#8).
+
+    Backported to v4 by ENC-TSK-J91 (ENC-ISS-441 Ph1). Invoked by the
+    AgentSessionIdleSweepSchedule EventBridge rule, NOT an HTTP route — there is no API
+    Gateway envelope, auth, or claims on this path. Flips sessions left in a live status
+    (allocated/claimed) past the configured idle threshold to 'retired' via the append-only
+    conditional update in agent_id_alloc.sweep_idle_sessions (NOT a delete; NOT native
+    DynamoDB TTL). On v4 the idle reference prefers last_activity_at (ENC-TSK-J71/J83
+    heartbeat) over claimed_at/created_at. Returns a plain summary dict for CloudWatch.
+    """
+    if not AGENT_SESSIONS_IDLE_SWEEP_ENABLED:
+        logger.info("[INFO] idle-sweep skipped — AGENT_SESSIONS_IDLE_SWEEP_ENABLED is false")
+        return {"enabled": False, "reason": "disabled", "retired_count": 0}
+    # The schedule delivers the rule's Input JSON verbatim; allow an optional per-invoke
+    # threshold/dry_run override, else fall back to the configured default.
+    raw_threshold = event.get("idle_threshold_seconds")
+    sweep_kwargs: Dict[str, Any] = {"dry_run": bool(event.get("dry_run", False))}
+    if raw_threshold is not None:
+        try:
+            sweep_kwargs["idle_threshold_seconds"] = int(raw_threshold)
+        except (TypeError, ValueError):
+            return {
+                "enabled": True,
+                "error": "idle_threshold_seconds must be an integer",
+                "retired_count": 0,
+            }
+    try:
+        summary = _agent_id_alloc.sweep_idle_sessions(**sweep_kwargs)
+    except ValueError as exc:
+        return {"enabled": True, "error": str(exc), "retired_count": 0}
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] idle-sweep DynamoDB failure: %s", exc)
+        return {"enabled": True, "error": "DynamoDB error during idle-sweep", "retired_count": 0}
+    logger.info("[SUCCESS] idle-sweep retired %d session(s)", summary.get("retired_count", 0))
+    return summary
+
+
 # ---------------------------------------------------------------------------
 # Main Lambda handler
 # ---------------------------------------------------------------------------
@@ -15056,6 +15100,12 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     ):
         logger.info("[INFO] EventBridge callback event received")
         return _handle_eventbridge_callback(event)
+
+    # --- ENC-TSK-I71: scheduled agent-session idle-sweep (ENC-FTR-117 AC#8) ---
+    # The AgentSessionIdleSweepSchedule rule delivers its Input JSON verbatim as the event.
+    if event.get("action") == "agent_session_idle_sweep":
+        logger.info("[INFO] Scheduled agent-session idle-sweep invoked")
+        return _handle_agent_session_idle_sweep(event)
 
     # --- v0.3: SQS callback ingestion ---
     # SQS events have 'Records' with 'eventSource' = 'aws:sqs'.

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -215,6 +215,12 @@ Resources:
           AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
           AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"
           AGENT_CREDENTIALS_TABLE: !Sub "agent-credentials${EnvironmentSuffix}"
+          # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91: idle-sweep
+          # backstop config. Enable flag read by lambda_function; threshold read by
+          # config.py / agent_id_alloc.sweep_idle_sessions. 86400 = 24h (I71 default;
+          # ENC-ISS-441 Ph4 tightens this to 7200).
+          AGENT_SESSIONS_IDLE_SWEEP_ENABLED: "true"
+          AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS: "86400"
           # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
@@ -1894,6 +1900,34 @@ Resources:
       Targets:
         - Arn: !GetAtt CoordinationApiFunction.Arn
           Id: coordination-batch-poll
+
+  # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91 (ENC-ISS-441 Ph1). The
+  # rule invokes the coordination_api with a fixed Input action; the handler reaps sessions
+  # left allocated/claimed past AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS via an append-only flip
+  # to 'retired' (NOT native DynamoDB TTL — TTL hard-deletes and would break the append-only
+  # retire model from ENC-TSK-I38). Targets the unqualified function ARN, matching the
+  # CoordinationBatchPollerRule precedent above. Unlike that rule, this one ships with its
+  # required AWS::Lambda::Permission so EventBridge can actually invoke the function.
+  AgentSessionIdleSweepSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-session-idle-sweep${EnvironmentSuffix}"
+      Description: "ENC-TSK-I71: reap abandoned agent sessions (append-only retire backstop for ENC-FTR-117 AC#8)"
+      ScheduleExpression: rate(1 hour)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: agent-session-idle-sweep
+          Input: '{"action": "agent_session_idle_sweep"}'
+
+  AgentSessionIdleSweepPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AgentSessionIdleSweepSchedule.Arn
 
   DeployCodeBuildFinalizeRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
## Summary
ENC-ISS-441 Ph1 (ENC-PLN-062 / ENC-FTR-122). Makes v4/main a superset of main's agent-session lifecycle before the SCI gate work, so v3-prod Lambda promotes built from v4/main cannot regress the I71 idle sweep already live on prod.

- coordination_api/lambda_function.py: `_handle_agent_session_idle_sweep` + EventBridge action dispatch (`agent_session_idle_sweep`) + module-level enable flag — the v4 sweep engine (agent_id_alloc.sweep_idle_sessions with last_activity_at-preferred idle reference per J71/J83) was already present and is unchanged.
- 02-compute.yaml (v4): `AgentSessionIdleSweepSchedule` rate(1 hour) + `AgentSessionIdleSweepPermission` (logical IDs mirror main), sweep env vars on CoordinationApiFunction (86400s default; ENC-TSK-J94 tightens to 7200s).
- governance_data_dictionary.json: new entity `coordination.agent_session_idle_sweep`, version 2026-07-02.07 + change_log (dict gate).

## Tracker
- Task: ENC-TSK-J91 (plan ENC-PLN-062, feature ENC-FTR-122, issue ENC-ISS-441)
- CCI-59f7fb5775d14257b3134e58be24733b

🤖 Generated with [Claude Code](https://claude.com/claude-code)