### PR TITLE
ENC-TSK-K01: fix drift-audit pure-ADD false-fail + stale fetchFeed test

### DIFF
--- a/frontend/ui/src/api/client.test.ts
+++ b/frontend/ui/src/api/client.test.ts
@@ -47,7 +47,9 @@ describe('client api helpers', () => {
     expect(data.tasks).toEqual([])
 
     const [url] = fetchMock.mock.calls[0] as [string]
-    expect(url).toBe('/mobile/v1/tasks.json')
+    const [path, query] = url.split('?')
+    expect(path).toBe('/mobile/v1/tasks.json')
+    expect(query).toMatch(/^_t=\d+$/)
   })
 
   it('probeSession throws when probe endpoint is non-2xx', async () => {

--- a/tests/tools/test_audit_cfn_drift.py
+++ b/tests/tools/test_audit_cfn_drift.py
@@ -259,3 +259,47 @@ def test_self_check_passes(mod):
     """The tool's own offline self-check (ENC-TSK-J12) must pass; this pins
     it as a real regression signal rather than a script that always exits 0."""
     assert mod._self_check() is True
+
+
+def test_has_failing_drift_pure_add_cfn_only_passes_pre_deploy(mod):
+    """ENC-ISS-467: a branch that only ADDS a route (cfn_only, no live_only)
+    must pass the pre-deploy gate -- this is what the FTR-120 change-set
+    review is for -- but must still fail the strict scheduled-audit mode."""
+    report = {
+        "apigw_routes": {"inconclusive": False, "live_only": [], "cfn_only": ["GET /new"]},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    assert mod._has_failing_drift(report, pre_deploy=True) is False
+    assert mod._has_failing_drift(report, pre_deploy=False) is True
+
+
+def test_has_failing_drift_live_only_fails_both_modes(mod):
+    """live_only stays fail-closed everywhere -- it's the
+    AWS::EarlyValidation::ResourceExistenceCheck wedge guard, not something
+    a change-set review compensates for."""
+    report = {
+        "apigw_routes": {"inconclusive": False, "live_only": ["GET /orphan"], "cfn_only": []},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    assert mod._has_failing_drift(report, pre_deploy=True) is True
+    assert mod._has_failing_drift(report, pre_deploy=False) is True
+
+
+def test_has_failing_drift_no_drift_passes_both_modes(mod):
+    report = {
+        "apigw_routes": {"inconclusive": False, "live_only": [], "cfn_only": []},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    assert mod._has_failing_drift(report, pre_deploy=True) is False
+    assert mod._has_failing_drift(report, pre_deploy=False) is False
+
+
+def test_has_failing_drift_ignores_inconclusive_sections(mod):
+    """An AccessDenied-inconclusive section must never itself trigger a fail
+    (ENC-TSK-J22 / GH#672) in either mode."""
+    report = {
+        "apigw_routes": {"inconclusive": True, "live_only": [], "cfn_only": []},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    assert mod._has_failing_drift(report, pre_deploy=True) is False
+    assert mod._has_failing_drift(report, pre_deploy=False) is False

--- a/tools/audit_cfn_drift.py
+++ b/tools/audit_cfn_drift.py
@@ -478,8 +478,63 @@ def _self_check() -> bool:
             "enceladus-prod-only" not in gamma_rules,
         )
 
+    # ENC-ISS-467: pure-ADD cfn_only must pass --pre-deploy --fail-on-drift,
+    # but still fail strict (scheduled reconcile) mode; live_only must fail
+    # closed in BOTH modes (the EarlyValidation-wedge guard).
+    pure_add_report = {
+        "apigw_routes": {"inconclusive": False, "live_only": [], "cfn_only": ["GET /new"]},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    check(
+        "pure-ADD cfn_only passes pre-deploy mode",
+        not _has_failing_drift(pure_add_report, pre_deploy=True),
+    )
+    check(
+        "pure-ADD cfn_only still fails strict mode",
+        _has_failing_drift(pure_add_report, pre_deploy=False),
+    )
+    live_only_report = {
+        "apigw_routes": {"inconclusive": False, "live_only": ["GET /orphan"], "cfn_only": []},
+        "eventbridge_rules": {"inconclusive": False, "live_only": [], "cfn_only": []},
+    }
+    check(
+        "live_only fails pre-deploy mode (EarlyValidation-wedge guard)",
+        _has_failing_drift(live_only_report, pre_deploy=True),
+    )
+    check(
+        "live_only fails strict mode",
+        _has_failing_drift(live_only_report, pre_deploy=False),
+    )
+
     print(f"[{'PASS' if not failures else 'FAIL'}] self-check: {len(failures)} failure(s)")
     return not failures
+
+
+def _has_failing_drift(report: Dict[str, Dict[str, object]], pre_deploy: bool = False) -> bool:
+    """Does ``report`` contain drift severe enough to fail --fail-on-drift?
+
+    Strict mode (``pre_deploy=False`` — the scheduled reconcile audit, GH
+    workflow cfn-drift-audit.yml) fails on ANY live_only or cfn_only delta,
+    matching prior behavior: post-merge main should eventually match live.
+
+    Pre-deploy mode (ENC-ISS-467) fails ONLY on live_only. A pure-ADD cfn_only
+    delta — a resource newly declared in CFN that doesn't exist live yet — is
+    exactly what the FTR-120 plan/apply change-set review approves; failing
+    pre-deploy contexts on it forced a redundant two-phase io approval for
+    every route-adding PR (CI run 28572125111). live_only stays fail-closed in
+    BOTH modes — it is the AWS::EarlyValidation::ResourceExistenceCheck wedge
+    guard (a plan that ADDs/adopts something already live out-of-band wedges
+    the stack), and relaxing it would reintroduce that class of incident.
+    """
+    for section in ("apigw_routes", "eventbridge_rules"):
+        data = report[section]
+        if data.get("inconclusive"):
+            continue
+        if data["live_only"]:
+            return True
+        if not pre_deploy and data["cfn_only"]:
+            return True
+    return False
 
 
 def main() -> int:
@@ -511,6 +566,19 @@ def main() -> int:
     )
     ap.add_argument("--output-json", default=None)
     ap.add_argument("--fail-on-drift", action="store_true")
+    ap.add_argument(
+        "--pre-deploy",
+        action="store_true",
+        help=(
+            "Relax --fail-on-drift to fail only on live_only (pure-ADD cfn_only "
+            "deltas are still reported, just don't fail the gate). Use in "
+            "pre-deploy contexts (pre-deploy-health-gate.sh Check 7, the "
+            "compute-stack plan job) where a plan/apply change-set review is "
+            "the compensating control for newly declared-but-not-yet-live "
+            "resources (ENC-ISS-467). Default (unset) is unchanged strict mode "
+            "for the scheduled reconcile audit (cfn-drift-audit.yml)."
+        ),
+    )
     args = ap.parse_args()
 
     if args.self_check:
@@ -552,12 +620,7 @@ def main() -> int:
             "failing closed as 'CFN drift detected' (ENC-TSK-J22 / GH#672)."
         )
 
-    any_drift = any(
-        not report[section].get("inconclusive")
-        and (report[section]["live_only"] or report[section]["cfn_only"])
-        for section in ("apigw_routes", "eventbridge_rules")
-    )
-    if args.fail_on_drift and any_drift:
+    if args.fail_on_drift and _has_failing_drift(report, pre_deploy=args.pre_deploy):
         return 1
     if inconclusive_sections:
         return 2

--- a/tools/pre-deploy-health-gate.sh
+++ b/tools/pre-deploy-health-gate.sh
@@ -239,11 +239,19 @@ if [[ "${HEALTH_GATE_SKIP_DRIFT:-0}" == "1" ]]; then
     echo "[CHECK 7/7] SKIPPED — HEALTH_GATE_SKIP_DRIFT=1 (change-set IMPORT context;"
     echo "            assert_changeset_safe.py mode=import is the compensating control)."
 else
-    echo "[CHECK 7/7] Validating no live CFN drift (environment=${DRIFT_ENV}, fail-on-drift)..."
+    echo "[CHECK 7/7] Validating no live CFN drift (environment=${DRIFT_ENV}, fail-on-drift, pre-deploy)..."
+    # ENC-ISS-467: --pre-deploy relaxes the fail-on-drift decision to live_only
+    # only. A pure-ADD cfn_only delta (a branch declaring a new route/rule that
+    # isn't live yet) is exactly what the FTR-120 plan/apply change-set review
+    # approves; failing this pre-deploy gate on it forced a redundant two-phase
+    # io approval for every route-adding PR (CI run 28572125111). live_only
+    # stays fail-closed -- that's the AWS::EarlyValidation::ResourceExistenceCheck
+    # wedge guard this check exists for.
     if python3 "${REPO_ROOT}/tools/audit_cfn_drift.py" \
             --environment "${DRIFT_ENV}" \
             --output-json "${DRIFT_REPORT}" \
-            --fail-on-drift; then
+            --fail-on-drift \
+            --pre-deploy; then
         echo "[PASS] No CFN drift detected for ${DRIFT_ENV}"
         DRIFT_RC=0
     else


### PR DESCRIPTION
## Summary
- ENC-ISS-467: `tools/audit_cfn_drift.py` gains `--pre-deploy`, relaxing `--fail-on-drift` to fail only on `live_only` (pure-ADD `cfn_only` deltas pass with a visible report, which is exactly what the FTR-120 plan/apply change-set review is for). Strict mode is unchanged for the scheduled reconcile audit (`cfn-drift-audit.yml`). Wired into `pre-deploy-health-gate.sh` Check 7, which the compute-stack plan job's embedded gate already calls.
- ENC-ISS-468: `frontend/ui/src/api/client.test.ts` fetchFeed assertion is now cache-buster-aware (tolerates the `?_t=<Date.now()>` param fetchFeed appends) instead of asserting a bare URL.

## Test plan
- [x] `python3 tools/audit_cfn_drift.py --self-check` — PASS (8/8, including new pre-deploy-mode checks)
- [x] `PYTHONPATH=backend/lambda/shared_layer/python python3 -m pytest tests/tools/test_audit_cfn_drift.py -v` — 17/17 passed
- [x] `npx vitest run` (frontend/ui) — 105/105 passed

CCI-428adbf7ab254ab6a1b258b71e89be3d

🤖 Generated with [Claude Code](https://claude.com/claude-code)