### PR TITLE
[ENC-TSK-K51] Fix em-dash in AppConfig resource Descriptions (ENC-ISS-479)

### DIFF
--- a/infrastructure/cloudformation/06-feature-flags.yaml
+++ b/infrastructure/cloudformation/06-feature-flags.yaml
@@ -109,7 +109,7 @@ Resources:
       ApplicationId: !Ref FeatureFlagsApplication
       ConfigurationProfileId: !Ref FeatureFlagsProfile
       ContentType: application/json
-      Description: "Initial version — all flags enabled (migrated from ENABLE_* env vars)"
+      Description: "Initial version - all flags enabled (migrated from ENABLE_* env vars)"
       Content: |
         {
           "enable_claude_headless": true,
@@ -129,7 +129,7 @@ Resources:
     Type: AWS::AppConfig::DeploymentStrategy
     Properties:
       Name: !Sub "enceladus-immediate${EnvironmentSuffix}"
-      Description: Immediate activation, no bake time — safe for boolean feature flags
+      Description: Immediate activation, no bake time - safe for boolean feature flags
       ReplicateTo: NONE
       DeploymentDurationInMinutes: 0
       FinalBakeTimeInMinutes: 0
@@ -148,7 +148,7 @@ Resources:
       ConfigurationProfileId: !Ref FeatureFlagsProfile
       ConfigurationVersion: !Ref FeatureFlagsInitialVersion
       DeploymentStrategyId: !Ref FeatureFlagsDeploymentStrategy
-      Description: "Initial activation — migrated from ENABLE_* env vars (ENC-TSK-F63)"
+      Description: "Initial activation - migrated from ENABLE_* env vars (ENC-TSK-F63)"
 
 Outputs:
   ApplicationId:

--- a/infrastructure/cloudformation/09-appconfig-governance.yaml
+++ b/infrastructure/cloudformation/09-appconfig-governance.yaml
@@ -70,7 +70,7 @@ Resources:
       ConfigurationProfileId: !Ref BudgetHierarchyProfile
       ContentType: application/json
       Description: >-
-        Initial version — mirrors DEFAULT_SCALE_BUDGETS_TOKENS in
+        Initial version - mirrors DEFAULT_SCALE_BUDGETS_TOKENS in
         budget_hierarchy.py exactly, so activation is a no-op until someone
         deliberately pushes a change.
       Content: |
@@ -85,7 +85,7 @@ Resources:
     Type: AWS::AppConfig::DeploymentStrategy
     Properties:
       Name: !Sub "enceladus-governance-immediate${EnvironmentSuffix}"
-      Description: Immediate activation, no bake time — matches feature-flags precedent.
+      Description: Immediate activation, no bake time - matches feature-flags precedent.
       ReplicateTo: NONE
       DeploymentDurationInMinutes: 0
       FinalBakeTimeInMinutes: 0
@@ -100,7 +100,7 @@ Resources:
       ConfigurationProfileId: !Ref BudgetHierarchyProfile
       ConfigurationVersion: !Ref BudgetHierarchyInitialVersion
       DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
-      Description: "Initial activation — ENC-TSK-K33, defaults match hardcoded fallback"
+      Description: "Initial activation - ENC-TSK-K33, defaults match hardcoded fallback"
 
   # ---------------------------------------------------------------------------
   # governance-doctrine — string/number/boolean doctrine levers. No named
@@ -117,7 +117,7 @@ Resources:
       LocationUri: hosted
       Description: >-
         Typed-open doctrine levers (string/number/boolean) that are neither a
-        boolean feature gate nor a budget number — e.g. a canary preference
+        boolean feature gate nor a budget number - e.g. a canary preference
         name, an SLA minute count. Placeholder until a first real consumer
         lands; see DOC-623CAFD9D1F6.
       Validators:
@@ -140,7 +140,7 @@ Resources:
       ApplicationId: !Ref AppConfigApplicationId
       ConfigurationProfileId: !Ref GovernanceDoctrineProfile
       ContentType: application/json
-      Description: "Placeholder — synthetic canary key only, no real consumer yet (ENC-TSK-K33)"
+      Description: "Placeholder - synthetic canary key only, no real consumer yet (ENC-TSK-K33)"
       Content: |
         {
           "_canary": "k33-verification-placeholder"
@@ -154,7 +154,7 @@ Resources:
       ConfigurationProfileId: !Ref GovernanceDoctrineProfile
       ConfigurationVersion: !Ref GovernanceDoctrineInitialVersion
       DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
-      Description: "Initial activation — placeholder, ENC-TSK-K33"
+      Description: "Initial activation - placeholder, ENC-TSK-K33"
 
 Outputs:
   BudgetHierarchyProfileId:


### PR DESCRIPTION
## Summary
- CloudFormation's SigV4 signing to the AppConfig API fails when a `Description` property on an `AppConfig::HostedConfigurationVersion`, `Deployment`, `DeploymentStrategy`, or `ConfigurationProfile` resource contains an em-dash (U+2014) -- the canonical string CFN builds shows it mangled to `?`, so the signed bytes diverge from the bytes sent, and the call fails `403 SignatureDoesNotMatch`.
- Replaces em-dash with ASCII hyphen in the `Description` properties of every AppConfig resource in `06-feature-flags.yaml` and `09-appconfig-governance.yaml`. No other content changes -- flag values, schemas, comments, and CFN `Outputs` descriptions (never sent to the AppConfig API) are untouched.
- Discovered blocking ENC-TSK-K33: both `enceladus-feature-flags-gamma` (update) and `enceladus-appconfig-governance-gamma` (create) failed identically on this signature mismatch. Both attempts rolled back cleanly with no partial application.

CCI-afe6f10c6406476fa7b71261a6df547e

ENC-TSK-K51 / ENC-ISS-479

## Test plan
- [x] Both templates pass `aws cloudformation validate-template`
- [x] Diff scoped to only em-dash -> hyphen substitutions in AppConfig-resource `Description` properties (9 lines changed per file)
- [ ] `enceladus-feature-flags-gamma` deploys `UPDATE_COMPLETE` from this template (blocked on merge)
- [ ] `enceladus-appconfig-governance-gamma` deploys `CREATE_COMPLETE` from this template (blocked on merge)
- [ ] Live-push round-trip verification for both profiles (ENC-TSK-K33, resumes after this merges)