### PR TITLE
ENC-TSK-G19: Anthropic Batch API for non-interactive workloads

### DIFF
--- a/backend/lambda/coordination_api/anthropic_batch.py
+++ b/backend/lambda/coordination_api/anthropic_batch.py
@@ -1,0 +1,207 @@
+"""Anthropic Message Batches API integration (ENC-TSK-G19 / Strategy #8).
+
+Non-interactive workloads route through POST /v1/messages/batches for 50% batch
+pricing, stacked with ephemeral_1h prompt caching on the static system + toolset
+prefix (~95% effective cost on cache hits for recurring workloads).
+
+Cost comparison (nightly changelog generation, Sonnet 4, illustrative):
+- Synchronous: ~120k input tokens/night @ $3/M = $0.36/night ($131/year)
+- Batch + 1h cache (90% cache hit): ~12k billable input + batch 50% off
+  ≈ $0.018/night ($6.6/year) — ~95% reduction vs uncached sync baseline.
+See NON_INTERACTIVE_WORKLOADS for enumerated call sites.
+"""
+from __future__ import annotations
+
+import json
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from config import ANTHROPIC_API_BASE_URL, ANTHROPIC_API_VERSION
+
+BATCH_POLL_INTERVAL_SECONDS = 60
+
+# Enumerated non-interactive workloads (AC#1).
+NON_INTERACTIVE_WORKLOADS: Dict[str, Dict[str, str]] = {
+    "nightly_changelog_generation": {
+        "description": "Scheduled changelog doc generation from tracker/git deltas",
+        "trigger": "EventBridge nightly schedule / memory consolidation follow-up",
+        "provider_preference": "batch_eligible=true",
+    },
+    "governance_audit_doc_patching": {
+        "description": "Governance audit Lambda patches compliance docs after stream events",
+        "trigger": "GovernanceAuditRole DynamoDB stream",
+        "provider_preference": "batch_eligible=true",
+    },
+    "compliance_doc_creation": {
+        "description": "Compliance self-assessment doc creation (DOC-6EFD5DB32CD8 Phase 5)",
+        "trigger": "coordination dispatch with compliance workload tag",
+        "provider_preference": "batch_eligible=true",
+    },
+    "memory_consolidation_bulk": {
+        "description": "Bulk operations triggered by memory consolidation Lambda (ENC-FTR-096)",
+        "trigger": "memory consolidation Lambda fan-out",
+        "provider_preference": "batch_eligible=true",
+    },
+}
+
+NIGHTLY_CHANGELOG_COST_COMPARISON: Dict[str, Any] = {
+    "workload": "nightly_changelog_generation",
+    "model": "claude-sonnet-4-20250514",
+    "assumptions": {
+        "nightly_input_tokens": 120_000,
+        "cache_hit_ratio_post_migration": 0.90,
+        "batch_discount": 0.50,
+        "input_price_per_million_usd": 3.0,
+    },
+    "baseline_sync_usd_per_night": 0.36,
+    "batch_cached_usd_per_night": 0.018,
+    "effective_reduction_pct": 95,
+    "notes": "Batch pricing stacks with ephemeral_1h cache on static system+toolset prefix.",
+}
+
+
+def _cert_context(cert_bundle: Optional[str]):
+    return ssl.create_default_context(cafile=cert_bundle) if cert_bundle else None
+
+
+def anthropic_http_json(
+    *,
+    api_key: str,
+    method: str,
+    url: str,
+    body: Optional[Dict[str, Any]] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+    timeout: int = 60,
+    cert_bundle: Optional[str] = None,
+) -> Tuple[int, Dict[str, Any], Dict[str, str]]:
+    """Issue an Anthropic API request and parse a JSON object response."""
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+        "content-type": "application/json",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url=url, method=method, data=data, headers=headers)
+    context = _cert_context(cert_bundle)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=context) as resp:
+            status = int(getattr(resp, "status", 0) or 0)
+            response_headers = dict(resp.headers.items())
+            raw = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(raw) if raw.strip() else {}
+        except json.JSONDecodeError:
+            payload = {"error": {"message": raw[:400] or str(exc)}}
+        if not isinstance(payload, dict):
+            payload = {"raw": payload}
+        return int(exc.code), payload, {}
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Anthropic API request failed: {exc.reason}") from exc
+
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"Anthropic API request returned http_{status}")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Anthropic API response was not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Anthropic API response payload is not an object")
+    return status, payload, response_headers
+
+
+def submit_messages_batch(
+    *,
+    api_key: str,
+    requests: List[Dict[str, Any]],
+    cert_bundle: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """POST /v1/messages/batches with one or more custom_id + params items."""
+    endpoint = f"{ANTHROPIC_API_BASE_URL.rstrip('/')}/v1/messages/batches"
+    _status, payload, _headers = anthropic_http_json(
+        api_key=api_key,
+        method="POST",
+        url=endpoint,
+        body={"requests": requests},
+        extra_headers=extra_headers,
+        cert_bundle=cert_bundle,
+    )
+    if isinstance(payload.get("error"), dict):
+        error_type = str(payload["error"].get("type") or "unknown")
+        error_message = str(payload["error"].get("message") or "Unknown batch API error")
+        raise RuntimeError(f"Anthropic batch error ({error_type}): {error_message}")
+    return payload
+
+
+def get_messages_batch(
+    *,
+    api_key: str,
+    batch_id: str,
+    cert_bundle: Optional[str] = None,
+) -> Dict[str, Any]:
+    """GET /v1/messages/batches/{batch_id}."""
+    endpoint = f"{ANTHROPIC_API_BASE_URL.rstrip('/')}/v1/messages/batches/{batch_id}"
+    _status, payload, _headers = anthropic_http_json(
+        api_key=api_key,
+        method="GET",
+        url=endpoint,
+        cert_bundle=cert_bundle,
+    )
+    if isinstance(payload.get("error"), dict):
+        error_type = str(payload["error"].get("type") or "unknown")
+        error_message = str(payload["error"].get("message") or "Unknown batch API error")
+        raise RuntimeError(f"Anthropic batch status error ({error_type}): {error_message}")
+    return payload
+
+
+def download_batch_results(
+    *,
+    api_key: str,
+    results_url: str,
+    cert_bundle: Optional[str] = None,
+    timeout: int = 120,
+) -> str:
+    """Download JSONL batch results from the signed results_url."""
+    headers = {"x-api-key": api_key, "anthropic-version": ANTHROPIC_API_VERSION}
+    req = urllib.request.Request(url=results_url, method="GET", headers=headers)
+    context = _cert_context(cert_bundle)
+    with urllib.request.urlopen(req, timeout=timeout, context=context) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def batch_processing_ended(batch_status: Dict[str, Any]) -> bool:
+    return str(batch_status.get("processing_status") or "").strip().lower() == "ended"
+
+
+def alert_batch_subrequest_failure(
+    emit_observability: Callable[..., None],
+    *,
+    request_id: str,
+    dispatch_id: str,
+    batch_id: str,
+    custom_id: str,
+    error_type: str,
+    error_message: str,
+) -> None:
+    """Emit structured alert for a failed batch sub-request (AC#5)."""
+    emit_observability(
+        component="coordination_api",
+        event="batch_subrequest_failure",
+        request_id=request_id,
+        dispatch_id=dispatch_id or custom_id,
+        tool_name="anthropic.messages.batches",
+        error_code="batch_subrequest_failed",
+        extra={
+            "batch_id": batch_id,
+            "custom_id": custom_id,
+            "anthropic_error_type": error_type,
+            "anthropic_error_message": error_message[:500],
+            "alert": True,
+        },
+    )

--- a/backend/lambda/coordination_api/decomposition.py
+++ b/backend/lambda/coordination_api/decomposition.py
@@ -128,6 +128,10 @@ def _validate_provider_session(raw: Any) -> Dict[str, Any]:
         "thinking",
         "stream",
         "batch_eligible",
+        "batch_workload_type",
+        "deferred_tool_loading",
+        "mcp_server_name",
+        "eager_load_tools",
     }
     unknown = sorted(k for k in raw.keys() if k not in allowed)
     if unknown:
@@ -322,6 +326,15 @@ def _validate_provider_session(raw: Any) -> Dict[str, Any]:
         if not isinstance(batch_eligible, bool):
             raise ValueError("'provider_preferences.batch_eligible' must be a boolean")
         out["batch_eligible"] = batch_eligible
+
+    batch_workload_type = raw.get("batch_workload_type")
+    if batch_workload_type not in (None, ""):
+        if not isinstance(batch_workload_type, str):
+            raise ValueError("'provider_preferences.batch_workload_type' must be a string")
+        workload = batch_workload_type.strip()
+        if len(workload) > 128:
+            raise ValueError("'provider_preferences.batch_workload_type' exceeds max length (128)")
+        out["batch_workload_type"] = workload
 
     return out
 

--- a/backend/lambda/coordination_api/dispatch_ssm.py
+++ b/backend/lambda/coordination_api/dispatch_ssm.py
@@ -112,6 +112,7 @@ __all__ = [
     "_coerce_openai_tools",
     "_count_claude_tokens",
     "_dispatch_claude_api",
+    "_dispatch_claude_batch_api",
     "_dispatch_openai_codex_api",
     "_extract_claude_text_response",
     "_extract_claude_thinking_response",
@@ -1665,6 +1666,203 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
         "completed_at": completed_at,
         "status": "succeeded",
         "provider_result": provider_result,
+    }
+
+
+def _maybe_attach_deferred_tool_loading(
+    provider_session: Dict[str, Any],
+    request_body: Dict[str, Any],
+    request_headers: Dict[str, str],
+) -> bool:
+    """Attach BM25 tool search + mcp_toolset when provider_session requests defer_loading."""
+    if not provider_session.get("deferred_tool_loading"):
+        return False
+    try:
+        from mcp_integration import _load_tool_defer_loading_module
+
+        policy = _load_tool_defer_loading_module()
+        mcp_server_name = str(
+            provider_session.get("mcp_server_name") or policy.DEFAULT_MCP_SERVER_NAME
+        ).strip()
+        eager_tools = provider_session.get("eager_load_tools")
+        tools = policy.build_anthropic_deferred_tools_array(
+            mcp_server_name=mcp_server_name,
+            eager_tools=eager_tools if isinstance(eager_tools, list) else None,
+        )
+        request_body["tools"] = tools
+        request_headers["anthropic-beta"] = policy.anthropic_beta_headers()
+        return bool(
+            tools and isinstance(tools[-1], dict) and tools[-1].get("cache_control")
+        )
+    except Exception as exc:
+        logger.warning("deferred_tool_loading attach failed: %s", exc)
+        return False
+
+
+def _dispatch_claude_batch_api(
+    request: Dict[str, Any],
+    prompt: Optional[str],
+    dispatch_id: str,
+) -> Dict[str, Any]:
+    """Submit a Claude Messages request via Anthropic Batch API (ENC-TSK-G19)."""
+    from anthropic_batch import NON_INTERACTIVE_WORKLOADS, submit_messages_batch
+
+    provider_session = request.get("provider_session") or {}
+    model = _resolve_claude_model(provider_session)
+    task_complexity = str(provider_session.get("task_complexity") or "standard").strip().lower()
+    workload_type = str(provider_session.get("batch_workload_type") or "").strip()
+    if workload_type and workload_type not in NON_INTERACTIVE_WORKLOADS:
+        logger.warning("Unknown batch_workload_type=%s; proceeding anyway", workload_type)
+
+    resolved_prompt = str(prompt or "").strip()
+    if not resolved_prompt:
+        initiative = str(request.get("initiative_title") or "").strip()
+        outcomes = [str(item).strip() for item in (request.get("outcomes") or []) if str(item).strip()]
+        lines = []
+        if initiative:
+            lines.append(f"Initiative: {initiative}")
+        if outcomes:
+            lines.append("Outcomes:")
+            lines.extend(f"- {item}" for item in outcomes)
+        resolved_prompt = "\n".join(lines).strip()
+    if not resolved_prompt:
+        raise RuntimeError("Missing prompt for claude_agent_sdk batch dispatch")
+    resolved_prompt, governance_context = _build_managed_session_prompt(
+        resolved_prompt,
+        str(request.get("project_id") or ""),
+    )
+
+    max_tokens = _coerce_claude_max_tokens((request.get("constraints") or {}).get("max_tokens"))
+    api_key = _fetch_provider_api_key("anthropic", ANTHROPIC_API_KEY_SECRET_ID)
+    batch_endpoint = f"{ANTHROPIC_API_BASE_URL.rstrip('/')}/v1/messages/batches"
+
+    system_prompt = provider_session.get("system_prompt")
+    system_blocks = None
+    if system_prompt:
+        system_blocks = [
+            {
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral", "ttl": CLAUDE_PROMPT_CACHE_TTL},
+            }
+        ]
+
+    message_params: Dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": resolved_prompt}],
+    }
+    if system_blocks:
+        message_params["system"] = system_blocks
+
+    thinking_param = _build_claude_thinking_param(provider_session, model)
+    if thinking_param:
+        message_params["thinking"] = thinking_param
+        budget = thinking_param.get("budget_tokens")
+        if budget is not None and max_tokens <= budget:
+            max_tokens = budget + max(budget, CLAUDE_API_MAX_TOKENS_DEFAULT)
+            message_params["max_tokens"] = max_tokens
+
+    preflight_token_count = _count_claude_tokens(
+        api_key=api_key,
+        model=model,
+        messages=message_params["messages"],
+        system=system_blocks,
+    )
+    context_limit = _CLAUDE_CONTEXT_LIMITS.get(model, _CLAUDE_DEFAULT_CONTEXT_LIMIT)
+    if preflight_token_count is not None and preflight_token_count > context_limit:
+        raise RuntimeError(
+            f"Estimated input tokens ({preflight_token_count}) exceed model context "
+            f"window ({context_limit}) for {model}"
+        )
+
+    anthropic_headers: Dict[str, str] = {}
+    toolset_cache_attached = _maybe_attach_deferred_tool_loading(
+        provider_session, message_params, anthropic_headers
+    )
+
+    started_at = _now_z()
+    started = time.perf_counter()
+    try:
+        batch_payload = submit_messages_batch(
+            api_key=api_key,
+            requests=[{"custom_id": dispatch_id, "params": message_params}],
+            cert_bundle=_CERT_BUNDLE,
+            extra_headers=anthropic_headers or None,
+        )
+    except Exception as exc:
+        _emit_structured_observability(
+            component="coordination_api",
+            event="dispatch_claude_batch_api",
+            request_id=str(request.get("request_id") or ""),
+            dispatch_id=dispatch_id,
+            tool_name="anthropic.messages.batches.create",
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            error_code="batch_submit_failed",
+            extra={"execution_mode": "claude_agent_sdk", "model": model, "reason": str(exc)},
+        )
+        raise
+
+    batch_id = str(batch_payload.get("id") or "").strip()
+    processing_status = str(batch_payload.get("processing_status") or "in_progress").strip().lower()
+    if not batch_id:
+        raise RuntimeError("Anthropic batch API response missing batch id")
+
+    batch_context = dict(request.get("batch_context") or {})
+    batch_context.update(
+        {
+            "batch_eligible": True,
+            "batch_id": batch_id,
+            "batch_submitted_at": started_at,
+            "processing_status": processing_status,
+            "batch_max_timeout_hours": 24,
+            "cost_savings_estimate": "50%",
+            "poll_interval_seconds": 60,
+            "workload_type": workload_type or None,
+            "features_used": {
+                "prompt_caching": bool(system_blocks),
+                "cache_ttl": CLAUDE_PROMPT_CACHE_TTL if system_blocks else None,
+                "toolset_caching": toolset_cache_attached,
+                "toolset_cache_ttl": CLAUDE_PROMPT_CACHE_TTL if toolset_cache_attached else None,
+                "preflight_token_count": preflight_token_count,
+            },
+        }
+    )
+    request["batch_context"] = batch_context
+
+    _emit_structured_observability(
+        component="coordination_api",
+        event="dispatch_claude_batch_api",
+        request_id=str(request.get("request_id") or ""),
+        dispatch_id=dispatch_id,
+        tool_name="anthropic.messages.batches.create",
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        error_code="",
+        extra={
+            "execution_mode": "claude_agent_sdk",
+            "model": model,
+            "batch_id": batch_id,
+            "processing_status": processing_status,
+            "task_complexity": task_complexity,
+            "workload_type": workload_type,
+            "toolset_cache_attached": toolset_cache_attached,
+            "preflight_token_count": preflight_token_count,
+            "governance_loaded": bool(governance_context.get("loaded")),
+        },
+    )
+    return {
+        "dispatch_id": dispatch_id,
+        "execution_id": batch_id,
+        "execution_mode": "claude_agent_sdk",
+        "provider": "claude_agent_sdk",
+        "transport": "anthropic_messages_batches_api",
+        "api_endpoint": batch_endpoint,
+        "project_id": request.get("project_id"),
+        "coordination_request_id": request.get("request_id"),
+        "provider_secret_refs": [ANTHROPIC_API_KEY_SECRET_ID] if ANTHROPIC_API_KEY_SECRET_ID else [],
+        "sent_at": started_at,
+        "status": "running",
+        "batch_context": batch_context,
     }
 
 

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.14",
-  "updated_at": "2026-07-02T10:20:00Z",
-  "last_change_summary": "ENC-TSK-G17 (FTR-099 A3.5): context-management beta for long coordination loops — provider_session.context_management_enabled gates _maybe_attach_context_management in coordination_api dispatch_claude_api; emits clear_tool_uses_20250919 (100k trigger, keep 5, exclude memory), optional clear_thinking_20251015 on Opus+thinking, memory_20250818 tool registration, and context-management-2025-06-27 anthropic-beta header (appended, composes with deferred_tool_loading). New entity mcp_server.context_management. Rebased onto ENC-TSK-J94 (retirement sweeps, .13) -- both changes' entities preserved.",
+  "version": "2026-07-02.15",
+  "updated_at": "2026-07-02T10:05:00Z",
+  "last_change_summary": "ENC-TSK-G19 (FTR-099 A3.6): Anthropic Message Batches API routing — provider_preferences.batch_eligible routes claude_agent_sdk dispatches through _dispatch_claude_batch_api (POST /v1/messages/batches), EventBridge coordination_batch_poll (60s interval), batch_subrequest_failure alerts, ephemeral_1h cache on static prefix. New entity coordination_api.anthropic_batch. Merged with ENC-TSK-G17 context-management (.14) and ENC-TSK-J94 retirement sweeps (.13).",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -2272,6 +2272,39 @@
         }
       }
     },
+    "coordination_api.anthropic_batch": {
+      "description": "Anthropic Message Batches API routing for non-interactive workloads (ENC-TSK-G19 / FTR-099 Strategy #8). Submits via POST /v1/messages/batches when provider_preferences.batch_eligible=true; EventBridge poller (rate 1 minute, 60s min interval) finalizes via batch-results callback.",
+      "fields": {
+        "batch_eligible": {
+          "type": "boolean",
+          "definition": "Provider preference signaling deferred batch execution (50% Anthropic batch pricing). Incompatible with execution_mode=preflight.",
+          "usage_guidance": "Set in provider_preferences on coordination request intake or dispatch body. Routes claude_agent_sdk dispatches through _dispatch_claude_batch_api instead of synchronous Messages API."
+        },
+        "batch_workload_type": {
+          "type": "enum",
+          "enum": [
+            "nightly_changelog_generation",
+            "governance_audit_doc_patching",
+            "compliance_doc_creation",
+            "memory_consolidation_bulk"
+          ],
+          "definition": "Optional workload classifier for telemetry and cost attribution. See NON_INTERACTIVE_WORKLOADS in anthropic_batch.py."
+        },
+        "ephemeral_1h_cache": {
+          "type": "object",
+          "definition": "cache_control {type: ephemeral, ttl: 1h} on system prompt and mcp_toolset prefix blocks in batch params.",
+          "usage_guidance": "Stacks with batch 50% discount for ~95% effective cost on recurring static-prefix workloads (NIGHTLY_CHANGELOG_COST_COMPARISON in anthropic_batch.py)."
+        },
+        "poll_interval_seconds": {
+          "type": "integer",
+          "definition": "Minimum 60 seconds between Anthropic batch status polls per request (BATCH_POLL_INTERVAL_SECONDS)."
+        },
+        "batch_subrequest_failure_alert": {
+          "type": "observability",
+          "definition": "Structured CloudWatch event batch_subrequest_failure with alert=true emitted for each errored batch result line."
+        }
+      }
+    },
     "mcp_server.cognito_oauth": {
       "description": "Cognito-direct OAuth authentication mode for MCP endpoints (ENC-FTR-045). When active, OAuth metadata points authorization_endpoint and token_endpoint directly to Cognito Hosted UI, DCR returns pre-configured Cognito app client credentials, and bearer tokens are validated as Cognito JWTs.",
       "fields": {

--- a/backend/lambda/coordination_api/handlers.py
+++ b/backend/lambda/coordination_api/handlers.py
@@ -87,6 +87,7 @@ from http_utils import _error, _json_body, _path_method, _response
 from project_utils import _load_project_meta
 from mcp_integration import _load_mcp_server_module
 from tracker_ops import _append_tracker_history, _collect_tracker_snapshots, _related_records_mutated, _requires_related_record_mutation_guard, _set_tracker_status
+from anthropic_batch import NON_INTERACTIVE_WORKLOADS
 from decomposition import (
     _acquire_dispatch_lock,
     _classify_dispatch_failure,
@@ -121,6 +122,7 @@ from dispatch_ssm import (
     _append_dispatch_worklog,
     _build_result_payload,
     _dispatch_claude_api,
+    _dispatch_claude_batch_api,
     _dispatch_openai_codex_api,
     _is_timeout_failure,
     _lambda_provider_preflight,
@@ -515,8 +517,10 @@ def _handle_capabilities() -> Dict[str, Any]:
                                 "description": "Deferred batch execution via Anthropic Message Batches API for 50% cost savings",
                                 "max_timeout_hours": 24,
                                 "cost_savings_estimate": "50%",
+                                "poll_interval_seconds": 60,
                                 "incompatible_modes": ["preflight"],
                                 "preference_field": "provider_preferences.batch_eligible",
+                                "non_interactive_workloads": sorted(NON_INTERACTIVE_WORKLOADS.keys()),
                             },
                         },
                         "secret_ref_configured": provider_secrets["claude_agent_sdk"].get("secret_ref_configured"),
@@ -1096,12 +1100,13 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
         if is_batch and execution_mode == "claude_agent_sdk":
             # Batch mode: set batch_context metadata, dispatch async
             request["batch_context"] = {
+                **(request.get("batch_context") or {}),
                 "batch_eligible": True,
                 "batch_submitted_at": now,
                 "batch_max_timeout_hours": 24,
                 "cost_savings_estimate": "50%",
             }
-            dispatch_meta = _dispatch_claude_api(
+            dispatch_meta = _dispatch_claude_batch_api(
                 request=request,
                 prompt=prompt,
                 dispatch_id=dispatch_id,
@@ -1193,6 +1198,21 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
         if execution_mode in {"claude_agent_sdk", "codex_app_server", "codex_full_auto"}:
             provider_result = dispatch_meta.get("provider_result") or {}
             terminal_state = str(dispatch_meta.get("status") or "succeeded").strip().lower()
+
+            if terminal_state == "running":
+                request["updated_at"] = now
+                request["updated_epoch"] = now_epoch
+                _update_request(request)
+                return _response(
+                    202,
+                    {
+                        "success": True,
+                        "request": _redact_request(request),
+                        "dispatch": dispatch_meta,
+                        "plan_status": _compute_plan_status(request),
+                    },
+                )
+
             if terminal_state not in _VALID_TERMINAL_STATES:
                 terminal_state = "succeeded"
 

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -2141,6 +2141,11 @@ def _validate_provider_session(raw: Any) -> Dict[str, Any]:
         "task_complexity",
         "thinking",
         "stream",
+        "batch_eligible",
+        "batch_workload_type",
+        "deferred_tool_loading",
+        "mcp_server_name",
+        "eager_load_tools",
     }
     unknown = sorted(k for k in raw.keys() if k not in allowed)
     if unknown:
@@ -2328,6 +2333,39 @@ def _validate_provider_session(raw: Any) -> Dict[str, Any]:
         if not isinstance(stream, bool):
             raise ValueError("'provider_preferences.stream' must be a boolean")
         out["stream"] = stream
+
+    batch_eligible = raw.get("batch_eligible")
+    if batch_eligible is not None:
+        if not isinstance(batch_eligible, bool):
+            raise ValueError("'provider_preferences.batch_eligible' must be a boolean")
+        out["batch_eligible"] = batch_eligible
+
+    batch_workload_type = raw.get("batch_workload_type")
+    if batch_workload_type not in (None, ""):
+        if not isinstance(batch_workload_type, str):
+            raise ValueError("'provider_preferences.batch_workload_type' must be a string")
+        workload = batch_workload_type.strip()
+        if len(workload) > 128:
+            raise ValueError("'provider_preferences.batch_workload_type' exceeds max length (128)")
+        out["batch_workload_type"] = workload
+
+    deferred_tool_loading = raw.get("deferred_tool_loading")
+    if deferred_tool_loading is not None:
+        if not isinstance(deferred_tool_loading, bool):
+            raise ValueError("'provider_preferences.deferred_tool_loading' must be a boolean")
+        out["deferred_tool_loading"] = deferred_tool_loading
+
+    mcp_server_name = raw.get("mcp_server_name")
+    if mcp_server_name not in (None, ""):
+        if not isinstance(mcp_server_name, str):
+            raise ValueError("'provider_preferences.mcp_server_name' must be a string")
+        out["mcp_server_name"] = mcp_server_name.strip()
+
+    eager_load_tools = raw.get("eager_load_tools")
+    if eager_load_tools is not None:
+        if not isinstance(eager_load_tools, list):
+            raise ValueError("'provider_preferences.eager_load_tools' must be a list")
+        out["eager_load_tools"] = [str(t).strip() for t in eager_load_tools if str(t).strip()]
 
     return out
 
@@ -5427,6 +5465,355 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
         "status": "succeeded",
         "provider_result": provider_result,
     }
+
+
+def _dispatch_claude_batch_api(
+    request: Dict[str, Any],
+    prompt: Optional[str],
+    dispatch_id: str,
+) -> Dict[str, Any]:
+    """Submit a Claude Messages request via Anthropic Batch API (ENC-TSK-G19)."""
+    from anthropic_batch import (
+        NON_INTERACTIVE_WORKLOADS,
+        submit_messages_batch,
+    )
+
+    provider_session = request.get("provider_session") or {}
+    model = _resolve_claude_model(provider_session)
+    task_complexity = str(provider_session.get("task_complexity") or "standard").strip().lower()
+    workload_type = str(
+        provider_session.get("batch_workload_type")
+        or (request.get("batch_context") or {}).get("workload_type")
+        or ""
+    ).strip()
+    if workload_type and workload_type not in NON_INTERACTIVE_WORKLOADS:
+        logger.warning("Unknown batch_workload_type=%s; proceeding anyway", workload_type)
+
+    resolved_prompt = str(prompt or "").strip() or _default_dispatch_prompt(request)
+    if not resolved_prompt:
+        raise RuntimeError("Missing prompt for claude_agent_sdk batch dispatch")
+    resolved_prompt, governance_context = _build_managed_session_prompt(
+        resolved_prompt,
+        str(request.get("project_id") or ""),
+    )
+
+    max_tokens = _coerce_claude_max_tokens((request.get("constraints") or {}).get("max_tokens"))
+    api_key = _fetch_provider_api_key("anthropic", ANTHROPIC_API_KEY_SECRET_ID)
+    batch_endpoint = f"{ANTHROPIC_API_BASE_URL.rstrip('/')}/v1/messages/batches"
+
+    system_prompt = provider_session.get("system_prompt")
+    system_blocks = None
+    if system_prompt:
+        system_blocks = [
+            {
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral", "ttl": CLAUDE_PROMPT_CACHE_TTL},
+            }
+        ]
+
+    message_params: Dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": resolved_prompt}],
+    }
+    if system_blocks:
+        message_params["system"] = system_blocks
+
+    thinking_param = _build_claude_thinking_param(provider_session, model)
+    if thinking_param:
+        message_params["thinking"] = thinking_param
+        budget = thinking_param.get("budget_tokens")
+        if budget is not None and max_tokens <= budget:
+            max_tokens = budget + max(budget, CLAUDE_API_MAX_TOKENS_DEFAULT)
+            message_params["max_tokens"] = max_tokens
+
+    preflight_token_count = _count_claude_tokens(
+        api_key=api_key,
+        model=model,
+        messages=message_params["messages"],
+        system=system_blocks,
+    )
+    context_limit = _CLAUDE_CONTEXT_LIMITS.get(model, _CLAUDE_DEFAULT_CONTEXT_LIMIT)
+    if preflight_token_count is not None and preflight_token_count > context_limit:
+        raise RuntimeError(
+            f"Estimated input tokens ({preflight_token_count}) exceed model context "
+            f"window ({context_limit}) for {model}"
+        )
+
+    anthropic_headers: Dict[str, str] = {}
+    toolset_cache_attached = _maybe_attach_deferred_tool_loading(
+        provider_session, message_params, anthropic_headers
+    )
+
+    started_at = _now_z()
+    started = time.perf_counter()
+    try:
+        batch_payload = submit_messages_batch(
+            api_key=api_key,
+            requests=[{"custom_id": dispatch_id, "params": message_params}],
+            cert_bundle=_CERT_BUNDLE,
+            extra_headers=anthropic_headers or None,
+        )
+    except Exception as exc:
+        _emit_structured_observability(
+            component="coordination_api",
+            event="dispatch_claude_batch_api",
+            request_id=str(request.get("request_id") or ""),
+            dispatch_id=dispatch_id,
+            tool_name="anthropic.messages.batches.create",
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            error_code="batch_submit_failed",
+            extra={"execution_mode": "claude_agent_sdk", "model": model, "reason": str(exc)},
+        )
+        raise
+
+    batch_id = str(batch_payload.get("id") or "").strip()
+    processing_status = str(batch_payload.get("processing_status") or "in_progress").strip().lower()
+    if not batch_id:
+        raise RuntimeError("Anthropic batch API response missing batch id")
+
+    batch_context = dict(request.get("batch_context") or {})
+    batch_context.update(
+        {
+            "batch_eligible": True,
+            "batch_id": batch_id,
+            "batch_submitted_at": started_at,
+            "processing_status": processing_status,
+            "batch_max_timeout_hours": 24,
+            "cost_savings_estimate": "50%",
+            "poll_interval_seconds": 60,
+            "workload_type": workload_type or None,
+            "features_used": {
+                "prompt_caching": bool(system_blocks),
+                "cache_ttl": CLAUDE_PROMPT_CACHE_TTL if system_blocks else None,
+                "toolset_caching": toolset_cache_attached,
+                "toolset_cache_ttl": CLAUDE_PROMPT_CACHE_TTL if toolset_cache_attached else None,
+                "preflight_token_count": preflight_token_count,
+            },
+        }
+    )
+    request["batch_context"] = batch_context
+
+    _emit_structured_observability(
+        component="coordination_api",
+        event="dispatch_claude_batch_api",
+        request_id=str(request.get("request_id") or ""),
+        dispatch_id=dispatch_id,
+        tool_name="anthropic.messages.batches.create",
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        error_code="",
+        extra={
+            "execution_mode": "claude_agent_sdk",
+            "model": model,
+            "batch_id": batch_id,
+            "processing_status": processing_status,
+            "task_complexity": task_complexity,
+            "workload_type": workload_type,
+            "toolset_cache_attached": toolset_cache_attached,
+            "preflight_token_count": preflight_token_count,
+            "governance_loaded": bool(governance_context.get("loaded")),
+        },
+    )
+    return {
+        "dispatch_id": dispatch_id,
+        "execution_id": batch_id,
+        "execution_mode": "claude_agent_sdk",
+        "provider": "claude_agent_sdk",
+        "transport": "anthropic_messages_batches_api",
+        "api_endpoint": batch_endpoint,
+        "project_id": request.get("project_id"),
+        "coordination_request_id": request.get("request_id"),
+        "provider_secret_refs": [ANTHROPIC_API_KEY_SECRET_ID] if ANTHROPIC_API_KEY_SECRET_ID else [],
+        "sent_at": started_at,
+        "status": "running",
+        "batch_context": batch_context,
+    }
+
+
+def _find_pending_batch_requests(limit: int = 25) -> List[Dict[str, Any]]:
+    """Scan for running coordination requests awaiting Anthropic batch completion."""
+    ddb = _get_ddb()
+    pending: List[Dict[str, Any]] = []
+    last_evaluated_key = None
+    while len(pending) < limit:
+        kwargs: Dict[str, Any] = {
+            "TableName": COORDINATION_TABLE,
+            "FilterExpression": "#s = :running AND attribute_exists(batch_context.#bid)",
+            "ExpressionAttributeNames": {"#s": "state", "#bid": "batch_id"},
+            "ExpressionAttributeValues": {
+                ":running": _serialize(_STATE_RUNNING),
+            },
+            "Limit": min(50, limit - len(pending)),
+        }
+        if last_evaluated_key:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+        try:
+            resp = ddb.scan(**kwargs)
+        except (BotoCoreError, ClientError) as exc:
+            logger.warning("batch poller scan failed: %s", exc)
+            break
+        for raw in resp.get("Items", []):
+            item = _deserialize(raw)
+            batch_ctx = item.get("batch_context") or {}
+            if not isinstance(batch_ctx, dict):
+                continue
+            batch_id = str(batch_ctx.get("batch_id") or "").strip()
+            if not batch_id:
+                continue
+            if str(batch_ctx.get("processing_status") or "").lower() == "ended":
+                if batch_ctx.get("results_processed"):
+                    continue
+            pending.append(item)
+            if len(pending) >= limit:
+                break
+        last_evaluated_key = resp.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+    return pending
+
+
+def _poll_single_anthropic_batch_request(request: Dict[str, Any]) -> Dict[str, Any]:
+    """Poll one batch-backed request; finalize via batch-results callback when ended."""
+    from anthropic_batch import (
+        alert_batch_subrequest_failure,
+        batch_processing_ended,
+        download_batch_results,
+        get_messages_batch,
+    )
+
+    request_id = str(request.get("request_id") or "").strip()
+    batch_context = dict(request.get("batch_context") or {})
+    batch_id = str(batch_context.get("batch_id") or "").strip()
+    if not request_id or not batch_id:
+        return {"request_id": request_id, "skipped": True, "reason": "missing_batch_id"}
+
+    from anthropic_batch import BATCH_POLL_INTERVAL_SECONDS
+
+    last_polled_epoch = int(batch_context.get("last_polled_epoch") or 0)
+    now_epoch = _unix_now()
+    if last_polled_epoch and (now_epoch - last_polled_epoch) < BATCH_POLL_INTERVAL_SECONDS:
+        return {
+            "request_id": request_id,
+            "batch_id": batch_id,
+            "skipped": True,
+            "reason": "poll_interval_not_elapsed",
+            "seconds_until_next_poll": BATCH_POLL_INTERVAL_SECONDS - (now_epoch - last_polled_epoch),
+        }
+
+    api_key = _fetch_provider_api_key("anthropic", ANTHROPIC_API_KEY_SECRET_ID)
+    status_payload = get_messages_batch(
+        api_key=api_key,
+        batch_id=batch_id,
+        cert_bundle=_CERT_BUNDLE,
+    )
+    processing_status = str(status_payload.get("processing_status") or "").strip().lower()
+    batch_context["processing_status"] = processing_status
+    batch_context["last_polled_at"] = _now_z()
+    batch_context["last_polled_epoch"] = now_epoch
+    request["batch_context"] = batch_context
+    request["updated_at"] = _now_z()
+    request["updated_epoch"] = _unix_now()
+    _update_request(request)
+
+    if not batch_processing_ended(status_payload):
+        return {
+            "request_id": request_id,
+            "batch_id": batch_id,
+            "processing_status": processing_status,
+            "finalized": False,
+        }
+
+    results_url = str(status_payload.get("results_url") or "").strip()
+    if not results_url:
+        return {
+            "request_id": request_id,
+            "batch_id": batch_id,
+            "processing_status": processing_status,
+            "finalized": False,
+            "error": "missing_results_url",
+        }
+
+    results_jsonl = download_batch_results(
+        api_key=api_key,
+        results_url=results_url,
+        cert_bundle=_CERT_BUNDLE,
+    )
+    for line in results_jsonl.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            item = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(item, dict):
+            continue
+        result_obj = item.get("result") if isinstance(item.get("result"), dict) else {}
+        result_type = str(result_obj.get("type") or "").strip().lower()
+        if result_type == "errored":
+            error_payload = result_obj.get("error") if isinstance(result_obj.get("error"), dict) else {}
+            alert_batch_subrequest_failure(
+                _emit_structured_observability,
+                request_id=request_id,
+                dispatch_id=str(item.get("custom_id") or ""),
+                batch_id=batch_id,
+                custom_id=str(item.get("custom_id") or ""),
+                error_type=str(error_payload.get("type") or "batch_error"),
+                error_message=str(error_payload.get("message") or "batch sub-request failed"),
+            )
+
+    callback_event = {
+        "headers": {"x-coordination-callback-token": str(request.get("callback_token") or "")},
+        "body": json.dumps(
+            {
+                "batch_id": batch_id,
+                "results_jsonl": results_jsonl,
+                "model": ((request.get("provider_session") or {}).get("model") or DEFAULT_CLAUDE_AGENT_MODEL),
+            }
+        ),
+    }
+    callback_resp = _handle_anthropic_batch_results_callback(callback_event, request_id)
+    latest = _get_request(request_id) or request
+    latest_batch = dict(latest.get("batch_context") or {})
+    latest_batch["results_processed"] = True
+    latest_batch["processing_status"] = "ended"
+    latest["batch_context"] = latest_batch
+    _update_request(latest)
+
+    return {
+        "request_id": request_id,
+        "batch_id": batch_id,
+        "processing_status": "ended",
+        "finalized": True,
+        "callback_status": int(callback_resp.get("statusCode") or 0),
+    }
+
+
+def _handle_coordination_batch_poll(_event: Dict[str, Any]) -> Dict[str, Any]:
+    """Scheduled poller: check Anthropic batch status every 60s (via rate(1 minute) rule)."""
+    pending = _find_pending_batch_requests()
+    outcomes: List[Dict[str, Any]] = []
+    for request in pending:
+        try:
+            outcomes.append(_poll_single_anthropic_batch_request(request))
+        except Exception as exc:
+            logger.exception("batch poll failed request_id=%s", request.get("request_id"))
+            outcomes.append(
+                {
+                    "request_id": request.get("request_id"),
+                    "error": str(exc),
+                    "finalized": False,
+                }
+            )
+    return _response(
+        200,
+        {
+            "success": True,
+            "polled_count": len(outcomes),
+            "outcomes": outcomes,
+        },
+    )
 
 
 def _build_mcp_connectivity_check_commands() -> List[str]:
@@ -12183,11 +12570,26 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
             )
 
         if execution_mode == "claude_agent_sdk":
-            dispatch_meta = _dispatch_claude_api(
-                request=request,
-                prompt=prompt,
-                dispatch_id=dispatch_id,
-            )
+            is_batch = bool((request.get("provider_session") or {}).get("batch_eligible"))
+            if is_batch:
+                request["batch_context"] = {
+                    **(request.get("batch_context") or {}),
+                    "batch_eligible": True,
+                    "batch_submitted_at": now,
+                    "batch_max_timeout_hours": 24,
+                    "cost_savings_estimate": "50%",
+                }
+                dispatch_meta = _dispatch_claude_batch_api(
+                    request=request,
+                    prompt=prompt,
+                    dispatch_id=dispatch_id,
+                )
+            else:
+                dispatch_meta = _dispatch_claude_api(
+                    request=request,
+                    prompt=prompt,
+                    dispatch_id=dispatch_id,
+                )
         elif execution_mode in {"codex_app_server", "codex_full_auto"}:
             dispatch_meta = _dispatch_openai_codex_api(
                 request=request,
@@ -12280,6 +12682,21 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
         if execution_mode in {"claude_agent_sdk", "codex_app_server", "codex_full_auto", "bedrock_agent"}:
             provider_result = dispatch_meta.get("provider_result") or {}
             terminal_state = str(dispatch_meta.get("status") or "succeeded").strip().lower()
+
+            if terminal_state == "running":
+                request["updated_at"] = now
+                request["updated_epoch"] = now_epoch
+                _update_request(request)
+                return _response(
+                    202,
+                    {
+                        "success": True,
+                        "request": _redact_request(request),
+                        "dispatch": dispatch_meta,
+                        "plan_status": _compute_plan_status(request),
+                    },
+                )
+
             if terminal_state not in _VALID_TERMINAL_STATES:
                 terminal_state = "succeeded"
 
@@ -15212,6 +15629,11 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     if event.get("action") == "agent_session_idle_sweep":
         logger.info("[INFO] Scheduled agent-session idle-sweep invoked")
         return _handle_agent_session_idle_sweep(event)
+
+    # --- ENC-TSK-G19: Anthropic batch status poller (60s via rate(1 minute) rule) ---
+    if event.get("action") == "coordination_batch_poll":
+        logger.info("[INFO] Scheduled Anthropic batch poller invoked")
+        return _handle_coordination_batch_poll(event)
 
     # --- v0.3: SQS callback ingestion ---
     # SQS events have 'Records' with 'eventSource' = 'aws:sqs'.

--- a/backend/lambda/coordination_api/test_anthropic_batch.py
+++ b/backend/lambda/coordination_api/test_anthropic_batch.py
@@ -1,0 +1,66 @@
+"""Tests for anthropic_batch module (ENC-TSK-G19)."""
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import anthropic_batch as ab
+
+
+class AnthropicBatchModuleTests(unittest.TestCase):
+    def test_non_interactive_workloads_enumerated(self):
+        self.assertIn("nightly_changelog_generation", ab.NON_INTERACTIVE_WORKLOADS)
+        self.assertIn("governance_audit_doc_patching", ab.NON_INTERACTIVE_WORKLOADS)
+        self.assertGreaterEqual(len(ab.NON_INTERACTIVE_WORKLOADS), 4)
+
+    def test_batch_poll_interval_is_60_seconds(self):
+        self.assertEqual(ab.BATCH_POLL_INTERVAL_SECONDS, 60)
+
+    def test_batch_processing_ended(self):
+        self.assertTrue(ab.batch_processing_ended({"processing_status": "ended"}))
+        self.assertFalse(ab.batch_processing_ended({"processing_status": "in_progress"}))
+
+    def test_submit_messages_batch_success(self):
+        payload = {"id": "batch_abc", "processing_status": "in_progress"}
+        with patch.object(ab, "anthropic_http_json", return_value=(200, payload, {})):
+            out = ab.submit_messages_batch(
+                api_key="sk-test",
+                requests=[{"custom_id": "d1", "params": {"model": "claude", "max_tokens": 100, "messages": []}}],
+            )
+        self.assertEqual(out["id"], "batch_abc")
+
+    def test_submit_messages_batch_raises_on_error(self):
+        with patch.object(
+            ab,
+            "anthropic_http_json",
+            return_value=(200, {"error": {"type": "invalid", "message": "bad"}}, {}),
+        ):
+            with self.assertRaises(RuntimeError):
+                ab.submit_messages_batch(api_key="sk-test", requests=[])
+
+    def test_alert_batch_subrequest_failure_emits_observability(self):
+        emit = MagicMock()
+        ab.alert_batch_subrequest_failure(
+            emit,
+            request_id="CRQ-1",
+            dispatch_id="DISP-1",
+            batch_id="batch_abc",
+            custom_id="DISP-1",
+            error_type="rate_limit",
+            error_message="too many",
+        )
+        emit.assert_called_once()
+        kwargs = emit.call_args.kwargs
+        self.assertEqual(kwargs["event"], "batch_subrequest_failure")
+        self.assertEqual(kwargs["error_code"], "batch_subrequest_failed")
+        self.assertTrue(kwargs["extra"]["alert"])
+
+    def test_cost_comparison_documented(self):
+        cmp_doc = ab.NIGHTLY_CHANGELOG_COST_COMPARISON
+        self.assertEqual(cmp_doc["workload"], "nightly_changelog_generation")
+        self.assertGreater(cmp_doc["effective_reduction_pct"], 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -2630,6 +2630,80 @@ class SessionBridgeIntegrationTests(unittest.TestCase):
         mock_send_dispatch.assert_not_called()
         mock_find_host_dispatch.assert_not_called()
 
+    def test_dispatch_claude_batch_eligible_returns_202_running(self):
+        request = {
+            "request_id": "CRQ-CLAUDE-BATCH",
+            "project_id": "enceladus",
+            "state": "queued",
+            "dispatch_attempts": 0,
+            "provider_session": {
+                "preferred_provider": "claude_agent_sdk",
+                "batch_eligible": True,
+                "batch_workload_type": "nightly_changelog_generation",
+            },
+            "task_ids": [],
+            "feature_id": None,
+            "issue_ids": [],
+        }
+        updated_items = []
+        event = {
+            "body": json.dumps(
+                {
+                    "execution_mode": "claude_agent_sdk",
+                    "dispatch_id": "DSP-BATCH01",
+                    "prompt": "Generate nightly changelog",
+                    "provider_preferences": {
+                        "batch_eligible": True,
+                        "batch_workload_type": "nightly_changelog_generation",
+                    },
+                }
+            )
+        }
+
+        with patch.object(coordination_lambda, "_get_request", return_value=request), \
+             patch.object(coordination_lambda, "_acquire_dispatch_lock", return_value=True), \
+             patch.object(coordination_lambda, "_lambda_provider_preflight", return_value={"passed": True, "results": []}), \
+             patch.object(
+                 coordination_lambda,
+                 "_dispatch_claude_batch_api",
+                 return_value={
+                     "dispatch_id": "DSP-BATCH01",
+                     "execution_id": "batch_abc123",
+                     "execution_mode": "claude_agent_sdk",
+                     "provider": "claude_agent_sdk",
+                     "transport": "anthropic_messages_batches_api",
+                     "api_endpoint": "https://api.anthropic.com/v1/messages/batches",
+                     "sent_at": "2026-07-02T00:00:00Z",
+                     "status": "running",
+                     "batch_context": {
+                         "batch_id": "batch_abc123",
+                         "processing_status": "in_progress",
+                     },
+                 },
+             ) as mock_batch_dispatch, \
+             patch.object(coordination_lambda, "_dispatch_claude_api") as mock_sync_dispatch, \
+             patch.object(coordination_lambda, "_finalize_tracker_from_request"), \
+             patch.object(coordination_lambda, "_update_request", side_effect=lambda item: updated_items.append(dict(item))):
+            resp = coordination_lambda._handle_dispatch_request(event, "CRQ-CLAUDE-BATCH")
+
+        self.assertEqual(resp["statusCode"], 202)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        self.assertEqual((body.get("dispatch") or {}).get("status"), "running")
+        self.assertGreaterEqual(len(updated_items), 1)
+        final = updated_items[-1]
+        self.assertEqual(final.get("state"), "running")
+        mock_batch_dispatch.assert_called_once()
+        mock_sync_dispatch.assert_not_called()
+
+    def test_handle_coordination_batch_poll_invokes_pending_scan(self):
+        with patch.object(coordination_lambda, "_find_pending_batch_requests", return_value=[]):
+            resp = coordination_lambda._handle_coordination_batch_poll({"action": "coordination_batch_poll"})
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        self.assertEqual(body["polled_count"], 0)
+
     def test_dispatch_bedrock_agent_routes_to_direct_api(self):
         request = {
             "request_id": "CRQ-BEDROCK-DIRECT",

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1898,11 +1898,21 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       Name: !Sub "devops-coordination-batch-poller${EnvironmentSuffix}"
-      ScheduleExpression: rate(5 minutes)
+      Description: "ENC-TSK-G19: poll Anthropic Message Batches every 60s until ended"
+      ScheduleExpression: rate(1 minute)
       State: ENABLED
       Targets:
         - Arn: !GetAtt CoordinationApiFunction.Arn
           Id: coordination-batch-poll
+          Input: '{"action": "coordination_batch_poll"}'
+
+  CoordinationBatchPollerPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CoordinationBatchPollerRule.Arn
 
   # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91 (ENC-ISS-441 Ph1). The
   # rule invokes the coordination_api with a fixed Input action; the handler reaps sessions


### PR DESCRIPTION
CCI-9e3b66a2f37740b08c1f136bb365b82e

CCI-9e3b66a2f37740b08c1f136bb365b82e

## Summary
- Implements `POST /v1/messages/batches` submit path for `batch_eligible` Claude dispatches with ephemeral_1h cache on system + deferred toolset prefix
- Adds scheduled batch poller (`coordination_batch_poll` every 60s via EventBridge) that finalizes requests through existing batch-results callback
- Enumerates non-interactive workloads in capabilities; emits structured alerts on batch sub-request failures; documents nightly changelog cost comparison

## Test plan
- [x] `pytest test_anthropic_batch.py` (7 tests)
- [x] `pytest test_lambda_function.py -k batch` (12 tests)
- [ ] Gamma deploy + live batch dispatch smoke test after merge