### PR TITLE
[ENC-TSK-J94] ISS-441 Ph4 — retirement sweeps: 10-min unclaim TTL + 2h idle TTL + SCI revocation

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -47,6 +47,7 @@ from config import (
     AGENT_CREDENTIALS_TABLE,
     AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS,
     AGENT_SESSIONS_TABLE,
+    AGENT_SESSIONS_UNCLAIM_TTL_MINUTES,
     AGENT_TYPES_TABLE,
     CHECKOUT_TOKENS_TABLE,
     logger,
@@ -86,6 +87,7 @@ __all__ = [
     "rotate_credential",
     "revoke_credential",
     "sweep_idle_sessions",
+    "sweep_unclaimed_sessions",
     "list_sessions",
     "list_agent_types",
     "list_credentials",
@@ -761,6 +763,7 @@ def sweep_idle_sessions(
 
     retired: List[str] = []
     skipped: List[Dict[str, str]] = []
+    revoked_scis: List[str] = []
     if not dry_run:
         for sid in candidate_ids:
             try:
@@ -769,6 +772,12 @@ def sweep_idle_sessions(
             except ValueError as exc:
                 # Concurrently retired/transitioned between scan and update — idempotent skip.
                 skipped.append({"session_id": sid, "reason": str(exc)})
+                continue
+            # ENC-ISS-441 / ENC-TSK-J94: a swept session's SCI must never mutate again.
+            # Revocation failure is non-fatal (logged; the next sweep re-revokes).
+            token = _revoke_sci_after_sweep(sid, reason="idle_ttl_exceeded")
+            if token:
+                revoked_scis.append(token)
 
     summary: Dict[str, Any] = {
         "enabled": True,
@@ -782,8 +791,129 @@ def sweep_idle_sessions(
         "retired": retired,
         "skipped_count": len(skipped),
         "skipped": skipped,
+        "revoked_sci_count": len(revoked_scis),
+        "revoked_scis": revoked_scis,
     }
     logger.info("[INFO] Agent-session idle-sweep: %s", json.dumps(summary, default=str))
+    return summary
+
+
+def _revoke_sci_after_sweep(session_id: str, *, reason: str) -> Optional[str]:
+    """Best-effort SCI revocation for a just-swept session (ENC-ISS-441 / ENC-TSK-J94).
+
+    Returns the token id when THIS call performed the revocation; None when the session
+    had no SCI, the token was already revoked (idempotent re-run), or revocation failed
+    (logged — the next sweep pass re-revokes, and an expired token fails closed anyway).
+    """
+    try:
+        revoked = revoke_sci_for_session(session_id, reason=reason)
+    except (ValueError, BotoCoreError, ClientError) as exc:
+        logger.warning(
+            "[ERROR] SCI revocation failed for swept session %s (reason=%s): %s",
+            session_id, reason, exc,
+        )
+        return None
+    if revoked and not revoked.get("already_revoked"):
+        token_id = str(revoked.get("token_id") or revoked.get("pk") or "")
+        logger.info(
+            "[INFO] Revoked SCI %s for swept session %s (reason=%s)",
+            token_id, session_id, reason,
+        )
+        return token_id or None
+    return None
+
+
+def sweep_unclaimed_sessions(
+    *,
+    unclaim_ttl_minutes: int = AGENT_SESSIONS_UNCLAIM_TTL_MINUTES,
+    now: Optional[dt.datetime] = None,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Reap ghost registrations: ``allocated`` sessions never claimed within the TTL
+    (ENC-ISS-441 retirement lifecycle part 1 / ENC-TSK-J94).
+
+    A session that calls ``agent.register`` but never ``agent.claim`` within
+    ``unclaim_ttl_minutes`` (default 10) of ``created_at`` is flipped to ``retired`` —
+    the ENC-ISS-441 evidence found 10 of 24 production sessions in exactly this ghost
+    state. The reference timestamp is strictly ``created_at`` (an allocated session has
+    no claim heartbeat by definition; io design decision on the issue).
+
+    Same append-only, idempotent construction as ``sweep_idle_sessions``: candidates are
+    retired through ``retire_session``'s conditional flip, concurrent transitions are
+    skipped, nothing is deleted. Although an allocated session should have no SCI (SCIs
+    are minted at claim), revocation is still attempted per retired session as
+    defense-in-depth (reason=unclaim_ttl_exceeded).
+    """
+    if isinstance(unclaim_ttl_minutes, bool) or not isinstance(unclaim_ttl_minutes, int):
+        raise ValueError(
+            f"unclaim_ttl_minutes must be an int, got {type(unclaim_ttl_minutes).__name__}"
+        )
+    if unclaim_ttl_minutes < 0:
+        raise ValueError(f"unclaim_ttl_minutes must be >= 0, got {unclaim_ttl_minutes}")
+
+    now_dt = now or dt.datetime.now(dt.timezone.utc)
+    cutoff = (now_dt - dt.timedelta(minutes=unclaim_ttl_minutes)).strftime(_TS_FORMAT)
+
+    ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": AGENT_SESSIONS_TABLE,
+        "FilterExpression": (
+            "NOT begins_with(session_id, :ctr_pfx) AND #st = :allocated"
+        ),
+        "ExpressionAttributeNames": {"#st": "status"},
+        "ExpressionAttributeValues": {
+            ":ctr_pfx": _serialize("counter#"),
+            ":allocated": _serialize("allocated"),
+        },
+    }
+
+    scanned_allocated = 0
+    candidate_ids: List[str] = []
+    scan = ddb.scan(**scan_kwargs)
+    while True:
+        for raw in scan.get("Items", []):
+            item = _deserialize(raw)
+            scanned_allocated += 1
+            created_at = str(item.get("created_at") or "")
+            if created_at and created_at < cutoff:
+                candidate_ids.append(item["session_id"])
+        last_key = scan.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        scan = ddb.scan(ExclusiveStartKey=last_key, **scan_kwargs)
+
+    retired: List[str] = []
+    skipped: List[Dict[str, str]] = []
+    revoked_scis: List[str] = []
+    if not dry_run:
+        for sid in candidate_ids:
+            try:
+                retire_session(sid)
+                retired.append(sid)
+            except ValueError as exc:
+                # Claimed or retired between scan and update — idempotent skip.
+                skipped.append({"session_id": sid, "reason": str(exc)})
+                continue
+            token = _revoke_sci_after_sweep(sid, reason="unclaim_ttl_exceeded")
+            if token:
+                revoked_scis.append(token)
+
+    summary: Dict[str, Any] = {
+        "enabled": True,
+        "dry_run": dry_run,
+        "unclaim_ttl_minutes": unclaim_ttl_minutes,
+        "cutoff": cutoff,
+        "scanned_allocated": scanned_allocated,
+        "candidate_count": len(candidate_ids),
+        "candidate_ids": candidate_ids,
+        "retired_count": len(retired),
+        "retired": retired,
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+        "revoked_sci_count": len(revoked_scis),
+        "revoked_scis": revoked_scis,
+    }
+    logger.info("[INFO] Agent-session unclaim-sweep: %s", json.dumps(summary, default=str))
     return summary
 
 

--- a/backend/lambda/coordination_api/config.py
+++ b/backend/lambda/coordination_api/config.py
@@ -64,6 +64,8 @@ __all__ = [
     "AGENT_CREDENTIALS_TABLE",
     "AGENT_SESSIONS_IDLE_SWEEP_ENABLED",
     "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS",
+    "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED",
+    "AGENT_SESSIONS_UNCLAIM_TTL_MINUTES",
     "DRIFT_TELEMETRY_TABLE",
     "GRAPH_QUERY_API_URL",
     "COORDINATION_PUBLIC_BASE_URL",
@@ -194,8 +196,20 @@ AGENT_CREDENTIALS_TABLE = os.environ.get("AGENT_CREDENTIALS_TABLE", "agent-crede
 AGENT_SESSIONS_IDLE_SWEEP_ENABLED = (
     os.environ.get("AGENT_SESSIONS_IDLE_SWEEP_ENABLED", "true").lower() == "true"
 )
+# ENC-ISS-441 / ENC-TSK-J94: default tightened from I71's 86400 (24h) to 7200 (2h) per the
+# io design decision on the issue. The idle reference prefers last_activity_at (J71/J83
+# heartbeat), so listening agents polling escalation.watch are exempt while they poll.
 AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS = int(
-    os.environ.get("AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS", "86400")
+    os.environ.get("AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS", "7200")
+)
+# ENC-ISS-441 / ENC-TSK-J94: unclaim TTL sweep — a session registered (allocated) but never
+# claimed within this many minutes is a ghost registration and is reaped to 'retired'.
+# 10 of 24 production sessions exhibited this pattern (the ENC-ISS-441 evidence).
+AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED = (
+    os.environ.get("AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED", "true").lower() == "true"
+)
+AGENT_SESSIONS_UNCLAIM_TTL_MINUTES = int(
+    os.environ.get("AGENT_SESSIONS_UNCLAIM_TTL_MINUTES", "10")
 )
 # ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122): Session Claim ID (SCI) tokens live in the SAME
 # DynamoDB table the checkout service uses for CAI/CCI (pk = token id, token_type

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.12",
-  "updated_at": "2026-07-02T10:02:00Z",
-  "last_change_summary": "ENC-TSK-J92 (ENC-ISS-441 Ph2, ENC-FTR-122): Session Claim ID (SCI) primitive shipped DARK - agent.claim mints SCI-{uuid4_hex} into the checkout-tokens table (token_type=SCI, 24h TTL, env-suffixed CHECKOUT_TOKENS_TABLE) and returns it in the claim envelope; agent.retire revokes (revoked/revoked_at/revocation_reason); session item stamped with sci_token_id. New entity coordination.session_claim_id. IAM SciTokenAccess grant + CHECKOUT_TOKENS_TABLE env on CoordinationApiFunction (02-compute.yaml v4). No enforcement until ENC-TSK-J93. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.13",
+  "updated_at": "2026-07-02T10:15:00Z",
+  "last_change_summary": "ENC-TSK-J94 (ENC-ISS-441 Ph4, ENC-FTR-122): retirement sweeps - new coordination.agent_session_unclaim_sweep entity (rate(10 minutes) EventBridge rule, allocated-only, created_at reference, SCI revocation unclaim_ttl_exceeded); idle sweep default threshold tightened 86400->7200 with last_activity_at-preferred reference and SCI revocation idle_ttl_exceeded (revoked_scis/revoked_sci_count in both sweep summaries). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
   "owners": [
     "enceladus-platform"
   ],
@@ -6614,7 +6614,7 @@
       "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
     },
     "coordination.agent_session_idle_sweep": {
-      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep.",
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep. ENC-TSK-J94: the sweep now also revokes each retired session's SCI (revocation_reason=idle_ttl_exceeded) and the default threshold is 7200s.",
       "fields": {
         "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
           "type": "boolean",
@@ -6622,7 +6622,7 @@
         },
         "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS": {
           "type": "integer",
-          "definition": "Env var (config.py), default 86400 (24h) at J91 backport time. A live session whose idle reference is older than this is reaped. Operator-configurable per ENC-TSK-I71 AC#2; ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default to 7200 (2h)."
+          "definition": "Env var (config.py), default 7200 (2h) since ENC-ISS-441 Ph4 (ENC-TSK-J94; was 86400/24h under I71). A live session whose idle reference (last_activity_at > claimed_at > created_at) is older than this is reaped. escalation.watch polling refreshes last_activity_at (J71/J83), so listening agents are exempt while they poll."
         },
         "action": {
           "type": "string",
@@ -6631,6 +6631,10 @@
         "summary": {
           "type": "object",
           "definition": "Return value (CloudWatch only - no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+        },
+        "revoked_scis": {
+          "type": "array",
+          "definition": "ENC-TSK-J94: token ids of SCIs revoked by this sweep pass (revocation_reason=idle_ttl_exceeded). revoked_sci_count carries the count; both appear in the summary envelope and CloudWatch logs."
         }
       }
     },
@@ -6668,6 +6672,27 @@
         "sci_token_id": {
           "type": "string",
           "definition": "On the agent-sessions item (NOT this token record): the session's active SCI pointer, stamped at claim. Post-mint attribute outside SESSION_NODE_PROPERTIES."
+        }
+      }
+    },
+    "coordination.agent_session_unclaim_sweep": {
+      "description": "ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep - retirement lifecycle part 1 from the io design decision on ENC-ISS-441. The AgentSessionUnclaimSweepSchedule EventBridge rule (02-compute.yaml, rate(10 minutes)) invokes coordination_api with Input {\"action\":\"agent_session_unclaim_sweep\"}; lambda_handler dispatches to _handle_agent_session_unclaim_sweep -> agent_id_alloc.sweep_unclaimed_sessions. Sessions in status=allocated (registered via agent.register but never claimed) whose created_at is older than AGENT_SESSIONS_UNCLAIM_TTL_MINUTES are flipped to 'retired' via the same append-only conditional UpdateItem as agent.retire, and any bound SCI is revoked (revocation_reason=unclaim_ttl_exceeded; defense-in-depth - allocated sessions normally have no SCI since SCIs mint at claim). Reference timestamp is strictly created_at. Idempotent; dry_run-capable; master-flag guarded. Closes the ghost-registration gap (10 of 24 prod sessions were unclaimed, the ENC-ISS-441 evidence).",
+      "fields": {
+        "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits."
+        },
+        "AGENT_SESSIONS_UNCLAIM_TTL_MINUTES": {
+          "type": "integer",
+          "definition": "Env var (config.py), default 10. An allocated session whose created_at is older than this is a ghost registration and is reaped."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator, fixed 'agent_session_unclaim_sweep'. Optional unclaim_ttl_minutes and dry_run keys override defaults per-invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only): {enabled, dry_run, unclaim_ttl_minutes, cutoff, scanned_allocated, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis}."
         }
       }
     }
@@ -6773,6 +6798,11 @@
       "version": "2026-07-02.12",
       "date": "2026-07-02",
       "summary": "ENC-TSK-J92 (ENC-ISS-441 Ph2, ENC-FTR-122): Session Claim ID (SCI) primitive shipped DARK - agent.claim mints SCI-{uuid4_hex} into the checkout-tokens table (token_type=SCI, 24h TTL, env-suffixed CHECKOUT_TOKENS_TABLE) and returns it in the claim envelope; agent.retire revokes (revoked/revoked_at/revocation_reason); session item stamped with sci_token_id. New entity coordination.session_claim_id. IAM SciTokenAccess grant + CHECKOUT_TOKENS_TABLE env on CoordinationApiFunction (02-compute.yaml v4). No enforcement until ENC-TSK-J93. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.13",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J94 (ENC-ISS-441 Ph4, ENC-FTR-122): retirement sweeps - new coordination.agent_session_unclaim_sweep entity (rate(10 minutes) EventBridge rule, allocated-only, created_at reference, SCI revocation unclaim_ttl_exceeded); idle sweep default threshold tightened 86400->7200 with last_activity_at-preferred reference and SCI revocation idle_ttl_exceeded (revoked_scis/revoked_sci_count in both sweep summaries). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -378,6 +378,12 @@ FEED_SUBSCRIPTIONS_TABLE = os.environ.get("FEED_SUBSCRIPTIONS_TABLE", "feed-subs
 AGENT_SESSIONS_IDLE_SWEEP_ENABLED = (
     os.environ.get("AGENT_SESSIONS_IDLE_SWEEP_ENABLED", "true").lower() == "true"
 )
+# ENC-ISS-441 / ENC-TSK-J94: master enable flag for the 10-minute unclaim TTL sweep
+# (ghost-registration reaper). TTL default lives in config.py and is the default of
+# agent_id_alloc.sweep_unclaimed_sessions; only the enable flag is read here.
+AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED = (
+    os.environ.get("AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED", "true").lower() == "true"
+)
 # ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init intent classifier config.
 GRAPH_QUERY_API_URL = os.environ.get("GRAPH_QUERY_API_URL", "").strip()
 DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
@@ -15190,6 +15196,47 @@ def _handle_agent_session_idle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
     return summary
 
 
+def _handle_agent_session_unclaim_sweep(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Scheduled ghost-registration reaper (ENC-ISS-441 / ENC-TSK-J94).
+
+    Invoked by the AgentSessionUnclaimSweepSchedule EventBridge rule (rate(10 minutes)),
+    NOT an HTTP route — no API Gateway envelope, auth, or claims on this path. Flips
+    'allocated' sessions never claimed within AGENT_SESSIONS_UNCLAIM_TTL_MINUTES of
+    created_at to 'retired' via the append-only conditional update in
+    agent_id_alloc.sweep_unclaimed_sessions, revoking any bound SCI. Returns a plain
+    summary dict for CloudWatch.
+    """
+    if not AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED:
+        logger.info(
+            "[INFO] unclaim-sweep skipped — AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED is false"
+        )
+        return {"enabled": False, "reason": "disabled", "retired_count": 0}
+    raw_ttl = event.get("unclaim_ttl_minutes")
+    sweep_kwargs: Dict[str, Any] = {"dry_run": bool(event.get("dry_run", False))}
+    if raw_ttl is not None:
+        try:
+            sweep_kwargs["unclaim_ttl_minutes"] = int(raw_ttl)
+        except (TypeError, ValueError):
+            return {
+                "enabled": True,
+                "error": "unclaim_ttl_minutes must be an integer",
+                "retired_count": 0,
+            }
+    try:
+        summary = _agent_id_alloc.sweep_unclaimed_sessions(**sweep_kwargs)
+    except ValueError as exc:
+        return {"enabled": True, "error": str(exc), "retired_count": 0}
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] unclaim-sweep DynamoDB failure: %s", exc)
+        return {"enabled": True, "error": "DynamoDB error during unclaim-sweep", "retired_count": 0}
+    logger.info(
+        "[SUCCESS] unclaim-sweep retired %d session(s), revoked %d SCI(s)",
+        summary.get("retired_count", 0),
+        summary.get("revoked_sci_count", 0),
+    )
+    return summary
+
+
 # ---------------------------------------------------------------------------
 # Main Lambda handler
 # ---------------------------------------------------------------------------
@@ -15212,6 +15259,12 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     if event.get("action") == "agent_session_idle_sweep":
         logger.info("[INFO] Scheduled agent-session idle-sweep invoked")
         return _handle_agent_session_idle_sweep(event)
+
+    # --- ENC-ISS-441 / ENC-TSK-J94: scheduled unclaim TTL sweep (ghost registrations) ---
+    # The AgentSessionUnclaimSweepSchedule rule delivers its Input JSON verbatim as the event.
+    if event.get("action") == "agent_session_unclaim_sweep":
+        logger.info("[INFO] Scheduled agent-session unclaim-sweep invoked")
+        return _handle_agent_session_unclaim_sweep(event)
 
     # --- v0.3: SQS callback ingestion ---
     # SQS events have 'Records' with 'eventSource' = 'aws:sqs'.

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -807,5 +807,108 @@ class SciTokenTest(unittest.TestCase):
             alloc.revoke_sci_for_session("ENC-SES-404")
 
 
+@mock_aws
+class UnclaimAndRevocationSweepTest(unittest.TestCase):
+    """ENC-ISS-441 / ENC-TSK-J94: unclaim TTL sweep + sweep->SCI revocation bridging."""
+
+    def setUp(self):
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        for table, key in (
+            (config.AGENT_SESSIONS_TABLE, "session_id"),
+            (config.AGENT_TYPES_TABLE, "agent_type_id"),
+            (config.CHECKOUT_TOKENS_TABLE, "pk"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self._future = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=2)
+
+    def _mint(self, status="allocated"):
+        return alloc.mint_session_id(
+            agent_type_id="ENC-AGT-001", runtime="test", status=status
+        )
+
+    def _get_token(self, token_id):
+        resp = self.ddb.get_item(
+            TableName=config.CHECKOUT_TOKENS_TABLE, Key={"pk": {"S": token_id}}
+        )
+        return resp.get("Item")
+
+    # -- config defaults per the io design decision on ENC-ISS-441 -----------
+    def test_defaults_are_two_hours_and_ten_minutes(self):
+        self.assertEqual(config.AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS, 7200)
+        self.assertEqual(config.AGENT_SESSIONS_UNCLAIM_TTL_MINUTES, 10)
+
+    # -- unclaim candidate selection ------------------------------------------
+    def test_unclaim_sweep_retires_stale_allocated_session(self):
+        sid = self._mint(status="allocated")["session_id"]
+        summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertIn(sid, summary["retired"])
+        self.assertEqual(alloc.get_session(sid)["status"], "retired")
+
+    def test_unclaim_sweep_ignores_claimed_sessions(self):
+        minted = self._mint(status="allocated")
+        alloc.claim_session(minted["session_id"])
+        summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+        self.assertEqual(summary["candidate_count"], 0)
+        self.assertEqual(alloc.get_session(minted["session_id"])["status"], "claimed")
+
+    def test_unclaim_sweep_leaves_fresh_allocated_sessions(self):
+        sid = self._mint(status="allocated")["session_id"]
+        # now() ~ mint time; a 10-minute TTL means the session is not yet a ghost.
+        summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10)
+        self.assertEqual(summary["candidate_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "allocated")
+
+    def test_unclaim_sweep_dry_run_mutates_nothing(self):
+        sid = self._mint(status="allocated")["session_id"]
+        summary = alloc.sweep_unclaimed_sessions(
+            unclaim_ttl_minutes=10, now=self._future, dry_run=True
+        )
+        self.assertEqual(summary["candidate_count"], 1)
+        self.assertEqual(summary["retired_count"], 0)
+        self.assertEqual(alloc.get_session(sid)["status"], "allocated")
+
+    def test_unclaim_sweep_validates_ttl(self):
+        for bad in (True, -1, "10"):
+            with self.assertRaises(ValueError):
+                alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=bad)  # type: ignore[arg-type]
+
+    # -- sweep -> SCI revocation bridging --------------------------------------
+    def test_idle_sweep_revokes_sci_of_swept_session(self):
+        minted = self._mint(status="allocated")
+        session = alloc.claim_session(minted["session_id"])
+        sci = alloc.mint_sci(session)
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+        self.assertIn(minted["session_id"], summary["retired"])
+        self.assertEqual(summary["revoked_sci_count"], 1)
+        self.assertIn(sci["token_id"], summary["revoked_scis"])
+        item = self._get_token(sci["token_id"])
+        self.assertTrue(item["revoked"]["BOOL"])
+        self.assertEqual(item["revocation_reason"]["S"], "idle_ttl_exceeded")
+
+    def test_unclaim_sweep_without_sci_reports_zero_revocations(self):
+        self._mint(status="allocated")
+        summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertEqual(summary["revoked_sci_count"], 0)
+        self.assertEqual(summary["revoked_scis"], [])
+
+    def test_unclaim_sweep_is_idempotent_on_rerun(self):
+        self._mint(status="allocated")
+        first = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+        second = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+        self.assertEqual(first["retired_count"], 1)
+        self.assertEqual(second["candidate_count"], 0)
+        self.assertEqual(second["retired_count"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -217,10 +217,15 @@ Resources:
           AGENT_CREDENTIALS_TABLE: !Sub "agent-credentials${EnvironmentSuffix}"
           # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91: idle-sweep
           # backstop config. Enable flag read by lambda_function; threshold read by
-          # config.py / agent_id_alloc.sweep_idle_sessions. 86400 = 24h (I71 default;
-          # ENC-ISS-441 Ph4 tightens this to 7200).
+          # config.py / agent_id_alloc.sweep_idle_sessions. ENC-ISS-441 / ENC-TSK-J94:
+          # threshold tightened from I71's 86400 (24h) to 7200 (2h); the idle reference
+          # prefers last_activity_at (J71/J83), so polling listeners stay exempt.
           AGENT_SESSIONS_IDLE_SWEEP_ENABLED: "true"
-          AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS: "86400"
+          AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS: "7200"
+          # ENC-ISS-441 / ENC-TSK-J94: unclaim TTL sweep — allocated sessions never
+          # claimed within the TTL are ghost registrations and get reaped + SCI-revoked.
+          AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED: "true"
+          AGENT_SESSIONS_UNCLAIM_TTL_MINUTES: "10"
           # ENC-ISS-441 / ENC-TSK-J92: SCI tokens share the checkout service's token table
           # (pk = token id, token_type=SCI). Env-suffixed so gamma writes the -gamma twin.
           CHECKOUT_TOKENS_TABLE: !Sub "enceladus-checkout-tokens${EnvironmentSuffix}"
@@ -1931,6 +1936,32 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt AgentSessionIdleSweepSchedule.Arn
+
+  # ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep. Reaps ghost
+  # registrations — sessions that called agent.register but never agent.claim within
+  # AGENT_SESSIONS_UNCLAIM_TTL_MINUTES of created_at (10 of 24 prod sessions showed this
+  # pattern, the ENC-ISS-441 evidence). Same append-only retire flip + Lambda::Permission
+  # discipline as the I71 idle-sweep rule above; both sweeps also revoke the session's SCI.
+  AgentSessionUnclaimSweepSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-session-unclaim-sweep${EnvironmentSuffix}"
+      Description: "ENC-ISS-441/ENC-TSK-J94: reap never-claimed (ghost) agent sessions after the 10-min unclaim TTL and revoke their SCIs"
+      ScheduleExpression: rate(10 minutes)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: agent-session-unclaim-sweep
+          Input: '{"action": "agent_session_unclaim_sweep"}'
+
+  AgentSessionUnclaimSweepPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AgentSessionUnclaimSweepSchedule.Arn
 
   DeployCodeBuildFinalizeRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
## Summary
ENC-ISS-441 Ph4 (ENC-PLN-062 / ENC-FTR-122). The io-designed session retirement lifecycle:

- **Unclaim TTL sweep**: new `agent_session_unclaim_sweep` action + `AgentSessionUnclaimSweepSchedule` EventBridge rule (rate(10 minutes)) — reaps `allocated` sessions never claimed within 10 min of `created_at` (the ghost-registration gap: 10/24 prod sessions).
- **Idle TTL tightened**: default 86400s → **7200s (2h)**; idle reference prefers `last_activity_at` (J83 heartbeat), so escalation.watch listeners stay exempt.
- **Sweep → SCI revocation**: both sweeps revoke each swept session's SCI (`unclaim_ttl_exceeded` / `idle_ttl_exceeded`) and report `revoked_sci_count`/`revoked_scis`.
- Both sweeps dry_run-capable + master-flag guarded.
- governance_data_dictionary.json → 2026-07-02.13 (new unclaim-sweep entity; idle-sweep entity amended).
- Tests: 9 new cases; suite 80/80 green.

## Tracker
- Task: ENC-TSK-J94 (plan ENC-PLN-062, feature ENC-FTR-122, issue ENC-ISS-441)
- CCI-97203236689b4466b316fddbcb25658b

🤖 Generated with [Claude Code](https://claude.com/claude-code)