### PR TITLE
feat(ui-v2): ENC-TSK-K98 — hard auth gate (nothing visible pre-login)

### DIFF
--- a/frontend/ui-v2/src/api/client.ts
+++ b/frontend/ui-v2/src/api/client.ts
@@ -86,6 +86,17 @@ export async function fetchTrackerRecord<T>(
 }
 
 /**
+ * Session probe (ENC-TSK-K98 — hard auth gate). Hits an authenticated read
+ * route purely for its auth status so the app can gate on load: a live session
+ * resolves, a 401 throws SessionExpiredError. `/projects` is a lightweight
+ * authed list endpoint; the body is intentionally ignored. Any non-401 failure
+ * still throws (the gate fails closed — no session confirmed, no app).
+ */
+export async function probeSession(init?: FetchInit): Promise<void> {
+  await requestJson<unknown>(`${API_BASE}/projects`, init)
+}
+
+/**
  * Document fetch. Path convention (from frontend/ui/src/api/documents.ts):
  *   `${API_BASE}/documents/{documentId}`.
  * Backend envelopes as `{ document: T }`.

--- a/frontend/ui-v2/src/auth/AuthGate.tsx
+++ b/frontend/ui-v2/src/auth/AuthGate.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { probeSession } from '../api/client'
+import { LoggedOutScreen } from './LoggedOutScreen'
+
+/**
+ * ENC-TSK-K98 — hard auth gate.
+ *
+ * Wraps the ENTIRE app (mounted above the realtime feed provider and the
+ * router in main.tsx) so an unauthenticated visitor sees ONLY the sign-in
+ * screen — no shell, no feed pane, no snapshot fetch, nothing. On load we probe
+ * an authenticated endpoint once:
+ *   - pending  -> a minimal branded splash (the probe is a single fast request)
+ *   - error    -> LoggedOutScreen (401/SessionExpiredError — or any failure to
+ *                 confirm a live session; we fail closed)
+ *   - success  -> render the app
+ *
+ * This is the proactive counterpart to the router's defaultErrorComponent
+ * (ENC-TSK-K95): that catches a 401 thrown mid-navigation; this stops the app
+ * from mounting at all until a session is confirmed.
+ */
+export function AuthGate({ children }: { children: ReactNode }) {
+  const { status } = useQuery({
+    queryKey: ['auth', 'session'],
+    queryFn: async ({ signal }) => {
+      await probeSession({ signal })
+      return true
+    },
+    retry: false,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+
+  if (status === 'success') return <>{children}</>
+  if (status === 'error') return <LoggedOutScreen />
+  return <AuthSplash />
+}
+
+/** Minimal pre-auth splash — design tokens only, no shell, no data. */
+function AuthSplash() {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--enc-void)',
+      }}
+    >
+      <p
+        style={{
+          fontFamily: 'var(--font-body)',
+          fontSize: 'var(--text-xs)',
+          textTransform: 'uppercase',
+          letterSpacing: 'var(--tracking-label)',
+          color: 'var(--fg-muted)',
+          margin: 0,
+        }}
+      >
+        Enceladus · Governance Cockpit
+      </p>
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/main.tsx
+++ b/frontend/ui-v2/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from '@tanstack/react-router'
 import { queryClient } from './api/queryClient'
 import { router } from './routes/router'
 import { RealtimeFeedProvider } from './realtime/RealtimeFeedProvider'
+import { AuthGate } from './auth/AuthGate'
 import './styles.css'
 
 const rootEl = document.getElementById('root')
@@ -13,9 +14,11 @@ if (!rootEl) throw new Error('Root element #root not found')
 createRoot(rootEl).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RealtimeFeedProvider>
-        <RouterProvider router={router} />
-      </RealtimeFeedProvider>
+      <AuthGate>
+        <RealtimeFeedProvider>
+          <RouterProvider router={router} />
+        </RealtimeFeedProvider>
+      </AuthGate>
     </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## ENC-TSK-K98 (Part 1 of 2) — cockpit hard auth gate

**Problem (io-reported):** an unauthenticated visitor to the gamma cockpit could see the app shell and the feed pane's record summaries, because the home route makes no authed API call (the SPA just renders) and the feed pane fetches a public snapshot.

**Fix (Part 1 — frontend):** wrap the entire app in an `AuthGate` mounted **above** `RealtimeFeedProvider` and the router. On load it probes an authenticated endpoint (`/api/v1/projects`) exactly once:
- **pending** → a minimal branded splash (no shell, no data)
- **error** (401 / `SessionExpiredError`, or any failure to confirm a session) → `LoggedOutScreen` and nothing else — fail closed
- **success** → render the app

This is the proactive counterpart to K95's router `defaultErrorComponent` (which only catches a 401 thrown *mid-navigation*). Nothing is visible pre-login.

**Follow-up (Part 2, separate PR):** route the feed snapshot through an authenticated API path so `/mobile/v1/tasks.json` is no longer publicly readable by URL. Tracked under the same task (AC-2).

### Verification
- `vite build` ✓ (bundle `index-BAi92pNB.js`)
- `vitest run` ✓ 7/7
- No test mounts `main`/`AuthGate`; pre-existing `tsc -b` strictness errors in `router.tsx`/`CommandPalette.tsx` are unchanged and not gated by CI.

Gamma-only (v4/main). Follows K95 (login) + K97 (primitive hardening).

CCI-d394ca2db9dc4da2ae7ff75a23dc3986

🤖 Generated with [Claude Code](https://claude.com/claude-code)