### PR TITLE
feat(cockpit-auth): ENC-TSK-K95 — ui-v2 login flow + same-origin /api/v1/auth/callback exchange

### DIFF
--- a/backend/lambda/auth_refresh/lambda_function.py
+++ b/backend/lambda/auth_refresh/lambda_function.py
@@ -38,7 +38,7 @@ import time
 import urllib.request
 import urllib.error
 from typing import Any, Dict, Optional
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
@@ -66,6 +66,23 @@ LAMBDA_REGION = os.environ.get("AWS_REGION", "us-west-2")
 CORS_ORIGIN = "https://jreese.net"
 ID_TOKEN_MAX_AGE = 3600       # 1 hour
 SESSION_COOKIE_MAX_AGE = 3600  # 1 hour
+REFRESH_TOKEN_MAX_AGE = 2592000  # 30 days
+
+# ENC-TSK-K95 — gamma cockpit OAuth2 authorization-code callback (GET
+# /api/v1/auth/callback). Mirrors the prod auth_edge Lambda@Edge exchange, but
+# same-origin behind the gamma API so the v4 cockpit (frontend/ui-v2) can log
+# in without a Lambda@Edge. Public app client (no secret). The redirect_uri is
+# a FIXED registered Cognito callback (the durable vanity URL); the post-login
+# 302 uses a relative Location so the browser returns to whatever host it is
+# on. Prod is untouched (it keeps its own edge + jreese.net callback).
+COGNITO_HOSTED_UI_DOMAIN = os.environ.get(
+    "COGNITO_HOSTED_UI_DOMAIN",
+    "https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com",
+)
+WEBUI_OAUTH_REDIRECT_URI = os.environ.get(
+    "WEBUI_OAUTH_REDIRECT_URI",
+    "https://enceladus-gamma.jreese.net/api/v1/auth/callback",
+)
 GITHUB_APP_ID = os.environ.get("GITHUB_APP_ID", "")
 GITHUB_INSTALLATION_ID = os.environ.get("GITHUB_INSTALLATION_ID", "")
 GITHUB_PRIVATE_KEY_SECRET = os.environ.get("GITHUB_PRIVATE_KEY_SECRET", "devops/github-app/private-key")
@@ -283,6 +300,120 @@ def _handle_github_token(event: Dict) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# OAuth2 authorization-code callback (ENC-TSK-K95)
+# ---------------------------------------------------------------------------
+
+import base64  # noqa: E402  (grouped with the callback feature)
+
+
+def _b64url_decode_path(state: str) -> str:
+    """Decode the base64url `state` param (the pre-login path) set by the SPA.
+
+    Falls back to '/' on any decode error or a non-local/callback-looping value
+    so a crafted state can never open-redirect off-site.
+    """
+    if not state:
+        return "/"
+    try:
+        pad = "=" * ((4 - len(state) % 4) % 4)
+        decoded = base64.urlsafe_b64decode(state + pad).decode("utf-8")
+    except Exception:  # noqa: BLE001
+        return "/"
+    # Only same-origin absolute paths are allowed (no scheme/host, no protocol-
+    # relative //host), and never bounce back into the callback.
+    if not decoded.startswith("/") or decoded.startswith("//"):
+        return "/"
+    if decoded.startswith("/api/v1/auth/callback"):
+        return "/"
+    return decoded
+
+
+def _exchange_code_for_tokens(code: str) -> Dict[str, Optional[str]]:
+    """POST the authorization code to Cognito's /oauth2/token endpoint.
+
+    Public client (no secret) — grant_type=authorization_code with
+    client_id + code + the fixed registered redirect_uri. Raises ValueError on
+    any non-200 or missing id_token.
+    """
+    body = urlencode({
+        "grant_type": "authorization_code",
+        "client_id": COGNITO_CLIENT_ID,
+        "code": code,
+        "redirect_uri": WEBUI_OAUTH_REDIRECT_URI,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{COGNITO_HOSTED_UI_DOMAIN}/oauth2/token",
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        logger.warning("oauth token exchange failed: %s %s", exc.code, detail)
+        raise ValueError("token_exchange_failed") from exc
+    except urllib.error.URLError as exc:
+        logger.error("oauth token endpoint unreachable: %s", exc)
+        raise ValueError("token_endpoint_unreachable") from exc
+
+    id_token = data.get("id_token")
+    if not id_token:
+        raise ValueError("no_id_token")
+    return {"id_token": id_token, "refresh_token": data.get("refresh_token")}
+
+
+def _handle_oauth_callback(event: Dict) -> Dict:
+    """GET /api/v1/auth/callback — Cognito Hosted-UI redirect lands here.
+
+    Exchanges ?code for tokens, sets the session cookies (host-scoped, matching
+    the prod auth_edge format), and 302-redirects to the ?state path.
+    """
+    params = event.get("queryStringParameters") or {}
+    code = params.get("code")
+    state = params.get("state") or ""
+
+    # Cognito surfaces auth errors as ?error=...; send the user back to sign in.
+    if params.get("error"):
+        logger.info("oauth callback error param: %s", params.get("error"))
+        return {"statusCode": 302, "headers": {"Location": "/", "Cache-Control": "no-store"}, "body": ""}
+    if not code:
+        return _error(400, "Missing authorization code.")
+
+    try:
+        tokens = _exchange_code_for_tokens(code)
+    except ValueError as exc:
+        logger.warning("oauth callback exchange failed: %s", exc)
+        # Bounce to the app root rather than showing a raw error; the SPA will
+        # re-prompt sign-in if still unauthenticated.
+        return {"statusCode": 302, "headers": {"Location": "/", "Cache-Control": "no-store"}, "body": ""}
+
+    target = _b64url_decode_path(state)
+    now_ms = str(int(time.time() * 1000))
+
+    cookies = [
+        f"enceladus_id_token={tokens['id_token']}; "
+        f"Path=/; Secure; HttpOnly; SameSite=None; Max-Age={ID_TOKEN_MAX_AGE}",
+        f"enceladus_session_at={now_ms}; "
+        f"Path=/enceladus; Secure; SameSite=None; Max-Age={SESSION_COOKIE_MAX_AGE}",
+    ]
+    if tokens.get("refresh_token"):
+        cookies.append(
+            f"enceladus_refresh_token={tokens['refresh_token']}; "
+            f"Path=/; Secure; HttpOnly; SameSite=None; Max-Age={REFRESH_TOKEN_MAX_AGE}"
+        )
+
+    logger.info("oauth callback succeeded; redirecting to %s", target)
+    return {
+        "statusCode": 302,
+        "headers": {"Location": target, "Cache-Control": "no-store"},
+        "cookies": cookies,
+        "body": "",
+    }
+
+
+# ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
 
@@ -307,6 +438,11 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
 
     if method == "GET" and path.rstrip("/").endswith("/github-token"):
         return _handle_github_token(event)
+
+    # ENC-TSK-K95: Cognito Hosted-UI authorization-code callback for the v4
+    # cockpit (same-origin login, no Lambda@Edge).
+    if method == "GET" and path.rstrip("/").endswith("/auth/callback"):
+        return _handle_oauth_callback(event)
 
     if method != "POST":
         return _error(405, "Method not allowed.")

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-07-02.35",
-  "updated_at": "2026-07-02T19:20:00Z",
+  "version": "2026-07-02.36",
+  "updated_at": "2026-07-02T20:55:00Z",
   "last_change_summary": "ENC-TSK-K34 (ENC-ISS-477 cutover, DOC-F234A4E11DFD Option E): the DynamoDB governance-policies mirror of this dictionary is retired from the read path. coordination_api._load_governance_dictionary now serves this bundled file exclusively -- no DDB scan, no fallback branch. ENC-TSK-K31 found the DDB mirror had never once served as a live, independently-authored hot-patch target (every write only ever caught DynamoDB up to a prior git/S3 change), and it had been unwritable since 2026-06-29 (509KB item vs DynamoDB's 400KB cap). document_api's dictionary-specific DDB propagation is removed alongside it. This file (repo -> Lambda bundle -> deploy) is now the sole and always-authoritative source; check_governance_dictionary_sync.py remains the enforcement that this file stays current with schema-affecting code changes. No entity schema changed.",
   "owners": [
     "enceladus-platform"

--- a/frontend/ui-v2/src/auth/LoggedOutScreen.tsx
+++ b/frontend/ui-v2/src/auth/LoggedOutScreen.tsx
@@ -1,0 +1,82 @@
+import { redirectToLogin } from './authConfig'
+
+/**
+ * ENC-TSK-K95 — full-screen sign-in prompt.
+ *
+ * Rendered by the router's defaultErrorComponent when a loader/query throws
+ * SessionExpiredError (a 401 from the API). Replaces the generic
+ * "Something went wrong!" crash the cockpit used to show on every record click
+ * for an unauthenticated visitor. Design tokens only (no hardcoded hex).
+ */
+export function LoggedOutScreen() {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: 'var(--space-6)',
+        background: 'var(--enc-void)',
+      }}
+    >
+      <p
+        style={{
+          fontFamily: 'var(--font-body)',
+          fontSize: 'var(--text-xs)',
+          textTransform: 'uppercase',
+          letterSpacing: 'var(--tracking-label)',
+          color: 'var(--fg-muted)',
+          margin: '0 0 var(--space-2)',
+        }}
+      >
+        Enceladus · Governance Cockpit
+      </p>
+      <h1
+        style={{
+          fontFamily: 'var(--font-heading)',
+          fontWeight: 'var(--fw-bold)',
+          fontSize: 'var(--text-2xl)',
+          lineHeight: 'var(--lh-tight)',
+          color: 'var(--fg-display)',
+          margin: '0 0 var(--space-2)',
+        }}
+      >
+        Sign in to continue
+      </h1>
+      <p
+        style={{
+          color: 'var(--fg-muted)',
+          fontSize: 'var(--text-sm)',
+          lineHeight: 'var(--lh-relaxed)',
+          margin: '0 0 var(--space-6)',
+          maxWidth: '38ch',
+        }}
+      >
+        Your session isn't active. Sign in with your Enceladus account to view
+        live records, plans, and documents.
+      </p>
+      <button
+        type="button"
+        onClick={redirectToLogin}
+        style={{
+          fontFamily: 'var(--font-body)',
+          fontSize: 'var(--text-sm)',
+          fontWeight: 'var(--fw-medium)',
+          color: 'var(--enc-void)',
+          background: 'var(--accent)',
+          border: '1px solid var(--accent)',
+          borderRadius: 'var(--radius-md)',
+          padding: 'var(--space-3) var(--space-6)',
+          cursor: 'pointer',
+          boxShadow: 'var(--glow-teal)',
+        }}
+      >
+        Sign In
+      </button>
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/auth/RouteError.tsx
+++ b/frontend/ui-v2/src/auth/RouteError.tsx
@@ -1,0 +1,73 @@
+import type { ErrorComponentProps } from '@tanstack/react-router'
+import { SessionExpiredError } from '../api/client'
+import { LoggedOutScreen } from './LoggedOutScreen'
+
+/**
+ * ENC-TSK-K95 — router-wide error component.
+ *
+ * A 401 from any loader/query surfaces as SessionExpiredError; instead of the
+ * generic crash, prompt sign-in. Everything else falls back to a minimal,
+ * design-token error card (no raw stack, no white screen).
+ */
+export function RouteError({ error }: ErrorComponentProps) {
+  if (error instanceof SessionExpiredError) {
+    return <LoggedOutScreen />
+  }
+
+  const message =
+    error instanceof Error ? error.message : 'An unexpected error occurred.'
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: 'var(--space-8) var(--space-6)',
+        color: 'var(--fg)',
+      }}
+    >
+      <h1
+        style={{
+          fontFamily: 'var(--font-heading)',
+          fontWeight: 'var(--fw-bold)',
+          fontSize: 'var(--text-lg)',
+          color: 'var(--fg-display)',
+          margin: '0 0 var(--space-2)',
+        }}
+      >
+        Something went wrong
+      </h1>
+      <p
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          color: 'var(--fg-muted)',
+          margin: '0 0 var(--space-4)',
+          maxWidth: '52ch',
+          wordBreak: 'break-word',
+        }}
+      >
+        {message}
+      </p>
+      <button
+        type="button"
+        onClick={() => window.location.assign('/')}
+        style={{
+          fontFamily: 'var(--font-body)',
+          fontSize: 'var(--text-sm)',
+          color: 'var(--fg)',
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 'var(--radius-md)',
+          padding: 'var(--space-2) var(--space-5)',
+          cursor: 'pointer',
+        }}
+      >
+        Back to cockpit
+      </button>
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/auth/authConfig.ts
+++ b/frontend/ui-v2/src/auth/authConfig.ts
@@ -1,0 +1,50 @@
+/**
+ * ENC-TSK-K95 — Cognito Hosted-UI OAuth2 (authorization-code) login config for
+ * the v4 cockpit.
+ *
+ * Public app client (no secret): the SPA only starts the flow. The one-time
+ * code is exchanged server-side at `GET /api/v1/auth/callback` (auth_refresh),
+ * which sets the session cookies and 302s back to the pre-login path. So there
+ * is no token/secret handling in the browser and no SPA callback route.
+ *
+ * These are public identifiers (client id + hosted-UI domain ship in every
+ * OAuth redirect regardless). REDIRECT_URI is a FIXED registered Cognito
+ * callback — it must match byte-for-byte both the redirect_uri auth_refresh
+ * uses for the token exchange and a CallbackURL on the app client.
+ */
+
+const COGNITO_HOSTED_UI_DOMAIN =
+  'https://enceladus-status-356364570033.auth.us-east-1.amazoncognito.com'
+const COGNITO_CLIENT_ID = '6q607dk3liirhtecgps7hifmlk'
+const COGNITO_SCOPES = 'openid email profile'
+const OAUTH_REDIRECT_URI =
+  'https://enceladus-gamma.jreese.net/api/v1/auth/callback'
+
+/** base64url so it round-trips through the Python `base64.urlsafe_b64decode`
+ *  in auth_refresh (standard btoa yields '+', '/', '=' which corrupt it). */
+function base64UrlEncode(input: string): string {
+  return btoa(input)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/** Build the Cognito `/oauth2/authorize` URL, carrying the current in-app path
+ *  in `state` so the callback can return the user to where they were. */
+export function buildLoginUrl(): string {
+  const currentPath = window.location.pathname + window.location.search
+  const state = base64UrlEncode(currentPath)
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: COGNITO_CLIENT_ID,
+    redirect_uri: OAUTH_REDIRECT_URI,
+    scope: COGNITO_SCOPES,
+    state,
+  })
+  return `${COGNITO_HOSTED_UI_DOMAIN}/oauth2/authorize?${params.toString()}`
+}
+
+/** Start the login flow (full-page navigation to the Cognito Hosted UI). */
+export function redirectToLogin(): void {
+  window.location.assign(buildLoginUrl())
+}

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -7,6 +7,7 @@ import {
 import { AppShell } from '../shell/AppShell'
 import { HomeRoute } from './HomeRoute'
 import { createRecordRoute } from './recordRoute'
+import { RouteError } from '../auth/RouteError'
 import {
   documentQueryOptions,
   featureQueryOptions,
@@ -82,6 +83,9 @@ const routeTree = rootRoute.addChildren([
 export const router = createRouter({
   routeTree,
   defaultPreload: 'intent',
+  // ENC-TSK-K95 — a 401 (SessionExpiredError) from any loader/query renders the
+  // sign-in prompt instead of the generic crash.
+  defaultErrorComponent: RouteError,
 })
 
 declare module '@tanstack/react-router' {

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -731,6 +731,17 @@ Resources:
       RouteKey: POST /api/v1/auth/refresh
       Target: !Sub integrations/${AuthRefreshIntegration}
 
+  # ENC-TSK-K95: Cognito Hosted-UI OAuth2 authorization-code callback for the
+  # v4 cockpit (frontend/ui-v2). Same-origin login exchange handled by
+  # auth_refresh — no Lambda@Edge. Public (no authorizer): it receives an
+  # opaque one-time code and sets the session cookie itself.
+  RouteAuthCallback:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/auth/callback
+      Target: !Sub integrations/${AuthRefreshIntegration}
+
   RouteAuthGitHubToken:
     Type: AWS::ApiGatewayV2::Route
     Properties:


### PR DESCRIPTION
## ENC-TSK-K95 — the durable fix for the gamma cockpit (B67)

**Problem:** ui-v2 (K21 scaffold) shipped the data layer but **no login flow** — an unauthenticated visitor hits 401 on every record/document click and the router shows a generic *"Something went wrong!"* crash. The prod auth machinery (`auth_edge` Lambda@Edge) is hardcoded to `jreese.net` and isn't attached to the cockpit distribution.

**Fix (per io: same-origin exchange, no Lambda@Edge; additive gamma callback on the shared client):**
- **auth_refresh** — new `GET /api/v1/auth/callback`: exchanges the Cognito authorization code (public client, no secret), sets host-scoped `enceladus_id_token`/`session_at`/`refresh_token` cookies (same format as the prod edge), 302s back to the pre-login path. Hardened `state` decode rejects open-redirects (`//host`, `http(s)://`, callback loops → `/`).
- **03-api.yaml** — routes `GET /api/v1/auth/callback` to the existing `AuthRefreshIntegration`.
- **ui-v2** — `LoggedOutScreen` (design tokens) + a router `defaultErrorComponent` that prompts **Sign In** on `SessionExpiredError` instead of crashing.

Fixed `redirect_uri = https://enceladus-gamma.jreese.net/api/v1/auth/callback` (the durable canonical URL). Gamma-only; **prod untouched** (keeps its own edge + jreese.net callback).

**Validation:** py_compile + state-guard smoke (incl. open-redirect rejections) OK; 03-api parses (route present); ui-v2 typecheck + build + `npm test` (7/7) green. The 5 eslint errors under CI are pre-existing on v4/main (feed/realtime files, being reworked by K23/K24) and CI doesn't gate on lint.

**Post-merge (io/product-lead):** additively register `https://enceladus-gamma.jreese.net/api/v1/auth/callback` on the shared Cognito app client, then a full browser login on enceladus-gamma.jreese.net signs in cleanly.

CCI-4e34f16db8e945be9df74bdaa58a947c

🤖 Generated with [Claude Code](https://claude.com/claude-code)