### PR TITLE
ENC-TSK-L11 — provider adapter interface in coordination API (B64 Ph3)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-02.38",
-  "updated_at": "2026-07-02T21:35:00Z",
-  "last_change_summary": "ENC-TSK-K98: feed_query gains an authenticated cold-start snapshot route (GET /api/v1/feed/tasks.json, JWT-gated, minimal projection) replacing the previously-public /mobile/v1 S3 objects; feed_publisher gains FEED_S3_PUBLISH_ENABLED to disable the public /mobile publish + CF invalidation on gamma (cockpit reads the authed API instead). No governed record schema change.",
+  "version": "2026-07-05.1",
+  "updated_at": "2026-07-05T06:16:00Z",
+  "last_change_summary": "ENC-TSK-L11: provider_adapters package + dispatch registry wiring in coordination_api (Claude/Codex/Bedrock/A2A seam). No governed record schema or enum change; dictionary bump satisfies CI guard for handlers.py/lambda_function.py touch.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/coordination_api/handlers.py
+++ b/backend/lambda/coordination_api/handlers.py
@@ -131,6 +131,7 @@ from dispatch_ssm import (
     _refresh_request_from_ssm,
     _send_dispatch,
 )
+from provider_adapters import dispatch_via_provider_adapter, wire_default_provider_adapters
 from lifecycle import (
     _compute_plan_status,
     _emit_callback_event,
@@ -163,6 +164,24 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
+
+_PROVIDER_ADAPTERS_WIRED = False
+
+
+def _ensure_provider_adapters_wired() -> None:
+    global _PROVIDER_ADAPTERS_WIRED
+    if _PROVIDER_ADAPTERS_WIRED:
+        return
+
+    def _bedrock_unavailable(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+        raise RuntimeError("bedrock_agent direct dispatch is not wired in handlers path")
+
+    wire_default_provider_adapters(
+        claude_dispatch=_dispatch_claude_api,
+        codex_dispatch=_dispatch_openai_codex_api,
+        bedrock_dispatch=_bedrock_unavailable,
+    )
+    _PROVIDER_ADAPTERS_WIRED = True
 
 
 def _mcp_jsonrpc_response(request_id: Any, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -1097,6 +1116,7 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
         # Check if batch mode is requested via provider_preferences
         is_batch = bool((request.get("provider_session") or {}).get("batch_eligible"))
 
+        dispatch_meta: Optional[Dict[str, Any]] = None
         if is_batch and execution_mode == "claude_agent_sdk":
             # Batch mode: set batch_context metadata, dispatch async
             request["batch_context"] = {
@@ -1111,20 +1131,15 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
                 prompt=prompt,
                 dispatch_id=dispatch_id,
             )
-        elif execution_mode == "claude_agent_sdk":
-            dispatch_meta = _dispatch_claude_api(
-                request=request,
-                prompt=prompt,
-                dispatch_id=dispatch_id,
+        if dispatch_meta is None:
+            _ensure_provider_adapters_wired()
+            dispatch_meta = dispatch_via_provider_adapter(
+                execution_mode,
+                request,
+                prompt,
+                dispatch_id,
             )
-        elif execution_mode in {"codex_app_server", "codex_full_auto"}:
-            dispatch_meta = _dispatch_openai_codex_api(
-                request=request,
-                prompt=prompt,
-                dispatch_id=dispatch_id,
-                execution_mode=execution_mode,
-            )
-        else:
+        if dispatch_meta is None:
             dispatch_meta = _send_dispatch(
                 request,
                 execution_mode=execution_mode,

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -94,6 +94,21 @@ except ModuleNotFoundError:  # pragma: no cover - packaging fallback
     _agent_id_alloc = importlib.util.module_from_spec(_AIA_SPEC)  # type: ignore[arg-type]
     _AIA_SPEC.loader.exec_module(_agent_id_alloc)  # type: ignore[union-attr]
 
+# ENC-TSK-L11 / B64 Ph3: provider adapter interface + registry.
+try:
+    from provider_adapters import (
+        dispatch_via_provider_adapter,
+        wire_default_provider_adapters,
+    )
+except ModuleNotFoundError:  # pragma: no cover - packaging fallback
+    _PA_PATH = pathlib.Path(__file__).with_name("provider_adapters")
+    _PA_INIT = _PA_PATH / "__init__.py"
+    _PA_SPEC = importlib.util.spec_from_file_location("provider_adapters", _PA_INIT)
+    _PA_MODULE = importlib.util.module_from_spec(_PA_SPEC)  # type: ignore[arg-type]
+    _PA_SPEC.loader.exec_module(_PA_MODULE)  # type: ignore[union-attr]
+    dispatch_via_provider_adapter = _PA_MODULE.dispatch_via_provider_adapter
+    wire_default_provider_adapters = _PA_MODULE.wire_default_provider_adapters
+
 try:
     import jwt
     from jwt.algorithms import RSAAlgorithm
@@ -5814,6 +5829,21 @@ def _dispatch_claude_api(request: Dict[str, Any], prompt: Optional[str], dispatc
         "status": "succeeded",
         "provider_result": provider_result,
     }
+
+
+_PROVIDER_ADAPTERS_WIRED = False
+
+
+def _ensure_provider_adapters_wired() -> None:
+    global _PROVIDER_ADAPTERS_WIRED
+    if _PROVIDER_ADAPTERS_WIRED:
+        return
+    wire_default_provider_adapters(
+        claude_dispatch=_dispatch_claude_api,
+        codex_dispatch=_dispatch_openai_codex_api,
+        bedrock_dispatch=_dispatch_bedrock_api,
+    )
+    _PROVIDER_ADAPTERS_WIRED = True
 
 
 def _dispatch_claude_batch_api(
@@ -12918,6 +12948,7 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
                 request.get("related_record_ids") or []
             )
 
+        dispatch_meta: Optional[Dict[str, Any]] = None
         if execution_mode == "claude_agent_sdk":
             is_batch = bool((request.get("provider_session") or {}).get("batch_eligible"))
             if is_batch:
@@ -12933,26 +12964,15 @@ def _handle_dispatch_request(event: Dict[str, Any], request_id: str) -> Dict[str
                     prompt=prompt,
                     dispatch_id=dispatch_id,
                 )
-            else:
-                dispatch_meta = _dispatch_claude_api(
-                    request=request,
-                    prompt=prompt,
-                    dispatch_id=dispatch_id,
-                )
-        elif execution_mode in {"codex_app_server", "codex_full_auto"}:
-            dispatch_meta = _dispatch_openai_codex_api(
-                request=request,
-                prompt=prompt,
-                dispatch_id=dispatch_id,
-                execution_mode=execution_mode,
+        if dispatch_meta is None:
+            _ensure_provider_adapters_wired()
+            dispatch_meta = dispatch_via_provider_adapter(
+                execution_mode,
+                request,
+                prompt,
+                dispatch_id,
             )
-        elif execution_mode == "bedrock_agent":
-            dispatch_meta = _dispatch_bedrock_api(
-                request=request,
-                prompt=prompt,
-                dispatch_id=dispatch_id,
-            )
-        else:
+        if dispatch_meta is None:
             dispatch_meta = _send_dispatch(
                 request,
                 execution_mode=execution_mode,

--- a/backend/lambda/coordination_api/provider_adapters/__init__.py
+++ b/backend/lambda/coordination_api/provider_adapters/__init__.py
@@ -1,0 +1,29 @@
+"""Provider adapter package for coordination API outbound dispatch."""
+
+from .base import CallableProviderAdapter, ProviderAdapter, UnimplementedProviderAdapter
+from .a2a import A2AProviderAdapter
+from .registry import (
+    dispatch_via_provider_adapter,
+    get_adapter_for_execution_mode,
+    get_provider_adapter,
+    list_registered_provider_ids,
+    register_callable_adapter,
+    register_provider_adapter,
+    reset_provider_adapters_for_tests,
+    wire_default_provider_adapters,
+)
+
+__all__ = [
+    "A2AProviderAdapter",
+    "CallableProviderAdapter",
+    "ProviderAdapter",
+    "UnimplementedProviderAdapter",
+    "dispatch_via_provider_adapter",
+    "get_adapter_for_execution_mode",
+    "get_provider_adapter",
+    "list_registered_provider_ids",
+    "register_callable_adapter",
+    "register_provider_adapter",
+    "reset_provider_adapters_for_tests",
+    "wire_default_provider_adapters",
+]

--- a/backend/lambda/coordination_api/provider_adapters/a2a.py
+++ b/backend/lambda/coordination_api/provider_adapters/a2a.py
@@ -1,0 +1,25 @@
+"""A2A provider adapter seam (empty implementation, ENC-TSK-L11 AC-3)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import UnimplementedProviderAdapter
+
+
+class A2AProviderAdapter(UnimplementedProviderAdapter):
+    """Placeholder for Agent-to-Agent transport; intentionally unimplemented."""
+
+    provider_id = "a2a"
+
+    def dispatch(
+        self,
+        request: Dict[str, Any],
+        prompt: Optional[str],
+        dispatch_id: str,
+        *,
+        execution_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError(
+            "A2A provider adapter seam is committed but not yet implemented"
+        )

--- a/backend/lambda/coordination_api/provider_adapters/base.py
+++ b/backend/lambda/coordination_api/provider_adapters/base.py
@@ -1,0 +1,63 @@
+"""Provider adapter interface for coordination API dispatch (ENC-TSK-L11 / B64 Ph3)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
+
+
+DispatchFn = Callable[..., Dict[str, Any]]
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Outbound dispatch contract for a managed agent provider surface."""
+
+    provider_id: str
+
+    def dispatch(
+        self,
+        request: Dict[str, Any],
+        prompt: Optional[str],
+        dispatch_id: str,
+        *,
+        execution_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Execute provider-specific dispatch and return dispatch metadata."""
+
+
+class CallableProviderAdapter:
+    """Thin adapter wrapper around an existing dispatch callable."""
+
+    __slots__ = ("provider_id", "_dispatch_fn")
+
+    def __init__(self, provider_id: str, dispatch_fn: DispatchFn) -> None:
+        self.provider_id = provider_id
+        self._dispatch_fn = dispatch_fn
+
+    def dispatch(
+        self,
+        request: Dict[str, Any],
+        prompt: Optional[str],
+        dispatch_id: str,
+        *,
+        execution_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return self._dispatch_fn(request, prompt, dispatch_id)
+
+
+class UnimplementedProviderAdapter(ABC):
+    """Seam for future providers; committed empty implementation for A2A."""
+
+    provider_id: str
+
+    @abstractmethod
+    def dispatch(
+        self,
+        request: Dict[str, Any],
+        prompt: Optional[str],
+        dispatch_id: str,
+        *,
+        execution_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError

--- a/backend/lambda/coordination_api/provider_adapters/bedrock.py
+++ b/backend/lambda/coordination_api/provider_adapters/bedrock.py
@@ -1,0 +1,18 @@
+"""AWS Bedrock Agent provider adapter (delegates to coordination dispatch)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import CallableProviderAdapter, DispatchFn
+
+
+class BedrockProviderAdapter(CallableProviderAdapter):
+    provider_id = "aws_bedrock_agent"
+
+    def __init__(self, dispatch_fn: DispatchFn) -> None:
+        super().__init__("aws_bedrock_agent", dispatch_fn)
+
+
+def build_bedrock_adapter(dispatch_fn: DispatchFn) -> BedrockProviderAdapter:
+    return BedrockProviderAdapter(dispatch_fn)

--- a/backend/lambda/coordination_api/provider_adapters/claude.py
+++ b/backend/lambda/coordination_api/provider_adapters/claude.py
@@ -1,0 +1,18 @@
+"""Claude Agent SDK provider adapter (delegates to coordination dispatch)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import CallableProviderAdapter, DispatchFn
+
+
+class ClaudeProviderAdapter(CallableProviderAdapter):
+    provider_id = "claude_agent_sdk"
+
+    def __init__(self, dispatch_fn: DispatchFn) -> None:
+        super().__init__("claude_agent_sdk", dispatch_fn)
+
+
+def build_claude_adapter(dispatch_fn: DispatchFn) -> ClaudeProviderAdapter:
+    return ClaudeProviderAdapter(dispatch_fn)

--- a/backend/lambda/coordination_api/provider_adapters/codex.py
+++ b/backend/lambda/coordination_api/provider_adapters/codex.py
@@ -1,0 +1,34 @@
+"""OpenAI Codex provider adapter (delegates to coordination dispatch)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .base import DispatchFn, ProviderAdapter
+
+
+class CodexProviderAdapter:
+    provider_id = "openai_codex"
+
+    def __init__(self, dispatch_fn: DispatchFn) -> None:
+        self._dispatch_fn = dispatch_fn
+
+    def dispatch(
+        self,
+        request: Dict[str, Any],
+        prompt: Optional[str],
+        dispatch_id: str,
+        *,
+        execution_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        mode = execution_mode or "codex_app_server"
+        return self._dispatch_fn(
+            request,
+            prompt,
+            dispatch_id,
+            execution_mode=mode,
+        )
+
+
+def build_codex_adapter(dispatch_fn: DispatchFn) -> CodexProviderAdapter:
+    return CodexProviderAdapter(dispatch_fn)

--- a/backend/lambda/coordination_api/provider_adapters/registry.py
+++ b/backend/lambda/coordination_api/provider_adapters/registry.py
@@ -1,0 +1,88 @@
+"""Registry and routing for coordination API provider adapters (ENC-TSK-L11)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .a2a import A2AProviderAdapter
+from .base import CallableProviderAdapter, DispatchFn, ProviderAdapter
+from .bedrock import build_bedrock_adapter
+from .claude import build_claude_adapter
+from .codex import build_codex_adapter
+
+_EXECUTION_MODE_ALIASES: Dict[str, str] = {
+    "claude_agent_sdk": "claude_agent_sdk",
+    "codex_app_server": "openai_codex",
+    "codex_full_auto": "openai_codex",
+    "bedrock_agent": "aws_bedrock_agent",
+    "a2a": "a2a",
+}
+
+_ADAPTERS: Dict[str, ProviderAdapter] = {}
+_A2A_ADAPTER = A2AProviderAdapter()
+_WIRED = False
+
+
+def register_provider_adapter(provider_id: str, adapter: ProviderAdapter) -> None:
+    _ADAPTERS[str(provider_id).strip()] = adapter
+
+
+def register_callable_adapter(provider_id: str, dispatch_fn: DispatchFn) -> None:
+    register_provider_adapter(provider_id, CallableProviderAdapter(provider_id, dispatch_fn))
+
+
+def get_provider_adapter(provider_id: str) -> Optional[ProviderAdapter]:
+    return _ADAPTERS.get(str(provider_id or "").strip())
+
+
+def get_adapter_for_execution_mode(execution_mode: str) -> Optional[ProviderAdapter]:
+    provider_id = _EXECUTION_MODE_ALIASES.get(str(execution_mode or "").strip())
+    if not provider_id:
+        return None
+    return get_provider_adapter(provider_id)
+
+
+def list_registered_provider_ids() -> List[str]:
+    return sorted(_ADAPTERS.keys())
+
+
+def dispatch_via_provider_adapter(
+    execution_mode: str,
+    request: Dict[str, Any],
+    prompt: Optional[str],
+    dispatch_id: str,
+    **kwargs: Any,
+) -> Optional[Dict[str, Any]]:
+    adapter = get_adapter_for_execution_mode(execution_mode)
+    if adapter is None:
+        return None
+    return adapter.dispatch(
+        request,
+        prompt,
+        dispatch_id,
+        execution_mode=execution_mode,
+        **kwargs,
+    )
+
+
+def wire_default_provider_adapters(
+    *,
+    claude_dispatch: DispatchFn,
+    codex_dispatch: DispatchFn,
+    bedrock_dispatch: DispatchFn,
+) -> None:
+    """Bind live dispatch callables once lambda_function defines them."""
+    global _WIRED
+    if _WIRED:
+        return
+    register_provider_adapter("claude_agent_sdk", build_claude_adapter(claude_dispatch))
+    register_provider_adapter("openai_codex", build_codex_adapter(codex_dispatch))
+    register_provider_adapter("aws_bedrock_agent", build_bedrock_adapter(bedrock_dispatch))
+    register_provider_adapter("a2a", _A2A_ADAPTER)
+    _WIRED = True
+
+
+def reset_provider_adapters_for_tests() -> None:
+    global _WIRED
+    _ADAPTERS.clear()
+    _WIRED = False

--- a/backend/lambda/coordination_api/test_provider_adapters.py
+++ b/backend/lambda/coordination_api/test_provider_adapters.py
@@ -1,0 +1,96 @@
+"""Unit tests for provider adapter registry (ENC-TSK-L11)."""
+
+from __future__ import annotations
+
+import unittest
+
+from provider_adapters import (
+    A2AProviderAdapter,
+    get_adapter_for_execution_mode,
+    get_provider_adapter,
+    list_registered_provider_ids,
+    reset_provider_adapters_for_tests,
+    wire_default_provider_adapters,
+)
+
+
+class ProviderAdapterRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_provider_adapters_for_tests()
+
+    def tearDown(self) -> None:
+        reset_provider_adapters_for_tests()
+
+    def test_wire_registers_claude_codex_bedrock_and_a2a(self) -> None:
+        wire_default_provider_adapters(
+            claude_dispatch=lambda *_a, **_k: {"provider": "claude_agent_sdk"},
+            codex_dispatch=lambda *_a, **_k: {"provider": "openai_codex"},
+            bedrock_dispatch=lambda *_a, **_k: {"provider": "aws_bedrock_agent"},
+        )
+        self.assertEqual(
+            sorted(list_registered_provider_ids()),
+            ["a2a", "aws_bedrock_agent", "claude_agent_sdk", "openai_codex"],
+        )
+
+    def test_execution_mode_aliases_resolve(self) -> None:
+        wire_default_provider_adapters(
+            claude_dispatch=lambda *_a, **_k: {},
+            codex_dispatch=lambda *_a, **_k: {},
+            bedrock_dispatch=lambda *_a, **_k: {},
+        )
+        self.assertEqual(
+            get_adapter_for_execution_mode("codex_full_auto").provider_id,
+            "openai_codex",
+        )
+        self.assertEqual(
+            get_adapter_for_execution_mode("bedrock_agent").provider_id,
+            "aws_bedrock_agent",
+        )
+
+    def test_claude_adapter_delegates(self) -> None:
+        seen = {}
+
+        def _dispatch(request, prompt, dispatch_id):
+            seen.update(
+                {
+                    "request": request,
+                    "prompt": prompt,
+                    "dispatch_id": dispatch_id,
+                }
+            )
+            return {"provider": "claude_agent_sdk", "dispatch_id": dispatch_id}
+
+        wire_default_provider_adapters(
+            claude_dispatch=_dispatch,
+            codex_dispatch=lambda *_a, **_k: {},
+            bedrock_dispatch=lambda *_a, **_k: {},
+        )
+        adapter = get_provider_adapter("claude_agent_sdk")
+        result = adapter.dispatch({"request_id": "req-1"}, "hello", "disp-1")
+        self.assertEqual(result["provider"], "claude_agent_sdk")
+        self.assertEqual(seen["prompt"], "hello")
+
+    def test_codex_adapter_passes_execution_mode(self) -> None:
+        seen = {}
+
+        def _dispatch(request, prompt, dispatch_id, execution_mode=None):
+            seen["execution_mode"] = execution_mode
+            return {"provider": "openai_codex"}
+
+        wire_default_provider_adapters(
+            claude_dispatch=lambda *_a, **_k: {},
+            codex_dispatch=_dispatch,
+            bedrock_dispatch=lambda *_a, **_k: {},
+        )
+        adapter = get_adapter_for_execution_mode("codex_full_auto")
+        adapter.dispatch({}, None, "disp-2", execution_mode="codex_full_auto")
+        self.assertEqual(seen["execution_mode"], "codex_full_auto")
+
+    def test_a2a_adapter_is_empty_implementation(self) -> None:
+        adapter = A2AProviderAdapter()
+        with self.assertRaises(NotImplementedError):
+            adapter.dispatch({}, None, "disp-a2a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `provider_adapters` package with Claude, Codex, Bedrock, and A2A empty-impl seam
- Route managed-session dispatch through adapter registry in `lambda_function` and `handlers`
- Unit tests for registry wiring and delegation

CCI-4e4ce4f27b504081b2960357350ce455

## Test plan
- [x] `pytest test_provider_adapters.py` (5 passed)
- [ ] CI green on PR
- [ ] Gamma deploy coordination-api


Made with [Cursor](https://cursor.com)