### PR TITLE
fix(mcp): add mcp_streamable to Gen2 MCP runtime packaging (K12)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -125,10 +125,11 @@ jobs:
             # Copy source.
             rsync -a --exclude='__pycache__' --exclude='*.pyc' "$srcdir/" "$workdir/"
 
-            # ENC-TSK-K11/K12: coordination_api and mcp_code load server.py from the
-            # function zip root (ENCELADUS_MCP_SERVER_PATH=server.py). Package the full
-            # MCP server runtime module set — telemetry_rank and siblings are required.
-            if [ "$fn" = "mcp_code" ] || [ "$fn" = "coordination_api" ]; then
+            # ENC-TSK-K11/K12: coordination_api, mcp_code, and mcp_streamable load
+            # server.py from the function zip root (ENCELADUS_MCP_SERVER_PATH=server.py).
+            # Package the full MCP server runtime module set — telemetry_rank and siblings
+            # are required (mcp.jreese.net Function URL -> enceladus-mcp-streamable*).
+            if [ "$fn" = "mcp_code" ] || [ "$fn" = "coordination_api" ] || [ "$fn" = "mcp_streamable" ]; then
               for py in tools/enceladus-mcp-server/*.py; do
                 base=$(basename "$py")
                 case "$base" in

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.24",
-  "updated_at": "2026-07-02T11:25:00Z",
-  "last_change_summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — weekly EventBridge job, versioned S3 record_boosts, TRAINING_HARD_DISABLED kill switch (default ON), holdout degradation guard, one-call rollback, cost-preflight ~$0.04/mo.",
+  "version": "2026-07-02.25",
+  "updated_at": "2026-07-02T11:50:00Z",
+  "last_change_summary": "ENC-TSK-K12: add mcp_streamable to Gen2 MCP runtime packaging (lambda_function.py shim + _build.yml) so enceladus-mcp-streamable-gamma receives server.py siblings on deploy.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/mcp_streamable/lambda_function.py
+++ b/backend/lambda/mcp_streamable/lambda_function.py
@@ -1,0 +1,12 @@
+"""Gen2 build entrypoint for enceladus-mcp-streamable (ENC-TSK-K12).
+
+The deployed Lambda handler remains ``server.lambda_handler`` (see
+infrastructure/lambda-manifests/enceladus-mcp-streamable.json if present).
+This shim exists so ``_build.yml`` discovers ``mcp_streamable`` via
+``lambda_function.py`` and packages ``tools/enceladus-mcp-server/`` runtime
+modules into the artifact zip (mcp.jreese.net Function URL path).
+"""
+
+from server import lambda_handler  # noqa: F401
+
+__all__ = ["lambda_handler"]


### PR DESCRIPTION
## Summary
- Add `backend/lambda/mcp_streamable/lambda_function.py` so Gen2 `_build.yml` discovers and packages `enceladus-mcp-streamable-gamma` on every v4-gamma deploy.
- Extend the MCP runtime module copy step (`tools/enceladus-mcp-server/*.py`) to include `mcp_streamable` alongside `mcp_code` and `coordination_api`.
- Bump governance dictionary to `2026-07-02.25`.

## Context
PR #768 (K11) fixed `enceladus-mcp-code-gamma` but `mcp.jreese.net` / streamable Function URL traffic uses `enceladus-mcp-streamable-gamma`, which was **not** in the Gen2 build matrix. Gamma coordination MCP already passes ISS-473/474 smoke; this PR ensures streamable catches up on the next deploy.

## Test plan
- [ ] CI build log shows `[mcp_streamable] packaged tools/enceladus-mcp-server runtime modules`
- [ ] Post-deploy: `enceladus-mcp-streamable-gamma:live` CodeSha256 updates
- [ ] Gamma streamable smoke: `telemetry.rank`, `tracker.embeddings_for`, `tracker.sheaf_cohomology`

CCI-dd49edc781d04fca917593824a456c6f