### PR TITLE
K11: Package enceladus-mcp-code-gamma in Gen2 build (ISS-473/474)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -125,6 +125,20 @@ jobs:
             # Copy source.
             rsync -a --exclude='__pycache__' --exclude='*.pyc' "$srcdir/" "$workdir/"
 
+            # ENC-TSK-K11: enceladus-mcp-code-gamma runs server.py at the zip root
+            # (Handler=server.lambda_handler). Package the MCP server runtime modules
+            # alongside requirements — telemetry_rank and siblings are not optional.
+            if [ "$fn" = "mcp_code" ]; then
+              for py in tools/enceladus-mcp-server/*.py; do
+                base=$(basename "$py")
+                case "$base" in
+                  test_*) continue ;;
+                esac
+                cp "$py" "$workdir/$base"
+              done
+              echo "  [mcp_code] packaged tools/enceladus-mcp-server runtime modules"
+            fi
+
             # ENC-TSK-G43: cross-Lambda module sharing via .build_extras manifest.
             # Each non-comment line is a path (relative to repo root) to a single
             # file that gets copied to the function root. Used by Lambdas that

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -125,10 +125,10 @@ jobs:
             # Copy source.
             rsync -a --exclude='__pycache__' --exclude='*.pyc' "$srcdir/" "$workdir/"
 
-            # ENC-TSK-K11: enceladus-mcp-code-gamma runs server.py at the zip root
-            # (Handler=server.lambda_handler). Package the MCP server runtime modules
-            # alongside requirements — telemetry_rank and siblings are not optional.
-            if [ "$fn" = "mcp_code" ]; then
+            # ENC-TSK-K11/K12: coordination_api and mcp_code load server.py from the
+            # function zip root (ENCELADUS_MCP_SERVER_PATH=server.py). Package the full
+            # MCP server runtime module set — telemetry_rank and siblings are required.
+            if [ "$fn" = "mcp_code" ] || [ "$fn" = "coordination_api" ]; then
               for py in tools/enceladus-mcp-server/*.py; do
                 base=$(basename "$py")
                 case "$base" in
@@ -136,7 +136,7 @@ jobs:
                 esac
                 cp "$py" "$workdir/$base"
               done
-              echo "  [mcp_code] packaged tools/enceladus-mcp-server runtime modules"
+              echo "  [$fn] packaged tools/enceladus-mcp-server runtime modules"
             fi
 
             # ENC-TSK-G43: cross-Lambda module sharing via .build_extras manifest.

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.21",
-  "updated_at": "2026-07-02T11:02:00Z",
-  "last_change_summary": "ENC-TSK-J52 (FTR-104 Ph3): promote I99-tuned energy lambda weights (lambda_graph=1.0, lambda_kw=0.1) to live hybrid retrieval defaults + gamma ENERGY_LAMBDA_* env vars; optional include_energy query flag exposes energy_score + energy_breakdown on hybrid nodes.",
+  "version": "2026-07-02.22",
+  "updated_at": "2026-07-02T11:20:00Z",
+  "last_change_summary": "ENC-TSK-K11: enceladus-mcp-code Gen2 build packaging — mcp_code/lambda_function.py shim + _build.yml copies tools/enceladus-mcp-server runtime modules (telemetry_rank) into enceladus-mcp-code-gamma artifact.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.22",
-  "updated_at": "2026-07-02T11:20:00Z",
-  "last_change_summary": "ENC-TSK-K11: enceladus-mcp-code Gen2 build packaging — mcp_code/lambda_function.py shim + _build.yml copies tools/enceladus-mcp-server runtime modules (telemetry_rank) into enceladus-mcp-code-gamma artifact.",
+  "version": "2026-07-02.23",
+  "updated_at": "2026-07-02T11:25:00Z",
+  "last_change_summary": "ENC-TSK-K12: Gen2 build packages tools/enceladus-mcp-server runtime modules into coordination_api and mcp_code artifacts so gamma MCP gateway can load server.py (ISS-473/474 live smoke).",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/mcp_code/lambda_function.py
+++ b/backend/lambda/mcp_code/lambda_function.py
@@ -1,0 +1,11 @@
+"""Gen2 build entrypoint for enceladus-mcp-code (ENC-TSK-K11).
+
+The deployed Lambda handler remains ``server.lambda_handler`` (see
+infrastructure/lambda-manifests/enceladus-mcp-code.json). This shim exists so
+``_build.yml`` discovers ``mcp_code`` via ``lambda_function.py`` and packages
+``tools/enceladus-mcp-server/`` runtime modules into the artifact zip.
+"""
+
+from server import lambda_handler  # noqa: F401
+
+__all__ = ["lambda_handler"]


### PR DESCRIPTION
## Summary
- Package full `tools/enceladus-mcp-server` runtime into Gen2 `coordination_api` and `mcp_code` Lambda artifacts
- Fixes gamma MCP gateway `server.py` module-not-found blocking ISS-473/474 live smoke
- Adds `mcp_code/lambda_function.py` shim for Gen2 discovery

ENC-TSK-K17 | ENC-ISS-473 | ENC-ISS-474

CCI-fb283a2e94c74000b6d0e42ad05d4e9a

## Test plan
- [x] `pytest` embeddings_for, sheaf_cohomology, telemetry_rank (18 passed)
- [ ] Gamma deploy coordination_api + mcp_code
- [ ] Live MCP smoke on `https://enceladus-gamma.jreese.net/api/v1/coordination/mcp`:
  - `telemetry.rank`
  - `tracker.embeddings_for`
  - `tracker.sheaf_cohomology`