### PR TITLE
[ENC-TSK-K16] ISS-441 Ph9a — v4 envs/v3-prod.yaml: deploy-both fan-out for checkout_service

### DIFF
--- a/envs/v3-prod.yaml
+++ b/envs/v3-prod.yaml
@@ -66,7 +66,7 @@ function_name_map:
   auth_refresh: auth-refresh
   bedrock_agent_actions: enceladus-bedrock-agent-actions
   changelog_api: devops-changelog-api
-  checkout_service: enceladus-checkout-service-auto
+  checkout_service: enceladus-checkout-service,enceladus-checkout-service-auto
   coordination_api: devops-coordination-api
   coordination_monitor_api: devops-coordination-monitor-api
   deploy_decide: devops-deploy-decide


### PR DESCRIPTION
## Summary
ENC-ISS-441 Ph9a (ENC-PLN-062 / ENC-FTR-122). The v3-prod promote resolves `envs/v3-prod.yaml` from the artifact commit (v4/main), which still carried the pre-H76 single value — so the ENC-ISS-441 promote (run 28584431376) skipped the **primary** `enceladus-checkout-service` Lambda while updating coordination_api / tracker_mutation / mcp_code. One line, byte-identical to main's ENC-TSK-H76/#548 (ENC-ISS-398) value:

`checkout_service: enceladus-checkout-service,enceladus-checkout-service-auto`

The comma-list fan-out in `_deploy.yml` already supports it. After merge the fresh Gen2 green fires a new v3-prod promote request for io's approval (ENC-TSK-J99 consumes it).

## Tracker
- Task: ENC-TSK-K16 (plan ENC-PLN-062, feature ENC-FTR-122, issue ENC-ISS-441)
- CCI-9a9f7f50cad94a70999ba0e018b06b3e

🤖 Generated with [Claude Code](https://claude.com/claude-code)