### PR TITLE
ENC-TSK-K09: codify lambda:*FunctionUrlConfig grant for CFN deploy role

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-fnurlconfig-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-fnurlconfig-patch.yml
@@ -1,0 +1,82 @@
+name: IAM CFN Deploy Role — Lambda FunctionUrlConfig Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant lambda:*FunctionUrlConfig on enceladus-mcp-code-gamma to CFN deploy role (ENC-TSK-K07/K09, 04-github-roles LambdaComputeOps stale)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with Lambda Function URL config permissions
+    # ENC-TSK-K09 / ENC-ISS-469: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    #
+    # ENC-TSK-K07's EnceladusMcpCodeGammaLiveFunctionUrl (AWS::Lambda::Url) apply
+    # failed AccessDenied 2026-07-02T10:00:43Z on lambda:CreateFunctionUrlConfig —
+    # the CloudFormationDeployPolicy LambdaComputeOps statement never granted
+    # Function URL config actions. Stack rolled back cleanly (UPDATE_ROLLBACK_COMPLETE,
+    # no wedge). Immediately unblocked same-session via a manual aws iam
+    # put-role-policy patch broadening LambdaComputeOps (Resource: "*", matching
+    # its existing scope) with product-lead IAM. This workflow codifies an
+    # equivalent, tightly-scoped, git-tracked, re-runnable grant (scoped to the
+    # specific gamma function rather than "*") so the fix survives as CI-executed
+    # and reviewable rather than only living as an invisible manual CLI mutation —
+    # mirrors the iam-cfn-deploy-role-gamma-patch.yml / iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+    # precedent for 04-github-roles.yaml drift of this role.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — Lambda Function URL config (mcp-code-gamma)
+        run: |
+          set -euo pipefail
+          cat > /tmp/lambda-fnurlconfig-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "LambdaFunctionUrlConfigMcpCodeGamma",
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:CreateFunctionUrlConfig",
+                  "lambda:GetFunctionUrlConfig",
+                  "lambda:UpdateFunctionUrlConfig",
+                  "lambda:DeleteFunctionUrlConfig"
+                ],
+                "Resource": [
+                  "arn:aws:lambda:us-west-2:356364570033:function:enceladus-mcp-code-gamma",
+                  "arn:aws:lambda:us-west-2:356364570033:function:enceladus-mcp-code-gamma:*"
+                ]
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-lambda-fnurlconfig-v1" \
+            --policy-document "file:///tmp/lambda-fnurlconfig-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-lambda-fnurlconfig-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -144,17 +144,30 @@ Resources:
 
               # Lambda compute-stack mutations cover functions, permissions,
               # event-source mappings, and layer validation.
+              #
+              # ENC-TSK-K09 / ENC-ISS-469: lambda:*FunctionUrlConfig actions added.
+              # ENC-TSK-K07's EnceladusMcpCodeGammaLiveFunctionUrl (AWS::Lambda::Url)
+              # apply failed AccessDenied 2026-07-02T10:00:43Z -- this Sid never
+              # granted Function URL config actions (stack rolled back cleanly,
+              # no wedge). Immediately unblocked by a manual aws iam put-role-policy
+              # patch to the live role (same session, product-lead IAM); this change
+              # codifies that identical patch so a future github-roles deploy
+              # reconciles cleanly instead of reverting it, and it stops being
+              # invisible to drift auditing.
               - Sid: LambdaComputeOps
                 Effect: Allow
                 Action:
                   - lambda:AddPermission
                   - lambda:CreateEventSourceMapping
                   - lambda:CreateFunction
+                  - lambda:CreateFunctionUrlConfig
                   - lambda:DeleteEventSourceMapping
                   - lambda:DeleteFunction
+                  - lambda:DeleteFunctionUrlConfig
                   - lambda:GetEventSourceMapping
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
+                  - lambda:GetFunctionUrlConfig
                   - lambda:GetLayerVersion
                   - lambda:PublishVersion
                   - lambda:RemovePermission
@@ -162,6 +175,7 @@ Resources:
                   - lambda:UntagResource
                   - lambda:UpdateEventSourceMapping
                   - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionUrlConfig
                   - lambda:UpdateFunctionConfiguration
                 Resource: "*"
 

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -184,6 +184,13 @@
         "wire-notification"
       ],
       "notes": "ENC-TSK-J65: environment chosen from environment_suffix input (-gamma -> v4-gamma, '' -> v3-prod). Caught by the guard's own first fail-closed run."
+    },
+    "iam-cfn-deploy-role-fnurlconfig-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-K09: environment: v3-prod \u2014 patches the SHARED CFN deploy role object with lambda:*FunctionUrlConfig on enceladus-mcp-code-gamma (ENC-TSK-K07 unblock)."
     }
   }
 }


### PR DESCRIPTION
## Summary
- ENC-TSK-K07's `EnceladusMcpCodeGammaLiveFunctionUrl` apply failed `AccessDenied` on `lambda:CreateFunctionUrlConfig` — `enceladus-cloudformation-deploy-github-role` never had Function URL config actions. Stack rolled back cleanly (`UPDATE_ROLLBACK_COMPLETE`), nothing wedged.
- Unblocked same-session via a manual `aws iam put-role-policy` patch to `CloudFormationDeployPolicy`'s `LambdaComputeOps` statement (product-lead IAM).
- Codifies the fix two ways:
  - `04-github-roles.yaml` `LambdaComputeOps` gains the 4 actions, matching the live patch (documentation parity — this role has known pre-existing template drift, see `enceladus-cfn-deploy-gamma-*` precedent).
  - New `iam-cfn-deploy-role-fnurlconfig-patch.yml` workflow (`v3-prod` Environment-gated, mirrors `iam-cfn-deploy-role-gamma-patch.yml`) applies an equivalent but tightly-scoped (single function ARN, not `*`) grant via CI — git-tracked and re-runnable instead of only living as a manual CLI mutation.

## Related
ENC-ISS-469, ENC-TSK-K07, ENC-TSK-K09

CCI-ffb8df1b657a45d890a97be180d6e532

## Test plan
- [x] YAML syntax validated locally (template + workflow)
- [ ] CI required checks green
- [ ] Post-merge: manually dispatch `iam-cfn-deploy-role-fnurlconfig-patch.yml`, wait for `v3-prod` Environment approval
- [ ] `aws iam get-role-policy` confirms the new policy is attached
- [ ] Re-verify ENC-TSK-K07's Function URL create no longer AccessDenies

🤖 Generated with Claude Code — ENC-SES-025