### PR TITLE
[ENC-TSK-K44] infra: gamma import manifest + staged snapshot for ProdHealthMonitor orphan adoption

### DIFF
--- a/infrastructure/cloudformation/02-compute-import-stage-k44.yaml
+++ b/infrastructure/cloudformation/02-compute-import-stage-k44.yaml
@@ -1,0 +1,5475 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus Compute Layer — Lambda functions, EventBridge rules, Pipes.
+  Part of ENC-TSK-532: IaC templates for Enceladus AWS resources.
+
+  WARNING: Lambda Code properties use placeholder ZipFile values. Actual code
+  is deployed via each Lambda's deploy.sh script. NEVER change the ZipFile
+  values — doing so will cause CloudFormation to overwrite deployed code.
+  The EarlyValidation hook requires Code to be present for import operations.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues: [production, gamma]
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+    Description: >
+      Appended to every resource name. Production uses "" (zero drift),
+      gamma uses "-gamma" for parallel deployment.
+  S3EnvPrefix:
+    Type: String
+    Default: ""
+    Description: >
+      Prefix for S3 paths in gamma. Production uses "" (no prefix),
+      gamma uses "gamma/" to isolate S3 content.
+  DataStackName:
+    Type: String
+    Default: enceladus-data
+    Description: Name of the 01-data stack for cross-stack references.
+  S3Bucket:
+    Type: String
+    Default: jreese-net
+  CognitoUserPoolId:
+    Type: String
+    Default: us-east-1_b2D0V3E1k
+  CognitoClientId:
+    Type: String
+    Default: 6q607dk3liirhtecgps7hifmlk
+  CorsOrigin:
+    Type: String
+    Default: https://jreese.net
+  SharedLayerArn:
+    Type: String
+    # ENC-TSK-H05: bumped :7 -> :10 to match the live/working prod layer. The F65 hotfix
+    # (2026-04-21) moved functions to enceladus-shared:10 (the version WITH appconfig_flags)
+    # out-of-band but never updated this default; the 2026-06-18 deploy then reset functions
+    # to :7 -> Runtime.ImportModuleError 'No module named enceladus_shared.appconfig_flags'
+    # (AXIS 2 of the Sev-1). Codifying :10 here prevents a default-driven re-incident.
+    # ENC-TSK-H24: this Default is the canonical pin ENFORCED by
+    # tools/verify_shared_layer_version.py (pre-deploy gate). :10 == :7 + appconfig_flags
+    # (ENC-LSN-020 three-flag ABI). To change it, bump CANONICAL_SHARED_LAYER_ARN in that
+    # script too, or the layer-version parity gate fails the deploy.
+    Default: arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10
+  # ENC-ISS-197: Referenced by deploy_decide Lambda env vars but were missing from Parameters
+  GitHubAppId:
+    Type: String
+    Default: "2946766"
+    Description: GitHub App numeric ID for deploy_decide Lambda.
+  GitHubInstallationId:
+    Type: String
+    Default: "112392089"
+    Description: GitHub App installation ID for NX-2021-L org.
+  # ENC-TSK-F57 AC-2 / ENC-ISS-280: CoordinationInternalApiKey{,Previous} must be referenceable
+  # by CFN env vars so that stack deploys don't strip the out-of-band live values. Deploy
+  # workflow is expected to pass real values via --parameter-overrides (empty defaults would
+  # zero the env on the Lambda and regress the fix). NoEcho prevents logging.
+  CoordinationInternalApiKey:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Shared internal API key used by coordination-tier Lambdas to authenticate requests
+      between the MCP servers, intake, coordination API, and graph_query_api. Supplied at
+      deploy time via workflow parameter-overrides; defaults empty to avoid leaking in
+      repo. Graph Query API and other consumers read from COORDINATION_INTERNAL_API_KEY
+      env var populated by this parameter.
+  CoordinationInternalApiKeyPrevious:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Previous COORDINATION_INTERNAL_API_KEY value used during dual-accept rotation windows
+      (ENC-ISS-276). Populates COORDINATION_INTERNAL_API_KEY_PREVIOUS env var on downstream
+      consumers. Empty default is expected after each rotation cycle completes.
+  # ADE Component C: shared secret for verifying Cursor Cloud Agents completion
+  # webhook signatures (HMAC-SHA256 over the raw body). NoEcho; supplied at deploy
+  # time via --parameter-overrides. Mirrors the CoordinationInternalApiKey pattern.
+  CursorWebhookSecret:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Shared secret used by the coordination API Lambda to verify the X-Webhook-Signature
+      HMAC-SHA256 header on POST /api/v1/cursor/webhook (ADE Component C). Populates the
+      CURSOR_WEBHOOK_SECRET env var. Kept out of the repo; injected at deploy/IMPORT via
+      --parameter-overrides. io must populate this from the value configured in the Cursor
+      Cloud Agents webhook settings.
+  # ENC-TSK-F74 / ENC-ISS-279: Cognito client secret required by enceladus-mcp-code-gamma
+  # (and future prod twin) for OAuth-direct flows. NoEcho; supplied via --parameter-overrides
+  # at deploy/IMPORT time.
+  EnceladusCognitoClientSecret:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >
+      Cognito confidential-client secret for the Enceladus app client. Required by the
+      enceladus-mcp-code-gamma Lambda OAuth-direct path. Kept out of the repo; injected
+      at deploy/IMPORT via --parameters.
+
+  # ENC-TSK-F63 AC-1: AppConfig extension layer ARNs.
+  # Arch-specific; separate params because AWS publishes distinct layer versions.
+  # See: https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html
+  AppConfigExtensionLayerArnX86:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension:147"
+    Description: AppConfig Lambda extension layer ARN for x86_64 (us-west-2). Pin to latest per AWS docs.
+  AppConfigExtensionLayerArnArm64:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension-Arm64:147"
+    Description: AppConfig Lambda extension layer ARN for arm64 (us-west-2). Pin to latest per AWS docs.
+
+  # ENC-TSK-F63 AC-1: AppConfig IDs — populated after 06-feature-flags.yaml stack deploy.
+  # Empty defaults disable AppConfig polling; appconfig_flags.flag() falls back to env_fallback.
+  AppConfigApplicationId:
+    Type: String
+    Default: ""
+    Description: AppConfig Application ID from 06-feature-flags stack. Pass via --parameter-overrides.
+  AppConfigEnvironmentId:
+    Type: String
+    Default: ""
+    Description: AppConfig Environment ID from 06-feature-flags stack. Pass via --parameter-overrides.
+
+  # ENC-TSK-F63 AC-2: SnapStart.ApplyOn=PublishedVersions. Only arm64/py3.12 supports it.
+  # v3-prod (x86_64/py3.11): false. v4-gamma/v4-prod (arm64/py3.12): true.
+  EnableSnapStart:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Enable SnapStart on all Lambdas. Set true only for arm64/python3.12 stacks.
+
+Conditions:
+  IsProduction: !Equals [!Ref Environment, "production"]
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+  # ENC-TSK-F63 AC-2: SnapStart enabled only when EnableSnapStart=true (arm64/py3.12 targets).
+  # Replaces the old IsProduction-negation pattern (was: !If [IsProduction, NoValue, SnapStart]).
+  SnapStartEnabled: !Equals [!Ref EnableSnapStart, "true"]
+  # ENC-TSK-F63 AC-1: AppConfig layer conditional — only attach when an ARN is provided.
+  HasAppConfigLayer: !Not [!Equals [!Ref AppConfigExtensionLayerArnX86, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # Lambda Functions — API Tier (Cognito-authenticated, API GW proxied)
+  # ---------------------------------------------------------------------------
+
+  CoordinationApiFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-coordination-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt CoordinationApiRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (MCP Server / governed-mutation API
+      # surface — CoordinationApiFunction is the gamma-deployable stand-in for "MCP Server"
+      # in the five-service trace; EnceladusMcpCodeGammaFunction is prod-stack-owned
+      # (Condition: IsProduction) and out of reach for a gamma-only compute deploy).
+      TracingConfig:
+        Mode: Active
+      Layers:
+        - !Ref SharedLayerArn
+        # ENC-TSK-F63 AC-1: AppConfig extension layer (arch-conditional)
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          # ENC-TSK-J57: DocumentsTableRead/DocumentsTableCandidateDecisionWrite grant
+          # access to documents${EnvironmentSuffix}, but this env var was never wired
+          # up -- the code's os.environ.get("DOCUMENTS_TABLE", "documents") fallback
+          # silently pointed every environment at the unsuffixed prod table name,
+          # which gamma's IAM (correctly scoped to documents-gamma) then denied.
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          SSM_REGION: !Ref AWS::Region
+          SECRETS_REGION: !Ref AWS::Region
+          CORS_ORIGIN: !Ref CorsOrigin
+          ENCELADUS_MCP_INTERFACE_MODE: code
+          DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
+          # ENC-TSK-J70 / ENC-FTR-121 Ph3: applyEscalatedMutation lives in
+          # tracker_mutation; the Cognito approval flow invokes it directly.
+          TRACKER_MUTATION_LAMBDA_NAME: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
+          # ADE Component C: Cursor webhook HMAC verification secret (POST /api/v1/cursor/webhook)
+          CURSOR_WEBHOOK_SECRET: !Ref CursorWebhookSecret
+          COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-FTR-116 / ENC-TSK-I29: canonical governance-version DDB record.
+          GOVERNANCE_VERSION_TABLE: !Sub "governance-version${EnvironmentSuffix}"
+          # ENC-TSK-I37 / ENC-TSK-J04 (ENC-FTR-117 / ENC-FTR-074): agent identity stores.
+          # Env-suffixed so gamma resolves the "-gamma" tables; the agent_id_alloc
+          # allocator + credential lifecycle read these names.
+          AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
+          AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"
+          AGENT_CREDENTIALS_TABLE: !Sub "agent-credentials${EnvironmentSuffix}"
+          # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91: idle-sweep
+          # backstop config. Enable flag read by lambda_function; threshold read by
+          # config.py / agent_id_alloc.sweep_idle_sessions. ENC-ISS-441 / ENC-TSK-J94:
+          # threshold tightened from I71's 86400 (24h) to 7200 (2h); the idle reference
+          # prefers last_activity_at (J71/J83), so polling listeners stay exempt.
+          AGENT_SESSIONS_IDLE_SWEEP_ENABLED: "true"
+          AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS: "7200"
+          # ENC-ISS-441 / ENC-TSK-J94: unclaim TTL sweep — allocated sessions never
+          # claimed within the TTL are ghost registrations and get reaped + SCI-revoked.
+          AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED: "true"
+          AGENT_SESSIONS_UNCLAIM_TTL_MINUTES: "10"
+          # ENC-ISS-441 / ENC-TSK-J92: SCI tokens share the checkout service's token table
+          # (pk = token id, token_type=SCI). Env-suffixed so gamma writes the -gamma twin.
+          CHECKOUT_TOKENS_TABLE: !Sub "enceladus-checkout-tokens${EnvironmentSuffix}"
+          # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+          # ENC-TSK-K02 / FTR-084 Ph2: intent-classifier training loop (weekly EventBridge).
+          # TRAINING_HARD_DISABLED=1 is the ISS-465-style kill switch — installed before
+          # the first scheduled run; io clears to "0" to enable mutations.
+          TRAINING_HARD_DISABLED: "1"
+          INTENT_TRAINING_BUCKET: !Ref S3Bucket
+          INTENT_TRAINING_PREFIX: !Sub "${S3EnvPrefix}intent-training"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+
+  TrackerMutationFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 10
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt TrackerMutationRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing ("Record" service — TrackerMutationFunction
+      # writes/records the governed tracker mutation for every task/issue/feature/lesson).
+      TracingConfig:
+        Mode: Active
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+          # ENC-TSK-H46: the Lifecycle Service to invoke when enable_lifecycle_service_extraction
+          # is ON. The flag itself lives in AppConfig (independently toggleable); it defaults OFF
+          # so this var is inert until the flag is flipped — a zero-behavior-change deploy.
+          LIFECYCLE_SERVICE_FUNCTION: !Sub "enceladus-lifecycle-service${EnvironmentSuffix}"
+          # ENC-TSK-H47: the lesson-scoring SNS topic tracker_mutation publishes to when
+          # enable_scoring_service_extraction is ON. Inert until the (default-OFF) flag is flipped.
+          LESSON_SCORING_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+          # ENC-TSK-J72 / ENC-FTR-121 Ph5: io's [ESCALATION] email rides the existing
+          # feed-alerts topic (§5.8 topic reuse; sub-dollar budget). Empty = publish skipped.
+          ESCALATION_ALERTS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
+          # ENC-TSK-J87 (gamma twin of ENC-TSK-J86 / ENC-LSN-053): codify the flag's
+          # env_fallback so compute deploys stop stripping it out-of-band. appconfig_flags
+          # resolves AppConfig-first with default=False, so this fallback is load-bearing
+          # whenever AppConfig is unreachable.
+          ENABLE_LESSON_PRIMITIVE: "true"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: tracker
+
+  DocumentApiFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-document-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DocumentApiRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          S3_BUCKET: !Ref S3Bucket
+          S3_PREFIX: !Sub "${S3EnvPrefix}agent-documents"
+          S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
+          S3_GOVERNANCE_PREFIX: !Sub "${S3EnvPrefix}governance/live"
+          # ENC-TSK-I63 / ENC-TSK-I62: needed so the governance sync path can propagate a
+          # governance_data_dictionary.json change into the governance-policies record.
+          GOVERNANCE_POLICIES_TABLE: !Sub "governance-policies${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: documents
+
+  # ENC-TSK-H46 / B63 Phase 2A — Lifecycle Service. Standalone validator owning
+  # transition_type_matrix validation, STRICTNESS_RANK, subtask gates, and the gate_class
+  # taxonomy (ENC-FTR-111). Synchronously invoked by tracker_mutation. Pure DynamoDB reader
+  # (tracker + component-registry); no GitHub, no AppConfig (never calls flag()).
+  LifecycleServiceFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-lifecycle-service${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 10
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt LifecycleServiceRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (Lifecycle service).
+      TracingConfig:
+        Mode: Active
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-H84 / ENC-FTR-111 AC-5: read the per-project deploy_policy to gate deploy-init auto-walk.
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: lifecycle
+
+  # ENC-TSK-H47 / B63 Phase 2B — Scoring Service. Standalone, SNS-triggered ASYNC consumer that owns
+  # lesson constitutional scoring (pillar_composite + resonance_score, ENC-FTR-054) and the lesson
+  # scoring_status: pending -> scored lifecycle. Subscribes to LessonScoringTopic; pure DynamoDB
+  # writer (tracker table only). No GitHub, no AppConfig (the flag gates the PUBLISHER, not this
+  # consumer). See ScoringServiceSubscription / ScoringServiceSnsPermission for the SNS wiring.
+  ScoringServiceFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-scoring-service${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ScoringServiceRole.Arn
+      # ENC-TSK-K45 / B66 AC-1: active X-Ray tracing (Scoring service).
+      TracingConfig:
+        Mode: Active
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: scoring
+
+  # ENC-TSK-H47: subscribe the Scoring Service to the lesson-scoring topic (async fan-out). Lambda
+  # protocol SNS subscriptions cannot use raw message delivery, so the function receives the
+  # standard SNS Notification envelope ({Records:[{Sns:{Message}}]}), which the handler unwraps.
+  ScoringServiceSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+      Protocol: lambda
+      Endpoint: !GetAtt ScoringServiceFunction.Arn
+
+  # ENC-TSK-H47: allow SNS to invoke the Scoring Service for the subscription above.
+  ScoringServiceSnsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ScoringServiceFunction
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+
+  ProjectServiceFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-project-service${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ProjectServiceRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          S3_BUCKET: !Ref S3Bucket
+          S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: projects
+
+  FeedQueryFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-feed-query-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 60  # ENC-TSK-797: increased from 15 for synchronous feed_publisher invoke
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt FeedQueryRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          FEED_PUBLISHER_FUNCTION: !Sub "devops-feed-publisher${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: feed
+
+  CoordinationMonitorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-coordination-monitor-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt CoordinationMonitorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: coordination
+
+  DeployIntakeFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-deploy-intake${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DeployIntakeRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DEPLOY_REGION: !Ref AWS::Region
+          # ENC-TSK-H26 / ENC-ISS-283: deploy-critical out-of-band var. A full 02-compute
+          # replace would strip the live value (ENC-LSN-053), leaving deploy-intake unable
+          # to enqueue deploy triggers. Codified from the canonical 01-data DeployQueueUrl
+          # export, mirroring the DeployQueueArn import used by DeployOrchestratorSqsTrigger.
+          SQS_QUEUE_URL: !ImportValue
+            Fn::Sub: ${DataStackName}-DeployQueueUrl
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          CONFIG_BUCKET: !Ref S3Bucket
+          CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
+          CORS_ORIGIN: !Ref CorsOrigin
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: deployment
+
+  ReferenceSearchFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-reference-search${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 10
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ReferenceSearchRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          S3_BUCKET: !Ref S3Bucket
+          S3_REFERENCE_PREFIX: !Sub "${S3EnvPrefix}mobile/v1/reference"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: reference
+
+  AuthRefreshFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "auth-refresh${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 128
+      Timeout: 10
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt AuthRefreshRole.Arn
+      Layers:
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          COGNITO_REGION: us-east-1
+          GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
+          GITHUB_PRIVATE_KEY_SECRET: devops/github-app/private-key
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: auth
+
+  # ---------------------------------------------------------------------------
+  # Lambda Functions — Backend Tier (event-driven, no direct API)
+  # ---------------------------------------------------------------------------
+
+  DeployOrchestratorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-deploy-orchestrator${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DeployOrchestratorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DEPLOY_REGION: !Ref AWS::Region
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          CONFIG_BUCKET: !Ref S3Bucket
+          CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
+          CODEBUILD_PROJECT: devops-ui-deploy-builder
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: deployment
+
+  DeployFinalizeFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-deploy-finalize${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DeployFinalizeRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DEPLOY_REGION: !Ref AWS::Region
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          CONFIG_BUCKET: !Ref S3Bucket
+          CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: deployment
+
+  # GMF: Deploy Decide Lambda (DOC-63420302EF65 §6.2)
+  # Cognito-only auth — human governance decisions for production deployments
+  DeployDecideFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-deploy-decide${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DeployDecideRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DEPLOY_REGION: !Ref AWS::Region
+          CORS_ORIGIN: !Ref CorsOrigin
+          GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
+          GITHUB_PRIVATE_KEY_SECRET: devops/github-app/private-key
+          ALLOWED_REPOS: NX-2021-L/enceladus
+          GAMMA_INTEGRATION_BRANCH: v4/main
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: deployment
+
+  # ENC-FTR-091 / ENC-TSK-F87 — Deploy Parity Validator
+  DeployParityValidatorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-deploy-parity-validator${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      # ENC-TSK-G43: raised from 120 to 300 to fit chained
+      # daily_drift_audit + mentions_drift_audit (~100 graphsearch round-trips)
+      # in one EventBridge-triggered invocation.
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DeployParityValidatorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DEPLOY_REGION: !Ref AWS::Region
+          ENVIRONMENT_SUFFIX: !Ref EnvironmentSuffix
+          GITHUB_TOKEN_SECRET: devops/github-app/private-key
+          DOCUMENT_API_URL: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1
+          TRACKER_API_URL: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+          SNS_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-deploy-alerts"
+          CFN_DRIFT_STACKS: "enceladus-data,enceladus-api,enceladus-github-roles,enceladus-monitoring"
+          SNAPSTART_MAX_STALE_VERSIONS: "5"
+          DRIFT_POLL_TIMEOUT: "240"
+          # ENC-TSK-G43 / ENC-FTR-098 AC-7 — mentions_drift_audit
+          TRACKER_TABLE:    !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DOCUMENTS_TABLE:  !Sub "documents${EnvironmentSuffix}"
+          MENTIONS_AUDIT_SAMPLE_SIZE: "100"
+          MENTIONS_AUDIT_THRESHOLD:   "0.01"
+          # Required for the audit to POST drift findings to tracker_api
+          # (X-Coordination-Internal-Key) and to query graph_query_api when
+          # they enforce internal-key auth on service-to-service calls.
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: deployment
+
+  FeedPublisherFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-feed-publisher${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 512
+      Timeout: 600
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt FeedPublisherRole.Arn
+      Description: Event-driven mobile feed publisher triggered by DynamoDB Streams via SQS FIFO
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          TRACKER_REGION: !Ref AWS::Region
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          PROJECTS_REGION: !Ref AWS::Region
+          FEED_BUCKET: !Ref S3Bucket
+          FEED_PREFIX: !Sub "${S3EnvPrefix}mobile/v1"
+          EVENT_BUS: default
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: feed
+
+  GovernanceAuditFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-governance-audit${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 128
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GovernanceAuditRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance
+
+  DocPrepFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-doc-prep${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt DocPrepRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          S3_BUCKET: !Ref S3Bucket
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: documents
+
+  BedrockAgentActionsFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-bedrock-agent-actions${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt BedrockActionsRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          S3_BUCKET: !Ref S3Bucket
+          GOVERNANCE_POLICIES_TABLE: !Sub "governance-policies${EnvironmentSuffix}"
+          AGENT_COMPLIANCE_TABLE: !Sub "agent-compliance-violations${EnvironmentSuffix}"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: bedrock
+
+  ChangelogApiFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-changelog-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 30
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ChangelogApiRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
+          DYNAMODB_REGION: !Ref AWS::Region
+          CONFIG_BUCKET: !Ref S3Bucket
+          CONFIG_PREFIX: !Sub "${S3EnvPrefix}deploy-config"
+          CORS_ORIGIN: !Ref CorsOrigin
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: changelog
+
+  GraphSyncFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-graph-sync${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GraphSyncRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
+          SECRETS_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: graph
+
+  GraphQueryApiFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-graph-query-api${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      # ENC-TSK-F36 / ENC-ISS-268: raised from 10s to 180s. Worst-case Bolt
+      # pool rebuild after a NAT 350s idle-kill can take ~60-120s; the prior
+      # 10s CFN value was shadowed by deploy.sh's 30s update anyway. The
+      # live function setting is governed by deploy.sh update-function-
+      # configuration; this value is the CFN baseline for drift recovery.
+      Timeout: 180
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GraphQueryApiRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
+          SECRETS_REGION: !Ref AWS::Region
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          CORS_ORIGIN: !Ref CorsOrigin
+          # ENC-TSK-F57 AC-2 / ENC-ISS-280: internal-key auth vars added out-of-band to
+          # live function during the 2026-04-20 override session (DOC-D45141D94C55). CFN
+          # now declares them via parameters so the next stack deploy does not strip the
+          # vars and regress graphsearch 401 PERMISSION_DENIED. Deploy workflow must pass
+          # both values via --parameter-overrides.
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+          # ENC-FTR-101 Option B / ENC-TSK-H37: activates the standing GDS projection.
+          # A non-empty prefix turns on the warm read path (_hybrid_graph_ranks_gds_warm)
+          # and the out-of-band refresher; projection name resolves to
+          # f"{prefix}_{project_id}" lowercased with dashes->underscores
+          # (e.g. gds_standing_enceladus). Codified here — NOT set out-of-band — so the
+          # next compute deploy does not strip it (ENC-LSN-053 strip-class drift).
+          # Prod-only: gamma uses a separate AuraDB and its compute deploy is blocked
+          # (ENC-ISS-197), so the feature stays dormant there (AWS::NoValue omits the key).
+          # ENC-ISS-465 / ENC-TSK-J41 (SEV-1 cost kill): standing GDS projection retired.
+          # Prefix forced to AWS::NoValue (feature OFF) and GDS_HARD_DISABLED=1 short-circuits
+          # _check_gds_available()->False so NO Aura Graph Analytics session (standing warm-path
+          # OR per-query gds.graph.project) is ever created; graph signal uses cypher_fallback.
+          GDS_STANDING_PROJECTION_PREFIX: !Ref "AWS::NoValue"
+          GDS_HARD_DISABLED: "1"
+          # ENC-FTR-087 Phase 1 (ENC-TSK-I85): wave-close drift telemetry sink.
+          # Codified here so a compute deploy never strips it (ENC-LSN-053 class).
+          DRIFT_TELEMETRY_TABLE: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
+          # ENC-FTR-109 / ENC-TSK-K05: stigmergic exploration trace sink.
+          STIGMERGIC_TRACE_TABLE: !Sub "enceladus-stigmergic-trace${EnvironmentSuffix}"
+          # ENC-TSK-J52 / FTR-104 Ph3: I99-tuned energy lambda weights on gamma.
+          ENERGY_LAMBDA_GRAPH: "1.0"
+          ENERGY_LAMBDA_KW: "0.1"
+          # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 sink. Setting
+          # the bucket activates the durable .jsonl append-log (the code degrades
+          # to CloudWatch when unset — ENC-TSK-H38); prefix is env-partitioned via
+          # S3EnvPrefix (prod "" / gamma "gamma/"). Registered deploy-critical in
+          # env_drift_registry.json so the env-parity gate protects them.
+          PATHWAY_TELEMETRY_BUCKET: !Ref S3Bucket
+          PATHWAY_TELEMETRY_PREFIX: !Sub "${S3EnvPrefix}pathway-telemetry"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: graph
+
+  # ---------------------------------------------------------------------------
+  # Convergence Surface fan-out + increment Lambda (ENC-FTR-086 Ph1 / ENC-TSK-I82)
+  # ---------------------------------------------------------------------------
+  # One function, two event sources (dispatched on eventSource in the handler):
+  #   - DynamoDB Stream (tracker) -> fan-out per open-taxonomy attribute to SQS
+  #   - SQS FIFO -> idempotent counter increment with 10k-cap lowest-count eviction
+  # ENC-FTR-086 D1: isolated tier-1 service — its own IAM role, no import path
+  # from any governance Lambda; tracker mutations never wait on it.
+  ConvergenceTelemetryFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ConvergenceTelemetryRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          CONVERGENCE_TABLE: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
+          CONVERGENCE_QUEUE_URL: !ImportValue
+            Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueUrl
+          CONVERGENCE_TTL_DAYS: "90"
+          CONVERGENCE_CAP: "10000"
+          DYNAMODB_REGION: !Ref AWS::Region
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: convergence
+        - Key: Feature
+          Value: ENC-FTR-086
+
+  # ---------------------------------------------------------------------------
+  # Neo4j Backup Lambda
+  # ---------------------------------------------------------------------------
+
+  Neo4jBackupFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-neo4j-backup${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt Neo4jBackupRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
+          S3_BUCKET: !Ref S3Bucket
+          S3_PREFIX: !Sub "${S3EnvPrefix}neo4j-backups/"
+          SECRETS_REGION: !Ref "AWS::Region"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: neo4j-backup
+
+  # ---------------------------------------------------------------------------
+  # ENC-FTR-096 Ph1 / ENC-TSK-I84: Memory Consolidation Lambda
+  # Nightly EventBridge scan of Handoff docs -> co-citation clusters ->
+  # lesson-candidate drafts (draft-only, io-approval gated). OGTM: no new edge
+  # types; graph_sync untouched (related_items project to existing RELATED_TO).
+  # ---------------------------------------------------------------------------
+  MemoryConsolidationFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-memory-consolidation${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt MemoryConsolidationRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          S3_BUCKET: !Ref S3Bucket
+          S3_PREFIX: !Sub "${S3EnvPrefix}agent-documents"
+          CONSOLIDATION_PROJECT_IDS: enceladus
+          CONSOLIDATION_LOOKBACK_HOURS: "24"
+          CONSOLIDATION_MIN_WAVES: "2"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: memory-consolidation
+
+  # ---------------------------------------------------------------------------
+  # ENC-FTR-106 / ENC-TSK-K03: Unlearning Lambda (Crick-Mitchison reverse-consolidation)
+  # Nightly per-invocation pass: stigmergic-trace miss clusters + drift SAR waves ->
+  # unlearning-candidate reports; optional archive of reference records via graph_sync.
+  # DATA-SAFETY: UNLEARNING_DRY_RUN=1, UNLEARNING_MUTATION_ENABLED=0, IO_APPROVAL_RUNS=3.
+  # ---------------------------------------------------------------------------
+  UnlearningFunction:
+    Type: AWS::Lambda::Function
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-unlearning${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt UnlearningRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DRIFT_TELEMETRY_TABLE: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
+          STIGMERGIC_TRACE_TABLE: !Sub "enceladus-stigmergic-trace${EnvironmentSuffix}"
+          UNLEARNING_BUCKET: !Ref S3Bucket
+          UNLEARNING_PREFIX: !Sub "${S3EnvPrefix}unlearning-tombstones"
+          UNLEARNING_STATE_PREFIX: !Sub "${S3EnvPrefix}unlearning-state"
+          DEFAULT_PROJECT_ID: enceladus
+          UNLEARNING_DRY_RUN: "1"
+          UNLEARNING_MUTATION_ENABLED: "0"
+          IO_APPROVAL_RUNS: "3"
+          TOMBSTONE_RECOVERY_DAYS: "30"
+          UNLEARNING_LOOKBACK_HOURS: "24"
+          UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD: "0.5"
+          UNLEARNING_MIN_MISS_COUNT: "3"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: unlearning
+        - Key: Feature
+          Value: ENC-FTR-106
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-F73 / ENC-ISS-283: Env Drift Auditor Lambda (F57 AC-3/4 CFN adoption)
+  # Live resource created out-of-band for ENC-ISS-283; imported under this stack
+  # via create-change-set --change-set-type=IMPORT. EventBridge schedule
+  # (devops-env-drift-auditor-hourly) remains unmanaged and is not in scope here.
+  # ---------------------------------------------------------------------------
+
+  DevopsEnvDriftAuditorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-env-drift-auditor${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt EnvDriftAuditorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          TRACKER_API_BASE: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          ISSUE_PROJECT_ID: enceladus
+          DRIFT_SEVERITY: P0
+          DRY_RUN: "false"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: env-drift-auditor
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-H51 / ENC-ISS-142 gate #3: Stale-Checkout Monitor (Escalation Protocol).
+  # Read-only scheduled detector; emits stale_checkout_signal CloudWatch log lines for
+  # long-held checkouts + stale in-progress tasks. Code managed out-of-band (matrix-build
+  # / _deploy.yml). ACTIVATION (this block + first deploy) is a privileged compute-stack
+  # deploy step, gamma only per DOC-499FA089EC30.
+  # NOTE: PROJECTS_TABLE + the IAM table ARN default to "projects" (the shared tracker
+  # table); CONFIRM the gamma projects-table name at deploy time before applying.
+  # ---------------------------------------------------------------------------
+  StaleCheckoutMonitorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-stale-checkout-monitor${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt StaleCheckoutMonitorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          PROJECTS_TABLE: projects
+          STALE_CHECKOUT_THRESHOLD_MINUTES: "240"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: stale-checkout-monitor
+
+  StaleCheckoutMonitorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-stale-checkout-monitor-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: stale-checkout-monitor-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects/index/*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: stale-checkout-monitor
+
+  StaleCheckoutMonitorSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "enceladus-stale-checkout-monitor-schedule${EnvironmentSuffix}"
+      ScheduleExpression: rate(30 minutes)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt StaleCheckoutMonitorFunction.Arn
+          Id: stale-checkout-monitor-target
+
+  StaleCheckoutMonitorPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref StaleCheckoutMonitorFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt StaleCheckoutMonitorSchedule.Arn
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-K44 / ENC-FTR-071 (B66 Ph5): Production Health Monitor Lambda.
+  # Moved from infrastructure/cloudformation/05-monitoring.yaml so the Lambda
+  # Workflow Coverage Guard recognizes it as a coverage-tracked function (the
+  # guard only parses AWS::Lambda::Function resources out of THIS template).
+  # 05-monitoring.yaml retains the IAM-independent bits that reference this
+  # function by name: the EventBridge 15-min schedule + permission, and the
+  # CloudWatch Alarms (CodeSizeMinimumAlarm plus the new K44 per-service
+  # alarms), mirroring the existing cross-stack pattern used there for
+  # devops-deploy-parity-validator / devops-env-drift-auditor (hardcoded
+  # !Sub ARN by function name, not !ImportValue — 05-monitoring.yaml does not
+  # take a compute-stack import today and this avoids a stack-dependency
+  # ordering change for a single Lambda move).
+  # Health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start
+  # baseline) publish DynamoDBThrottle / GraphSyncLag / MCPColdStart metrics
+  # feeding the B66 dashboard panels. Gamma only; not a v3-prod patch
+  # (ENC-PLN-019 lock) — deploys via the standard IsGamma/IsProduction !If
+  # arch/runtime conditions like every other Lambda in this template.
+  # ---------------------------------------------------------------------------
+
+  ProdHealthMonitorFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-prod-health-monitor${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ProdHealthMonitorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          FUNCTION_NAMES: "[]"
+          DYNAMODB_TABLE_NAME: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
+          S3_HEALTH_BUCKET: !Ref S3Bucket
+          GRAPH_SYNC_QUEUE_URL: !ImportValue
+            Fn::Sub: ${DataStackName}-GraphSyncQueueUrl
+          SECRETS_REGION: !Ref "AWS::Region"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: health-monitor
+
+  ProdHealthMonitorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-prod-health-monitor-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ProdHealthMonitorPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "arn:aws:logs:*:*:*"
+              - Sid: LambdaConfigRead
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:ListFunctions
+                Resource: "*"
+              - Sid: CloudWatchMetrics
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+              - Sid: DynamoDBHealthCheck
+                Effect: Allow
+                Action:
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+              - Sid: SecretsManagerNeo4j
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+              - Sid: S3HealthCheck
+                Effect: Allow
+                Action:
+                  - s3:HeadBucket
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}"
+              - Sid: SqsHealthCheck
+                Effect: Allow
+                Action:
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: health-monitor
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-C10: Graph Health Metrics Lambda (CloudWatch proxy path)
+  # ---------------------------------------------------------------------------
+
+  GraphHealthMetricsFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-graph-health-metrics${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GraphHealthMetricsRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
+          CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
+          PROJECT_ID: enceladus
+          SECRETS_REGION: !Ref "AWS::Region"
+          # ENC-TSK-I10 (Dedup P6): convergence-probe signal configuration
+          # (DOC-DF651F07D5C2 §10). The walk-back model-health loop reads the
+          # production auto-merge/walk-back audit counters back from CloudWatch.
+          DEDUP_NAMESPACE: Enceladus/DedupConvergence
+          DEDUP_AUDIT_NAMESPACE: Enceladus/DedupConvergence
+          DEDUP_COSINE_THRESHOLD: "0.95"
+          DEDUP_PRECISION_FLOOR: "0.999"
+          DEDUP_FLOW_WINDOW_DAYS: "7"
+          DEDUP_WALKBACK_WINDOW_DAYS: "30"
+          DEDUP_VECTOR_TOP_K: "25"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: graph-health-metrics
+
+  GraphHealthMetricsSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-graph-health-daily${EnvironmentSuffix}"
+      ScheduleExpression: "cron(0 8 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt GraphHealthMetricsFunction.Arn
+          Id: graph-health-daily
+
+  GraphHealthMetricsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GraphHealthMetricsFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GraphHealthMetricsSchedule.Arn
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-I88 / ENC-FTR-085 — comp-percolation-monitor (ENC-PLN-006 v4/gamma)
+  # Nightly percolation-threshold telemetry: analytical p_c (Molloy-Reed) +
+  # empirical p_c (Monte Carlo). Reads the graph ONLY via the graph_query_api
+  # endpoint (search_type=adjacency) — no direct Neo4j, no new edge type (OGTM
+  # N/A). Gamma-only (Condition: IsGamma): v3-prod is frozen (DOC-499FA089EC30)
+  # and these resources must never be created on the prod stack. Runtime/arch
+  # use the IsGamma !If form so the arch-parity guard passes; on this gamma-only
+  # resource they always resolve to python3.12/arm64.
+  # ---------------------------------------------------------------------------
+  PercolationMonitorFunction:
+    Type: AWS::Lambda::Function
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-percolation-monitor${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 1024
+      Timeout: 900
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt PercolationMonitorRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          GRAPH_QUERY_API_BASE: !Sub "https://enceladus-gamma.jreese.net/api/v1/tracker/graphsearch"
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          PERCOLATION_TABLE: !Sub "enceladus-percolation-telemetry${EnvironmentSuffix}"
+          CLOUDWATCH_NAMESPACE: Enceladus/Percolation
+          PROJECT_ID: enceladus
+          MC_TRIALS: "40"
+          MC_NUM_P: "30"
+          MC_P_MIN: "0.02"
+          MC_P_MAX: "0.60"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: percolation-monitor
+        - Key: Feature
+          Value: ENC-FTR-085
+
+  PercolationMonitorSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsGamma
+    Properties:
+      Name: !Sub "enceladus-percolation-nightly${EnvironmentSuffix}"
+      Description: "ENC-FTR-085: nightly percolation-threshold measurement at 03:00 UTC."
+      ScheduleExpression: "cron(0 3 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt PercolationMonitorFunction.Arn
+          Id: percolation-nightly
+
+  PercolationMonitorPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Ref PercolationMonitorFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt PercolationMonitorSchedule.Arn
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-H86 / ENC-FTR-111 Phase 1 (T5): Universal Arc-Walker telemetry +
+  # convergence-probe Lambda. Read-only — scans the tracker table and publishes
+  # CloudWatch metrics (Enceladus/ArcWalk).
+  # ---------------------------------------------------------------------------
+  ArcWalkMetricsFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-arc-walk-metrics${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 120
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt ArcWalkMetricsRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
+          CLOUDWATCH_NAMESPACE: Enceladus/ArcWalk
+          DYNAMODB_REGION: !Ref "AWS::Region"
+          PROJECT_ID: enceladus
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: arc-walk-metrics
+
+  ArcWalkMetricsSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-arc-walk-metrics-hourly${EnvironmentSuffix}"
+      ScheduleExpression: "rate(1 hour)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt ArcWalkMetricsFunction.Arn
+          Id: arc-walk-metrics-hourly
+
+  ArcWalkMetricsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ArcWalkMetricsFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ArcWalkMetricsSchedule.Arn
+
+  # ENC-TSK-H86 / ENC-FTR-111 (T5): Arc-Walk Metrics Lambda IAM Role.
+  ArcWalkMetricsRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-arc-walk-metrics-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ArcWalkMetricsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: CloudWatchMetrics
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+              - Sid: TrackerAndProjectsReadOnly
+                Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ---------------------------------------------------------------------------
+  # ENC-FTR-101 Option B (ENC-TSK-H37): standing-projection out-of-band refresh
+  # Keeps the named GDS projection warm so anchored hybrid PPR runs
+  # gds.pageRank.stream against a standing projection instead of provisioning a
+  # ~58s session per request. The refresh handler keys off Input.action; the
+  # feature itself is gated by GDS_STANDING_PROJECTION_PREFIX on the function
+  # (an unset prefix makes the refresh a graceful no-op). Cadence bounds the
+  # AC-3 staleness window; ~58s cold build leaves ample headroom at 30m.
+  # Prod-only to match the validated target (DOC-B46C9EF2444D, exit 0).
+  # ---------------------------------------------------------------------------
+  StandingProjectionRefreshSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsProduction
+    Properties:
+      Name: !Sub "enceladus-standing-projection-refresh${EnvironmentSuffix}"
+      Description: "ENC-FTR-101 Option B: refresh the standing GDS projection for graph_query_api hybrid PPR."
+      ScheduleExpression: rate(30 minutes)
+      State: DISABLED  # ENC-ISS-465/J41: 30-min AGA warmer retired (cost kill)
+      Targets:
+        - Arn: !GetAtt GraphQueryApiFunction.Arn
+          Id: standing-projection-refresh
+          Input: '{"action":"refresh_projection","project_ids":["enceladus"]}'
+
+  StandingProjectionRefreshPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsProduction
+    Properties:
+      FunctionName: !Ref GraphQueryApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt StandingProjectionRefreshSchedule.Arn
+
+  GraphConnectivityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-graph-connectivity-low${EnvironmentSuffix}"
+      AlarmDescription: >-
+        Graph edge density below threshold indicates graph is approaching
+        disconnection — PLAN_CONTAINS / IMPLEMENTS traversals may degrade.
+      Namespace: Enceladus/GraphHealth
+      MetricName: FiedlerAlgebraicConnectivity
+      Dimensions:
+        - Name: ProjectId
+          Value: enceladus
+      Statistic: Average
+      Period: 86400
+      EvaluationPeriods: 1
+      Threshold: 0.1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+
+  # ---------------------------------------------------------------------------
+  # SQS -> Lambda Event Source Mappings
+  # ---------------------------------------------------------------------------
+
+  DeployOrchestratorSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-DeployQueueArn
+      FunctionName: !Ref DeployOrchestratorFunction
+      BatchSize: 1
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      Enabled: true
+
+  FeedPublisherSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-FeedPublishQueueArn
+      FunctionName: !Ref FeedPublisherFunction
+      BatchSize: 10
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      Enabled: true
+
+  GraphSyncSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      FunctionName: !Ref GraphSyncFunction
+      BatchSize: 10
+      Enabled: true
+
+  # ---------------------------------------------------------------------------
+  # DynamoDB Stream -> Lambda (Governance Audit)
+  # ---------------------------------------------------------------------------
+
+  GovernanceAuditStreamTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      FunctionName: !Ref GovernanceAuditFunction
+      BatchSize: 25
+      MaximumBatchingWindowInSeconds: 30
+      StartingPosition: LATEST
+      Enabled: true
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: tracker DynamoDB Stream -> convergence fan-out.
+  ConvergenceStreamTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      FunctionName: !Ref ConvergenceTelemetryFunction
+      BatchSize: 25
+      MaximumBatchingWindowInSeconds: 30
+      StartingPosition: LATEST
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Enabled: true
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: convergence SQS FIFO -> idempotent increment.
+  ConvergenceSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueArn
+      FunctionName: !Ref ConvergenceTelemetryFunction
+      BatchSize: 10
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      Enabled: true
+
+  # ---------------------------------------------------------------------------
+  # EventBridge Rules
+  # ---------------------------------------------------------------------------
+
+  CoordinationBatchPollerRule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-coordination-batch-poller${EnvironmentSuffix}"
+      Description: "ENC-TSK-G19: poll Anthropic Message Batches every 60s until ended"
+      ScheduleExpression: rate(1 minute)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: coordination-batch-poll
+          Input: '{"action": "coordination_batch_poll"}'
+
+  CoordinationBatchPollerPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CoordinationBatchPollerRule.Arn
+
+  # ENC-TSK-I71 (ENC-FTR-117 AC#8), backported to v4 by ENC-TSK-J91 (ENC-ISS-441 Ph1). The
+  # rule invokes the coordination_api with a fixed Input action; the handler reaps sessions
+  # left allocated/claimed past AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS via an append-only flip
+  # to 'retired' (NOT native DynamoDB TTL — TTL hard-deletes and would break the append-only
+  # retire model from ENC-TSK-I38). Targets the unqualified function ARN, matching the
+  # CoordinationBatchPollerRule precedent above. Unlike that rule, this one ships with its
+  # required AWS::Lambda::Permission so EventBridge can actually invoke the function.
+  AgentSessionIdleSweepSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-session-idle-sweep${EnvironmentSuffix}"
+      Description: "ENC-TSK-I71: reap abandoned agent sessions (append-only retire backstop for ENC-FTR-117 AC#8)"
+      ScheduleExpression: rate(1 hour)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: agent-session-idle-sweep
+          Input: '{"action": "agent_session_idle_sweep"}'
+
+  AgentSessionIdleSweepPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AgentSessionIdleSweepSchedule.Arn
+
+  # ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep. Reaps ghost
+  # registrations — sessions that called agent.register but never agent.claim within
+  # AGENT_SESSIONS_UNCLAIM_TTL_MINUTES of created_at (10 of 24 prod sessions showed this
+  # pattern, the ENC-ISS-441 evidence). Same append-only retire flip + Lambda::Permission
+  # discipline as the I71 idle-sweep rule above; both sweeps also revoke the session's SCI.
+  AgentSessionUnclaimSweepSchedule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-session-unclaim-sweep${EnvironmentSuffix}"
+      Description: "ENC-ISS-441/ENC-TSK-J94: reap never-claimed (ghost) agent sessions after the 10-min unclaim TTL and revoke their SCIs"
+      ScheduleExpression: rate(10 minutes)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: agent-session-unclaim-sweep
+          Input: '{"action": "agent_session_unclaim_sweep"}'
+
+  AgentSessionUnclaimSweepPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AgentSessionUnclaimSweepSchedule.Arn
+
+  # ENC-TSK-K02 / FTR-084 Ph2: weekly intent-classifier training (per-invocation only).
+  IntentClassifierTrainingSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-intent-classifier-training${EnvironmentSuffix}"
+      Description: "ENC-TSK-K02: weekly intent-classifier weight mutation (TRAINING_HARD_DISABLED until io clears)"
+      ScheduleExpression: "cron(0 4 ? * SUN *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CoordinationApiFunction.Arn
+          Id: intent-classifier-training
+          Input: '{"action": "intent_classifier_training"}'
+
+  IntentClassifierTrainingPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Ref CoordinationApiFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt IntentClassifierTrainingSchedule.Arn
+
+  IntentTrainingCostHeadroomAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsGamma
+    Properties:
+      AlarmName: !Sub "enceladus-intent-training-invocations${EnvironmentSuffix}"
+      AlarmDescription: >-
+        ENC-TSK-K02 cost-preflight guard: 7-day invocation window; weekly cadence
+        should be <=1/week (threshold 2 allows buffer). Breach indicates runaway schedule.
+      Namespace: AWS/Events
+      MetricName: Invocations
+      Dimensions:
+        - Name: RuleName
+          Value: !Sub "devops-intent-classifier-training${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 604800
+      EvaluationPeriods: 1
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # ENC-TSK-K03 / FTR-106: nightly unlearning cost-preflight (gamma only).
+  UnlearningCostHeadroomAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsGamma
+    Properties:
+      AlarmName: !Sub "enceladus-unlearning-invocations${EnvironmentSuffix}"
+      AlarmDescription: >-
+        ENC-TSK-K03 cost-preflight guard: 7-day invocation window; nightly cadence
+        should be <=7/week (threshold 10 allows buffer). Breach indicates runaway schedule.
+      Namespace: AWS/Events
+      MetricName: Invocations
+      Dimensions:
+        - Name: RuleName
+          Value: !Sub "devops-unlearning-nightly${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 604800
+      EvaluationPeriods: 1
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  DeployCodeBuildFinalizeRule:
+    Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-deploy-codebuild-finalize${EnvironmentSuffix}"
+      EventPattern:
+        source:
+          - aws.codebuild
+        detail-type:
+          - CodeBuild Build State Change
+        detail:
+          project-name:
+            - devops-ui-deploy-builder
+          build-status:
+            - SUCCEEDED
+            - FAILED
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt DeployFinalizeFunction.Arn
+          Id: deploy-finalize-target
+
+  Neo4jBackupSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-neo4j-backup-daily${EnvironmentSuffix}"
+      ScheduleExpression: "cron(0 3 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt Neo4jBackupFunction.Arn
+          Id: neo4j-backup-daily
+
+  Neo4jBackupPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref Neo4jBackupFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt Neo4jBackupSchedule.Arn
+
+  # ENC-FTR-096 Ph1 / ENC-TSK-I84: nightly memory consolidation trigger (02:00 UTC)
+  MemoryConsolidationSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-memory-consolidation-nightly${EnvironmentSuffix}"
+      Description: "Nightly handoff-to-lesson consolidation scan (ENC-FTR-096 Ph1)"
+      ScheduleExpression: "cron(0 2 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt MemoryConsolidationFunction.Arn
+          Id: memory-consolidation-nightly
+
+  MemoryConsolidationPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref MemoryConsolidationFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt MemoryConsolidationSchedule.Arn
+
+  # ENC-FTR-106 / ENC-TSK-K03: nightly unlearning trigger (04:00 UTC, after percolation)
+  UnlearningSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-unlearning-nightly${EnvironmentSuffix}"
+      Description: "Nightly Crick-Mitchison unlearning pass (ENC-FTR-106 / ENC-TSK-K03)"
+      ScheduleExpression: "cron(0 4 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt UnlearningFunction.Arn
+          Id: unlearning-nightly
+
+  UnlearningPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Ref UnlearningFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt UnlearningSchedule.Arn
+
+  ProjectJsonSyncRule:
+    Type: AWS::Events::Rule
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "on-project-json-sync${EnvironmentSuffix}"
+      EventPattern:
+        source:
+          - devops.json-sync
+        detail-type:
+          - project-json-sync
+      State: ENABLED
+      Targets:
+        - Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-json-to-parquet-transformer
+          Id: devops-json-to-parquet-transformer
+
+  # ---------------------------------------------------------------------------
+  # EventBridge Pipes (Tracker/Documents Streams -> Feed Queue)
+  # ---------------------------------------------------------------------------
+
+  TrackerToFeedPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-tracker-to-feed-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt FeedPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"dynamodb":{"NewImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-FeedPublishQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: $.dynamodb.NewImage.project_id.S
+          MessageDeduplicationId: $.dynamodb.Keys.record_id.S
+
+  DocumentsToFeedPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-documents-to-feed-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt FeedPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-DocumentsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-FeedPublishQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: $.dynamodb.NewImage.project_id.S
+          MessageDeduplicationId: $.dynamodb.Keys.document_id.S
+
+  TrackerToGraphPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-tracker-to-graph-sync-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt GraphPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"dynamodb":{"NewImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: $.dynamodb.NewImage.project_id.S
+          MessageDeduplicationId: $.dynamodb.Keys.record_id.S
+
+  # ENC-PLN-014 / ENC-FTR-065: Document node graph projection.
+  # Second EventBridge Pipe modeled on TrackerToGraphPipe, sourcing from the
+  # DocumentsTable DynamoDB Stream and targeting the same GraphSyncQueue. The
+  # graph_sync Lambda consumes both pipes' output transparently via its
+  # existing SQS event source. The MessageGroupId is the literal string
+  # "document" to keep document mutations in a distinct FIFO group from the
+  # tracker stream's project-scoped groups.
+  DocumentsToGraphPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-documents-to-graph-sync-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt GraphPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-DocumentsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: document
+          MessageDeduplicationId: $.dynamodb.Keys.document_id.S
+
+  # ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-identity graph projection pipes. Three more
+  # EventBridge Pipes modeled on TrackerToGraphPipe/DocumentsToGraphPipe, each sourcing a
+  # distinct agent-store DynamoDB Stream and targeting the SAME GraphSyncQueue. graph_sync
+  # consumes all pipes transparently via its existing SQS event source. Each uses a literal
+  # MessageGroupId (the store name) so agent mutations stay in a distinct FIFO group from
+  # the tracker/document groups; the store's own id field is the dedup id.
+  AgentSessionsToGraphPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-sessions-to-graph-sync-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt GraphPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-AgentSessionsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: agent-session
+          MessageDeduplicationId: $.dynamodb.Keys.session_id.S
+
+  AgentTypesToGraphPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-types-to-graph-sync-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt GraphPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-AgentTypesStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: agent-identity
+          MessageDeduplicationId: $.dynamodb.Keys.agent_type_id.S
+
+  AgentCredentialsToGraphPipe:
+    Type: AWS::Pipes::Pipe
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-agent-credentials-to-graph-sync-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt GraphPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-AgentCredentialsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: agent-credential
+          MessageDeduplicationId: $.dynamodb.Keys.credential_id.S
+
+  # ---------------------------------------------------------------------------
+  # IAM Roles (placeholder — full policies in each Lambda's deploy.sh)
+  # ---------------------------------------------------------------------------
+
+  CoordinationApiRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-coordination-api-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted the lambda-invoke grant).
+        - PolicyName: devops-coordination-api-bedrock-dispatch
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeBedrockAgentAlias
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeAgent
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent-alias/*"
+              - Sid: InvokeBedrockActionLambda
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-bedrock-agent-actions${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-bedrock-agent-actions${EnvironmentSuffix}:*"
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-coordination-api-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeBedrockAgentAlias
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeAgent
+                Resource: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent-alias/*"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-coordination-api${EnvironmentSuffix}*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/enceladus/mcp/server*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/enceladus/coordination/worker-runtime*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
+              - Sid: CoordinationTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}/index/*"
+              - Sid: TrackerTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              # ENC-TSK-I37 / ENC-TSK-J04 (ENC-FTR-117 / ENC-FTR-074): agent identity stores.
+              # agent_id_alloc mints ENC-SES/ENC-AGT and the credential lifecycle
+              # (issue/rotate/revoke + cascade) reads/writes the agent-credentials table.
+              - Sid: AgentIdStoresAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-sessions${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-types${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-credentials${EnvironmentSuffix}"
+              # ENC-ISS-441 / ENC-TSK-J92: agent.claim mints Session Claim ID (SCI) tokens
+              # into the checkout-tokens table (token_type=SCI); agent.retire and the J94
+              # sweeps revoke them. Minimal grant — no Scan/Query/Delete.
+              - Sid: SciTokenAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-checkout-tokens${EnvironmentSuffix}"
+              - Sid: GovernancePoliciesReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}/index/*"
+              # ENC-TSK-I57 / ENC-ISS-421: read the canonical governance-version record (ENC-TSK-I27/I29).
+              # The Lambda env sets GOVERNANCE_VERSION_TABLE and _compute_governance_hash_local() reads it;
+              # without this grant the prod role gets AccessDenied -> empty governance_hash -> global mutation block.
+              # ${EnvironmentSuffix} covers prod ("") and gamma ("-gamma"), superseding the one-shot gamma grant workflow.
+              - Sid: GovernanceVersionRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-version${EnvironmentSuffix}"
+              - Sid: DocumentsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              # ENC-TSK-J46 / ENC-FTR-096 Ph2: lesson-candidate approve/reject writes the
+              # curation decision directly (documents.patch's internal-key auth is shared
+              # with the MCP server's agent-facing path, so it cannot distinguish an
+              # already-Cognito-verified coordination_api relay from a bare agent call --
+              # direct-write here keeps the Cognito gate solely at coordination_api's own
+              # HTTP layer, where it is actually enforceable).
+              - Sid: DocumentsTableCandidateDecisionWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+              # ENC-TSK-J70 / ENC-FTR-121 Ph3: the Cognito-gated escalation
+              # approval flow drives applyEscalatedMutation (ENC-TSK-J69) in
+              # tracker_mutation via direct Lambda invoke -- the only reachable
+              # entry to the single privileged apply path (DOC-5B888FCA43B8 §6).
+              - Sid: InvokeTrackerMutationEscalationApply
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-tracker-mutation-api${EnvironmentSuffix}:*"
+              - Sid: ComponentRegistryTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}/index/*"
+              - Sid: GovernanceAndReferenceS3Read
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::jreese-net"
+              - Sid: GovernanceAndReferenceS3Get
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - "arn:aws:s3:::jreese-net/governance/*"
+                  - "arn:aws:s3:::jreese-net/projects/*"
+                  - "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
+              - Sid: GovernanceS3Write
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource:
+                  - "arn:aws:s3:::jreese-net/governance/live/*"
+                  - "arn:aws:s3:::jreese-net/governance/history/*"
+              # ENC-TSK-K02 / FTR-084 Ph2: versioned intent-training weight snapshots + labels.
+              - Sid: IntentTrainingS3ReadWrite
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}intent-training/*"
+              - Sid: S3HeadBucket
+                Effect: Allow
+                Action:
+                  - s3:HeadBucket
+                  - s3:GetBucketLocation
+                Resource: "arn:aws:s3:::jreese-net"
+              - Sid: SSMDispatch
+                Effect: Allow
+                Action:
+                  - ssm:SendCommand
+                  - ssm:GetCommandInvocation
+                  - ssm:ListCommands
+                  - ssm:ListCommandInvocations
+                  - ssm:DescribeInstanceInformation
+                Resource: "*"
+              - Sid: EC2FleetDispatch
+                Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ec2:DescribeLaunchTemplates
+                  - ec2:DescribeLaunchTemplateVersions
+                  - ec2:RunInstances
+                  - ec2:TerminateInstances
+                  - ec2:CreateTags
+                Resource: "*"
+              - Sid: ProviderSecretsRead
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/coordination/*"
+              - Sid: ComponentEventsTopicPublish
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-component-registry-events${EnvironmentSuffix}"
+              - Sid: CognitoTerminalAuth
+                Effect: Allow
+                Action:
+                  - cognito-idp:InitiateAuth
+                Resource: !Sub "arn:aws:cognito-idp:us-east-1:${AWS::AccountId}:userpool/us-east-1_b2D0V3E1k"
+              - Sid: CognitoOAuthClientManagement
+                Effect: Allow
+                Action:
+                  - cognito-idp:CreateUserPoolClient
+                  - cognito-idp:DeleteUserPoolClient
+                  - cognito-idp:DescribeUserPoolClient
+                  - cognito-idp:UpdateUserPoolClient
+                Resource: !Sub "arn:aws:cognito-idp:us-east-1:${AWS::AccountId}:userpool/us-east-1_b2D0V3E1k"
+              - Sid: BedrockAgentLifecycle
+                Effect: Allow
+                Action:
+                  - bedrock:CreateAgent
+                  - bedrock:GetAgent
+                  - bedrock:DeleteAgent
+                  - bedrock:PrepareAgent
+                  - bedrock:CreateAgentActionGroup
+                  - bedrock:GetAgentActionGroup
+                  - bedrock:DeleteAgentActionGroup
+                  - bedrock:CreateAgentAlias
+                  - bedrock:GetAgentAlias
+                  - bedrock:DeleteAgentAlias
+                  - bedrock:AssociateAgentKnowledgeBase
+                  - bedrock:DisassociateAgentKnowledgeBase
+                Resource: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent/*"
+              - Sid: BedrockAgentInvoke
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeAgent
+                Resource: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:agent-alias/*"
+              - Sid: BedrockPassAgentRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/enceladus-bedrock-agent-execution-role${EnvironmentSuffix}"
+              - Sid: FleetHostPassRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  TrackerMutationRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-tracker-mutation-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      # ENC-ISS-401: CloudWatch Logs (CreateLogGroup/CreateLogStream/PutLogEvents). The
+      # G95 codification below captured this role's INLINE policies from the live IAM dump
+      # but missed its ATTACHED managed policies (logs + DynamoDB + projects). On gamma the
+      # role is created fresh by this template, so those grants were absent and the Lambda
+      # failed every request with 500 'Database read failed' (and had no log group).
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access ("Record" service).
+        - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        # ENC-ISS-401: the DynamoDB + projects grants below were ATTACHED managed
+        # policies on prod-live (devops-tracker-dynamodb-policy, projects-read-policy)
+        # which are scoped to PROD table ARNs — so they are codified inline here with
+        # EnvironmentSuffix instead, resolving to the correct per-env table on gamma too.
+        - PolicyName: tracker-dynamodb
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: TrackerTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+        - PolicyName: projects-read
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ProjectsRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
+        - PolicyName: eventbridge-put-events
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - events:PutEvents
+                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+        # ENC-TSK-H46: allow tracker_mutation to synchronously invoke the Lifecycle Service.
+        - PolicyName: invoke-lifecycle-service
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeLifecycleService
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-lifecycle-service${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-lifecycle-service${EnvironmentSuffix}:*"
+        # ENC-TSK-H47: allow tracker_mutation to publish lesson-scoring requests to the Scoring
+        # Service SNS topic (least-privilege: this one topic only).
+        - PolicyName: publish-lesson-scoring
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: PublishLessonScoring
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"
+              # ENC-TSK-J72 / ENC-FTR-121 Ph5: escalation notifications to io
+              # ride the existing feed-alerts topic (DOC-5B888FCA43B8 §5.8).
+              - Sid: PublishEscalationAlerts
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-feed-alerts${EnvironmentSuffix}"
+
+  # ENC-TSK-H46 / B63 Phase 2A — execution role for the Lifecycle Service. Read-only:
+  # tracker table (subtask gate child lookups) + component-registry (STRICTNESS_RANK).
+  LifecycleServiceRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-lifecycle-service-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: enceladus-lifecycle-service-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/enceladus-lifecycle-service${EnvironmentSuffix}*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
+              - Sid: DynamoDBTrackerRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: DynamoDBComponentRegistryRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/component-registry${EnvironmentSuffix}"
+              # ENC-TSK-H84 / ENC-FTR-111 AC-5: read the projects table for the per-project
+              # deploy_policy that gates deploy-init auto-walk (evaluate_auto_walk action).
+              - Sid: DynamoDBProjectsRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+
+  # ENC-TSK-H47 / B63 Phase 2B — execution role for the Scoring Service. Least-privilege: CloudWatch
+  # Logs + write-back of the scoring attributes on the tracker (lesson) table only. GetItem/UpdateItem
+  # are scoped to the tracker table; the conditional write-back touches only the scoring_status /
+  # pillar_composite / resonance_score / scoring_completed_at attributes of an existing lesson item.
+  ScoringServiceRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-scoring-service-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: enceladus-scoring-service-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/enceladus-scoring-service${EnvironmentSuffix}*"
+              # ENC-TSK-K45 / B66 AC-1: X-Ray active tracing write access.
+              - Sid: XRayTracing
+                Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: "*"
+              - Sid: DynamoDBLessonScoringWriteback
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+
+  DocumentApiRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-document-api-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-document-api-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-document-api${EnvironmentSuffix}*"
+              - Sid: DynamoDBDocuments
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: DynamoDBProjectsRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: DynamoDBTrackerRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: S3DocumentsObjectAccess
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:DeleteObject
+                Resource: !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
+              # ENC-TSK-I70 / ENC-TSK-I62: env-prefix-aware so the gamma stack can read its
+              # own gamma/governance/live + gamma/mobile/v1/reference objects. Was hardcoded to
+              # the unprefixed prod paths, so the gamma governance sync 500'd on s3:GetObject
+              # (AccessDenied). No-op for prod (S3EnvPrefix is empty there).
+              - Sid: S3ReferenceRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}mobile/v1/reference/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}governance/live/*"
+              - Sid: S3ListPrefixes
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::jreese-net"
+              # ENC-TSK-I72 / ENC-TSK-I62: the governance sync path propagates a
+              # governance_data_dictionary.json change into the governance-policies record
+              # (discrete version + updated_at + dictionary_json blob), so the document-api
+              # role needs read+write here. (The ENC-TSK-I63 grant was misplaced on
+              # BedrockActionsRole; this is the corrective grant on the real DocumentApiRole.)
+              - Sid: GovernancePoliciesReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}/index/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  ProjectServiceRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-project-service-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted s3 reference write/delete).
+        - PolicyName: devops-project-service-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ProjectsTableFullAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
+              - Sid: TrackerTableLimitedWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: S3ReferenceWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource: "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: G95RestoredGrants
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ProjectsTableFullAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
+              - Sid: TrackerTableLimitedWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  FeedQueryRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-feed-query-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # ENC-ISS-313 / ENC-TSK-G95 (H02): only live CloudWatch Logs grant; preserve.
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: InvokeFeedPublisher
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeFeedPublisher
+                Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-feed-publisher${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-feed-publisher${EnvironmentSuffix}:*"
+        # ENC-ISS-313 / ENC-TSK-G95 (H02): restore DynamoDB read dropped by ENC-TSK-G43.
+        - PolicyName: devops-feed-query-dynamodb-read
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DynamoDBRead
+                Effect: Allow
+                Action:
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  CoordinationMonitorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-coordination-monitor-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-coordination-monitor-api-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-coordination-monitor-api${EnvironmentSuffix}*"
+              - Sid: CoordinationTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  DeployIntakeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-deploy-intake-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-deploy-intake-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-deploy-intake${EnvironmentSuffix}*"
+              - Sid: DeployTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: S3ConfigAccess
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: "arn:aws:s3:::jreese-net/deploy-config/*"
+              - Sid: SQSSendMessage
+                Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:GetQueueUrl
+                Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:devops-deploy-queue${EnvironmentSuffix}.fifo"
+              - Sid: InvokeDocPrepLambda
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-doc-prep${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-doc-prep${EnvironmentSuffix}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  DeployOrchestratorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-deploy-orchestrator-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: G95RestoredGrants
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DeployTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: TrackerTableWorklog
+                Effect: Allow
+                Action:
+                  - dynamodb:UpdateItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+              - Sid: S3ConfigAccess
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: "arn:aws:s3:::jreese-net/deploy-config/*"
+              - Sid: S3SourceRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - "arn:aws:s3:::jreese-net"
+                  - "arn:aws:s3:::jreese-net/deploy-sources/*"
+              - Sid: CodeBuildStart
+                Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                Resource: !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/devops-ui-deploy-builder${EnvironmentSuffix}"
+        - PolicyName: SqsEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeDeployQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-DeployQueueArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  DeployFinalizeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-deploy-finalize-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted these grants).
+        - PolicyName: devops-deploy-finalize-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-deploy-finalize${EnvironmentSuffix}*"
+              - Sid: DeployTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: TrackerTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: VersionFileWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: "arn:aws:s3:::jreese-net/deploy-config/*/current-version.json"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  # GMF: Deploy Decide IAM Role (DOC-63420302EF65)
+  DeployDecideRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-deploy-decide-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: DeployDecideInline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DynamoDBAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:PutItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: SecretsManagerAccess
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/github-app/*"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  # ENC-FTR-091 / ENC-TSK-F87 — Deploy Parity Validator IAM role
+  DeployParityValidatorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-deploy-parity-validator-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: DeployParityValidatorInline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: LambdaReadAndFixEnv
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:UpdateFunctionConfiguration
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-deploy-intake${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-deploy-decide${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-deploy-finalize${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-deploy-orchestrator${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-code${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-streamable${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-coordination-api${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-github-integration${EnvironmentSuffix}"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-code-gamma"
+              - Sid: DeployTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: SecretsManagerRead
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/github-app/*"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+              - Sid: DriftAuditCfn
+                Effect: Allow
+                Action:
+                  - cloudformation:DetectStackDrift
+                  - cloudformation:DescribeStackDriftDetectionStatus
+                Resource: "*"
+              - Sid: DriftAuditLambdaRead
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:ListFunctions
+                  - lambda:ListVersionsByFunction
+                Resource: "*"
+              - Sid: DriftAuditSns
+                Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-deploy-alerts"
+              # ENC-TSK-G43 / ENC-FTR-098 AC-7 — mentions_drift_audit needs
+              # read access to tracker + documents (base + type-updated-index)
+              # to sample recently-mutated records and recompute expected
+              # MENTIONS edges. Read-only by design — drift findings emit via
+              # the tracker_api HTTP path (X-Coordination-Internal-Key), not
+              # direct DDB write.
+              - Sid: MentionsAuditTrackerRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  ReferenceSearchRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-reference-search-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-reference-search-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-reference-search${EnvironmentSuffix}*"
+              - Sid: S3ReferenceRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  FeedPublisherRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-feed-publisher-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # ENC-ISS-313 / ENC-TSK-G95 (H02): out-of-band projects-read grant; preserve.
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/projects-read-policy"
+      Policies:
+        - PolicyName: SqsEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeFeedQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-FeedPublishQueueArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        # ENC-ISS-313 / ENC-TSK-G95 (H02): restore business grants dropped by ENC-TSK-G43.
+        # Analytics/CloudFront/SNS gated on IsProduction (prod-only pipeline).
+        - PolicyName: G95RestoredGrants
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DynamoDBRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: S3MobileFeedsWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}mobile/v1/*"
+              - Sid: EventBridgePut
+                Effect: Allow
+                Action: events:PutEvents
+                Resource: "*"
+              - !If
+                - IsProduction
+                - Sid: S3AnalyticsSyncStageWrite
+                  Effect: Allow
+                  Action: s3:PutObject
+                  Resource: "arn:aws:s3:::devops-agentcli-compute/projects/sync-stage/*"
+                - !Ref AWS::NoValue
+              - !If
+                - IsProduction
+                - Sid: CloudFrontInvalidation
+                  Effect: Allow
+                  Action: cloudfront:CreateInvalidation
+                  Resource: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/E2BOQXCW1TA6Y4"
+                - !Ref AWS::NoValue
+              - !If
+                - IsProduction
+                - Sid: SNSPublish
+                  Effect: Allow
+                  Action: sns:Publish
+                  Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-project-json-sync"
+                - !Ref AWS::NoValue
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  GovernanceAuditRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-governance-audit-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: DynamoDBStreamEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        # ENC-ISS-313 / ENC-TSK-G95 (H02): restore SNS publish (prod-only pipeline).
+        - !If
+          - IsProduction
+          - PolicyName: G95RestoredGrants
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Sid: SNSPublish
+                  Effect: Allow
+                  Action: sns:Publish
+                  Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:devops-project-json-sync"
+          - !Ref AWS::NoValue
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  DocPrepRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-doc-prep-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted these grants).
+        - PolicyName: devops-doc-prep-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-doc-prep${EnvironmentSuffix}*"
+              - Sid: DynamoDBProjects
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: DynamoDBTracker
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: DynamoDBDocuments
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: S3ReadDocs
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - "arn:aws:s3:::jreese-net/mobile/v1/reference/*"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  BedrockActionsRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-bedrock-actions-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: enceladus-bedrock-actions-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/enceladus-bedrock-agent-actions${EnvironmentSuffix}*"
+              - Sid: TrackerTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: ProjectsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+              - Sid: DocumentsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: CoordinationTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}/index/*"
+              - Sid: DeploymentTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+              - Sid: GovernancePoliciesRead
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/governance-policies${EnvironmentSuffix}/index/*"
+              - Sid: ComplianceTableWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-compliance-violations${EnvironmentSuffix}"
+              - Sid: S3ReadAccess
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - "arn:aws:s3:::jreese-net"
+                  - !Sub "arn:aws:s3:::jreese-net/${S3EnvPrefix}agent-documents/*"
+                  - "arn:aws:s3:::jreese-net/reference/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  ChangelogApiRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-changelog-api-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-ISS-313 / ENC-TSK-G95: grants applied out-of-band by the tombstoned
+        # per-Lambda deploy.sh ensure_role() (dropped by matrix-build migration
+        # ENC-TSK-G43), codified here from the live IAM dump. Each statement is
+        # proven to resolve identically to prod-live (EnvironmentSuffix='') and
+        # gamma-live (EnvironmentSuffix='-gamma'). See tools/iam-audit/.
+        - PolicyName: devops-changelog-api-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/devops-changelog-api${EnvironmentSuffix}*"
+              - Sid: DeployTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-deployment-manager${EnvironmentSuffix}/index/*"
+              - Sid: S3VersionRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: "arn:aws:s3:::jreese-net/deploy-config/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  AuthRefreshRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "auth-refresh-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted the Cognito grant).
+        - PolicyName: cognito-refresh-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CognitoInitiateAuth
+                Effect: Allow
+                Action: cognito-idp:InitiateAuth
+                Resource: !Sub "arn:aws:cognito-idp:us-east-1:${AWS::AccountId}:userpool/${CognitoUserPoolId}"
+        - PolicyName: SecretsManagerGitHubApp
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: SecretsManagerAccess
+                Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/github-app/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+
+  FeedPipeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-feed-pipe-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: pipes.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PipeSourceDynamoDBStreams
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerAndDocumentsStreams
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource:
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-TrackerStreamArn
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-DocumentsStreamArn
+        - PolicyName: PipeTargetSqs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: WriteFeedPublishQueue
+                Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:GetQueueUrl
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-FeedPublishQueueArn
+
+  GraphSyncRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-graph-sync-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: SqsEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeGraphSyncQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+        # ENC-ISS-313 / ENC-TSK-G95: restore grants the tombstoned per-Lambda
+        # deploy.sh ensure_role() applied, dropped by the matrix-build migration
+        # (ENC-TSK-G43). graph_sync reads the Neo4j secret and writes Titan V2
+        # embeddings via backend/lambda/graph_sync/embedding.py invoke_titan_v2.
+        - PolicyName: SecretsManagerNeo4j
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: SecretsManagerNeo4j
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        - PolicyName: BedrockTitanInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: BedrockTitanV2InvokeModel
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.titan-embed-text-v2:0"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-FTR-086 Ph1 / ENC-TSK-I82: Convergence Surface Lambda role.
+  # D1 architectural separation: read-only on the tracker STREAM (never the
+  # governance tables) + read/write only on its own counter table + consume/send
+  # on its own FIFO queue. Governance Lambdas have no access to the counter table.
+  ConvergenceTelemetryRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-convergence-telemetry-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ReadTrackerStream
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+        - PolicyName: ConvergenceQueue
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeAndSendConvergenceQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:GetQueueUrl
+                  - sqs:SendMessage
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-ConvergenceTelemetryQueueArn
+        - PolicyName: ConvergenceCounterTable
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CounterTableReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                  - dynamodb:Query
+                Resource:
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-ConvergenceTelemetryTableArn
+                  - !Sub
+                    - "${TableArn}/index/*"
+                    - TableArn: !ImportValue
+                        Fn::Sub: ${DataStackName}-ConvergenceTelemetryTableArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  GraphQueryApiRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-graph-query-api-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+        # ENC-ISS-304 / ENC-TSK-G94: re-grant the Bedrock Titan V2 invoke that the
+        # tombstoned per-Lambda deploy.sh ensure_role() used to apply. Required by
+        # backend/lambda/graph_sync/embedding.py invoke_titan_v2 for the
+        # hybrid-retrieval query-side embedding (the vector signal). Foundation-model
+        # ARNs are region-scoped and account-less.
+        - PolicyName: BedrockTitanInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: BedrockTitanV2InvokeModel
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                Resource:
+                  - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.titan-embed-text-v2:0"
+        # ENC-ISS-313 / ENC-TSK-G95: restore grants dropped by the deploy.sh
+        # tombstoning (ENC-TSK-G43). graph_query_api writes its own log group and
+        # reads the Neo4j secret for hybrid-retrieval. (Bedrock Titan grant above
+        # was added by ENC-TSK-G94.)
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: SecretsManagerNeo4j
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: SecretsManagerNeo4j
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        # ENC-FTR-087 Phase 1 (ENC-TSK-I85): write the per-wave drift-telemetry
+        # record + read the per-project time series via the GSI.
+        - PolicyName: DriftTelemetryTableAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DriftTelemetryReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}/index/*"
+        # ENC-FTR-109 / ENC-TSK-K05: stigmergic exploration trace writes.
+        - PolicyName: StigmergicTraceTableAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: StigmergicTraceWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-stigmergic-trace${EnvironmentSuffix}"
+        # ENC-FTR-082 AC-1 (ENC-TSK-H44): raw pathway-telemetry S3 append-log sink.
+        # The Lambda already emits envelopes and degrades to CloudWatch when
+        # PATHWAY_TELEMETRY_BUCKET is unset (ENC-TSK-H38); this grant + the env
+        # vars on GraphQueryApiFunction turn the durable sink on.
+        # ENC-TSK-K14: close_wave (PR #741) aggregates telemetry back via
+        # ListBucket+GetObject, scoped to the same prefix as the existing
+        # PutObject grant (still no access outside gamma/pathway-telemetry/).
+        - PolicyName: PathwayTelemetrySinkWrite
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: PathwayTelemetryPutObject
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}pathway-telemetry/*"
+              - Sid: PathwayTelemetryListBucket
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}"
+                Condition:
+                  StringLike:
+                    s3:prefix:
+                      - !Sub "${S3EnvPrefix}pathway-telemetry/*"
+        # ENC-TSK-K43 (B66 Ph5): publish the Fiedler lambda2 GraphHealth metric.
+        # PutMetricData has no resource-level restriction in the CloudWatch API
+        # (metric namespaces are not ARN-addressable), matching the identical
+        # unscoped grant on ProdHealthMonitorPolicy (05-monitoring.yaml).
+        - PolicyName: GraphHealthMetricPublish
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: GraphHealthPutMetricData
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  Neo4jBackupRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-neo4j-backup-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: neo4j-backup-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: SecretsManagerNeo4j
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+              - Sid: S3BackupWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}neo4j-backups/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-FTR-096 Ph1 / ENC-TSK-I84: Memory Consolidation Lambda IAM Role
+  MemoryConsolidationRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-memory-consolidation-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: memory-consolidation-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              # Read Handoff docs (Query via project-updated-index), read/put
+              # lesson-candidate drafts. No tracker table access — io-approval gate.
+              - Sid: DocumentsTableReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Query
+                  - dynamodb:PutItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: S3DocumentsObjectAccess
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}agent-documents/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-FTR-106 / ENC-TSK-K03: Unlearning Lambda IAM Role (gamma-only)
+  UnlearningRole:
+    Type: AWS::IAM::Role
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-unlearning-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: unlearning-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: DriftTelemetryQuery
+                Effect: Allow
+                Action:
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-drift-telemetry${EnvironmentSuffix}/index/*"
+              - Sid: StigmergicTraceQuery
+                Effect: Allow
+                Action:
+                  - dynamodb:Query
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-stigmergic-trace${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-stigmergic-trace${EnvironmentSuffix}/index/*"
+              - Sid: DocumentsTableReadWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+              - Sid: TrackerReferenceArchive
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+              - Sid: UnlearningS3Tombstones
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                  - s3:ListBucket
+                Resource:
+                  - !Sub "arn:aws:s3:::${S3Bucket}"
+                  - !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}unlearning-tombstones/*"
+                  - !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}unlearning-state/*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-TSK-C10: Graph Health Metrics Lambda IAM Role
+  GraphHealthMetricsRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-graph-health-metrics-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: GraphHealthMetricsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: CloudWatchMetrics
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+              # ENC-TSK-I10 (Dedup P6): the walk-back model-health loop reads
+              # the auto-merge/walk-back audit counters back from CloudWatch.
+              - Sid: CloudWatchMetricsRead
+                Effect: Allow
+                Action:
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:GetMetricData
+                Resource: "*"
+              - Sid: SecretsManagerNeo4j
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-TSK-I88 / ENC-FTR-085: comp-percolation-monitor execution role (gamma-only).
+  # Reads the graph over HTTPS via graph_query_api (no Neo4j/Secrets access);
+  # writes telemetry to its own DynamoDB table and CloudWatch metrics only.
+  PercolationMonitorRole:
+    Type: AWS::IAM::Role
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-percolation-monitor-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PercolationMonitorPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: CloudWatchMetrics
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+              - Sid: PercolationTelemetryWrite
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-percolation-telemetry${EnvironmentSuffix}"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  GraphPipeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-graph-pipe-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: pipes.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PipeSourceDynamoDBStream
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+              # ENC-PLN-014 / ENC-FTR-065: DocumentsToGraphPipe source perms
+              - Sid: ReadDocumentsStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-DocumentsStreamArn
+              # ENC-TSK-J04 / ENC-FTR-074 Ph3: Agent*ToGraphPipe source perms
+              - Sid: ReadAgentStreams
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource:
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-AgentSessionsStreamArn
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-AgentTypesStreamArn
+                  - !ImportValue
+                    Fn::Sub: ${DataStackName}-AgentCredentialsStreamArn
+        - PolicyName: PipeTargetSqs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: WriteGraphSyncQueue
+                Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:GetQueueUrl
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-TSK-F73 / ENC-ISS-283: EnvDriftAuditor IAM role (F57 AC-4 CFN adoption).
+  # Inline policy `env-drift-auditor-inline` is stamped to match live exactly so
+  # the CFN IMPORT change set reports no drift on the imported role.
+  EnvDriftAuditorRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-env-drift-auditor-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: env-drift-auditor-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Sid: LambdaConfigRead
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:ListFunctions
+                Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: env-drift-auditor
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-F74 / ENC-ISS-279: MCP Code Gamma Lambda (F57 AC-6 CFN adoption).
+  # Live resource created out-of-band in DOC-D45141D94C55 §1.4 (2026-04-20T06:14Z).
+  # Imported into this stack via create-change-set --change-set-type=IMPORT.
+  # IAM role devops-coordination-api-lambda-role-gamma is out-of-band and
+  # referenced by ARN (not CFN-managed from this stack).
+  # Literal "-gamma" suffix — resource is gamma-only, not gamma-aware.
+  # ---------------------------------------------------------------------------
+
+  EnceladusMcpCodeGammaFunction:
+    Type: AWS::Lambda::Function
+    # ENC-TSK-H29 / ENC-ISS-386: FunctionName is a hardcoded literal (no ${EnvironmentSuffix}),
+    # so this resource maps to the SAME physical function in every stack that renders it. The
+    # prod stack (enceladus-compute, Environment=production) already owns enceladus-mcp-code-gamma;
+    # without this condition the gamma stack (enceladus-compute-gamma) also tries to CREATE it and
+    # AWS::EarlyValidation::ResourceExistenceCheck rejects the cross-stack name collision, blocking
+    # every gamma compute deploy. Gating on IsProduction keeps the function prod-owned (zero prod
+    # change) and stops gamma from contending for the name. The live gamma environment continues to
+    # use this function unchanged.
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: enceladus-mcp-code-gamma
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: python3.12
+      Handler: server.lambda_handler
+      MemorySize: 512
+      Timeout: 30
+      Architectures:
+        - arm64
+      # ENC-TSK-F63 AC-2: SnapStart enabled (arm64/py3.12)
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/devops-coordination-api-lambda-role-gamma"
+      Layers:
+        - !Ref SharedLayerArn
+        # ENC-TSK-F63 AC-1: AppConfig extension layer (arm64)
+        - !If
+          - HasAppConfigLayer
+          - !Ref AppConfigExtensionLayerArnArm64
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEYS: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          COORDINATION_INTERNAL_API_KEY_SCOPES: ""
+          COORDINATION_TABLE: coordination-requests-gamma
+          COORDINATION_GSI_IDEMPOTENCY: idempotency-key-index
+          TRACKER_TABLE: devops-project-tracker-gamma
+          PROJECTS_TABLE: projects-gamma
+          DOCUMENTS_TABLE: documents-gamma
+          GOVERNANCE_POLICIES_TABLE: governance-policies-gamma
+          GOVERNANCE_DICTIONARY_POLICY_ID: governance_data_dictionary
+          # ENC-FTR-116 / ENC-TSK-I29: canonical governance-version DDB record.
+          GOVERNANCE_VERSION_TABLE: governance-version-gamma
+          DYNAMODB_REGION: us-west-2
+          SECRETS_REGION: us-west-2
+          S3_BUCKET: jreese-net
+          S3_GOVERNANCE_HISTORY_PREFIX: governance/history
+          S3_GOVERNANCE_PREFIX: governance/live
+          CORS_ORIGIN: https://jreese.net
+          ENVIRONMENT_SUFFIX: "-gamma"
+          ENCELADUS_MCP_SERVER_PATH: server.py
+          ENCELADUS_MCP_TRANSPORT: streamable_http
+          ENCELADUS_MCP_INTERFACE_MODE: code
+          ENCELADUS_COGNITO_USER_POOL_ID: us-east-1_b2D0V3E1k
+          ENCELADUS_COGNITO_CLIENT_ID: 6q607dk3liirhtecgps7hifmlk
+          ENCELADUS_COGNITO_CLIENT_SECRET: !Ref EnceladusCognitoClientSecret
+          ENCELADUS_COGNITO_REGION: us-east-1
+          ENCELADUS_COGNITO_DOMAIN: https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com
+          MCP_AUDIT_CALLER_IDENTITY: devops-coordination-api-gamma
+          MCP_SERVER_LOG_GROUP: /enceladus/mcp/server
+          # ENC-ISS-410 / ENC-TSK-I14: gamma backend bases. The MCP front-end (server.py)
+          # proxies the coordination, tracker, and graph planes to these hosts; if unset it
+          # falls back to hardcoded prod defaults (https://jreese.net/... and the prod
+          # graphsearch APIGW), which silently routes the 'gamma' connector's tracker+graph
+          # planes to the PROD corpus (the ENC-ISS-410 misroute). Round-1/round-2 set these
+          # live on enceladus-mcp-streamable-gamma; codified here so they survive a stack
+          # deploy. All three resolve to the gamma gateway (enceladus-gamma.jreese.net) and
+          # are values verified against the live function on 2026-06-25.
+          ENCELADUS_COORDINATION_API_URL: https://enceladus-gamma.jreese.net/api/v1
+          ENCELADUS_TRACKER_API_BASE: https://enceladus-gamma.jreese.net/api/v1/tracker
+          ENCELADUS_GRAPH_QUERY_API_BASE: https://enceladus-gamma.jreese.net/api/v1/tracker/graphsearch
+          # ENC-TSK-F63 AC-1 / ENC-ISS-313 H02 audit: flags are migrating to AppConfig, but the
+          # AppConfig application/environment are not yet provisioned on this stack (IDs empty),
+          # so these ENABLE_* remain as the appconfig_flags.flag() env_fallback to keep gamma's
+          # live features on. AppConfig takes precedence automatically once populated.
+          ENABLE_CLAUDE_HEADLESS: "true"
+          ENABLE_COMPONENT_PROPOSAL: "true"
+          ENABLE_CONTEXT_NODES: "true"
+          ENABLE_HANDOFF_PRIMITIVE: "true"
+          ENABLE_LESSON_PRIMITIVE: "true"
+          ENABLE_TYPED_RELATIONSHIPS: "true"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          # ENC-TSK-J31 / ENC-ISS-462: this function is a GAMMA function but is prod-stack-owned
+          # (Condition: IsProduction, H29/ISS-386 name-collision guard), so it inherits the PROD
+          # stack's AppConfigApplicationId param. Hardcode the GAMMA AppConfig ids so a prod compute
+          # deploy sets it to read gamma feature-flags (enceladus-feature-flags-gamma), not prod's.
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, "fhhcl7m", !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, "zecfu42", !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: mcp-code
+        - Key: Environment
+          Value: gamma
+
+
+  # ---------------------------------------------------------------------------
+  # ENC-ISS-422 (residual of ENC-ISS-306): enceladus-mcp-streamable Function URL
+  # was left at Qualifier=NONE (-> $LATEST) when ENC-TSK-I24 fixed only mcp-code,
+  # so any update-function-code on streamable is an unguarded prod traffic switch
+  # (same class as the 2026-04-25 mcp-code Sev1). Mirror the I24 mcp-code mitigation:
+  # repoint the streamable Function URL to the `live` alias and codify it here so it
+  # is stack-managed. As with mcp-code, the `live` ALIAS itself is deliberately NOT
+  # codified (AWS::Lambda::Alias requires a FunctionVersion ops moves on every
+  # promotion -> ENC-ISS-313 CFN-stomp class); the Url references the alias by name
+  # and the alias stays operationally managed.
+  #
+  # ADOPTED OUT-OF-BAND (import-first, like EnceladusMcpCodeLiveFunctionUrl): ops
+  # creates the streamable `live` alias, repoints the Function URL to Qualifier=live,
+  # then a non-destructive CFN IMPORT adopts THIS resource with the identical physical
+  # id (mcp.jreese.net served uninterrupted). Do not let a normal compute deploy try to
+  # CREATE it. Prod-only (Condition: IsProduction) — not rendered on the gamma stack.
+  # ---------------------------------------------------------------------------
+  EnceladusMcpStreamableLiveFunctionUrl:
+    Type: AWS::Lambda::Url
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      TargetFunctionArn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-streamable"
+      Qualifier: live
+      AuthType: NONE
+      InvokeMode: BUFFERED
+      Cors:
+        AllowCredentials: true
+        AllowHeaders:
+          - content-type
+          - authorization
+          - accept
+          - mcp-session-id
+        AllowMethods:
+          - "*"
+        AllowOrigins:
+          - "https://claude.ai"
+        ExposeHeaders:
+          - mcp-session-id
+        MaxAge: 86400
+
+  # ENC-TSK-J13 (ENC-ISS-455): enceladus-checkout-auto — the sole documented prod
+  # EventBridge orphan (created out-of-band via CLI for ENC-FTR-037). ADOPTED via
+  # `create-change-set --change-set-type IMPORT` (resource-import-checkout-auto.json)
+  # BEFORE any normal compute deploy. A plain deploy that ADDs this rule fails closed
+  # at AWS::Events::Rule "already exists" (the enceladus-monitoring UPDATE_ROLLBACK
+  # class); import first. Literal prod-only name (Condition: IsProduction) — no gamma
+  # sibling exists. DeletionPolicy/UpdateReplacePolicy: Retain so a stack op never
+  # deletes the live auto-checkout schedule. Properties mirror live EXACTLY for a
+  # clean Import/no-op change-set (rate(5 minutes), ENABLED, target the -auto Lambda).
+  # NOTE: the events->lambda AWS::Lambda::Permission is NOT importable and stays
+  # out-of-band (ENC-ISS-394 precedent); only the rule is adopted here.
+  # After import, J14 drops the audit's documented-exception for enceladus-checkout-auto.
+  CheckoutAutoScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: IsProduction
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: enceladus-checkout-auto
+      Description: "Auto-checkout Enceladus tasks after 15-minute window (ENC-FTR-037)"
+      ScheduleExpression: "rate(5 minutes)"
+      State: ENABLED
+      Targets:
+        - Id: checkout-auto-target
+          Arn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-checkout-service-auto"
+
+  # ENC-TSK-I27 / ENC-FTR-116 Wave 2: recompute-governance Lambda.
+  # Triggered by S3 ObjectCreated on governance/live/*; writes canonical
+  # governance-version DDB record. IAM sole-writer grant (I28).
+  RecomputeGovernanceFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-recompute-governance${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt RecomputeGovernanceRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          GOVERNANCE_VERSION_TABLE: !Sub "governance-version${EnvironmentSuffix}"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance
+
+  RecomputeGovernanceRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-recompute-governance-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3GovernanceRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadGovernanceLiveObjects
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:HeadObject
+                  - s3:GetObjectAttributes
+                Resource: "arn:aws:s3:::jreese-net/governance/live/*"
+              - Sid: ListGovernanceLivePrefix
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::jreese-net"
+                Condition:
+                  StringLike:
+                    "s3:prefix": "governance/live/*"
+        - PolicyName: GovernanceVersionDDBWrite
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: WriteCanonicalRecord
+                Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GovernanceVersionTableArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  # ENC-TSK-I32 / ENC-FTR-116: governance drift-detection backstop.
+  # Scheduled Argo/FIM-style reconcile — recomputes the §4.3 bundle hash from
+  # live S3 and compares it against the canonical governance-version record.
+  # Read-only (never writes the record or governance/live/*); emits a
+  # CloudWatch metric + SNS alert on disagreement or recompute failure.
+  GovernanceDriftCheckFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-governance-drift-check${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt GovernanceDriftCheckRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          GOVERNANCE_VERSION_TABLE: !Sub "governance-version${EnvironmentSuffix}"
+          GOVERNANCE_S3_BUCKET: jreese-net
+          DRIFT_METRIC_NAMESPACE: Enceladus/Governance
+          GOVERNANCE_ALERT_SNS_ARN: !ImportValue
+            Fn::Sub: ${DataStackName}-DeadLetterTopicArn
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance
+
+  GovernanceDriftCheckRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-governance-drift-check-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3GovernanceRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadGovernanceLiveObjects
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:HeadObject
+                  - s3:GetObjectAttributes
+                Resource: "arn:aws:s3:::jreese-net/governance/live/*"
+              - Sid: ListGovernanceLivePrefix
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::jreese-net"
+                Condition:
+                  StringLike:
+                    "s3:prefix": "governance/live/*"
+        - PolicyName: GovernanceVersionDDBRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Read-only: drift check NEVER writes the canonical record (I28
+              # reserves writes to the recompute role alone).
+              - Sid: ReadCanonicalRecord
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-GovernanceVersionTableArn
+        - PolicyName: DriftTelemetry
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EmitDriftMetric
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "cloudwatch:namespace": Enceladus/Governance
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  # SNS publish to the existing dead-letter/alert topic for drift alerts.
+  GovernanceDriftCheckSnsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "governance-drift-check-sns-publish${EnvironmentSuffix}"
+      Roles:
+        - !Ref GovernanceDriftCheckRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: PublishDriftAlert
+            Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !ImportValue
+              Fn::Sub: ${DataStackName}-DeadLetterTopicArn
+
+  # Hourly schedule — the FIM-style backstop cadence (recompute already keeps
+  # the record warm on every write; this catches lost events / silent drift).
+  GovernanceDriftCheckSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "devops-governance-drift-check${EnvironmentSuffix}"
+      Description: Hourly governance-version drift reconcile (ENC-TSK-I32).
+      ScheduleExpression: "rate(1 hour)"
+      State: ENABLED
+      Targets:
+        - Id: GovernanceDriftCheckTarget
+          Arn: !GetAtt GovernanceDriftCheckFunction.Arn
+
+  GovernanceDriftCheckSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GovernanceDriftCheckFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GovernanceDriftCheckSchedule.Arn
+
+  # ENC-TSK-I58 / ENC-ISS-421 (durable fix #2): hourly recompute backstop.
+  # The S3 governance/live/* -> recompute relay is wired for gamma only (the relay
+  # SNS topic + bucket notification are out-of-band, us-west-1), so the PROD canonical
+  # governance-version record would otherwise freeze at the manual backfill seed and go
+  # stale on the next agents.md change (the drift-check Lambda only ALARMS, it never
+  # writes). This schedule invokes the recompute (the I28 sole-writer) hourly with a
+  # synthetic governance/live/agents.md S3 event so it recomputes the bundle hash from
+  # live S3 and refreshes the canonical record. Empty sequencer intentionally bypasses
+  # the recompute's exact-sequencer dedup (handler: `prev_seq and prev_seq == seq`), so
+  # every scheduled tick recomputes. Hourly latency is acceptable for a backstop and
+  # matches the GovernanceDriftCheckSchedule cadence above. Templated -> prod and gamma
+  # (gamma keeps its event-driven path; this is an additional safety net there).
+  RecomputeGovernanceSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "devops-recompute-governance-backstop${EnvironmentSuffix}"
+      Description: Hourly governance-version recompute backstop (ENC-TSK-I58 / ENC-ISS-421).
+      ScheduleExpression: "rate(1 hour)"
+      State: ENABLED
+      Targets:
+        - Id: RecomputeGovernanceBackstopTarget
+          Arn: !GetAtt RecomputeGovernanceFunction.Arn
+          Input: '{"Records":[{"eventSource":"aws:scheduled-backstop","s3":{"object":{"key":"governance/live/agents.md","sequencer":"","versionId":""}}}]}'
+
+  RecomputeGovernanceSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref RecomputeGovernanceFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt RecomputeGovernanceSchedule.Arn
+
+  # Drift alarm — fires when the canonical record disagrees with live S3.
+  GovernanceVersionDriftAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-governance-version-drift${EnvironmentSuffix}"
+      AlarmDescription: >-
+        Canonical governance-version record disagrees with live S3 checksums
+        (ENC-ISS-390 backstop). The drift-check Lambda emits
+        GovernanceVersionDrift=1 on hash mismatch, a missing record, or a
+        failed recompute from live S3.
+      Namespace: Enceladus/Governance
+      MetricName: GovernanceVersionDrift
+      Statistic: Maximum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # Recompute-failure alarm — the canonical record cannot rotate if the
+  # storage-event recompute Lambda is erroring.
+  RecomputeGovernanceErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-recompute-governance-errors${EnvironmentSuffix}"
+      AlarmDescription: >-
+        The recompute-governance Lambda is failing; canonical governance-version
+        record may be stale relative to live S3 (ENC-ISS-390 backstop).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref RecomputeGovernanceFunction
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  # The drift-checker itself failing is a blind-spot — alarm on its errors too.
+  GovernanceDriftCheckErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-governance-drift-check-errors${EnvironmentSuffix}"
+      AlarmDescription: >-
+        The governance drift-check Lambda is failing; drift detection is blind
+        until it recovers (ENC-TSK-I32).
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref GovernanceDriftCheckFunction
+      Statistic: Sum
+      Period: 3600
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+Outputs:
+  CoordinationApiFunctionArn:
+    Value: !GetAtt CoordinationApiFunction.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-CoordinationApiFunctionArn
+  DocumentApiFunctionArn:
+    Value: !GetAtt DocumentApiFunction.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DocumentApiFunctionArn

--- a/infrastructure/cloudformation/resource-import-compute-gamma-k44.json
+++ b/infrastructure/cloudformation/resource-import-compute-gamma-k44.json
@@ -1,0 +1,12 @@
+[
+  {
+    "ResourceType": "AWS::Lambda::Function",
+    "LogicalResourceId": "ProdHealthMonitorFunction",
+    "ResourceIdentifier": { "FunctionName": "enceladus-prod-health-monitor-gamma" }
+  },
+  {
+    "ResourceType": "AWS::IAM::Role",
+    "LogicalResourceId": "ProdHealthMonitorRole",
+    "ResourceIdentifier": { "RoleName": "enceladus-prod-health-monitor-role-gamma" }
+  }
+]


### PR DESCRIPTION
## Summary
Follow-up to #779 (ENC-TSK-K44). Moving `ProdHealthMonitorFunction`/`ProdHealthMonitorRole` from `05-monitoring.yaml` into `02-compute.yaml` left the live physical resources (`enceladus-prod-health-monitor-gamma` Lambda + `enceladus-prod-health-monitor-role-gamma` IAM role, both `DeletionPolicy: Retain`) orphaned relative to `enceladus-compute-gamma` — the ENC-TSK-H29 orphan guard in `CloudFormation Compute Stack Deploy` correctly failed closed on this (run 28595431851).

Adds two inert support files (no workflow path-filter references either, so this PR triggers no deploy):
- `infrastructure/cloudformation/resource-import-compute-gamma-k44.json` — resources-to-import manifest for the ENC-TSK-J13 `cfn-resource-import.yml` workflow.
- `infrastructure/cloudformation/02-compute-import-stage-k44.yaml` — a snapshot of `02-compute.yaml` at commit `a6e48d9` (my last K44 commit, pre-K41/#782 merge). CFN `change-set-type=IMPORT` requires the diff to contain ONLY `Action=Import` (enforced by `tools/assert_changeset_safe.py`); the current HEAD template also carries K41's new (not-yet-live) `CorpusEntropyEngine*` resources, which would appear as `Action=Add` and abort the import. This snapshot's `ProdHealthMonitorFunction`/`Role` blocks are byte-identical to current HEAD.

Both files are needed on `v4/main` (not just a side branch) because `tools/pre-deploy-health-gate.sh` in the import workflow resolves `template_file` against the plain dispatch-ref checkout, not the `source_ref` staged checkout.

After merge: dispatch `cfn-resource-import.yml` (mode=import, stack=enceladus-compute-gamma, template=`02-compute-import-stage-k44.yaml`, manifest=`resource-import-compute-gamma-k44.json`) to adopt the two orphaned resources. A preview run (28595941157) already proved the change-set is a clean 2-resource Import with `[PASS] change-set is SAFE to execute autonomously`; only the health-gate template path was missing pre-merge.

Part of the same ENC-TSK-K44 delivery as #779 (still in deploy-init).

CCI-a16da6d976244ffb89beac29cf8b4719

## Test plan
- [x] Preview dispatch (run 28595941157): change-set = `Import AWS::Lambda::Function ProdHealthMonitorFunction` + `Import AWS::IAM::Role ProdHealthMonitorRole`, `assert_changeset_safe.py` PASS
- [ ] Post-merge: re-dispatch with `preview_only=false` to execute the import
- [ ] Confirm `enceladus-compute-gamma` stack lists both resources as managed
- [ ] Re-run `CloudFormation Compute Stack Deploy` on `v4/main` — orphan guard should pass