### PR TITLE
fix(ui-v2): ENC-TSK-K97 — guard primitives against sparse gamma record fields

### DIFF
--- a/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
@@ -21,10 +21,10 @@ export function DocumentPrimitive({ record }: { record: Document }) {
         <MetaRow label="Subtype">{record.document_subtype}</MetaRow>
       ) : null}
       <MetaRow label="Version">
-        <Metric>v{record.version}</Metric>
+        <Metric>v{record.version ?? '?'}</Metric>
       </MetaRow>
       <MetaRow label="Keywords">
-        {record.keywords.length > 0 ? record.keywords.join(', ') : 'None'}
+        {(record.keywords ?? []).length > 0 ? (record.keywords ?? []).join(', ') : 'None'}
       </MetaRow>
       <MetaRow label="Created by">{record.created_by}</MetaRow>
     </PrimitiveCard>

--- a/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
@@ -12,16 +12,16 @@ export function FeaturePrimitive({ record }: { record: Feature }) {
     >
       <Prose>{record.description}</Prose>
       <MetaRow label="Owners">
-        {record.owners.length > 0 ? record.owners.join(', ') : 'Unowned'}
+        {(record.owners ?? []).length > 0 ? (record.owners ?? []).join(', ') : 'Unowned'}
       </MetaRow>
       <MetaRow label="Success metrics">
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
           <Sparkles size={14} strokeWidth={1.5} color="var(--accent)" />
-          <Metric>{record.success_metrics.length}</Metric>
+          <Metric>{record.success_metrics?.length ?? 0}</Metric>
         </span>
       </MetaRow>
       <MetaRow label="Related tasks">
-        <Metric>{record.related_task_ids.length}</Metric>
+        <Metric>{record.related_task_ids?.length ?? 0}</Metric>
       </MetaRow>
     </PrimitiveCard>
   )

--- a/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
@@ -46,10 +46,10 @@ export function LessonPrimitive({ record }: { record: Lesson }) {
         {record.insight}
       </blockquote>
       <MetaRow label="Confidence">
-        <Metric>{record.confidence.toFixed(2)}</Metric>
+        <Metric>{(record.confidence ?? 0).toFixed(2)}</Metric>
       </MetaRow>
       <MetaRow label="Resonance">
-        <Metric>{record.resonance_score.toFixed(2)}</Metric>
+        <Metric>{(record.resonance_score ?? 0).toFixed(2)}</Metric>
       </MetaRow>
       <MetaRow label="Provenance">{record.provenance}</MetaRow>
     </PrimitiveCard>

--- a/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
@@ -16,11 +16,11 @@ export function PlanPrimitive({ record }: { record: Plan }) {
       <MetaRow label="Objectives">
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
           <MapIcon size={14} strokeWidth={1.5} color="var(--accent)" />
-          <Metric>{record.objectives_set.length}</Metric>
+          <Metric>{record.objectives_set?.length ?? 0}</Metric>
         </span>
       </MetaRow>
       <MetaRow label="Attached docs">
-        <Metric>{record.attached_documents.length}</Metric>
+        <Metric>{record.attached_documents?.length ?? 0}</Metric>
       </MetaRow>
     </PrimitiveCard>
   )

--- a/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
@@ -17,15 +17,15 @@ export function TaskPrimitive({ record }: { record: Task }) {
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
           <ListChecks size={14} strokeWidth={1.5} color="var(--accent)" />
           <Metric>
-            {record.checklist_done}/{record.checklist_total}
+            {record.checklist_done ?? 0}/{record.checklist_total ?? 0}
           </Metric>
         </span>
       </MetaRow>
       <MetaRow label="Related">
         <Metric>
-          {record.related_task_ids.length +
-            record.related_issue_ids.length +
-            record.related_feature_ids.length}
+          {(record.related_task_ids?.length ?? 0) +
+            (record.related_issue_ids?.length ?? 0) +
+            (record.related_feature_ids?.length ?? 0)}
         </Metric>{' '}
         edges
       </MetaRow>


### PR DESCRIPTION
## ENC-TSK-K97 — live cockpit crash fix (P0)

Navigating to a gamma Feature threw **`undefined is not an object (evaluating 's.owners.length')`**. K21's primitives access optional array/number fields the TS types mark as present, but the **gamma API omits empty/absent fields** on sparse fork-seeded records.

Guards **every** such access across all six primitives so a missing field renders an empty state instead of crashing:
- Feature: `owners`, `success_metrics`, `related_task_ids`
- Plan: `objectives_set`, `attached_documents`
- Task: `related_task/issue/feature_ids`, `checklist_done/total`
- Document: `keywords`, `version`
- Lesson: `confidence`/`resonance_score` `.toFixed`
- Issue: already safe

typecheck + build + `npm test` (7/7) green; grep confirms zero residual unguarded field access. Pure frontend (only `_ui_deploy`).

CCI-723103e2ae9e496ea0598dee868686df

🤖 Generated with [Claude Code](https://claude.com/claude-code)