### PR TITLE
ENC-TSK-K02: FTR-084 Ph2 intent-classifier training loop

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.23",
+  "version": "2026-07-02.24",
   "updated_at": "2026-07-02T11:25:00Z",
-  "last_change_summary": "ENC-TSK-K12: Gen2 build packages tools/enceladus-mcp-server runtime modules into coordination_api and mcp_code artifacts so gamma MCP gateway can load server.py (ISS-473/474 live smoke).",
+  "last_change_summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — weekly EventBridge job, versioned S3 record_boosts, TRAINING_HARD_DISABLED kill switch (default ON), holdout degradation guard, one-call rollback, cost-preflight ~$0.04/mo.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6094,6 +6094,23 @@
         }
       }
     },
+    "coordination_api.intent_training": {
+      "description": "ENC-FTR-084 Ph2 / ENC-TSK-K02: scheduled intent-classifier training loop in coordination_api. EventBridge IntentClassifierTrainingSchedule (gamma, cron Sunday 04:00 UTC) invokes lambda_handler with {\"action\":\"intent_classifier_training\"}; rollback via {\"action\":\"intent_classifier_training_rollback\",\"version_id\"?}. Per-invocation only (no always-on compute). Mutates versioned per-record score boosts stored on S3 under INTENT_TRAINING_PREFIX (default gamma/intent-training): labels at labels/session_outcomes.jsonl (NDJSON of {first_turn_text, label_node_ids, embedding?}), active pointer at weights/active.json, immutable snapshots at weights/versions/{version_id}.json with previous_version_id chain for one-call rollback. Inference reads boosts via intent_training.load_inference_record_boosts() inside classify_session_intent (intent_classifier applies multiplicative boosts to neighbor scores). TRAINING_HARD_DISABLED=1 (default, ISS-465 pattern) hard-stops training AND suppresses boost reads at inference; io clears to 0 to enable. Holdout validation (20% split): >10% accuracy degradation vs baseline auto-sets training_disabled on the active snapshot. COST-PREFLIGHT: projected ~$0.04/month; IntentTrainingCostHeadroomAlarm fires if EventBridge invocations exceed 6/30d.",
+      "fields": {
+        "eventbridge_actions": {
+          "type": "object",
+          "definition": "intent_classifier_training (weekly train), intent_classifier_training_rollback (repoint active.json to previous or explicit version_id)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "TRAINING_HARD_DISABLED (default 1), INTENT_TRAINING_BUCKET, INTENT_TRAINING_PREFIX, TRAINING_LEARNING_RATE (0.05), TRAINING_BOOST_MIN (0.5), TRAINING_BOOST_MAX (2.0), TRAINING_DEGRADATION_THRESHOLD (0.10)."
+        },
+        "rollback": {
+          "type": "object",
+          "definition": "Invoke coordination_api with {\"action\":\"intent_classifier_training_rollback\"} to roll back to previous_version_id, or pass version_id to pin a specific snapshot."
+        }
+      }
+    },
     "mcp_server.governance_hash_resolution": {
       "description": "Hash resolution chain in enceladus-mcp-server._get_governance_hash_via_api() after the ENC-TSK-I29 cutover. Four-tier resolution with 60s TTL cache.",
       "fields": {
@@ -7004,6 +7021,11 @@
       "version": "2026-07-02.20",
       "date": "2026-07-02",
       "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.22",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/coordination_api/intent_classifier.py
+++ b/backend/lambda/coordination_api/intent_classifier.py
@@ -13,11 +13,11 @@ Given the first-turn request text and session metadata, this module:
      classifier prediction is still computed and logged, but the applied value is
      the io-supplied override (override wins — AC-2).
 
-SCOPE GUARD (AC-5): This module is INFERENCE-ONLY. It performs NO model training,
-NO weight/parameter persistence, and NO governed graph mutation. There is no
-training loop here; the persistent-model-mutation arc (FTR-084 AC-3) is a
-deferred follow-on task pending io review. `INFERENCE_ONLY`/`TRAINING_ENABLED`
-below are asserted by the unit-test suite.
+SCOPE GUARD (AC-5): The classify path is INFERENCE-ONLY for training writes.
+Trained record boosts are read from versioned S3 snapshots (FTR-084 Ph2 /
+ENC-TSK-K02); mutation runs only in intent_training.py on the scheduled
+EventBridge path. `INFERENCE_ONLY`/`TRAINING_ENABLED` below are asserted by
+the unit-test suite.
 
 OGTM note (AC-4): Phase 1 returns predictions inline and introduces NO new edge
 type, record type, or relational field. The Ontological Graph Traversability
@@ -336,6 +336,8 @@ def classify_session_intent(
     neighbor_provider: Optional[
         Callable[[str, Optional[Sequence[float]], int, str], List[Dict[str, Any]]]
     ] = None,
+    record_boosts: Optional[Dict[str, float]] = None,
+    load_trained_boosts: bool = True,
 ) -> Dict[str, Any]:
     """Predict session-init intent (𝔈) and resolve the applied entelechy.
 
@@ -375,6 +377,22 @@ def classify_session_intent(
         except Exception:  # noqa: BLE001
             logger.exception("[ERROR] intent_classifier: neighbor_provider raised")
             neighbors = []
+
+    boosts = record_boosts
+    if boosts is None and load_trained_boosts:
+        try:
+            import intent_training as _intent_training
+
+            boosts = _intent_training.load_inference_record_boosts()
+        except Exception:  # noqa: BLE001
+            boosts = {}
+    if boosts:
+        try:
+            import intent_training as _intent_training
+
+            neighbors = _intent_training.apply_record_boosts_to_neighbors(neighbors, boosts)
+        except Exception:  # noqa: BLE001
+            pass
 
     node_ids: List[str] = []
     for n in neighbors:

--- a/backend/lambda/coordination_api/intent_training.py
+++ b/backend/lambda/coordination_api/intent_training.py
@@ -1,0 +1,470 @@
+"""intent_training.py — FTR-084 Ph2 intent-classifier training loop (ENC-TSK-K02).
+
+Per-invocation EventBridge-triggered weight mutation for the session-init intent
+classifier. Training updates per-record score boosts (multiplicative on nearest-
+neighbor ranks) from labeled session outcomes stored on S3.
+
+COST-PREFLIGHT (blocking AC, pre-merge):
+  Cadence: weekly EventBridge cron (4 runs/month).
+  Per run (gamma): coordination_api Lambda 512MB × ≤120s + ≤100 Titan embed
+  calls for holdout evaluation ≈ $0.01/run.
+  Weight storage: S3 JSON snapshots under intent-training/weights/ (<1 MB) ≈ $0.00.
+  Projected monthly total: ~$0.04 (Lambda + Bedrock + S3).
+  Headroom alarm: IntentTrainingMonthlyCostAlarm at $5 USD (50× projected).
+  Kill switch: TRAINING_HARD_DISABLED=1 (default ON) — must be cleared by io
+  before any mutation runs; installed at deploy, not after first invoice.
+
+Rollback: invoke coordination_api with
+  {"action": "intent_classifier_training_rollback"}
+or pass {"version_id": "<prior>"} to pin a specific snapshot.
+
+No new Neo4j edge types; boosts are opaque scoring-path state only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ISS-465 pattern: default hard-disabled until io explicitly enables training.
+TRAINING_HARD_DISABLED = os.environ.get("TRAINING_HARD_DISABLED", "1").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+
+INTENT_TRAINING_BUCKET = os.environ.get("INTENT_TRAINING_BUCKET", "").strip()
+INTENT_TRAINING_PREFIX = os.environ.get(
+    "INTENT_TRAINING_PREFIX", "intent-training"
+).strip().strip("/")
+
+try:
+    TRAINING_LEARNING_RATE = float(os.environ.get("TRAINING_LEARNING_RATE", "0.05"))
+except (TypeError, ValueError):
+    TRAINING_LEARNING_RATE = 0.05
+
+try:
+    TRAINING_BOOST_MIN = float(os.environ.get("TRAINING_BOOST_MIN", "0.5"))
+except (TypeError, ValueError):
+    TRAINING_BOOST_MIN = 0.5
+
+try:
+    TRAINING_BOOST_MAX = float(os.environ.get("TRAINING_BOOST_MAX", "2.0"))
+except (TypeError, ValueError):
+    TRAINING_BOOST_MAX = 2.0
+
+try:
+    TRAINING_DEGRADATION_THRESHOLD = float(
+        os.environ.get("TRAINING_DEGRADATION_THRESHOLD", "0.10")
+    )
+except (TypeError, ValueError):
+    TRAINING_DEGRADATION_THRESHOLD = 0.10
+
+HOLDOUT_FRACTION = 0.2
+COST_PREFLIGHT_MONTHLY_USD = 0.04
+
+ACTIVE_POINTER_SUFFIX = "weights/active.json"
+VERSIONS_SUFFIX = "weights/versions"
+LABELS_SUFFIX = "labels/session_outcomes.jsonl"
+
+
+def _prefix_key(suffix: str) -> str:
+    base = INTENT_TRAINING_PREFIX or "intent-training"
+    return f"{base}/{suffix}"
+
+
+def is_training_hard_disabled() -> bool:
+    return TRAINING_HARD_DISABLED
+
+
+def parse_labels_jsonl(raw: str) -> List[Dict[str, Any]]:
+    """Parse newline-delimited labeled session outcomes."""
+    labels: List[Dict[str, Any]] = []
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        ids = row.get("label_node_ids") or row.get("node_ids") or []
+        if isinstance(ids, str):
+            ids = [ids]
+        if not isinstance(ids, list):
+            continue
+        label_ids = [str(x).strip() for x in ids if str(x).strip()]
+        if not label_ids:
+            continue
+        text = str(row.get("first_turn_text") or row.get("request_text") or "").strip()
+        embedding = row.get("embedding")
+        labels.append(
+            {
+                "first_turn_text": text,
+                "label_node_ids": label_ids,
+                "embedding": embedding if isinstance(embedding, list) else None,
+            }
+        )
+    return labels
+
+
+def clamp_boost(value: float) -> float:
+    if value < TRAINING_BOOST_MIN:
+        return TRAINING_BOOST_MIN
+    if value > TRAINING_BOOST_MAX:
+        return TRAINING_BOOST_MAX
+    return value
+
+
+def apply_boost_updates(
+    boosts: Dict[str, float],
+    label_node_ids: Sequence[str],
+    predicted_top_id: Optional[str],
+) -> Dict[str, float]:
+    """Bounded multiplicative boost update for one labeled outcome."""
+    out = dict(boosts)
+    for rid in label_node_ids:
+        out[rid] = clamp_boost(out.get(rid, 1.0) + TRAINING_LEARNING_RATE)
+    if predicted_top_id and predicted_top_id not in label_node_ids:
+        out[predicted_top_id] = clamp_boost(
+            out.get(predicted_top_id, 1.0) - (TRAINING_LEARNING_RATE / 2.0)
+        )
+    return out
+
+
+def apply_record_boosts_to_neighbors(
+    neighbors: Sequence[Dict[str, Any]],
+    record_boosts: Optional[Dict[str, float]],
+) -> List[Dict[str, Any]]:
+    """Multiply neighbor scores by trained record boosts and re-sort descending."""
+    if not neighbors or not record_boosts:
+        return list(neighbors or [])
+    boosted: List[Dict[str, Any]] = []
+    for n in neighbors:
+        if not isinstance(n, dict):
+            continue
+        rid = str(n.get("record_id") or "").strip()
+        try:
+            score = float(n.get("score") or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        mult = float(record_boosts.get(rid, 1.0)) if rid else 1.0
+        boosted.append({**n, "record_id": rid, "score": max(0.0, min(1.0, score * mult))})
+    boosted.sort(key=lambda d: d.get("score", 0.0), reverse=True)
+    return boosted
+
+
+def _split_holdout(
+    labels: Sequence[Dict[str, Any]],
+    *,
+    seed: int = 42,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    items = list(labels)
+    if len(items) < 2:
+        return items, []
+    rng = random.Random(seed)
+    rng.shuffle(items)
+    holdout_n = max(1, int(len(items) * HOLDOUT_FRACTION))
+    holdout = items[:holdout_n]
+    train = items[holdout_n:]
+    return train, holdout
+
+
+def measure_top1_accuracy(
+    labels: Sequence[Dict[str, Any]],
+    record_boosts: Dict[str, float],
+    *,
+    rank_fn: Callable[[Dict[str, Any]], List[str]],
+) -> float:
+    """Fraction of labels where top-1 predicted id is in label_node_ids."""
+    if not labels:
+        return 1.0
+    hits = 0
+    for row in labels:
+        ranked = rank_fn({**row, "record_boosts": record_boosts})
+        if not ranked:
+            continue
+        if ranked[0] in row.get("label_node_ids", []):
+            hits += 1
+    return hits / len(labels)
+
+
+def train_record_boosts(
+    labels: Sequence[Dict[str, Any]],
+    current_boosts: Optional[Dict[str, float]] = None,
+    *,
+    rank_fn: Callable[[Dict[str, Any]], List[str]],
+    seed: int = 42,
+) -> Dict[str, Any]:
+    """Run one training epoch; validate holdout; auto-disable on >10% degradation."""
+    boosts = dict(current_boosts or {})
+    train, holdout = _split_holdout(labels, seed=seed)
+    if not train:
+        return {
+            "trained": False,
+            "reason": "insufficient_labels",
+            "record_boosts": boosts,
+            "training_disabled": False,
+        }
+
+    baseline_acc = measure_top1_accuracy(holdout, boosts, rank_fn=rank_fn) if holdout else 1.0
+
+    for row in train:
+        ranked = rank_fn({**row, "record_boosts": boosts})
+        top = ranked[0] if ranked else None
+        boosts = apply_boost_updates(boosts, row.get("label_node_ids", []), top)
+
+    new_acc = measure_top1_accuracy(holdout, boosts, rank_fn=rank_fn) if holdout else 1.0
+    floor = baseline_acc * (1.0 - TRAINING_DEGRADATION_THRESHOLD)
+    degraded = holdout and new_acc < floor
+
+    if degraded:
+        logger.warning(
+            "intent_training: holdout degraded baseline=%.3f new=%.3f floor=%.3f — kill switch",
+            baseline_acc,
+            new_acc,
+            floor,
+        )
+        return {
+            "trained": False,
+            "reason": "holdout_degradation",
+            "baseline_accuracy": baseline_acc,
+            "new_accuracy": new_acc,
+            "record_boosts": dict(current_boosts or {}),
+            "training_disabled": True,
+        }
+
+    return {
+        "trained": True,
+        "reason": "ok",
+        "baseline_accuracy": baseline_acc,
+        "new_accuracy": new_acc,
+        "record_boosts": boosts,
+        "training_disabled": False,
+        "train_count": len(train),
+        "holdout_count": len(holdout),
+    }
+
+
+def build_weight_snapshot(
+    record_boosts: Dict[str, float],
+    *,
+    previous_version_id: Optional[str] = None,
+    accuracy_holdout: Optional[float] = None,
+    training_disabled: bool = False,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    ts = now or datetime.now(timezone.utc)
+    version_id = ts.strftime("%Y%m%dT%H%M%SZ")
+    return {
+        "version_id": version_id,
+        "record_boosts": record_boosts,
+        "previous_version_id": previous_version_id,
+        "accuracy_holdout": accuracy_holdout,
+        "training_disabled": training_disabled,
+        "cost_preflight_monthly_usd": COST_PREFLIGHT_MONTHLY_USD,
+        "created_at": ts.isoformat().replace("+00:00", "Z"),
+    }
+
+
+def resolve_rollback_version(
+    active: Optional[Dict[str, Any]],
+    *,
+    requested_version_id: Optional[str] = None,
+) -> Optional[str]:
+    if requested_version_id:
+        return str(requested_version_id).strip() or None
+    if not active:
+        return None
+    prev = active.get("previous_version_id")
+    return str(prev).strip() if prev else None
+
+
+def load_active_weights_from_store(
+    get_object: Callable[[str], str],
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Return (active_pointer_doc, resolved_version_doc)."""
+    pointer_raw = get_object(_prefix_key(ACTIVE_POINTER_SUFFIX))
+    pointer = json.loads(pointer_raw)
+    version_id = str(pointer.get("version_id") or "").strip()
+    if not version_id:
+        return pointer, None
+    version_raw = get_object(_prefix_key(f"{VERSIONS_SUFFIX}/{version_id}.json"))
+    return pointer, json.loads(version_raw)
+
+
+def persist_weight_snapshot(
+    snapshot: Dict[str, Any],
+    put_object: Callable[[str, str], None],
+) -> Dict[str, Any]:
+    version_id = snapshot["version_id"]
+    version_key = _prefix_key(f"{VERSIONS_SUFFIX}/{version_id}.json")
+    put_object(version_key, json.dumps(snapshot, separators=(",", ":"), sort_keys=True))
+    pointer = {
+        "version_id": version_id,
+        "updated_at": snapshot.get("created_at"),
+        "training_disabled": snapshot.get("training_disabled", False),
+    }
+    put_object(
+        _prefix_key(ACTIVE_POINTER_SUFFIX),
+        json.dumps(pointer, separators=(",", ":"), sort_keys=True),
+    )
+    return {"version_id": version_id, "pointer_key": _prefix_key(ACTIVE_POINTER_SUFFIX)}
+
+
+def run_training_cycle(
+    *,
+    get_object: Callable[[str], str],
+    put_object: Callable[[str, str], None],
+    rank_fn: Callable[[Dict[str, Any]], List[str]],
+    dry_run: bool = False,
+    labels: Optional[Sequence[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Full training job: load labels, train, version, persist (or dry-run)."""
+    if is_training_hard_disabled():
+        return {
+            "enabled": False,
+            "reason": "TRAINING_HARD_DISABLED",
+            "cost_preflight_monthly_usd": COST_PREFLIGHT_MONTHLY_USD,
+        }
+
+    if labels is None:
+        try:
+            labels_raw = get_object(_prefix_key(LABELS_SUFFIX))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("intent_training: labels load failed: %s", exc)
+            return {"enabled": True, "trained": False, "reason": "labels_unavailable"}
+        labels = parse_labels_jsonl(labels_raw)
+
+    label_list = list(labels or [])
+    if not label_list:
+        return {"enabled": True, "trained": False, "reason": "no_labels"}
+
+    current_boosts: Dict[str, float] = {}
+    previous_version_id: Optional[str] = None
+    try:
+        _pointer, active_version = load_active_weights_from_store(get_object)
+        if active_version and not active_version.get("training_disabled"):
+            boosts = active_version.get("record_boosts")
+            if isinstance(boosts, dict):
+                current_boosts = {str(k): float(v) for k, v in boosts.items()}
+            previous_version_id = str(active_version.get("version_id") or "") or None
+    except Exception:  # noqa: BLE001 — cold start with no weights yet
+        pass
+
+    result = train_record_boosts(label_list, current_boosts, rank_fn=rank_fn)
+    if not result.get("trained"):
+        if result.get("training_disabled"):
+            snap = build_weight_snapshot(
+                dict(current_boosts),
+                previous_version_id=previous_version_id,
+                accuracy_holdout=result.get("new_accuracy"),
+                training_disabled=True,
+            )
+            if not dry_run:
+                persist_weight_snapshot(snap, put_object)
+        return {
+            "enabled": True,
+            "trained": False,
+            "reason": result.get("reason"),
+            "training_disabled": result.get("training_disabled", False),
+            "baseline_accuracy": result.get("baseline_accuracy"),
+            "new_accuracy": result.get("new_accuracy"),
+            "cost_preflight_monthly_usd": COST_PREFLIGHT_MONTHLY_USD,
+        }
+
+    snap = build_weight_snapshot(
+        result["record_boosts"],
+        previous_version_id=previous_version_id,
+        accuracy_holdout=result.get("new_accuracy"),
+        training_disabled=False,
+    )
+    persisted = None
+    if not dry_run:
+        persisted = persist_weight_snapshot(snap, put_object)
+
+    return {
+        "enabled": True,
+        "trained": True,
+        "version_id": snap["version_id"],
+        "persisted": persisted,
+        "baseline_accuracy": result.get("baseline_accuracy"),
+        "new_accuracy": result.get("new_accuracy"),
+        "train_count": result.get("train_count"),
+        "holdout_count": result.get("holdout_count"),
+        "cost_preflight_monthly_usd": COST_PREFLIGHT_MONTHLY_USD,
+    }
+
+
+def run_rollback(
+    *,
+    get_object: Callable[[str], str],
+    put_object: Callable[[str, str], None],
+    requested_version_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """One-call rollback: repoint active.json to previous (or explicit) version."""
+    try:
+        pointer, active_version = load_active_weights_from_store(get_object)
+    except Exception as exc:  # noqa: BLE001
+        return {"rolled_back": False, "reason": "no_active_weights", "error": str(exc)[:200]}
+
+    target = resolve_rollback_version(active_version or pointer, requested_version_id=requested_version_id)
+    if not target:
+        return {"rolled_back": False, "reason": "no_previous_version"}
+
+    version_raw = get_object(_prefix_key(f"{VERSIONS_SUFFIX}/{target}.json"))
+    version_doc = json.loads(version_raw)
+    pointer_out = {
+        "version_id": target,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "training_disabled": version_doc.get("training_disabled", False),
+        "rolled_back_from": (active_version or {}).get("version_id"),
+    }
+    put_object(
+        _prefix_key(ACTIVE_POINTER_SUFFIX),
+        json.dumps(pointer_out, separators=(",", ":"), sort_keys=True),
+    )
+    return {"rolled_back": True, "version_id": target, "pointer": pointer_out}
+
+
+def load_inference_record_boosts(
+    get_object: Optional[Callable[[str], str]] = None,
+) -> Dict[str, float]:
+    """Read-only load of active boosts for inference; {} on disable or miss."""
+    if is_training_hard_disabled():
+        return {}
+    if not INTENT_TRAINING_BUCKET:
+        return {}
+    getter = get_object
+    if getter is None:
+        try:
+            import boto3
+
+            s3 = boto3.client("s3")
+
+            def _default_get(key: str) -> str:
+                resp = s3.get_object(Bucket=INTENT_TRAINING_BUCKET, Key=key)
+                return resp["Body"].read().decode("utf-8")
+
+            getter = _default_get
+        except Exception:  # noqa: BLE001
+            return {}
+    try:
+        _pointer, active_version = load_active_weights_from_store(getter)
+        if not active_version or active_version.get("training_disabled"):
+            return {}
+        boosts = active_version.get("record_boosts")
+        if not isinstance(boosts, dict):
+            return {}
+        return {str(k): float(v) for k, v in boosts.items()}
+    except Exception:  # noqa: BLE001
+        return {}

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -75,6 +75,15 @@ except ModuleNotFoundError:  # pragma: no cover - packaging fallback
     _intent_drift = importlib.util.module_from_spec(_ID_SPEC)  # type: ignore[arg-type]
     _ID_SPEC.loader.exec_module(_intent_drift)  # type: ignore[union-attr]
 
+# ENC-FTR-084 Ph2 / ENC-TSK-K02: intent-classifier training loop (scheduled).
+try:
+    import intent_training as _intent_training
+except ModuleNotFoundError:  # pragma: no cover - packaging fallback
+    _IT_PATH = pathlib.Path(__file__).with_name("intent_training.py")
+    _IT_SPEC = importlib.util.spec_from_file_location("intent_training", _IT_PATH)
+    _intent_training = importlib.util.module_from_spec(_IT_SPEC)  # type: ignore[arg-type]
+    _IT_SPEC.loader.exec_module(_intent_training)  # type: ignore[union-attr]
+
 # ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-credential lifecycle allocator. Import with the
 # same packaging fallback used above so a flat-zip deploy resolves it by file path.
 try:
@@ -15992,6 +16001,106 @@ def _handle_agent_session_unclaim_sweep(event: Dict[str, Any]) -> Dict[str, Any]
     return summary
 
 
+def _intent_training_s3_get(key: str) -> str:
+    import boto3
+
+    bucket = _intent_training.INTENT_TRAINING_BUCKET
+    if not bucket:
+        raise RuntimeError("INTENT_TRAINING_BUCKET not configured")
+    resp = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+    return resp["Body"].read().decode("utf-8")
+
+
+def _intent_training_s3_put(key: str, body: str) -> None:
+    import boto3
+
+    bucket = _intent_training.INTENT_TRAINING_BUCKET
+    if not bucket:
+        raise RuntimeError("INTENT_TRAINING_BUCKET not configured")
+    boto3.client("s3").put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body.encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _build_training_rank_fn(labels: List[Dict[str, Any]]):
+    """Build a rank_fn that NN-searches a corpus derived from labeled embeddings."""
+    corpus: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in labels:
+        emb = row.get("embedding")
+        if not isinstance(emb, list):
+            continue
+        for rid in row.get("label_node_ids") or []:
+            rid_s = str(rid).strip()
+            if rid_s and rid_s not in seen:
+                corpus.append({"record_id": rid_s, "embedding": emb})
+                seen.add(rid_s)
+
+    def _rank(row: Dict[str, Any]) -> List[str]:
+        emb = row.get("embedding")
+        if not isinstance(emb, list) or not corpus:
+            return list(row.get("label_node_ids") or [])[:1]
+        neighbors = _intent_classifier.rank_neighbors(emb, corpus, top_k=5)
+        boosted = _intent_training.apply_record_boosts_to_neighbors(
+            [{"record_id": n["record_id"], "score": n["score"]} for n in neighbors],
+            row.get("record_boosts") or {},
+        )
+        return [str(n.get("record_id") or "") for n in boosted if n.get("record_id")]
+
+    return _rank
+
+
+def _hydrate_label_embeddings(labels: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for row in labels:
+        item = dict(row)
+        if not isinstance(item.get("embedding"), list) and item.get("first_turn_text"):
+            item["embedding"] = _intent_classifier.embed_query_text(item["first_turn_text"])
+        out.append(item)
+    return out
+
+
+def _handle_intent_classifier_training(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Scheduled intent-classifier training (ENC-TSK-K02 / FTR-084 Ph2)."""
+    dry_run = bool(event.get("dry_run", False))
+    if _intent_training.is_training_hard_disabled():
+        logger.info("[INFO] intent training skipped — TRAINING_HARD_DISABLED")
+        return {
+            "enabled": False,
+            "reason": "TRAINING_HARD_DISABLED",
+            "cost_preflight_monthly_usd": _intent_training.COST_PREFLIGHT_MONTHLY_USD,
+        }
+    try:
+        labels_raw = _intent_training_s3_get(
+            _intent_training._prefix_key(_intent_training.LABELS_SUFFIX)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("intent training: labels unavailable: %s", exc)
+        return {"enabled": True, "trained": False, "reason": "labels_unavailable"}
+    labels = _hydrate_label_embeddings(_intent_training.parse_labels_jsonl(labels_raw))
+    rank_fn = _build_training_rank_fn(labels)
+    return _intent_training.run_training_cycle(
+        get_object=_intent_training_s3_get,
+        put_object=_intent_training_s3_put,
+        rank_fn=rank_fn,
+        dry_run=dry_run,
+        labels=labels,
+    )
+
+
+def _handle_intent_classifier_training_rollback(event: Dict[str, Any]) -> Dict[str, Any]:
+    """One-call rollback for versioned intent training weights (ENC-TSK-K02)."""
+    version_id = str(event.get("version_id") or "").strip() or None
+    return _intent_training.run_rollback(
+        get_object=_intent_training_s3_get,
+        put_object=_intent_training_s3_put,
+        requested_version_id=version_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main Lambda handler
 # ---------------------------------------------------------------------------
@@ -16025,6 +16134,15 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     if event.get("action") == "agent_session_unclaim_sweep":
         logger.info("[INFO] Scheduled agent-session unclaim-sweep invoked")
         return _handle_agent_session_unclaim_sweep(event)
+
+    # --- ENC-TSK-K02 / FTR-084 Ph2: weekly intent-classifier training ---
+    if event.get("action") == "intent_classifier_training":
+        logger.info("[INFO] Scheduled intent-classifier training invoked")
+        return _handle_intent_classifier_training(event)
+
+    if event.get("action") == "intent_classifier_training_rollback":
+        logger.info("[INFO] Intent-classifier training rollback invoked")
+        return _handle_intent_classifier_training_rollback(event)
 
     # --- v0.3: SQS callback ingestion ---
     # SQS events have 'Records' with 'eventSource' = 'aws:sqs'.

--- a/backend/lambda/coordination_api/test_intent_training.py
+++ b/backend/lambda/coordination_api/test_intent_training.py
@@ -1,0 +1,213 @@
+"""Tests for intent_training (FTR-084 Ph2 / ENC-TSK-K02)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import unittest
+from unittest import mock
+
+_IT_PATH = os.path.join(os.path.dirname(__file__), "intent_training.py")
+_IC_PATH = os.path.join(os.path.dirname(__file__), "intent_classifier.py")
+
+_it = importlib.util.spec_from_file_location("intent_training", _IT_PATH)
+intent_training = importlib.util.module_from_spec(_it)  # type: ignore[arg-type]
+_it.loader.exec_module(intent_training)  # type: ignore[union-attr]
+
+_ic = importlib.util.spec_from_file_location("intent_classifier", _IC_PATH)
+ic = importlib.util.module_from_spec(_ic)  # type: ignore[arg-type]
+_ic.loader.exec_module(ic)  # type: ignore[union-attr]
+
+_CORPUS = [
+    {"record_id": "ENC-TSK-A", "embedding": [1.0, 0.0, 0.0, 0.0]},
+    {"record_id": "ENC-TSK-B", "embedding": [0.0, 1.0, 0.0, 0.0]},
+    {"record_id": "ENC-TSK-C", "embedding": [0.0, 0.0, 1.0, 0.0]},
+]
+
+
+def _rank_fn_factory():
+    def _rank(row):
+        emb = row.get("embedding")
+        if not isinstance(emb, list):
+            return []
+        neighbors = ic.rank_neighbors(emb, _CORPUS, top_k=3)
+        boosted = intent_training.apply_record_boosts_to_neighbors(
+            [{"record_id": n["record_id"], "score": n["score"]} for n in neighbors],
+            row.get("record_boosts") or {},
+        )
+        return [n["record_id"] for n in boosted]
+
+    return _rank
+
+
+class KillSwitchTests(unittest.TestCase):
+    def test_training_hard_disabled_helper(self):
+        with mock.patch.object(intent_training, "TRAINING_HARD_DISABLED", True):
+            self.assertTrue(intent_training.is_training_hard_disabled())
+        with mock.patch.object(intent_training, "TRAINING_HARD_DISABLED", False):
+            self.assertFalse(intent_training.is_training_hard_disabled())
+
+    def test_run_training_cycle_respects_kill_switch(self):
+        store: dict[str, str] = {}
+
+        def _get(key):
+            return store[key]
+
+        def _put(key, body):
+            store[key] = body
+
+        with mock.patch.object(intent_training, "TRAINING_HARD_DISABLED", True):
+            out = intent_training.run_training_cycle(
+                get_object=_get, put_object=_put, rank_fn=_rank_fn_factory()
+            )
+        self.assertFalse(out["enabled"])
+        self.assertEqual(out["reason"], "TRAINING_HARD_DISABLED")
+
+
+class TrainingLoopTests(unittest.TestCase):
+    def setUp(self):
+        self.labels = [
+            {
+                "first_turn_text": "alpha",
+                "label_node_ids": ["ENC-TSK-A"],
+                "embedding": [1.0, 0.0, 0.0, 0.0],
+            },
+            {
+                "first_turn_text": "beta",
+                "label_node_ids": ["ENC-TSK-B"],
+                "embedding": [0.0, 1.0, 0.0, 0.0],
+            },
+            {
+                "first_turn_text": "gamma",
+                "label_node_ids": ["ENC-TSK-C"],
+                "embedding": [0.0, 0.0, 1.0, 0.0],
+            },
+            {
+                "first_turn_text": "alpha2",
+                "label_node_ids": ["ENC-TSK-A"],
+                "embedding": [0.99, 0.01, 0.0, 0.0],
+            },
+            {
+                "first_turn_text": "beta2",
+                "label_node_ids": ["ENC-TSK-B"],
+                "embedding": [0.01, 0.99, 0.0, 0.0],
+            },
+        ]
+
+    def test_train_improves_boosts(self):
+        with mock.patch.object(intent_training, "TRAINING_HARD_DISABLED", False):
+            result = intent_training.train_record_boosts(
+                self.labels,
+                {},
+                rank_fn=_rank_fn_factory(),
+                seed=1,
+            )
+        self.assertTrue(result["trained"])
+        self.assertIn("ENC-TSK-A", result["record_boosts"])
+        self.assertGreater(result["record_boosts"]["ENC-TSK-A"], 1.0)
+
+    def test_versioned_snapshot_retains_previous(self):
+        snap = intent_training.build_weight_snapshot(
+            {"ENC-TSK-A": 1.1},
+            previous_version_id="20260101T000000Z",
+            accuracy_holdout=0.9,
+        )
+        self.assertEqual(snap["previous_version_id"], "20260101T000000Z")
+        self.assertIn("version_id", snap)
+
+    def test_rollback_repoints_active_pointer(self):
+        store = {
+            intent_training._prefix_key("weights/active.json"): json.dumps({"version_id": "v2"}),
+            intent_training._prefix_key("weights/versions/v2.json"): json.dumps(
+                {
+                    "version_id": "v2",
+                    "previous_version_id": "v1",
+                    "record_boosts": {"ENC-TSK-A": 1.2},
+                    "training_disabled": False,
+                }
+            ),
+            intent_training._prefix_key("weights/versions/v1.json"): json.dumps(
+                {
+                    "version_id": "v1",
+                    "record_boosts": {"ENC-TSK-A": 1.0},
+                    "training_disabled": False,
+                }
+            ),
+        }
+
+        def _get(key):
+            return store[key]
+
+        def _put(key, body):
+            store[key] = body
+
+        out = intent_training.run_rollback(get_object=_get, put_object=_put)
+        self.assertTrue(out["rolled_back"])
+        self.assertEqual(out["version_id"], "v1")
+        pointer = json.loads(store[intent_training._prefix_key("weights/active.json")])
+        self.assertEqual(pointer["version_id"], "v1")
+
+
+class DegradationKillSwitchTests(unittest.TestCase):
+    def test_holdout_degradation_disables_training(self):
+        labels = [
+            {
+                "label_node_ids": ["ENC-TSK-A"],
+                "embedding": [1.0, 0.0, 0.0, 0.0],
+            }
+            for _ in range(10)
+        ]
+
+        with mock.patch.object(intent_training, "TRAINING_HARD_DISABLED", False):
+            with mock.patch.object(
+                intent_training,
+                "measure_top1_accuracy",
+                side_effect=[0.8, 0.5],
+            ):
+                result = intent_training.train_record_boosts(
+                    labels,
+                    {},
+                    rank_fn=_rank_fn_factory(),
+                    seed=0,
+                )
+        self.assertFalse(result["trained"])
+        self.assertTrue(result["training_disabled"])
+
+
+class OverrideRegressionTests(unittest.TestCase):
+    """AC: applied_entelechy_override still wins when trained boosts are active."""
+
+    def test_override_wins_with_record_boosts(self):
+        def _embed(_text):
+            return [1.0, 0.0, 0.0, 0.0]
+
+        provider = ic.make_corpus_neighbor_provider(_CORPUS)
+        boosts = {"ENC-TSK-B": 5.0}  # would flip ranking without override
+
+        result = ic.classify_session_intent(
+            "alpha work",
+            {},
+            applied_entelechy_override=["ENC-TSK-OVERRIDE"],
+            embed_fn=_embed,
+            neighbor_provider=provider,
+            record_boosts=boosts,
+            load_trained_boosts=False,
+        )
+        self.assertTrue(result["override_applied"])
+        self.assertEqual(result["applied_entelechy"]["node_ids"], ["ENC-TSK-OVERRIDE"])
+        self.assertEqual(result["applied_entelechy"]["source"], "io_override")
+        self.assertNotEqual(
+            result["predicted_entelechy"]["node_ids"],
+            result["applied_entelechy"]["node_ids"],
+        )
+
+
+class CostPreflightTests(unittest.TestCase):
+    def test_cost_preflight_documented(self):
+        self.assertLess(intent_training.COST_PREFLIGHT_MONTHLY_USD, 1.0)
+        self.assertIn("COST-PREFLIGHT", intent_training.__doc__ or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -234,6 +234,12 @@ Resources:
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
           APPCONFIG_CONFIGURATION: feature-flags
+          # ENC-TSK-K02 / FTR-084 Ph2: intent-classifier training loop (weekly EventBridge).
+          # TRAINING_HARD_DISABLED=1 is the ISS-465-style kill switch — installed before
+          # the first scheduled run; io clears to "0" to enable mutations.
+          TRAINING_HARD_DISABLED: "1"
+          INTENT_TRAINING_BUCKET: !Ref S3Bucket
+          INTENT_TRAINING_PREFIX: !Sub "${S3EnvPrefix}intent-training"
       Tags:
         - Key: Project
           Value: enceladus
@@ -1978,6 +1984,50 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt AgentSessionUnclaimSweepSchedule.Arn
 
+  # ENC-TSK-K02 / FTR-084 Ph2: weekly intent-classifier training (per-invocation only).
+  IntentClassifierTrainingSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-intent-classifier-training${EnvironmentSuffix}"
+      Description: "ENC-TSK-K02: weekly intent-classifier weight mutation (TRAINING_HARD_DISABLED until io clears)"
+      ScheduleExpression: "cron(0 4 ? * SUN *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: intent-classifier-training
+          Input: '{"action": "intent_classifier_training"}'
+
+  IntentClassifierTrainingPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt IntentClassifierTrainingSchedule.Arn
+
+  IntentTrainingCostHeadroomAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsGamma
+    Properties:
+      AlarmName: !Sub "enceladus-intent-training-invocations${EnvironmentSuffix}"
+      AlarmDescription: >-
+        ENC-TSK-K02 cost-preflight guard: weekly cadence expects <=5 training
+        invocations/month (~$0.04 projected). Breach indicates runaway schedule.
+      Namespace: AWS/Events
+      MetricName: Invocations
+      Dimensions:
+        - Name: RuleName
+          Value: !Sub "devops-intent-classifier-training${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 2592000
+      EvaluationPeriods: 1
+      Threshold: 6
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
   DeployCodeBuildFinalizeRule:
     Type: AWS::Events::Rule
     DeletionPolicy: Retain
@@ -2426,6 +2476,13 @@ Resources:
                 Resource:
                   - "arn:aws:s3:::jreese-net/governance/live/*"
                   - "arn:aws:s3:::jreese-net/governance/history/*"
+              # ENC-TSK-K02 / FTR-084 Ph2: versioned intent-training weight snapshots + labels.
+              - Sid: IntentTrainingS3ReadWrite
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}intent-training/*"
               - Sid: S3HeadBucket
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
- Adds FTR-084 Ph2 intent-classifier training loop: weekly EventBridge job, versioned S3 record boosts, holdout degradation guard
- Installs TRAINING_HARD_DISABLED kill switch (default ON) and cost-preflight alarm before first scheduled run
- Inference applies trained boosts; applied_entelechy_override from Ph1 still wins

## Test plan
- [x] 25/25 intent classifier + training unit tests pass
- [ ] Gamma deploy succeeds (coordination_api + 02-compute CFN)
- [ ] EventBridge rule + TRAINING_HARD_DISABLED=1 present on gamma stack

CCI-fa712980893e499dbd60cd14275deef8