### PR TITLE
feat(ui-v2): ENC-TSK-K70 — gamma-native home links + AppSync build-env injection

### DIFF
--- a/.github/workflows/_ui_deploy.yml
+++ b/.github/workflows/_ui_deploy.yml
@@ -96,6 +96,24 @@ jobs:
         env:
           # Same-origin API base (07-ui-cdn /api/* behavior proxies to API GW).
           VITE_API_BASE: /api/v1
+          # Same-origin feed snapshot base — the gamma feed publisher writes
+          # mobile/v1/tasks.json into the UI origin bucket (ENC-TSK-K72).
+          VITE_FEED_BASE_URL: /mobile/v1
+          # ENC-TSK-K70: AppSync Events realtime config. Sourced from GitHub
+          # repo VARIABLES (not CFN describe-stacks) because this build job is
+          # deliberately credential-less and ungated — granting it AWS access
+          # to resolve stack outputs would weaken the FTR-120 gating model.
+          # Set once after 06-appsync-events.yaml provisions (K56):
+          #   gh variable set VITE_APPSYNC_HTTP_HOST     --body <HttpEndpoint host>
+          #   gh variable set VITE_APPSYNC_REALTIME_HOST --body <RealtimeEndpoint host>
+          #   gh variable set VITE_APPSYNC_API_KEY       --body <ApiKey>
+          # Empty/unset => appsyncConfig.ts disables realtime and the feed pane
+          # degrades to S3-snapshot mode (skip-if-absent by construction). The
+          # API key is public-by-design (it ships in the JS bundle either way).
+          VITE_APPSYNC_HTTP_HOST: ${{ vars.VITE_APPSYNC_HTTP_HOST }}
+          VITE_APPSYNC_REALTIME_HOST: ${{ vars.VITE_APPSYNC_REALTIME_HOST }}
+          VITE_APPSYNC_API_KEY: ${{ vars.VITE_APPSYNC_API_KEY }}
+          VITE_APPSYNC_REGION: us-west-2
         run: npm run build
 
       - name: Upload dist artifact

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -4,13 +4,18 @@ import { RECORD_ROUTE_PATH } from './recordLink'
 import { RecordId } from '../components/RecordId'
 import type { RecordType } from '../types/records'
 
+// ENC-TSK-K70: sample IDs point at records verified PRESENT in the GAMMA
+// tables (devops-project-tracker-gamma / documents-gamma) — the prior IDs
+// existed only in prod, so every card 404ed against the gamma shadow data
+// (io gamma-native data decision, ENC-PLN-066). Re-verify against the gamma
+// list API before changing.
 const ENTRY: Array<{ type: RecordType; label: string; sampleId: string }> = [
-  { type: 'task', label: 'Task', sampleId: 'ENC-TSK-K21' },
-  { type: 'issue', label: 'Issue', sampleId: 'ENC-ISS-137' },
-  { type: 'feature', label: 'Feature', sampleId: 'ENC-FTR-050' },
-  { type: 'plan', label: 'Plan', sampleId: 'ENC-PLN-006' },
-  { type: 'lesson', label: 'Lesson', sampleId: 'ENC-LSN-001' },
-  { type: 'document', label: 'Document', sampleId: 'DOC-E470AC8CE9A8' },
+  { type: 'task', label: 'Task', sampleId: 'ENC-TSK-H68' },
+  { type: 'issue', label: 'Issue', sampleId: 'ENC-ISS-058' },
+  { type: 'feature', label: 'Feature', sampleId: 'ENC-FTR-096' },
+  { type: 'plan', label: 'Plan', sampleId: 'ENC-PLN-051' },
+  { type: 'lesson', label: 'Lesson', sampleId: 'ENC-LSN-057' },
+  { type: 'document', label: 'Document', sampleId: 'DOC-12A69AF1D3BE' },
 ]
 
 export function HomeRoute() {


### PR DESCRIPTION
## ENC-TSK-K70 — ENC-PLN-066 Wave 2

**(a) Gamma-native home links** (io gamma-native data decision): the six `HomeRoute` sample IDs pointed at prod-only records and 404ed against the gamma shadow tables. Repointed to records **verified 200 against the live gamma API pre-merge**: task `ENC-TSK-H68`, issue `ENC-ISS-058`, feature `ENC-FTR-096`, plan `ENC-PLN-051`, lesson `ENC-LSN-057`, document `DOC-12A69AF1D3BE` (task/plan/lesson are gamma-native records created this session — the H55 seed had zero of those types).

**(b) AppSync build env**: `_ui_deploy` build now injects `VITE_FEED_BASE_URL=/mobile/v1` + `VITE_APPSYNC_HTTP_HOST/REALTIME_HOST/API_KEY` from **GitHub repo variables** (`vars.*`) + `VITE_APPSYNC_REGION=us-west-2`. Repo vars rather than `describe-stacks` because the build job is deliberately credential-less/ungated (FTR-120); unset ⇒ snapshot-only (skip-if-absent by construction). Post-K56 activation: `gh variable set` ×3 + rebuild.

Local: npm ci + typecheck + build green. Feed snapshot already live at `/mobile/v1/tasks.json` (K72+K73).

CCI-f21e88212af0440cb92b93565a93446a

🤖 Generated with [Claude Code](https://claude.com/claude-code)