### PR TITLE
ENC-TSK-G15: defer_loading + BM25 tool search (FTR-099 A3.2)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.09",
-  "updated_at": "2026-07-02T09:30:00Z",
-  "last_change_summary": "ENC-TSK-J91 (ENC-ISS-441 Ph1): I71 agent-session idle-sweep backported to v4/main - _handle_agent_session_idle_sweep + EventBridge dispatch in coordination_api, AgentSessionIdleSweepSchedule rule + permission + env vars in 02-compute.yaml (v4). New entity coordination.agent_session_idle_sweep documenting the v4 idle-reference precedence (last_activity_at > claimed_at > created_at). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.10",
+  "updated_at": "2026-07-02T09:40:00Z",
+  "last_change_summary": "ENC-TSK-G15: deferred tool loading policy (tool_defer_loading.py), BM25 tool search, mcp_toolset defer-by-default, coordination_capabilities.features.deferred_tool_loading, provider_session.deferred_tool_loading opt-in for Claude dispatch. (Rebased atop ENC-TSK-J91 idle-sweep dictionary bump.)",
   "owners": [
     "enceladus-platform"
   ],
@@ -1607,6 +1607,11 @@
           "definition": "Optional raw MCP tool allowlist used internally by code-mode action resolution.",
           "usage_guidance": "Code-mode sessions pass this boundary to the MCP server via COORDINATION_ALLOWED_RAW_TOOLS[_JSON]. Meta-tools may resolve only to raw tools listed here."
         },
+        "provider_session.deferred_tool_loading": {
+          "type": "boolean",
+          "definition": "When true on claude_agent_sdk dispatch, coordination attaches Anthropic deferred tool-loading tools array (mcp_toolset + BM25 tool search) and advanced-tool-use beta headers to the Messages API request.",
+          "usage_guidance": "Opt-in per coordination request. Eager-load tools default to search, get_compact_context, execute, coordination; all other MCP tools defer until BM25 retrieval. See mcp_server.deferred_tool_loading entity."
+        },
         "dispatch_target_task_ids": {
           "type": "array",
           "item_type": "string",
@@ -2229,6 +2234,36 @@
           "type": "array",
           "item_type": "string",
           "definition": "Raw MCP tools that code-mode meta-tools may resolve onto within the current session boundary."
+        }
+      }
+    },
+    "mcp_server.deferred_tool_loading": {
+      "description": "Anthropic deferred tool-loading policy for Enceladus MCP (ENC-TSK-G15 / FTR-099 A3.2). Reduces per-turn tool-definition token footprint by deferring non-essential tools and registering BM25 on-demand retrieval.",
+      "fields": {
+        "eager_load_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Code-mode meta-tools always loaded (not deferred): search, get_compact_context, execute, coordination.",
+          "usage_guidance": "Configured in tools/enceladus-mcp-server/tool_defer_loading.py EAGER_LOAD_TOOLS; surfaced via coordination_capabilities.features.deferred_tool_loading."
+        },
+        "mcp_toolset": {
+          "type": "object",
+          "definition": "Anthropic mcp_toolset block with default_config.defer_loading=true and per-tool eager overrides.",
+          "usage_guidance": "Built by build_mcp_toolset() in tool_defer_loading.py; attached to Claude dispatch when provider_session.deferred_tool_loading=true."
+        },
+        "tool_search_tool_bm25_20251119": {
+          "type": "tool",
+          "definition": "BM25 tool search registered in the Anthropic tools array for deferred tool discovery.",
+          "usage_guidance": "Keyword-rich ENCELADUS_MCP_SERVER_INSTRUCTIONS and MCP initialize serverInfo.instructions improve BM25 routing for tracker, docstore, checkout, deploy, and governance queries."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Required beta headers: advanced-tool-use-2025-11-20 and mcp-client-2025-11-20 when using defer_loading with MCP connector."
+        },
+        "token_footprint_reduction": {
+          "type": "behavior",
+          "definition": "Estimated >70% reduction in tool-definition tokens per turn when 4 eager + 36 deferred tools (validated in test_tool_defer_loading.py)."
         }
       }
     },

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -5097,6 +5097,45 @@ def _parse_sse_stream(resp) -> Dict[str, Any]:
     return message
 
 
+def _get_claude_deferred_tool_loading_capabilities() -> Dict[str, Any]:
+    """Expose ENC-TSK-G15 defer_loading + BM25 policy for coordination capabilities."""
+    try:
+        from mcp_integration import _get_defer_loading_policy_summary
+
+        return _get_defer_loading_policy_summary(
+            deferred_tool_count=len(_ENCELADUS_ALLOWED_RAW_TOOLS),
+        )
+    except Exception as exc:
+        logger.warning("deferred_tool_loading capabilities unavailable: %s", exc)
+        return {"supported": False, "error": str(exc)}
+
+
+def _maybe_attach_deferred_tool_loading(
+    provider_session: Dict[str, Any],
+    request_body: Dict[str, Any],
+    request_headers: Dict[str, str],
+) -> None:
+    """Attach BM25 tool search + mcp_toolset when provider_session requests defer_loading."""
+    if not provider_session.get("deferred_tool_loading"):
+        return
+    try:
+        from mcp_integration import _load_tool_defer_loading_module
+
+        policy = _load_tool_defer_loading_module()
+        mcp_server_name = str(
+            provider_session.get("mcp_server_name") or policy.DEFAULT_MCP_SERVER_NAME
+        ).strip()
+        eager_tools = provider_session.get("eager_load_tools")
+        tools = policy.build_anthropic_deferred_tools_array(
+            mcp_server_name=mcp_server_name,
+            eager_tools=eager_tools if isinstance(eager_tools, list) else None,
+        )
+        request_body["tools"] = tools
+        request_headers["anthropic-beta"] = policy.anthropic_beta_headers()
+    except Exception as exc:
+        logger.warning("deferred_tool_loading attach failed: %s", exc)
+
+
 def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatch_id: str) -> Dict[str, Any]:
     """Dispatch a request to the Anthropic Messages API with full feature support.
 
@@ -5206,15 +5245,19 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
     started_at = _now_z()
     started = time.perf_counter()
     timeout = ANTHROPIC_API_STREAM_TIMEOUT_SECONDS if use_streaming else ANTHROPIC_API_TIMEOUT_SECONDS
+    anthropic_headers = {
+        "x-api-key": api_key,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+        "content-type": "application/json",
+    }
+    _maybe_attach_deferred_tool_loading(provider_session, request_body, anthropic_headers)
+    if "tools" in request_body:
+        request_json = json.dumps(request_body).encode("utf-8")
     req = urllib.request.Request(
         url=endpoint,
         method="POST",
         data=request_json,
-        headers={
-            "x-api-key": api_key,
-            "anthropic-version": ANTHROPIC_API_VERSION,
-            "content-type": "application/json",
-        },
+        headers=anthropic_headers,
     )
     context = ssl.create_default_context(cafile=_CERT_BUNDLE) if _CERT_BUNDLE else None
     try:
@@ -7747,12 +7790,24 @@ def _dispatch_mcp_jsonrpc_method(method: str, params: Dict[str, Any]) -> Dict[st
     module = _load_mcp_server_module()
 
     if method_name == "initialize":
+        server_info: Dict[str, Any] = {
+            "name": "enceladus",
+            "version": "0.4.1",
+        }
+        try:
+            from mcp_integration import _get_defer_loading_policy_summary
+
+            policy = _get_defer_loading_policy_summary(
+                deferred_tool_count=len(_ENCELADUS_ALLOWED_RAW_TOOLS),
+            )
+            instructions = str(policy.get("server_instructions") or "").strip()
+            if instructions:
+                server_info["instructions"] = instructions
+        except Exception as exc:
+            logger.warning("MCP initialize: defer-loading server instructions unavailable: %s", exc)
         return {
             "protocolVersion": "2024-11-05",
-            "serverInfo": {
-                "name": "enceladus",
-                "version": "0.4.1",
-            },
+            "serverInfo": server_info,
             "capabilities": {
                 "tools": {"listChanged": False},
                 "resources": {"subscribe": False, "listChanged": False},
@@ -11410,6 +11465,9 @@ def _handle_capabilities() -> Dict[str, Any]:
                             "interface_modes": sorted(_ENCELADUS_INTERFACE_MODES),
                             "default_interface_mode": _ENCELADUS_DEFAULT_INTERFACE_MODE,
                             "code_mode_tools": sorted(_ENCELADUS_CODE_MODE_TOOLS),
+                            "server_instructions": _get_claude_deferred_tool_loading_capabilities().get(
+                                "server_instructions", ""
+                            ),
                             "access_token_secret_ref": provider_secrets["openai_codex"].get("secret_ref"),
                             "compatibility": {
                                 "chatgpt_custom_gpt": True,
@@ -11450,6 +11508,7 @@ def _handle_capabilities() -> Dict[str, Any]:
                                 "budget_range": [CLAUDE_THINKING_BUDGET_MIN, CLAUDE_THINKING_BUDGET_MAX],
                                 "default_budget": CLAUDE_THINKING_BUDGET_DEFAULT,
                             },
+                            "deferred_tool_loading": _get_claude_deferred_tool_loading_capabilities(),
                             "streaming": True,
                             "token_counting": True,
                             "cost_attribution": True,

--- a/backend/lambda/coordination_api/mcp_integration.py
+++ b/backend/lambda/coordination_api/mcp_integration.py
@@ -42,10 +42,14 @@ from project_utils import _ENCELADUS_MCP_SERVER_MODULE
 
 __all__ = [
     "_compute_governance_hash_local",
+    "_get_defer_loading_policy_summary",
     "_load_mcp_server_module",
+    "_load_tool_defer_loading_module",
     "_parse_mcp_result",
     "_resolve_mcp_server_path",
 ]
+
+_TOOL_DEFER_LOADING_MODULE: Any = None
 
 # ---------------------------------------------------------------------------
 # Tracker record helpers
@@ -85,6 +89,35 @@ def _load_mcp_server_module():
     spec.loader.exec_module(module)
     _ENCELADUS_MCP_SERVER_MODULE = module
     return _ENCELADUS_MCP_SERVER_MODULE
+
+
+def _load_tool_defer_loading_module():
+    """Load ENC-TSK-G15 policy module sibling to server.py."""
+    global _TOOL_DEFER_LOADING_MODULE
+    if _TOOL_DEFER_LOADING_MODULE is not None:
+        return _TOOL_DEFER_LOADING_MODULE
+
+    server_module = _load_mcp_server_module()
+    policy_path = pathlib.Path(getattr(server_module, "__file__", "")).with_name("tool_defer_loading.py")
+    if not policy_path.is_file():
+        raise RuntimeError(f"tool_defer_loading.py not found beside MCP server at {policy_path}")
+
+    spec = importlib.util.spec_from_file_location("enceladus_tool_defer_loading", policy_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load defer-loading policy from {policy_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _TOOL_DEFER_LOADING_MODULE = module
+    return _TOOL_DEFER_LOADING_MODULE
+
+
+def _get_defer_loading_policy_summary(*, deferred_tool_count: int = 0) -> Dict[str, Any]:
+    policy = _load_tool_defer_loading_module()
+    summary_fn = getattr(policy, "defer_loading_policy_summary", None)
+    if not callable(summary_fn):
+        raise RuntimeError("tool_defer_loading.defer_loading_policy_summary is missing")
+    return summary_fn(deferred_tool_count=deferred_tool_count)
 
 
 def _parse_mcp_result(result: Any) -> Dict[str, Any]:

--- a/tools/enceladus-mcp-server/test_tool_defer_loading.py
+++ b/tools/enceladus-mcp-server/test_tool_defer_loading.py
@@ -1,0 +1,66 @@
+"""Tests for ENC-TSK-G15 deferred tool-loading policy."""
+
+from __future__ import annotations
+
+import unittest
+
+from tool_defer_loading import (
+    BM25_REPRESENTATIVE_QUERIES,
+    EAGER_LOAD_TOOLS,
+    ENCELADUS_MCP_SERVER_INSTRUCTIONS,
+    anthropic_beta_headers,
+    build_anthropic_deferred_tools_array,
+    build_mcp_toolset,
+    defer_loading_policy_summary,
+    estimate_tool_definition_token_footprint,
+)
+
+
+class ToolDeferLoadingPolicyTests(unittest.TestCase):
+    def test_eager_load_tools_are_four_code_mode_meta_tools(self):
+        self.assertEqual(
+            set(EAGER_LOAD_TOOLS),
+            {"search", "get_compact_context", "execute", "coordination"},
+        )
+
+    def test_build_mcp_toolset_defers_by_default(self):
+        toolset = build_mcp_toolset()
+        self.assertEqual(toolset["type"], "mcp_toolset")
+        self.assertTrue(toolset["default_config"]["defer_loading"])
+        for tool in EAGER_LOAD_TOOLS:
+            self.assertFalse(toolset["configs"][tool]["defer_loading"])
+
+    def test_build_anthropic_deferred_tools_array_registers_bm25(self):
+        tools = build_anthropic_deferred_tools_array()
+        self.assertEqual(len(tools), 2)
+        self.assertEqual(tools[0]["type"], "tool_search_tool_bm25_20251119")
+        self.assertEqual(tools[1]["type"], "mcp_toolset")
+
+    def test_server_instructions_are_keyword_rich(self):
+        text = ENCELADUS_MCP_SERVER_INSTRUCTIONS.lower()
+        for keyword in (
+            "tracker",
+            "docstore",
+            "checkout",
+            "deploy",
+            "governance",
+            "dispatch",
+        ):
+            self.assertIn(keyword, text)
+
+    def test_token_footprint_reduction_exceeds_seventy_percent(self):
+        footprint = estimate_tool_definition_token_footprint(
+            eager_tool_count=len(EAGER_LOAD_TOOLS),
+            deferred_tool_count=36,
+        )
+        self.assertGreaterEqual(footprint["reduction_percent_est"], 70.0)
+
+    def test_policy_summary_includes_representative_queries(self):
+        summary = defer_loading_policy_summary(deferred_tool_count=36)
+        self.assertEqual(summary["bm25_representative_queries"], list(BM25_REPRESENTATIVE_QUERIES))
+        self.assertIn("advanced-tool-use", summary["anthropic_beta"])
+        self.assertIn("mcp-client", summary["anthropic_beta"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/tool_defer_loading.py
+++ b/tools/enceladus-mcp-server/tool_defer_loading.py
@@ -1,0 +1,151 @@
+"""Anthropic deferred tool-loading policy for Enceladus MCP (ENC-TSK-G15 / FTR-099 A3.2).
+
+Single source of truth for:
+- eager-load (non-deferred) code-mode tools
+- BM25 tool search registration
+- mcp_toolset default_config / per-tool configs
+- keyword-rich server instructions for BM25 discovery
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+# Beta headers required when using tool search + defer_loading with MCP connector.
+ANTHROPIC_ADVANCED_TOOL_USE_BETA = "advanced-tool-use-2025-11-20"
+ANTHROPIC_MCP_CLIENT_BETA = "mcp-client-2025-11-20"
+
+BM25_TOOL_SEARCH_TYPE = "tool_search_tool_bm25_20251119"
+BM25_TOOL_SEARCH_NAME = "tool_search_tool_bm25"
+
+DEFAULT_MCP_SERVER_NAME = "enceladus"
+
+# Telemetry-informed eager-load set (G49): highest-frequency governed session tools.
+EAGER_LOAD_TOOLS: Tuple[str, ...] = (
+    "search",
+    "get_compact_context",
+    "execute",
+    "coordination",
+)
+
+# Representative natural-language queries BM25 should route correctly (AC-3).
+BM25_REPRESENTATIVE_QUERIES: Tuple[str, ...] = (
+    "get tracker task record by id",
+    "search documents in docstore",
+    "advance checkout task lifecycle status",
+    "list open tasks for project",
+    "deploy lambda to gamma environment",
+)
+
+ENCELADUS_MCP_SERVER_INSTRUCTIONS = """
+Enceladus governed MCP server for multi-agent software delivery.
+
+Use search for read-only discovery: tracker.get, tracker.list, tracker.graphsearch,
+documents.search, documents.get, deploy.history, governance.dictionary,
+reference.search, system.connection_health, projects.list.
+
+Use get_compact_context for budgeted composite context: record, issue, task, feature,
+project, document, topic modes; hybrid retrieval with vector graph keyword RRF.
+
+Use execute for governed mutations and lifecycle: tracker.set, tracker.set_acceptance_evidence,
+checkout.task, checkout.advance, checkout.release, documents.put, documents.patch,
+deploy.submit, github.create_issue, plan operations.
+
+Use coordination for dispatch plans, capabilities, request inspection, cognito session.
+
+Deferred raw tools include tracker CRUD, docstore read/write, deploy triggers,
+changelog, governance hash, dispatch_plan_generate, github projects, code map,
+architecture excerpts, issue context, component registry, and handoff helpers.
+Search by tool name, record type (task issue feature plan lesson), lifecycle,
+docstore, deploy gamma, governance hash, checkout, tracker mutation.
+""".strip()
+
+
+def normalize_eager_tools(tools: Optional[Iterable[str]] = None) -> Tuple[str, ...]:
+    source = tools if tools is not None else EAGER_LOAD_TOOLS
+    normalized: List[str] = []
+    for item in source:
+        name = str(item or "").strip()
+        if name and name not in normalized:
+            normalized.append(name)
+    return tuple(normalized)
+
+
+def build_mcp_toolset(
+    *,
+    mcp_server_name: str = DEFAULT_MCP_SERVER_NAME,
+    eager_tools: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Anthropic mcp_toolset block: defer all tools except eager-load overrides."""
+    eager = normalize_eager_tools(eager_tools)
+    configs = {tool: {"defer_loading": False} for tool in eager}
+    return {
+        "type": "mcp_toolset",
+        "mcp_server_name": mcp_server_name,
+        "default_config": {"defer_loading": True},
+        "configs": configs,
+    }
+
+
+def build_bm25_tool_search_tool() -> Dict[str, str]:
+    return {
+        "type": BM25_TOOL_SEARCH_TYPE,
+        "name": BM25_TOOL_SEARCH_NAME,
+    }
+
+
+def build_anthropic_deferred_tools_array(
+    *,
+    mcp_server_name: str = DEFAULT_MCP_SERVER_NAME,
+    eager_tools: Optional[Iterable[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Tools array for Anthropic Messages API: BM25 search + deferred MCP toolset."""
+    return [
+        build_bm25_tool_search_tool(),
+        build_mcp_toolset(mcp_server_name=mcp_server_name, eager_tools=eager_tools),
+    ]
+
+
+def anthropic_beta_headers() -> str:
+    return f"{ANTHROPIC_ADVANCED_TOOL_USE_BETA},{ANTHROPIC_MCP_CLIENT_BETA}"
+
+
+def estimate_tool_definition_token_footprint(
+    *,
+    eager_tool_count: int,
+    deferred_tool_count: int,
+    tokens_per_tool: int = 800,
+) -> Dict[str, int]:
+    """Rough before/after footprint for AC-4 measurement (/context style)."""
+    before = (eager_tool_count + deferred_tool_count) * tokens_per_tool
+    # Loaded up front: BM25 search tool (~200) + eager tools only.
+    after = 200 + (eager_tool_count * tokens_per_tool)
+    reduction_pct = 0.0
+    if before > 0:
+        reduction_pct = round((1.0 - (after / before)) * 100.0, 1)
+    return {
+        "before_tokens_est": before,
+        "after_tokens_est": after,
+        "reduction_percent_est": reduction_pct,
+    }
+
+
+def defer_loading_policy_summary(
+    *,
+    eager_tools: Optional[Iterable[str]] = None,
+    deferred_tool_count: int = 0,
+) -> Dict[str, Any]:
+    eager = normalize_eager_tools(eager_tools)
+    footprint = estimate_tool_definition_token_footprint(
+        eager_tool_count=len(eager),
+        deferred_tool_count=deferred_tool_count,
+    )
+    return {
+        "eager_load_tools": list(eager),
+        "bm25_tool_search": build_bm25_tool_search_tool(),
+        "mcp_toolset": build_mcp_toolset(eager_tools=eager),
+        "server_instructions": ENCELADUS_MCP_SERVER_INSTRUCTIONS,
+        "anthropic_beta": anthropic_beta_headers(),
+        "bm25_representative_queries": list(BM25_REPRESENTATIVE_QUERIES),
+        "token_footprint_estimate": footprint,
+    }


### PR DESCRIPTION
## Summary
- Add `tool_defer_loading.py` as single-source policy for eager-load tools (`search`, `get_compact_context`, `execute`, `coordination`), BM25 tool search registration, and `mcp_toolset` defer-by-default config
- Expose policy via `coordination_capabilities` (`deferred_tool_loading`), MCP `initialize` server instructions, and optional Claude dispatch when `provider_session.deferred_tool_loading=true`
- Unit tests validate >70% estimated tool-definition token reduction and keyword-rich server instructions
- Bump `governance_data_dictionary.json` for schema-affecting coordination_api changes

## Test plan
- [x] `python3 -m unittest test_tool_defer_loading.py` from `tools/enceladus-mcp-server`
- [ ] Merge to v4/main and verify gamma coordination_api capabilities include `deferred_tool_loading`
- [ ] Confirm MCP initialize returns `serverInfo.instructions`

CCI-9860ca4283bd4479b1828e4eea699cb1