### PR TITLE
[ENC-TSK-G17] Context-management beta: clear_tool_uses + memory tool for long coordination loops

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.13",
-  "updated_at": "2026-07-02T10:15:00Z",
-  "last_change_summary": "ENC-TSK-J94 (ENC-ISS-441 Ph4, ENC-FTR-122): retirement sweeps - new coordination.agent_session_unclaim_sweep entity (rate(10 minutes) EventBridge rule, allocated-only, created_at reference, SCI revocation unclaim_ttl_exceeded); idle sweep default threshold tightened 86400->7200 with last_activity_at-preferred reference and SCI revocation idle_ttl_exceeded (revoked_scis/revoked_sci_count in both sweep summaries). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.14",
+  "updated_at": "2026-07-02T10:20:00Z",
+  "last_change_summary": "ENC-TSK-G17 (FTR-099 A3.5): context-management beta for long coordination loops — provider_session.context_management_enabled gates _maybe_attach_context_management in coordination_api dispatch_claude_api; emits clear_tool_uses_20250919 (100k trigger, keep 5, exclude memory), optional clear_thinking_20251015 on Opus+thinking, memory_20250818 tool registration, and context-management-2025-06-27 anthropic-beta header (appended, composes with deferred_tool_loading). New entity mcp_server.context_management. Rebased onto ENC-TSK-J94 (retirement sweeps, .13) -- both changes' entities preserved.",
   "owners": [
     "enceladus-platform"
   ],
@@ -1612,6 +1612,11 @@
           "definition": "When true on claude_agent_sdk dispatch, coordination attaches Anthropic deferred tool-loading tools array (mcp_toolset + BM25 tool search) and advanced-tool-use beta headers to the Messages API request.",
           "usage_guidance": "Opt-in per coordination request. Eager-load tools default to search, get_compact_context, execute, coordination; all other MCP tools defer until BM25 retrieval. See mcp_server.deferred_tool_loading entity."
         },
+        "provider_session.context_management_enabled": {
+          "type": "boolean",
+          "definition": "When true on claude_agent_sdk dispatch, coordination attaches Anthropic context-management beta (clear_tool_uses_20250919 + memory_20250818 tool) to the Messages API request for long loops.",
+          "usage_guidance": "Opt-in per coordination request for sessions expected to exceed ~20 tool calls. Composes with deferred_tool_loading. See mcp_server.context_management entity."
+        },
         "dispatch_target_task_ids": {
           "type": "array",
           "item_type": "string",
@@ -2269,6 +2274,36 @@
           "type": "object",
           "definition": "Ephemeral 1h cache_control attached to the last tool in the Anthropic tools array (mcp_toolset block) when deferred_tool_loading is enabled.",
           "usage_guidance": "Requires catalog_tokens_est above Sonnet 2048 / Opus 4096 minimums (see toolset_cache_eligibility in capabilities). Per-turn cache_read_input_tokens and cache_creation_input_tokens logged via dispatch_claude_api observability."
+        }
+      }
+    },
+    "mcp_server.context_management": {
+      "description": "Anthropic context-management beta for long coordination loops (ENC-TSK-G17 / FTR-099 A3.5). Evicts stale tool results once input-token threshold is crossed while preserving memory tool writes.",
+      "fields": {
+        "context_management_enabled": {
+          "type": "boolean",
+          "definition": "Provider-session flag gating _maybe_attach_context_management in coordination_api dispatch_claude_api.",
+          "usage_guidance": "Set provider_session.context_management_enabled=true for sessions expected to exceed ~20 tool calls."
+        },
+        "clear_tool_uses_20250919": {
+          "type": "edit",
+          "definition": "Context edit: trigger at 100k input tokens, keep last 5 tool_uses, exclude_tools=[memory].",
+          "usage_guidance": "Wired in _build_claude_context_management_config(); memory tool excluded from eviction."
+        },
+        "clear_thinking_20251015": {
+          "type": "edit",
+          "definition": "Optional companion edit appended only when model is Opus and extended thinking is active.",
+          "usage_guidance": "Gated on thinking_param and opus model id in _maybe_attach_context_management."
+        },
+        "memory_20250818": {
+          "type": "tool",
+          "definition": "Anthropic memory tool registered on the tools array when context management is enabled.",
+          "usage_guidance": "Enceladus memory file schema (_ENCELADUS_MEMORY_FILE_SCHEMA) defines plan anchors, governance_hash, active task state. Durable S3/local backend is a follow-up."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Appends context-management-2025-06-27 via _append_anthropic_beta (composes with deferred_tool_loading headers)."
         }
       }
     },

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -460,6 +460,65 @@ _CLAUDE_CONTEXT_LIMITS = {
     "claude-opus-4-6": 200_000,
 }
 _CLAUDE_DEFAULT_CONTEXT_LIMIT = 200_000
+
+# --- Context-management beta (ENC-TSK-G17 / G60/G61/G62) -------------------
+# Anthropic's context-management beta evicts stale tool_use/tool_result blocks
+# once an input-token threshold is crossed, so long coordination loops stop
+# carrying thousands of tokens of dead context after 20+ tool calls.
+CLAUDE_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
+_CLAUDE_CLEAR_TOOL_USES_EDIT_TYPE = "clear_tool_uses_20250919"
+_CLAUDE_CLEAR_THINKING_EDIT_TYPE = "clear_thinking_20251015"
+# clear_tool_uses config: trigger at 100k input tokens, keep the last 5 tool-use
+# records so the agent retains recent working context.
+_CLAUDE_CONTEXT_MANAGEMENT_TRIGGER_INPUT_TOKENS = 100_000
+_CLAUDE_CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 5
+# Client-side memory tool (Anthropic-defined, schema-less) used to persist what
+# matters before eviction. The tool itself is excluded from clear_tool_uses so
+# the agent never loses its own memory writes/reads.
+_CLAUDE_MEMORY_TOOL_TYPE = "memory_20250818"
+_CLAUDE_MEMORY_TOOL_NAME = "memory"
+# Enceladus memory-file schema: what a coordination agent should preserve across
+# eviction. This documents the intended memory-file content shape; the actual
+# storage backend is a follow-up (see _dispatch_claude_api docstring / report).
+_ENCELADUS_MEMORY_FILE_SCHEMA = {
+    "type": "object",
+    "description": "Enceladus coordination-loop memory record preserved across "
+    "context-management tool-result eviction.",
+    "properties": {
+        "plan_anchors": {
+            "type": "array",
+            "description": "Stable ENC-PLN/ENC-TSK/DOC anchors and their intent.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+                "required": ["id"],
+                "additionalProperties": False,
+            },
+        },
+        "active_governance_hash": {
+            "type": "string",
+            "description": "The governance_hash captured at session init.",
+        },
+        "active_task_state": {
+            "type": "object",
+            "description": "Checkout/lifecycle state for the task in flight.",
+            "properties": {
+                "task_id": {"type": "string"},
+                "status": {"type": "string"},
+                "transition_type": {"type": "string"},
+                "components": {"type": "array", "items": {"type": "string"}},
+                "cai": {"type": "string"},
+                "cci": {"type": "string"},
+                "commit_sha": {"type": "string"},
+            },
+            "additionalProperties": True,
+        },
+    },
+    "additionalProperties": True,
+}
 _VALID_TERMINAL_STATES = {"succeeded", "failed", "cancelled", "dead_letter"}
 _VALID_PROVIDERS = {"claude_agent_sdk", "openai_codex", "aws_native", "aws_bedrock_agent"}
 _CLAUDE_PERMISSION_MODES = {"plan", "acceptEdits", "default"}
@@ -5149,6 +5208,111 @@ def _maybe_attach_deferred_tool_loading(
         return False
 
 
+def _append_anthropic_beta(request_headers: Dict[str, str], *beta_values: str) -> None:
+    """Append beta flag(s) to the comma-separated ``anthropic-beta`` header.
+
+    Anthropic's beta header is a comma-joined list. This MUST NOT overwrite any
+    value another feature (e.g. _maybe_attach_deferred_tool_loading) already set
+    — it appends new flags, de-duplicated, preserving prior order. Composable
+    regardless of the order in which the two attach helpers run.
+    """
+    existing = str(request_headers.get("anthropic-beta", "") or "")
+    ordered: List[str] = []
+    seen = set()
+    for value in list(part.strip() for part in existing.split(",")) + list(beta_values):
+        if value and value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    if ordered:
+        request_headers["anthropic-beta"] = ",".join(ordered)
+
+
+def _build_claude_context_management_config() -> Dict[str, Any]:
+    """Build the ``context_management`` request-body block for coordination loops.
+
+    Wires a ``clear_tool_uses_20250919`` edit: trigger eviction at 100k input
+    tokens, keep the last 5 tool-use records, and exclude the memory tool so the
+    agent never loses its own memory writes/reads.
+
+    NOTE (verify against current Anthropic context-management docs before ship):
+    the field used to exempt a tool from clearing is assumed to be
+    ``exclude_tools`` (a list of tool_name strings). If Anthropic's current API
+    uses a different field name, only this key needs to change. Flagged in the
+    ENC-TSK-G17 report.
+    """
+    return {
+        "edits": [
+            {
+                "type": _CLAUDE_CLEAR_TOOL_USES_EDIT_TYPE,
+                "trigger": {
+                    "type": "input_tokens",
+                    "value": _CLAUDE_CONTEXT_MANAGEMENT_TRIGGER_INPUT_TOKENS,
+                },
+                "keep": {
+                    "type": "tool_uses",
+                    "value": _CLAUDE_CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+                },
+                # Exempt the memory tool from eviction (G61).
+                "exclude_tools": [_CLAUDE_MEMORY_TOOL_NAME],
+            }
+        ]
+    }
+
+
+def _maybe_attach_context_management(
+    provider_session: Dict[str, Any],
+    request_body: Dict[str, Any],
+    request_headers: Dict[str, str],
+    model: str,
+    thinking_param: Optional[Dict[str, Any]],
+) -> bool:
+    """Attach context-management beta (clear_tool_uses + memory tool) when enabled.
+
+    Gated behind ``provider_session["context_management_enabled"]`` — the caller
+    sets this for sessions expected to exceed ~20 tool calls (ENC-TSK-G17 AC).
+    Composes with _maybe_attach_deferred_tool_loading: appends the beta header
+    (never overwrites) and appends the memory tool (never clobbers an existing
+    tools array). Returns True when the context_management block was attached.
+    """
+    if not provider_session.get("context_management_enabled"):
+        return False
+    try:
+        context_management = _build_claude_context_management_config()
+
+        # G62 companion: clear_thinking is only valid/useful when the resolved
+        # model is an Opus model AND extended/adaptive thinking is active for
+        # this call. Reuse the existing thinking detection (thinking_param) —
+        # it is non-None exactly when thinking was constructed for this request.
+        if thinking_param and "opus" in str(model).lower():
+            context_management["edits"].append(
+                {"type": _CLAUDE_CLEAR_THINKING_EDIT_TYPE}
+            )
+
+        request_body["context_management"] = context_management
+
+        # Add the memory tool (G61) to the tools array, appending so we compose
+        # with the deferred-tool-loading toolset rather than overwriting it.
+        memory_tool = {
+            "type": _CLAUDE_MEMORY_TOOL_TYPE,
+            "name": _CLAUDE_MEMORY_TOOL_NAME,
+        }
+        tools = request_body.get("tools")
+        if not isinstance(tools, list):
+            tools = []
+        if not any(
+            isinstance(t, dict) and t.get("type") == _CLAUDE_MEMORY_TOOL_TYPE
+            for t in tools
+        ):
+            tools.append(memory_tool)
+        request_body["tools"] = tools
+
+        _append_anthropic_beta(request_headers, CLAUDE_CONTEXT_MANAGEMENT_BETA)
+        return True
+    except Exception as exc:
+        logger.warning("context_management attach failed: %s", exc)
+        return False
+
+
 def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatch_id: str) -> Dict[str, Any]:
     """Dispatch a request to the Anthropic Messages API with full feature support.
 
@@ -5159,6 +5323,12 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
     - Streaming SSE support
     - Pre-flight token counting
     - Enhanced observability with token breakdown and cost attribution
+    - Context-management beta for long coordination loops (ENC-TSK-G17):
+      clear_tool_uses_20250919 eviction + memory_20250818 tool, gated on
+      provider_session["context_management_enabled"]. NOTE: the memory tool is
+      registered and excluded from eviction, but a durable S3/local storage
+      backend for the Enceladus memory-file schema (_ENCELADUS_MEMORY_FILE_SCHEMA)
+      is a follow-up — this wires the API contract, not the backend.
     """
     provider_session = request.get("provider_session") or {}
 
@@ -5266,7 +5436,13 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
     toolset_cache_attached = _maybe_attach_deferred_tool_loading(
         provider_session, request_body, anthropic_headers
     )
-    if "tools" in request_body:
+    # Context-management beta runs AFTER deferred tool loading so its beta-header
+    # append composes with (never overwrites) the deferred beta values, and the
+    # memory tool appends to any deferred toolset (ENC-TSK-G17 / G60/G61).
+    context_management_attached = _maybe_attach_context_management(
+        provider_session, request_body, anthropic_headers, model, thinking_param
+    )
+    if "tools" in request_body or "context_management" in request_body:
         request_json = json.dumps(request_body).encode("utf-8")
     req = urllib.request.Request(
         url=endpoint,
@@ -5377,6 +5553,8 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
             "extended_thinking": bool(thinking_param),
             "streaming": use_streaming,
             "preflight_token_count": preflight_token_count,
+            "context_management": context_management_attached,
+            "memory_tool": context_management_attached,
         },
         "governance_context": {
             "loaded": bool(governance_context.get("loaded")),
@@ -5411,6 +5589,7 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
             "total_cost_usd": cost_attribution.get("total_cost_usd"),
             "cache_hit_ratio": cost_attribution.get("cache_hit_ratio"),
             "toolset_cache_attached": toolset_cache_attached,
+            "context_management_attached": context_management_attached,
             "streaming": use_streaming,
             "thinking_enabled": bool(thinking_param),
             "preflight_token_count": preflight_token_count,

--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -3550,5 +3550,191 @@ class TriggerGovernanceSyncPushTests(unittest.TestCase):
         coordination_lambda._lambda_client = None
 
 
+class ContextManagementG17Tests(unittest.TestCase):
+    """ENC-TSK-G17 (G60/G61/G62): context-management beta wiring.
+
+    These are structural/config tests. G62's AC asks for a 30-turn live governed
+    session showing >=50% input-token reduction by turn 30 — that requires a real
+    Anthropic API session and cannot be honestly asserted in this sandbox. The
+    tests below verify the WIRING is correct (the config the Lambda emits would
+    trigger clearing above the 100k threshold with a keep-5 policy), not a live
+    measured reduction.
+    """
+
+    def test_append_anthropic_beta_appends_not_overwrites(self):
+        # Simulate deferred-tool-loading having already set the header first.
+        headers = {"anthropic-beta": "advanced-tool-use-2024,mcp-client-2025-11-20"}
+        coordination_lambda._append_anthropic_beta(
+            headers, coordination_lambda.CLAUDE_CONTEXT_MANAGEMENT_BETA
+        )
+        values = headers["anthropic-beta"].split(",")
+        # Both the pre-existing mcp-client-style beta AND context-management present.
+        self.assertIn("mcp-client-2025-11-20", values)
+        self.assertIn("advanced-tool-use-2024", values)
+        self.assertIn("context-management-2025-06-27", values)
+        # Comma-joined, order preserved (existing first), no clobber.
+        self.assertEqual(
+            headers["anthropic-beta"],
+            "advanced-tool-use-2024,mcp-client-2025-11-20,context-management-2025-06-27",
+        )
+
+    def test_append_anthropic_beta_deduplicates(self):
+        headers = {"anthropic-beta": "context-management-2025-06-27"}
+        coordination_lambda._append_anthropic_beta(
+            headers, coordination_lambda.CLAUDE_CONTEXT_MANAGEMENT_BETA
+        )
+        self.assertEqual(headers["anthropic-beta"], "context-management-2025-06-27")
+
+    def test_append_anthropic_beta_from_empty(self):
+        headers = {}
+        coordination_lambda._append_anthropic_beta(
+            headers, coordination_lambda.CLAUDE_CONTEXT_MANAGEMENT_BETA
+        )
+        self.assertEqual(headers["anthropic-beta"], "context-management-2025-06-27")
+
+    def test_context_management_config_shape(self):
+        cfg = coordination_lambda._build_claude_context_management_config()
+        edits = cfg["edits"]
+        self.assertEqual(len(edits), 1)
+        edit = edits[0]
+        self.assertEqual(edit["type"], "clear_tool_uses_20250919")
+        self.assertEqual(edit["trigger"], {"type": "input_tokens", "value": 100_000})
+        self.assertEqual(edit["keep"], {"type": "tool_uses", "value": 5})
+        # Memory tool is excluded from eviction (G61).
+        self.assertEqual(edit["exclude_tools"], ["memory"])
+
+    def test_attach_registers_memory_tool_and_composes_with_deferred(self):
+        # Simulate deferred tool loading having run first: a toolset + beta header.
+        request_body = {"tools": [{"type": "tool_search_tool_bm25_20251119"}]}
+        headers = {"anthropic-beta": "mcp-client-2025-11-20"}
+        attached = coordination_lambda._maybe_attach_context_management(
+            {"context_management_enabled": True},
+            request_body,
+            headers,
+            "claude-sonnet-4-6",
+            None,
+        )
+        self.assertTrue(attached)
+        # context_management block present with clear_tool_uses.
+        self.assertIn("context_management", request_body)
+        self.assertEqual(
+            request_body["context_management"]["edits"][0]["type"],
+            "clear_tool_uses_20250919",
+        )
+        # Memory tool appended (not clobbering the deferred toolset).
+        tool_types = [t.get("type") for t in request_body["tools"]]
+        self.assertIn("tool_search_tool_bm25_20251119", tool_types)
+        self.assertIn("memory_20250818", tool_types)
+        # Memory tool excluded from eviction.
+        self.assertIn(
+            "memory", request_body["context_management"]["edits"][0]["exclude_tools"]
+        )
+        # Beta header appended, not overwritten.
+        betas = headers["anthropic-beta"].split(",")
+        self.assertIn("mcp-client-2025-11-20", betas)
+        self.assertIn("context-management-2025-06-27", betas)
+
+    def test_attach_disabled_is_noop(self):
+        request_body = {}
+        headers = {}
+        attached = coordination_lambda._maybe_attach_context_management(
+            {}, request_body, headers, "claude-sonnet-4-6", None
+        )
+        self.assertFalse(attached)
+        self.assertNotIn("context_management", request_body)
+        self.assertNotIn("tools", request_body)
+        self.assertEqual(headers, {})
+
+    def test_attach_does_not_duplicate_memory_tool(self):
+        request_body = {"tools": [{"type": "memory_20250818", "name": "memory"}]}
+        headers = {}
+        coordination_lambda._maybe_attach_context_management(
+            {"context_management_enabled": True},
+            request_body,
+            headers,
+            "claude-sonnet-4-6",
+            None,
+        )
+        memory_tools = [
+            t for t in request_body["tools"] if t.get("type") == "memory_20250818"
+        ]
+        self.assertEqual(len(memory_tools), 1)
+
+    def test_clear_thinking_added_only_for_opus_with_thinking(self):
+        # Opus + active thinking -> clear_thinking companion edit present.
+        rb = {}
+        coordination_lambda._maybe_attach_context_management(
+            {"context_management_enabled": True},
+            rb,
+            {},
+            "claude-opus-4-6",
+            {"type": "adaptive"},
+        )
+        edit_types = [e["type"] for e in rb["context_management"]["edits"]]
+        self.assertIn("clear_thinking_20251015", edit_types)
+
+    def test_clear_thinking_absent_for_opus_without_thinking(self):
+        rb = {}
+        coordination_lambda._maybe_attach_context_management(
+            {"context_management_enabled": True},
+            rb,
+            {},
+            "claude-opus-4-6",
+            None,
+        )
+        edit_types = [e["type"] for e in rb["context_management"]["edits"]]
+        self.assertNotIn("clear_thinking_20251015", edit_types)
+
+    def test_clear_thinking_absent_for_non_opus_with_thinking(self):
+        rb = {}
+        coordination_lambda._maybe_attach_context_management(
+            {"context_management_enabled": True},
+            rb,
+            {},
+            "claude-sonnet-4-6",
+            {"type": "adaptive"},
+        )
+        edit_types = [e["type"] for e in rb["context_management"]["edits"]]
+        self.assertNotIn("clear_thinking_20251015", edit_types)
+
+    def test_g62_synthetic_30_turn_clearing_wiring(self):
+        """G62 wiring proof (NOT a live 50% measurement).
+
+        Build a synthetic sequence of 30 tool_use/tool_result turns whose
+        accumulated input tokens cross the configured 100k trigger, then apply
+        the keep-5 policy pulled from the SAME config the Lambda emits. Asserts:
+        (a) the config trigger would fire above threshold, and (b) keep-5 retains
+        the last 5 tool-use records and evicts the older 25, yielding a large
+        input-token reduction. This validates the config/wiring, not a live
+        Anthropic-measured reduction.
+        """
+        cfg = coordination_lambda._build_claude_context_management_config()
+        edit = cfg["edits"][0]
+        trigger_tokens = edit["trigger"]["value"]
+        keep = edit["keep"]["value"]
+
+        # Synthetic accumulation: 30 turns, each tool_use+tool_result ~= 4000 tok.
+        per_turn_tokens = 4000
+        turns = [
+            {"index": i, "tokens": per_turn_tokens} for i in range(30)
+        ]
+        total_before = sum(t["tokens"] for t in turns)
+
+        # (a) Config trigger would fire: accumulated context exceeds 100k.
+        self.assertGreater(total_before, trigger_tokens)
+
+        # (b) Apply keep-5 eviction policy from the wired config.
+        retained = turns[-keep:]
+        evicted = turns[:-keep]
+        self.assertEqual(len(retained), 5)
+        self.assertEqual(len(evicted), 25)
+
+        total_after = sum(t["tokens"] for t in retained)
+        reduction_pct = (1.0 - total_after / total_before) * 100.0
+        # keep-5 of 30 evenly-sized turns => ~83% structural reduction of
+        # evictable tool context. (Structural, not a live token-count claim.)
+        self.assertGreater(reduction_pct, 50.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Enables Anthropic's context-management beta (`context-management-2025-06-27`) in `coordination_api._dispatch_claude_api` so long agent sessions stop carrying dead tool-result context (DOC-B8641F56EED3 Strategy #4).
- **G60**: New `_maybe_attach_context_management()` gates on `provider_session["context_management_enabled"]` (mirrors the `deferred_tool_loading` flag convention). Emits a `clear_tool_uses_20250919` edit: trigger at 100k input tokens, keep last 5 tool_uses, `exclude_tools=["memory"]`. Beta header is **appended, never overwritten** via `_append_anthropic_beta`, composing correctly with `_maybe_attach_deferred_tool_loading`'s existing header assignment (G15/G16). `clear_thinking_20251015` added only when the resolved model is Opus AND extended thinking is active.
- **G61**: Registers the `memory_20250818` tool and defines `_ENCELADUS_MEMORY_FILE_SCHEMA` (plan anchors / active `governance_hash` / active task state). **Storage backend is a documented stub** — no S3/local persistence layer exists yet; this wires the API contract only.
- **G62**: Structural/config unit tests only — a synthetic 30-turn tool_use/tool_result accumulation confirms the wired trigger/keep-5 config would clear above the 100k threshold. This is **not** a live-measured ≥50% token reduction (that requires a real 30-turn Anthropic session, out of scope for this sandbox).

## Known gaps (flagged, not hidden)
- `exclude_tools` field name in the `clear_tool_uses_20250919` edit is a best-effort match to Anthropic's current context-management API shape — recommend a doc cross-check before enabling this flag for real traffic. Flag-gated off by default, so this doesn't block merging.
- Memory tool has no persistence backend yet (G61 AC-1 left open on the tracker).
- G62's AC (live 30-turn measured reduction) also left open on the tracker — needs a real session with API budget to close.

## Test plan
- [x] 11 new unit tests: beta-header append/dedup, context_management body shape, memory tool registration + eviction exclusion, clear_thinking Opus/thinking gating, synthetic 30-turn wiring test
- [x] Full coordination_api suite: 591 passed, 2 skipped, 13 subtests passed (2 pre-existing unrelated DynamoDB-auth failures confirmed present on clean v4/main baseline too — zero regressions from this change)

CCI-5211540636b54624a3f1235a55aacff0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-5211540636b54624a3f1235a55aacff0