### PR TITLE
[ENC-TSK-K42] Fix gamma function_name_map for GDMP remediation Lambda

### DIFF
--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -94,3 +94,4 @@ function_name_map:
   scoring_service: enceladus-scoring-service-gamma
   recompute_governance: devops-recompute-governance-gamma
   corpus_entropy_engine: enceladus-corpus-entropy-engine-gamma
+  corpus_entropy_gdmp_remediation: enceladus-corpus-entropy-gdmp-remediation-gamma


### PR DESCRIPTION
## Summary
- Fast-follow to #792. The new `corpus_entropy_gdmp_remediation` Lambda built and uploaded its artifact successfully in the Gen2 deploy, but the "Deploy Lambda functions" step skipped the actual `update-function-code` call: `[skip] corpus_entropy_gdmp_remediation (not in function_name_map)`.
- `envs/v4-gamma.yaml`'s `function_name_map` (backend/lambda/<dir> -> deployed gamma function name) had no entry for the new directory. Adds `corpus_entropy_gdmp_remediation: enceladus-corpus-entropy-gdmp-remediation-gamma`, matching the CFN `FunctionName` in `02-compute.yaml`.
- No `v3-prod`/`v4-prod` entry needed — this Lambda is gamma-only (`Condition: IsGamma`), same convention as `corpus_entropy_engine`.

## Test plan
- [x] Confirmed `enceladus-corpus-entropy-engine-gamma`'s existing map entry is the model for the new line; format matches.
- [ ] Next gamma deploy run picks up the mapping and successfully updates `enceladus-corpus-entropy-gdmp-remediation-gamma` function code (to be confirmed post-merge via GH Actions Jobs API).

Same task as #792 (ENC-TSK-K42), currently at deploy-init (commit_complete_id not yet cleared — that only happens at deploy-success). Reusing the task's still-live CCI below since this is a same-task pre-deploy-success fix, not a new commit lifecycle.

CCI-9d7a6a194dac4158b24e5a239cd565ef