### PR TITLE
[ENC-TSK-K14] Grant s3:ListBucket+GetObject on pathway-telemetry prefix (close_wave read-back)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4186,8 +4186,10 @@ Resources:
         # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 append-log sink.
         # The Lambda already emits envelopes and degrades to CloudWatch when
         # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env
-        # vars on GraphQueryApiFunction turn the durable sink on. Write-only,
-        # prefix-scoped.
+        # vars on GraphQueryApiFunction turn the durable sink on.
+        # ENC-TSK-J90: close_wave aggregates telemetry back via ListBucket+GetObject,
+        # scoped to the same prefix as the existing PutObject grant (still no access
+        # outside gamma/pathway-telemetry/).
         - PolicyName: PathwayTelemetrySinkWrite
           PolicyDocument:
             Version: '2012-10-17'
@@ -4196,7 +4198,17 @@ Resources:
                 Effect: Allow
                 Action:
                   - s3:PutObject
+                  - s3:GetObject
                 Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}pathway-telemetry/*"
+              - Sid: PathwayTelemetryListBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}"
+                Condition:
+                  StringLike:
+                    s3:prefix:
+                      - !Sub "${S3EnvPrefix}pathway-telemetry/*"
       Tags:
         - Key: Project
           Value: enceladus

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4187,9 +4187,9 @@ Resources:
         # The Lambda already emits envelopes and degrades to CloudWatch when
         # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env
         # vars on GraphQueryApiFunction turn the durable sink on.
-        # ENC-TSK-J90: close_wave aggregates telemetry back via ListBucket+GetObject,
-        # scoped to the same prefix as the existing PutObject grant (still no access
-        # outside gamma/pathway-telemetry/).
+        # ENC-TSK-K14: close_wave (PR #741) aggregates telemetry back via
+        # ListBucket+GetObject, scoped to the same prefix as the existing
+        # PutObject grant (still no access outside gamma/pathway-telemetry/).
         - PolicyName: PathwayTelemetrySinkWrite
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
## Summary
- `close_wave` (graph_query_api, PR #741) aggregates per-wave pathway-telemetry JSONL objects from S3 to compute `spurious_attractor_rate`, but `devops-graph-query-api-lambda-role-gamma`'s `PathwayTelemetrySinkWrite` IAM policy only granted `s3:PutObject` on the prefix.
- Confirmed live: invoked `close_wave` against a real seeded wave (`wave_id=j90-live-verify-20260702T1035Z`, 2 real telemetry objects confirmed present via `aws s3api list-objects-v2`) and it returned `objects_seen: 0, records_aggregated: 0, spurious_attractor_rate: null`. Not a code bug — a missing IAM grant.
- Fix: `infrastructure/cloudformation/02-compute.yaml` — adds `s3:GetObject` to the existing `PathwayTelemetryPutObject` statement (same object-prefix ARN, unchanged scope) and a new `PathwayTelemetryListBucket` statement granting `s3:ListBucket` on the bucket ARN with a `StringLike` `s3:prefix` condition scoped to the same `pathway-telemetry/` prefix. No widening beyond the existing write scope.
- Blocks ENC-FTR-105 AC-2 (spurious_attractor_rate emission at wave-close) from ever being live-verifiable until this lands + deploys to gamma.

## Test plan
- [x] CFN template change only, no Lambda code change — no new unit tests needed
- [ ] Post-merge: gamma compute deploy succeeds
- [ ] Post-deploy: re-invoke `close_wave` against `wave_id=j90-live-verify-20260702T1035Z` and confirm `objects_seen=2`, `records_aggregated>0`, non-null `spurious_attractor_rate`

CCI-868617e7e54e41da973af49b50e73466

🤖 Generated with [Claude Code](https://claude.com/claude-code)