### PR TITLE
fix(deploy): add corpus_entropy_engine to v4-gamma function_name_map

### DIFF
--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -93,3 +93,4 @@ function_name_map:
   lifecycle_service: enceladus-lifecycle-service-gamma
   scoring_service: enceladus-scoring-service-gamma
   recompute_governance: devops-recompute-governance-gamma
+  corpus_entropy_engine: enceladus-corpus-entropy-engine-gamma


### PR DESCRIPTION
## Summary
- Follow-up to ENC-TSK-K41 (PR #782, merged): `envs/v4-gamma.yaml`'s `function_name_map` was missing a `corpus_entropy_engine` entry, so the Gen2 deploy step's `update-function-code` silently skipped it (per the file's own documented behavior: "Functions absent from this map are silently skipped by the deploy step")
- The CFN `CorpusEntropyEngineFunction` resource now exists live (created after the K44 out-of-band-Lambda-import fix unblocked the compute stack apply) but only with its CFN `ZipFile` stub as code — this entry is required for the next Gen2 deploy to push the real Lambda code

CCI-5f14ab4a407142f88352ca126fb01b1e

ENC-TSK-K41

## Test plan
- [x] `envs/v4-gamma.yaml` diff reviewed — single-line addition, alphabetically consistent with sibling entries
- [ ] Next `_deploy.yml` push-triggered run on `v4/main` shows `enceladus-corpus-entropy-engine-gamma` in the deploy step's function name map and updates its code (CodeSize > 1024)