### PR TITLE
[ENC-TSK-K58] Fix Draft-04 exclusiveMinimum in AppConfig JSON_SCHEMA validator (ENC-ISS-480)

### DIFF
--- a/infrastructure/cloudformation/09-appconfig-governance.yaml
+++ b/infrastructure/cloudformation/09-appconfig-governance.yaml
@@ -47,13 +47,13 @@ Resources:
         - Type: JSON_SCHEMA
           Content: |
             {
-              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "$schema": "http://json-schema.org/draft-04/schema#",
               "type": "object",
               "properties": {
-                "budget_session_tokens": { "type": "number", "exclusiveMinimum": 0 },
-                "budget_wave_tokens":    { "type": "number", "exclusiveMinimum": 0 },
-                "budget_project_tokens": { "type": "number", "exclusiveMinimum": 0 },
-                "budget_corpus_tokens":  { "type": "number", "exclusiveMinimum": 0 }
+                "budget_session_tokens": { "type": "number", "minimum": 0, "exclusiveMinimum": true },
+                "budget_wave_tokens":    { "type": "number", "minimum": 0, "exclusiveMinimum": true },
+                "budget_project_tokens": { "type": "number", "minimum": 0, "exclusiveMinimum": true },
+                "budget_corpus_tokens":  { "type": "number", "minimum": 0, "exclusiveMinimum": true }
               },
               "additionalProperties": { "type": "number" }
             }


### PR DESCRIPTION
## Summary
- AppConfig's backend JSON Schema validator does not support Draft 2019-09/2020-12 numeric `exclusiveMinimum` (e.g. `{"type": "number", "exclusiveMinimum": 0}`) regardless of the declared `$schema` URI -- it expects Draft-04-style boolean `exclusiveMinimum` paired with `minimum` (e.g. `{"minimum": 0, "exclusiveMinimum": true}`). AppConfig returned `400 InvalidRequest` ("value has incorrect type (found integer, expected one of [boolean])") for the `exclusiveMinimum` keyword, failing `enceladus-appconfig-governance-gamma`'s create. Rolled back cleanly, no partial application.
- Rewrites `BudgetHierarchyProfile`'s `Validators` JSON_SCHEMA to Draft-04 style and aligns the declared `$schema` to draft-04 to match what AppConfig actually enforces. No semantic change to the constraint -- each budget field is still required to be a number > 0.

CCI-09e7cabaf9354a2397c0a16f088c094b

ENC-TSK-K58 / ENC-ISS-480

## Test plan
- [x] `aws cloudformation validate-template` passes
- [x] Diff scoped to only the one Validators JSON_SCHEMA block, 5 lines changed
- [ ] `enceladus-appconfig-governance-gamma` deploys `CREATE_COMPLETE` from this template (blocked on merge, resumes ENC-TSK-K33)