### PR TITLE
ENC-TSK-K09 fix: use attached managed policy (inline quota exhausted)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-fnurlconfig-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-fnurlconfig-patch.yml
@@ -23,13 +23,15 @@ jobs:
     # the CloudFormationDeployPolicy LambdaComputeOps statement never granted
     # Function URL config actions. Stack rolled back cleanly (UPDATE_ROLLBACK_COMPLETE,
     # no wedge). Immediately unblocked same-session via a manual aws iam
-    # put-role-policy patch broadening LambdaComputeOps (Resource: "*", matching
-    # its existing scope) with product-lead IAM. This workflow codifies an
-    # equivalent, tightly-scoped, git-tracked, re-runnable grant (scoped to the
-    # specific gamma function rather than "*") so the fix survives as CI-executed
-    # and reviewable rather than only living as an invisible manual CLI mutation —
-    # mirrors the iam-cfn-deploy-role-gamma-patch.yml / iam-cfn-deploy-role-eventbridge-listrules-patch.yml
-    # precedent for 04-github-roles.yaml drift of this role.
+    # put-role-policy patch broadening LambdaComputeOps (Resource: "*") with
+    # product-lead IAM. This workflow's first version tried to codify an
+    # equivalent grant as a NEW inline policy and hit LimitExceeded — the role's
+    # aggregate inline-policy quota (10,240 bytes) is already exhausted (same
+    # failure class as ENC-TSK-J85 / CodeDeployStackOpsPolicy). Corrected to
+    # create+attach a MANAGED policy instead (create-policy is idempotent-guarded:
+    # reuses an existing policy ARN and just attaches/updates rather than
+    # erroring on re-run), matching the LambdaFunctionUrlConfigPolicy CFN
+    # resource in 04-github-roles.yaml exactly (name, Sid, actions, resources).
     environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -43,7 +45,7 @@ jobs:
       - name: Verify caller identity
         run: aws sts get-caller-identity
 
-      - name: Apply inline policy — Lambda Function URL config (mcp-code-gamma)
+      - name: Create or update managed policy — Lambda Function URL config (mcp-code-gamma)
         run: |
           set -euo pipefail
           cat > /tmp/lambda-fnurlconfig-policy.json <<'JSON'
@@ -68,15 +70,28 @@ jobs:
           }
           JSON
 
-          aws iam put-role-policy \
-            --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-lambda-fnurlconfig-v1" \
-            --policy-document "file:///tmp/lambda-fnurlconfig-policy.json"
+          POLICY_ARN="arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-lambda-fnurlconfig-v1"
 
-      - name: Verify inline policy attached
-        run: |
-          aws iam get-role-policy \
+          if aws iam get-policy --policy-arn "$POLICY_ARN" >/dev/null 2>&1; then
+            echo "Policy exists — creating a new default version"
+            aws iam create-policy-version \
+              --policy-arn "$POLICY_ARN" \
+              --policy-document "file:///tmp/lambda-fnurlconfig-policy.json" \
+              --set-as-default
+          else
+            echo "Policy does not exist — creating it"
+            aws iam create-policy \
+              --policy-name "enceladus-cfn-deploy-lambda-fnurlconfig-v1" \
+              --policy-document "file:///tmp/lambda-fnurlconfig-policy.json"
+          fi
+
+          aws iam attach-role-policy \
             --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-lambda-fnurlconfig-v1" \
-            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --policy-arn "$POLICY_ARN"
+
+      - name: Verify managed policy attached
+        run: |
+          aws iam list-attached-role-policies \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --query 'AttachedPolicies[?PolicyName==`enceladus-cfn-deploy-lambda-fnurlconfig-v1`]' \
             --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -145,29 +145,22 @@ Resources:
               # Lambda compute-stack mutations cover functions, permissions,
               # event-source mappings, and layer validation.
               #
-              # ENC-TSK-K09 / ENC-ISS-469: lambda:*FunctionUrlConfig actions added.
-              # ENC-TSK-K07's EnceladusMcpCodeGammaLiveFunctionUrl (AWS::Lambda::Url)
-              # apply failed AccessDenied 2026-07-02T10:00:43Z -- this Sid never
-              # granted Function URL config actions (stack rolled back cleanly,
-              # no wedge). Immediately unblocked by a manual aws iam put-role-policy
-              # patch to the live role (same session, product-lead IAM); this change
-              # codifies that identical patch so a future github-roles deploy
-              # reconciles cleanly instead of reverting it, and it stops being
-              # invisible to drift auditing.
+              # ENC-TSK-K09 / ENC-ISS-469: lambda:*FunctionUrlConfig actions were
+              # first attempted HERE (inline), but the role's aggregate inline-policy
+              # quota (10,240 bytes) is exhausted -- same failure class as ENC-TSK-J85
+              # below (LimitExceeded). Shipped instead as the attached MANAGED
+              # LambdaFunctionUrlConfigPolicy resource further down this file.
               - Sid: LambdaComputeOps
                 Effect: Allow
                 Action:
                   - lambda:AddPermission
                   - lambda:CreateEventSourceMapping
                   - lambda:CreateFunction
-                  - lambda:CreateFunctionUrlConfig
                   - lambda:DeleteEventSourceMapping
                   - lambda:DeleteFunction
-                  - lambda:DeleteFunctionUrlConfig
                   - lambda:GetEventSourceMapping
                   - lambda:GetFunction
                   - lambda:GetFunctionConfiguration
-                  - lambda:GetFunctionUrlConfig
                   - lambda:GetLayerVersion
                   - lambda:PublishVersion
                   - lambda:RemovePermission
@@ -175,7 +168,6 @@ Resources:
                   - lambda:UntagResource
                   - lambda:UpdateEventSourceMapping
                   - lambda:UpdateFunctionCode
-                  - lambda:UpdateFunctionUrlConfig
                   - lambda:UpdateFunctionConfiguration
                 Resource: "*"
 
@@ -390,6 +382,38 @@ Resources:
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:application:enceladus-lambda*"
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentgroup:enceladus-lambda*"
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentconfig:*"
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-K09 / ENC-ISS-469 -- same failure class as CodeDeployStackOpsPolicy
+  # above (ENC-TSK-J85): ENC-TSK-K07's EnceladusMcpCodeGammaLiveFunctionUrl
+  # (AWS::Lambda::Url) apply failed AccessDenied 2026-07-02T10:00:43Z on
+  # lambda:CreateFunctionUrlConfig -- LambdaComputeOps never granted Function
+  # URL config actions, and the role's aggregate inline-policy quota (10,240
+  # bytes) is already exhausted, so a further inline grant LimitExceeded
+  # (confirmed live 2026-07-02T10:30:26Z via the ENC-TSK-K09 patch workflow's
+  # first attempt). Shipped as an attached MANAGED policy instead, mirroring
+  # CodeDeployStackOpsPolicy exactly. Scoped to enceladus-mcp-code-gamma only
+  # (tighter than LambdaComputeOps's Resource: "*").
+  # ---------------------------------------------------------------------------
+  LambdaFunctionUrlConfigPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-lambda-fnurlconfig-v1
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: LambdaFunctionUrlConfigMcpCodeGamma
+            Effect: Allow
+            Action:
+              - lambda:CreateFunctionUrlConfig
+              - lambda:GetFunctionUrlConfig
+              - lambda:UpdateFunctionUrlConfig
+              - lambda:DeleteFunctionUrlConfig
+            Resource:
+              - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:enceladus-mcp-code-gamma"
+              - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:enceladus-mcp-code-gamma:*"
 
   BackendDeployRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary
Follow-up to #759 (merged). The codified inline-policy grant failed live: `LimitExceeded: Maximum policy size of 10240 bytes exceeded for role enceladus-cloudformation-deploy-github-role` when the patch workflow ran — the role's aggregate inline-policy quota is exhausted (same failure class as ENC-TSK-J85 / `CodeDeployStackOpsPolicy`, which hit this exact wall before).

- Reverted the `LambdaComputeOps` inline addition in `04-github-roles.yaml`.
- Added `LambdaFunctionUrlConfigPolicy` (`AWS::IAM::ManagedPolicy`), mirroring `CodeDeployStackOpsPolicy` exactly, scoped to `enceladus-mcp-code-gamma` only.
- Updated `iam-cfn-deploy-role-fnurlconfig-patch.yml` to create/attach a managed policy (idempotent re-run via `create-policy-version`) instead of `put-role-policy`.

## Related
ENC-ISS-469, ENC-TSK-K07, ENC-TSK-K09

CCI-ffb8df1b657a45d890a97be180d6e532

## Test plan
- [x] YAML syntax validated locally (template + workflow)
- [x] prod_gate_coverage_guard.py passes locally
- [ ] CI required checks green
- [ ] Post-merge: re-dispatch `iam-cfn-deploy-role-fnurlconfig-patch.yml`, wait for `v3-prod` approval
- [ ] `aws iam list-attached-role-policies` confirms attachment
- [ ] Re-verify ENC-TSK-K07's Function URL create no longer AccessDenies

🤖 Generated with Claude Code — ENC-SES-025