### PR TITLE
B66 Ph5 — Fiedler lambda2 GraphHealth metric (gamma) + F_governance percentile normalization [ENC-TSK-K43]

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.27",
-  "updated_at": "2026-07-02T13:15:00Z",
-  "last_change_summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.28",
+  "updated_at": "2026-07-02T13:50:00Z",
+  "last_change_summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection) + F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) in the Scoring Service. New entities graph_query_api.publish_graph_health and scoring_service.f_governance.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6267,6 +6267,49 @@
         }
       }
     },
+    "graph_query_api.publish_graph_health": {
+      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) — never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
+      "fields": {
+        "project_id": {
+          "type": "string"
+        },
+        "project_ids": {
+          "type": "array"
+        },
+        "limit": {
+          "type": "integer"
+        },
+        "k": {
+          "type": "integer"
+        },
+        "lambda2": {
+          "type": "number"
+        },
+        "lambda0": {
+          "type": "number"
+        },
+        "published": {
+          "type": "integer"
+        }
+      }
+    },
+    "scoring_service.f_governance": {
+      "description": "ENC-TSK-K43 (B66 Ph5): F_governance percentile normalization integrated into the Scoring Service's _compute_resonance_score (math gate DOC-A3D0CDF91CE9 Q3.1). F_governance = percentile_rank(F_structural) + percentile_rank(F_temporal) + percentile_rank(F_evidential), bounded [0,3], 0 = perfect governance health. governance_compliance_weight maps it to a [0,1] compliance weight applied as an optional multiplicative term on resonance_score (backward compatible: omitted -> pre-K43 score unchanged). Optional message-level f_governance field on {lesson.scoring.requested} wires through score_lesson end-to-end.",
+      "fields": {
+        "f_governance": {
+          "type": "number"
+        },
+        "f_structural": {
+          "type": "number"
+        },
+        "f_temporal": {
+          "type": "number"
+        },
+        "f_evidential": {
+          "type": "number"
+        }
+      }
+    },
     "monitoring.convergence_telemetry": {
       "description": "ENC-TSK-I82 (FTR-086 Ph1): Convergence Surface DDB counter table + SQS FIFO + Streams fan-out Lambda.",
       "fields": {
@@ -7150,6 +7193,11 @@
       "date": "2026-07-02",
       "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
       "version": "2026-07-02.27"
+    },
+    {
+      "version": "2026-07-02.28",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     }
   ]
 }

--- a/backend/lambda/graph_query_api/graph_health_metric.py
+++ b/backend/lambda/graph_query_api/graph_health_metric.py
@@ -1,0 +1,217 @@
+"""ENC-TSK-K43 (B66 Phase-5, gamma re-delivery of ENC-TSK-C10) -- Fiedler
+lambda-2 GraphHealth CloudWatch metric.
+
+Publishes the graph's algebraic connectivity (the Fiedler value, lambda-2 --
+the smallest *non-trivial* eigenvalue of the graph Laplacian) to CloudWatch
+under the ``Enceladus/GraphHealth`` namespace, as the primary structural
+health signal for the extended-mind substrate (DOC-A3D0CDF91CE9 Q3.3).
+
+ISS-465 GDS cost-kill compliance: this module computes lambda-2 EXCLUSIVELY
+via the existing FTR-088 ``_query_laplacian`` CSR/Fiedler path in
+lambda_function.py -- an ad-hoc, per-invocation scipy.sparse.linalg.eigsh (or
+dense numpy.linalg.eigh fallback) computation over an induced subgraph. It
+never touches Neo4j GDS / Aura Graph Analytics (gds.graph.project, an AGA
+session, or any standing/materialized graph catalog projection) and is NOT
+gated by _GDS_HARD_DISABLED -- that flag only governs the separate ENC-FTR-101
+standing-projection code path used by hybrid retrieval's graph signal. The two
+paths are architecturally distinct; this module only ever calls the former.
+
+Invocation contract (mirrors the FTR-101 _handle_refresh_projection / FTR-108
+_handle_refresh_flow_weight pattern in lambda_function.py -- same Lambda, same
+file layout, action-dispatched):
+
+    lambda_handler(event, context) with event like
+        {"action": "publish_graph_health"}                      # full defaults
+        {"action": "publish_graph_health", "project_id": "...",
+         "limit": 500, "k": 3}                                  # overrides
+
+EventBridge wiring: a scheduled rule Input carrying the JSON above, mirroring
+prod_health_monitor's 15-minute cadence (05-monitoring.yaml
+HealthProbeScheduleRule). The CFN rule for this task targets the existing
+devops-graph-query-api Lambda (no new function), consistent with the
+ParityDriftDailyScheduleRule precedent of pointing a schedule's Input at an
+existing multi-action Lambda.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# CloudWatch namespace + metric name (AC-1).
+GRAPH_HEALTH_NAMESPACE = "Enceladus/GraphHealth"
+FIEDLER_METRIC_NAME = "FiedlerValue"
+
+# Default project + vertex cap for the scheduled probe. Mirrors
+# _HEALTH_PROBE_PROJECT (ENC-ISS-312) -- the canonical project this Lambda's
+# other scheduled/health probes already default to.
+DEFAULT_PROJECT_ID = "enceladus"
+DEFAULT_VERTEX_LIMIT = 500
+DEFAULT_K = 3
+
+# CloudWatch PutMetricData accepts at most 20 MetricDatum entries per call.
+_CLOUDWATCH_BATCH_SIZE = 20
+
+
+def compute_fiedler_value(
+    driver: Any,
+    project_id: str,
+    *,
+    query_laplacian_fn,
+    limit: int = DEFAULT_VERTEX_LIMIT,
+    k: int = DEFAULT_K,
+    vertex_set_query: str = "",
+    edge_type_filter: str = "",
+) -> Dict[str, Any]:
+    """Derive lambda-2 (the Fiedler value) via the FTR-088 CSR/Fiedler path.
+
+    ``query_laplacian_fn`` is dependency-injected (the caller passes
+    lambda_function._query_laplacian) so this module never imports the parent
+    package -- it stays a plain, independently unit-testable function. The
+    Laplacian handler's eigenvalues are returned ascending with eigenvalues[0]
+    the trivial (~0) eigenpair for a connected graph, so eigenvalues[1] is
+    lambda-2 whenever k >= 2 -- request-side k is bumped to 2 for that reason.
+
+    Returns {"ok": True, "lambda2": float, "n": int, "eig_method": str, ...}
+    on success, or {"ok": False, "error": str} on any resolution failure
+    (empty vertex set, <2 vertices, disconnected-graph degenerate spectrum,
+    etc.) -- never raises, so a bad probe cannot break the caller's publish
+    loop.
+    """
+    req_k = max(2, k)
+    result = query_laplacian_fn(
+        driver,
+        project_id,
+        {
+            "k": req_k,
+            "limit": limit,
+            "vertex_set_query": vertex_set_query,
+            "edge_type_filter": edge_type_filter,
+            "normalization": "combinatorial",
+        },
+    )
+    if "error" in result:
+        return {"ok": False, "error": result["error"], "project_id": project_id}
+
+    eigenvalues: List[float] = result.get("eigenvalues") or []
+    if len(eigenvalues) < 2:
+        return {
+            "ok": False,
+            "error": f"graph_laplacian returned {len(eigenvalues)} eigenvalue(s); need >= 2 for lambda2",
+            "project_id": project_id,
+        }
+
+    lambda2 = float(eigenvalues[1])
+    laplacian_meta = result.get("laplacian") or {}
+    return {
+        "ok": True,
+        "lambda2": lambda2,
+        "lambda0": float(eigenvalues[0]),
+        "n": laplacian_meta.get("n"),
+        "edge_count": laplacian_meta.get("edge_count"),
+        "eig_method": laplacian_meta.get("eig_method"),
+        "normalization": laplacian_meta.get("normalization"),
+        "project_id": project_id,
+    }
+
+
+def build_fiedler_metric_datum(fiedler_result: Dict[str, Any], *, timestamp=None) -> Dict[str, Any]:
+    """Assemble one CloudWatch MetricDatum for a successful compute_fiedler_value result."""
+    if timestamp is None:
+        from datetime import datetime, timezone
+        timestamp = datetime.now(timezone.utc)
+    return {
+        "MetricName": FIEDLER_METRIC_NAME,
+        "Value": fiedler_result["lambda2"],
+        "Unit": "None",
+        "Timestamp": timestamp,
+        "Dimensions": [
+            {"Name": "ProjectId", "Value": fiedler_result.get("project_id") or DEFAULT_PROJECT_ID},
+        ],
+    }
+
+
+def publish_metric_data(cw_client: Any, metric_data: List[Dict[str, Any]]) -> int:
+    """PutMetricData in batches of <= 20 (CloudWatch's per-call cap). Returns
+    the number of datapoints published. Empty input is a no-op (returns 0)."""
+    published = 0
+    for i in range(0, len(metric_data), _CLOUDWATCH_BATCH_SIZE):
+        batch = metric_data[i:i + _CLOUDWATCH_BATCH_SIZE]
+        cw_client.put_metric_data(Namespace=GRAPH_HEALTH_NAMESPACE, MetricData=batch)
+        published += len(batch)
+    return published
+
+
+def run_publish_graph_health(
+    driver: Any,
+    cw_client: Any,
+    *,
+    query_laplacian_fn,
+    project_ids: Optional[List[str]] = None,
+    limit: int = DEFAULT_VERTEX_LIMIT,
+    k: int = DEFAULT_K,
+) -> Dict[str, Any]:
+    """End-to-end: compute lambda-2 per project (FTR-088 CSR/Fiedler path,
+    ISS-465-compliant -- no GDS) and publish each as one CloudWatch datapoint
+    to Enceladus/GraphHealth. Never raises -- per-project failures are
+    collected in ``results`` so one bad project cannot blank the whole probe.
+    """
+    projects = project_ids or [DEFAULT_PROJECT_ID]
+    results: List[Dict[str, Any]] = []
+    metric_data: List[Dict[str, Any]] = []
+
+    for project_id in projects:
+        fiedler = compute_fiedler_value(
+            driver, project_id, query_laplacian_fn=query_laplacian_fn, limit=limit, k=k,
+        )
+        results.append(fiedler)
+        if fiedler.get("ok"):
+            metric_data.append(build_fiedler_metric_datum(fiedler))
+        else:
+            logger.warning(
+                "[WARNING] GraphHealth lambda2 probe failed for project_id=%s: %s",
+                project_id, fiedler.get("error"),
+            )
+
+    published = publish_metric_data(cw_client, metric_data) if metric_data else 0
+    ok = published > 0
+    logger.info(
+        "[%s] GraphHealth publish: %d/%d project(s) published to %s",
+        "SUCCESS" if ok else "WARNING", published, len(projects), GRAPH_HEALTH_NAMESPACE,
+    )
+    return {"ok": ok, "published": published, "namespace": GRAPH_HEALTH_NAMESPACE, "results": results}
+
+
+def handle_publish_graph_health(
+    event: Dict[str, Any],
+    *,
+    get_driver_fn,
+    get_cloudwatch_fn,
+    query_laplacian_fn,
+) -> Dict[str, Any]:
+    """EventBridge / direct-invoke entrypoint (action='publish_graph_health').
+
+    Mirrors _handle_refresh_projection's/_handle_refresh_flow_weight's
+    dependency-injection contract: the caller (lambda_function.lambda_handler)
+    passes its own driver/cloudwatch-client/getter and the FTR-088
+    _query_laplacian function, so this module has no import-time coupling to
+    lambda_function.py and stays independently unit-testable.
+    """
+    driver = get_driver_fn()
+    if driver is None:
+        return {"ok": False, "error": "neo4j driver unavailable"}
+    cw_client = get_cloudwatch_fn()
+    project_ids = event.get("project_ids") or ([event["project_id"]] if event.get("project_id") else None)
+    limit = int(event.get("limit", DEFAULT_VERTEX_LIMIT) or DEFAULT_VERTEX_LIMIT)
+    k = int(event.get("k", DEFAULT_K) or DEFAULT_K)
+    return run_publish_graph_health(
+        driver, cw_client,
+        query_laplacian_fn=query_laplacian_fn,
+        project_ids=project_ids,
+        limit=limit,
+        k=k,
+    )

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -255,6 +255,7 @@ STIGMERGIC_TRACE_TABLE = os.environ.get("STIGMERGIC_TRACE_TABLE", "").strip()
 
 _s3 = None
 _dynamodb = None
+_cloudwatch = None
 
 
 def _get_secretsmanager():
@@ -302,6 +303,21 @@ def _get_dynamodb():
             config=Config(retries={"max_attempts": 3, "mode": "standard"}),
         )
     return _dynamodb
+
+
+def _get_cloudwatch():
+    """Lazy CloudWatch client for the ENC-TSK-K43 GraphHealth lambda2 metric
+    publisher (mirrors _get_dynamodb / _get_s3 lazy-singleton convention)."""
+    global _cloudwatch
+    if _cloudwatch is None:
+        import boto3
+        from botocore.config import Config
+        _cloudwatch = boto3.client(
+            "cloudwatch",
+            region_name=SECRETS_REGION,
+            config=Config(retries={"max_attempts": 3, "mode": "standard"}),
+        )
+    return _cloudwatch
 
 
 _SPURIOUS_ATTRACTOR_RECENT_LIMIT = 5
@@ -1683,6 +1699,31 @@ def _handle_refresh_flow_weight(event: Dict) -> Dict[str, Any]:
     if driver is None:
         return {"ok": False, "error": "neo4j driver unavailable after rebuild attempt"}
     return _fwr.run_refresh(driver, _get_s3(), event)
+
+
+def _handle_publish_graph_health(event: Dict) -> Dict[str, Any]:
+    """ENC-TSK-K43 (B66 Ph5, gamma re-delivery of ENC-TSK-C10) out-of-band
+    Fiedler lambda-2 GraphHealth metric publisher entrypoint. Mirrors
+    _handle_refresh_projection's/_handle_refresh_flow_weight's contract:
+    invoked by an EventBridge scheduled rule or a direct Lambda invoke
+    carrying action='publish_graph_health' (dispatched in lambda_handler
+    below); NOT exposed on the public API Gateway route. Delegates to
+    graph_health_metric, which computes lambda2 exclusively via the existing
+    FTR-088 _query_laplacian CSR/Fiedler path (ISS-465: no GDS projection —
+    see graph_health_metric.py module docstring) and publishes it to the
+    Enceladus/GraphHealth CloudWatch namespace.
+    """
+    try:
+        import graph_health_metric as _ghm
+    except Exception:
+        logger.exception("[ERROR] graph_health_metric module unavailable")
+        return {"ok": False, "error": "graph_health_metric module unavailable"}
+    return _ghm.handle_publish_graph_health(
+        event,
+        get_driver_fn=lambda: _ensure_live_driver(_get_neo4j_driver()),
+        get_cloudwatch_fn=_get_cloudwatch,
+        query_laplacian_fn=_query_laplacian,
+    )
 
 
 def _hybrid_keyword_ranks(
@@ -3501,6 +3542,14 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # never falls through to the FTR-101 projection-refresh handler.
     if isinstance(event, dict) and event.get("action") == "refresh_flow_weight":
         return _handle_refresh_flow_weight(event)
+
+    # ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda-2 GraphHealth metric
+    # publish. Checked before the generic aws.events/Scheduled-Event fallback
+    # below (same reasoning as refresh_flow_weight above) so an explicit
+    # action='publish_graph_health' invoke (or EventBridge rule Input) never
+    # falls through to the FTR-101 projection-refresh handler.
+    if isinstance(event, dict) and event.get("action") == "publish_graph_health":
+        return _handle_publish_graph_health(event)
 
     # ENC-FTR-101 (Option B): out-of-band standing-projection refresh. EventBridge
     # scheduled events / direct invokes carry action='refresh_projection' (and lack

--- a/backend/lambda/graph_query_api/test_graph_health_metric_k43.py
+++ b/backend/lambda/graph_query_api/test_graph_health_metric_k43.py
@@ -1,0 +1,281 @@
+"""Unit tests for ENC-TSK-K43 (B66 Ph5) Fiedler lambda-2 GraphHealth metric.
+
+Exercises graph_health_metric.py in isolation (no real AWS, no live AuraDB):
+the FTR-088 _query_laplacian dependency is dependency-injected as a plain
+function, so these tests never import lambda_function.py (no Neo4j driver /
+scipy / boto3 required for the fake-driver-free tests) and reuse the same
+fake-eigenvalue-result-injection pattern for the handler-level tests.
+
+Covers:
+  - AC-1: lambda2 == eigenvalues[1] resolved from a _query_laplacian-shaped
+    result and assembled into a well-formed CloudWatch MetricDatum in the
+    Enceladus/GraphHealth namespace.
+  - AC-2: ISS-465 GDS cost-kill -- compute_fiedler_value only ever calls the
+    injected query_laplacian_fn (the FTR-088 CSR/Fiedler path); it never
+    imports or references gds.graph.project / an AGA session / any standing
+    projection helper.
+  - Batching: publish_metric_data batches at <= 20 MetricDatum per
+    put_metric_data call.
+  - Degradation: a <2-eigenvalue or error result from query_laplacian_fn
+    yields {"ok": False, ...} rather than raising, and a failed project is
+    excluded from metric_data (no partial datapoint published) while other
+    projects still succeed.
+  - handle_publish_graph_health: action-dispatch entrypoint contract (driver
+    unavailable -> ok=False without touching cloudwatch; happy path calls
+    put_metric_data exactly once for a single default project).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import graph_health_metric as ghm  # noqa: E402
+
+
+def _laplacian_result(eigenvalues, *, n=10, edge_count=9, eig_method="eigsh_SA", normalization="combinatorial"):
+    return {
+        "eigenvalues": eigenvalues,
+        "laplacian": {
+            "n": n,
+            "edge_count": edge_count,
+            "eig_method": eig_method,
+            "normalization": normalization,
+        },
+    }
+
+
+def _fake_query_laplacian_fn(eigenvalues_by_project, calls_log=None):
+    """Build a query_laplacian_fn stand-in keyed by project_id. Records
+    (driver, project_id, params) tuples into calls_log when supplied, so
+    tests can assert exactly what compute_fiedler_value passed through."""
+    def _fn(driver, project_id, params):
+        if calls_log is not None:
+            calls_log.append((driver, project_id, dict(params)))
+        spec = eigenvalues_by_project.get(project_id)
+        if spec is None:
+            return {"error": f"no fixture for project_id={project_id}"}
+        if isinstance(spec, dict) and "error" in spec:
+            return spec
+        return _laplacian_result(spec)
+    return _fn
+
+
+class TestComputeFiedlerValue(unittest.TestCase):
+    def test_lambda2_is_eigenvalues_index_1_ac1(self):
+        calls = []
+        fn = _fake_query_laplacian_fn({"enceladus": [0.0, 0.42, 1.1]}, calls_log=calls)
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=fn)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["lambda2"], 0.42)
+        self.assertEqual(result["lambda0"], 0.0)
+        self.assertEqual(result["project_id"], "enceladus")
+        self.assertEqual(result["n"], 10)
+        self.assertEqual(result["eig_method"], "eigsh_SA")
+        # AC-2 / ISS-465: only the injected FTR-088 path was called -- one call,
+        # requesting k>=2 (so the Fiedler index-1 eigenpair is always resolvable).
+        self.assertEqual(len(calls), 1)
+        _driver, _pid, params = calls[0]
+        self.assertGreaterEqual(params["k"], 2)
+        self.assertEqual(params["normalization"], "combinatorial")
+
+    def test_k_is_floored_at_2_even_when_caller_requests_1(self):
+        calls = []
+        fn = _fake_query_laplacian_fn({"enceladus": [0.0, 0.1]}, calls_log=calls)
+        ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=fn, k=1)
+        self.assertEqual(calls[0][2]["k"], 2)
+
+    def test_propagates_query_laplacian_error(self):
+        fn = _fake_query_laplacian_fn({"enceladus": {"error": "Laplacian requires at least 2 vertices"}})
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=fn)
+        self.assertFalse(result["ok"])
+        self.assertIn("at least 2 vertices", result["error"])
+
+    def test_degrades_on_too_few_eigenvalues(self):
+        # A pathological/degenerate response with only the trivial eigenpair.
+        fn = _fake_query_laplacian_fn({"enceladus": [0.0]})
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=fn)
+        self.assertFalse(result["ok"])
+        self.assertIn("lambda2", result["error"])
+
+    def test_never_touches_gds_projection_helpers(self):
+        # AC-2 hard gate: the module's *code* (not its explanatory docstrings/
+        # comments) must never invoke a GDS/AGA symbol -- only the injected
+        # FTR-088 query_laplacian_fn. Strip comments/docstring-only lines so
+        # this checks executable statements, not prose that documents the
+        # deliberate absence of those calls.
+        import ast
+        import inspect
+        src = inspect.getsource(ghm)
+        tree = ast.parse(src)
+        # Collect every Attribute/Call dotted-name actually used in code (not
+        # string literals/docstrings, which ast.walk over Constant nodes would
+        # also catch and produce false positives against this module's prose).
+        used_names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                parts = []
+                cur = node
+                while isinstance(cur, ast.Attribute):
+                    parts.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    parts.append(cur.id)
+                used_names.add(".".join(reversed(parts)))
+            elif isinstance(node, ast.Name):
+                used_names.add(node.id)
+        forbidden_substrings = ("gds", "AGA", "_refresh_standing_projection", "standing_projection")
+        for name in used_names:
+            lowered = name.lower()
+            for forbidden in forbidden_substrings:
+                self.assertNotIn(
+                    forbidden.lower(), lowered,
+                    f"graph_health_metric.py code references {name!r} containing forbidden {forbidden!r} (ISS-465)",
+                )
+
+
+class TestMetricAssemblyAndPublish(unittest.TestCase):
+    def test_build_fiedler_metric_datum_shape(self):
+        fiedler = {"ok": True, "lambda2": 0.37, "project_id": "enceladus"}
+        datum = ghm.build_fiedler_metric_datum(fiedler)
+        self.assertEqual(datum["MetricName"], ghm.FIEDLER_METRIC_NAME)
+        self.assertEqual(datum["Value"], 0.37)
+        self.assertEqual(datum["Dimensions"], [{"Name": "ProjectId", "Value": "enceladus"}])
+        self.assertIn("Timestamp", datum)
+
+    def test_publish_metric_data_batches_at_20(self):
+        calls = []
+
+        class _FakeCW:
+            def put_metric_data(self, **kwargs):
+                calls.append(kwargs)
+
+        metric_data = [{"MetricName": "x", "Value": float(i)} for i in range(45)]
+        published = ghm.publish_metric_data(_FakeCW(), metric_data)
+        self.assertEqual(published, 45)
+        self.assertEqual(len(calls), 3)  # 20 + 20 + 5
+        self.assertEqual(len(calls[0]["MetricData"]), 20)
+        self.assertEqual(len(calls[1]["MetricData"]), 20)
+        self.assertEqual(len(calls[2]["MetricData"]), 5)
+        for call in calls:
+            self.assertEqual(call["Namespace"], ghm.GRAPH_HEALTH_NAMESPACE)
+
+    def test_publish_metric_data_empty_is_noop(self):
+        class _FakeCW:
+            def put_metric_data(self, **kwargs):
+                raise AssertionError("must not call put_metric_data for empty input")
+
+        self.assertEqual(ghm.publish_metric_data(_FakeCW(), []), 0)
+
+
+class TestRunPublishGraphHealth(unittest.TestCase):
+    def test_single_project_happy_path(self):
+        class _FakeCW:
+            def __init__(self):
+                self.calls = []
+
+            def put_metric_data(self, **kwargs):
+                self.calls.append(kwargs)
+
+        cw = _FakeCW()
+        fn = _fake_query_laplacian_fn({"enceladus": [0.0, 0.55, 1.2]})
+        out = ghm.run_publish_graph_health(object(), cw, query_laplacian_fn=fn, project_ids=["enceladus"])
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["published"], 1)
+        self.assertEqual(out["namespace"], ghm.GRAPH_HEALTH_NAMESPACE)
+        self.assertEqual(len(cw.calls), 1)
+        self.assertEqual(cw.calls[0]["MetricData"][0]["Value"], 0.55)
+
+    def test_partial_failure_publishes_only_successful_projects(self):
+        class _FakeCW:
+            def __init__(self):
+                self.calls = []
+
+            def put_metric_data(self, **kwargs):
+                self.calls.append(kwargs)
+
+        cw = _FakeCW()
+        fn = _fake_query_laplacian_fn({
+            "enceladus": [0.0, 0.3, 0.9],
+            "broken-project": {"error": "boom"},
+        })
+        out = ghm.run_publish_graph_health(
+            object(), cw, query_laplacian_fn=fn, project_ids=["enceladus", "broken-project"],
+        )
+        self.assertTrue(out["ok"])  # at least one datapoint published
+        self.assertEqual(out["published"], 1)
+        self.assertEqual(len(out["results"]), 2)
+        ok_flags = sorted(r["ok"] for r in out["results"])
+        self.assertEqual(ok_flags, [False, True])
+
+    def test_all_projects_fail_yields_ok_false_zero_published(self):
+        class _FakeCW:
+            def put_metric_data(self, **kwargs):
+                raise AssertionError("must not publish when nothing succeeded")
+
+        fn = _fake_query_laplacian_fn({"enceladus": {"error": "boom"}})
+        out = ghm.run_publish_graph_health(object(), _FakeCW(), query_laplacian_fn=fn, project_ids=["enceladus"])
+        self.assertFalse(out["ok"])
+        self.assertEqual(out["published"], 0)
+
+
+class TestHandlePublishGraphHealth(unittest.TestCase):
+    def test_driver_unavailable_short_circuits_before_cloudwatch(self):
+        cw_called = []
+
+        def _get_cw():
+            cw_called.append(True)
+            return object()
+
+        out = ghm.handle_publish_graph_health(
+            {"action": "publish_graph_health"},
+            get_driver_fn=lambda: None,
+            get_cloudwatch_fn=_get_cw,
+            query_laplacian_fn=lambda *a, **k: {"error": "unreachable"},
+        )
+        self.assertFalse(out["ok"])
+        self.assertIn("driver", out["error"])
+        self.assertEqual(cw_called, [])  # never even fetched a CloudWatch client
+
+    def test_happy_path_single_default_project(self):
+        class _FakeCW:
+            def __init__(self):
+                self.calls = []
+
+            def put_metric_data(self, **kwargs):
+                self.calls.append(kwargs)
+
+        cw = _FakeCW()
+        fn = _fake_query_laplacian_fn({ghm.DEFAULT_PROJECT_ID: [0.0, 0.61, 1.4]})
+        out = ghm.handle_publish_graph_health(
+            {"action": "publish_graph_health"},
+            get_driver_fn=lambda: object(),
+            get_cloudwatch_fn=lambda: cw,
+            query_laplacian_fn=fn,
+        )
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["published"], 1)
+        self.assertEqual(len(cw.calls), 1)
+
+    def test_explicit_project_id_override(self):
+        calls = []
+        fn = _fake_query_laplacian_fn({"other-project": [0.0, 0.2]}, calls_log=calls)
+
+        class _FakeCW:
+            def put_metric_data(self, **kwargs):
+                pass
+
+        ghm.handle_publish_graph_health(
+            {"action": "publish_graph_health", "project_id": "other-project"},
+            get_driver_fn=lambda: object(),
+            get_cloudwatch_fn=lambda: _FakeCW(),
+            query_laplacian_fn=fn,
+        )
+        self.assertEqual(calls[0][1], "other-project")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/scoring_service/lambda_function.py
+++ b/backend/lambda/scoring_service/lambda_function.py
@@ -82,6 +82,90 @@ _VIBE_BOARD_ANCHORS = {
 
 _REQUIRED_PILLARS = {"efficiency", "human_protection", "intention", "alignment"}
 
+# ---------------------------------------------------------------------------
+# ENC-TSK-K43 (B66 Ph5) — F_governance percentile normalization.
+# Math gate: DOC-A3D0CDF91CE9 Q3.1 ("Explicit F_governance Functional",
+# ENRICHING -> CORRECTED). F_structural, F_temporal, and F_evidential are not
+# directly summable (different units/scales); the corrected composite is a
+# percentile-rank sum, bounded [0, 3] where 0 == perfect health across all
+# three governance free-energy dimensions:
+#
+#   F_governance = percentile_rank(F_structural) + percentile_rank(F_temporal)
+#                  + percentile_rank(F_evidential)
+#
+# F_governance = 0 is NOT achievable in practice (Q3.1 sub-question — each
+# term is strictly >= 0 / > 0 for an active project), so this module treats
+# LOW F_governance (near the achievable minimum) as high compliance and HIGH
+# F_governance (near the theoretical max of 3.0) as low compliance, and folds
+# that into the Scoring Service's existing resonance anti-pattern-penalty
+# mechanism (_compute_resonance_score) as a governance compliance weighting
+# term — not a parallel scoring path, per the task's integration contract.
+# ---------------------------------------------------------------------------
+F_GOVERNANCE_MAX = 3.0  # theoretical ceiling: percentile_rank in [0,1] per term, 3 terms.
+
+# Multiplicative band the governance-compliance weight maps onto in
+# _compute_resonance_score, symmetric around 1.0x at weight==0.5 (neutral) so
+# a record with no historical distribution (percentile_rank's own neutral
+# midpoint) reproduces the exact pre-K43 score. Mirrors the scale of the
+# existing anti-pattern penalties immediately below (0.5x-0.8x) rather than a
+# wider swing, so F_governance nudges ranking without a single low-compliance
+# record ever dominating the vibe-board terms.
+_GOVERNANCE_MIN_MULTIPLIER = 0.8   # weight == 0.0 (worst observed governance health)
+_GOVERNANCE_MAX_MULTIPLIER = 1.2   # weight == 1.0 (perfect governance health, F_governance == 0)
+
+
+def percentile_rank(value: float, distribution) -> float:
+    """Fraction of ``distribution`` that is <= ``value``, in [0.0, 1.0].
+
+    Pure order-statistic percentile rank (no interpolation) against a
+    historical distribution — matches the Q3.1 gate's "percentile ranks
+    computed against historical distributions across all project-phases"
+    definition. An empty/falsy distribution degrades to the neutral midpoint
+    (0.5) rather than raising, since a governance signal with no history yet
+    (e.g. a brand-new project-phase) should neither help nor hurt ranking.
+    """
+    if not distribution:
+        return 0.5
+    values = sorted(float(v) for v in distribution)
+    n = len(values)
+    value = float(value)
+    count_le = sum(1 for v in values if v <= value)
+    return max(0.0, min(1.0, count_le / n))
+
+
+def compute_f_governance(
+    f_structural: float,
+    f_temporal: float,
+    f_evidential: float,
+    *,
+    structural_distribution=None,
+    temporal_distribution=None,
+    evidential_distribution=None,
+) -> float:
+    """DOC-A3D0CDF91CE9 Q3.1 corrected composite: sum of percentile ranks.
+
+    Each raw F_* value is converted to a percentile rank against its own
+    historical distribution (commensurability fix — the three free-energy
+    terms have different units and are not directly summable), then summed.
+    Bounded [0.0, 3.0]; 0.0 == perfect health on all three dimensions.
+    """
+    ps = percentile_rank(f_structural, structural_distribution)
+    pt = percentile_rank(f_temporal, temporal_distribution)
+    pe = percentile_rank(f_evidential, evidential_distribution)
+    return round(ps + pt + pe, 4)
+
+
+def governance_compliance_weight(f_governance: float) -> float:
+    """Map F_governance in [0, F_GOVERNANCE_MAX] to a compliance weight in
+    [0.0, 1.0], where 0.0 == worst-observed governance health and 1.0 ==
+    perfect health (F_governance == 0, per Q3.1). Linear inverse mapping —
+    simplest monotonic transform consistent with "lower F_governance is
+    better" and adequate for a first-order compliance weighting term (no
+    claim of a more elaborate curve; DOC-A3D0CDF91CE9 does not specify one).
+    """
+    clamped = max(0.0, min(F_GOVERNANCE_MAX, float(f_governance)))
+    return round(1.0 - (clamped / F_GOVERNANCE_MAX), 4)
+
 
 def _compute_lesson_pillar_composite(pillar_scores) -> float:
     """Weighted pillar composite: 0.25*eff + 0.30*hp + 0.20*int + 0.25*aln."""
@@ -91,8 +175,25 @@ def _compute_lesson_pillar_composite(pillar_scores) -> float:
     return round(composite, 4)
 
 
-def _compute_resonance_score(pillar_scores, anchor_alignments=None) -> float:
-    """Vibe board resonance with anti-pattern penalties. Returns [0.0, 1.0]."""
+def _compute_resonance_score(pillar_scores, anchor_alignments=None, f_governance: Optional[float] = None) -> float:
+    """Vibe board resonance with anti-pattern penalties. Returns [0.0, 1.0].
+
+    ``f_governance`` (ENC-TSK-K43 / B66 Ph5, additive keyword-only so the
+    verbatim-parity call sites in tracker_mutation / coordination_api that do
+    not pass it are unaffected) is the optional DOC-A3D0CDF91CE9 Q3.1
+    composite (percentile_rank(F_structural) + percentile_rank(F_temporal) +
+    percentile_rank(F_evidential), bounded [0, 3], 0 == perfect governance
+    health) for the record/project this score is being computed for. When
+    supplied, it is converted via governance_compliance_weight into a
+    multiplicative governance-compliance term applied the SAME way the
+    existing anti-pattern checks below apply their penalties — a bounded
+    multiplicative factor on ``raw`` — rather than a separate additive score
+    or a parallel ranking path. Below-median compliance (weight < 0.5, i.e.
+    F_governance above its own achievable-minimum band) dampens resonance;
+    above-median compliance (weight > 0.5) gives a mild boost, symmetric
+    around a neutral 1.0x at weight==0.5 (matches percentile_rank's own
+    neutral-midpoint convention for an unseeded distribution).
+    """
     if anchor_alignments:
         raw = sum(w * max(0.0, min(1.0, float(anchor_alignments.get(word, 0.0))))
                   for word, w in _VIBE_BOARD_ANCHORS.items())
@@ -120,6 +221,16 @@ def _compute_resonance_score(pillar_scores, anchor_alignments=None) -> float:
         raw *= 0.6
     if float(anchor_alignments.get("convergence", 0)) > 0.8 and float(anchor_alignments.get("play", 0)) < 0.2:
         raw *= 0.8
+
+    # ENC-TSK-K43: F_governance percentile-normalized compliance weighting.
+    # weight in [0,1], 0.5 neutral -> multiplier in [GOVERNANCE_MIN_MULTIPLIER, GOVERNANCE_MAX_MULTIPLIER].
+    if f_governance is not None:
+        weight = governance_compliance_weight(f_governance)
+        multiplier = (
+            _GOVERNANCE_MIN_MULTIPLIER
+            + (weight * (_GOVERNANCE_MAX_MULTIPLIER - _GOVERNANCE_MIN_MULTIPLIER))
+        )
+        raw *= multiplier
 
     return round(max(0.0, min(1.0, raw)), 4)
 
@@ -209,8 +320,23 @@ def score_lesson(message: dict) -> Tuple[str, dict]:
         logger.error("[H47] message for %s has missing/invalid pillar_scores; skipping", record_id)
         return "skipped", {"outcome": "skipped", "reason": "invalid_pillar_scores", "record_id": record_id}
 
+    # ENC-TSK-K43 (B66 Ph5): optional F_governance composite carried on the
+    # {lesson.scoring.requested} message (publisher-computed, e.g. by
+    # tracker_mutation from the record's own F_structural/F_temporal/
+    # F_evidential percentile ranks per DOC-A3D0CDF91CE9 Q3.1). Absent on
+    # messages from a publisher that hasn't wired governance signals in yet —
+    # _compute_resonance_score treats None as "no governance weighting term",
+    # so this degrades to the pre-K43 score rather than erroring.
+    f_governance = message.get("f_governance")
+    if f_governance is not None:
+        try:
+            f_governance = float(f_governance)
+        except (TypeError, ValueError):
+            logger.warning("[K43] message for %s has non-numeric f_governance=%r; ignoring", record_id, f_governance)
+            f_governance = None
+
     pillar_composite = _compute_lesson_pillar_composite(pillar_scores)
-    resonance_score = _compute_resonance_score(pillar_scores)
+    resonance_score = _compute_resonance_score(pillar_scores, f_governance=f_governance)
     outcome = _apply_scores(project_id, record_id, pillar_composite, resonance_score)
     detail = {
         "record_id": record_id,
@@ -218,6 +344,8 @@ def score_lesson(message: dict) -> Tuple[str, dict]:
         "resonance_score": resonance_score,
         "outcome": outcome,
     }
+    if f_governance is not None:
+        detail["f_governance"] = f_governance
     if outcome == "scored":
         logger.info(
             "[H47] scored %s pillar_composite=%s resonance_score=%s",

--- a/backend/lambda/scoring_service/test_f_governance_k43.py
+++ b/backend/lambda/scoring_service/test_f_governance_k43.py
@@ -1,0 +1,227 @@
+"""Unit tests for ENC-TSK-K43 (B66 Ph5) F_governance percentile normalization
+in the Scoring Service.
+
+Math gate: DOC-A3D0CDF91CE9 Q3.1 ("Explicit F_governance Functional",
+ENRICHING -> CORRECTED).
+
+  F_governance = percentile_rank(F_structural) + percentile_rank(F_temporal)
+                 + percentile_rank(F_evidential)
+
+bounded [0, 3], where 0 == perfect health (not achievable in practice per the
+Q3.1 sub-question, since each term is strictly positive for an active
+project). Covers:
+
+  - percentile_rank: order-statistic semantics, degrades to neutral 0.5 for
+    an empty/absent historical distribution.
+  - compute_f_governance: sums three independent percentile ranks, bounded
+    [0, 3].
+  - governance_compliance_weight: linear inverse map onto [0, 1], 1.0 at
+    F_governance==0 (perfect health), 0.0 at F_governance==F_GOVERNANCE_MAX.
+  - _compute_resonance_score(..., f_governance=...): AC-3 hard requirement —
+    a unit test asserting the percentile weighting SHIFTS RANKING in the
+    expected direction: two records with identical pillar_scores but
+    different F_governance must rank in compliance order (better governance
+    health -> higher resonance_score -> higher retrieval/context-assembly
+    rank), and the effect must vanish (score unchanged) when f_governance is
+    omitted, preserving pre-K43 backward compatibility.
+  - score_lesson: end-to-end wiring — an optional message-level f_governance
+    field flows through to the resonance computation and is degraded (not
+    erroring) when absent or malformed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import lambda_function as sf  # noqa: E402
+
+
+GOOD_PILLARS = {"efficiency": 0.8, "human_protection": 0.7, "intention": 0.6, "alignment": 0.75}
+
+
+# ---------------------------------------------------------------------------
+# percentile_rank
+# ---------------------------------------------------------------------------
+def test_percentile_rank_order_statistic():
+    dist = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert sf.percentile_rank(3.0, dist) == 0.6  # 3 of 5 values <= 3.0
+    assert sf.percentile_rank(0.0, dist) == 0.0
+    assert sf.percentile_rank(5.0, dist) == 1.0
+    assert sf.percentile_rank(100.0, dist) == 1.0  # clamped
+
+
+def test_percentile_rank_empty_distribution_is_neutral():
+    assert sf.percentile_rank(0.5, []) == 0.5
+    assert sf.percentile_rank(0.5, None) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# compute_f_governance
+# ---------------------------------------------------------------------------
+def test_compute_f_governance_sums_three_percentile_ranks():
+    # percentile_rank is an order-statistic "fraction <= value": querying the
+    # true median of a 3-point distribution captures 2 of 3 points (itself
+    # plus everything below), i.e. 0.667 per term -> sum 2.0.
+    dist = [0.0, 0.5, 1.0]
+    fg = sf.compute_f_governance(
+        0.5, 0.5, 0.5,
+        structural_distribution=dist, temporal_distribution=dist, evidential_distribution=dist,
+    )
+    assert fg == round(3 * (2 / 3), 4)
+
+
+def test_compute_f_governance_bounded_0_to_3():
+    dist = [0.0, 1.0]
+    worst = sf.compute_f_governance(
+        999, 999, 999,
+        structural_distribution=dist, temporal_distribution=dist, evidential_distribution=dist,
+    )
+    assert worst == 3.0
+    best = sf.compute_f_governance(
+        -999, -999, -999,
+        structural_distribution=dist, temporal_distribution=dist, evidential_distribution=dist,
+    )
+    assert best == 0.0
+
+
+def test_compute_f_governance_no_distributions_is_neutral_1_5():
+    # Each term degrades to percentile_rank==0.5 with no history -> sum 1.5.
+    assert sf.compute_f_governance(0.3, 10.0, -5.0) == 1.5
+
+
+# ---------------------------------------------------------------------------
+# governance_compliance_weight
+# ---------------------------------------------------------------------------
+def test_compliance_weight_perfect_health_is_1():
+    assert sf.governance_compliance_weight(0.0) == 1.0
+
+
+def test_compliance_weight_worst_health_is_0():
+    assert sf.governance_compliance_weight(sf.F_GOVERNANCE_MAX) == 0.0
+
+
+def test_compliance_weight_midpoint_is_neutral_0_5():
+    assert sf.governance_compliance_weight(sf.F_GOVERNANCE_MAX / 2) == 0.5
+
+
+def test_compliance_weight_clamps_out_of_range():
+    assert sf.governance_compliance_weight(-5.0) == 1.0
+    assert sf.governance_compliance_weight(999.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# AC-3 (hard requirement): percentile weighting shifts ranking in the
+# expected direction.
+# ---------------------------------------------------------------------------
+def test_f_governance_shifts_ranking_ac3():
+    """Two records with IDENTICAL pillar_scores but different governance
+    health must rank in compliance order: the better-governed record (lower
+    F_governance, i.e. closer to the Q3.1 perfect-health floor) must score
+    strictly higher than the worse-governed record (higher F_governance),
+    and both must differ from the ungoverned (no f_governance) baseline —
+    proving the weighting term actually moves the ranking signal rather than
+    being a inert no-op."""
+    baseline = sf._compute_resonance_score(GOOD_PILLARS)
+
+    good_governance = sf._compute_resonance_score(GOOD_PILLARS, f_governance=0.0)  # perfect health
+    poor_governance = sf._compute_resonance_score(GOOD_PILLARS, f_governance=sf.F_GOVERNANCE_MAX)  # worst
+
+    # Directionality: better governance health outranks worse governance health.
+    assert good_governance > poor_governance
+
+    # Both diverge from the ungoverned baseline (the term has real effect).
+    assert good_governance > baseline
+    assert poor_governance < baseline
+
+    # Neutral midpoint (weight==0.5, multiplier==1.0x) reproduces the baseline exactly.
+    neutral = sf._compute_resonance_score(GOOD_PILLARS, f_governance=sf.F_GOVERNANCE_MAX / 2)
+    assert neutral == baseline
+
+
+def test_f_governance_omitted_preserves_pre_k43_score():
+    # Backward compatibility: no f_governance kwarg -> byte-identical to the
+    # pre-K43 call signature (verbatim-parity call sites in tracker_mutation /
+    # coordination_api that never pass f_governance are unaffected).
+    assert sf._compute_resonance_score(GOOD_PILLARS) == sf._compute_resonance_score(GOOD_PILLARS, f_governance=None)
+
+
+def test_f_governance_still_bounded_unit_interval():
+    r_good = sf._compute_resonance_score(GOOD_PILLARS, f_governance=0.0)
+    r_bad = sf._compute_resonance_score(GOOD_PILLARS, f_governance=sf.F_GOVERNANCE_MAX)
+    assert 0.0 <= r_good <= 1.0
+    assert 0.0 <= r_bad <= 1.0
+
+
+def test_f_governance_composes_with_anti_pattern_penalties():
+    # A spiky (force/surrender anti-pattern) profile with perfect governance
+    # health must still rank below a balanced profile with worst governance
+    # health is NOT asserted (the anti-pattern penalty is intentionally
+    # strong) — but perfect governance health must measurably lift the spiky
+    # profile's own score relative to itself without governance weighting.
+    spiky = {"efficiency": 1.0, "human_protection": 0.0, "intention": 0.0, "alignment": 0.0}
+    spiky_baseline = sf._compute_resonance_score(spiky)
+    spiky_good_gov = sf._compute_resonance_score(spiky, f_governance=0.0)
+    assert spiky_good_gov > spiky_baseline
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring through score_lesson
+# ---------------------------------------------------------------------------
+def _scoring_message(**over):
+    msg = {
+        "event_type": "lesson.scoring.requested",
+        "schema_version": 1,
+        "project_id": "enceladus",
+        "record_id": "lesson#ENC-LSN-001",
+        "item_id": "ENC-LSN-001",
+        "pillar_scores": dict(GOOD_PILLARS),
+    }
+    msg.update(over)
+    return msg
+
+
+def test_score_lesson_wires_f_governance_through():
+    outcome_good, detail_good = sf.score_lesson(_scoring_message(f_governance=0.0))
+    outcome_poor, detail_poor = sf.score_lesson(_scoring_message(
+        record_id="lesson#ENC-LSN-002", f_governance=sf.F_GOVERNANCE_MAX,
+    ))
+    assert outcome_good == "error" or outcome_good in ("scored", "noop")  # DDB unmocked here; just check detail math
+    assert detail_good["f_governance"] == 0.0
+    assert detail_poor["f_governance"] == sf.F_GOVERNANCE_MAX
+    assert detail_good["resonance_score"] > detail_poor["resonance_score"]
+
+
+def test_score_lesson_missing_f_governance_omits_detail_key():
+    _outcome, detail = sf.score_lesson(_scoring_message())
+    assert "f_governance" not in detail
+
+
+def test_score_lesson_malformed_f_governance_degrades_gracefully():
+    # A non-numeric f_governance must not raise or poison the score — it is
+    # logged and treated as absent (same as the omitted case).
+    outcome, detail = sf.score_lesson(_scoring_message(f_governance="not-a-number"))
+    assert outcome in ("scored", "noop", "error")  # never 'skipped' due to f_governance parsing
+    assert "f_governance" not in detail
+    baseline = sf._compute_resonance_score(GOOD_PILLARS)
+    assert detail["resonance_score"] == baseline
+
+
+if __name__ == "__main__":
+    fns = [g for n, g in sorted(globals().items()) if n.startswith("test_") and callable(g)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4411,6 +4411,19 @@ Resources:
                   StringLike:
                     s3:prefix:
                       - !Sub "${S3EnvPrefix}pathway-telemetry/*"
+        # ENC-TSK-K43 (B66 Ph5): publish the Fiedler lambda2 GraphHealth metric.
+        # PutMetricData has no resource-level restriction in the CloudWatch API
+        # (metric namespaces are not ARN-addressable), matching the identical
+        # unscoped grant on ProdHealthMonitorPolicy (05-monitoring.yaml).
+        - PolicyName: GraphHealthMetricPublish
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: GraphHealthPutMetricData
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
       Tags:
         - Key: Project
           Value: enceladus

--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -99,6 +99,41 @@ Resources:
           Arn: !GetAtt ProdHealthMonitorFunction.Arn
 
   # ---------------------------------------------------------------------------
+  # ENC-TSK-K43 (B66 Ph5) — Fiedler lambda-2 GraphHealth metric schedule
+  # ---------------------------------------------------------------------------
+  # Gamma re-delivery of ENC-TSK-C10 (v3, closed). Triggers the existing
+  # devops-graph-query-api Lambda every 15 minutes (same cadence as
+  # HealthProbeScheduleRule above) with action='publish_graph_health', which
+  # computes the graph's Fiedler value (lambda2, algebraic connectivity) via
+  # the FTR-088 CSR/Fiedler _query_laplacian path (ISS-465-compliant: no GDS
+  # projection) and publishes it to the Enceladus/GraphHealth CloudWatch
+  # namespace. No new Lambda function — targets the existing graph_query_api
+  # function by ARN + Input, mirroring the ParityDriftDailyScheduleRule
+  # precedent immediately below of pointing a schedule's Input at an existing
+  # multi-action Lambda rather than minting a dedicated one.
+  GraphHealthScheduleRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-graph-health-schedule${EnvironmentSuffix}"
+      Description: >
+        Triggers graph_query_api publish_graph_health (Fiedler lambda2 ->
+        Enceladus/GraphHealth) every 15 minutes (ENC-TSK-K43)
+      ScheduleExpression: "rate(15 minutes)"
+      State: ENABLED
+      Targets:
+        - Id: GraphHealthMetricTarget
+          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+          Input: '{"action": "publish_graph_health"}'
+
+  GraphHealthScheduleInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GraphHealthScheduleRule.Arn
+
+  # ---------------------------------------------------------------------------
   # ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily parity + drift schedule
   # ---------------------------------------------------------------------------
   # Extends devops-deploy-parity-validator (ENC-TSK-F87) via EventBridge to run
@@ -222,3 +257,7 @@ Outputs:
   ParityDriftDailyScheduleRuleArn:
     Description: ARN of the daily parity+drift EventBridge schedule (ENC-TSK-F64 / AC-20)
     Value: !GetAtt ParityDriftDailyScheduleRule.Arn
+
+  GraphHealthScheduleRuleArn:
+    Description: ARN of the Fiedler lambda2 GraphHealth EventBridge schedule (ENC-TSK-K43)
+    Value: !GetAtt GraphHealthScheduleRule.Arn


### PR DESCRIPTION
## Summary

ENC-TSK-K43 — B66 Phase-5 delivery items 3+4, PLN-006 Phase 5 Gate.

**(a) Fiedler lambda-2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10)**
- New `backend/lambda/graph_query_api/graph_health_metric.py`: computes the graph's algebraic connectivity (lambda-2, the Fiedler value) exclusively via the existing FTR-088 `_query_laplacian` CSR/Fiedler path (scipy `eigsh`/dense `eigh` over an induced subgraph). Never touches Neo4j GDS / Aura Graph Analytics — honors the **ISS-465 GDS cost-kill invariant** (no standing projection).
- Wired into `lambda_function.lambda_handler` as a new `action='publish_graph_health'` dispatch entry, mirroring the existing `refresh_projection`/`refresh_flow_weight` out-of-band pattern.
- Publishes to the `Enceladus/GraphHealth` CloudWatch namespace (new lazy `_get_cloudwatch()` client, batched ≤20 MetricDatum/call).
- CFN: `GraphHealthScheduleRule` (15-min EventBridge schedule targeting the existing `devops-graph-query-api` Lambda, mirrors `HealthProbeScheduleRule`/`ParityDriftDailyScheduleRule` precedent — no new Lambda function) + `cloudwatch:PutMetricData` grant on `GraphQueryApiRole`. **Note:** this repo's CFN stacks are not deployed by `_deploy.yml` (Lambda-code-only matrix deploy) — the EventBridge rule/IAM grant require a separate out-of-band stack update before the schedule is live; AC-1 evidence will instead be gathered via a direct `aws lambda invoke` with `action=publish_graph_health` post-merge.

**(b) F_governance percentile normalization in the Scoring Service**
- Math gate: DOC-A3D0CDF91CE9 §Q3.1 — `F_governance = percentile_rank(F_structural) + percentile_rank(F_temporal) + percentile_rank(F_evidential)`, bounded [0,3], 0 = perfect health.
- New `percentile_rank`, `compute_f_governance`, `governance_compliance_weight` pure functions in `backend/lambda/scoring_service/lambda_function.py`.
- Integrated into the existing `_compute_resonance_score(pillar_scores, anchor_alignments=None, f_governance=None)` as an optional multiplicative governance-compliance term, following the same pattern as the existing anti-pattern penalties (force/surrender dampening etc.) — not a parallel scoring path. Backward compatible: omitting `f_governance` reproduces the exact pre-K43 score.
- `score_lesson` wires an optional message-level `f_governance` field through end-to-end.

**OGTM:** no new edge types — both are read/scoring-path integrations over existing graph surfaces.

## Test plan
- [x] `backend/lambda/graph_query_api/test_graph_health_metric_k43.py` — 14 new tests (lambda2 = eigenvalues[1] resolution, CloudWatch batching, error degradation, AST-based check that the module's code never calls a GDS/AGA symbol, handler dispatch contract).
- [x] `backend/lambda/scoring_service/test_f_governance_k43.py` — 16 new tests, including the **AC-3 required test** (`test_f_governance_shifts_ranking_ac3`) asserting the percentile weighting shifts ranking in the expected direction, plus backward-compat with the pre-K43 call signature.
- [x] Full existing suites pass with zero regressions: `graph_query_api` 288/288, `scoring_service` 31/31 (15 pre-existing + 16 new).
- [ ] AC-1 (baseline CloudWatch datapoint) to be confirmed post-merge via direct Lambda invoke + `get-metric-statistics`.

CCI-f49c4f638afe4558b61eed25e7200c2f

🤖 Generated with [Claude Code](https://claude.com/claude-code)