### PR TITLE
[ENC-TSK-K62] Go-live: clear K41/K42 kill switches + reconcile K44 health-monitor

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1650,6 +1650,15 @@ Resources:
           Value: enceladus
         - Key: Component
           Value: health-monitor
+        - Key: ReconciledBy
+          # ENC-TSK-K44 follow-up (2026-07-02): forces CFN to recompute a real
+          # diff on this resource. Post-IMPORT, `aws cloudformation deploy`'s
+          # change-set shortcut saw "template text unchanged" and skipped
+          # reconciling this function's Layers/Environment against the live
+          # (pre-import) values -- this tag bump is a real property change so
+          # the next Apply picks up SharedLayerArn + the DynamoDB/Neo4j/S3/SQS
+          # env vars that were already correct in the template but never applied.
+          Value: "ENC-TSK-K44-reconcile-20260702"
 
   ProdHealthMonitorRole:
     Type: AWS::IAM::Role
@@ -1922,7 +1931,9 @@ Resources:
           # ISS-465-style kill switch -- installed before the first scheduled
           # run; io clears to "0" to enable. Mirrors TRAINING_HARD_DISABLED
           # (K02) / UNLEARNING_MUTATION_ENABLED (K03) sibling convention.
-          CEE_HARD_DISABLED: "1"
+          # Cleared 2026-07-02 per io: telemetry-only detector, no corpus
+          # mutation -- safe to run on its initial nightly schedule (ENC-TSK-K41).
+          CEE_HARD_DISABLED: "0"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
@@ -2014,7 +2025,11 @@ Resources:
           # ISS-465-style kill switch -- installed disabled by default; io
           # clears to "0" to enable. Mirrors CEE_HARD_DISABLED (K41) /
           # UNLEARNING_MUTATION_ENABLED (K03) sibling convention.
-          CEE_GDMP_HARD_DISABLED: "1"
+          # Cleared 2026-07-02 per io: lets the Lambda run on its initial
+          # nightly schedule. GDMP_DRY_RUN stays "1" / GDMP_MUTATION_ENABLED
+          # stays "0" -- this produces real candidate reports without
+          # mutating any documents yet (ENC-TSK-K42).
+          CEE_GDMP_HARD_DISABLED: "0"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]


### PR DESCRIPTION
## Summary
io directive 2026-07-02: get B66 Phase-5 Lambdas running on their initial gamma schedules ASAP, without further manual approval steps.

- **ENC-TSK-K41**: `CEE_HARD_DISABLED` 1 → 0. Telemetry-only corpus entropy detector (no document mutation) — safe to run on its 05:00 UTC nightly schedule immediately.
- **ENC-TSK-K42**: `CEE_GDMP_HARD_DISABLED` 1 → 0. `GDMP_DRY_RUN` stays `"1"` and `GDMP_MUTATION_ENABLED` stays `"0"` — the Lambda now runs on its 06:00 UTC nightly schedule and produces real candidate reports, but does **not** mutate any governed documents yet. Flipping to mutation-enabled remains a separate, explicit decision pending observed dry-run behavior — will follow up once real cycles have run.
- **ENC-TSK-K44**: `ProdHealthMonitorFunction`'s `Layers`/`Environment` were already correct in the template but never applied post-IMPORT (`aws cloudformation deploy`'s change-set shortcut saw no template-text diff and skipped reconciliation — confirmed via live `aws lambda get-function-configuration`: `Layers: null`, only `FUNCTION_NAMES` env var present). Added a `Tag` bump to force a real property diff so the next Apply picks up `SharedLayerArn` + the DynamoDB/Neo4j/S3/SQS env vars.

Routed as a new task (ENC-TSK-K62) rather than reopening K41/K42's own arcs — their `coding-updates` re-entry transition is broken (`tracker.validation_rules` lists it as valid forward from `deploy-success`, but the actual advance call rejects it for `transition_type=github_pr_deploy`); documented on both tasks' worklogs.

CCI-910deaf2aff64edaa5b8889f714f2883

ENC-TSK-K62, ENC-TSK-K41, ENC-TSK-K42, ENC-TSK-K44

## Test plan
- [x] YAML validated (135 resources parse cleanly)
- [x] K41 test suite: 33 passed
- [x] K42 test suite: 37 passed
- [ ] Post-deploy: `CEE_HARD_DISABLED=0` and `CEE_GDMP_HARD_DISABLED=0` confirmed live via `aws lambda get-function-configuration`
- [ ] Post-deploy: `ProdHealthMonitorFunction` shows `SharedLayerArn` attached + full env var set