### PR TITLE
fix(graph-health-metrics): real Fiedler lambda2 replaces GraphEdgeDensity placeholder [ENC-TSK-K43]

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.30",
-  "updated_at": "2026-07-02T13:00:00Z",
-  "last_change_summary": "ENC-TSK-K41 (B66 Ph5, ENC-PLN-064): Corpus Entropy Engine (CEE) Lambda -- nightly EventBridge (gamma, cron 05:00 UTC) telemetry-only scan for five entropy categories: orphan (no parent_task_id/related_task_ids or wave doc missing plan_anchor_id), stagnation (open tasks with no worklog within STAGNATION_THRESHOLD_DAYS=14), relational (declared related_*_ids with no corresponding graph_query_api adjacency edge), retention (Lesson stability < FSRS_T3_THRESHOLD=0.7, falling back to resonance_score), and compliance/semantic (document compliance_score below COMPLIANCE_SCORE_THRESHOLD=70 AND document_maturity_state=raw). Reads exclusively through the tracker/document/graph_query_api HTTP surface (no direct DynamoDB access, no new edge types -- OGTM). CEE_HARD_DISABLED=1 kill switch ships ON by default; io clears to 0 to enable the first scheduled run. Emits per-category EntropyFindingCount to CloudWatch namespace Enceladus/CEE. Cost-preflight (ISS-465): nightly cadence, 512MB/300s ceiling, well under $1/mo; CorpusEntropyEngineCostHeadroomAlarm guards EventBridge invocation count. New entity corpus_entropy_engine.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "version": "2026-07-02.31",
+  "updated_at": "2026-07-02T14:00:00Z",
+  "last_change_summary": "ENC-TSK-K43 (B66 Ph5) follow-up: FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2 via a cross-Lambda invoke from graph_health_metrics into graph_query_api's action='publish_graph_health' (FTR-088 CSR/Fiedler path, ISS-465-compliant), replacing the pre-K43 GraphEdgeDensity placeholder. New entity graph_health_metrics.real_fiedler_lambda2.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6272,6 +6272,15 @@
         }
       }
     },
+    "graph_health_metrics.real_fiedler_lambda2": {
+      "description": "ENC-TSK-K43 (B66 Ph5): FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2, not the pre-K43 GraphEdgeDensity placeholder. graph_health_metrics._fetch_real_fiedler_value cross-Lambda-invokes devops-graph-query-api's action='publish_graph_health' (the FTR-088 CSR/Fiedler path, ISS-465-compliant -- no GDS) and folds lambda2 into this Lambda's own metrics dict. Falls back to the original GraphEdgeDensity proxy only if the invoke fails, never blocking GraphNodeCount/GraphEdgeDensity/OrphanNodeRatio.",
+      "fields": {
+        "GRAPH_QUERY_API_LAMBDA_NAME": {
+          "type": "string",
+          "definition": "Cross-Lambda invoke target function name (default devops-graph-query-api, env-suffix-aware via CFN Sub)."
+        }
+      }
+    },
     "graph_query_api.graph_laplacian": {
       "description": "ENC-TSK-I81 (FTR-088): graph Laplacian read action via tracker.graph_laplacian. Returns adjacency_csr (base64 float32 CSR), fiedler_vector, eigenvalues[:k], vertex_map. Uses scipy.sparse.linalg.eigsh.",
       "fields": {
@@ -7264,6 +7273,11 @@
       "version": "2026-07-02.30",
       "date": "2026-07-02",
       "summary": "ENC-TSK-K41 (B66 Ph5, ENC-PLN-064): Corpus Entropy Engine (CEE) Lambda -- nightly EventBridge (gamma, cron 05:00 UTC) telemetry-only scan for five entropy categories: orphan (no parent_task_id/related_task_ids or wave doc missing plan_anchor_id), stagnation (open tasks with no worklog within STAGNATION_THRESHOLD_DAYS=14), relational (declared related_*_ids with no corresponding graph_query_api adjacency edge), retention (Lesson stability < FSRS_T3_THRESHOLD=0.7, falling back to resonance_score), and compliance/semantic (document compliance_score below COMPLIANCE_SCORE_THRESHOLD=70 AND document_maturity_state=raw). Reads exclusively through the tracker/document/graph_query_api HTTP surface (no direct DynamoDB access, no new edge types -- OGTM). CEE_HARD_DISABLED=1 kill switch ships ON by default; io clears to 0 to enable the first scheduled run. Emits per-category EntropyFindingCount to CloudWatch namespace Enceladus/CEE. Cost-preflight (ISS-465): nightly cadence, 512MB/300s ceiling, well under $1/mo; CorpusEntropyEngineCostHeadroomAlarm guards EventBridge invocation count. New entity corpus_entropy_engine.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.31",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K43 (B66 Ph5) follow-up: FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2 via a cross-Lambda invoke from graph_health_metrics into graph_query_api's action='publish_graph_health' (FTR-088 CSR/Fiedler path, ISS-465-compliant), replacing the pre-K43 GraphEdgeDensity placeholder. New entity graph_health_metrics.real_fiedler_lambda2."
     }
   ]
 }

--- a/backend/lambda/graph_health_metrics/lambda_function.py
+++ b/backend/lambda/graph_health_metrics/lambda_function.py
@@ -1,21 +1,35 @@
 """
 Enceladus Graph Health Metrics Lambda — ENC-TSK-C10 / AC-13 (CloudWatch Proxy Path)
+Updated ENC-TSK-K43 (B66 Ph5): FiedlerAlgebraicConnectivity now carries the
+REAL Fiedler lambda2 (algebraic connectivity), not the GraphEdgeDensity proxy.
 
-Computes graph health proxy metrics and publishes to CloudWatch.
-GDS is unavailable on the current AuraDB tier, so this Lambda uses pure Cypher
-queries to compute proxy metrics instead of native Fiedler λ₂ computation.
+Computes graph health proxy metrics and publishes to CloudWatch. GDS is
+unavailable on the current AuraDB tier (ISS-465 additionally hard-forbids any
+standing GDS projection), so node/edge/orphan counts still use pure Cypher.
+FiedlerAlgebraicConnectivity, however, is now sourced from the real FTR-088
+graph_laplacian CSR/Fiedler path via a cross-Lambda invoke into
+devops-graph-query-api's action='publish_graph_health' entrypoint (see
+_fetch_real_fiedler_value) -- that entrypoint uses a BOUNDED induced subgraph
++ scipy.sparse.linalg.eigsh, which is the only tractable eigensolver at
+Enceladus's ~1,500-node scale (dense Jacobi over the unbounded full graph this
+Lambda already queries would be O(n^3) and infeasible in pure Python). Falls
+back to the original GraphEdgeDensity proxy only if that invoke fails.
 
 Metrics published:
   - GraphEdgeDensity (edges / nodes) in Enceladus/GraphHealth
   - OrphanNodeRatio (orphan nodes / total nodes) in Enceladus/GraphHealth
   - GraphNodeCount (total node count) in Enceladus/GraphHealth
+  - FiedlerAlgebraicConnectivity (real lambda2 via graph_query_api; proxy
+    GraphEdgeDensity value on invoke failure) in Enceladus/GraphHealth
 
 Triggered by EventBridge on a daily schedule.
 
 Environment variables:
-  NEO4J_SECRET_NAME    Secrets Manager secret ID (default: enceladus/neo4j/auradb-credentials)
-  CLOUDWATCH_NAMESPACE CloudWatch namespace (default: Enceladus/GraphHealth)
-  PROJECT_ID           Project dimension value (default: enceladus)
+  NEO4J_SECRET_NAME          Secrets Manager secret ID (default: enceladus/neo4j/auradb-credentials)
+  CLOUDWATCH_NAMESPACE       CloudWatch namespace (default: Enceladus/GraphHealth)
+  PROJECT_ID                 Project dimension value (default: enceladus)
+  GRAPH_QUERY_API_LAMBDA_NAME  Function name for the ENC-TSK-K43 cross-Lambda
+                                Fiedler lambda2 invoke (default: devops-graph-query-api)
 """
 
 import json
@@ -34,6 +48,19 @@ logger.setLevel(logging.INFO)
 NEO4J_SECRET_NAME = os.environ.get("NEO4J_SECRET_NAME", "enceladus/neo4j/auradb-credentials")
 CLOUDWATCH_NAMESPACE = os.environ.get("CLOUDWATCH_NAMESPACE", "Enceladus/GraphHealth")
 PROJECT_ID = os.environ.get("PROJECT_ID", "enceladus")
+
+# ENC-TSK-K43 (B66 Ph5): real Fiedler lambda2 via a cross-Lambda invoke into
+# devops-graph-query-api's action='publish_graph_health' entrypoint (FTR-088
+# graph_laplacian CSR/Fiedler path -- scipy eigsh/dense eigh over a BOUNDED
+# induced subgraph, never Neo4j GDS/AGA per ISS-465). Dense Jacobi
+# eigendecomposition over the FULL graph (this Lambda's existing
+# MATCH (n) RETURN count(n) query has no upper bound; DOC-A3D0CDF91CE9 Q3.3
+# estimates ~1,500 nodes at Enceladus scale) is O(n^3) and infeasible in pure
+# Python inside a Lambda -- graph_query_api._query_laplacian's
+# LAPLACIAN_MAX_VERTICES=500 cap plus scipy.sparse.linalg.eigsh is the only
+# tractable path at this corpus size, so this Lambda delegates rather than
+# reimplementing a second (necessarily also-bounded) eigensolver here.
+GRAPH_QUERY_API_LAMBDA_NAME = os.environ.get("GRAPH_QUERY_API_LAMBDA_NAME", "devops-graph-query-api")
 
 # --- ENC-TSK-I10 (Dedup P6) convergence-probe configuration ----------------
 # Governed dedup-convergence signals (DOC-DF651F07D5C2 §10) are published to
@@ -63,6 +90,50 @@ def _dedup_int(name: str, default: int) -> int:
 
 _neo4j_driver = None
 _creds_cache = None
+_lambda_client = None
+
+
+def _get_lambda_client():
+    global _lambda_client
+    if _lambda_client is None:
+        _lambda_client = boto3.client("lambda")
+    return _lambda_client
+
+
+def _fetch_real_fiedler_value() -> Dict[str, Any]:
+    """ENC-TSK-K43: cross-Lambda invoke into devops-graph-query-api's
+    action='publish_graph_health' entrypoint to obtain the REAL Fiedler
+    lambda2 (algebraic connectivity) via the bounded FTR-088 CSR/Fiedler path
+    (graph_health_metric.compute_fiedler_value -> lambda_function._query_laplacian).
+    That entrypoint already publishes its own Enceladus/GraphHealth datapoint
+    (metric FiedlerValue) as a side effect -- this call additionally folds the
+    lambda2 scalar into THIS Lambda's own metrics dict so the legacy
+    FiedlerAlgebraicConnectivity metric name (ENC-TSK-C10) carries the real
+    value too, preserving any existing alarms/dashboards keyed on it.
+
+    Returns {"ok": True, "lambda2": float} on success, or {"ok": False,
+    "error": str} on any invoke/parse failure -- never raises, so a
+    graph_query_api outage degrades this probe rather than breaking it (same
+    contract as the pre-existing dedup-convergence isolation in handler())."""
+    try:
+        response = _get_lambda_client().invoke(
+            FunctionName=GRAPH_QUERY_API_LAMBDA_NAME,
+            InvocationType="RequestResponse",
+            Payload=json.dumps({"action": "publish_graph_health", "project_id": PROJECT_ID}).encode("utf-8"),
+        )
+        payload_raw = response.get("Payload").read()
+        decoded = payload_raw.decode("utf-8") if isinstance(payload_raw, (bytes, bytearray)) else str(payload_raw)
+        body = json.loads(decoded or "{}")
+        if response.get("FunctionError"):
+            return {"ok": False, "error": f"FunctionError: {body}"}
+        results = body.get("results") or []
+        for result in results:
+            if result.get("ok") and result.get("project_id") == PROJECT_ID:
+                return {"ok": True, "lambda2": float(result["lambda2"])}
+        return {"ok": False, "error": f"no successful lambda2 result for project_id={PROJECT_ID}: {body}"}
+    except Exception as exc:  # pragma: no cover - defensive, mirrors dedup probe isolation
+        logger.warning("[WARNING] cross-Lambda publish_graph_health invoke failed: %s", exc)
+        return {"ok": False, "error": str(exc)}
 
 
 def _get_neo4j_creds():
@@ -120,9 +191,21 @@ def _compute_metrics(driver) -> Dict[str, float]:
         else:
             metrics["OrphanNodeRatio"] = 0.0
 
-        # Also publish FiedlerLambda2 as the proxy value (edge density as placeholder)
-        # This satisfies the CloudWatch metric name requirement while GDS is unavailable
-        metrics["FiedlerAlgebraicConnectivity"] = metrics["GraphEdgeDensity"]
+        # ENC-TSK-K43 (B66 Ph5): real Fiedler lambda2 via the FTR-088 CSR/
+        # Fiedler path (cross-Lambda invoke into graph_query_api, see
+        # _fetch_real_fiedler_value). Falls back to the original GraphEdgeDensity
+        # proxy (the pre-K43 ENC-TSK-C10 placeholder, documented above) only if
+        # the invoke fails -- never blocks the rest of this Lambda's metrics.
+        fiedler = _fetch_real_fiedler_value()
+        if fiedler.get("ok"):
+            metrics["FiedlerAlgebraicConnectivity"] = fiedler["lambda2"]
+        else:
+            logger.warning(
+                "[WARNING] real Fiedler lambda2 unavailable (%s); falling back to "
+                "GraphEdgeDensity proxy for FiedlerAlgebraicConnectivity",
+                fiedler.get("error"),
+            )
+            metrics["FiedlerAlgebraicConnectivity"] = metrics["GraphEdgeDensity"]
 
     return metrics
 

--- a/backend/lambda/graph_health_metrics/test_fiedler_k43.py
+++ b/backend/lambda/graph_health_metrics/test_fiedler_k43.py
@@ -1,0 +1,199 @@
+"""Unit tests for ENC-TSK-K43 (B66 Ph5) real Fiedler lambda2 wiring in
+graph_health_metrics.
+
+Prior to K43, FiedlerAlgebraicConnectivity was a placeholder aliased to
+GraphEdgeDensity (documented in the ENC-TSK-C10 module docstring as a stopgap
+while GDS was unavailable). K43 replaces it with the REAL Fiedler lambda2 via
+a cross-Lambda invoke into devops-graph-query-api's action='publish_graph_health'
+entrypoint (the FTR-088 CSR/Fiedler path, ISS-465-compliant -- no GDS
+projection), falling back to the GraphEdgeDensity proxy only if that invoke
+fails.
+
+Covers:
+  - _fetch_real_fiedler_value: successful invoke parses the nested
+    publish_graph_health response and extracts lambda2 for the right
+    project_id; a FunctionError, malformed payload, or no matching
+    project_id result all degrade to {"ok": False, ...} rather than raising.
+  - _compute_metrics: FiedlerAlgebraicConnectivity carries the REAL lambda2
+    on a successful invoke (and is NOT equal to the GraphEdgeDensity proxy
+    when the two values differ), and falls back to the GraphEdgeDensity
+    proxy when the invoke fails -- preserving the pre-K43 degrade behavior
+    exactly (never blocks GraphNodeCount/GraphEdgeDensity/OrphanNodeRatio).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+# dedup_convergence is packaged in via .build_extras at deploy time; for local
+# tests resolve it from its canonical owner (graph_query_api), appended LAST so
+# it never shadows this dir's lambda_function.
+sys.path.append(str(_HERE.parent / "graph_query_api"))
+sys.path.insert(0, str(_HERE))
+
+import lambda_function as lf  # noqa: E402
+
+
+class _FakePayload:
+    def __init__(self, body: dict):
+        self._raw = json.dumps(body).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+
+class _FakeLambdaClient:
+    def __init__(self, response=None, raise_exc=None):
+        self._response = response
+        self._raise_exc = raise_exc
+        self.invoke_calls = []
+
+    def invoke(self, **kwargs):
+        self.invoke_calls.append(kwargs)
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+
+def _publish_graph_health_response(lambda2: float, project_id: str = "enceladus", ok: bool = True):
+    body = {
+        "ok": ok,
+        "published": 1 if ok else 0,
+        "namespace": "Enceladus/GraphHealth",
+        "results": [{"ok": ok, "lambda2": lambda2, "project_id": project_id}],
+    }
+    return {"Payload": _FakePayload(body)}
+
+
+class FetchRealFiedlerValueTests(unittest.TestCase):
+    def setUp(self):
+        lf._lambda_client = None  # reset lazy singleton between tests
+
+    def test_successful_invoke_extracts_lambda2(self):
+        lf._get_lambda_client = lambda: _FakeLambdaClient(_publish_graph_health_response(0.42))
+        result = lf._fetch_real_fiedler_value()
+        self.assertEqual(result, {"ok": True, "lambda2": 0.42})
+
+    def test_invoke_payload_shape(self):
+        fake = _FakeLambdaClient(_publish_graph_health_response(0.1))
+        lf._get_lambda_client = lambda: fake
+        lf._fetch_real_fiedler_value()
+        self.assertEqual(len(fake.invoke_calls), 1)
+        call = fake.invoke_calls[0]
+        self.assertEqual(call["FunctionName"], lf.GRAPH_QUERY_API_LAMBDA_NAME)
+        self.assertEqual(call["InvocationType"], "RequestResponse")
+        payload = json.loads(call["Payload"].decode("utf-8"))
+        self.assertEqual(payload["action"], "publish_graph_health")
+        self.assertEqual(payload["project_id"], lf.PROJECT_ID)
+
+    def test_function_error_degrades_gracefully(self):
+        response = _publish_graph_health_response(0.5)
+        response["FunctionError"] = "Unhandled"
+        lf._get_lambda_client = lambda: _FakeLambdaClient(response)
+        result = lf._fetch_real_fiedler_value()
+        self.assertFalse(result["ok"])
+        self.assertIn("FunctionError", result["error"])
+
+    def test_no_matching_project_result_degrades_gracefully(self):
+        lf._get_lambda_client = lambda: _FakeLambdaClient(
+            _publish_graph_health_response(0.3, project_id="other-project")
+        )
+        result = lf._fetch_real_fiedler_value()
+        self.assertFalse(result["ok"])
+
+    def test_all_projects_failed_degrades_gracefully(self):
+        lf._get_lambda_client = lambda: _FakeLambdaClient(
+            _publish_graph_health_response(0.3, ok=False)
+        )
+        result = lf._fetch_real_fiedler_value()
+        self.assertFalse(result["ok"])
+
+    def test_exception_during_invoke_degrades_gracefully(self):
+        lf._get_lambda_client = lambda: _FakeLambdaClient(raise_exc=RuntimeError("network unreachable"))
+        result = lf._fetch_real_fiedler_value()
+        self.assertFalse(result["ok"])
+        self.assertIn("network unreachable", result["error"])
+
+    def test_malformed_payload_degrades_gracefully(self):
+        class _BadPayload:
+            def read(self):
+                return b"{not-json"
+
+        lf._get_lambda_client = lambda: _FakeLambdaClient({"Payload": _BadPayload()})
+        result = lf._fetch_real_fiedler_value()
+        self.assertFalse(result["ok"])
+
+
+class _Sess:
+    def __init__(self, driver):
+        self._d = driver
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def run(self, cypher, **params):
+        if "orphans" in cypher:
+            return _Single({"orphans": self._d.orphan_count})
+        if "count(n)" in cypher:
+            return _Single({"total": self._d.node_count})
+        if "count(r)" in cypher:
+            return _Single({"total": self._d.edge_count})
+        return _Single({})
+
+
+class _Single:
+    def __init__(self, d):
+        self._d = d
+
+    def single(self):
+        return self._d
+
+
+class _Driver:
+    def __init__(self, node_count=10, edge_count=20, orphan_count=1):
+        self.node_count = node_count
+        self.edge_count = edge_count
+        self.orphan_count = orphan_count
+
+    def session(self):
+        return _Sess(self)
+
+
+class ComputeMetricsTests(unittest.TestCase):
+    def setUp(self):
+        lf._lambda_client = None
+
+    def test_fiedler_algebraic_connectivity_uses_real_value_on_success(self):
+        driver = _Driver(node_count=10, edge_count=20, orphan_count=1)  # GraphEdgeDensity = 2.0
+        lf._fetch_real_fiedler_value = lambda: {"ok": True, "lambda2": 0.37}
+        metrics = lf._compute_metrics(driver)
+        self.assertEqual(metrics["FiedlerAlgebraicConnectivity"], 0.37)
+        self.assertEqual(metrics["GraphEdgeDensity"], 2.0)
+        # The real value must differ from (not silently equal) the old proxy,
+        # proving this is no longer the GraphEdgeDensity alias.
+        self.assertNotEqual(metrics["FiedlerAlgebraicConnectivity"], metrics["GraphEdgeDensity"])
+
+    def test_fiedler_algebraic_connectivity_falls_back_to_proxy_on_failure(self):
+        driver = _Driver(node_count=10, edge_count=20, orphan_count=1)  # GraphEdgeDensity = 2.0
+        lf._fetch_real_fiedler_value = lambda: {"ok": False, "error": "graph_query_api unavailable"}
+        metrics = lf._compute_metrics(driver)
+        self.assertEqual(metrics["FiedlerAlgebraicConnectivity"], metrics["GraphEdgeDensity"])
+        self.assertEqual(metrics["FiedlerAlgebraicConnectivity"], 2.0)
+
+    def test_other_metrics_unaffected_by_fiedler_fetch(self):
+        driver = _Driver(node_count=50, edge_count=75, orphan_count=3)
+        lf._fetch_real_fiedler_value = lambda: {"ok": True, "lambda2": 0.15}
+        metrics = lf._compute_metrics(driver)
+        self.assertEqual(metrics["GraphNodeCount"], 50.0)
+        self.assertEqual(metrics["GraphEdgeDensity"], 1.5)
+        self.assertEqual(metrics["OrphanNodeRatio"], 0.06)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1748,6 +1748,9 @@ Resources:
           CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
           PROJECT_ID: enceladus
           SECRETS_REGION: !Ref "AWS::Region"
+          # ENC-TSK-K43: cross-Lambda invoke target for the real Fiedler lambda2
+          # (FTR-088 CSR/Fiedler path, ISS-465-compliant).
+          GRAPH_QUERY_API_LAMBDA_NAME: !Sub "devops-graph-query-api${EnvironmentSuffix}"
           # ENC-TSK-I10 (Dedup P6): convergence-probe signal configuration
           # (DOC-DF651F07D5C2 §10). The walk-back model-health loop reads the
           # production auto-merge/walk-back audit counters back from CloudWatch.
@@ -4889,6 +4892,14 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+              # ENC-TSK-K43 (B66 Ph5): cross-Lambda invoke into graph_query_api's
+              # publish_graph_health entrypoint for the real Fiedler lambda2
+              # (see _fetch_real_fiedler_value in lambda_function.py).
+              - Sid: InvokeGraphQueryApi
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -90,6 +90,41 @@ Resources:
       SourceArn: !GetAtt GraphHealthScheduleRule.Arn
 
   # ---------------------------------------------------------------------------
+  # ENC-TSK-K43 (B66 Ph5) — Fiedler lambda-2 GraphHealth metric schedule
+  # ---------------------------------------------------------------------------
+  # Gamma re-delivery of ENC-TSK-C10 (v3, closed). Triggers the existing
+  # devops-graph-query-api Lambda every 15 minutes (same cadence as
+  # HealthProbeScheduleRule above) with action='publish_graph_health', which
+  # computes the graph's Fiedler value (lambda2, algebraic connectivity) via
+  # the FTR-088 CSR/Fiedler _query_laplacian path (ISS-465-compliant: no GDS
+  # projection) and publishes it to the Enceladus/GraphHealth CloudWatch
+  # namespace. No new Lambda function — targets the existing graph_query_api
+  # function by ARN + Input, mirroring the ParityDriftDailyScheduleRule
+  # precedent immediately below of pointing a schedule's Input at an existing
+  # multi-action Lambda rather than minting a dedicated one.
+  GraphHealthScheduleRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-graph-health-schedule${EnvironmentSuffix}"
+      Description: >
+        Triggers graph_query_api publish_graph_health (Fiedler lambda2 ->
+        Enceladus/GraphHealth) every 15 minutes (ENC-TSK-K43)
+      ScheduleExpression: "rate(15 minutes)"
+      State: ENABLED
+      Targets:
+        - Id: GraphHealthMetricTarget
+          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+          Input: '{"action": "publish_graph_health"}'
+
+  GraphHealthScheduleInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GraphHealthScheduleRule.Arn
+
+  # ---------------------------------------------------------------------------
   # ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily parity + drift schedule
   # ---------------------------------------------------------------------------
   # Extends devops-deploy-parity-validator (ENC-TSK-F87) via EventBridge to run


### PR DESCRIPTION
## Summary

Follow-up to #781 (ENC-TSK-K43), tracked as ENC-TSK-K50. While gathering AC-1 evidence for K43 I discovered that ENC-TSK-C10's already-deployed `graph_health_metrics` Lambda (`enceladus-graph-health-metrics`, daily EventBridge schedule) publishes `Enceladus/GraphHealth`'s `FiedlerAlgebraicConnectivity` metric as a **documented placeholder**: `metrics["FiedlerAlgebraicConnectivity"] = metrics["GraphEdgeDensity"]`, a "GDS unavailable" stopgap that predates FTR-088. K43's own new `graph_query_api.publish_graph_health` action (#781) computes the REAL lambda2 via the bounded FTR-088 CSR/Fiedler path but published it under a separate metric name (`FiedlerValue`), leaving the legacy/dashboarded `FiedlerAlgebraicConnectivity` metric still fake.

- `graph_health_metrics/lambda_function.py`: cross-Lambda-invokes `devops-graph-query-api`'s `action=publish_graph_health` entrypoint and folds the real `lambda2` into `FiedlerAlgebraicConnectivity`, falling back to the original `GraphEdgeDensity` proxy only if the invoke fails (never blocks `GraphNodeCount`/`GraphEdgeDensity`/`OrphanNodeRatio`).
- Dense full-graph Jacobi eigendecomposition was ruled out as infeasible at Enceladus's ~1,500-node scale (O(n^3), pure Python, no numpy/scipy in this Lambda's `requirements.txt`) — delegating to `graph_query_api`'s bounded (`LAPLACIAN_MAX_VERTICES=500`) scipy-`eigsh` path is the only tractable option, consistent with the existing cross-Lambda `RequestResponse` invoke pattern already used elsewhere in this codebase (`coordination_api`, `deploy_intake`, `feed_query`, `tracker_mutation`).
- CFN: `lambda:InvokeFunction` grant on `GraphHealthMetricsRole` scoped to `devops-graph-query-api`; `GRAPH_QUERY_API_LAMBDA_NAME` env var.

## Test plan
- [x] 10 new unit tests in `backend/lambda/graph_health_metrics/test_fiedler_k43.py` (invoke payload shape, FunctionError/malformed-payload/no-matching-project degrade paths, real-value-vs-proxy assertions).
- [x] Full `graph_health_metrics` (14), `graph_query_api` (288), `scoring_service` (31), `prod_health_monitor` (29) suites pass with zero regressions.
- [ ] Post-merge: confirm `FiedlerAlgebraicConnectivity` datapoint reflects a real lambda2 (not equal to `GraphEdgeDensity`) via `aws cloudwatch get-metric-statistics` after the next daily 08:00 UTC schedule fire, or a manual invoke if available.

CCI-2f645805d8d64d67b6ff00f8c43e9421

🤖 Generated with [Claude Code](https://claude.com/claude-code)