### PR TITLE
[ENC-TSK-K59] IAM patch: grant cloudwatch:PutDashboard to CFN deploy role (gamma)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml
@@ -1,0 +1,66 @@
+name: IAM CFN Deploy Role — CloudWatch Dashboard Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant cloudwatch:PutDashboard (+ Get/Delete/List) on the gamma v4 architecture dashboard to the CFN deploy role (ENC-TSK-K46 / ENC-TSK-K59, enceladus-monitoring-gamma UPDATE_ROLLBACK_COMPLETE due to missing permission)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with gamma CloudWatch Dashboard permissions
+    # ENC-TSK-K59 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — gamma CloudWatch Dashboard bootstrap
+        run: |
+          set -euo pipefail
+          cat > /tmp/gamma-cloudwatch-dashboard-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "GammaCloudWatchDashboardBootstrap",
+                "Effect": "Allow",
+                "Action": [
+                  "cloudwatch:PutDashboard",
+                  "cloudwatch:GetDashboard",
+                  "cloudwatch:DeleteDashboards",
+                  "cloudwatch:ListDashboards"
+                ],
+                "Resource": "arn:aws:cloudwatch::356364570033:dashboard/enceladus-v4-architecture-gamma"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-cloudwatch-dashboard-v1" \
+            --policy-document "file:///tmp/gamma-cloudwatch-dashboard-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-cloudwatch-dashboard-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -107,6 +107,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-K59: environment: v3-prod \u2014 despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
+    },
     "iam-cloudformation-unblock.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
- Unblocks ENC-TSK-K46's EnceladusV4Dashboard gamma deploy — CloudFormation Monitoring Stack Deploy (run 28598749617) failed because `enceladus-cloudformation-deploy-github-role` lacks `cloudwatch:PutDashboard`. Stack `enceladus-monitoring-gamma` rolled back cleanly (`UPDATE_ROLLBACK_COMPLETE`, no orphaned resources).
- New narrowly-scoped `workflow_dispatch` workflow, following the exact `iam-cfn-deploy-role-gamma-patch.yml` pattern: `environment: v3-prod` gate per ENC-FTR-120 (this patches a role shared with prod, even though the grant is gamma-scoped), least-privilege to the single dashboard ARN `arn:aws:cloudwatch::356364570033:dashboard/enceladus-v4-architecture-gamma`.
- **This PR makes no IAM change by itself.** Merging just adds the workflow file. A follow-up `workflow_dispatch` will create a request that pauses at the v3-prod required-reviewer gate for io's approval — not requested or approved by this agent session.

CCI-09720814d20744c0a4bd63bdf246e733

ENC-TSK-K59

## Test plan
- [x] YAML reviewed against the working `iam-cfn-deploy-role-gamma-patch.yml` sibling workflow — identical structure, only the policy statement and target resource differ
- [ ] Post-merge: dispatch via `gh workflow run`, confirm the run pauses at the v3-prod environment gate (not auto-applied)