### PR TITLE
fix(feed): ENC-TSK-K74 — bare item_id in AppSync per-record channel/recordId/summary

### DIFF
--- a/backend/lambda/appsync_feed_publisher/lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/lambda_function.py
@@ -304,6 +304,19 @@ def build_event_payload(record: Dict[str, Any], batch_counter: int) -> Optional[
     if not record_id:
         return None
 
+    # ENC-TSK-K74: the tracker's composite record_id ("task#ENC-TSK-004")
+    # contains '#', which AppSync Events rejects as a channel segment
+    # (400 Invalid Channel Format — verified live during K56 provisioning:
+    # feed/updates and projects/{id} publish 200, records/task#... 400).
+    # Use the bare item_id ("ENC-TSK-004") for the per-record channel, the
+    # payload recordId, and the pre-rendered summary — this also matches the
+    # ui-v2 client's /records/{recordId} subscription contract, which
+    # subscribes with bare item ids from route params.
+    item_id = _first_nonempty(
+        primary.get("item_id"),
+        record_id.split("#")[-1],
+    )
+
     record_type = _first_nonempty(primary.get("record_type"), "record")
     project_id = _first_nonempty(primary.get("project_id"), keys.get("project_id")) or DEFAULT_PROJECT_ID
     title = _first_nonempty(primary.get("title"), primary.get("name"))
@@ -317,12 +330,12 @@ def build_event_payload(record: Dict[str, Any], batch_counter: int) -> Optional[
     cursor = derive_cursor(approx_ms, batch_counter)
     event_id = uuid7(approx_ms)
 
-    summary = build_summary(actor_id, action, record_type, record_id, title)
+    summary = build_summary(actor_id, action, record_type, item_id, title)
 
     # Short-ish but readable keys; no raw item image inlined.
     payload: Dict[str, Any] = {
         "eventId": event_id,
-        "recordId": record_id,
+        "recordId": item_id,
         "record_type": record_type,
         "action": action,
         "actorType": actor_type,
@@ -331,7 +344,7 @@ def build_event_payload(record: Dict[str, Any], batch_counter: int) -> Optional[
         "cursor": cursor,
         "channels": [
             "/feed/updates",
-            f"/records/{record_id}",
+            f"/records/{item_id}",
             f"/projects/{project_id}",
         ],
     }

--- a/backend/lambda/appsync_feed_publisher/test_lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/test_lambda_function.py
@@ -274,3 +274,63 @@ def test_handler_skips_unresolvable_record_without_failing():
     with patch.object(mod, "DRY_RUN", True):
         result = mod.handler(event, None)
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-K74 regression: composite record_id must never leak '#' into the
+# per-record channel (AppSync rejects it: 400 Invalid Channel Format —
+# verified live during K56 gamma provisioning), nor into recordId/summary.
+# Real tracker rows carry composite record_id ("task#ENC-TSK-004") plus a
+# bare item_id attribute; the original fixture above used a bare record_id,
+# which is why this bug escaped the suite.
+# ---------------------------------------------------------------------------
+
+
+def test_composite_record_id_uses_bare_item_id_everywhere():
+    rec = _stream_record(
+        event_name="MODIFY",
+        new_image={
+            "record_id": "task#ENC-TSK-004",
+            "item_id": "ENC-TSK-004",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "title": "Composite id row",
+        },
+        old_image={
+            "record_id": "task#ENC-TSK-004",
+            "item_id": "ENC-TSK-004",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "title": "Composite id row",
+            "status": "open",
+        },
+    )
+    payload = mod.build_event_payload(rec, 0)
+    assert payload is not None
+    assert payload["recordId"] == "ENC-TSK-004"
+    assert payload["channels"] == [
+        "/feed/updates",
+        "/records/ENC-TSK-004",
+        "/projects/enceladus",
+    ]
+    assert "#" not in payload["summary"]
+    for channel in payload["channels"]:
+        assert "#" not in channel
+
+
+def test_composite_record_id_without_item_id_falls_back_to_suffix():
+    # Older rows may lack the bare item_id attribute — the suffix after the
+    # last '#' is the bare id.
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={
+            "record_id": "lesson#ENC-LSN-057",
+            "record_type": "lesson",
+            "project_id": "enceladus",
+            "title": "No item_id attribute",
+        },
+    )
+    payload = mod.build_event_payload(rec, 0)
+    assert payload is not None
+    assert payload["recordId"] == "ENC-LSN-057"
+    assert "/records/ENC-LSN-057" in payload["channels"]

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-07-02.34",
-  "updated_at": "2026-07-02T15:45:00Z",
+  "version": "2026-07-02.35",
+  "updated_at": "2026-07-02T19:20:00Z",
   "last_change_summary": "ENC-TSK-K34 (ENC-ISS-477 cutover, DOC-F234A4E11DFD Option E): the DynamoDB governance-policies mirror of this dictionary is retired from the read path. coordination_api._load_governance_dictionary now serves this bundled file exclusively -- no DDB scan, no fallback branch. ENC-TSK-K31 found the DDB mirror had never once served as a live, independently-authored hot-patch target (every write only ever caught DynamoDB up to a prior git/S3 change), and it had been unwritable since 2026-06-29 (509KB item vs DynamoDB's 400KB cap). document_api's dictionary-specific DDB propagation is removed alongside it. This file (repo -> Lambda bundle -> deploy) is now the sole and always-authoritative source; check_governance_dictionary_sync.py remains the enforcement that this file stays current with schema-affecting code changes. No entity schema changed.",
   "owners": [
     "enceladus-platform"


### PR DESCRIPTION
## ENC-TSK-K74 — ENC-PLN-066 feed realtime tail (follow-up to K56 smoke)

**Bug (live-verified):** `build_event_payload` used the composite DynamoDB `record_id` (`task#ENC-TSK-004`) for the `/records/{id}` channel — AppSync Events rejects `#` (400 `Invalid Channel Format`; `feed/updates` + `projects/{id}` publish 200). The composite also leaked into `recordId` and the pre-rendered summary.

**Fix:** derive bare `item_id` (attribute, fallback `record_id.split('#')[-1]`) for channel + recordId + summary — matching the ui-v2 client's bare-id `/records/{recordId}` subscription contract. Regression tests with a composite-id fixture added (the prior fixture used a bare record_id, masking the bug); 22/22 green. Dictionary bumped to 2026-07-02.35 per guard.

Deploys via Gen2 thanks to K56's map entry (sequenced first).

CCI-bd8d3470c4654056b93e5bb17e62db81

🤖 Generated with [Claude Code](https://claude.com/claude-code)