### PR TITLE
[ENC-TSK-K42] GDMP Stage-1 CEE auto-remediation Lambda (io-approval ramp)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.31",
-  "updated_at": "2026-07-02T14:00:00Z",
-  "last_change_summary": "ENC-TSK-K43 (B66 Ph5) follow-up: FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2 via a cross-Lambda invoke from graph_health_metrics into graph_query_api's action='publish_graph_health' (FTR-088 CSR/Fiedler path, ISS-465-compliant), replacing the pre-K43 GraphEdgeDensity placeholder. New entity graph_health_metrics.real_fiedler_lambda2.",
+  "version": "2026-07-02.32",
+  "updated_at": "2026-07-02T14:44:00Z",
+  "last_change_summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda (enceladus-corpus-entropy-gdmp-remediation) added. Consumes K41's Compliance/Semantic detector output and deterministically resolves a whitelist of compliance_warnings classes (missing fence language identifier, missing metadata field label) via document_api PATCH, advancing raw documents to compliant document_maturity_state with no agent involvement. Dry-run default-on plus a 3-run io-approval ramp (FTR-106 AC-4 pattern reuse) gate mutation mode; CEE_GDMP_HARD_DISABLED kill switch ships ON by default. New entity corpus_entropy_gdmp_remediation.lambda.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7115,10 +7115,48 @@
           "definition": "Lessons with FSRS-6 stability (or resonance_score fallback) below this value are flagged as retention entropy. Matches the canonical T3 threshold already used by graph_query_api._apply_fsrs_t3_filter."
         }
       }
+    },
+    "corpus_entropy_gdmp_remediation.lambda": {
+      "description": "ENC-TSK-K42 / B66 Ph5 (ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda (enceladus-corpus-entropy-gdmp-remediation). EventBridge CorpusEntropyGdmpRemediationSchedule (gamma, cron 06:00 UTC, after K41's 05:00 detection scan) invokes lambda_handler per project. Reuses K41's corpus_entropy_core.detect_compliance_semantic_entropy unmodified (shared via .build_extras) to find raw documents with compliance_warnings, then classifies each warning against a fixed deterministic whitelist (gdmp_remediation_core.DETERMINISTIC_WARNING_CLASSIFIERS: fence_missing_language, metadata_field_missing) -- ambiguous/content-changing warnings (title format, empty document, heading hierarchy, list-marker consistency, table dividers, malformed alerts, COE section gaps) are left for agent/human review. For whitelisted findings, applies an additive pure-function text remediation (never deletes original content) and PATCHes the document via the governed document_api HTTP surface (documents.patch: content, then document_maturity_state=compliant once compliance_score clears COMPLIANCE_SCORE_THRESHOLD with zero remaining warnings) -- never direct DynamoDB/S3 document writes. Idempotency guard (is_already_compliant) skips any document already at compliant maturity or with zero compliance_warnings, so re-running Stage-1 on a compliant document is a no-op with no version churn. io-approval ramp (FTR-106 AC-4 / ENC-TSK-K03 pattern reuse, same S3 run-counter shape as UnlearningFunction): GDMP_DRY_RUN=1 (default) prevents all mutation; GDMP_MUTATION_ENABLED=0 (default) keeps report-only even when dry-run is off; GDMP_IO_APPROVAL_RUNS=3 gates the first three live (non-dry-run) invocations to candidate-report-only regardless of GDMP_MUTATION_ENABLED. CEE_GDMP_HARD_DISABLED kill switch (default \"1\") is checked first in the handler, mirroring CEE_HARD_DISABLED (K41). Every applied patch is logged with before/after compliance_score. Cost-preflight ISS-465: nightly-only cadence, well under $1/mo; CorpusEntropyGdmpRemediationCostHeadroomAlarm guards EventBridge invocation count (7-day window, threshold 10).",
+      "owner": "enceladus-platform",
+      "source": "ENC-TSK-K42 / ENC-TSK-B66",
+      "telemetry_eligible": true,
+      "fields": {
+        "CEE_GDMP_HARD_DISABLED": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "Mandatory kill switch, installed ON before first scheduled run. When truthy (1/true/yes), handler skips all governed reads/writes for that invocation. Mirrors CEE_HARD_DISABLED (K41)."
+        },
+        "GDMP_DRY_RUN": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "When truthy (default), the handler never PATCHes any document -- it only computes and reports remediation candidates. Dry-run default-on is a hard DATA-SAFETY requirement."
+        },
+        "GDMP_MUTATION_ENABLED": {
+          "type": "feature_flag",
+          "default": "0",
+          "definition": "When falsy (default), the handler stays report-only even if GDMP_DRY_RUN is explicitly disabled. Must be explicitly enabled by io after reviewing candidate reports."
+        },
+        "GDMP_IO_APPROVAL_RUNS": {
+          "type": "integer",
+          "default": 3,
+          "definition": "Number of live (non-dry-run) invocations that must complete in report-only mode before mutation mode can activate, regardless of GDMP_MUTATION_ENABLED. Tracked via a persisted S3 run counter (GDMP_STATE_BUCKET/GDMP_STATE_PREFIX), mirroring IO_APPROVAL_RUNS (K03 unlearning)."
+        },
+        "COMPLIANCE_SCORE_THRESHOLD": {
+          "type": "integer",
+          "default": 70,
+          "definition": "A remediated document only advances document_maturity_state to compliant once its post-PATCH compliance_score is at or above this value AND zero compliance_warnings remain. Matches CEE's (K41) COMPLIANCE_SCORE_THRESHOLD."
+        }
+      }
     }
   },
-  "change_summary": "ENC-TSK-K41 (B66 Ph5, ENC-PLN-064): Corpus Entropy Engine (CEE) Lambda -- nightly EventBridge (gamma, cron 05:00 UTC) telemetry-only scan for five entropy categories: orphan (no parent_task_id/related_task_ids or wave doc missing plan_anchor_id), stagnation (open tasks with no worklog within STAGNATION_THRESHOLD_DAYS=14), relational (declared related_*_ids with no corresponding graph_query_api adjacency edge), retention (Lesson stability < FSRS_T3_THRESHOLD=0.7, falling back to resonance_score), and compliance/semantic (document compliance_score below COMPLIANCE_SCORE_THRESHOLD=70 AND document_maturity_state=raw). Reads exclusively through the tracker/document/graph_query_api HTTP surface (no direct DynamoDB access, no new edge types -- OGTM). CEE_HARD_DISABLED=1 kill switch ships ON by default; io clears to 0 to enable the first scheduled run. Emits per-category EntropyFindingCount to CloudWatch namespace Enceladus/CEE. Cost-preflight (ISS-465): nightly cadence, 512MB/300s ceiling, well under $1/mo; CorpusEntropyEngineCostHeadroomAlarm guards EventBridge invocation count. New entity corpus_entropy_engine.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "change_summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda -- nightly EventBridge (gamma, cron 06:00 UTC, after K41's 05:00 CEE scan) consumes K41's Compliance/Semantic detector output and deterministically resolves a whitelist of compliance_warnings classes (fence_missing_language, metadata_field_missing) via document_api PATCH, advancing raw documents to compliant document_maturity_state with no agent session involvement. DATA-SAFETY: only the deterministic whitelist is auto-remediated; ambiguous/content-changing warnings are left for agent review; every auto-patch is logged with before/after compliance_score. Dry-run default-on (GDMP_DRY_RUN=1) plus a 3-run io-approval ramp (GDMP_IO_APPROVAL_RUNS=3, GDMP_MUTATION_ENABLED=0) reuse the FTR-106 / ENC-TSK-K03 unlearning Lambda's S3 run-counter pattern verbatim. CEE_GDMP_HARD_DISABLED=1 kill switch ships ON by default. Idempotent: is_already_compliant guards against re-patching already-compliant documents. New entity corpus_entropy_gdmp_remediation.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
   "change_log": [
+    {
+      "version": "2026-07-02.32",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda added -- nightly EventBridge (gamma, cron 06:00 UTC) deterministic whitelist remediation of compliance_warnings via document_api PATCH, io-approval ramp (FTR-106 AC-4 pattern), CEE_GDMP_HARD_DISABLED kill switch. New entity corpus_entropy_gdmp_remediation.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
     {
       "version": "2026-06-27.05",
       "date": "2026-06-27",

--- a/backend/lambda/corpus_entropy_gdmp_remediation/.build_extras
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/.build_extras
@@ -1,0 +1,7 @@
+# ENC-TSK-K42: cross-Lambda module sharing manifest (honored by _build.yml).
+# GDMP Stage-1 remediation reuses K41's Compliance/Semantic detector
+# (detect_compliance_semantic_entropy) unmodified, so this Lambda scans with
+# the exact same finding shape corpus_entropy_engine emits. Declared here so
+# `import corpus_entropy_core` resolves at runtime; keep in lockstep with the
+# canonical owner (backend/lambda/corpus_entropy_engine/corpus_entropy_core.py).
+backend/lambda/corpus_entropy_engine/corpus_entropy_core.py

--- a/backend/lambda/corpus_entropy_gdmp_remediation/deploy.sh
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# ENC-TSK-K42 -- tombstone. corpus_entropy_gdmp_remediation is built by the Gen2
+# matrix build (_build.yml, auto-discovered via `find backend/lambda -name
+# lambda_function.py`) and deployed by .github/workflows/_deploy.yml ("Deploy
+# Lambda Artifacts (Gen2)"). This script is a no-op retained only to satisfy
+# the lambda_workflow_manifest.json deploy_script coverage check
+# (tools/verify_lambda_workflow_coverage.py). Do NOT deploy from here.
+echo "corpus_entropy_gdmp_remediation is managed by the Gen2 pipeline (_build.yml + _deploy.yml); this is a no-op tombstone."
+exit 0

--- a/backend/lambda/corpus_entropy_gdmp_remediation/gdmp_remediation_core.py
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/gdmp_remediation_core.py
@@ -1,0 +1,354 @@
+"""gdmp_remediation_core — pure-function GDMP Stage-1 auto-remediation logic.
+
+ENC-TSK-K42 / B66 Phase-5 (ENC-PLN-064, parent ENC-TSK-B66), per DOC-A3D0CDF91CE9.
+Consumes the Compliance/Semantic detector output shipped in K41
+(corpus_entropy_core.detect_compliance_semantic_entropy) and deterministically
+resolves a narrow whitelist of `compliance_warnings` classes so raw documents
+can advance to `compliant` maturity without agent involvement.
+
+This module is network-free and unit-testable in isolation; the Lambda's HTTP
+calls (document GET/PATCH against document_api) live in lambda_function.py,
+mirroring the corpus_entropy_core / lambda_function split established by K41.
+
+DATA-SAFETY (AC-2):
+  * Only a fixed whitelist of deterministic, structure-only warning classes is
+    auto-remediated (`DETERMINISTIC_WARNING_CLASSIFIERS` below). Every other
+    warning (title format, empty document, heading hierarchy, list-marker
+    consistency, table dividers, malformed alerts, COE section gaps) is
+    left untouched for agent/human review — remediating those would require
+    guessing at document *meaning*, not just structure.
+  * Remediation never invents prose. It only inserts placeholder metadata
+    lines / language tags that a human or agent later fills in — the
+    resulting text is a strict superset of the original content.
+
+io-approval ramp (AC-3): reuses the exact FTR-106 / ENC-TSK-K03 pattern
+(unlearning_core.mutation_allowed / io_approval_ramp_active) — a persisted
+run counter gates live runs to candidate-report-only until IO_APPROVAL_RUNS
+successful dry-run cycles have been observed and mutation mode is explicitly
+enabled by io.
+
+Idempotency (AC-4): `plan_remediation` is a no-op (no whitelisted warnings,
+no content change) when a document has no matching warnings, and
+`remediate_content` is stable under repeated application — applying it twice
+to already-remediated content yields the same content unchanged (each fixer
+checks for its own applied marker before acting again).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+COST_PREFLIGHT_MONTHLY_USD = 0.10
+GDMP_REPORT_SUBTYPEPATTERN = "gdmp-stage1-candidate"
+
+# ---------------------------------------------------------------------------
+# DATA-SAFETY whitelist: deterministic, structure-only warning classes.
+#
+# Each entry maps a `reason`/pattern key to a matcher (identifies whether a
+# raw compliance_warnings string belongs to this class) and a fixer (pure
+# function content -> content). Anything not matched here is left alone.
+# ---------------------------------------------------------------------------
+
+_FENCE_LANG_RE = re.compile(r"^Code fence at line (\d+) should include a language identifier\.$")
+_METADATA_FIELD_RE = re.compile(r"^Metadata block missing '\*\*(\w+)\*\*:' near top of document\.$")
+
+DEFAULT_FENCE_LANGUAGE = "text"
+
+
+def _classify_fence_missing_language(warning: str) -> Optional[Dict[str, Any]]:
+    m = _FENCE_LANG_RE.match(warning.strip())
+    if not m:
+        return None
+    return {"class": "fence_missing_language", "line": int(m.group(1))}
+
+
+def _classify_metadata_field_missing(warning: str) -> Optional[Dict[str, Any]]:
+    m = _METADATA_FIELD_RE.match(warning.strip())
+    if not m:
+        return None
+    return {"class": "metadata_field_missing", "field": m.group(1)}
+
+
+# Ordered list of (classifier) -- order matters only for readability; fixers
+# are independent and commute against disjoint parts of the document.
+DETERMINISTIC_WARNING_CLASSIFIERS: Sequence[Callable[[str], Optional[Dict[str, Any]]]] = (
+    _classify_fence_missing_language,
+    _classify_metadata_field_missing,
+)
+
+# Metadata fields recognized by document_api._evaluate_markdown_compliance's
+# Rule 1+7 scan (backend/lambda/document_api/lambda_function.py), in the
+# canonical order they're checked.
+KNOWN_METADATA_FIELDS = ("Project", "Related", "Created", "Author")
+
+
+def classify_warning(warning: str) -> Optional[Dict[str, Any]]:
+    """Return a classification dict if `warning` matches a deterministic
+    whitelisted class, else None (ambiguous/content-changing -> leave alone).
+    """
+    for classifier in DETERMINISTIC_WARNING_CLASSIFIERS:
+        result = classifier(warning)
+        if result is not None:
+            return result
+    return None
+
+
+def partition_warnings(warnings: Sequence[str]) -> Dict[str, List[Any]]:
+    """Split compliance_warnings into deterministic (whitelisted, auto-fixable)
+    vs. ambiguous (left for agent/human review) buckets.
+    """
+    deterministic: List[Dict[str, Any]] = []
+    ambiguous: List[str] = []
+    for w in warnings or []:
+        classification = classify_warning(w)
+        if classification is not None:
+            classification["warning"] = w
+            deterministic.append(classification)
+        else:
+            ambiguous.append(w)
+    return {"deterministic": deterministic, "ambiguous": ambiguous}
+
+
+# ---------------------------------------------------------------------------
+# Fixers -- pure content -> content transforms. Additive only (never deletes
+# or rewrites existing lines), so remediation is always a strict superset of
+# the original content and safe to re-run (idempotent).
+# ---------------------------------------------------------------------------
+
+def _fix_fence_missing_language(content: str) -> str:
+    """Insert DEFAULT_FENCE_LANGUAGE on every opening fence line missing a
+    language identifier. Idempotent: a fence that already has a language tag
+    (including one this function previously added) is left untouched.
+    """
+    lines = content.splitlines(keepends=False)
+    out: List[str] = []
+    in_fence = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if not in_fence:
+                in_fence = True
+                lang = stripped[3:].strip()
+                if not lang:
+                    indent = line[: len(line) - len(line.lstrip())]
+                    out.append(f"{indent}```{DEFAULT_FENCE_LANGUAGE}")
+                    continue
+            else:
+                in_fence = False
+        out.append(line)
+    result = "\n".join(out)
+    if content.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def _fix_metadata_field_missing(content: str, field: str) -> str:
+    """Insert a `**Field**: TBD` placeholder line into the metadata block near
+    the top of the document. Idempotent: if the field label is already present
+    anywhere in the metadata window, no change is made.
+
+    Insertion point: immediately after the title line (first non-empty line)
+    if it's a heading, else at the very top. This mirrors the metadata-window
+    scan in document_api._evaluate_markdown_compliance (first 30 lines).
+    """
+    if f"**{field}**:" in "\n".join(content.splitlines()[:30]):
+        return content  # already present -- idempotent no-op
+
+    lines = content.splitlines(keepends=False)
+    first_non_empty_idx = None
+    for idx, line in enumerate(lines):
+        if line.strip():
+            first_non_empty_idx = idx
+            break
+
+    placeholder = f"**{field}**: TBD"
+    if first_non_empty_idx is None:
+        new_lines = [placeholder]
+    elif lines[first_non_empty_idx].lstrip().startswith("#"):
+        insert_at = first_non_empty_idx + 1
+        new_lines = lines[:insert_at] + ["", placeholder] + lines[insert_at:]
+    else:
+        new_lines = [placeholder, ""] + lines
+
+    result = "\n".join(new_lines)
+    if content.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def remediate_content(content: str, deterministic_findings: Sequence[Dict[str, Any]]) -> str:
+    """Apply every whitelisted deterministic fixer for this document's
+    findings, in a stable order (fence fixes before metadata fixes), and
+    return the remediated content. Pure function; never mutates input.
+    """
+    remediated = content
+    if any(f["class"] == "fence_missing_language" for f in deterministic_findings):
+        remediated = _fix_fence_missing_language(remediated)
+    metadata_fields = sorted(
+        {f["field"] for f in deterministic_findings if f["class"] == "metadata_field_missing"},
+        key=lambda name: KNOWN_METADATA_FIELDS.index(name) if name in KNOWN_METADATA_FIELDS else 99,
+    )
+    for field in metadata_fields:
+        remediated = _fix_metadata_field_missing(remediated, field)
+    return remediated
+
+
+# ---------------------------------------------------------------------------
+# Remediation plan -- decides whether a document is a no-op, a
+# fully-deterministic candidate, or requires agent review (has ambiguous
+# warnings that the whitelist cannot resolve).
+# ---------------------------------------------------------------------------
+
+def plan_remediation(finding: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a remediation plan for a single Compliance/Semantic finding
+    (the shape produced by corpus_entropy_core.detect_compliance_semantic_entropy,
+    joined with the document's full compliance_warnings list by the caller).
+
+    Returns a dict describing what would happen -- callers combine this with
+    io-approval-ramp state to decide whether to actually PATCH.
+    """
+    record_id = finding.get("record_id") or ""
+    warnings = finding.get("compliance_warnings") or []
+    partitioned = partition_warnings(warnings)
+    deterministic = partitioned["deterministic"]
+    ambiguous = partitioned["ambiguous"]
+
+    if not warnings:
+        return {
+            "record_id": record_id,
+            "action": "noop",
+            "reason": "no_compliance_warnings",
+            "deterministic_findings": [],
+            "ambiguous_warnings": [],
+        }
+
+    if not deterministic:
+        return {
+            "record_id": record_id,
+            "action": "agent_review",
+            "reason": "no_deterministic_warnings_matched",
+            "deterministic_findings": [],
+            "ambiguous_warnings": ambiguous,
+        }
+
+    action = "remediate" if not ambiguous else "partial_remediate"
+    return {
+        "record_id": record_id,
+        "action": action,
+        "reason": "deterministic_whitelist_match",
+        "deterministic_findings": deterministic,
+        "ambiguous_warnings": ambiguous,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Idempotency guard (AC-4): a document already at `compliant` maturity (or
+# with zero compliance_warnings) is always a no-op -- never re-patched.
+# ---------------------------------------------------------------------------
+
+COMPLIANT_MATURITY_STATE = "compliant"
+RAW_MATURITY_STATE = "raw"
+
+
+def is_already_compliant(document: Dict[str, Any]) -> bool:
+    maturity = str(
+        document.get("document_maturity_state") or document.get("maturity_state") or ""
+    ).lower()
+    warnings = document.get("compliance_warnings") or []
+    return maturity == COMPLIANT_MATURITY_STATE or not warnings
+
+
+# ---------------------------------------------------------------------------
+# io-approval ramp -- verbatim pattern reuse from FTR-106 / ENC-TSK-K03
+# (unlearning_core.py: IO_APPROVAL_RUNS / mutation_allowed / is_dry_run).
+# ---------------------------------------------------------------------------
+
+GDMP_DRY_RUN = os.environ.get("GDMP_DRY_RUN", "1").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+GDMP_MUTATION_ENABLED = os.environ.get("GDMP_MUTATION_ENABLED", "0").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+
+try:
+    GDMP_IO_APPROVAL_RUNS = int(os.environ.get("GDMP_IO_APPROVAL_RUNS", "3"))
+except (TypeError, ValueError):
+    GDMP_IO_APPROVAL_RUNS = 3
+
+
+def is_dry_run(event: Optional[Dict[str, Any]] = None) -> bool:
+    if isinstance(event, dict) and "dry_run" in event:
+        return bool(event.get("dry_run"))
+    return GDMP_DRY_RUN
+
+
+def io_approval_ramp_active(run_count: int) -> bool:
+    """True while live runs are still in the report-only ramp."""
+    return run_count < GDMP_IO_APPROVAL_RUNS
+
+
+def mutation_allowed(
+    *,
+    run_count: int,
+    dry_run: bool,
+    mutation_enabled: bool = GDMP_MUTATION_ENABLED,
+) -> bool:
+    if dry_run or not mutation_enabled:
+        return False
+    return not io_approval_ramp_active(run_count)
+
+
+def is_hard_disabled(env: Dict[str, str]) -> bool:
+    """CEE_GDMP_HARD_DISABLED kill switch -- mandatory before first scheduled
+    run, mirroring CEE_HARD_DISABLED (K41) / UNLEARNING_MUTATION_ENABLED (K03)
+    sibling convention. Any of "1"/"true"/"yes" (case-insensitive) disables.
+    """
+    val = str(env.get("CEE_GDMP_HARD_DISABLED", "0")).strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def build_candidate_report_body(
+    project_id: str,
+    plans: Sequence[Dict[str, Any]],
+    *,
+    run_count: int,
+    dry_run: bool,
+    mutation_enabled: bool,
+) -> str:
+    """Human-readable candidate report -- mirrors
+    unlearning_core.build_candidate_report_body's shape for consistency
+    across the two io-approval-ramp Lambdas in this repo.
+    """
+    remediate_count = sum(1 for p in plans if p["action"] in ("remediate", "partial_remediate"))
+    review_count = sum(1 for p in plans if p["action"] == "agent_review")
+    lines = [
+        f"# GDMP Stage-1 remediation candidate report — {project_id}",
+        "",
+        f"- run_count: {run_count}",
+        f"- dry_run: {dry_run}",
+        f"- mutation_enabled: {mutation_enabled}",
+        f"- io_approval_ramp_active: {io_approval_ramp_active(run_count)}",
+        f"- candidates_for_auto_remediation: {remediate_count}",
+        f"- candidates_requiring_agent_review: {review_count}",
+        "",
+        "## Candidates",
+        "",
+    ]
+    if not plans:
+        lines.append("_No raw documents with compliance_warnings identified._")
+    else:
+        for p in plans:
+            lines.append(
+                f"- `{p.get('record_id')}` — action={p.get('action')} "
+                f"deterministic={len(p.get('deterministic_findings', []))} "
+                f"ambiguous={len(p.get('ambiguous_warnings', []))}"
+            )
+    return "\n".join(lines) + "\n"

--- a/backend/lambda/corpus_entropy_gdmp_remediation/lambda_function.py
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/lambda_function.py
@@ -1,0 +1,302 @@
+"""corpus_entropy_gdmp_remediation — GDMP Stage-1 auto-remediation Lambda handler.
+
+ENC-TSK-K42 / B66 Phase-5 (ENC-PLN-064, parent ENC-TSK-B66), per
+DOC-A3D0CDF91CE9. Consumes K41's Compliance/Semantic detector output
+(corpus_entropy_core.detect_compliance_semantic_entropy) and deterministically
+resolves a whitelist of `compliance_warnings` classes via `documents.patch`,
+advancing raw documents to compliant `document_maturity_state` with no agent
+session involvement.
+
+Read/write boundary: this Lambda calls the SAME governed HTTP surface the MCP
+server wraps (tracker API for the compliance/semantic scan reuse + document
+API for GET/PATCH), authenticated with the internal API key — never raw
+DynamoDB/S3 writes. Mirrors corpus_entropy_engine/lambda_function.py (K41)
+for reads and adds governed PATCH calls for remediation.
+
+DATA-SAFETY:
+  * GDMP_DRY_RUN=1 (default) — no document mutations, candidate report only.
+  * GDMP_MUTATION_ENABLED=0 (default) — report-only even when dry_run off.
+  * GDMP_IO_APPROVAL_RUNS=3 — first three live runs emit reports only
+    (FTR-106 AC-4 / ENC-TSK-K03 io-approval-ramp pattern, reused verbatim).
+  * Only the deterministic whitelist in gdmp_remediation_core.py is ever
+    auto-patched; ambiguous/content-changing warnings are left for agent
+    review. Every auto-patch is logged with before/after compliance_score.
+  * CEE_GDMP_HARD_DISABLED is the mandatory kill switch, checked before any
+    work begins (mirrors CEE_HARD_DISABLED / K41 convention).
+
+Trigger: EventBridge per-invocation (no standing compute), scheduled after
+the CEE nightly detection scan so remediation always sees fresh findings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from corpus_entropy_core import detect_compliance_semantic_entropy, is_hard_disabled as _cee_is_hard_disabled
+from gdmp_remediation_core import (
+    COMPLIANT_MATURITY_STATE,
+    build_candidate_report_body,
+    is_already_compliant,
+    is_dry_run,
+    is_hard_disabled,
+    mutation_allowed,
+    plan_remediation,
+    remediate_content,
+)
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+DOCUMENT_API_BASE = os.environ.get(
+    "DOCUMENT_API_BASE",
+    "https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/documents",
+)
+COORDINATION_INTERNAL_API_KEY = os.environ.get("COORDINATION_INTERNAL_API_KEY", "")
+PROJECT_ID = os.environ.get("PROJECT_ID", "enceladus")
+COMPLIANCE_SCORE_THRESHOLD = int(os.environ.get("COMPLIANCE_SCORE_THRESHOLD", "70"))
+GDMP_STATE_BUCKET = os.environ.get("GDMP_STATE_BUCKET", "")
+GDMP_STATE_PREFIX = os.environ.get("GDMP_STATE_PREFIX", "gdmp-remediation-state")
+_HTTP_TIMEOUT_S = 30
+_MAX_DOCS_PER_RUN = int(os.environ.get("GDMP_MAX_DOCS_PER_RUN", "200"))
+
+_s3_client = None
+
+
+def _get_s3():
+    global _s3_client
+    if _s3_client is None:
+        import boto3
+
+        _s3_client = boto3.client("s3", region_name=REGION)
+    return _s3_client
+
+
+# ---------------------------------------------------------------------------
+# Governed HTTP (document API) -- mirrors corpus_entropy_engine/lambda_function.py.
+# No direct DynamoDB/S3 document access; stays within the governed read/write
+# boundary (internal API key auth against the same surface the MCP server wraps).
+# ---------------------------------------------------------------------------
+
+def _http_request(url: str, *, method: str, body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Coordination-Internal-Key": COORDINATION_INTERNAL_API_KEY,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def _fetch_documents() -> List[Dict[str, Any]]:
+    url = f"{DOCUMENT_API_BASE}/search?project={urllib.parse.quote(PROJECT_ID)}"
+    try:
+        payload = _http_request(url, method="GET")
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        logger.error("[ERROR] document fetch failed: %s", exc)
+        return []
+    return payload.get("documents", [])
+
+
+def _fetch_document_with_content(document_id: str) -> Optional[Dict[str, Any]]:
+    url = f"{DOCUMENT_API_BASE}/{urllib.parse.quote(document_id, safe='')}"
+    try:
+        payload = _http_request(url, method="GET")
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        logger.error("[ERROR] document GET failed id=%s: %s", document_id, exc)
+        return None
+    return payload.get("document") or payload
+
+
+def _patch_document(document_id: str, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    url = f"{DOCUMENT_API_BASE}/{urllib.parse.quote(document_id, safe='')}"
+    try:
+        return _http_request(url, method="PATCH", body=body)
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        logger.error("[ERROR] document PATCH failed id=%s: %s", document_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# io-approval ramp state (S3 run counter) -- verbatim pattern from
+# unlearning/lambda_function.py (_load_run_counter / _save_run_counter).
+# ---------------------------------------------------------------------------
+
+def _load_run_counter() -> int:
+    if not GDMP_STATE_BUCKET:
+        return 0
+    key = f"{GDMP_STATE_PREFIX.strip().strip('/')}/run_counter.json"
+    try:
+        resp = _get_s3().get_object(Bucket=GDMP_STATE_BUCKET, Key=key)
+        payload = json.loads(resp["Body"].read().decode("utf-8"))
+        return int(payload.get("run_count") or 0)
+    except Exception:
+        return 0
+
+
+def _save_run_counter(run_count: int) -> None:
+    if not GDMP_STATE_BUCKET:
+        return
+    key = f"{GDMP_STATE_PREFIX.strip().strip('/')}/run_counter.json"
+    _get_s3().put_object(
+        Bucket=GDMP_STATE_BUCKET,
+        Key=key,
+        Body=json.dumps({"run_count": run_count}).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
+    event = event or {}
+
+    if is_hard_disabled(os.environ) or _cee_is_hard_disabled(os.environ):
+        logger.info("[SKIP] CEE_GDMP_HARD_DISABLED (or CEE_HARD_DISABLED) is set; GDMP Stage-1 skipped")
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"success": True, "skipped": True, "reason": "hard_disabled"}),
+        }
+
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    dry_run = is_dry_run(event)
+    run_count = _load_run_counter()
+    logger.info(
+        "[START] GDMP Stage-1 remediation: project=%s dry_run=%s run_count=%s",
+        PROJECT_ID, dry_run, run_count,
+    )
+
+    try:
+        documents = _fetch_documents()
+        findings = detect_compliance_semantic_entropy(
+            documents, score_threshold=COMPLIANCE_SCORE_THRESHOLD
+        )
+        # Join findings back to their full compliance_warnings list (the
+        # detector output only carries score/maturity/threshold, not the
+        # warning strings themselves -- fetch from the source document row).
+        by_id = {
+            (d.get("record_id") or d.get("document_id") or d.get("item_id") or ""): d
+            for d in documents
+        }
+
+        plans: List[Dict[str, Any]] = []
+        for finding in findings[:_MAX_DOCS_PER_RUN]:
+            record_id = finding.get("record_id") or ""
+            doc_row = by_id.get(record_id, {})
+            enriched_finding = dict(finding)
+            enriched_finding["compliance_warnings"] = doc_row.get("compliance_warnings") or []
+            plans.append(plan_remediation(enriched_finding))
+
+        allow_mutate = mutation_allowed(run_count=run_count, dry_run=dry_run)
+
+        applied: List[Dict[str, Any]] = []
+        skipped_idempotent: List[str] = []
+
+        if allow_mutate:
+            for plan in plans:
+                if plan["action"] not in ("remediate", "partial_remediate"):
+                    continue
+                document_id = plan["record_id"]
+                if not document_id:
+                    continue
+
+                doc = _fetch_document_with_content(document_id)
+                if not doc:
+                    continue
+
+                # AC-4 idempotency guard: never re-patch an already-compliant
+                # document, even if it was queued from a stale scan.
+                if is_already_compliant(doc):
+                    skipped_idempotent.append(document_id)
+                    continue
+
+                content = doc.get("content")
+                if not content:
+                    continue
+
+                before_score = doc.get("compliance_score")
+                remediated_content = remediate_content(content, plan["deterministic_findings"])
+                if remediated_content == content:
+                    # No actual text change produced (e.g. fixer found nothing
+                    # left to do) -- idempotent no-op, do not PATCH.
+                    skipped_idempotent.append(document_id)
+                    continue
+
+                patch_resp = _patch_document(document_id, {"content": remediated_content})
+                if not patch_resp or patch_resp.get("success") is False:
+                    logger.error("[ERROR] content PATCH failed for %s", document_id)
+                    continue
+
+                after_score = (patch_resp.get("document") or patch_resp).get("compliance_score")
+                after_warnings = (patch_resp.get("document") or patch_resp).get(
+                    "compliance_warnings", []
+                )
+
+                maturity_patch_resp = None
+                if after_score is not None and after_score >= COMPLIANCE_SCORE_THRESHOLD and not after_warnings:
+                    maturity_patch_resp = _patch_document(
+                        document_id, {"document_maturity_state": COMPLIANT_MATURITY_STATE}
+                    )
+
+                applied.append({
+                    "record_id": document_id,
+                    "before_compliance_score": before_score,
+                    "after_compliance_score": after_score,
+                    "remaining_warnings": after_warnings,
+                    "advanced_to_compliant": bool(
+                        maturity_patch_resp and maturity_patch_resp.get("success", True)
+                    ),
+                    "deterministic_classes_applied": sorted(
+                        {f["class"] for f in plan["deterministic_findings"]}
+                    ),
+                })
+                logger.info(
+                    "[REMEDIATED] %s before_score=%s after_score=%s advanced_to_compliant=%s",
+                    document_id, before_score, after_score,
+                    bool(maturity_patch_resp and maturity_patch_resp.get("success", True)),
+                )
+
+        report_body = build_candidate_report_body(
+            PROJECT_ID, plans, run_count=run_count, dry_run=dry_run, mutation_enabled=allow_mutate,
+        )
+
+        if not dry_run:
+            _save_run_counter(run_count + 1)
+
+        result = {
+            "success": True,
+            "project_id": PROJECT_ID,
+            "scanned_at": now_iso,
+            "dry_run": dry_run,
+            "run_count": run_count,
+            "mutation_allowed": allow_mutate,
+            "candidate_count": len(plans),
+            "remediated_count": len(applied),
+            "skipped_idempotent_count": len(skipped_idempotent),
+            "applied": applied,
+            "report_preview": report_body[:2000],
+        }
+        logger.info(
+            "[END] GDMP Stage-1 run complete: candidates=%d remediated=%d idempotent_skips=%d",
+            len(plans), len(applied), len(skipped_idempotent),
+        )
+        return {"statusCode": 200, "body": json.dumps(result)}
+    except Exception as exc:  # noqa: BLE001 -- top-level handler must never raise
+        logger.error("[ERROR] GDMP Stage-1 remediation failed: %s", exc, exc_info=True)
+        return {"statusCode": 500, "body": json.dumps({"success": False, "error": str(exc)})}

--- a/backend/lambda/corpus_entropy_gdmp_remediation/test_lambda_function.py
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/test_lambda_function.py
@@ -1,0 +1,464 @@
+"""Tests for GDMP Stage-1 auto-remediation -- ENC-TSK-K42 / B66 Ph5.
+
+Two layers, mirroring corpus_entropy_engine/test_lambda_function.py and
+unlearning/test_unlearning.py conventions in this repo:
+
+  1. Pure-function tests against gdmp_remediation_core (no AWS, no HTTP) --
+     warning classification, deterministic content fixers, remediation
+     planning, idempotency guard, and the io-approval ramp gate.
+  2. Handler-level tests against lambda_function, monkeypatching the governed
+     HTTP fetch/patch functions and the S3 run-counter so no real network/AWS
+     call is made. Includes a kill-switch test and a "never mutates when
+     mutation not allowed" guard.
+
+Runs under pytest (test_* discovery). corpus_entropy_core.py is provided at
+collection time via sys.path (co-located at repo path during local test runs;
+copied to the function root by _build.yml's .build_extras step at deploy time).
+"""
+
+import json
+import os
+import sys
+
+# Own directory takes priority so `lambda_function` resolves to THIS Lambda's
+# handler, not corpus_entropy_engine's. corpus_entropy_core.py is co-located
+# at the function root in the deployed artifact (via .build_extras); for local
+# test runs it's appended (not inserted at 0) so it never shadows this dir's
+# own lambda_function.py.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "corpus_entropy_engine"
+    )
+)
+
+import gdmp_remediation_core as core  # noqa: E402
+import lambda_function as mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Warning classification (DATA-SAFETY whitelist)
+# ---------------------------------------------------------------------------
+
+def test_fence_missing_language_is_classified_deterministic():
+    result = core.classify_warning("Code fence at line 12 should include a language identifier.")
+    assert result == {"class": "fence_missing_language", "line": 12}
+
+
+def test_metadata_field_missing_is_classified_deterministic():
+    result = core.classify_warning("Metadata block missing '**Author**:' near top of document.")
+    assert result == {"class": "metadata_field_missing", "field": "Author"}
+
+
+def test_title_format_warning_is_ambiguous_not_classified():
+    assert core.classify_warning("Title should follow '# {ITEM_ID} Title' (e.g., '# DVP-TSK-123 Name').") is None
+
+
+def test_empty_document_warning_is_ambiguous_not_classified():
+    assert core.classify_warning("Document is empty.") is None
+
+
+def test_heading_hierarchy_warning_is_ambiguous_not_classified():
+    assert core.classify_warning("Heading level jump detected at line 5 (h1 -> h3).") is None
+
+
+def test_unclosed_fence_warning_is_ambiguous_not_classified():
+    assert core.classify_warning("Unclosed code fence opened at line 3.") is None
+
+
+def test_partition_warnings_splits_deterministic_and_ambiguous():
+    warnings = [
+        "Code fence at line 4 should include a language identifier.",
+        "Document is empty.",
+        "Metadata block missing '**Project**:' near top of document.",
+    ]
+    result = core.partition_warnings(warnings)
+    assert len(result["deterministic"]) == 2
+    assert result["ambiguous"] == ["Document is empty."]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fixers -- additive, idempotent
+# ---------------------------------------------------------------------------
+
+def test_fix_fence_missing_language_adds_default_language():
+    content = "# Doc\n\n```\ncode here\n```\n"
+    fixed = core._fix_fence_missing_language(content)
+    assert "```text\ncode here\n```" in fixed
+
+
+def test_fix_fence_missing_language_leaves_tagged_fence_untouched():
+    content = "# Doc\n\n```python\ncode here\n```\n"
+    assert core._fix_fence_missing_language(content) == content
+
+
+def test_fix_fence_missing_language_is_idempotent():
+    content = "# Doc\n\n```\ncode here\n```\n"
+    once = core._fix_fence_missing_language(content)
+    twice = core._fix_fence_missing_language(once)
+    assert once == twice
+
+
+def test_fix_metadata_field_missing_inserts_placeholder_after_title():
+    content = "# ENC-TSK-K42 Title\n\nSome body text.\n"
+    fixed = core._fix_metadata_field_missing(content, "Author")
+    lines = fixed.splitlines()
+    assert lines[0] == "# ENC-TSK-K42 Title"
+    assert "**Author**: TBD" in fixed
+    assert "Some body text." in fixed
+
+
+def test_fix_metadata_field_missing_is_idempotent():
+    content = "# ENC-TSK-K42 Title\n\nBody.\n"
+    once = core._fix_metadata_field_missing(content, "Project")
+    twice = core._fix_metadata_field_missing(once, "Project")
+    assert once == twice
+
+
+def test_fix_metadata_field_missing_noop_when_field_already_present():
+    content = "# Title\n\n**Author**: io\n\nBody.\n"
+    assert core._fix_metadata_field_missing(content, "Author") == content
+
+
+def test_remediate_content_applies_both_fixer_classes():
+    content = "# Doc\n\n```\ncode\n```\n"
+    findings = [
+        {"class": "fence_missing_language", "line": 3, "warning": "..."},
+        {"class": "metadata_field_missing", "field": "Project", "warning": "..."},
+    ]
+    remediated = core.remediate_content(content, findings)
+    assert "```text" in remediated
+    assert "**Project**: TBD" in remediated
+
+
+def test_remediate_content_never_deletes_original_text():
+    content = "# Doc\n\nOriginal important sentence.\n\n```\ncode\n```\n"
+    findings = [{"class": "fence_missing_language", "line": 5, "warning": "..."}]
+    remediated = core.remediate_content(content, findings)
+    assert "Original important sentence." in remediated
+
+
+# ---------------------------------------------------------------------------
+# Remediation planning
+# ---------------------------------------------------------------------------
+
+def test_plan_remediation_noop_when_no_warnings():
+    plan = core.plan_remediation({"record_id": "DOC-1", "compliance_warnings": []})
+    assert plan["action"] == "noop"
+
+
+def test_plan_remediation_agent_review_when_all_ambiguous():
+    plan = core.plan_remediation({
+        "record_id": "DOC-2",
+        "compliance_warnings": ["Document is empty."],
+    })
+    assert plan["action"] == "agent_review"
+    assert plan["ambiguous_warnings"] == ["Document is empty."]
+
+
+def test_plan_remediation_full_remediate_when_all_deterministic():
+    plan = core.plan_remediation({
+        "record_id": "DOC-3",
+        "compliance_warnings": [
+            "Code fence at line 2 should include a language identifier.",
+        ],
+    })
+    assert plan["action"] == "remediate"
+    assert len(plan["deterministic_findings"]) == 1
+
+
+def test_plan_remediation_partial_when_mixed():
+    plan = core.plan_remediation({
+        "record_id": "DOC-4",
+        "compliance_warnings": [
+            "Code fence at line 2 should include a language identifier.",
+            "Document is empty.",
+        ],
+    })
+    assert plan["action"] == "partial_remediate"
+    assert len(plan["deterministic_findings"]) == 1
+    assert len(plan["ambiguous_warnings"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Idempotency guard (AC-4)
+# ---------------------------------------------------------------------------
+
+def test_already_compliant_maturity_is_idempotent_noop():
+    doc = {"document_maturity_state": "compliant", "compliance_warnings": ["stale warning"]}
+    assert core.is_already_compliant(doc) is True
+
+
+def test_zero_warnings_is_idempotent_noop_even_if_raw():
+    doc = {"document_maturity_state": "raw", "compliance_warnings": []}
+    assert core.is_already_compliant(doc) is True
+
+
+def test_raw_with_warnings_is_not_idempotent_noop():
+    doc = {"document_maturity_state": "raw", "compliance_warnings": ["Document is empty."]}
+    assert core.is_already_compliant(doc) is False
+
+
+# ---------------------------------------------------------------------------
+# io-approval ramp (FTR-106 AC-4 pattern reuse)
+# ---------------------------------------------------------------------------
+
+def test_io_approval_ramp_active_below_threshold():
+    assert core.io_approval_ramp_active(0) is True
+    assert core.io_approval_ramp_active(2) is True
+
+
+def test_io_approval_ramp_inactive_at_threshold():
+    assert core.io_approval_ramp_active(3) is False
+    assert core.io_approval_ramp_active(4) is False
+
+
+def test_mutation_never_allowed_during_dry_run():
+    assert core.mutation_allowed(run_count=10, dry_run=True, mutation_enabled=True) is False
+
+
+def test_mutation_never_allowed_when_mutation_disabled():
+    assert core.mutation_allowed(run_count=10, dry_run=False, mutation_enabled=False) is False
+
+
+def test_mutation_blocked_during_ramp_even_if_enabled():
+    assert core.mutation_allowed(run_count=1, dry_run=False, mutation_enabled=True) is False
+
+
+def test_mutation_allowed_after_ramp_when_enabled_and_not_dry_run():
+    assert core.mutation_allowed(run_count=3, dry_run=False, mutation_enabled=True) is True
+
+
+# ---------------------------------------------------------------------------
+# Kill switch
+# ---------------------------------------------------------------------------
+
+def test_hard_disabled_true_variants():
+    for val in ("1", "true", "True", "YES", "yes"):
+        assert core.is_hard_disabled({"CEE_GDMP_HARD_DISABLED": val}) is True
+
+
+def test_hard_disabled_false_when_unset_or_zero():
+    assert core.is_hard_disabled({}) is False
+    assert core.is_hard_disabled({"CEE_GDMP_HARD_DISABLED": "0"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Handler-level tests (mock HTTP + S3, never touch AWS/network)
+# ---------------------------------------------------------------------------
+
+class _FakeS3:
+    def __init__(self, initial_counter=None):
+        self._store = {}
+        if initial_counter is not None:
+            self._store["gdmp-remediation-state/run_counter.json"] = json.dumps(
+                {"run_count": initial_counter}
+            ).encode("utf-8")
+
+    def get_object(self, Bucket, Key):
+        if Key not in self._store:
+            raise KeyError(Key)
+        import io
+        return {"Body": io.BytesIO(self._store[Key])}
+
+    def put_object(self, Bucket, Key, Body, ContentType=None):
+        self._store[Key] = Body if isinstance(Body, bytes) else Body.encode("utf-8")
+
+
+def test_handler_respects_kill_switch(monkeypatch):
+    monkeypatch.setenv("CEE_GDMP_HARD_DISABLED", "1")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("must not fetch when kill switch is set")
+
+    monkeypatch.setattr(mod, "_fetch_documents", _boom)
+    result = mod.lambda_handler({}, None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["skipped"] is True
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+
+
+def test_handler_dry_run_default_never_patches(monkeypatch):
+    """Dry-run default-on (AC-3): the handler must never call _patch_document
+    even when deterministic candidates exist, unless dry_run is explicitly off
+    AND mutation_enabled AND the io-approval ramp has cleared."""
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+    monkeypatch.setattr(mod, "_fetch_documents", lambda: [
+        {
+            "record_id": "DOC-RAW1",
+            "compliance_score": 40,
+            "document_maturity_state": "raw",
+            "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        },
+    ])
+
+    def _boom_patch(*args, **kwargs):
+        raise AssertionError("must not PATCH during dry-run")
+
+    monkeypatch.setattr(mod, "_patch_document", _boom_patch)
+    monkeypatch.setattr(mod, "_get_s3", lambda: _FakeS3())
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["dry_run"] is True
+    assert body["mutation_allowed"] is False
+    assert body["remediated_count"] == 0
+    assert body["candidate_count"] == 1
+
+
+def test_handler_remediates_when_ramp_cleared_and_mutation_enabled(monkeypatch):
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+
+    # GDMP_DRY_RUN / GDMP_MUTATION_ENABLED are read once at gdmp_remediation_core
+    # import time, so patch the already-imported module's constants directly
+    # (and the handler's imported references to is_dry_run/mutation_allowed)
+    # rather than relying on env vars + a re-import.
+    import gdmp_remediation_core as gcore
+    monkeypatch.setattr(gcore, "GDMP_DRY_RUN", False)
+    monkeypatch.setattr(gcore, "GDMP_MUTATION_ENABLED", True)
+    monkeypatch.setattr(mod, "is_dry_run", lambda event=None: False)
+    monkeypatch.setattr(mod, "mutation_allowed", lambda **kw: gcore.mutation_allowed(
+        run_count=kw["run_count"], dry_run=False, mutation_enabled=True
+    ))
+
+    monkeypatch.setattr(mod, "_fetch_documents", lambda: [
+        {
+            "record_id": "DOC-RAW2",
+            "compliance_score": 40,
+            "document_maturity_state": "raw",
+            "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        },
+    ])
+    monkeypatch.setattr(mod, "_fetch_document_with_content", lambda doc_id: {
+        "record_id": doc_id,
+        "document_maturity_state": "raw",
+        "compliance_score": 40,
+        "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        "content": "# Doc\n\n```\ncode\n```\n",
+    })
+
+    patch_calls = []
+
+    def _fake_patch(document_id, body):
+        patch_calls.append((document_id, body))
+        if "content" in body:
+            return {
+                "success": True,
+                "document": {
+                    "compliance_score": 100,
+                    "compliance_warnings": [],
+                },
+            }
+        return {"success": True, "document": {"document_maturity_state": "compliant"}}
+
+    monkeypatch.setattr(mod, "_patch_document", _fake_patch)
+    monkeypatch.setattr(mod, "GDMP_STATE_BUCKET", "fake-bucket")
+    monkeypatch.setattr(mod, "_get_s3", lambda: _FakeS3(initial_counter=3))
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["remediated_count"] == 1
+    assert body["applied"][0]["after_compliance_score"] == 100
+    assert body["applied"][0]["advanced_to_compliant"] is True
+    # Two PATCH calls: one for content, one for document_maturity_state.
+    assert len(patch_calls) == 2
+    assert patch_calls[0][1] == {"content": "# Doc\n\n```text\ncode\n```\n"}
+    assert patch_calls[1][1] == {"document_maturity_state": "compliant"}
+
+
+def test_handler_idempotent_skip_when_already_compliant(monkeypatch):
+    """AC-4: re-running Stage-1 on an already-compliant document is a no-op."""
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+    monkeypatch.setattr(mod, "_fetch_documents", lambda: [
+        {
+            "record_id": "DOC-RAW3",
+            "compliance_score": 40,
+            "document_maturity_state": "raw",
+            "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        },
+    ])
+    # Simulate the document having *already* been remediated by a concurrent
+    # run by the time this run fetches full content (maturity flipped).
+    monkeypatch.setattr(mod, "_fetch_document_with_content", lambda doc_id: {
+        "record_id": doc_id,
+        "document_maturity_state": "compliant",
+        "compliance_score": 100,
+        "compliance_warnings": [],
+        "content": "# Doc\n\n```text\ncode\n```\n",
+    })
+
+    def _boom_patch(*args, **kwargs):
+        raise AssertionError("must not PATCH an already-compliant document")
+
+    monkeypatch.setattr(mod, "_patch_document", _boom_patch)
+    monkeypatch.setattr(mod, "mutation_allowed", lambda **kw: True)
+    monkeypatch.setattr(mod, "_get_s3", lambda: _FakeS3(initial_counter=5))
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["remediated_count"] == 0
+    assert body["skipped_idempotent_count"] == 1
+
+
+def test_handler_returns_500_on_unexpected_exception(monkeypatch):
+    def _boom():
+        raise RuntimeError("document api down")
+
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+    monkeypatch.setattr(mod, "_fetch_documents", _boom)
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 500
+    body = json.loads(result["body"])
+    assert body["success"] is False
+
+
+def test_http_request_get_uses_get_method(monkeypatch):
+    seen_methods = []
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"success": true, "documents": []}'
+
+    def _fake_urlopen(req, timeout=30):
+        seen_methods.append(req.get_method())
+        return _FakeResp()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen)
+    mod._http_request("https://example.invalid/api/v1/documents/search", method="GET")
+    assert seen_methods == ["GET"]
+
+
+def test_http_request_patch_uses_patch_method(monkeypatch):
+    seen_methods = []
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"success": true}'
+
+    def _fake_urlopen(req, timeout=30):
+        seen_methods.append(req.get_method())
+        return _FakeResp()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen)
+    mod._http_request(
+        "https://example.invalid/api/v1/documents/DOC-1", method="PATCH", body={"content": "x"}
+    )
+    assert seen_methods == ["PATCH"]

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1960,6 +1960,98 @@ Resources:
       SourceArn: !GetAtt CorpusEntropyEngineSchedule.Arn
 
   # ---------------------------------------------------------------------------
+  # ENC-TSK-K42 / B66 Ph5: GDMP Stage-1 auto-remediation Lambda. Consumes K41's
+  # Compliance/Semantic detector output and deterministically resolves a
+  # whitelist of compliance_warnings classes via documents.patch, advancing
+  # raw documents to compliant maturity_state with no agent involvement.
+  # DATA-SAFETY: GDMP_DRY_RUN=1, GDMP_MUTATION_ENABLED=0, GDMP_IO_APPROVAL_RUNS=3
+  # (FTR-106 AC-4 io-approval-ramp pattern, same shape as UnlearningFunction).
+  # CEE_GDMP_HARD_DISABLED is the mandatory kill switch (ISS-465 cost-preflight
+  # precedent), checked first thing in the handler. Gamma-only (Condition:
+  # IsGamma): v3-prod is frozen (DOC-499FA089EC30).
+  # ---------------------------------------------------------------------------
+  CorpusEntropyGdmpRemediationFunction:
+    Type: AWS::Lambda::Function
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-corpus-entropy-gdmp-remediation${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      MemorySize: 512
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt CorpusEntropyGdmpRemediationRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DOCUMENT_API_BASE: !Sub "https://enceladus-gamma.jreese.net/api/v1/documents"
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
+          PROJECT_ID: enceladus
+          COMPLIANCE_SCORE_THRESHOLD: "70"
+          GDMP_STATE_BUCKET: !Ref S3Bucket
+          GDMP_STATE_PREFIX: !Sub "${S3EnvPrefix}gdmp-remediation-state"
+          GDMP_MAX_DOCS_PER_RUN: "200"
+          # DATA-SAFETY defaults -- io clears CEE_GDMP_HARD_DISABLED and later
+          # flips GDMP_MUTATION_ENABLED only after IO_APPROVAL_RUNS candidate
+          # reports have been reviewed. Mirrors UNLEARNING_* (K03) convention.
+          GDMP_DRY_RUN: "1"
+          GDMP_MUTATION_ENABLED: "0"
+          GDMP_IO_APPROVAL_RUNS: "3"
+          # ISS-465-style kill switch -- installed disabled by default; io
+          # clears to "0" to enable. Mirrors CEE_HARD_DISABLED (K41) /
+          # UNLEARNING_MUTATION_ENABLED (K03) sibling convention.
+          CEE_GDMP_HARD_DISABLED: "1"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: corpus-entropy-gdmp-remediation
+        - Key: Feature
+          Value: ENC-TSK-K42
+
+  # Nightly at 06:00 UTC -- after the CEE detection scan (05:00), so
+  # remediation always sees the freshest Compliance/Semantic findings.
+  CorpusEntropyGdmpRemediationSchedule:
+    Type: AWS::Events::Rule
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "enceladus-corpus-entropy-gdmp-nightly${EnvironmentSuffix}"
+      Description: "Nightly GDMP Stage-1 auto-remediation pass (ENC-TSK-K42 / B66 Ph5)"
+      ScheduleExpression: "cron(0 6 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt CorpusEntropyGdmpRemediationFunction.Arn
+          Id: corpus-entropy-gdmp-nightly
+
+  CorpusEntropyGdmpRemediationPermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsGamma
+    Properties:
+      FunctionName: !Ref CorpusEntropyGdmpRemediationFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CorpusEntropyGdmpRemediationSchedule.Arn
+
+  # ---------------------------------------------------------------------------
   # ENC-TSK-H86 / ENC-FTR-111 Phase 1 (T5): Universal Arc-Walker telemetry +
   # convergence-probe Lambda. Read-only — scans the tracker table and publishes
   # CloudWatch metrics (Enceladus/ArcWalk).
@@ -2353,6 +2445,30 @@ Resources:
       Dimensions:
         - Name: RuleName
           Value: !Sub "enceladus-corpus-entropy-nightly${EnvironmentSuffix}"
+      Statistic: Sum
+      Period: 604800
+      EvaluationPeriods: 1
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+  # ENC-TSK-K42 / B66 Ph5: GDMP Stage-1 remediation cost-preflight guard
+  # (ISS-465). Nightly cadence (1/day, EventBridge per-invocation, no standing
+  # compute) is far below the threshold. 7-day invocation window mirrors the
+  # K03/K41 sibling alarms; breach indicates a runaway/duplicate schedule.
+  CorpusEntropyGdmpRemediationCostHeadroomAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsGamma
+    Properties:
+      AlarmName: !Sub "enceladus-corpus-entropy-gdmp-invocations${EnvironmentSuffix}"
+      AlarmDescription: >-
+        ENC-TSK-K42 cost-preflight guard: 7-day invocation window; nightly cadence
+        should be <=7/week (threshold 10 allows buffer). Breach indicates runaway schedule.
+      Namespace: AWS/Events
+      MetricName: Invocations
+      Dimensions:
+        - Name: RuleName
+          Value: !Sub "enceladus-corpus-entropy-gdmp-nightly${EnvironmentSuffix}"
       Statistic: Sum
       Period: 604800
       EvaluationPeriods: 1
@@ -5006,6 +5122,59 @@ Resources:
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  # ENC-TSK-K42 / B66 Ph5: GDMP Stage-1 remediation Lambda IAM Role
+  # (gamma-only). No direct DynamoDB/S3 document access -- all document
+  # reads/writes go through the governed document_api HTTP surface
+  # (internal API key auth). S3 access is scoped ONLY to this Lambda's own
+  # io-approval-ramp run-counter state prefix, mirroring UnlearningRole's
+  # narrow-prefix S3 scoping convention.
+  CorpusEntropyGdmpRemediationRole:
+    Type: AWS::IAM::Role
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-corpus-entropy-gdmp-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CorpusEntropyGdmpRemediationPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: GdmpRampStateS3
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource:
+                  - !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}gdmp-remediation-state/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -276,6 +276,12 @@
       "lambda_dir": "backend/lambda/corpus_entropy_engine",
       "workflow_file": ".github/workflows/_deploy.yml",
       "deploy_script": "backend/lambda/corpus_entropy_engine/deploy.sh"
+    },
+    {
+      "function_name": "enceladus-corpus-entropy-gdmp-remediation",
+      "lambda_dir": "backend/lambda/corpus_entropy_gdmp_remediation",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/corpus_entropy_gdmp_remediation/deploy.sh"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New `corpus_entropy_gdmp_remediation` Lambda consumes K41's Compliance/Semantic detector output and deterministically resolves a narrow whitelist of `compliance_warnings` classes (missing fence language identifier, missing metadata field labels) via `documents.patch`, advancing raw documents to `compliant` maturity state with no agent session involvement.
- DATA-SAFETY: only the two deterministic, structure-only warning classes are auto-remediated; title-format, empty-document, heading-hierarchy, list-marker, table-divider, and malformed-alert warnings are left for agent/human review. Every applied patch is logged with before/after `compliance_score`.
- io-approval ramp (FTR-106 AC-4 pattern, reused verbatim from `unlearning_core.py`): `GDMP_DRY_RUN=1` default-on, `GDMP_MUTATION_ENABLED=0` default-off, `GDMP_IO_APPROVAL_RUNS=3` gates live runs to candidate-report-only until io explicitly enables mutation mode. Persisted via an S3 run counter.
- Own `CEE_GDMP_HARD_DISABLED` kill switch (installed disabled-by-default), mirroring K41's `CEE_HARD_DISABLED` convention. Idempotency guard (`is_already_compliant`) skips any document already compliant or with zero warnings — no version churn on re-run.
- CFN: new gamma-only Lambda + IAM role (scoped to governed document_api HTTP surface + a narrow S3 ramp-state prefix, no direct DynamoDB access) + EventBridge nightly schedule (06:00 UTC, after CEE's 05:00 scan) + cost-headroom alarm in `02-compute.yaml`. Manifest entry added for Gen2 build/deploy coverage. `.build_extras` shares `corpus_entropy_core.py` from `corpus_entropy_engine` so detector logic stays single-sourced.

## Test plan
- [x] 37 new pytest cases in `backend/lambda/corpus_entropy_gdmp_remediation/test_lambda_function.py`: pure-function warning classification/fixers/remediation-planning/idempotency/io-approval-ramp gate, plus handler-level dry-run-default/mutation-enabled/kill-switch/HTTP-method guards (all mocked, no live AWS/network).
- [x] K41 (`corpus_entropy_engine`) and FTR-106 (`unlearning`) test suites re-run green and unaffected (33 + 7 passed).
- [x] `tools/verify_lambda_workflow_coverage.py` passes (36 production Lambdas mapped).
- [x] `cfn-lint` run against `02-compute.yaml` — no new finding classes introduced beyond the template's pre-existing baseline patterns (SnapStart/py3.11 combo, `IsGamma` reachability, `DeletionPolicy` pairing — identical on every sibling Lambda).
- [ ] Live gamma dry-run candidate reports + io approval to flip to mutation mode (post-deploy, out of scope for this PR).

CCI-9d7a6a194dac4158b24e5a239cd565ef