### PR TITLE
ENC-TSK-K08: prod CodeDeploy canary → Canary10Percent5Minutes (ENC-ISS-471)

### DIFF
--- a/.github/workflows/cloudformation-codedeploy-stack-deploy.yml
+++ b/.github/workflows/cloudformation-codedeploy-stack-deploy.yml
@@ -43,7 +43,7 @@ on:
         description: "CodeDeploy canary preference"
         type: choice
         required: false
-        default: "Linear10PercentEvery10Minutes"
+        default: "Canary10Percent5Minutes"
         options:
           - Canary10Percent5Minutes
           - Canary10Percent10Minutes
@@ -69,7 +69,7 @@ env:
   TEMPLATE_FILE: infrastructure/cloudformation/07-codedeploy.yaml
   DEFAULT_STACK_NAME: enceladus-codedeploy
   DEFAULT_COMPUTE_STACK_NAME: enceladus-compute
-  DEFAULT_CANARY_PREFERENCE: Linear10PercentEvery10Minutes
+  DEFAULT_CANARY_PREFERENCE: Canary10Percent5Minutes
 
 jobs:
   plan:

--- a/infrastructure/cloudformation/07-codedeploy.yaml
+++ b/infrastructure/cloudformation/07-codedeploy.yaml
@@ -20,7 +20,7 @@ Parameters:
     Description: Name of the 02-compute stack; used for cross-stack Lambda ARN imports.
   CanaryPreference:
     Type: String
-    Default: Linear10PercentEvery10Minutes
+    Default: Canary10Percent5Minutes
     AllowedValues:
       - Canary10Percent5Minutes
       - Canary10Percent10Minutes


### PR DESCRIPTION
## Summary
Today's first promote through the J63/J85 canary lane proved `Linear10PercentEvery10Minutes` (~100-min shift) structurally exceeds `_deploy`'s 900s waiter — **every** v3-prod promote run fails while deployments succeed underneath ([ENC-ISS-471], P1; run 28579110339 was the first casualty).

Per io directive: flip the three defaults to `Canary10Percent5Minutes` (~5–6 min shift; 10% canary for 5 min, then full):
- `DEFAULT_CANARY_PREFERENCE` env in `cloudformation-codedeploy-stack-deploy.yml`
- the `workflow_dispatch` input default (same file)
- `CanaryPreference` template `Default` in `07-codedeploy.yaml`

Alarms + auto-rollback retained; the slow config stays selectable via AllowedValues. **Gamma unaffected** — it has zero CodeDeploy groups and already runs ~6 min end-to-end.

## Deploy
Merge fires the codedeploy stack workflow: plan creates the change-set (expect 22 deployment-group Modifies, config only), apply **pauses on the v3-prod Environment** for io. Sequencing: io is separately stopping the 22 in-flight 100-min shifts (io-dev-admin; agent StopDeployment correctly AccessDenied), then re-promoting artifact set `7f63525` on the new schedule.

## Tracker
ENC-TSK-K08 (remediates ENC-ISS-471)

CCI-f370529beb354cd89f7b76fb73ce6ab7

🤖 Generated with [Claude Code](https://claude.com/claude-code)