### PR TITLE
[ENC-TSK-J96] ISS-441 Ph6 — retirement_prompt on terminal-state success envelopes

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -982,6 +982,22 @@ def _delete_token(token_id: str) -> None:
 # deploys (PLN-047 / ENC-LSN-053 Sev1 class).
 SCI_ENFORCEMENT_EPOCH = "2026-07-02T12:00:00Z"
 
+# ENC-ISS-441 / ENC-TSK-J96: terminal-state retirement nudge (part 3 of the io-designed
+# session retirement lifecycle). Injected verbatim into terminal-state success envelopes;
+# the acting agent either retires its session autonomously (scope exhausted) or surfaces
+# the prompt to io. Exact io-specified text from the ENC-ISS-441 worklog.
+RETIREMENT_PROMPT = (
+    "Prompt the user if this session can now be retired, or retire the session if it "
+    "is certain that the full scope of the current session assignment is complete."
+)
+
+
+def _with_retirement_prompt(envelope: dict, new_status: str, terminal_statuses=("closed",)) -> dict:
+    """Inject the ENC-TSK-J96 retirement nudge when a record lands in a final state."""
+    if new_status in terminal_statuses:
+        envelope["retirement_prompt"] = RETIREMENT_PROMPT
+    return envelope
+
 # J92 token shape: pk = "SCI-{uuid4_hex}"
 _SCI_TOKEN_RE = re.compile(r"^SCI-[0-9a-f]{32}$")
 # I37 minted session ids: ENC-SES-NNN (base-36, uppercase)
@@ -3045,14 +3061,17 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         "advance OK: %s %s->%s (type=%s, matrix_version=%d)",
         task_id, current_status, target_status, transition_type, MATRIX_VERSION,
     )
-    return _response(200, {
+    advance_envelope = {
         "success": True,
         "task": updated_task,
         "previous_status": current_status,
         "new_status": target_status,
         "matrix_version": MATRIX_VERSION,
         **response_extras,
-    })
+    }
+    # ENC-ISS-441 / ENC-TSK-J96: task reached its final lifecycle state — nudge the
+    # acting session toward retirement (additive-only envelope field).
+    return _response(200, _with_retirement_prompt(advance_envelope, target_status))
 
 
 def _handle_log(project_id: str, task_id: str, body: dict) -> dict:
@@ -3470,12 +3489,16 @@ def _handle_plan_advance(project_id: str, plan_id: str, body: dict) -> dict:
         _release_plan(project_id, plan_id)
 
     _, updated_plan = _get_plan(project_id, plan_id)
-    return _response(200, {
+    plan_envelope = {
         "success": True,
         "plan": updated_plan,
         "previous_status": current_status,
         "new_status": target_status,
-    })
+    }
+    # ENC-ISS-441 / ENC-TSK-J96: plan reached its final lifecycle state — retirement nudge.
+    return _response(
+        200, _with_retirement_prompt(plan_envelope, target_status, terminal_statuses=("complete",))
+    )
 
 
 def _handle_plan_log(project_id: str, plan_id: str, body: dict) -> dict:

--- a/backend/lambda/checkout_service/test_retirement_prompt.py
+++ b/backend/lambda/checkout_service/test_retirement_prompt.py
@@ -1,0 +1,48 @@
+"""ENC-ISS-441 / ENC-TSK-J96: terminal-state retirement nudge (checkout service side).
+
+The nudge is injected via _with_retirement_prompt at the two advance return sites
+(task -> closed, plan -> complete). These tests pin the exact io-specified prompt
+text and the presence/absence semantics per terminal state; the wire-level envelope
+is exercised on gamma (ENC-TSK-J98).
+"""
+import unittest
+
+import lambda_function as checkout_lambda
+
+_IO_PROMPT = (
+    "Prompt the user if this session can now be retired, or retire the session if it "
+    "is certain that the full scope of the current session assignment is complete."
+)
+
+
+class RetirementPromptTests(unittest.TestCase):
+    def test_prompt_text_is_the_exact_io_specified_string(self):
+        self.assertEqual(checkout_lambda.RETIREMENT_PROMPT, _IO_PROMPT)
+
+    def test_task_closed_gets_prompt(self):
+        env = checkout_lambda._with_retirement_prompt({"success": True}, "closed")
+        self.assertEqual(env["retirement_prompt"], _IO_PROMPT)
+
+    def test_plan_complete_gets_prompt(self):
+        env = checkout_lambda._with_retirement_prompt(
+            {"success": True}, "complete", terminal_statuses=("complete",)
+        )
+        self.assertEqual(env["retirement_prompt"], _IO_PROMPT)
+
+    def test_non_terminal_statuses_untouched(self):
+        for status in ("coding-complete", "committed", "pr", "merged-main",
+                       "deploy-init", "deploy-success", "in-progress"):
+            env = checkout_lambda._with_retirement_prompt({"success": True}, status)
+            self.assertNotIn("retirement_prompt", env, status)
+
+    def test_plan_incomplete_is_not_nudged(self):
+        # 'incomplete' is an abandonment terminal, not a completed-scope terminal —
+        # the io design nudges only on success-shaped finals.
+        env = checkout_lambda._with_retirement_prompt(
+            {"success": True}, "incomplete", terminal_statuses=("complete",)
+        )
+        self.assertNotIn("retirement_prompt", env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.16",
-  "updated_at": "2026-07-02T10:14:00Z",
-  "last_change_summary": "ENC-TSK-J93 (ENC-ISS-441 Ph3, ENC-FTR-122): SCI enforcement gate live in checkout_service (checkout/advance/log) + tracker_mutation (set/log/create) - 403 SCI_REQUIRED on absent/unknown/wrong-type/revoked/expired/mismatched SCI for post-epoch ENC-SES identities; fabricated session ids fail closed; SCI_ENFORCEMENT_EPOCH 2026-07-02T12:00:00Z grandfathers pre-existing sessions; identity-shape exemptions (non-ENC-SES providers) + FTR-037 checkout-service-key exemption in tracker_mutation; SCI-validated mutations refresh last_activity_at (J83). New entities checkout_service.sci_enforcement_gate + tracker.sci_enforcement_gate. The ENC-ISS-441 register->claim handshake is now ENFORCED. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.17",
+  "updated_at": "2026-07-02T10:30:00Z",
+  "last_change_summary": "ENC-TSK-J96 (ENC-ISS-441 Ph6, ENC-FTR-122): retirement_prompt injected verbatim into terminal-state success envelopes - checkout_service task->closed + plan->complete advances, tracker_mutation status writes to task/issue closed, feature production/deprecated, plan complete. Additive-only; non-terminal envelopes byte-identical. New entity tracker.retirement_prompt. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
   "owners": [
     "enceladus-platform"
   ],
@@ -6793,6 +6793,15 @@
           "definition": "X-Checkout-Service-Key-authenticated requests (FTR-037) skip the gate; the gate already ran at the checkout_service edge for the originating agent call."
         }
       }
+    },
+    "tracker.retirement_prompt": {
+      "description": "ENC-ISS-441 / ENC-TSK-J96 (ENC-FTR-122): terminal-state retirement nudge, part 3 of the io-designed session retirement lifecycle (issue worklog 2026-06-30). Whenever a success response is returned for a record reaching a FINAL lifecycle state, the envelope carries an additive-only string field retirement_prompt with the exact io-specified text: 'Prompt the user if this session can now be retired, or retire the session if it is certain that the full scope of the current session assignment is complete.' The acting agent either calls coordination agent.retire autonomously (scope exhausted) or surfaces the prompt to io. Injection points: checkout_service _handle_advance (task -> closed) and _handle_plan_advance (plan -> complete); tracker_mutation _handle_update_field status writes landing task/issue -> closed, feature -> production or deprecated, plan -> complete (_is_terminal_transition map). 'superseded' and plan 'incomplete' are NOT nudged (supersession is a server op, incomplete is an abandonment terminal). Non-terminal envelopes are byte-identical; consumers that ignore unknown fields are unaffected.",
+      "fields": {
+        "retirement_prompt": {
+          "type": "string",
+          "definition": "Fixed io-specified nudge text, present ONLY on terminal-state success envelopes. Complements the ENC-TSK-J94 sweeps: the prompt handles well-behaved agents, the sweeps catch the rest."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6906,6 +6915,11 @@
       "version": "2026-07-02.16",
       "date": "2026-07-02",
       "summary": "ENC-TSK-J93 (ENC-ISS-441 Ph3, ENC-FTR-122): SCI enforcement gate live in checkout_service (checkout/advance/log) + tracker_mutation (set/log/create) - 403 SCI_REQUIRED on absent/unknown/wrong-type/revoked/expired/mismatched SCI for post-epoch ENC-SES identities; fabricated session ids fail closed; SCI_ENFORCEMENT_EPOCH 2026-07-02T12:00:00Z grandfathers pre-existing sessions; identity-shape exemptions (non-ENC-SES providers) + FTR-037 checkout-service-key exemption in tracker_mutation; SCI-validated mutations refresh last_activity_at (J83). New entities checkout_service.sci_enforcement_gate + tracker.sci_enforcement_gate. The ENC-ISS-441 register->claim handshake is now ENFORCED. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.17",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J96 (ENC-ISS-441 Ph6, ENC-FTR-122): retirement_prompt injected verbatim into terminal-state success envelopes - checkout_service task->closed + plan->complete advances, tracker_mutation status writes to task/issue closed, feature production/deprecated, plan complete. Additive-only; non-terminal envelopes byte-identical. New entity tracker.retirement_prompt. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -1172,6 +1172,34 @@ def _is_conditional_check_failed(exc: Exception) -> bool:
 # deploys (PLN-047 / ENC-LSN-053 Sev1 class).
 SCI_ENFORCEMENT_EPOCH = "2026-07-02T12:00:00Z"
 
+# ENC-ISS-441 / ENC-TSK-J96: terminal-state retirement nudge (part 3 of the io-designed
+# session retirement lifecycle). Injected verbatim into terminal-state success envelopes;
+# the acting agent either retires its session autonomously (scope exhausted) or surfaces
+# the prompt to io. Exact io-specified text from the ENC-ISS-441 worklog.
+RETIREMENT_PROMPT = (
+    "Prompt the user if this session can now be retired, or retire the session if it "
+    "is certain that the full scope of the current session assignment is complete."
+)
+
+# Final lifecycle states per record type (io design decision on ENC-ISS-441: task closed,
+# issue closed, feature production/deprecated, plan complete). 'superseded' is set only by
+# the supersession op, not a direct status write, so it never reaches this map.
+_TERMINAL_STATUSES_BY_TYPE = {
+    "task": {"closed"},
+    "issue": {"closed"},
+    "feature": {"production", "deprecated"},
+    "plan": {"complete"},
+}
+
+
+def _is_terminal_transition(record_type: Any, value: Any) -> bool:
+    """True when a status write lands a record in its final lifecycle state (ENC-TSK-J96)."""
+    return (
+        str(value or "").strip().lower()
+        in _TERMINAL_STATUSES_BY_TYPE.get(str(record_type or "").strip().lower(), set())
+    )
+
+
 # J92 token shape: pk = "SCI-{uuid4_hex}"
 _SCI_TOKEN_RE = re.compile(r"^SCI-[0-9a-f]{32}$")
 # I37 minted session ids: ENC-SES-NNN (base-36, uppercase)
@@ -5124,6 +5152,11 @@ def _handle_update_field(
     }
     if warnings:
         result["warnings"] = warnings
+
+    # ENC-ISS-441 / ENC-TSK-J96: record reached its final lifecycle state — nudge the
+    # acting session toward retirement (additive-only envelope field).
+    if field == "status" and _is_terminal_transition(record_type, value):
+        result["retirement_prompt"] = RETIREMENT_PROMPT
 
     # ENC-TSK-H85 / ENC-FTR-111 Phase 1: after a successful FORWARD task status advance, hand off to
     # the Universal Arc-Walker to walk forward across the mechanical gates in the same invocation

--- a/backend/lambda/tracker_mutation/test_retirement_prompt.py
+++ b/backend/lambda/tracker_mutation/test_retirement_prompt.py
@@ -1,0 +1,136 @@
+"""ENC-ISS-441 / ENC-TSK-J96: terminal-state retirement nudge (tracker mutation side).
+
+Covers the _is_terminal_transition truth table (task closed, issue closed, feature
+production/deprecated, plan complete) plus a full moto-backed status write proving the
+retirement_prompt field lands in the success envelope and stays absent for non-terminal
+writes. Reuses the ENC-TSK-J93 SCI-gate fixture (grandfathered session so the gate
+passes without a token).
+"""
+import json
+import unittest
+from unittest import mock
+
+import lambda_function as tm
+from test_sci_gate import (  # noqa: F401 — shared moto fixture
+    PRE_EPOCH_SESSION,
+    PRE_EPOCH_TS,
+    TrackerSciGateBase,
+    _body,
+)
+
+_IO_PROMPT = (
+    "Prompt the user if this session can now be retired, or retire the session if it "
+    "is certain that the full scope of the current session assignment is complete."
+)
+
+# Captured at import (collection) time, before any test runs: the arc-walker test modules
+# (h83/h85/h86) rebind these module seams in-place without restoration, so suite order
+# would otherwise leak their fakes into the moto-backed envelope tests below.
+_PRISTINE_SEAMS = {
+    name: getattr(tm, name)
+    for name in ("_get_events", "_get_record_raw", "_build_key", "_resolve_github_repo")
+    if hasattr(tm, name)
+}
+
+
+class TerminalTransitionTruthTableTests(unittest.TestCase):
+    def test_prompt_text_is_the_exact_io_specified_string(self):
+        self.assertEqual(tm.RETIREMENT_PROMPT, _IO_PROMPT)
+
+    def test_terminal_states_per_record_type(self):
+        for record_type, value in (
+            ("task", "closed"),
+            ("issue", "closed"),
+            ("feature", "production"),
+            ("feature", "deprecated"),
+            ("plan", "complete"),
+        ):
+            self.assertTrue(tm._is_terminal_transition(record_type, value), (record_type, value))
+
+    def test_non_terminal_states_are_not_flagged(self):
+        for record_type, value in (
+            ("task", "in-progress"),
+            ("task", "deploy-success"),
+            ("issue", "in-progress"),
+            ("feature", "completed"),
+            ("feature", "in-progress"),
+            ("plan", "started"),
+            ("plan", "incomplete"),
+            ("lesson", "closed"),
+            ("", "closed"),
+            ("task", ""),
+            ("task", None),
+        ):
+            self.assertFalse(tm._is_terminal_transition(record_type, value), (record_type, value))
+
+    def test_case_and_whitespace_are_normalized(self):
+        self.assertTrue(tm._is_terminal_transition("Issue", " Closed "))
+
+
+class RetirementPromptEnvelopeTests(TrackerSciGateBase):
+    """Moto-backed status writes through _handle_update_field (grandfathered session)."""
+
+    def setUp(self):
+        super().setUp()
+        # The arc-walker test modules rebind module seams (lf._get_ddb, _get_record_raw,
+        # ...) without restoration; re-point them at this test's moto client / their
+        # pristine originals so suite order can't leak fakes into these envelope tests.
+        seams = dict(_PRISTINE_SEAMS)
+        seams["_get_ddb"] = lambda: self.ddb
+        for name, value in seams.items():
+            patcher = mock.patch.object(tm, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def put_issue(self, item_id="ENC-ISS-941", status="in-progress"):
+        self.ddb.put_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Item={
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": f"issue#{item_id}"},
+                "item_id": {"S": item_id},
+                "record_type": {"S": "issue"},
+                "status": {"S": status},
+                "title": {"S": "retirement prompt test issue"},
+                "history": {"L": []},
+                "evidence": {"L": [{"M": {
+                    "description": {"S": "test evidence"},
+                    "steps_to_duplicate": {"L": [{"S": "step 1"}]},
+                }}]},
+            },
+        )
+
+    def _set_status(self, record_type, record_id, value):
+        return tm._handle_update_field(
+            "enceladus", record_type, record_id,
+            _body(provider=PRE_EPOCH_SESSION, field="status", value=value),
+        )
+
+    def test_issue_closed_envelope_carries_prompt(self):
+        self.put_session(session_id=PRE_EPOCH_SESSION, created_at=PRE_EPOCH_TS)
+        self.put_issue()
+        resp = self._set_status("issue", "ENC-ISS-941", "closed")
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertEqual(body.get("retirement_prompt"), _IO_PROMPT)
+
+    def test_non_terminal_status_write_has_no_prompt(self):
+        self.put_session(session_id=PRE_EPOCH_SESSION, created_at=PRE_EPOCH_TS)
+        self.put_issue(item_id="ENC-ISS-942", status="open")
+        resp = self._set_status("issue", "ENC-ISS-942", "in-progress")
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertNotIn("retirement_prompt", json.loads(resp["body"]))
+
+    def test_non_status_field_write_has_no_prompt(self):
+        self.put_session(session_id=PRE_EPOCH_SESSION, created_at=PRE_EPOCH_TS)
+        self.put_task(item_id="ENC-TSK-941")
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-941",
+            _body(provider=PRE_EPOCH_SESSION, field="description", value="closed"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertNotIn("retirement_prompt", json.loads(resp["body"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
ENC-ISS-441 Ph6 (ENC-PLN-062 / ENC-FTR-122). Part 3 of the io-designed session retirement lifecycle: terminal-state success envelopes now carry the exact io-specified `retirement_prompt` string, so the acting agent retires its session (scope exhausted) or surfaces the prompt to io.

- checkout_service: `_with_retirement_prompt` at the advance return sites (task → closed; plan → complete).
- tracker_mutation: `_is_terminal_transition` map (task/issue closed, feature production/deprecated, plan complete) → injected into the status-write result.
- Additive-only; non-terminal envelopes byte-identical. 'superseded' and plan 'incomplete' deliberately not nudged.
- Dict → 2026-07-02.17: new `tracker.retirement_prompt` entity.
- Tests: 14 new; suites 108 + 445 green (includes pristine-seam shielding against pre-existing arc-walker test-module leakage, documented in-file).

## Tracker
- Task: ENC-TSK-J96 (plan ENC-PLN-062, feature ENC-FTR-122, issue ENC-ISS-441)
- CCI-d7fbdd5499f54bf0a1549a5119bb8f38

🤖 Generated with [Claude Code](https://claude.com/claude-code)