### PR TITLE
fix(ui-cdn): ENC-TSK-K71 — CloudFront Function SPA rewrite replaces distribution-wide CustomErrorResponses

### DIFF
--- a/infrastructure/cloudformation/07-ui-cdn.yaml
+++ b/infrastructure/cloudformation/07-ui-cdn.yaml
@@ -21,6 +21,7 @@ Metadata:
       Role: AWS_CLOUDFORMATION_ROLE_TO_ASSUME (the privileged CFN OIDC role assumed by cloudformation-ui-cdn-stack-deploy.yml)
       MissingPermissions:
         - "cloudfront:* (CreateOriginAccessControl, CreateDistribution, UpdateDistribution, TagResource, GetDistribution, CreateInvalidation)"
+        - "cloudfront function ops for the SPA rewrite (ENC-TSK-K68): CreateFunction, PublishFunction, DescribeFunction, GetFunction, UpdateFunction, DeleteFunction"
         - "s3:CreateBucket, s3:PutBucketPolicy, s3:PutBucketVersioning, s3:PutBucketPublicAccessBlock, s3:PutEncryptionConfiguration, s3:PutBucketTagging, s3:GetBucket*, s3:DeleteBucketPolicy"
       Rationale: >
         The CFN deploy role's inline policy quota is exhausted (see memory:
@@ -156,6 +157,40 @@ Resources:
         SigningProtocol: sigv4
 
   # ---------------------------------------------------------------------------
+  # SPA rewrite function (viewer-request, DEFAULT behavior only) — ENC-TSK-K68
+  # ---------------------------------------------------------------------------
+  # Replaces the former distribution-wide CustomErrorResponses (403/404 ->
+  # 200 /index.html), which applied to ALL origins and therefore masked real
+  # API Gateway 404/403 JSON responses as 200 text/html — breaking the ui-v2
+  # client's NotFoundError/auth semantics. This function rewrites only
+  # extensionless, non-/api/* viewer URIs to /index.html BEFORE the cache/
+  # origin lookup, so:
+  #   - SPA deep links (/task/ENC-TSK-XXX) serve the app shell with a 200;
+  #   - /api/* passes through untouched (it has its own behavior anyway);
+  #   - real file misses (hashed assets, /mobile/v1/*.json) surface their true
+  #     origin status instead of a rewritten app shell.
+  UiSpaRewriteFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "enceladus-ui-v2-spa-rewrite${EnvironmentSuffix}"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: Rewrite extensionless non-API viewer URIs to /index.html for SPA client-side routing (S3 origin only).
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri;
+          if (!uri.startsWith('/api/')) {
+            var lastSegment = uri.split('/').pop();
+            if (!lastSegment.includes('.')) {
+              request.uri = '/index.html';
+            }
+          }
+          return request;
+        }
+
+  # ---------------------------------------------------------------------------
   # CloudFront Distribution — S3 (default) + API Gateway (/api/*)
   # ---------------------------------------------------------------------------
   UiDistribution:
@@ -206,6 +241,11 @@ Resources:
           CachedMethods: [GET, HEAD, OPTIONS]
           # AWS managed cache policy: CachingOptimized.
           CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+          # SPA client-side routing handled here (default/S3 behavior ONLY) so
+          # the /api/* behavior keeps true API status codes (ENC-TSK-K68).
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt UiSpaRewriteFunction.FunctionARN
         CacheBehaviors:
           # /api/* -> API Gateway custom origin. Forward ALL viewer
           # headers/cookies/querystring so auth cookies reach the API, and
@@ -222,17 +262,11 @@ Resources:
             # (forwards all viewer cookies/headers/querystring EXCEPT Host, so
             # API GW receives its own execute-api host and routes correctly).
             OriginRequestPolicyId: "b689b0a8-53d0-40ab-baf2-68738e2966ac"
-        # SPA client-side routing: unmatched paths (deep links) return the app
-        # shell with a 200 so the router can resolve them client-side.
-        CustomErrorResponses:
-          - ErrorCode: 403
-            ResponseCode: 200
-            ResponsePagePath: /index.html
-            ErrorCachingMinTTL: 10
-          - ErrorCode: 404
-            ResponseCode: 200
-            ResponsePagePath: /index.html
-            ErrorCachingMinTTL: 10
+        # NOTE (ENC-TSK-K68): the former CustomErrorResponses 403/404 ->
+        # 200 /index.html were REMOVED — they were distribution-wide and
+        # rewrote genuine API-origin errors into the app shell. SPA deep-link
+        # routing is now handled by UiSpaRewriteFunction on the default (S3)
+        # behavior only.
         PriceClass: PriceClass_100
       Tags:
         - Key: Project


### PR DESCRIPTION
## ENC-TSK-K71 (supersedes ENC-TSK-K68) — ENC-PLN-066 Wave 1

**Defect:** `CustomErrorResponses` (403/404 → 200 `/index.html`) apply distribution-wide, so genuine API-GW 404/403 JSON (e.g. `Record not found` from the gamma shadow table) is rewritten to 200 `text/html` — breaking ui-v2 `NotFoundError`/auth semantics and masking real API failures.

**Fix:** new `UiSpaRewriteFunction` (CloudFront Function, cloudfront-js-2.0, viewer-request, AutoPublish) rewrites extensionless non-`/api/*` URIs to `/index.html`, attached to the **default (S3) behavior only**; `CustomErrorResponses` removed. `/api/*` now passes true status codes.

**Validation:** PyYAML+intrinsics parse OK; structure asserts (no CustomErrorResponses, FunctionAssociations on default behavior only, /api/* untouched) PASS; prod_gate_coverage_guard PASS. Gamma-only; prod stack untouched until the io-gated cutover.

**Note:** if the gamma apply 403s on `cloudfront:CreateFunction`, the K65 fail-fast surfaces it in ~2 min → one-line io grant on the deploy-role managed policy.

CCI-e1c5379ac88c42aab6cbb2b9ef6d11bb

🤖 Generated with [Claude Code](https://claude.com/claude-code)