### PR TITLE
fix(ENC-TSK-K03): devops- EventBridge rule name for gamma deploy

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2100,7 +2100,7 @@ Resources:
       MetricName: Invocations
       Dimensions:
         - Name: RuleName
-          Value: !Sub "enceladus-unlearning-nightly${EnvironmentSuffix}"
+          Value: !Sub "devops-unlearning-nightly${EnvironmentSuffix}"
       Statistic: Sum
       Period: 604800
       EvaluationPeriods: 1
@@ -2173,7 +2173,7 @@ Resources:
     Condition: IsGamma
     DeletionPolicy: Retain
     Properties:
-      Name: !Sub "enceladus-unlearning-nightly${EnvironmentSuffix}"
+      Name: !Sub "devops-unlearning-nightly${EnvironmentSuffix}"
       Description: "Nightly Crick-Mitchison unlearning pass (ENC-FTR-106 / ENC-TSK-K03)"
       ScheduleExpression: "cron(0 4 * * ? *)"
       State: ENABLED


### PR DESCRIPTION
## Summary
- Renames `enceladus-unlearning-nightly` → `devops-unlearning-nightly` (rule + alarm dimension)
- Unblocks gamma CFN deploy: pre-deploy drift gate only audits `enceladus-*` EventBridge rules, so net-new `enceladus-*` schedules false-fail as `cfn_only` drift (same pattern as `devops-intent-classifier-training`)

ENC-TSK-K03 hotfix after failed deploy run 28589152495

CCI-62d1ed7a85a14392994266f556bc1a7e

## Test plan
- [ ] Gamma CloudFormation Compute Stack Deploy passes pre-deploy health gate
- [ ] `devops-unlearning-nightly-gamma` rule created on apply