### PR TITLE
fix(feed): ENC-TSK-K73 — grant FeedPublisherRole dynamodb:Scan on projects${EnvironmentSuffix}

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4178,6 +4178,12 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+                  # ENC-TSK-K73: the publisher's first step scans PROJECTS_TABLE
+                  # (_load_active_projects_from_ddb). This grant was missing, so
+                  # every gamma batch failed AccessDenied and the gamma snapshot
+                  # pipeline never completed a publish.
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
               - Sid: S3MobileFeedsWrite
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## ENC-TSK-K73 (linked follow-up to ENC-TSK-K72) — ENC-PLN-066 Wave 1

**Defect (live CloudWatch evidence, 18:26Z):** every `devops-feed-publisher-gamma` batch fails at `_load_active_projects_from_ddb()` — `AccessDeniedException: dynamodb:Scan on table/projects-gamma`. The `G95RestoredGrants` `DynamoDBRead` statement covers tracker + documents tables but not `projects${EnvironmentSuffix}`, so the **gamma snapshot pipeline has never completed a publish**.

**Fix:** add `projects${EnvironmentSuffix}` table + `index/*` ARNs to the statement (6 lines). Prod rendering gains read on the prod `projects` table — matching what the code has always required.

Unblocks K72 AC-3 (snapshot lands in `enceladus-ui-v2-gamma` → `/mobile/v1/tasks.json` serves through the gamma distribution).

CCI-5756b80645514043a3207b0f9ffccd48

🤖 Generated with [Claude Code](https://claude.com/claude-code)