### PR TITLE
[ENC-TSK-K10] ISS-441 Ph7b — MCP server sci pass-through (supersedes J97)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.18",
+  "version": "2026-07-02.19",
   "updated_at": "2026-07-02T10:40:00Z",
-  "last_change_summary": "ENC-TSK-K05 (ENC-FTR-109): stigmergic exploration trace emission — graph_query_api.stigmergic_trace entity documents DynamoDB sink enceladus-stigmergic-trace${EnvironmentSuffix}, STIGMERGIC_TRACE_TABLE env var, 90-day TTL, telemetry-only retrieval/traversal events.",
+  "last_change_summary": "ENC-TSK-K10 (ENC-ISS-441 Ph7b, ENC-FTR-122, supersedes J97): MCP server sci pass-through - optional sci property on checkout_task/advance_task_status/append_worklog schemas, strip-and-forward at 7 mutation-forwarding sites (checkout/advance/log, plan checkout/advance, tracker set/log; tracker_create via F76 passthrough), agent.claim raw response passthrough confirmed (sci/sci_issued_at/sci_ttl_seconds flow unchanged). No MCP-layer validation. New entity mcp_server.sci_passthrough. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
   "owners": [
     "enceladus-platform"
   ],
@@ -4914,7 +4914,7 @@
       }
     },
     "graph_query_api.stigmergic_trace": {
-      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation \u2014 exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
       "fields": {
         "table": {
           "type": "string",
@@ -6823,6 +6823,15 @@
           "definition": "Fixed io-specified nudge text, present ONLY on terminal-state success envelopes. Complements the ENC-TSK-J94 sweeps: the prompt handles well-behaved agents, the sweeps catch the rest."
         }
       }
+    },
+    "mcp_server.sci_passthrough": {
+      "description": "ENC-ISS-441 / ENC-TSK-K10 (ENC-FTR-122, supersedes ENC-TSK-J97): the MCP server (tools/enceladus-mcp-server/server.py, enceladus-mcp-code Lambda) carries the caller's Session Claim ID to the ENC-TSK-J93 backend enforcement points. checkout_task, advance_task_status and append_worklog tool schemas expose an OPTIONAL string property 'sci' (the SCI-{uuid4_hex} issued by coordination agent.claim); handlers strip-and-forward it into the backend payload ONLY when non-empty, so requests from grandfathered (pre-epoch) sessions stay byte-identical. The same guard covers _plan_checkout/_plan_advance and _tracker_set/_tracker_log; _tracker_create's ENC-TSK-F76 denylist passthrough forwards a caller-supplied sci automatically. The coordination agent.claim response is a RAW backend passthrough (do not reshape): the J92 fields sci / sci_issued_at / sci_ttl_seconds reach the calling agent unchanged. The MCP layer NEVER validates SCI - enforcement is backend-only (checkout_service + tracker_mutation, ENC-TSK-J93). Code-mode execute steps flow arguments verbatim (no per-action allowlist), so sci passes through execute(checkout.*/tracker.*/plan.*) unchanged. NOTE: enceladus-mcp-code has no auto-deploy lane; live deploys ride the ENC-FTR-077 handoff (DOC-359655466119 pattern) and must advance the :live alias (ISS-306 qualified-URL discipline).",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Optional on checkout_task / advance_task_status / append_worklog (and honored on plan/tracker mutation paths). Session Claim ID issued by coordination agent.claim (ENC-ISS-441). Required by the backend for agent sessions claimed after SCI_ENFORCEMENT_EPOCH; strip-and-forwarded, never validated at the MCP layer."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6941,6 +6950,11 @@
       "version": "2026-07-02.17",
       "date": "2026-07-02",
       "summary": "ENC-TSK-J96 (ENC-ISS-441 Ph6, ENC-FTR-122): retirement_prompt injected verbatim into terminal-state success envelopes - checkout_service task->closed + plan->complete advances, tracker_mutation status writes to task/issue closed, feature production/deprecated, plan complete. Additive-only; non-terminal envelopes byte-identical. New entity tracker.retirement_prompt. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.19",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K10 (ENC-ISS-441 Ph7b, ENC-FTR-122, supersedes J97): MCP server sci pass-through - optional sci property on checkout_task/advance_task_status/append_worklog schemas, strip-and-forward at 7 mutation-forwarding sites (checkout/advance/log, plan checkout/advance, tracker set/log; tracker_create via F76 passthrough), agent.claim raw response passthrough confirmed (sci/sci_issued_at/sci_ttl_seconds flow unchanged). No MCP-layer validation. New entity mcp_server.sci_passthrough. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5205,6 +5205,14 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Agent identity checking out the task (e.g., 'claude_agent_sdk').",
                     },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
+                    },
                     "governance_hash": {
                         "type": "string",
                         "description": "Current governance hash for write authorization.",
@@ -5271,6 +5279,14 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Provider advancing the task (must match checkout owner).",
                     },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
+                    },
                     "governance_hash": {
                         "type": "string",
                         "description": "Current governance hash for write authorization.",
@@ -5308,6 +5324,14 @@ async def list_tools() -> list[Tool]:
                     "provider": {
                         "type": "string",
                         "description": "Provider appending the worklog (must match checkout owner).",
+                    },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
                     },
                     "governance_hash": {
                         "type": "string",
@@ -6001,6 +6025,11 @@ async def _tracker_set(args: dict) -> list[TextContent]:
         payload["coordination"] = args["coordination"]
     if args.get("transition_evidence"):
         payload["transition_evidence"] = args["transition_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _tracker_api_request("PATCH", f"/{project_id}/{record_type}/{rid}", payload=payload)
     return _result_text(resp)
@@ -6044,6 +6073,11 @@ async def _tracker_log(args: dict) -> list[TextContent]:
         payload["dispatch_id"] = args["dispatch_id"]
     if args.get("provider"):
         payload["provider"] = args["provider"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _tracker_api_request("POST", f"/{project_id}/{record_type}/{rid}/log", payload=payload)
     return _result_text(resp)
@@ -6058,6 +6092,8 @@ async def _tracker_log(args: dict) -> list[TextContent]:
 # into the downstream POST body; every other field declared in tracker_mutation's
 # governance schema forwards automatically, and tracker_mutation remains the single
 # source of truth for which fields are valid per record_type.
+# ENC-ISS-441: the optional Session Claim ID ("sci") also rides this passthrough —
+# it is forwarded verbatim when the caller supplies it and never validated here.
 _TRACKER_CREATE_BODY_DENYLIST = frozenset({
     "project_id",
     "record_type",
@@ -9642,7 +9678,13 @@ async def _agent_register(args: dict) -> list[TextContent]:
 
 
 async def _agent_claim(args: dict) -> list[TextContent]:
-    """Claim a pre-minted ENC-SES-NNN (allocated → claimed, agent.claim)."""
+    """Claim a pre-minted ENC-SES-NNN (allocated → claimed, agent.claim).
+
+    ENC-ISS-441: the backend claim envelope now includes top-level
+    "sci", "sci_issued_at", and "sci_ttl_seconds". The response body is
+    returned unchanged (raw passthrough), so those fields flow to the
+    caller automatically — do not reshape this response.
+    """
     payload: Dict[str, Any] = {"session_id": args["session_id"]}
     if args.get("expected_agent_type_id"):
         payload["expected_agent_type_id"] = args["expected_agent_type_id"]
@@ -9806,6 +9848,12 @@ async def _checkout_task(args: dict) -> list[TextContent]:
     }
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty so requests stay byte-identical for grandfathered
+    # sessions that don't pass it.
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/checkout", payload=payload)
     if isinstance(resp, dict) and resp.get("success"):
@@ -9871,6 +9919,11 @@ async def _advance_task_status(args: dict) -> list[TextContent]:
         payload["coordination_request_id"] = args["coordination_request_id"]
     if args.get("live_validation_evidence"):
         payload["live_validation_evidence"] = args["live_validation_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/advance", payload=payload)
     if (
@@ -9917,6 +9970,11 @@ async def _append_worklog(args: dict) -> list[TextContent]:
         payload["provider"] = args["provider"]
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/log", payload=payload)
     return _result_text(resp)
@@ -10097,6 +10155,11 @@ async def _plan_checkout(args: dict) -> list[TextContent]:
     }
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/plan/{rid}/checkout", payload=payload)
     return _result_text(resp)
@@ -10131,6 +10194,11 @@ async def _plan_advance(args: dict) -> list[TextContent]:
     }
     if args.get("transition_evidence"):
         payload["transition_evidence"] = args["transition_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/plan/{rid}/advance", payload=payload)
     return _result_text(resp)


### PR DESCRIPTION
## Summary
ENC-ISS-441 Ph7b (ENC-PLN-062 / ENC-FTR-122; supersedes ENC-TSK-J97 per the plan's supersession protocol — registry-enforced arc). Carries the caller's Session Claim ID to the ENC-TSK-J93 enforcement points:

- Optional `sci` schema property on checkout_task / advance_task_status / append_worklog.
- Strip-and-forward at 7 mutation-forwarding sites (task checkout/advance/log, plan checkout/advance, tracker set/log); tracker_create flows sci via the F76 passthrough. Key omitted when absent — grandfathered-session requests stay byte-identical.
- agent.claim response confirmed raw passthrough: `sci`/`sci_issued_at`/`sci_ttl_seconds` reach callers unchanged.
- No MCP-layer validation (backend-only enforcement); code-mode execute flows args verbatim.
- Dict → 2026-07-02.19: `mcp_server.sci_passthrough` entity.

enceladus-mcp-code has **no auto-deploy lane** — live deploy rides the ENC-FTR-077 handoff (advance the `:live` alias, ISS-306 discipline).

## Tracker
- Task: ENC-TSK-K10 (plan ENC-PLN-062, feature ENC-FTR-122, issue ENC-ISS-441)
- CCI-a19a1675c08b44beb7c3d83e253dc7a4

🤖 Generated with [Claude Code](https://claude.com/claude-code)