### PR TITLE
feat(feed): ENC-TSK-L01 — cockpit snapshot behind auth; retire public /mobile/v1 (gamma)

### DIFF
--- a/.github/workflows/_ui_deploy.yml
+++ b/.github/workflows/_ui_deploy.yml
@@ -96,9 +96,11 @@ jobs:
         env:
           # Same-origin API base (07-ui-cdn /api/* behavior proxies to API GW).
           VITE_API_BASE: /api/v1
-          # Same-origin feed snapshot base — the gamma feed publisher writes
-          # mobile/v1/tasks.json into the UI origin bucket (ENC-TSK-K72).
-          VITE_FEED_BASE_URL: /mobile/v1
+          # ENC-TSK-K98: cold-start snapshot now comes from the AUTHENTICATED
+          # feed_query API (GET /api/v1/feed/tasks.json), not the public
+          # /mobile/v1/ S3 objects (which are being retired). Same-origin;
+          # the 07-ui-cdn /api/* behavior proxies to API GW.
+          VITE_FEED_BASE_URL: /api/v1/feed
           # ENC-TSK-K70: AppSync Events realtime config. Sourced from GitHub
           # repo VARIABLES (not CFN describe-stacks) because this build job is
           # deliberately credential-less and ungated — granting it AWS access

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.37",
-  "updated_at": "2026-07-02T21:01:00Z",
-  "last_change_summary": "ENC-PLN-068: monitoring.rhythm_cycle entity for enceladus-rhythm-cycle Lambda, EventBridge Scheduler tier groups, Enceladus/Rhythm CloudWatch namespace, S3 cycle-artifact convention, and Lyapunov backlog_open_leaves pathology alarm.",
+  "version": "2026-07-02.38",
+  "updated_at": "2026-07-02T21:35:00Z",
+  "last_change_summary": "ENC-TSK-K98: feed_query gains an authenticated cold-start snapshot route (GET /api/v1/feed/tasks.json, JWT-gated, minimal projection) replacing the previously-public /mobile/v1 S3 objects; feed_publisher gains FEED_S3_PUBLISH_ENABLED to disable the public /mobile publish + CF invalidation on gamma (cockpit reads the authed API instead). No governed record schema change.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/feed_publisher/lambda_function.py
+++ b/backend/lambda/feed_publisher/lambda_function.py
@@ -96,6 +96,14 @@ DOCUMENTS_REGION = os.environ.get("DOCUMENTS_REGION", "us-west-2")
 FEED_BUCKET = os.environ.get("FEED_BUCKET", DEFAULT_MOBILE_S3_BUCKET)
 FEED_PREFIX = os.environ.get("FEED_PREFIX", DEFAULT_MOBILE_S3_PREFIX)
 CF_DISTRIBUTION = os.environ.get("CF_DISTRIBUTION", DEFAULT_MOBILE_CF_DISTRIBUTION)
+# ENC-TSK-K98: gate the PUBLIC /mobile feed publish (+ its CF invalidation).
+# Prod keeps publishing (default "true"). Gamma sets this "false" because the
+# gamma /mobile/v1 objects are served PUBLICLY by the shared UI-origin cockpit
+# CDN (a full-record data leak), and the ui-v2 cockpit now reads its cold-start
+# snapshot from the AUTHENTICATED feed_query API (GET /api/v1/feed/tasks.json).
+FEED_S3_PUBLISH_ENABLED = (
+    os.environ.get("FEED_S3_PUBLISH_ENABLED", "true").strip().lower() != "false"
+)
 SNS_TOPIC = os.environ.get("SNS_TOPIC", DEFAULT_SNS_TOPIC)
 EVENT_BUS = os.environ.get("EVENT_BUS", DEFAULT_EVENT_BUS)
 ANALYTICS_BUCKET = os.environ.get("ANALYTICS_BUCKET", ANALYTICS_S3_BUCKET)
@@ -435,13 +443,25 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             # Non-fatal: continue without reference docs
 
         # 5. Publish feed files to S3
-        uploaded_keys = publish_mobile_feeds_to_s3(
-            feed_dir=feed_dir,
-            bucket=FEED_BUCKET,
-            s3_prefix=FEED_PREFIX,
-            dry_run=DRY_RUN,
-        )
-        logger.info("feed_publisher: published %d files to S3", len(uploaded_keys))
+        #
+        # ENC-TSK-K98: skip on gamma (FEED_S3_PUBLISH_ENABLED=false) — the
+        # /mobile/v1 objects are served PUBLICLY by the shared UI-origin cockpit
+        # CDN, and the ui-v2 cockpit now reads its snapshot from the
+        # authenticated feed_query API. Prod keeps publishing.
+        if FEED_S3_PUBLISH_ENABLED:
+            uploaded_keys = publish_mobile_feeds_to_s3(
+                feed_dir=feed_dir,
+                bucket=FEED_BUCKET,
+                s3_prefix=FEED_PREFIX,
+                dry_run=DRY_RUN,
+            )
+            logger.info("feed_publisher: published %d files to S3", len(uploaded_keys))
+        else:
+            uploaded_keys = []
+            logger.info(
+                "feed_publisher: PUBLIC /mobile S3 publish disabled "
+                "(FEED_S3_PUBLISH_ENABLED=false); skipping write + CF invalidation"
+            )
 
         # 5b. Write analytics sync-stage JSON for Trino/Superset pipeline
         analytics_stage_prefixes = {}  # project_name -> {artifact -> s3_prefix_uri}
@@ -465,16 +485,17 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             logger.error("feed_publisher: analytics sync-stage write failed: %s", exc)
             # Non-fatal: mobile feeds are already published
 
-        # 6. CloudFront invalidation
-        try:
-            inv_id = invalidate_mobile_cf(
-                distribution_id=CF_DISTRIBUTION,
-                dry_run=DRY_RUN,
-            )
-            logger.info("feed_publisher: CF invalidation id=%s", inv_id)
-        except Exception as exc:
-            logger.error("feed_publisher: CloudFront invalidation failed: %s", exc)
-            # Non-fatal: feeds are published even if invalidation fails
+        # 6. CloudFront invalidation (only when we actually published — K98)
+        if FEED_S3_PUBLISH_ENABLED:
+            try:
+                inv_id = invalidate_mobile_cf(
+                    distribution_id=CF_DISTRIBUTION,
+                    dry_run=DRY_RUN,
+                )
+                logger.info("feed_publisher: CF invalidation id=%s", inv_id)
+            except Exception as exc:
+                logger.error("feed_publisher: CloudFront invalidation failed: %s", exc)
+                # Non-fatal: feeds are published even if invalidation fails
 
         # 7. SNS signal for Trino/Superset pipeline
         try:

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -1472,6 +1472,62 @@ def _handle_feed_refresh() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _handle_snapshot() -> Dict[str, Any]:
+    """
+    ENC-TSK-K98 — authenticated cold-start snapshot (GET /api/v1/feed/tasks.json).
+
+    Replaces the previously PUBLIC S3 object at /mobile/v1/tasks.json. The whole
+    handler is JWT-gated (see lambda_handler: token is extracted + verified
+    before any dispatch), so an unauthenticated request 401s here instead of
+    reading a public file. Returns only the minimal fields the ui-v2 cockpit
+    needs to seed its feed before the realtime WSS connects
+    ({item_id, title, status, record_type, updated_at}) across all record types.
+    The minimal projection also shrinks the payload from ~7.7MB of full records
+    to a few KB and stops leaking descriptions / session / worklog data.
+    """
+    try:
+        tasks, issues, features, lessons, plans = _query_all_records()
+    except Exception as exc:  # noqa: BLE001 — surface a structured 500, not opaque
+        logger.error("snapshot query failed: %s", exc)
+        return _error(500, "Failed to query snapshot. Please try again.")
+
+    def _rows(records: List[Dict[str, Any]], id_key: str, record_type: str) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for r in records:
+            rid = r.get(id_key) or r.get("item_id")
+            if not rid:
+                continue
+            out.append(
+                {
+                    "item_id": rid,
+                    "title": r.get("title") or rid,
+                    "status": r.get("status") or "open",
+                    "record_type": record_type,
+                    "updated_at": r.get("updated_at") or None,
+                }
+            )
+        return out
+
+    rows = (
+        _rows(tasks, "task_id", "task")
+        + _rows(issues, "issue_id", "issue")
+        + _rows(features, "feature_id", "feature")
+        + _rows(lessons, "lesson_id", "lesson")
+        + _rows(plans, "plan_id", "plan")
+    )
+
+    body = {"generated_at": _now_z(), "tasks": rows}
+    return {
+        "statusCode": 200,
+        "headers": {
+            **_cors_headers(),
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+        },
+        "body": json.dumps(body),
+    }
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     method = (
         (event.get("requestContext") or {}).get("http", {}).get("method")
@@ -1535,6 +1591,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             return _error(404, f"Subscription '{subscription_id}' not found")
 
         return _response(200, {"success": True, "subscription": _subscription_public(sub)})
+
+    # ENC-TSK-K98 — authenticated cold-start snapshot; replaces the public
+    # /mobile/v1/tasks.json S3 object. JWT already enforced above.
+    if method == "GET" and re.search(r"/api/v1/feed/tasks\.json/?$", path):
+        return _handle_snapshot()
 
     if method != "GET" or not re.search(r"/api/v1/feed/?$", path):
         return _error(404, f"Unsupported route: {method} {path}")

--- a/frontend/ui-v2/src/api/feeds.ts
+++ b/frontend/ui-v2/src/api/feeds.ts
@@ -1,6 +1,9 @@
 import type { FeedRealtimeEvent, FeedSnapshot } from '../types/feedEvents'
 
-const FEED_BASE = (import.meta.env.VITE_FEED_BASE_URL ?? '/mobile/v1').replace(/\/$/, '')
+// ENC-TSK-K98: the cold-start snapshot is now served by the authenticated
+// feed_query API (GET /api/v1/feed/tasks.json), NOT the previously-public
+// /mobile/v1/ S3 objects. Same-origin, cookie-authenticated (see fetchJson).
+const FEED_BASE = (import.meta.env.VITE_FEED_BASE_URL ?? '/api/v1/feed').replace(/\/$/, '')
 
 async function fetchJson<T>(path: string): Promise<T> {
   const url = `${FEED_BASE}/${path}?_t=${Date.now()}`

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1054,6 +1054,15 @@ Resources:
             - IsGamma
             - !ImportValue "enceladus-ui-cdn-gamma-UiDistributionId"
             - !Ref "AWS::NoValue"
+          # ENC-TSK-K98: gamma's /mobile/v1 objects are served PUBLICLY by the
+          # shared UI-origin cockpit CDN (full-record data leak). The ui-v2
+          # cockpit now reads its snapshot from the authenticated feed_query API,
+          # so disable the public mobile publish + CF invalidation on gamma.
+          # Prod omits the var -> lambda default "true" (unchanged behaviour).
+          FEED_S3_PUBLISH_ENABLED: !If
+            - IsGamma
+            - "false"
+            - !Ref "AWS::NoValue"
           EVENT_BUS: default
           DEPLOY_TABLE: !Sub "devops-deployment-manager${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -594,6 +594,15 @@ Resources:
       RouteKey: GET /api/v1/feed
       Target: !Sub integrations/${FeedQueryIntegration}
 
+  # ENC-TSK-K98 — authenticated cold-start snapshot; replaces the public
+  # /mobile/v1/tasks.json S3 object. JWT-gated by the feed_query handler.
+  RouteFeedTasksJson:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/feed/tasks.json
+      Target: !Sub integrations/${FeedQueryIntegration}
+
   RouteFeedRefresh:
     Type: AWS::ApiGatewayV2::Route
     Properties:


### PR DESCRIPTION
## ENC-TSK-L01 — feed snapshot behind auth (K98 Part 2; delivers K98 AC-2)

**Problem:** the gamma cockpit's cold-start snapshot was served from **public** S3 objects under `/mobile/v1/` on the shared UI-origin CDN. Confirmed live: `GET /mobile/v1/tasks.json` → **200, 7.7 MB of full gamma records** (acceptance_criteria, `active_agent_session`, `assigned_to`, descriptions…) unauthenticated, on **both** cockpit hosts — plus `documents.json`/`features.json`/`issues.json`/`deploy-pending.json`.

**Fix (gamma-only; object-level so it covers both the canonical `d14d4` and vanity `c7a516` dists that share the bucket):**
1. **feed_query** — new authenticated `GET /api/v1/feed/tasks.json`. JWT-gated like the rest of the handler (token verified before dispatch → 401 without a session). Minimal `{item_id,title,status,record_type,updated_at}` projection across all record types (a few KB, not 7.7 MB; no descriptions/session/worklog leak).
2. **03-api** — `RouteFeedTasksJson → FeedQueryIntegration` (additive; harmless on prod).
3. **ui-v2** — `feeds.ts` + `_ui_deploy` `VITE_FEED_BASE_URL` repointed to `/api/v1/feed`, so cold-start hydrates from the authed API (same-origin, cookie-authenticated).
4. **feed_publisher** — `FEED_S3_PUBLISH_ENABLED` guard around the `/mobile` publish + CF invalidation; **02-compute** sets it `false` on gamma (`IsGamma`). Prod omits the var → lambda default `true` (byte-identical prod behaviour).
5. Governance dictionary bumped `2026-07-02.38` (path-triggered guard on the two lambda edits).

**Not in this PR:** a one-time privileged terminal delete of the already-written stale `s3://enceladus-ui-v2-gamma/mobile/` objects (dispatched via handoff) — after this merges, the gamma publisher stops rewriting them.

### Verification
- `vite build` ✓ (`index-DrZcnZR9.js`), `vitest run` ✓ 7/7
- `python -m py_compile` ✓ feed_query + feed_publisher
- cfn-lint: no new findings from the additions (pre-existing SnapStart warnings on unrelated functions only)

Gamma-only (v4/main). Follows K95 (login) + K97 (hardening) + K98 (app gate).

CCI-210f5b716d3c4cf9b0f0ff7e09be9e77

🤖 Generated with [Claude Code](https://claude.com/claude-code)