### PR TITLE
[ENC-TSK-K45] B66 Ph5: AWS X-Ray active tracing across v4 services

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -173,6 +173,12 @@ Resources:
         - ApplyOn: PublishedVersions
         - !Ref AWS::NoValue
       Role: !GetAtt CoordinationApiRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (MCP Server / governed-mutation API
+      # surface — CoordinationApiFunction is the gamma-deployable stand-in for "MCP Server"
+      # in the five-service trace; EnceladusMcpCodeGammaFunction is prod-stack-owned
+      # (Condition: IsProduction) and out of reach for a gamma-only compute deploy).
+      TracingConfig:
+        Mode: Active
       Layers:
         - !Ref SharedLayerArn
         # ENC-TSK-F63 AC-1: AppConfig extension layer (arch-conditional)
@@ -264,6 +270,10 @@ Resources:
         - ApplyOn: PublishedVersions
         - !Ref AWS::NoValue
       Role: !GetAtt TrackerMutationRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing ("Record" service — TrackerMutationFunction
+      # writes/records the governed tracker mutation for every task/issue/feature/lesson).
+      TracingConfig:
+        Mode: Active
       Layers:
         - !Ref SharedLayerArn
         - !If
@@ -377,6 +387,9 @@ Resources:
         - ApplyOn: PublishedVersions
         - !Ref AWS::NoValue
       Role: !GetAtt LifecycleServiceRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (Lifecycle service).
+      TracingConfig:
+        Mode: Active
       Layers:
         - !Ref SharedLayerArn
       Environment:
@@ -415,6 +428,9 @@ Resources:
         - ApplyOn: PublishedVersions
         - !Ref AWS::NoValue
       Role: !GetAtt ScoringServiceRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (Scoring service).
+      TracingConfig:
+        Mode: Active
       Layers:
         - !Ref SharedLayerArn
       Environment:
@@ -2436,6 +2452,13 @@ Resources:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-coordination-api${EnvironmentSuffix}*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/enceladus/mcp/server*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/enceladus/coordination/worker-runtime*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
               - Sid: CoordinationTableAccess
                 Effect: Allow
                 Action:
@@ -2700,6 +2723,8 @@ Resources:
       # failed every request with 500 'Database read failed' (and had no log group).
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access ("Record" service).
+        - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
       Policies:
         # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
         # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
@@ -2818,6 +2843,13 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/enceladus-lifecycle-service${EnvironmentSuffix}*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
               - Sid: DynamoDBTrackerRead
                 Effect: Allow
                 Action:
@@ -2867,6 +2899,13 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/enceladus-scoring-service${EnvironmentSuffix}*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
               - Sid: DynamoDBLessonScoringWriteback
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
- Adds `TracingConfig: {Mode: Active}` plus `xray:PutTraceSegments`/`xray:PutTelemetryRecords` IAM grants to the four CFN-managed v4 service Lambdas: `CoordinationApiFunction` (MCP Server / governed-mutation API surface), `TrackerMutationFunction` (Record), `LifecycleServiceFunction` (Lifecycle), `ScoringServiceFunction` (Scoring).
- Sampling rate: AWS default (1 req/sec reservoir + 5% of additional requests) — no custom `AWS::XRay::SamplingRule` added; no repo convention found suggesting an override.
- Narrow diff (39 lines, one file: `infrastructure/cloudformation/02-compute.yaml`), scoped to avoid collision with the parallel ENC-TSK-K44 PR also touching this file (K44 adds `ProdHealthMonitorFunction` in a disjoint region of the template).

## Known gap — Checkout not covered
`enceladus-checkout-service` has **no `AWS::Lambda::Function` CFN resource** anywhere in `infrastructure/cloudformation/*.yaml` or the `resource-import-*.json` files — confirmed by direct grep and cross-checked against `infrastructure/lambda_workflow_manifest.json` (no `cfn_managed: true` entry). It deploys out-of-band via `backend/lambda/checkout_service/deploy.sh` + the `_deploy.yml` matrix build. Enabling tracing on it needs either:
1. A CFN IMPORT adoption of the Lambda + its role (mirroring the `EnceladusMcpCodeGammaFunction` / `CheckoutAutoScheduleRule` precedent), or
2. A direct out-of-band `aws lambda update-function-configuration --tracing-config Mode=Active` + IAM policy grant.

The agent identity used for this task has an explicit IAM deny on `iam:ListAttachedRolePolicies`/`iam:ListRolePolicies`, so option 2 was not attempted blind. This is an open item against B66 AC-1 ("all five services") — 4/5 covered by this PR.

## MCP Server target note
`EnceladusMcpCodeGammaFunction` (the literal `enceladus-mcp-code-gamma` Lambda, `server.py`/`streamable_http`) was considered for "MCP Server" but is gated `Condition: IsProduction` — it only renders on a **prod** stack deploy despite targeting the gamma physical function, so it's unreachable from this gamma-only compute deploy. `CoordinationApiFunction` (`devops-coordination-api`) is used instead as the gamma-deployable governed-API entry point.

CCI-bf2203712df847f9bceb5c3367879fb4

## Test plan
- [x] `python3 -m pytest tools/test_cfn_env_resolver.py -q` — 14 passed (env-var resolution unaffected by the edits)
- [x] `tools/cfn_env_resolver.py --template infrastructure/cloudformation/02-compute.yaml --parameter Environment=gamma --parameter EnvironmentSuffix=-gamma` — resolves cleanly, no new missing/stripped vars
- [x] YAML parses cleanly (`yaml.safe_load` with CFN intrinsic tag passthrough)
- [ ] Post-merge: confirm gamma `_deploy.yml` / CloudFormation Compute Stack Deploy succeeds
- [ ] Post-deploy: verify `TracingConfig.Mode=Active` live on the 4 gamma functions via `aws lambda get-function-configuration`
- [ ] Post-deploy: attempt a connected cross-service X-Ray trace via a governed mutation (AC-2) and latency comparison (AC-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)