### PR TITLE
K05: Stigmergic exploration trace emission (FTR-109)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.17",
-  "updated_at": "2026-07-02T10:30:00Z",
-  "last_change_summary": "ENC-TSK-J96 (ENC-ISS-441 Ph6, ENC-FTR-122): retirement_prompt injected verbatim into terminal-state success envelopes - checkout_service task->closed + plan->complete advances, tracker_mutation status writes to task/issue closed, feature production/deprecated, plan complete. Additive-only; non-terminal envelopes byte-identical. New entity tracker.retirement_prompt. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.18",
+  "updated_at": "2026-07-02T10:40:00Z",
+  "last_change_summary": "ENC-TSK-K05 (ENC-FTR-109): stigmergic exploration trace emission — graph_query_api.stigmergic_trace entity documents DynamoDB sink enceladus-stigmergic-trace${EnvironmentSuffix}, STIGMERGIC_TRACE_TABLE env var, 90-day TTL, telemetry-only retrieval/traversal events.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4910,6 +4910,27 @@
         "telemetry_schema": {
           "type": "string",
           "definition": "enceladus.drift.telemetry.v1"
+        }
+      }
+    },
+    "graph_query_api.stigmergic_trace": {
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "fields": {
+        "table": {
+          "type": "string",
+          "definition": "enceladus-stigmergic-trace${EnvironmentSuffix} (01-data.yaml StigmergicTraceTable). PAY_PER_REQUEST. TTL on expires_at (90 days)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "STIGMERGIC_TRACE_TABLE on devops-graph-query-api (02-compute.yaml). GraphQueryApiRole StigmergicTraceTableAccess grants dynamodb:PutItem."
+        },
+        "record_fields": {
+          "type": "object",
+          "definition": "{schema:'enceladus.stigmergic.trace.v1', trace_id, project_id, session_id, event_type:'retrieval'|'traversal', record_id_path (pipe-delimited), timestamp (ISO-8601 UTC), outcome_signal (JSON string), expires_at (epoch seconds, TTL)}."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.stigmergic.trace.v1"
         }
       }
     },

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -250,6 +250,9 @@ except (TypeError, ValueError):
 # the per-project DynamoDB time series (queryable via the project-timestamp-index GSI).
 DRIFT_TELEMETRY_TABLE = os.environ.get("DRIFT_TELEMETRY_TABLE", "").strip()
 
+# ENC-FTR-109 / ENC-TSK-K05 — stigmergic exploration trace sink (telemetry-only).
+STIGMERGIC_TRACE_TABLE = os.environ.get("STIGMERGIC_TRACE_TABLE", "").strip()
+
 _s3 = None
 _dynamodb = None
 
@@ -2052,6 +2055,61 @@ def _emit_pathway_telemetry(record: Dict[str, Any]) -> None:
         logger.exception("[ERROR] pathway telemetry emit failed (suppressed)")
 
 
+def _emit_stigmergic_trace(record: Dict[str, Any]) -> None:
+    """ENC-FTR-109 / ENC-TSK-K05 sink. Persist one trace to DynamoDB when configured;
+    otherwise emit a structured CloudWatch line. Never raises into the request path."""
+    try:
+        line = json.dumps(record, default=str)
+        if STIGMERGIC_TRACE_TABLE:
+            try:
+                import stigmergic_trace
+
+                stigmergic_trace.emit_stigmergic_trace(
+                    _get_dynamodb(), STIGMERGIC_TRACE_TABLE, record,
+                )
+                return
+            except Exception as exc:
+                logger.warning(
+                    "[WARNING] stigmergic trace DDB put failed (%s); CloudWatch fallback",
+                    exc,
+                )
+        logger.info("STIGMERGIC_TRACE %s", line)
+    except Exception:
+        logger.exception("[ERROR] stigmergic trace emit failed (suppressed)")
+
+
+def _session_id_from_params(params: Dict[str, Any]) -> str:
+    for key in ("session_id", "agent_session_id", "wave_id"):
+        value = str(params.get(key) or "").strip()
+        if value:
+            return value
+    return "unassigned"
+
+
+def _maybe_emit_stigmergic_trace(
+    *,
+    project_id: str,
+    params: Dict[str, Any],
+    event_type: str,
+    result: Dict[str, Any],
+    outcome_signal: Dict[str, Any],
+) -> None:
+    """Build and emit one stigmergic trace record (telemetry-only)."""
+    try:
+        import stigmergic_trace
+
+        record = stigmergic_trace.build_trace_record(
+            project_id=project_id,
+            session_id=_session_id_from_params(params),
+            event_type=event_type,
+            record_id_path=stigmergic_trace.record_id_path_from_graph_result(result),
+            outcome_signal=outcome_signal,
+        )
+        _emit_stigmergic_trace(record)
+    except Exception:
+        logger.exception("[ERROR] stigmergic trace build failed (suppressed)")
+
+
 def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
     """Phase 1 hybrid retrieval: vector + graph + keyword fused via RRF.
 
@@ -2240,6 +2298,17 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
             signal_availability=_sig_avail, retrieval_records=[],
             lambda_graph=energy_lambda_graph, lambda_kw=energy_lambda_kw,
         ))
+        _maybe_emit_stigmergic_trace(
+            project_id=project_id,
+            params=params,
+            event_type="retrieval",
+            result={"pathway": {"node_sequence": []}, "nodes": []},
+            outcome_signal={
+                "result_count": 0,
+                "graph_algorithm": graph_algorithm,
+                "signal_availability": _sig_avail,
+            },
+        )
         return {
             "nodes": [],
             "edges": [],
@@ -2439,6 +2508,21 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         signal_availability=_sig_avail, retrieval_records=retrieval_records,
         lambda_graph=energy_lambda_graph, lambda_kw=energy_lambda_kw,
     ))
+    _maybe_emit_stigmergic_trace(
+        project_id=project_id,
+        params=params,
+        event_type="retrieval",
+        result={
+            "pathway": {"node_sequence": node_sequence},
+            "nodes": nodes,
+            "edges": edges_traversed,
+        },
+        outcome_signal={
+            "result_count": len(nodes),
+            "graph_algorithm": graph_algorithm,
+            "signal_availability": _sig_avail,
+        },
+    )
 
     return {
         "nodes": nodes,
@@ -2824,6 +2908,21 @@ def _handle_search(event: Dict) -> Dict:
             "query_cypher": result.get("query_cypher", ""),
         })
     )
+
+    if search_type != "hybrid":
+        _maybe_emit_stigmergic_trace(
+            project_id=project_id,
+            params=qs,
+            event_type="traversal",
+            result=result,
+            outcome_signal={
+                "search_type": search_type,
+                "node_count": len(result.get("nodes", [])),
+                "edge_count": len(result.get("edges", [])),
+                "path_count": len(result.get("paths", [])),
+                "duration_ms": duration_ms,
+            },
+        )
 
     response_body: Dict[str, Any] = {
         "success": True,

--- a/backend/lambda/graph_query_api/stigmergic_trace.py
+++ b/backend/lambda/graph_query_api/stigmergic_trace.py
@@ -1,0 +1,101 @@
+"""ENC-FTR-109 / ENC-TSK-K05 — Stigmergic exploration trace emission.
+
+Per-event telemetry records for retrieval and graph-traversal activity. Writes
+are fire-and-forget DynamoDB ``put_item`` calls (PAY_PER_REQUEST); when the
+table env var is unset the emitter degrades to a structured CloudWatch line.
+
+Telemetry-only: this module never mutates retrieval ranking, graph weights, or
+any governed record. Exploration-weighting is a future io decision informed by
+accumulated traces.
+
+OGTM (ENC-FTR-066): traces land in DynamoDB only — no new Neo4j edge type.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from drift_telemetry import to_ddb_item
+
+STIGMERGIC_TRACE_SCHEMA = "enceladus.stigmergic.trace.v1"
+TRACE_TTL_DAYS = 90
+
+
+def _iso_timestamp(ts: Optional[datetime] = None) -> str:
+    when = ts or datetime.now(timezone.utc)
+    return when.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def build_trace_record(
+    *,
+    project_id: str,
+    session_id: str,
+    event_type: str,
+    record_id_path: Sequence[str],
+    outcome_signal: Dict[str, Any],
+    timestamp: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build one stigmergic trace record with a 90-day TTL."""
+    if not project_id:
+        raise ValueError("build_trace_record requires project_id")
+    if event_type not in {"retrieval", "traversal"}:
+        raise ValueError("event_type must be 'retrieval' or 'traversal'")
+    when = now or datetime.now(timezone.utc)
+    expires_at = int((when + timedelta(days=TRACE_TTL_DAYS)).timestamp())
+    path = [str(rid).strip() for rid in record_id_path if str(rid).strip()]
+    return {
+        "schema": STIGMERGIC_TRACE_SCHEMA,
+        "trace_id": trace_id or uuid.uuid4().hex,
+        "project_id": project_id,
+        "session_id": str(session_id or "unassigned"),
+        "event_type": event_type,
+        "record_id_path": "|".join(path),
+        "timestamp": timestamp or _iso_timestamp(when),
+        "outcome_signal": json.dumps(outcome_signal, sort_keys=True, default=str),
+        "expires_at": expires_at,
+    }
+
+
+def emit_stigmergic_trace(
+    ddb_client: Any,
+    table_name: str,
+    record: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Persist one trace via ``put_item``. Client is injected for unit tests."""
+    if not table_name:
+        raise ValueError("emit_stigmergic_trace requires a table_name")
+    ddb_client.put_item(TableName=table_name, Item=to_ddb_item(record))
+    return record
+
+
+def record_id_path_from_graph_result(result: Dict[str, Any]) -> List[str]:
+    """Extract a stable record-id path from a graphsearch handler result."""
+    seen: set[str] = set()
+    ordered: List[str] = []
+
+    def _add(rid: Any) -> None:
+        token = str(rid or "").strip()
+        if token and token not in seen:
+            seen.add(token)
+            ordered.append(token)
+
+    pathway = result.get("pathway") or {}
+    for rid in pathway.get("node_sequence") or []:
+        _add(rid)
+
+    for node in result.get("nodes") or []:
+        if isinstance(node, dict):
+            _add(node.get("record_id"))
+
+    for path in result.get("paths") or []:
+        if not isinstance(path, dict):
+            continue
+        for rid in path.get("node_ids") or path.get("nodes") or []:
+            _add(rid)
+
+    return ordered

--- a/backend/lambda/graph_query_api/test_stigmergic_trace.py
+++ b/backend/lambda/graph_query_api/test_stigmergic_trace.py
@@ -1,0 +1,78 @@
+"""Unit tests for ENC-FTR-109 / ENC-TSK-K05 stigmergic trace emission."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+import stigmergic_trace as st
+
+
+class _FakeDdb:
+    def __init__(self) -> None:
+        self.items = []
+
+    def put_item(self, TableName, Item):  # noqa: N803
+        self.items.append({"TableName": TableName, "Item": Item})
+
+
+class StigmergicTraceTests(unittest.TestCase):
+    def test_build_trace_record_schema_and_ttl(self):
+        fixed = datetime(2026, 7, 2, 10, 0, 0, tzinfo=timezone.utc)
+        rec = st.build_trace_record(
+            project_id="enceladus",
+            session_id="ENC-SES-02L",
+            event_type="retrieval",
+            record_id_path=["ENC-TSK-K05", "ENC-FTR-109"],
+            outcome_signal={"result_count": 2},
+            now=fixed,
+        )
+        self.assertEqual(rec["schema"], st.STIGMERGIC_TRACE_SCHEMA)
+        self.assertEqual(rec["session_id"], "ENC-SES-02L")
+        self.assertEqual(rec["record_id_path"], "ENC-TSK-K05|ENC-FTR-109")
+        self.assertEqual(json.loads(rec["outcome_signal"]), {"result_count": 2})
+        self.assertEqual(rec["expires_at"], int(fixed.timestamp()) + 90 * 86400)
+
+    def test_emit_puts_ddb_item(self):
+        ddb = _FakeDdb()
+        rec = st.build_trace_record(
+            project_id="enceladus",
+            session_id="s1",
+            event_type="traversal",
+            record_id_path=["ENC-PLN-006"],
+            outcome_signal={"node_count": 1},
+        )
+        st.emit_stigmergic_trace(ddb, "enceladus-stigmergic-trace-gamma", rec)
+        self.assertEqual(len(ddb.items), 1)
+        self.assertEqual(ddb.items[0]["TableName"], "enceladus-stigmergic-trace-gamma")
+
+    def test_record_id_path_from_graph_result_prefers_pathway_sequence(self):
+        path = st.record_id_path_from_graph_result({
+            "pathway": {"node_sequence": ["A", "B"]},
+            "nodes": [{"record_id": "C"}],
+        })
+        self.assertEqual(path, ["A", "B", "C"])
+
+    def test_lambda_emit_suppressed_without_table(self):
+        import lambda_function as lf
+
+        with mock.patch.object(lf, "STIGMERGIC_TRACE_TABLE", ""):
+            with self.assertLogs(lf.logger, level="INFO") as cm:
+                lf._emit_stigmergic_trace({
+                    "project_id": "enceladus",
+                    "session_id": "s1",
+                    "event_type": "retrieval",
+                    "record_id_path": "A",
+                    "outcome_signal": {"result_count": 0},
+                    "timestamp": "2026-07-02T10:00:00.000000Z",
+                    "trace_id": "t1",
+                    "schema": st.STIGMERGIC_TRACE_SCHEMA,
+                    "expires_at": 1,
+                })
+        self.assertTrue(any("STIGMERGIC_TRACE" in line for line in cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -226,6 +226,44 @@ Resources:
         - Key: Component
           Value: drift-telemetry
 
+  # ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace telemetry.
+  # Per-event retrieval/traversal traces with 90-day TTL on expires_at.
+  StigmergicTraceTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "enceladus-stigmergic-trace${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: trace_id
+          AttributeType: S
+        - AttributeName: project_id
+          AttributeType: S
+        - AttributeName: timestamp
+          AttributeType: S
+      KeySchema:
+        - AttributeName: trace_id
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: project-timestamp-index
+          KeySchema:
+            - AttributeName: project_id
+              KeyType: HASH
+            - AttributeName: timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: true
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: graph-query-api
+        - Key: Feature
+          Value: ENC-FTR-109
+
   DeploymentManagerTable:
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Retain

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1208,6 +1208,8 @@ Resources:
           # ENC-FTR-087 Phase 1 (ENC-TSK-I85): wave-close drift telemetry sink.
           # Codified here so a compute deploy never strips it (ENC-LSN-053 class).
           DRIFT_TELEMETRY_TABLE: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
+          # ENC-FTR-109 / ENC-TSK-K05: stigmergic exploration trace sink.
+          STIGMERGIC_TRACE_TABLE: !Sub "enceladus-stigmergic-trace${EnvironmentSuffix}"
           # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 sink. Setting
           # the bucket activates the durable .jsonl append-log (the code degrades
           # to CloudWatch when unset — ENC-TSK-H38); prefix is env-partitioned via
@@ -4170,6 +4172,17 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}/index/*"
+        # ENC-FTR-109 / ENC-TSK-K05: stigmergic exploration trace writes.
+        - PolicyName: StigmergicTraceTableAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: StigmergicTraceWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-stigmergic-trace${EnvironmentSuffix}"
         # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 append-log sink.
         # The Lambda already emits envelopes and degrades to CloudWatch when
         # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env


### PR DESCRIPTION
## Summary
- Add `stigmergic_trace.py` module and DynamoDB sink `enceladus-stigmergic-trace` with 90-day TTL.
- Emit telemetry-only traces on hybrid retrieval and non-hybrid graphsearch traversals.
- Wire `STIGMERGIC_TRACE_TABLE` env + IAM on graph-query-api Lambda.

## Test plan
- [x] `pytest backend/lambda/graph_query_api/test_stigmergic_trace.py` (4 passed)

CCI-37b57c4c196e4e4c89ba96166c148f0c

ENC-TSK-K05