### PR TITLE
ENC-TSK-K77: codify CUSTOM_DOMAIN on gamma MCP Lambda (PLN-067 harden)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -5515,6 +5515,14 @@ Resources:
           ENCELADUS_COGNITO_DOMAIN: https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com
           MCP_AUDIT_CALLER_IDENTITY: devops-coordination-api-gamma
           MCP_SERVER_LOG_GROUP: /enceladus/mcp/server
+          # ENC-TSK-K77 / ENC-PLN-067: codify the OAuth issuer/callback host so a CFN compute
+          # deploy cannot strip the manually-set CUSTOM_DOMAIN (ENC-TSK-K75). Without it the MCP
+          # derives its OAuth issuer from the incoming Host header — which CloudFront sets to the
+          # origin Function-URL host (Managed-AllViewerExceptHostHeader) — so it advertised
+          # issuer=https://<raw-furl> and proxied /authorize to Cognito with an UNREGISTERED
+          # redirect_uri=https://<raw-furl>/callback, producing the Hosted-UI error (2026-07-02
+          # gamma auth outage). Mirrors prod enceladus-mcp-code's CUSTOM_DOMAIN=mcp.jreese.net.
+          CUSTOM_DOMAIN: mcp-gamma.jreese.net
           # ENC-ISS-410 / ENC-TSK-I14: gamma backend bases. The MCP front-end (server.py)
           # proxies the coordination, tracker, and graph planes to these hosts; if unset it
           # falls back to hardcoded prod defaults (https://jreese.net/... and the prod


### PR DESCRIPTION
## Summary
Codifies `CUSTOM_DOMAIN=mcp-gamma.jreese.net` on `EnceladusMcpCodeGammaFunction` in `02-compute.yaml` so a CFN compute-stack deploy cannot strip the value ENC-TSK-K75 set live — durability half of ENC-PLN-067.

Without `CUSTOM_DOMAIN` the MCP derives its OAuth issuer from the incoming Host header, which CloudFront (`Managed-AllViewerExceptHostHeader`) sets to the origin Function-URL host, so it advertised `issuer=https://<raw-furl>` and proxied `/authorize` to Cognito with an unregistered `redirect_uri` → Hosted-UI error (the 2026-07-02 gamma auth outage). Mirrors prod `enceladus-mcp-code`'s `CUSTOM_DOMAIN=mcp.jreese.net`.

## Root cause (CloudTrail-confirmed)
The CFN deploy pipeline (`enceladus-cloudformation-deploy-github-role` via `cloudformation.amazonaws.com`) provisioned `AWS::Lambda::Url` on `code-gamma:live` at 2026-07-02T11:08:47Z, minting a **new Function-URL hostname**; the out-of-band CloudFront distro (E2KVDHFSQ5G5VE) hard-codes the origin hostname and didn't follow → outage. Recovery + recurrence-guard runbook: **DOC-4CC1590D31CC**.

## Scope / safety
- The resource is `Condition: IsProduction` (prod-stack-owned), so this is a **no-op on the gamma compute stack** deploy and applies on the next prod compute deploy.
- Live-set value already verified working (issuer `https://mcp-gamma.jreese.net`, `/authorize`→Cognito login 200). Restores ISS-469/ISS-306 alias-safe pattern alongside ENC-TSK-K76.

Related: ENC-PLN-067, ENC-TSK-K75/K76, ENC-TSK-K67, ENC-ISS-469, ENC-TSK-K18

CCI-0d8a86266c7543c2815dfa85274063a0

🤖 Generated with [Claude Code](https://claude.com/claude-code)