### PR TITLE
ENC-PLN-068: Register scheduler IAM patch workflow on main

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-scheduler-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-scheduler-patch.yml
@@ -1,0 +1,83 @@
+name: IAM CFN Deploy Role — EventBridge Scheduler Patch
+
+# ENC-PLN-068: CloudFormationDeployRole lacked scheduler:GetScheduleGroup (and related
+# Scheduler API actions), blocking Rhythm Cycle ScheduleGroup creation on gamma compute
+# deploy (UPDATE_ROLLBACK_COMPLETE 2026-07-02). Durable fix in 04-github-roles.yaml;
+# this one-off dispatch applies the grant live ahead of the next github-roles stack deploy.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "ENC-PLN-068 — grant EventBridge Scheduler ops to CloudFormationDeployRole for Rhythm Cycle"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with scheduler:* for rhythm groups
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — EventBridge Scheduler
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          cat > /tmp/cfn-deploy-role-scheduler.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "RhythmCycleSchedulerOps",
+                "Effect": "Allow",
+                "Action": [
+                  "scheduler:CreateScheduleGroup",
+                  "scheduler:DeleteScheduleGroup",
+                  "scheduler:GetScheduleGroup",
+                  "scheduler:ListScheduleGroups",
+                  "scheduler:CreateSchedule",
+                  "scheduler:DeleteSchedule",
+                  "scheduler:GetSchedule",
+                  "scheduler:UpdateSchedule",
+                  "scheduler:ListSchedules",
+                  "scheduler:TagResource",
+                  "scheduler:UntagResource"
+                ],
+                "Resource": [
+                  "arn:aws:scheduler:us-west-2:${ACCOUNT_ID}:schedule-group/rhythm-*",
+                  "arn:aws:scheduler:us-west-2:${ACCOUNT_ID}:schedule/rhythm-*/*",
+                  "arn:aws:scheduler:us-west-2:${ACCOUNT_ID}:schedule-group/enceladus-*",
+                  "arn:aws:scheduler:us-west-2:${ACCOUNT_ID}:schedule/enceladus-*/*"
+                ]
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-scheduler-v1" \
+            --policy-document "file:///tmp/cfn-deploy-role-scheduler.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-scheduler-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -187,6 +187,27 @@ Resources:
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/enceladus-*"
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/on-project-json-sync*"
 
+              # ENC-PLN-068: Rhythm Cycle EventBridge Scheduler groups/schedules
+              - Sid: EventBridgeSchedulerOps
+                Effect: Allow
+                Action:
+                  - scheduler:CreateScheduleGroup
+                  - scheduler:DeleteScheduleGroup
+                  - scheduler:GetScheduleGroup
+                  - scheduler:ListScheduleGroups
+                  - scheduler:CreateSchedule
+                  - scheduler:DeleteSchedule
+                  - scheduler:GetSchedule
+                  - scheduler:UpdateSchedule
+                  - scheduler:ListSchedules
+                  - scheduler:TagResource
+                  - scheduler:UntagResource
+                Resource:
+                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/rhythm-*"
+                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/rhythm-*/*"
+                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/enceladus-*"
+                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/enceladus-*/*"
+
               - Sid: PipesOps
                 Effect: Allow
                 Action:

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -17,6 +17,13 @@
       ],
       "notes": "environment: parametrized per target (v3-prod reviewer-gated, v4-gamma ungated); dedicated per-env OIDC roles (PR #407)"
     },
+    "_ui_deploy.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "deploy"
+      ],
+      "notes": "ENC-TSK-K53 / T2 (v4 UI Deploy Pipeline, DOC-3EE4F709EC98 L2). Ships frontend/ui-v2 to the T1 07-ui-cdn S3+CloudFront stack. The deploy job (the sole AWS-mutating job) carries environment by ref: startsWith(github.ref,'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' (v4/** ungated gamma, main io-reviewer-gated). Bucket + distribution id resolved at runtime from the enceladus-ui-cdn${suffix} CFN exports; role AWS_UI_DEPLOY_ROLE_TO_ASSUME with AWS_CLOUDFORMATION_ROLE_TO_ASSUME fallback"
+    },
     "build-lambda-artifacts.yml": {
       "class": "inert",
       "notes": "S3 artifact staging bucket writes only; no live function/stack mutation"
@@ -71,6 +78,13 @@
       ],
       "notes": "ENC-TSK-J63 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
     },
+    "cloudformation-ui-cdn-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-K52 / T1 (v4 UI Deploy Pipeline, DOC-3EE4F709EC98) plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod). Deploys the 07-ui-cdn S3+CloudFront stack for frontend/ui-v2; gamma stands up on merge to v4/main, prod is a gated flip later"
+    },
     "component-registry-guard.yml": {
       "class": "inert",
       "notes": "guard"
@@ -92,6 +106,13 @@
         "patch-role"
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod (shared/global IAM role objects)"
+    },
+    "iam-cfn-deploy-role-scheduler-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-PLN-068: environment: v3-prod — grant EventBridge Scheduler ops to CloudFormationDeployRole for Rhythm Cycle"
     },
     "iam-cfn-deploy-role-gamma-patch.yml": {
       "class": "prod-mutating",
@@ -191,13 +212,6 @@
         "wire-notification"
       ],
       "notes": "ENC-TSK-J65: environment chosen from environment_suffix input (-gamma -> v4-gamma, '' -> v3-prod). Caught by the guard's own first fail-closed run."
-    },
-    "iam-cfn-deploy-role-fnurlconfig-patch.yml": {
-      "class": "prod-mutating",
-      "gated_jobs": [
-        "patch-role"
-      ],
-      "notes": "ENC-TSK-K09: environment: v3-prod \u2014 patches the SHARED CFN deploy role object with lambda:*FunctionUrlConfig on enceladus-mcp-code-gamma (ENC-TSK-K07 unblock)."
     }
   }
 }

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -126,7 +126,14 @@
       "gated_jobs": [
         "patch-role"
       ],
-      "notes": "ENC-TSK-K59: environment: v3-prod \u2014 despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
+      "notes": "ENC-TSK-K59: environment: v3-prod — despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
+    },
+    "iam-cfn-deploy-role-fnurlconfig-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-K09: environment: v3-prod — patches the SHARED CFN deploy role object with lambda:*FunctionUrlConfig on enceladus-mcp-code-gamma (ENC-TSK-K07 unblock)."
     },
     "iam-cloudformation-unblock.yml": {
       "class": "prod-mutating",


### PR DESCRIPTION
CCI-b13b481a50cd4b06bb9a803cb5c7a09d

## Summary
- Cherry-picks scheduler IAM patch onto **main** so GitHub Actions registers `workflow_dispatch`
- PR #814 merged to `v4/main` only; default branch is `main`, so the workflow was 404/undispatchable
- Restores missing `fnurlconfig` prod-gate baseline entry required by main CI

## Root cause (runtime evidence)
- `gh workflow list` shows EventBridge/Lambda/Gamma IAM patches but **no scheduler patch**
- `gh api .../workflows/iam-cfn-deploy-role-scheduler-patch.yml/dispatches` → HTTP 404
- Gamma CFN deploy failed: `scheduler:GetScheduleGroup` AccessDenied on `rhythm-*-gamma`

## Test plan
- [ ] Merge to main
- [ ] Dispatch **IAM CFN Deploy Role — EventBridge Scheduler Patch** (v3-prod gate)
- [ ] Re-run CloudFormation Compute Stack Deploy on v4/main