### PR TITLE
[ENC-TSK-K52] v4 UI pipeline T1 — 07-ui-cdn.yaml CFN + gated deploy lane

### DIFF
--- a/.github/workflows/cloudformation-ui-cdn-stack-deploy.yml
+++ b/.github/workflows/cloudformation-ui-cdn-stack-deploy.yml
@@ -1,0 +1,235 @@
+name: CloudFormation UI CDN Stack Deploy
+
+# ENC-TSK-K52 / T1 — v4 UI Deploy Pipeline (DOC-3EE4F709EC98).
+# plan/apply split with a GitHub Environment gate, mirroring the sibling CFN
+# stack-deploy workflows (compute/api/monitoring). The plan job creates — but
+# does not execute — the 07-ui-cdn change-set and writes its resource summary
+# to the job summary. The apply job runs inside a GitHub Environment: v3-prod
+# (required reviewer: io) for main, v4-gamma (no reviewer) for v4/**. A merge
+# to main therefore PAUSES as a reviewable, rejectable request instead of
+# deploying prod directly (the ENC-FTR-120 / 1292/J08 class).
+#
+# Change-set creation uses `aws cloudformation deploy --no-execute-changeset`
+# so a merge to v4/main stands gamma up automatically, while prod is a gated
+# flip later. The gamma stack (enceladus-ui-cdn-gamma) validates on the
+# distribution's default *.cloudfront.net domain (no ACM/Cloudflare).
+#
+# Escalated prereq (07-ui-cdn.yaml Metadata.EscalatedPrereqs): the privileged
+# CFN deploy role needs cloudfront:* + S3 bucket-create/policy perms via an
+# io-gated attached-managed-policy IAM patch BEFORE the first gamma apply, or
+# the apply AccessDenies at change-set execution.
+
+on:
+  push:
+    branches:
+      - main
+      - 'v4/**'
+    paths:
+      - "infrastructure/cloudformation/07-ui-cdn.yaml"
+      - ".github/workflows/cloudformation-ui-cdn-stack-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 07-ui-cdn template"
+        type: string
+        required: false
+        default: "enceladus-ui-cdn"
+      api_origin_domain_name:
+        description: "API Gateway origin host for the /api/* behavior (host only; blank => template default)"
+        type: string
+        required: false
+        default: ""
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual UI CDN stack deploy"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-ui-cdn-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/07-ui-cdn.yaml
+  ENVIRONMENT_SUFFIX: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
+  DEFAULT_STACK_NAME: enceladus-ui-cdn
+
+jobs:
+  plan:
+    name: Plan UI CDN stack change-set
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify CF role secret is set
+        run: |
+          if [ -z "${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}" ]; then
+            echo "::error::AWS_CLOUDFORMATION_ROLE_TO_ASSUME secret is not set or empty. Set it to the ARN of a role with cloudformation:*, cloudfront:*, and S3 bucket-create/policy permissions."
+            exit 1
+          fi
+          echo "AWS_CLOUDFORMATION_ROLE_TO_ASSUME is set."
+
+      - name: Configure AWS credentials (OIDC privileged CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        env:
+          INPUT_STACK_NAME: ${{ github.event.inputs.stack_name }}
+        run: |
+          set -euo pipefail
+
+          stack_name="${INPUT_STACK_NAME:-${DEFAULT_STACK_NAME}}${ENVIRONMENT_SUFFIX}"
+          [ -n "${ENVIRONMENT_SUFFIX}" ] && environment="gamma" || environment="production"
+
+          {
+            echo "stack_name=${stack_name}"
+            echo "environment=${environment}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create UI CDN stack change-set (no execute)
+        id: changeset
+        env:
+          INPUT_API_ORIGIN_DOMAIN_NAME: ${{ github.event.inputs.api_origin_domain_name }}
+        run: |
+          set -euo pipefail
+
+          # Only override ApiOriginDomainName when the dispatch supplied one;
+          # otherwise let the template Default (gamma execute-api host) stand,
+          # and `aws cloudformation deploy` reuse the stack's stored value on
+          # subsequent updates.
+          extra_overrides=()
+          if [ -n "${INPUT_API_ORIGIN_DOMAIN_NAME}" ]; then
+            extra_overrides+=("ApiOriginDomainName=${INPUT_API_ORIGIN_DOMAIN_NAME}")
+          fi
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 07-ui-cdn/ \
+            --parameter-overrides \
+              Environment="${{ steps.params.outputs.environment }}" \
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" \
+              "${extra_overrides[@]}" 2>&1 | tee /tmp/plan-ui-cdn.log
+
+          if grep -q "No changes to deploy" /tmp/plan-ui-cdn.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## UI CDN stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan-ui-cdn.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## UI CDN stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply UI CDN stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          echo "=== Stack events (last 20) ==="
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"
+
+      - name: Report deployed stack state + outputs
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
+            --output table
+          echo "=== Stack outputs (T2 UI deploy resolves UiBucketName + UiDistributionId from here) ==="
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].Outputs' \
+            --output table

--- a/infrastructure/cloudformation/07-ui-cdn.yaml
+++ b/infrastructure/cloudformation/07-ui-cdn.yaml
@@ -1,0 +1,258 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus UI CDN Layer — S3 origin + CloudFront distribution for the
+  frontend/ui-v2 PWA 2.0 (ENC-TSK-K52 / T1). Env-parameterized (gamma|prod)
+  mirroring 02-compute.yaml. Default cache behavior serves the SPA from a
+  private S3 bucket via an Origin Access Control (SigV4); an ordered /api/*
+  behavior proxies to the environment's API Gateway so the same-origin
+  fetches in frontend/ui-v2 (VITE_API_BASE=/api/v1) reach the backend with
+  their auth cookies intact. Custom-domain aliases + ACM are OPTIONAL and
+  gated behind the CustomDomain parameter, so gamma validates on the default
+  *.cloudfront.net domain with no ACM/Cloudflare dependency.
+  Part of the v4 UI Deploy Pipeline (DOC-3EE4F709EC98).
+
+Metadata:
+  EscalatedPrereqs:
+    # ENC-TSK-K52 / T1: a CloudFormation deploy role cannot self-grant the
+    # permissions it needs mid-deploy. These prerequisites are io-gated and
+    # MUST land BEFORE this stack's first gamma apply, or the apply
+    # AccessDenies at change-set execution.
+    DeployRoleIamPatch:
+      Role: AWS_CLOUDFORMATION_ROLE_TO_ASSUME (the privileged CFN OIDC role assumed by cloudformation-ui-cdn-stack-deploy.yml)
+      MissingPermissions:
+        - "cloudfront:* (CreateOriginAccessControl, CreateDistribution, UpdateDistribution, TagResource, GetDistribution, CreateInvalidation)"
+        - "s3:CreateBucket, s3:PutBucketPolicy, s3:PutBucketVersioning, s3:PutBucketPublicAccessBlock, s3:PutEncryptionConfiguration, s3:PutBucketTagging, s3:GetBucket*, s3:DeleteBucketPolicy"
+      Rationale: >
+        The CFN deploy role's inline policy quota is exhausted (see memory:
+        CFN deploy role inline quota exhausted). New grants must be an ATTACHED
+        managed policy (the J85 / PR #733 pattern), applied via an io-gated IAM
+        patch workflow, NOT an inline addition. Without it the gamma apply
+        fails AccessDenied on the S3 bucket create / bucket policy put / OAC
+        create / distribution create.
+    CustomDomainCutover:
+      Status: LATER STEP — deliberately NOT wired here.
+      Steps:
+        - "Provision an ACM certificate in us-east-1 (CloudFront requires us-east-1 certs) for the target hostname."
+        - "Set the CustomDomain + AcmCertificateArn parameters and redeploy so the distribution gains its Aliases + ViewerCertificate."
+        - "Add the Cloudflare CNAME (proxied) pointing the hostname at the distribution's *.cloudfront.net domain."
+      Rationale: >
+        Gamma is validated on the distribution's default *.cloudfront.net
+        domain (no cert required). The alias/ACM/Cloudflare wiring is a
+        separate, later cutover so gamma stand-up is not blocked on DNS/cert.
+
+Parameters:
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues: [production, gamma]
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+    Description: >
+      Appended to every resource name. Production uses "" (zero drift),
+      gamma uses "-gamma" for parallel deployment.
+  ApiOriginDomainName:
+    Type: String
+    Default: "hi0dzmvqrc.execute-api.us-west-2.amazonaws.com"
+    Description: >
+      Domain name of the API Gateway origin for the /api/* cache behavior
+      (host only — no scheme, no path). Default is the GAMMA HttpApi
+      (devops-tracker-api-gamma, id hi0dzmvqrc) regional execute-api endpoint
+      in us-west-2, sourced from 03-api.yaml's gamma tracker plane comment
+      (line ~368) and the HttpApi.ApiEndpoint output. This AWS-owned HTTPS
+      host needs no ACM/Cloudflare, so gamma validates without the
+      enceladus-gamma.jreese.net custom domain. For prod, override with the
+      prod HttpApi execute-api host (or the prod custom domain) via the deploy
+      workflow's --parameter-overrides at the io-gated cutover.
+  CustomDomain:
+    Type: String
+    Default: ""
+    Description: >
+      Optional FQDN alias for the distribution (e.g. ui-gamma.jreese.net).
+      Leave EMPTY (the gamma default) to serve on the distribution's own
+      *.cloudfront.net domain with no ACM cert. When set, AcmCertificateArn
+      MUST also be provided (a us-east-1 ACM cert covering this name).
+  AcmCertificateArn:
+    Type: String
+    Default: ""
+    Description: >
+      ARN of an ACM certificate in us-east-1 covering CustomDomain. Required
+      only when CustomDomain is set. Ignored when CustomDomain is empty.
+
+Conditions:
+  IsProduction: !Equals [!Ref Environment, "production"]
+  IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+  # Custom-domain aliases + ACM cert are attached ONLY when a CustomDomain is
+  # supplied. Empty (gamma default) => distribution serves on *.cloudfront.net
+  # with the default CloudFront certificate (no ACM required).
+  HasCustomDomain: !Not [!Equals [!Ref CustomDomain, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # S3 origin bucket — private, versioned (rollback), SSE, CloudFront-only read
+  # ---------------------------------------------------------------------------
+  UiBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "enceladus-ui-v2${EnvironmentSuffix}"
+      # Private: no public ACLs/policies of any kind. Read is granted ONLY to
+      # the CloudFront Origin Access Control via the bucket policy below.
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      # Versioning ENABLED so prior UI builds are retained for rollback.
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: true
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: ui-cdn
+
+  # Bucket policy: read ONLY to this distribution via the Origin Access Control
+  # (SigV4). Scoped to this distribution's ARN via SourceArn so no other
+  # distribution/principal can read the origin.
+  UiBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref UiBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCloudFrontOACReadOnly
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub "${UiBucket.Arn}/*"
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${UiDistribution}"
+
+  # ---------------------------------------------------------------------------
+  # CloudFront Origin Access Control (OAC, SigV4) for the S3 origin
+  # ---------------------------------------------------------------------------
+  UiOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub "enceladus-ui-v2-oac${EnvironmentSuffix}"
+        Description: SigV4 OAC granting the ui-v2 CloudFront distribution read access to the private S3 origin.
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # ---------------------------------------------------------------------------
+  # CloudFront Distribution — S3 (default) + API Gateway (/api/*)
+  # ---------------------------------------------------------------------------
+  UiDistribution:
+    Type: AWS::CloudFront::Distribution
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub "Enceladus ui-v2 PWA CDN (${Environment})"
+        DefaultRootObject: index.html
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        # Aliases attached ONLY when a CustomDomain is supplied (gamma: none).
+        Aliases: !If
+          - HasCustomDomain
+          - [!Ref CustomDomain]
+          - !Ref "AWS::NoValue"
+        # ViewerCertificate: default *.cloudfront.net cert unless a CustomDomain
+        # + us-east-1 ACM cert is supplied.
+        ViewerCertificate: !If
+          - HasCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2_2021
+          - CloudFrontDefaultCertificate: true
+        Origins:
+          # S3 origin (SPA static assets) — reached only via the OAC.
+          - Id: s3-ui-origin
+            DomainName: !GetAtt UiBucket.RegionalDomainName
+            OriginAccessControlId: !GetAtt UiOriginAccessControl.Id
+            S3OriginConfig:
+              # Empty OriginAccessIdentity => OAC (not legacy OAI) is in effect.
+              OriginAccessIdentity: ""
+          # API Gateway origin (custom origin) for the /api/* behavior.
+          - Id: api-gw-origin
+            DomainName: !Ref ApiOriginDomainName
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              HTTPSPort: 443
+              OriginSSLProtocols:
+                - TLSv1.2
+        DefaultCacheBehavior:
+          TargetOriginId: s3-ui-origin
+          ViewerProtocolPolicy: redirect-to-https
+          Compress: true
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          CachedMethods: [GET, HEAD, OPTIONS]
+          # AWS managed cache policy: CachingOptimized.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+        CacheBehaviors:
+          # /api/* -> API Gateway custom origin. Forward ALL viewer
+          # headers/cookies/querystring so auth cookies reach the API, and
+          # DISABLE caching (dynamic API responses).
+          - PathPattern: "/api/*"
+            TargetOriginId: api-gw-origin
+            ViewerProtocolPolicy: redirect-to-https
+            Compress: false
+            AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
+            CachedMethods: [GET, HEAD]
+            # AWS managed cache policy: CachingDisabled.
+            CachePolicyId: "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+            # AWS managed origin-request policy: AllViewerExceptHostHeader
+            # (forwards all viewer cookies/headers/querystring EXCEPT Host, so
+            # API GW receives its own execute-api host and routes correctly).
+            OriginRequestPolicyId: "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+        # SPA client-side routing: unmatched paths (deep links) return the app
+        # shell with a 200 so the router can resolve them client-side.
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+            ErrorCachingMinTTL: 10
+          - ErrorCode: 404
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+            ErrorCachingMinTTL: 10
+        PriceClass: PriceClass_100
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: ui-cdn
+
+Outputs:
+  UiBucketName:
+    Description: Name of the private S3 origin bucket holding the ui-v2 build.
+    Value: !Ref UiBucket
+    Export:
+      Name: !Sub "${AWS::StackName}-UiBucketName"
+  UiDistributionId:
+    Description: CloudFront distribution id (used by the T2 UI deploy workflow for invalidation).
+    Value: !Ref UiDistribution
+    Export:
+      Name: !Sub "${AWS::StackName}-UiDistributionId"
+  UiDistributionDomainName:
+    Description: The distribution's default *.cloudfront.net domain (gamma serves here, no ACM).
+    Value: !GetAtt UiDistribution.DomainName
+    Export:
+      Name: !Sub "${AWS::StackName}-UiDistributionDomainName"

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -71,6 +71,13 @@
       ],
       "notes": "ENC-TSK-J63 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
     },
+    "cloudformation-ui-cdn-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-K52 / T1 (v4 UI Deploy Pipeline, DOC-3EE4F709EC98) plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod). Deploys the 07-ui-cdn S3+CloudFront stack for frontend/ui-v2; gamma stands up on merge to v4/main, prod is a gated flip later"
+    },
     "component-registry-guard.yml": {
       "class": "inert",
       "notes": "guard"


### PR DESCRIPTION
## ENC-TSK-K52 (T1) — v4 UI CDN infra + gated deploy lane (ENC-PLN-065)

L1 of the v4 UI deploy pipeline per **DOC-3EE4F709EC98**. Reproducible, env-parameterized CloudFront+S3 CDN for `frontend/ui-v2`, mirroring the proven Gen2 Lambda pipeline. Gamma-only per DOC-499FA089EC30.

### What ships
- **`infrastructure/cloudformation/07-ui-cdn.yaml`** — S3 origin (private, OAC, versioned, `Retain`) + CloudFront with **two origins**: default → S3 SPA; `/api/*` → API-Gateway (`CachingDisabled` + `AllViewerExceptHostHeader` so the Cognito auth cookie reaches the API). SPA `403/404 → 200 /index.html`; `DefaultRootObject: index.html`. Custom domain (Alias+ACM) **gated behind `HasCustomDomain`** → gamma serves on `*.cloudfront.net` with no cert/DNS. Outputs `UiBucketName`/`UiDistributionId`/`UiDistributionDomainName` exported for T2.
- **`cloudformation-ui-cdn-stack-deploy.yml`** — plan/apply split; `on: push [main, v4/**]`; apply `environment: v4-gamma (ungated) | v3-prod (io-gated)` — FTR-120 backstop intact.
- **`prod_gate_baseline.json`** — new workflow classified; `prod_gate_coverage_guard.py` **passes**.

### Verified firsthand (ENC-SES-02W)
`prod_gate_coverage_guard.py` SUCCESS + 9 unit tests pass; both YAMLs parse (4 resources / 5 params / 3 outputs). Auth design pre-validated against the live gamma API: `/api/v1/projects` returns **401 no-auth / 200 with the Cognito `enceladus_id_token` cookie** — confirming the same-origin `/api/*` design end-to-end.

### On merge
The `v4-gamma` apply auto-runs (ungated). **If** `AWS_CLOUDFORMATION_ROLE_TO_ASSUME` lacks `cloudfront:*` + S3 bucket-create perms, the apply AccessDenies at change-set execution — that grant (attached managed policy, J85/PR#733 pattern) is an io-gated IAM patch, documented in the template `Metadata: EscalatedPrereqs`. I'll surface the exact result post-merge.

CCI-61866ae27b41462d87e7f4e7135edbb6