### PR TITLE
fix(deploy): ENC-TSK-K56 — add appsync_feed_publisher to v4-gamma function_name_map

### DIFF
--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -55,6 +55,11 @@ artifact_version_ids: {}
 # Functions absent from this map are silently skipped by the deploy step.
 # deploy_capability_auditor intentionally excluded — not provisioned in v4-gamma.
 function_name_map:
+  # ENC-TSK-K56: the AppSync FeedPublisher (K20) was missing from this map, so
+  # Gen2 silently skipped it and the fn kept its CFN placeholder code (loaded
+  # surgically as a stopgap during gamma provisioning). New-gamma-Lambda
+  # checklist step 3 — keep this map in lockstep with lambda_workflow_manifest.
+  appsync_feed_publisher: devops-appsync-feed-publisher-gamma
   auth_refresh: auth-refresh-gamma
   bedrock_agent_actions: enceladus-bedrock-agent-actions-gamma
   changelog_api: devops-changelog-api-gamma


### PR DESCRIPTION
## ENC-TSK-K56 — ENC-PLN-066 feed realtime tail

Gen2 pipeline gap found during gamma AppSync provisioning (terminal session ENC-SES-03F, DOC-CB34470FD768): `envs/v4-gamma.yaml` `function_name_map` had no `appsync_feed_publisher` entry, so `_deploy.yml` **silently skipped** the fn (green deploy, placeholder code stays). K20/PR#777 added CFN + manifest but missed new-gamma-Lambda checklist step 3.

One line + comment: `appsync_feed_publisher: devops-appsync-feed-publisher-gamma`. Future v4/main pushes carry the fn; the surgical load 03F performed becomes unnecessary.

CCI-09ac8877b6a14ac983f83683315962fb

🤖 Generated with [Claude Code](https://claude.com/claude-code)