### PR TITLE
fix(feed): ENC-TSK-K72 — gamma FeedPublisher env isolation + same-origin /mobile/v1 snapshot serving

### DIFF
--- a/.github/workflows/_ui_deploy.yml
+++ b/.github/workflows/_ui_deploy.yml
@@ -212,7 +212,12 @@ jobs:
           #    Default cache-control here is conservative; the app-shell files
           #    are re-put with no-cache below, and hashed assets/ are re-put
           #    immutable below, so the ordering does not matter for those.
+          #    ENC-TSK-K69: mobile/* is EXCLUDED from the delete-mirror — the
+          #    gamma feed publisher (devops-feed-publisher-gamma) writes the
+          #    /mobile/v1 snapshot JSON into this bucket for same-origin
+          #    serving; a UI deploy must never wipe it.
           aws s3 sync "${DIST_DIR}/" "s3://${BUCKET}/" --delete \
+            --exclude "mobile/*" \
             --cache-control "public,max-age=0,must-revalidate"
 
           # 2. Hashed, content-addressed build output under assets/ — safe to

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1017,8 +1017,32 @@ Resources:
           TRACKER_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           PROJECTS_REGION: !Ref AWS::Region
-          FEED_BUCKET: !Ref S3Bucket
-          FEED_PREFIX: !Sub "${S3EnvPrefix}mobile/v1"
+          # ENC-TSK-K69: without this the code default is the PROD "documents"
+          # table (feed_utils.DEFAULT_DOCUMENTS_TABLE) — the gamma publisher
+          # was reading prod documents cross-env. Prod rendering: "documents"
+          # (identical to the code default; no-op).
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          # ENC-TSK-K69 gamma env isolation: publish snapshots into the ui-v2
+          # origin bucket (07-ui-cdn.yaml exports) so the PWA's same-origin
+          # VITE_FEED_BASE_URL=/mobile/v1 fetch resolves through the gamma
+          # distribution, and invalidate THAT distribution — not the prod
+          # E2BOQXCW1TA6Y4 code default (whose grant is IsProduction-gated
+          # anyway, so gamma invalidations were failing silently). Prod
+          # branches render byte-identical to the previous template
+          # (jreese-net + ${S3EnvPrefix}mobile/v1 + CF_DISTRIBUTION absent ->
+          # code default).
+          FEED_BUCKET: !If
+            - IsGamma
+            - !ImportValue "enceladus-ui-cdn-gamma-UiBucketName"
+            - !Ref S3Bucket
+          FEED_PREFIX: !If
+            - IsGamma
+            - "mobile/v1"
+            - !Sub "${S3EnvPrefix}mobile/v1"
+          CF_DISTRIBUTION: !If
+            - IsGamma
+            - !ImportValue "enceladus-ui-cdn-gamma-UiDistributionId"
+            - !Ref "AWS::NoValue"
           EVENT_BUS: default
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
@@ -4159,7 +4183,13 @@ Resources:
                 Action:
                   - s3:PutObject
                   - s3:GetObject
-                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}mobile/v1/*"
+                # ENC-TSK-K69: gamma publishes into the ui-v2 origin bucket
+                # (same-origin /mobile/v1 serving through the gamma
+                # distribution); prod resource unchanged.
+                Resource: !If
+                  - IsGamma
+                  - !Sub "arn:aws:s3:::enceladus-ui-v2${EnvironmentSuffix}/mobile/v1/*"
+                  - !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}mobile/v1/*"
               - Sid: EventBridgePut
                 Effect: Allow
                 Action: events:PutEvents
@@ -4177,6 +4207,20 @@ Resources:
                   Effect: Allow
                   Action: cloudfront:CreateInvalidation
                   Resource: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/E2BOQXCW1TA6Y4"
+                - !Ref AWS::NoValue
+              # ENC-TSK-K69: gamma invalidates the ui-v2 gamma distribution
+              # after each snapshot publish (CF_DISTRIBUTION env). Previously
+              # gamma had NO invalidation grant and the code default pointed at
+              # the prod distribution — every gamma invalidation attempt failed.
+              - !If
+                - IsGamma
+                - Sid: CloudFrontInvalidationGamma
+                  Effect: Allow
+                  Action: cloudfront:CreateInvalidation
+                  Resource: !Join
+                    - ""
+                    - - !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/"
+                      - !ImportValue "enceladus-ui-cdn-gamma-UiDistributionId"
                 - !Ref AWS::NoValue
               - !If
                 - IsProduction


### PR DESCRIPTION
## ENC-TSK-K72 (supersedes ENC-TSK-K69) — ENC-PLN-066 Wave 1

**Defects (gamma `devops-feed-publisher-gamma`):**
- `DOCUMENTS_TABLE` absent from env → code default = **prod** `documents` table (cross-env read)
- `CF_DISTRIBUTION` absent → code default = **prod** distribution `E2BOQXCW1TA6Y4`, whose invalidation grant is `IsProduction`-gated → every gamma invalidation failed
- nothing serves `/mobile/v1/tasks.json` on the gamma UI distribution (ui-v2's `VITE_FEED_BASE_URL` snapshot fetch got SPA HTML)

**Fix:**
- `02-compute.yaml` FeedPublisherFunction env: `DOCUMENTS_TABLE=documents${EnvironmentSuffix}` (prod no-op) + IsGamma-conditional `FEED_BUCKET`/`FEED_PREFIX`/`CF_DISTRIBUTION` via `enceladus-ui-cdn-gamma` ImportValues — gamma publishes snapshots **into the ui-v2 origin bucket** for same-origin serving; **prod renderings byte-identical**
- FeedPublisherRole: IsGamma `S3MobileFeedsWrite` resource → `enceladus-ui-v2-gamma/mobile/v1/*`; new IsGamma `CloudFrontInvalidationGamma` scoped to the imported gamma distribution
- `_ui_deploy.yml`: root `s3 sync --delete` now `--exclude "mobile/*"` so UI deploys never wipe the snapshot

**Validation:** PyYAML parse OK both files; prod_gate_coverage_guard PASS. Escalated live-env verify folded into the K56 terminal dispatch (DOC-344DEE74F732 refresh).

CCI-949f5a5243184cbf83b9ec2dce3dc5bc

🤖 Generated with [Claude Code](https://claude.com/claude-code)