### PR TITLE
[ENC-TSK-K59] Mirror CloudWatch dashboard IAM patch workflow to main

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml
@@ -1,0 +1,66 @@
+name: IAM CFN Deploy Role — CloudWatch Dashboard Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant cloudwatch:PutDashboard (+ Get/Delete/List) on the gamma v4 architecture dashboard to the CFN deploy role (ENC-TSK-K46 / ENC-TSK-K59, enceladus-monitoring-gamma UPDATE_ROLLBACK_COMPLETE due to missing permission)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with gamma CloudWatch Dashboard permissions
+    # ENC-TSK-K59 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — gamma CloudWatch Dashboard bootstrap
+        run: |
+          set -euo pipefail
+          cat > /tmp/gamma-cloudwatch-dashboard-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "GammaCloudWatchDashboardBootstrap",
+                "Effect": "Allow",
+                "Action": [
+                  "cloudwatch:PutDashboard",
+                  "cloudwatch:GetDashboard",
+                  "cloudwatch:DeleteDashboards",
+                  "cloudwatch:ListDashboards"
+                ],
+                "Resource": "arn:aws:cloudwatch::356364570033:dashboard/enceladus-v4-architecture-gamma"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-cloudwatch-dashboard-v1" \
+            --policy-document "file:///tmp/gamma-cloudwatch-dashboard-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-gamma-cloudwatch-dashboard-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -100,6 +100,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-K59: environment: v3-prod \u2014 despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
+    },
     "iam-cloudformation-unblock.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
- Mirrors `.github/workflows/iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml` (already merged to `v4/main` via #794) onto `main`.
- **Mechanical GitHub requirement, not a policy change**: `workflow_dispatch` only works for workflow files present on the repo's default branch, even when dispatching `--ref v4/main`. The three existing sibling IAM patch workflows are all present on both branches for the same reason.
- Additive, `workflow_dispatch`-only file. No push/PR trigger. No IAM mutation occurs on merge. Its `patch-role` job is `environment: v3-prod` gated (ENC-FTR-120) — merging this does not touch IAM; only a subsequent `workflow_dispatch` + io's manual environment approval does.
- Also adds the required `tools/prod_gate_baseline.json` classification entry (the ENC-TSK-J65 prod-gate coverage guard runs in `ci.yml` on both branches).

CCI-09720814d20744c0a4bd63bdf246e733

ENC-TSK-K59 (same commit-complete-id as companion PR #794 — this is the same governed task's checkout arc, mirroring one additive file onto the default branch to satisfy GitHub's workflow_dispatch requirement).

## Test plan
- [x] `python3 tools/prod_gate_coverage_guard.py` passes locally
- [x] File content identical to the version merged via PR #794
- [ ] Post-merge: dispatch via `gh workflow run --ref v4/main` and confirm it's now resolvable (no more 404) and pauses at the v3-prod reviewer gate