### PR TITLE
[ENC-TSK-K22] B67 PWA2.0 Ph3: realtime WSS client + S3 feed fallback

### DIFF
--- a/frontend/ui-v2/.env.example
+++ b/frontend/ui-v2/.env.example
@@ -5,3 +5,13 @@
 # ${VITE_API_BASE}/tracker/{project}/{type}/{id}; documents from
 # ${VITE_API_BASE}/documents/{id}.
 VITE_API_BASE=/api/v1
+
+# Pre-computed S3 feed snapshots (cold-start + WSS-down fallback).
+VITE_FEED_BASE_URL=/mobile/v1
+
+# AppSync Events realtime (K20). When unset, ui-v2 degrades to S3 snapshot only.
+VITE_APPSYNC_HTTP_HOST=
+VITE_APPSYNC_REALTIME_HOST=
+VITE_APPSYNC_API_KEY=
+VITE_APPSYNC_REGION=us-west-2
+VITE_APPSYNC_FEED_CHANNEL=/feed/updates

--- a/frontend/ui-v2/package-lock.json
+++ b/frontend/ui-v2/package-lock.json
@@ -19,6 +19,7 @@
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-query-devtools": "^5.101.2",
+        "@testing-library/jest-dom": "^6.9.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -27,12 +28,83 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^16.5.0",
+        "jsdom": "^27.0.1",
         "tailwindcss": "^4.3.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^7.3.1",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1608,6 +1680,146 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -2205,6 +2417,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -3231,6 +3461,26 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -3291,6 +3541,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -3666,6 +3934,131 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -3687,6 +4080,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3729,6 +4132,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -3766,6 +4179,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3883,6 +4306,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -3934,6 +4367,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -4016,6 +4459,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4031,6 +4491,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -4129,12 +4599,120 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4208,6 +4786,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4271,6 +4866,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4321,6 +4923,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4430,6 +5045,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4738,6 +5360,16 @@
       },
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5310,6 +5942,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5352,6 +6025,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -5639,6 +6322,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5902,6 +6592,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -6306,6 +7073,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6343,6 +7117,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6543,6 +7334,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6595,6 +7399,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6718,6 +7539,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6964,6 +7799,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7159,6 +8007,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7226,6 +8081,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7354,6 +8223,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7366,6 +8248,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7392,6 +8294,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.2",
@@ -7462,6 +8371,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7477,6 +8400,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -7873,6 +8859,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
@@ -7904,12 +8913,108 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -8026,6 +9131,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8298,6 +9420,45 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/ui-v2/package.json
+++ b/frontend/ui-v2/package.json
@@ -9,7 +9,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
@@ -23,6 +25,7 @@
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query-devtools": "^5.101.2",
+    "@testing-library/jest-dom": "^6.9.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -31,10 +34,12 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^16.5.0",
+    "jsdom": "^27.0.1",
     "tailwindcss": "^4.3.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^7.3.1",
-    "vite-plugin-pwa": "^1.3.0"
+    "vite-plugin-pwa": "^1.3.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/ui-v2/src/api/appsyncConfig.ts
+++ b/frontend/ui-v2/src/api/appsyncConfig.ts
@@ -1,0 +1,25 @@
+export interface AppSyncEventsConfig {
+  httpHost: string
+  realtimeHost: string
+  apiKey: string
+  region: string
+  feedChannel: string
+  enabled: boolean
+}
+
+function stripProtocol(host: string): string {
+  return host.replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+}
+
+/** Build config from Vite env. When incomplete, realtime is disabled (S3-only degrade). */
+export function getAppSyncEventsConfig(): AppSyncEventsConfig {
+  const httpHost = stripProtocol(import.meta.env.VITE_APPSYNC_HTTP_HOST ?? '')
+  const realtimeHost = stripProtocol(import.meta.env.VITE_APPSYNC_REALTIME_HOST ?? '')
+  const apiKey = (import.meta.env.VITE_APPSYNC_API_KEY ?? '').trim()
+  const region = (import.meta.env.VITE_APPSYNC_REGION ?? 'us-west-2').trim()
+  const feedChannel = (import.meta.env.VITE_APPSYNC_FEED_CHANNEL ?? '/feed/updates').trim()
+
+  const enabled = Boolean(httpHost && realtimeHost && apiKey)
+
+  return { httpHost, realtimeHost, apiKey, region, feedChannel, enabled }
+}

--- a/frontend/ui-v2/src/api/feeds.ts
+++ b/frontend/ui-v2/src/api/feeds.ts
@@ -1,0 +1,73 @@
+import type { FeedRealtimeEvent, FeedSnapshot } from '../types/feedEvents'
+
+const FEED_BASE = (import.meta.env.VITE_FEED_BASE_URL ?? '/mobile/v1').replace(/\/$/, '')
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const url = `${FEED_BASE}/${path}?_t=${Date.now()}`
+  const res = await fetch(url, {
+    credentials: 'include',
+    cache: 'no-store',
+    headers: {
+      accept: 'application/json',
+      'x-requested-with': 'XMLHttpRequest',
+    },
+  })
+  if (!res.ok) throw new Error(`Feed fetch failed (${path}): ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+/** Minimal S3 snapshot row used to seed the feed before WSS connects. */
+interface SnapshotTask {
+  item_id?: string
+  id?: string
+  title?: string
+  status?: string
+  record_type?: string
+  updated_at?: string
+}
+
+interface TasksSnapshot {
+  tasks?: SnapshotTask[]
+  generated_at?: string
+}
+
+function taskToFeedEvent(task: SnapshotTask, cursor: number): FeedRealtimeEvent | null {
+  const recordId = task.item_id ?? task.id
+  if (!recordId) return null
+  const title = task.title ?? recordId
+  const status = task.status ?? 'open'
+  return {
+    eventId: `snapshot-${recordId}`,
+    recordId,
+    record_type: task.record_type ?? 'task',
+    action: status === 'closed' ? 'closed' : 'updated',
+    actorType: 'agent',
+    actorId: 'feed-snapshot',
+    summary: `${recordId}: ${title}`,
+    cursor,
+    channels: ['/feed/updates'],
+  }
+}
+
+/**
+ * Cold-start hydrate from the pre-computed S3 feed (B67 AC-4).
+ * Uses tasks.json as the primary snapshot; other feeds can extend this later.
+ */
+export async function fetchFeedSnapshot(): Promise<FeedSnapshot> {
+  const data = await fetchJson<TasksSnapshot>('tasks.json')
+  const baseCursor = data.generated_at
+    ? Date.parse(data.generated_at) * 1000
+    : Date.now() * 1000
+
+  const events = (data.tasks ?? [])
+    .map((task, index) => taskToFeedEvent(task, baseCursor + index))
+    .filter((event): event is FeedRealtimeEvent => event !== null)
+    .sort((a, b) => b.cursor - a.cursor)
+    .slice(0, 50)
+
+  return {
+    events,
+    hydratedAt: new Date().toISOString(),
+    source: 's3',
+  }
+}

--- a/frontend/ui-v2/src/env.d.ts
+++ b/frontend/ui-v2/src/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string
+  readonly VITE_FEED_BASE_URL?: string
+  readonly VITE_APPSYNC_HTTP_HOST?: string
+  readonly VITE_APPSYNC_REALTIME_HOST?: string
+  readonly VITE_APPSYNC_API_KEY?: string
+  readonly VITE_APPSYNC_REGION?: string
+  readonly VITE_APPSYNC_FEED_CHANNEL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/frontend/ui-v2/src/main.tsx
+++ b/frontend/ui-v2/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { queryClient } from './api/queryClient'
 import { router } from './routes/router'
+import { RealtimeFeedProvider } from './realtime/RealtimeFeedProvider'
 import './styles.css'
 
 const rootEl = document.getElementById('root')
@@ -12,7 +13,9 @@ if (!rootEl) throw new Error('Root element #root not found')
 createRoot(rootEl).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <RealtimeFeedProvider>
+        <RouterProvider router={router} />
+      </RealtimeFeedProvider>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -1,0 +1,160 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getAppSyncEventsConfig } from '../api/appsyncConfig'
+import { fetchFeedSnapshot } from '../api/feeds'
+import {
+  AppSyncRealtimeClient,
+  type RealtimeClientEvent,
+} from './appsyncRealtimeClient'
+import {
+  REALTIME_FEED_QUERY_KEY,
+  maxCursor,
+  mergeFeedEvents,
+  snapshotToFeedState,
+} from './feedEventReducer'
+import { useFeedConnectionStore } from '../store/feedConnectionStore'
+import type { FeedRealtimeEvent } from '../types/feedEvents'
+
+interface RealtimeFeedContextValue {
+  events: FeedRealtimeEvent[]
+  isHydrating: boolean
+  isSnapshotError: boolean
+  refetchSnapshot: () => void
+  manualReconnect: () => void
+}
+
+const RealtimeFeedContext = createContext<RealtimeFeedContextValue | null>(null)
+
+export function useRealtimeFeed(): RealtimeFeedContextValue {
+  const ctx = useContext(RealtimeFeedContext)
+  if (!ctx) throw new Error('useRealtimeFeed must be used within RealtimeFeedProvider')
+  return ctx
+}
+
+export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient()
+  const clientRef = useRef<AppSyncRealtimeClient | null>(null)
+  const [events, setEvents] = useState<FeedRealtimeEvent[]>([])
+
+  const setPhase = useFeedConnectionStore((s) => s.setPhase)
+  const setReconnectAttempt = useFeedConnectionStore((s) => s.setReconnectAttempt)
+  const resetFailedReconnects = useFeedConnectionStore((s) => s.resetFailedReconnects)
+  const recordLatency = useFeedConnectionStore((s) => s.recordLatency)
+  const setErrorMessage = useFeedConnectionStore((s) => s.setErrorMessage)
+
+  const snapshotQuery = useQuery({
+    queryKey: ['feed-snapshot'],
+    queryFn: fetchFeedSnapshot,
+    staleTime: 60_000,
+    retry: 2,
+  })
+
+  useEffect(() => {
+    if (!snapshotQuery.data) return
+    const seeded = snapshotToFeedState(snapshotQuery.data)
+    const merged = mergeFeedEvents(seeded, queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? [])
+    queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)
+    setEvents(merged)
+  }, [snapshotQuery.data, queryClient])
+
+  useEffect(() => {
+    const config = getAppSyncEventsConfig()
+    if (!config.enabled) {
+      setPhase('disconnected')
+      setErrorMessage('AppSync realtime not configured — S3 snapshot only')
+      return
+    }
+
+    const events = queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? []
+    const initialCursor = maxCursor(events)
+
+    const handleClientEvent = (event: RealtimeClientEvent) => {
+      switch (event.type) {
+        case 'connected':
+          setPhase('connected')
+          resetFailedReconnects()
+          setErrorMessage(null)
+          break
+        case 'reconnecting':
+          setPhase('reconnecting')
+          setReconnectAttempt(event.attempt)
+          break
+        case 'disconnected':
+          setPhase('disconnected')
+          setErrorMessage(event.reason)
+          break
+        case 'manual_retry_required':
+          setPhase('manual_retry')
+          setErrorMessage('Live feed disconnected after 12 reconnect attempts')
+          break
+        case 'feed_event':
+          recordLatency(event.latencyMs)
+          setEvents((prev) => {
+            const merged = mergeFeedEvents(prev, [event.event])
+            queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)
+            return merged
+          })
+          break
+        case 'gap_too_large':
+          setErrorMessage(event.signal.reason)
+          void snapshotQuery.refetch()
+          break
+        default:
+          break
+      }
+    }
+
+    setPhase('connecting')
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: initialCursor,
+      onEvent: handleClientEvent,
+    })
+    clientRef.current = client
+    client.start()
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        client.manualRetry()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      client.stop()
+      clientRef.current = null
+    }
+  }, [
+    queryClient,
+    recordLatency,
+    resetFailedReconnects,
+    setErrorMessage,
+    setPhase,
+    setReconnectAttempt,
+    snapshotQuery,
+  ])
+
+  const value: RealtimeFeedContextValue = {
+    events,
+    isHydrating: snapshotQuery.isPending,
+    isSnapshotError: snapshotQuery.isError,
+    refetchSnapshot: () => {
+      void snapshotQuery.refetch()
+    },
+    manualReconnect: () => {
+      clientRef.current?.manualRetry()
+      resetFailedReconnects()
+      setPhase('connecting')
+    },
+  }
+
+  return <RealtimeFeedContext.Provider value={value}>{children}</RealtimeFeedContext.Provider>
+}

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  AppSyncRealtimeClient,
+  BACKOFF_BASE_MS,
+  BACKOFF_CAP_MS,
+  GAP_CURSOR_THRESHOLD,
+  MAX_AUTO_RECONNECT_ATTEMPTS,
+} from './appsyncRealtimeClient'
+import type { AppSyncEventsConfig } from '../api/appsyncConfig'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static OPEN = 1
+
+  readyState = MockWebSocket.OPEN
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  sent: string[] = []
+
+  constructor(_url: string, _protocols: string[]) {
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = 3
+    this.onclose?.()
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+
+  open() {
+    this.onopen?.()
+  }
+}
+
+const config: AppSyncEventsConfig = {
+  httpHost: 'abc.appsync-api.us-west-2.amazonaws.com',
+  realtimeHost: 'abc.appsync-realtime-api.us-west-2.amazonaws.com',
+  apiKey: 'test-key',
+  region: 'us-west-2',
+  feedChannel: '/feed/updates',
+  enabled: true,
+}
+
+describe('AppSyncRealtimeClient', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    MockWebSocket.instances = []
+  })
+
+  it('sends connection_init then subscribes on connection_ack', () => {
+    const events: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => events.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    expect(socket.sent.some((msg) => msg.includes('connection_init'))).toBe(true)
+
+    socket.emit({ type: 'connection_ack' })
+    expect(socket.sent.some((msg) => msg.includes('subscribe'))).toBe(true)
+    expect(events).toContain('connected')
+    client.stop()
+  })
+
+  it('deduplicates feed events by eventId', () => {
+    const received: number[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => {
+        if (event.type === 'feed_event') received.push(event.event.cursor)
+      },
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+
+    const payload = {
+      eventId: 'evt-1',
+      recordId: 'ENC-TSK-1',
+      record_type: 'task',
+      action: 'updated',
+      actorType: 'agent',
+      actorId: 'ENC-SES-1',
+      summary: 'updated task',
+      cursor: 1_700_000_000_000,
+      channels: ['/feed/updates'],
+    }
+
+    socket.emit({ type: 'data', event: JSON.stringify(payload) })
+    socket.emit({ type: 'data', event: JSON.stringify(payload) })
+    expect(received).toEqual([1_700_000_000_000])
+    client.stop()
+  })
+
+  it('requires manual retry after max reconnect attempts', () => {
+    vi.useFakeTimers()
+    const phases: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => phases.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    for (let i = 0; i <= MAX_AUTO_RECONNECT_ATTEMPTS; i++) {
+      MockWebSocket.instances.at(-1)?.close()
+      vi.advanceTimersByTime(BACKOFF_CAP_MS)
+    }
+
+    expect(phases).toContain('manual_retry_required')
+    client.stop()
+  })
+
+  it('emits gap_too_large when cursor jump exceeds threshold', () => {
+    let gap = false
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 1,
+      onEvent: (event) => {
+        if (event.type === 'gap_too_large') gap = true
+      },
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+    socket.emit({
+      type: 'data',
+      event: JSON.stringify({
+        eventId: 'evt-gap',
+        recordId: 'ENC-TSK-9',
+        record_type: 'task',
+        action: 'updated',
+        actorType: 'agent',
+        actorId: 'ENC-SES-9',
+        summary: 'gap',
+        cursor: 1 + GAP_CURSOR_THRESHOLD + 1,
+        channels: ['/feed/updates'],
+      }),
+    })
+
+    expect(gap).toBe(true)
+    client.stop()
+  })
+})

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
@@ -1,0 +1,282 @@
+import type { AppSyncEventsConfig } from '../api/appsyncConfig'
+import type { FeedRealtimeEvent, GapTooLargeSignal } from '../types/feedEvents'
+
+export const GAP_CURSOR_THRESHOLD = 1_000_000_000 // ~1000 events at 1ms cursor spacing
+export const MAX_AUTO_RECONNECT_ATTEMPTS = 12
+export const HEARTBEAT_INTERVAL_MS = 30_000
+export const BACKOFF_BASE_MS = 500
+export const BACKOFF_CAP_MS = 30_000
+
+export type RealtimeClientEvent =
+  | { type: 'connected' }
+  | { type: 'disconnected'; reason: string }
+  | { type: 'feed_event'; event: FeedRealtimeEvent; latencyMs: number }
+  | { type: 'gap_too_large'; signal: GapTooLargeSignal }
+  | { type: 'manual_retry_required' }
+  | { type: 'reconnecting'; attempt: number; delayMs: number }
+
+export interface AppSyncRealtimeClientOptions {
+  config: AppSyncEventsConfig
+  lastCursor: number
+  onEvent: (event: RealtimeClientEvent) => void
+  webSocketFactory?: (url: string, protocols: string[]) => WebSocket
+}
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function buildAuthSubprotocol(config: AppSyncEventsConfig, sinceCursor?: number): string {
+  const header: Record<string, string> = {
+    host: config.httpHost,
+    'x-api-key': config.apiKey,
+  }
+  if (sinceCursor && sinceCursor > 0) {
+    header.since = String(sinceCursor)
+  }
+  return `header-${base64UrlEncode(JSON.stringify(header))}`
+}
+
+function parseFeedEvent(raw: unknown): FeedRealtimeEvent | null {
+  if (!raw || typeof raw !== 'object') return null
+  const event = raw as Partial<FeedRealtimeEvent>
+  if (
+    typeof event.eventId !== 'string' ||
+    typeof event.recordId !== 'string' ||
+    typeof event.summary !== 'string' ||
+    typeof event.cursor !== 'number'
+  ) {
+    return null
+  }
+  return event as FeedRealtimeEvent
+}
+
+function estimateServerMs(cursor: number): number {
+  return Math.floor(cursor / 1000)
+}
+
+export class AppSyncRealtimeClient {
+  private readonly config: AppSyncEventsConfig
+  private readonly onEvent: (event: RealtimeClientEvent) => void
+  private readonly wsFactory: (url: string, protocols: string[]) => WebSocket
+
+  private socket: WebSocket | null = null
+  private subscriptionId: string | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempt = 0
+  private disposed = false
+  private lastCursor: number
+  private seenEventIds = new Set<string>()
+
+  constructor(options: AppSyncRealtimeClientOptions) {
+    this.config = options.config
+    this.onEvent = options.onEvent
+    this.lastCursor = options.lastCursor
+    this.wsFactory =
+      options.webSocketFactory ??
+      ((url, protocols) => new WebSocket(url, protocols))
+  }
+
+  start(): void {
+    if (!this.config.enabled || this.disposed) return
+    this.connect()
+  }
+
+  stop(): void {
+    this.disposed = true
+    this.clearTimers()
+    if (this.socket) {
+      this.socket.close()
+      this.socket = null
+    }
+  }
+
+  /** User-initiated retry resets backoff and reconnects immediately. */
+  manualRetry(): void {
+    if (this.disposed || !this.config.enabled) return
+    this.reconnectAttempt = 0
+    this.clearTimers()
+    if (this.socket) {
+      this.socket.close()
+      this.socket = null
+    }
+    this.connect()
+  }
+
+  getLastCursor(): number {
+    return this.lastCursor
+  }
+
+  private connect(): void {
+    if (this.disposed || !this.config.enabled) return
+
+    const url = `wss://${this.config.realtimeHost}/event/realtime`
+    const protocols = ['aws-appsync-event-ws', buildAuthSubprotocol(this.config, this.lastCursor)]
+
+    try {
+      this.socket = this.wsFactory(url, protocols)
+    } catch (error) {
+      this.scheduleReconnect(`WebSocket constructor failed: ${String(error)}`)
+      return
+    }
+
+    const socket = this.socket
+    socket.onopen = () => {
+      socket.send(JSON.stringify({ type: 'connection_init' }))
+    }
+
+    socket.onmessage = (message) => {
+      this.handleMessage(message.data)
+    }
+
+    socket.onerror = () => {
+      // onclose will handle reconnect scheduling.
+    }
+
+    socket.onclose = () => {
+      this.clearHeartbeat()
+      if (!this.disposed) {
+        this.scheduleReconnect('socket closed')
+      }
+    }
+  }
+
+  private handleMessage(raw: unknown): void {
+    if (typeof raw !== 'string') return
+
+    let frame: { type?: string; id?: string; event?: unknown; errors?: unknown }
+    try {
+      frame = JSON.parse(raw) as { type?: string; id?: string; event?: unknown }
+    } catch {
+      return
+    }
+
+    if (frame.type === 'connection_ack') {
+      this.reconnectAttempt = 0
+      this.subscribe()
+      this.startHeartbeat()
+      this.onEvent({ type: 'connected' })
+      return
+    }
+
+    if (frame.type === 'ka') {
+      return
+    }
+
+    if (frame.type === 'error') {
+      this.onEvent({ type: 'disconnected', reason: JSON.stringify(frame.errors ?? frame) })
+      return
+    }
+
+    if (frame.type === 'data' && frame.event) {
+      if (typeof frame.event === 'string') {
+        try {
+          const parsed = JSON.parse(frame.event) as { type?: string }
+          if (parsed.type === 'gap_too_large') {
+            this.onEvent({
+              type: 'gap_too_large',
+              signal: {
+                type: 'gap_too_large',
+                lastCursor: this.lastCursor,
+                reason: 'server signaled gap_too_large',
+              },
+            })
+            return
+          }
+        } catch {
+          // fall through to feed event parse
+        }
+      }
+
+      const payload =
+        typeof frame.event === 'string' ? (JSON.parse(frame.event) as unknown) : frame.event
+      const feedEvent = parseFeedEvent(payload)
+      if (!feedEvent) return
+
+      if (this.seenEventIds.has(feedEvent.eventId)) return
+      this.seenEventIds.add(feedEvent.eventId)
+
+      const gap = feedEvent.cursor - this.lastCursor
+      if (this.lastCursor > 0 && gap > GAP_CURSOR_THRESHOLD) {
+        this.onEvent({
+          type: 'gap_too_large',
+          signal: {
+            type: 'gap_too_large',
+            lastCursor: this.lastCursor,
+            reason: `cursor gap ${gap} exceeds threshold`,
+          },
+        })
+      }
+
+      this.lastCursor = Math.max(this.lastCursor, feedEvent.cursor)
+      const latencyMs = Math.max(0, Date.now() - estimateServerMs(feedEvent.cursor))
+      this.onEvent({ type: 'feed_event', event: feedEvent, latencyMs })
+    }
+  }
+
+  private subscribe(): void {
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+
+    this.subscriptionId = crypto.randomUUID()
+    socket.send(
+      JSON.stringify({
+        type: 'subscribe',
+        id: this.subscriptionId,
+        channel: this.config.feedChannel,
+        authorization: {
+          host: this.config.httpHost,
+          'x-api-key': this.config.apiKey,
+          ...(this.lastCursor > 0 ? { since: String(this.lastCursor) } : {}),
+        },
+      }),
+    )
+  }
+
+  private startHeartbeat(): void {
+    this.clearHeartbeat()
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket?.readyState === WebSocket.OPEN) {
+        this.socket.send(JSON.stringify({ type: 'ka' }))
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  private scheduleReconnect(reason: string): void {
+    if (this.disposed) return
+
+    this.reconnectAttempt += 1
+    if (this.reconnectAttempt > MAX_AUTO_RECONNECT_ATTEMPTS) {
+      this.onEvent({ type: 'manual_retry_required' })
+      this.onEvent({ type: 'disconnected', reason: `manual retry required (${reason})` })
+      return
+    }
+
+    const exp = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * 2 ** (this.reconnectAttempt - 1))
+    const jitter = 0.5 + Math.random() * 0.5
+    const delayMs = Math.round(exp * jitter)
+
+    this.onEvent({ type: 'reconnecting', attempt: this.reconnectAttempt, delayMs })
+    this.clearTimers()
+    this.reconnectTimer = setTimeout(() => this.connect(), delayMs)
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private clearTimers(): void {
+    this.clearHeartbeat()
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+}

--- a/frontend/ui-v2/src/realtime/feedEventReducer.test.ts
+++ b/frontend/ui-v2/src/realtime/feedEventReducer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterFeedEvents,
+  mergeFeedEvents,
+  maxCursor,
+} from './feedEventReducer'
+import type { FeedRealtimeEvent } from '../../types/feedEvents'
+
+function event(partial: Partial<FeedRealtimeEvent> & Pick<FeedRealtimeEvent, 'eventId' | 'cursor'>): FeedRealtimeEvent {
+  return {
+    recordId: 'ENC-TSK-001',
+    record_type: 'task',
+    action: 'updated',
+    actorType: 'agent',
+    actorId: 'ENC-SES-001',
+    summary: 'test',
+    channels: ['/feed/updates'],
+    ...partial,
+  }
+}
+
+describe('feedEventReducer', () => {
+  it('merges by eventId and sorts by cursor desc', () => {
+    const a = event({ eventId: 'a', cursor: 100 })
+    const b = event({ eventId: 'b', cursor: 200 })
+    const merged = mergeFeedEvents([a], [b, { ...a, summary: 'updated' }])
+    expect(merged).toHaveLength(2)
+    expect(merged[0]?.eventId).toBe('b')
+    expect(merged.find((e) => e.eventId === 'a')?.summary).toBe('updated')
+  })
+
+  it('filters by record type when filters are active', () => {
+    const tasks = event({ eventId: 't1', cursor: 1, record_type: 'task' })
+    const issues = event({ eventId: 'i1', cursor: 2, record_type: 'issue' })
+    const filtered = filterFeedEvents([tasks, issues], ['task'])
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.record_type).toBe('task')
+  })
+
+  it('computes max cursor', () => {
+    expect(maxCursor([event({ eventId: 'a', cursor: 10 }), event({ eventId: 'b', cursor: 99 })])).toBe(99)
+  })
+})

--- a/frontend/ui-v2/src/realtime/feedEventReducer.ts
+++ b/frontend/ui-v2/src/realtime/feedEventReducer.ts
@@ -1,0 +1,30 @@
+import type { FeedRealtimeEvent, FeedSnapshot } from '../types/feedEvents'
+
+export const REALTIME_FEED_QUERY_KEY = ['realtime-feed'] as const
+
+export function mergeFeedEvents(
+  existing: FeedRealtimeEvent[],
+  incoming: FeedRealtimeEvent[],
+): FeedRealtimeEvent[] {
+  const byId = new Map<string, FeedRealtimeEvent>()
+  for (const event of existing) byId.set(event.eventId, event)
+  for (const event of incoming) byId.set(event.eventId, event)
+  return Array.from(byId.values()).sort((a, b) => b.cursor - a.cursor)
+}
+
+export function snapshotToFeedState(snapshot: FeedSnapshot): FeedRealtimeEvent[] {
+  return [...snapshot.events].sort((a, b) => b.cursor - a.cursor)
+}
+
+export function filterFeedEvents(
+  events: FeedRealtimeEvent[],
+  recordTypes: string[],
+): FeedRealtimeEvent[] {
+  if (recordTypes.length === 0) return events
+  const allowed = new Set(recordTypes)
+  return events.filter((event) => allowed.has(event.record_type))
+}
+
+export function maxCursor(events: FeedRealtimeEvent[]): number {
+  return events.reduce((max, event) => Math.max(max, event.cursor), 0)
+}

--- a/frontend/ui-v2/src/shell/FeedPane.tsx
+++ b/frontend/ui-v2/src/shell/FeedPane.tsx
@@ -1,16 +1,46 @@
+import { useMemo } from 'react'
 import { useUiStore } from '../store/uiStore'
+import { useFeedConnectionStore } from '../store/feedConnectionStore'
+import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
+import { filterFeedEvents } from '../realtime/feedEventReducer'
 import type { RecordType } from '../types/records'
 
 const FILTERABLE: RecordType[] = ['task', 'issue', 'feature', 'plan', 'lesson', 'document']
 
-/**
- * Feed placeholder pane. Live feed data lands in a later task; here it renders
- * the UI-only filter surface driven entirely by the Zustand store (AC-13 — no
- * server state, no useState holding record fields).
- */
+function phaseLabel(phase: string): string {
+  switch (phase) {
+    case 'connected':
+      return 'Live'
+    case 'connecting':
+      return 'Connecting…'
+    case 'reconnecting':
+      return 'Reconnecting…'
+    case 'manual_retry':
+      return 'Disconnected'
+    case 'disconnected':
+      return 'Offline (S3 snapshot)'
+    default:
+      return 'Idle'
+  }
+}
+
 export function FeedPane() {
   const filters = useUiStore((s) => s.filters)
   const toggleFilterType = useUiStore((s) => s.toggleFilterType)
+
+  const phase = useFeedConnectionStore((s) => s.phase)
+  const reconnectAttempt = useFeedConnectionStore((s) => s.reconnectAttempt)
+  const p50LatencyMs = useFeedConnectionStore((s) => s.p50LatencyMs)
+  const p99LatencyMs = useFeedConnectionStore((s) => s.p99LatencyMs)
+  const errorMessage = useFeedConnectionStore((s) => s.errorMessage)
+
+  const { events, isHydrating, isSnapshotError, refetchSnapshot, manualReconnect } =
+    useRealtimeFeed()
+
+  const visibleEvents = useMemo(
+    () => filterFeedEvents(events, filters.recordTypes),
+    [events, filters.recordTypes],
+  )
 
   return (
     <aside
@@ -21,23 +51,45 @@ export function FeedPane() {
         background: 'var(--bg-surface)',
         padding: 'var(--space-5)',
         overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-4)',
       }}
     >
-      <h4
-        style={{
-          fontFamily: 'var(--font-heading)',
-          fontSize: 'var(--text-xs)',
-          fontWeight: 'var(--fw-bold)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.09em',
-          color: 'var(--accent)',
-          margin: '0 0 var(--space-4)',
-        }}
-      >
-        Feed
-      </h4>
+      <div>
+        <h4
+          style={{
+            fontFamily: 'var(--font-heading)',
+            fontSize: 'var(--text-xs)',
+            fontWeight: 'var(--fw-bold)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.09em',
+            color: 'var(--accent)',
+            margin: '0 0 var(--space-2)',
+          }}
+        >
+          Feed
+        </h4>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-xs)',
+            color: 'var(--fg-muted)',
+            fontFamily: 'var(--font-mono)',
+          }}
+        >
+          {phaseLabel(phase)}
+          {reconnectAttempt > 0 ? ` · attempt ${reconnectAttempt}` : ''}
+        </p>
+        {p50LatencyMs !== null && (
+          <p style={{ margin: 'var(--space-1) 0 0', fontSize: 'var(--text-xs)', color: 'var(--fg-muted)' }}>
+            P50 {Math.round(p50LatencyMs)}ms
+            {p99LatencyMs !== null ? ` · P99 ${Math.round(p99LatencyMs)}ms` : ''}
+          </p>
+        )}
+      </div>
 
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)', marginBottom: 'var(--space-5)' }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)' }}>
         {FILTERABLE.map((type) => {
           const active = filters.recordTypes.includes(type)
           return (
@@ -64,10 +116,67 @@ export function FeedPane() {
         })}
       </div>
 
-      <p style={{ color: 'var(--fg-muted)', fontSize: 'var(--text-sm)', lineHeight: 'var(--lh-relaxed)' }}>
-        Live feed lands in a later task. Filters above are UI-only state held in
-        the Zustand store.
-      </p>
+      {(phase === 'manual_retry' || isSnapshotError) && (
+        <div role="alert" aria-live="assertive">
+          <p style={{ color: 'var(--fg-muted)', fontSize: 'var(--text-sm)', margin: '0 0 var(--space-2)' }}>
+            {errorMessage ?? 'Feed snapshot failed to load.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              manualReconnect()
+              refetchSnapshot()
+            }}
+            style={{
+              fontFamily: 'var(--font-heading)',
+              fontSize: 'var(--text-xs)',
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-sm)',
+              border: '1px solid var(--accent)',
+              background: 'rgba(61,155,168,0.12)',
+              color: 'var(--accent-hover)',
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        {isHydrating && visibleEvents.length === 0 && (
+          <p style={{ color: 'var(--fg-muted)', fontSize: 'var(--text-sm)' }}>Loading snapshot…</p>
+        )}
+        {!isHydrating && visibleEvents.length === 0 && (
+          <p style={{ color: 'var(--fg-muted)', fontSize: 'var(--text-sm)' }}>
+            No feed events yet. S3 snapshot and AppSync WSS will populate this pane.
+          </p>
+        )}
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+          {visibleEvents.slice(0, 30).map((event) => (
+            <li
+              key={event.eventId}
+              style={{
+                borderLeft: '2px solid rgba(61,155,168,0.35)',
+                paddingLeft: 'var(--space-3)',
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--accent)',
+                }}
+              >
+                {event.recordId}
+              </div>
+              <div style={{ fontSize: 'var(--text-sm)', color: 'var(--fg)', lineHeight: 'var(--lh-relaxed)' }}>
+                {event.summary}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
     </aside>
   )
 }

--- a/frontend/ui-v2/src/store/feedConnectionStore.ts
+++ b/frontend/ui-v2/src/store/feedConnectionStore.ts
@@ -1,0 +1,68 @@
+/**
+ * UI-only realtime connection surface (AC-13).
+ * Connection phase, reconnect attempt counts, and latency samples are ephemeral
+ * client telemetry — not server record fields.
+ */
+
+import { create } from 'zustand'
+import type { RealtimeConnectionPhase } from '../types/feedEvents'
+
+interface FeedConnectionState {
+  phase: RealtimeConnectionPhase
+  reconnectAttempt: number
+  failedReconnects: number
+  lastLatencyMs: number | null
+  p50LatencyMs: number | null
+  p99LatencyMs: number | null
+  latencySamples: number[]
+  errorMessage: string | null
+
+  setPhase: (phase: RealtimeConnectionPhase) => void
+  setReconnectAttempt: (attempt: number) => void
+  incrementFailedReconnects: () => void
+  resetFailedReconnects: () => void
+  recordLatency: (latencyMs: number) => void
+  setErrorMessage: (message: string | null) => void
+  resetLatency: () => void
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+  return sorted[index] ?? null
+}
+
+export const useFeedConnectionStore = create<FeedConnectionState>((set, get) => ({
+  phase: 'idle',
+  reconnectAttempt: 0,
+  failedReconnects: 0,
+  lastLatencyMs: null,
+  p50LatencyMs: null,
+  p99LatencyMs: null,
+  latencySamples: [],
+  errorMessage: null,
+
+  setPhase: (phase) => set({ phase }),
+  setReconnectAttempt: (attempt) => set({ reconnectAttempt: attempt }),
+  incrementFailedReconnects: () =>
+    set((state) => ({ failedReconnects: state.failedReconnects + 1 })),
+  resetFailedReconnects: () => set({ failedReconnects: 0, reconnectAttempt: 0 }),
+  recordLatency: (latencyMs) => {
+    const samples = [...get().latencySamples, latencyMs].slice(-200)
+    set({
+      lastLatencyMs: latencyMs,
+      latencySamples: samples,
+      p50LatencyMs: percentile(samples, 50),
+      p99LatencyMs: percentile(samples, 99),
+    })
+  },
+  setErrorMessage: (message) => set({ errorMessage: message }),
+  resetLatency: () =>
+    set({
+      lastLatencyMs: null,
+      p50LatencyMs: null,
+      p99LatencyMs: null,
+      latencySamples: [],
+    }),
+}))

--- a/frontend/ui-v2/src/test/setup.ts
+++ b/frontend/ui-v2/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/frontend/ui-v2/src/types/feedEvents.ts
+++ b/frontend/ui-v2/src/types/feedEvents.ts
@@ -1,0 +1,37 @@
+/** AppSync Events payload contract (B67 AC-10 / appsync_feed_publisher). */
+
+export type FeedAction = 'created' | 'updated' | 'closed' | 'removed'
+export type FeedActorType = 'human' | 'agent'
+
+export interface FeedRealtimeEvent {
+  eventId: string
+  recordId: string
+  record_type: string
+  action: FeedAction
+  actorType: FeedActorType
+  actorId: string
+  summary: string
+  cursor: number
+  channels: string[]
+}
+
+export interface FeedSnapshot {
+  events: FeedRealtimeEvent[]
+  hydratedAt: string
+  source: 's3' | 'realtime'
+}
+
+export type RealtimeConnectionPhase =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'manual_retry'
+
+/** Client-side signal when cursor gap exceeds replay threshold (DOC-E470AC8CE9A8 §5.4). */
+export interface GapTooLargeSignal {
+  type: 'gap_too_large'
+  lastCursor: number
+  reason: string
+}

--- a/frontend/ui-v2/vitest.config.ts
+++ b/frontend/ui-v2/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./src/test/setup.ts'],
+    },
+  }),
+)


### PR DESCRIPTION
## Summary
- Add AppSync Events WebSocket client for ui-v2 with exponential backoff reconnect, 30s heartbeat, cursor replay on subscribe, and manual retry after 12 failures.
- Hydrate FeedPane from S3 snapshot (`/mobile/v1`) as cold-start and WSS-down fallback; merge live events with dedup by `eventId`.
- Bootstrap vitest in ui-v2 with unit tests for realtime merge logic and WSS lifecycle behavior.

CCI-ac86effd84b24b7e952811678f8b9a93

## Test plan
- [x] `cd frontend/ui-v2 && npm run typecheck`
- [x] `cd frontend/ui-v2 && npm test` (7 tests)
- [ ] CI / Frontend UI Tests on PR
- [ ] Gamma deploy (web_deploy lane when AppSync env vars are wired)


Made with [Cursor](https://cursor.com)