### PR TITLE
[ENC-TSK-K65] ui pipeline finalization — deploy self-validation + wait-fail-fast + codify CF grant

### DIFF
--- a/.github/workflows/_ui_deploy.yml
+++ b/.github/workflows/_ui_deploy.yml
@@ -244,6 +244,81 @@ jobs:
             --distribution-id "${DIST}" \
             --paths /index.html /sw.js /manifest.webmanifest
 
+      # Post-deploy smoke test against the live distribution. Proves three
+      # things end-to-end: (1) the app shell serves 200 text/html from the S3
+      # origin, (2) /api/* routes to the API-Gateway origin (a 401 from the
+      # unauthenticated /api/v1/projects means the behavior reaches API GW and
+      # Cognito auth is enforced — a 200 would mean auth is OFF; a 404/000 means
+      # /api/* routing is broken). Health is a soft check (warning only). The
+      # resolved DOMAIN is echoed as LIVE_UI_URL= so it is greppable in the log.
+      - name: Validate live distribution (shell + /api routing)
+        env:
+          STACK: ${{ steps.resolve.outputs.stack_name }}
+        run: |
+          set -euo pipefail
+          DOMAIN=$(aws cloudformation describe-stacks \
+            --stack-name "${STACK}" --region "${AWS_REGION}" \
+            --query "Stacks[0].Outputs[?OutputKey=='UiDistributionDomainName'].OutputValue" \
+            --output text)
+          if [ -z "${DOMAIN}" ] || [ "${DOMAIN}" = "None" ]; then
+            echo "::error::UI CDN stack '${STACK}' is missing the UiDistributionDomainName output — cannot validate the live distribution."
+            exit 1
+          fi
+          echo "LIVE_UI_URL=https://${DOMAIN}/"
+
+          # Give the invalidation a moment to propagate before curling.
+          sleep 20
+
+          # Capture each result defensively so a curl failure surfaces as a
+          # 000 code under set -e rather than aborting the step early.
+          SHELL_RESULT=$(curl -sS -o /dev/null -w '%{http_code} %{content_type}' "https://${DOMAIN}/" || true)
+          SHELL_CODE=$(echo "${SHELL_RESULT}" | awk '{print $1}')
+          SHELL_CT=$(echo "${SHELL_RESULT}" | awk '{print $2}')
+          HEALTH=$(curl -sS -o /dev/null -w '%{http_code}' "https://${DOMAIN}/api/v1/health" || true)
+          PROJ=$(curl -sS -o /dev/null -w '%{http_code}' "https://${DOMAIN}/api/v1/projects" || true)
+
+          # Evaluate expectations.
+          shell_ok="FAIL"; [ "${SHELL_CODE}" = "200" ] && case "${SHELL_CT}" in text/html*) shell_ok="PASS";; esac
+          health_ok="WARN"; [ "${HEALTH}" = "200" ] && health_ok="PASS"
+          proj_ok="FAIL";  [ "${PROJ}" = "401" ] && proj_ok="PASS"
+
+          {
+            echo "## UI live-distribution validation — ${STACK}"
+            echo ""
+            echo "LIVE_UI_URL: https://${DOMAIN}/"
+            echo ""
+            echo "| Check | Endpoint | Result | Expected | Status |"
+            echo "| --- | --- | --- | --- | --- |"
+            echo "| Shell | \`/\` | \`${SHELL_CODE} ${SHELL_CT}\` | 200 + text/html | ${shell_ok} |"
+            echo "| Health | \`/api/v1/health\` | \`${HEALTH}\` | 200 | ${health_ok} |"
+            echo "| API routing/auth | \`/api/v1/projects\` | \`${PROJ}\` | 401 (auth enforced) | ${proj_ok} |"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+          echo "Shell:  ${SHELL_CODE} ${SHELL_CT}  -> ${shell_ok}"
+          echo "Health: ${HEALTH}  -> ${health_ok}"
+          echo "API:    ${PROJ}  -> ${proj_ok}"
+
+          # FAIL conditions: shell not 200/text/html, OR /api/v1/projects not 401
+          # (200 = auth not enforced; 404/000 = /api/* routing broken). A
+          # non-200 health is only a warning and never fails the step.
+          fatal=0
+          if [ "${shell_ok}" != "PASS" ]; then
+            echo "::error::App shell did not return 200 text/html (got '${SHELL_CODE} ${SHELL_CT}') at https://${DOMAIN}/"
+            fatal=1
+          fi
+          if [ "${proj_ok}" != "PASS" ]; then
+            echo "::error::/api/v1/projects returned '${PROJ}', expected 401. A 200 means Cognito auth is not enforced; a 404/000 means the /api/* behavior is not routing to the API-Gateway origin."
+            fatal=1
+          fi
+          if [ "${health_ok}" != "PASS" ]; then
+            echo "::warning::/api/v1/health returned '${HEALTH}' (expected 200) — non-fatal warning."
+          fi
+          if [ "${fatal}" -ne 0 ]; then
+            echo "Live-distribution validation: FAIL"
+            exit 1
+          fi
+          echo "Live-distribution validation: PASS"
+
   # ---------------------------------------------------------------------------
   # RECORD_DEPLOY — write a DPL record so deploy.history stays current
   # (ENC-ISS-451 mechanism, mirrored from _deploy.yml). Only runs after a

--- a/.github/workflows/cloudformation-ui-cdn-stack-deploy.yml
+++ b/.github/workflows/cloudformation-ui-cdn-stack-deploy.yml
@@ -242,6 +242,8 @@ jobs:
 
       - name: Execute reviewed change-set
         id: deploy
+        env:
+          STACK: ${{ needs.plan.outputs.stack_name }}
         run: |
           set -euo pipefail
           changeset_type=$(aws cloudformation describe-change-set \
@@ -251,15 +253,63 @@ jobs:
           aws cloudformation execute-change-set \
             --region "${AWS_REGION}" \
             --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+
+          # Terminal SUCCESS states depend on the change-set type; a fresh
+          # CREATE ends CREATE_COMPLETE, an UPDATE ends UPDATE_COMPLETE.
           if [ "${changeset_type}" = "CREATE" ]; then
-            aws cloudformation wait stack-create-complete \
-              --region "${AWS_REGION}" \
-              --stack-name "${{ needs.plan.outputs.stack_name }}"
+            success_state="CREATE_COMPLETE"
           else
-            aws cloudformation wait stack-update-complete \
-              --region "${AWS_REGION}" \
-              --stack-name "${{ needs.plan.outputs.stack_name }}"
+            success_state="UPDATE_COMPLETE"
           fi
+          echo "Change-set type ${changeset_type}; waiting for ${success_state} on ${STACK}."
+
+          # Bounded fail-fast poll instead of `aws cloudformation wait`. The
+          # blocking waiter kept polling through a rollback until the OIDC token
+          # expired (~60 min ExpiredToken); this exits IMMEDIATELY the moment a
+          # rollback/terminal-failed status appears, and has an ~80 min wall
+          # clock guard so it can never outlive the 90-min job timeout.
+          deadline=$(( $(date +%s) + 80*60 ))
+          while true; do
+            st=$(aws cloudformation describe-stacks \
+              --region "${AWS_REGION}" \
+              --stack-name "${STACK}" \
+              --query 'Stacks[0].StackStatus' \
+              --output text 2>/dev/null || echo "DESCRIBE_FAILED")
+            echo "$(date -u +%H:%M:%S) ${STACK} status: ${st}"
+
+            case "${st}" in
+              "${success_state}")
+                echo "Stack ${STACK} reached ${st}."
+                exit 0
+                ;;
+              CREATE_COMPLETE|UPDATE_COMPLETE)
+                # Tolerate the sibling success state defensively.
+                echo "Stack ${STACK} reached ${st}."
+                exit 0
+                ;;
+              ROLLBACK_IN_PROGRESS|ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED|UPDATE_ROLLBACK_IN_PROGRESS|UPDATE_ROLLBACK_COMPLETE|UPDATE_ROLLBACK_FAILED|DELETE_FAILED)
+                echo "::error::Stack ${STACK} entered terminal-failed status ${st} — failing fast (recent CREATE_FAILED events below)."
+                aws cloudformation describe-stack-events \
+                  --region "${AWS_REGION}" \
+                  --stack-name "${STACK}" \
+                  --query "reverse(StackEvents[?contains(ResourceStatus,'FAILED')].{t:Timestamp,id:LogicalResourceId,st:ResourceStatus,reason:ResourceStatusReason})" \
+                  --output table 2>/dev/null | head -60 || echo "(describe-stack-events unavailable)"
+                exit 1
+                ;;
+              *_IN_PROGRESS)
+                : # create/update still running — keep polling.
+                ;;
+              *)
+                echo "::warning::Unexpected stack status '${st}' for ${STACK} — continuing to poll."
+                ;;
+            esac
+
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "::error::Timed out after ~80 min waiting for ${STACK} to reach ${success_state} (last status ${st})."
+              exit 1
+            fi
+            sleep 15
+          done
 
       - name: Report stack events on failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -377,6 +377,89 @@ Resources:
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentgroup:enceladus-lambda*"
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentconfig:*"
 
+  # ENC-TSK-K65 — the CFN deploy role deploys 07-ui-cdn.yaml (CloudFront OAC +
+  # distribution, TagResource, invalidations) and syncs the ui-v2 build to its
+  # S3 origin, but the base CloudFormationDeployPolicy grants zero cloudfront:*
+  # and no S3 object perms on the UI bucket — the apply AccessDenied'd at
+  # change-set execution and the _ui_deploy.yml s3 sync AccessDenied'd. This was
+  # unblocked out-of-band by manually attaching the managed policy
+  # `enceladus-ui-cdn-deploy` (arn:aws:iam::356364570033:policy/enceladus-ui-cdn-deploy)
+  # to enceladus-cloudformation-deploy-github-role.
+  #
+  # Codified here as an ATTACHED MANAGED policy (mirroring CodeDeployStackOpsPolicy
+  # above) because the role's aggregate inline-policy quota (10,240 bytes) is
+  # exhausted by the out-of-band patch policies (J85 / PR #733 pattern). A
+  # DISTINCT ManagedPolicyName is used deliberately: managing the identically
+  # named live `enceladus-ui-cdn-deploy` would AlreadyExists-collide with the
+  # manual attachment, so this attaches a second managed policy with the same
+  # effective grant (idempotent at the permission level). The manual policy can
+  # be detached later without a CFN conflict once this stack update lands.
+  UiCdnDeployPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-ui-cdn-stack-ops
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # CloudFront distribution + Origin Access Control lifecycle for
+          # 07-ui-cdn.yaml, plus tagging and the app-shell invalidation the
+          # _ui_deploy.yml pipeline issues after each sync. CloudFront is a
+          # global service — actions are not region-scoped and the distribution
+          # ARN carries no region segment, so Resource is "*".
+          - Sid: CloudFrontUiCdnOps
+            Effect: Allow
+            Action:
+              - cloudfront:CreateOriginAccessControl
+              - cloudfront:GetOriginAccessControl
+              - cloudfront:UpdateOriginAccessControl
+              - cloudfront:DeleteOriginAccessControl
+              - cloudfront:CreateDistribution
+              - cloudfront:GetDistribution
+              - cloudfront:GetDistributionConfig
+              - cloudfront:UpdateDistribution
+              - cloudfront:DeleteDistribution
+              - cloudfront:TagResource
+              - cloudfront:UntagResource
+              - cloudfront:CreateInvalidation
+            Resource: "*"
+          # S3 bucket lifecycle for the ui-v2 origin bucket (07-ui-cdn creates
+          # it) + object put/get/delete/list for the _ui_deploy.yml sync
+          # (--delete diffing needs GetObject + ListBucket). Scoped to the
+          # enceladus-ui-v2* bucket family (prod + -gamma suffix).
+          - Sid: S3UiBucketOps
+            Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:DeleteBucket
+              - s3:PutBucketPolicy
+              - s3:GetBucketPolicy
+              - s3:DeleteBucketPolicy
+              - s3:PutBucketTagging
+              - s3:GetBucketTagging
+              - s3:PutBucketPublicAccessBlock
+              - s3:GetBucketPublicAccessBlock
+              - s3:PutBucketVersioning
+              - s3:GetBucketVersioning
+              - s3:PutLifecycleConfiguration
+              - s3:GetLifecycleConfiguration
+              - s3:PutBucketOwnershipControls
+              - s3:GetBucketOwnershipControls
+              - s3:ListBucket
+            Resource:
+              - "arn:aws:s3:::enceladus-ui-v2*"
+          - Sid: S3UiObjectOps
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObject
+              - s3:ListMultipartUploadParts
+              - s3:AbortMultipartUpload
+            Resource:
+              - "arn:aws:s3:::enceladus-ui-v2*/*"
+
   BackendDeployRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## ENC-TSK-K65 — v4 UI pipeline finalization (ENC-PLN-065)

Post-root-cause hardening. The CDN rollback root cause was the deploy role lacking `cloudfront:CreateOriginAccessControl` (403) — granted via managed policy `enceladus-ui-cdn-deploy`. This lands the durability + validation follow-through:

- **`_ui_deploy.yml`** — post-deploy **self-validation**: resolves `UiDistributionDomainName`, curls the SPA shell (expect `200 text/html`), `/api/v1/health` (200), `/api/v1/projects` (**401** unauth — proves `/api/*` routes to the API-GW origin). Prints `LIVE_UI_URL` + a PASS/FAIL summary; fails on `shell!=200` or `projects!=401`.
- **`cloudformation-ui-cdn-stack-deploy.yml`** — apply wait now **fails fast** on `ROLLBACK_*`/`CREATE_FAILED` (with event dump), fixing the `ExpiredToken` hang that masked the real failure for ~45 min.
- **`04-github-roles.yaml`** — codifies the grant as managed policy `enceladus-cfn-deploy-ui-cdn-stack-ops` on `CloudFormationDeployRole` (distinct name from the manual `enceladus-ui-cdn-deploy` to avoid a create collision; mirrors the `CodeDeployStackOpsPolicy` pattern). IAM-patch workflows are `workflow_dispatch`-only, so this is inert on merge.

Verified: 3-file scope, all parse, `prod_gate_coverage_guard` PASS. Merging re-fires `_ui_deploy` which (against the now-completing CDN stack) publishes `ui-v2` and self-validates the live distribution.

CCI-237ac20b02bc4728b455974f94d2d034