### PR TITLE
[ENC-TSK-K33] AppConfig governance-intent surface — Phase 2 (schema relax + budget-hierarchy + governance-doctrine)

### DIFF
--- a/backend/lambda/coordination_api/test_budget_hierarchy.py
+++ b/backend/lambda/coordination_api/test_budget_hierarchy.py
@@ -45,6 +45,23 @@ class TestScaleBudgetConfig(unittest.TestCase):
         finally:
             del os.environ["BUDGET_CORPUS_TOKENS"]
 
+    def test_appconfig_value_takes_precedence_over_env_and_default(self):
+        """ENC-TSK-K33: the `budget-hierarchy` AppConfig profile ships
+        `budget_<scale>_tokens` keys (see 09-appconfig-governance.yaml). Pins
+        that exact key format against the reader so a schema/key mismatch
+        between the CFN content and this resolver — the same silent-failure
+        class ENC-TSK-K32 found for the dedup flags — would fail loudly here
+        instead of being discovered live."""
+        original = bhc._appconfig_budget_config
+        bhc._appconfig_budget_config = lambda: {"budget_wave_tokens": 999}
+        os.environ["BUDGET_WAVE_TOKENS"] = "111"  # lower precedence than AppConfig
+        try:
+            budgets = bhc.load_scale_budgets()
+            self.assertEqual(budgets["wave"], 999)
+        finally:
+            bhc._appconfig_budget_config = original
+            del os.environ["BUDGET_WAVE_TOKENS"]
+
 
 class TestBanachSolver(unittest.TestCase):
     """AC-2: solver converges in <= 1 iteration on the interior 4-scale vector."""

--- a/infrastructure/cloudformation/06-feature-flags.yaml
+++ b/infrastructure/cloudformation/06-feature-flags.yaml
@@ -4,6 +4,9 @@ Description: >
   ENC-TSK-F63 AC-1: AppConfig application, environment, configuration profile,
   JSON Schema validator, and initial hosted configuration version replacing
   all ENABLE_* Lambda env vars with a governed, hot-reloadable config surface.
+  ENC-TSK-K33: schema relaxed from a closed key-enum to a typed-open schema
+  (additionalProperties typed, not false) so new boolean levers ship via an
+  AppConfig hosted-config push instead of a CFN deploy — see DOC-623CAFD9D1F6.
 
 Parameters:
   Environment:
@@ -74,9 +77,11 @@ Resources:
                 "enable_typed_relationships": { "type": "boolean" },
                 "enable_mcp_governance_prompt": { "type": "boolean" },
                 "enable_lifecycle_service_extraction": { "type": "boolean" },
-                "enable_scoring_service_extraction": { "type": "boolean" }
+                "enable_scoring_service_extraction": { "type": "boolean" },
+                "enable_dedup_auto_merge": { "type": "boolean" },
+                "dedup_auto_merge_kill_switch": { "type": "boolean" }
               },
-              "additionalProperties": false,
+              "additionalProperties": { "type": "boolean" },
               "required": [
                 "enable_claude_headless",
                 "enable_component_proposal",

--- a/infrastructure/cloudformation/09-appconfig-governance.yaml
+++ b/infrastructure/cloudformation/09-appconfig-governance.yaml
@@ -1,0 +1,168 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus governance-intent AppConfig surface — ENC-TSK-K33 (Phase 2 of the
+  ENC-ISS-477 retirement, per DOC-623CAFD9D1F6). Adds two configuration
+  profiles under the EXISTING AppConfig Application/Environment provisioned by
+  06-feature-flags.yaml: `budget-hierarchy` (numeric calibration, activates the
+  code already written in coordination_api/budget_hierarchy.py, previously
+  never CFN-codified) and `governance-doctrine` (typed-open string/number/
+  boolean doctrine levers, no consumer yet — infrastructure only). Neither
+  profile touches the DDB governance-dictionary surface or the `feature-flags`
+  profile; both are strictly additive per ENC-LSN-053 / PLN-047 discipline.
+
+Parameters:
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+  AppConfigApplicationId:
+    Type: String
+    Description: >-
+      AppConfig Application ID from the 06-feature-flags stack Outputs
+      (ApplicationId). Pass via --parameter-overrides.
+  AppConfigEnvironmentId:
+    Type: String
+    Description: >-
+      AppConfig Environment ID from the 06-feature-flags stack Outputs
+      (EnvironmentId). Pass via --parameter-overrides.
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # budget-hierarchy — numeric calibration surface (ENC-FTR-083 / ENC-TSK-I86)
+  # Activates coordination_api/budget_hierarchy.py::_appconfig_budget_config(),
+  # which has read this profile by convention since I86 but had no CFN
+  # resource behind it — always fell through to hardcoded defaults in practice.
+  # ---------------------------------------------------------------------------
+
+  BudgetHierarchyProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      Name: budget-hierarchy
+      LocationUri: hosted
+      Description: >-
+        Four-scale token budget vector (session/wave/project/corpus), live-
+        overridable per ENC-TSK-I86 AC-1 / ENC-TSK-K33.
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "type": "object",
+              "properties": {
+                "budget_session_tokens": { "type": "number", "exclusiveMinimum": 0 },
+                "budget_wave_tokens":    { "type": "number", "exclusiveMinimum": 0 },
+                "budget_project_tokens": { "type": "number", "exclusiveMinimum": 0 },
+                "budget_corpus_tokens":  { "type": "number", "exclusiveMinimum": 0 }
+              },
+              "additionalProperties": { "type": "number" }
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: budget-hierarchy
+
+  BudgetHierarchyInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      ConfigurationProfileId: !Ref BudgetHierarchyProfile
+      ContentType: application/json
+      Description: >-
+        Initial version — mirrors DEFAULT_SCALE_BUDGETS_TOKENS in
+        budget_hierarchy.py exactly, so activation is a no-op until someone
+        deliberately pushes a change.
+      Content: |
+        {
+          "budget_session_tokens": 200000,
+          "budget_wave_tokens": 50000,
+          "budget_project_tokens": 500000,
+          "budget_corpus_tokens": 2000000
+        }
+
+  BudgetHierarchyDeploymentStrategy:
+    Type: AWS::AppConfig::DeploymentStrategy
+    Properties:
+      Name: !Sub "enceladus-governance-immediate${EnvironmentSuffix}"
+      Description: Immediate activation, no bake time — matches feature-flags precedent.
+      ReplicateTo: NONE
+      DeploymentDurationInMinutes: 0
+      FinalBakeTimeInMinutes: 0
+      GrowthFactor: 100
+      GrowthType: LINEAR
+
+  BudgetHierarchyInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      EnvironmentId: !Ref AppConfigEnvironmentId
+      ConfigurationProfileId: !Ref BudgetHierarchyProfile
+      ConfigurationVersion: !Ref BudgetHierarchyInitialVersion
+      DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
+      Description: "Initial activation — ENC-TSK-K33, defaults match hardcoded fallback"
+
+  # ---------------------------------------------------------------------------
+  # governance-doctrine — string/number/boolean doctrine levers. No named
+  # consumer yet (ENC-TSK-K32 design: built for future levers, K33's
+  # verification is infrastructure-only — push/read round-trip via a
+  # synthetic canary key, not a behavioral test).
+  # ---------------------------------------------------------------------------
+
+  GovernanceDoctrineProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      Name: governance-doctrine
+      LocationUri: hosted
+      Description: >-
+        Typed-open doctrine levers (string/number/boolean) that are neither a
+        boolean feature gate nor a budget number — e.g. a canary preference
+        name, an SLA minute count. Placeholder until a first real consumer
+        lands; see DOC-623CAFD9D1F6.
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "type": "object",
+              "additionalProperties": { "type": ["string", "number", "boolean"] }
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance-doctrine
+
+  GovernanceDoctrineInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      ConfigurationProfileId: !Ref GovernanceDoctrineProfile
+      ContentType: application/json
+      Description: "Placeholder — synthetic canary key only, no real consumer yet (ENC-TSK-K33)"
+      Content: |
+        {
+          "_canary": "k33-verification-placeholder"
+        }
+
+  GovernanceDoctrineInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      EnvironmentId: !Ref AppConfigEnvironmentId
+      ConfigurationProfileId: !Ref GovernanceDoctrineProfile
+      ConfigurationVersion: !Ref GovernanceDoctrineInitialVersion
+      DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
+      Description: "Initial activation — placeholder, ENC-TSK-K33"
+
+Outputs:
+  BudgetHierarchyProfileId:
+    Value: !Ref BudgetHierarchyProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-BudgetHierarchyProfileId"
+
+  GovernanceDoctrineProfileId:
+    Value: !Ref GovernanceDoctrineProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-GovernanceDoctrineProfileId"


### PR DESCRIPTION
## Summary
- Phase 2 (BUILD) of the ENC-ISS-477 retirement path (`DOC-F234A4E11DFD` / `DOC-623CAFD9D1F6`). Purely additive AppConfig CFN — no application code changes, no DDB dictionary retirement (that's Phase 3, gated on this).
- Relax `06-feature-flags.yaml`'s schema from a closed 9-key enum (`additionalProperties: false`) to typed-open, which retroactively activates two flags already coded in `tracker_mutation` (`enable_dedup_auto_merge`, `dedup_auto_merge_kill_switch`) that have silently always fallen back to env vars since they were written — a real gap found during `ENC-TSK-K32`'s design pass, not a hypothetical.
- New `09-appconfig-governance.yaml`: `budget-hierarchy` profile (activates the AppConfig reader already written in `coordination_api/budget_hierarchy.py`, seeded with its exact current hardcoded defaults so activation is a no-op) + `governance-doctrine` profile (placeholder, no consumer yet).
- New regression test pinning the exact `budget_<scale>_tokens` key format the CFN content ships against `load_scale_budgets()`, guarding against the same silent key-mismatch class that broke the two dedup flags.

## Test plan
- [x] Both CFN templates pass `aws cloudformation validate-template`
- [x] `test_budget_hierarchy.py` + `test_budget_hierarchy_ph2.py`: 37/37 pass
- [ ] Post-merge: manual gamma stack apply (06/09 have no CI deploy workflow — always applied out-of-band by a privileged operator, consistent with existing precedent)
- [ ] Post-apply: live push→poll round-trip verification per `DOC-623CAFD9D1F6`'s AC-4 gate (captured on `ENC-TSK-K33`)

CCI-7741a128613347e5b444d56c4a7299e8

🤖 Generated with [Claude Code](https://claude.com/claude-code)