### PR TITLE
[ENC-TSK-K45] infra: force CFN reconcile of CheckoutServiceFunction TracingConfig

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -462,6 +462,17 @@ Resources:
           Value: enceladus
         - Key: Component
           Value: checkout
+        - Key: ReconciledBy
+          # ENC-TSK-K45 follow-up (2026-07-02): forces CFN to recompute a real
+          # diff on this resource, mirroring the ENC-TSK-K44 fix for
+          # ProdHealthMonitorFunction. Post-IMPORT, `aws cloudformation
+          # deploy`'s change-set shortcut saw "template text unchanged" (the
+          # IMPORT already matched the live pre-import config, including
+          # TracingConfig.Mode=PassThrough) and skipped reconciling this
+          # function's TracingConfig against the template's declared
+          # Mode=Active -- this tag bump is a real property change so the
+          # next Apply actually pushes TracingConfig.Mode=Active live.
+          Value: "ENC-TSK-K45-reconcile-20260702"
 
   # ENC-TSK-H47 / B63 Phase 2B — Scoring Service. Standalone, SNS-triggered ASYNC consumer that owns
   # lesson constitutional scoring (pillar_composite + resonance_score, ENC-FTR-054) and the lesson


### PR DESCRIPTION
## Summary
Follow-up to #800 (ENC-TSK-K45 AC-1). PR #800 added `CheckoutServiceFunction` to `infrastructure/cloudformation/02-compute.yaml` with `TracingConfig: {Mode: Active}`, and the ENC-TSK-J13 IMPORT workflow (run 28606588069) successfully adopted the live `enceladus-checkout-service-gamma` Lambda into the `enceladus-compute-gamma` stack (confirmed: `aws cloudformation list-stack-resources` shows `CheckoutServiceFunction` as `UPDATE_COMPLETE`).

However, `aws lambda get-function-configuration --function-name enceladus-checkout-service-gamma --query TracingConfig` still showed `Mode: PassThrough` post-IMPORT. CFN IMPORT adopts a resource matching its **current live config** — it does not push template-declared property changes. A follow-up `CloudFormation Compute Stack Deploy` (run 28607274305) then reported `No changes to deploy` for both stacks, because `aws cloudformation deploy`'s change-set shortcut saw no template-text diff and skipped reconciling `TracingConfig` against the live (pre-import) value.

This is the **exact same gap** ENC-TSK-K44 hit for `ProdHealthMonitorFunction` (commit `aaba39f`), whose fix was a `Tags` bump to force CFN to compute a real property diff. This PR applies the same fix to `CheckoutServiceFunction`: adds a `ReconciledBy` tag so the next deploy actually pushes `TracingConfig.Mode=Active` to the live function.

Gamma only; no v3-prod change.

CCI-0f51432aca52428ca0b7226df1a698a9

## Test plan
- [x] YAML syntax validated locally (`yaml.safe_load` w/ CFN tag constructors)
- [ ] CI green
- [ ] Post-merge: dispatch `CloudFormation Compute Stack Deploy` (stack_name=enceladus-compute, data_stack_name=enceladus-data — base names; workflow appends `-gamma` for `v4/*` refs) and confirm it reports a real change-set (not "No changes to deploy") for `CheckoutServiceFunction`
- [ ] Post-deploy: `aws lambda get-function-configuration --function-name enceladus-checkout-service-gamma --query TracingConfig` → `Mode: Active`