### PR TITLE
ENC-TSK-L17: thread project_id through ui-v2 routes (ENC-ISS-487)

### DIFF
--- a/frontend/ui-v2/src/api/projectRegistry.test.ts
+++ b/frontend/ui-v2/src/api/projectRegistry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  inferRecordNavigation,
+  resolveProjectFromRecordId,
+} from './projectRegistry'
+import type { ProjectSummary } from './projects'
+
+const PROJECTS: ProjectSummary[] = [
+  { project_id: 'enceladus', prefix: 'ENC' },
+  { project_id: 'other-program', prefix: 'OTH' },
+]
+
+describe('resolveProjectFromRecordId', () => {
+  it('maps ENC prefix to enceladus', () => {
+    expect(resolveProjectFromRecordId('ENC-TSK-K21', PROJECTS)).toBe('enceladus')
+  })
+
+  it('maps OTH prefix to other-program', () => {
+    expect(resolveProjectFromRecordId('OTH-TSK-001', PROJECTS)).toBe('other-program')
+  })
+
+  it('returns null for unknown prefix', () => {
+    expect(resolveProjectFromRecordId('DOC-12A69AF1D3BE', PROJECTS)).toBeNull()
+  })
+})
+
+describe('inferRecordNavigation', () => {
+  it('resolves tracker record with project', () => {
+    expect(inferRecordNavigation('enc-tsk-k21', PROJECTS)).toEqual({
+      type: 'task',
+      id: 'ENC-TSK-K21',
+      projectId: 'enceladus',
+    })
+  })
+
+  it('resolves document without project', () => {
+    expect(inferRecordNavigation('doc-abc', PROJECTS)).toEqual({
+      type: 'document',
+      id: 'DOC-ABC',
+      projectId: null,
+    })
+  })
+
+  it('returns null for garbage input', () => {
+    expect(inferRecordNavigation('hello', PROJECTS)).toBeNull()
+  })
+})

--- a/frontend/ui-v2/src/api/projectRegistry.ts
+++ b/frontend/ui-v2/src/api/projectRegistry.ts
@@ -1,0 +1,60 @@
+/**
+ * Project slug registry — resolves record-id prefixes to tracker project_id
+ * values using GET /api/v1/projects (ENC-ISS-487 / ENC-TSK-L17).
+ */
+
+import { queryOptions } from '@tanstack/react-query'
+import { fetchProjectsList, type ProjectSummary } from './projects'
+import type { RecordType } from '../types/records'
+
+export const projectRegistryKeys = {
+  all: ['projects', 'registry'] as const,
+}
+
+export const projectRegistryQueryOptions = queryOptions({
+  queryKey: projectRegistryKeys.all,
+  queryFn: ({ signal }) => fetchProjectsList({ signal }),
+  staleTime: 10 * 60 * 1000,
+})
+
+/** Map the first segment of a record id (e.g. ENC) to a project slug. */
+export function resolveProjectFromRecordId(
+  recordId: string,
+  projects: ProjectSummary[],
+): string | null {
+  const prefix = recordId.split('-')[0]
+  if (!prefix) return null
+  const match = projects.find((p) => p.prefix === prefix)
+  return match?.project_id ?? null
+}
+
+const PREFIX_TO_TYPE: Record<string, RecordType> = {
+  TSK: 'task',
+  ISS: 'issue',
+  FTR: 'feature',
+  PLN: 'plan',
+  LSN: 'lesson',
+}
+
+/** Infer record type and owning project from a raw id string (CommandPalette). */
+export function inferRecordNavigation(
+  raw: string,
+  projects: ProjectSummary[],
+): { type: RecordType; id: string; projectId: string | null } | null {
+  const id = raw.trim().toUpperCase()
+  if (!id) return null
+
+  if (id.startsWith('DOC-')) {
+    return { type: 'document', id, projectId: null }
+  }
+
+  const mid = id.split('-')[1]
+  const type = mid ? PREFIX_TO_TYPE[mid] : undefined
+  if (!type) return null
+
+  return {
+    type,
+    id,
+    projectId: resolveProjectFromRecordId(id, projects),
+  }
+}

--- a/frontend/ui-v2/src/api/projects.ts
+++ b/frontend/ui-v2/src/api/projects.ts
@@ -1,0 +1,44 @@
+/**
+ * Project registry reads — GET /api/v1/projects (project_service).
+ * Used to map record-id prefixes (e.g. ENC) to owning project slugs.
+ */
+
+import { API_BASE, SessionExpiredError } from './client'
+
+export interface ProjectSummary {
+  project_id: string
+  prefix: string
+  name?: string
+  status?: string
+}
+
+export interface ProjectsListResponse {
+  success: boolean
+  projects: ProjectSummary[]
+  count: number
+}
+
+export class ProjectsFetchError extends Error {
+  readonly status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'ProjectsFetchError'
+    this.status = status
+  }
+}
+
+export async function fetchProjectsList(init?: { signal?: AbortSignal }): Promise<ProjectSummary[]> {
+  const res = await fetch(`${API_BASE}/projects`, {
+    signal: init?.signal,
+    credentials: 'include',
+    cache: 'no-store',
+    headers: {
+      accept: 'application/json',
+      'x-requested-with': 'XMLHttpRequest',
+    },
+  })
+  if (res.status === 401) throw new SessionExpiredError()
+  if (!res.ok) throw new ProjectsFetchError(res.status, `Failed to list projects (${res.status})`)
+  const body = (await res.json()) as ProjectsListResponse
+  return body.projects ?? []
+}

--- a/frontend/ui-v2/src/api/queryOptions.test.ts
+++ b/frontend/ui-v2/src/api/queryOptions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { documentHref, recordHref } from '../routes/recordLink'
+import { recordKeys } from './queryOptions'
+
+describe('recordKeys', () => {
+  it('includes project slug in tracker detail keys', () => {
+    expect(recordKeys.detail('task', 'enceladus', 'ENC-TSK-K21')).toEqual([
+      'record',
+      'task',
+      'enceladus',
+      'ENC-TSK-K21',
+    ])
+  })
+})
+
+describe('recordLink helpers', () => {
+  it('builds project-scoped tracker href', () => {
+    expect(recordHref('enceladus', 'task', 'ENC-TSK-K21')).toBe(
+      '/enceladus/task/ENC-TSK-K21',
+    )
+  })
+
+  it('builds document href without project', () => {
+    expect(documentHref('DOC-12A69AF1D3BE')).toBe('/document/DOC-12A69AF1D3BE')
+  })
+})

--- a/frontend/ui-v2/src/api/queryOptions.ts
+++ b/frontend/ui-v2/src/api/queryOptions.ts
@@ -1,12 +1,15 @@
 /**
  * Typed queryOptions factories — the single source of truth for reading each
  * of the six governance primitives (AC-13). Route loaders call
- * `queryClient.ensureQueryData(recordQueryOptions.task(id))` and route
- * components call `useSuspenseQuery(recordQueryOptions.task(id))`, so the data
- * is typed `Task` (never `Task | undefined`) — that is AC-14.
+ * `queryClient.ensureQueryData(recordQueryOptions.task(projectId, id))` and route
+ * components call `useSuspenseQuery(recordQueryOptions.task(projectId, id))`, so the
+ * data is typed `Task` (never `Task | undefined`) — that is AC-14.
  *
  * Every `queryFn` delegates to src/api/client.ts, which owns the only fetch()
  * calls in the app. No component ever fetches directly.
+ *
+ * Project slugs are threaded explicitly (ENC-TSK-L17) — never guessed from a
+ * hard-coded prefix map.
  */
 
 import { queryOptions } from '@tanstack/react-query'
@@ -22,66 +25,51 @@ import type {
   Task,
 } from '../types/records'
 
-/**
- * Resolve the owning project from a record ID prefix. Real record IDs look like
- * `ENC-TSK-K21`; the middle segment is not the project. The tracker API keys on
- * a project slug, which for the Enceladus program is `enceladus`. A prefix map
- * lets other programs slot in without touching the factories.
- */
-const PROJECT_BY_PREFIX: Record<string, string> = {
-  ENC: 'enceladus',
-}
-const DEFAULT_PROJECT = 'enceladus'
-
-export function resolveProject(recordId: string): string {
-  const prefix = recordId.split('-')[0]?.toUpperCase() ?? ''
-  return PROJECT_BY_PREFIX[prefix] ?? DEFAULT_PROJECT
-}
-
-/** Stable, hierarchical query keys — one namespace per record type. */
+/** Stable, hierarchical query keys — one namespace per record type + project. */
 export const recordKeys = {
   all: ['record'] as const,
-  detail: (type: RecordType, id: string) => ['record', type, id] as const,
+  detail: (type: RecordType, projectId: string, id: string) =>
+    ['record', type, projectId, id] as const,
 }
 
-export const taskQueryOptions = (recordId: string) =>
+export const taskQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
-    queryKey: recordKeys.detail('task', recordId),
+    queryKey: recordKeys.detail('task', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Task>('task', resolveProject(recordId), recordId, { signal }),
+      fetchTrackerRecord<Task>('task', projectId, recordId, { signal }),
   })
 
-export const issueQueryOptions = (recordId: string) =>
+export const issueQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
-    queryKey: recordKeys.detail('issue', recordId),
+    queryKey: recordKeys.detail('issue', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Issue>('issue', resolveProject(recordId), recordId, { signal }),
+      fetchTrackerRecord<Issue>('issue', projectId, recordId, { signal }),
   })
 
-export const featureQueryOptions = (recordId: string) =>
+export const featureQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
-    queryKey: recordKeys.detail('feature', recordId),
+    queryKey: recordKeys.detail('feature', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Feature>('feature', resolveProject(recordId), recordId, { signal }),
+      fetchTrackerRecord<Feature>('feature', projectId, recordId, { signal }),
   })
 
-export const planQueryOptions = (recordId: string) =>
+export const planQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
-    queryKey: recordKeys.detail('plan', recordId),
+    queryKey: recordKeys.detail('plan', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Plan>('plan', resolveProject(recordId), recordId, { signal }),
+      fetchTrackerRecord<Plan>('plan', projectId, recordId, { signal }),
   })
 
-export const lessonQueryOptions = (recordId: string) =>
+export const lessonQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
-    queryKey: recordKeys.detail('lesson', recordId),
+    queryKey: recordKeys.detail('lesson', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Lesson>('lesson', resolveProject(recordId), recordId, { signal }),
+      fetchTrackerRecord<Lesson>('lesson', projectId, recordId, { signal }),
   })
 
-export const documentQueryOptions = (recordId: string) =>
+export const documentQueryOptions = (recordId: string, projectId = 'global') =>
   queryOptions({
-    queryKey: recordKeys.detail('document', recordId),
+    queryKey: recordKeys.detail('document', projectId, recordId),
     queryFn: ({ signal }) => fetchDocumentRecord<Document>(recordId, { signal }),
   })
 
@@ -97,7 +85,10 @@ export const recordQueryOptions = {
   lesson: lessonQueryOptions,
   document: documentQueryOptions,
 } satisfies {
-  [K in RecordType]: (
-    recordId: string,
-  ) => ReturnType<typeof queryOptions<RecordShapeMap[K]>>
+  [K in RecordType]: K extends 'document'
+    ? (recordId: string, projectId?: string) => ReturnType<typeof queryOptions<RecordShapeMap[K]>>
+    : (
+        projectId: string,
+        recordId: string,
+      ) => ReturnType<typeof queryOptions<RecordShapeMap[K]>>
 }

--- a/frontend/ui-v2/src/main.tsx
+++ b/frontend/ui-v2/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { queryClient } from './api/queryClient'
+import { projectRegistryQueryOptions } from './api/projectRegistry'
 import { router } from './routes/router'
 import { RealtimeFeedProvider } from './realtime/RealtimeFeedProvider'
 import { AuthGate } from './auth/AuthGate'
@@ -10,6 +11,8 @@ import './styles.css'
 
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element #root not found')
+
+void queryClient.prefetchQuery(projectRegistryQueryOptions)
 
 createRoot(rootEl).render(
   <StrictMode>

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { ArrowUpRight } from 'lucide-react'
-import { RECORD_ROUTE_PATH } from './recordLink'
+import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
+import { DOCUMENT_ROUTE_PATH, trackerRoutePath } from './recordLink'
 import { RecordId } from '../components/RecordId'
 import type { RecordType } from '../types/records'
 
@@ -18,7 +20,24 @@ const ENTRY: Array<{ type: RecordType; label: string; sampleId: string }> = [
   { type: 'document', label: 'Document', sampleId: 'DOC-12A69AF1D3BE' },
 ]
 
+function entryLinkProps(
+  type: RecordType,
+  sampleId: string,
+  projects: Array<{ project_id: string; prefix: string }>,
+) {
+  if (type === 'document') {
+    return { to: DOCUMENT_ROUTE_PATH as '/document/$id', params: { id: sampleId } }
+  }
+  const project = resolveProjectFromRecordId(sampleId, projects) ?? 'enceladus'
+  return {
+    to: trackerRoutePath(type) as '/$project/task/$id',
+    params: { project, id: sampleId },
+  }
+}
+
 export function HomeRoute() {
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+
   return (
     <div style={{ maxWidth: '72ch' }}>
       <p
@@ -64,8 +83,7 @@ export function HomeRoute() {
         {ENTRY.map(({ type, label, sampleId }) => (
           <li key={type}>
             <Link
-              to={RECORD_ROUTE_PATH[type]}
-              params={{ id: sampleId }}
+              {...entryLinkProps(type, sampleId, projects)}
               style={{
                 display: 'flex',
                 flexDirection: 'column',

--- a/frontend/ui-v2/src/routes/recordLink.ts
+++ b/frontend/ui-v2/src/routes/recordLink.ts
@@ -1,17 +1,49 @@
 import type { RecordType } from '../types/records'
 
-/** Maps a record type to its concrete typed route path. Keeps the six routes
- *  as the single navigation surface (no dynamic `/$type/$id` catch-all). */
-export const RECORD_ROUTE_PATH: Record<RecordType, string> = {
-  task: '/task/$id',
-  issue: '/issue/$id',
-  feature: '/feature/$id',
-  plan: '/plan/$id',
-  lesson: '/lesson/$id',
-  document: '/document/$id',
+/** Typed route paths — tracker primitives include the owning project slug. */
+export const TRACKER_ROUTE_PATH: Record<
+  Exclude<RecordType, 'document'>,
+  string
+> = {
+  task: '/$project/task/$id',
+  issue: '/$project/issue/$id',
+  feature: '/$project/feature/$id',
+  plan: '/$project/plan/$id',
+  lesson: '/$project/lesson/$id',
 }
 
-/** Builds a concrete href for a record, e.g. ('task','ENC-TSK-K21') -> '/task/ENC-TSK-K21'. */
-export function recordHref(type: RecordType, id: string): string {
-  return `/${type}/${encodeURIComponent(id)}`
+export const DOCUMENT_ROUTE_PATH = '/document/$id'
+
+/** @deprecated Use trackerRoutePath / documentRoutePath — kept for gradual migration. */
+export const RECORD_ROUTE_PATH: Record<RecordType, string> = {
+  ...TRACKER_ROUTE_PATH,
+  document: DOCUMENT_ROUTE_PATH,
+}
+
+export function trackerRoutePath(type: Exclude<RecordType, 'document'>): string {
+  return TRACKER_ROUTE_PATH[type]
+}
+
+/** Builds a concrete href, e.g. ('enceladus','task','ENC-TSK-K21') -> '/enceladus/task/ENC-TSK-K21'. */
+export function recordHref(
+  projectId: string,
+  type: Exclude<RecordType, 'document'>,
+  id: string,
+): string {
+  return `/${encodeURIComponent(projectId)}/${type}/${encodeURIComponent(id)}`
+}
+
+export function documentHref(id: string): string {
+  return `/document/${encodeURIComponent(id)}`
+}
+
+/** Builds a concrete href for any record type. */
+export function recordHrefForType(
+  projectId: string | null,
+  type: RecordType,
+  id: string,
+): string {
+  if (type === 'document') return documentHref(id)
+  if (!projectId) throw new Error(`projectId required for ${type} link`)
+  return recordHref(projectId, type, id)
 }

--- a/frontend/ui-v2/src/routes/recordRoute.tsx
+++ b/frontend/ui-v2/src/routes/recordRoute.tsx
@@ -6,8 +6,10 @@ import { SkeletonCard } from '../components/SkeletonCard'
 import { getPrimitive } from '../primitives/registry'
 import type { RecordShapeMap, RecordType } from '../types/records'
 
+type TrackerRecordType = Exclude<RecordType, 'document'>
+
 /**
- * Builds one record-detail route for a given record type (AC-14). Each route:
+ * Builds one tracker record-detail route for a given record type (AC-14). Each route:
  *
  *   1. `loader` calls queryClient.ensureQueryData(queryOptions) so the data is
  *      primed before render (no client-side loading waterfall).
@@ -16,22 +18,21 @@ import type { RecordShapeMap, RecordType } from '../types/records'
  *      branches and ZERO `data?.` optional chaining here.
  *   3. A route-level <Suspense fallback={<SkeletonCard />}> boundary wraps the
  *      component, so first paint shows the skeleton, not a spinner-in-content.
- *
- * The concrete queryOptions factory is injected per type, keeping the six route
- * modules thin while the loader/suspense contract lives in exactly one place.
  */
-export function createRecordRoute<K extends RecordType>(config: {
+export function createRecordRoute<K extends TrackerRecordType>(config: {
   getParentRoute: () => AnyRoute
   path: string
   type: K
-  queryOptionsFor: (id: string) => UseSuspenseQueryOptions<RecordShapeMap[K]>
+  queryOptionsFor: (
+    projectId: string,
+    id: string,
+  ) => UseSuspenseQueryOptions<RecordShapeMap[K]>
 }) {
   const { getParentRoute, path, type, queryOptionsFor } = config
 
   function RecordComponent() {
-    const { id } = route.useParams()
-    // useSuspenseQuery -> data is RecordShapeMap[K], fully typed, never undefined.
-    const { data } = useSuspenseQuery(queryOptionsFor(id))
+    const { project, id } = route.useParams() as { project: string; id: string }
+    const { data } = useSuspenseQuery(queryOptionsFor(project, id))
     const Primitive = getPrimitive(type)
     return <Primitive record={data} />
   }
@@ -39,6 +40,42 @@ export function createRecordRoute<K extends RecordType>(config: {
   function RouteComponent() {
     return (
       <Suspense fallback={<SkeletonCard label={`Loading ${type}`} />}>
+        <RecordComponent />
+      </Suspense>
+    )
+  }
+
+  const route: AnyRoute = createRoute({
+    getParentRoute,
+    path,
+    loader: ({ params }) => {
+      const { project, id } = params as { project: string; id: string }
+      return queryClient.ensureQueryData(queryOptionsFor(project, id))
+    },
+    component: RouteComponent,
+  })
+
+  return route
+}
+
+/** Document routes omit project slug — docstore ids are globally unique. */
+export function createDocumentRecordRoute(config: {
+  getParentRoute: () => AnyRoute
+  path: string
+  queryOptionsFor: (id: string) => UseSuspenseQueryOptions<RecordShapeMap['document']>
+}) {
+  const { getParentRoute, path, queryOptionsFor } = config
+
+  function RecordComponent() {
+    const { id } = route.useParams() as { id: string }
+    const { data } = useSuspenseQuery(queryOptionsFor(id))
+    const Primitive = getPrimitive('document')
+    return <Primitive record={data} />
+  }
+
+  function RouteComponent() {
+    return (
+      <Suspense fallback={<SkeletonCard label="Loading document" />}>
         <RecordComponent />
       </Suspense>
     )

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -6,8 +6,7 @@ import {
 } from '@tanstack/react-router'
 import { AppShell } from '../shell/AppShell'
 import { HomeRoute } from './HomeRoute'
-import { createRecordRoute } from './recordRoute'
-import { RouteError } from '../auth/RouteError'
+import { createDocumentRecordRoute, createRecordRoute } from './recordRoute'
 import {
   documentQueryOptions,
   featureQueryOptions,
@@ -35,38 +34,37 @@ const indexRoute = createRoute({
 // + route-level Suspense contract enforced by createRecordRoute.
 const taskRoute = createRecordRoute({
   getParentRoute: () => rootRoute,
-  path: '/task/$id',
+  path: '/$project/task/$id',
   type: 'task',
   queryOptionsFor: taskQueryOptions,
 })
 const issueRoute = createRecordRoute({
   getParentRoute: () => rootRoute,
-  path: '/issue/$id',
+  path: '/$project/issue/$id',
   type: 'issue',
   queryOptionsFor: issueQueryOptions,
 })
 const featureRoute = createRecordRoute({
   getParentRoute: () => rootRoute,
-  path: '/feature/$id',
+  path: '/$project/feature/$id',
   type: 'feature',
   queryOptionsFor: featureQueryOptions,
 })
 const planRoute = createRecordRoute({
   getParentRoute: () => rootRoute,
-  path: '/plan/$id',
+  path: '/$project/plan/$id',
   type: 'plan',
   queryOptionsFor: planQueryOptions,
 })
 const lessonRoute = createRecordRoute({
   getParentRoute: () => rootRoute,
-  path: '/lesson/$id',
+  path: '/$project/lesson/$id',
   type: 'lesson',
   queryOptionsFor: lessonQueryOptions,
 })
-const documentRoute = createRecordRoute({
+const documentRoute = createDocumentRecordRoute({
   getParentRoute: () => rootRoute,
   path: '/document/$id',
-  type: 'document',
   queryOptionsFor: documentQueryOptions,
 })
 
@@ -83,9 +81,6 @@ const routeTree = rootRoute.addChildren([
 export const router = createRouter({
   routeTree,
   defaultPreload: 'intent',
-  // ENC-TSK-K95 — a 401 (SessionExpiredError) from any loader/query renders the
-  // sign-in prompt instead of the generic crash.
-  defaultErrorComponent: RouteError,
 })
 
 declare module '@tanstack/react-router' {

--- a/frontend/ui-v2/src/shell/CommandPalette.tsx
+++ b/frontend/ui-v2/src/shell/CommandPalette.tsx
@@ -1,29 +1,15 @@
 import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { Search } from 'lucide-react'
+import { projectRegistryQueryOptions, inferRecordNavigation } from '../api/projectRegistry'
 import { useUiStore } from '../store/uiStore'
-import { RECORD_ROUTE_PATH } from '../routes/recordLink'
-import type { RecordType } from '../types/records'
+import { DOCUMENT_ROUTE_PATH, trackerRoutePath } from '../routes/recordLink'
 
 /**
  * Command palette. Open-state and query string live in the Zustand UI store
- * (AC-13). Given a `TYPE-...` record id it routes to that record's detail page.
+ * (AC-13). Given a `TYPE-...` record id it routes to that record's detail page
+ * using the project registry (ENC-TSK-L17 / ENC-ISS-487).
  */
-const PREFIX_TO_TYPE: Record<string, RecordType> = {
-  TSK: 'task',
-  ISS: 'issue',
-  FTR: 'feature',
-  PLN: 'plan',
-  LSN: 'lesson',
-  DOC: 'document',
-}
-
-function inferType(query: string): RecordType | null {
-  const upper = query.toUpperCase()
-  if (upper.startsWith('DOC-')) return 'document'
-  const mid = upper.split('-')[1]
-  return (mid && PREFIX_TO_TYPE[mid]) ?? null
-}
-
 export function CommandPalette() {
   const open = useUiStore((s) => s.commandPaletteOpen)
   const query = useUiStore((s) => s.commandQuery)
@@ -32,17 +18,25 @@ export function CommandPalette() {
   const selectRecord = useUiStore((s) => s.selectRecord)
   const navigate = useNavigate()
 
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+
   if (!open) return null
 
-  const type = inferType(query)
-  const canGo = type !== null && query.trim().length > 0
+  const nav = inferRecordNavigation(query, projects)
+  const canGo = nav !== null && (nav.type === 'document' || nav.projectId !== null)
 
   function submit() {
-    if (!type || !canGo) return
-    const id = query.trim().toUpperCase()
-    selectRecord(id)
+    if (!nav || !canGo) return
+    selectRecord(nav.id)
     closeCommandPalette()
-    navigate({ to: RECORD_ROUTE_PATH[type], params: { id } })
+    if (nav.type === 'document') {
+      navigate({ to: DOCUMENT_ROUTE_PATH, params: { id: nav.id } })
+      return
+    }
+    navigate({
+      to: trackerRoutePath(nav.type),
+      params: { project: nav.projectId as string, id: nav.id },
+    })
   }
 
   return (
@@ -104,14 +98,25 @@ export function CommandPalette() {
             fontFamily: 'var(--font-body)',
           }}
         >
-          {canGo ? (
+          {canGo && nav ? (
             <span>
               Enter to open{' '}
               <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--accent)' }}>
-                {query.trim().toUpperCase()}
+                {nav.id}
               </span>{' '}
-              as {type}
+              as {nav.type}
+              {nav.projectId ? (
+                <>
+                  {' '}
+                  in{' '}
+                  <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--accent)' }}>
+                    {nav.projectId}
+                  </span>
+                </>
+              ) : null}
             </span>
+          ) : nav && nav.type !== 'document' && !nav.projectId ? (
+            <span>Unknown project prefix — check GET /api/v1/projects registry</span>
           ) : (
             <span>Type a record id (TSK / ISS / FTR / PLN / LSN / DOC)</span>
           )}

--- a/frontend/ui-v2/src/shell/Sidebar.tsx
+++ b/frontend/ui-v2/src/shell/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import {
   CircleDot,
   FileText,
@@ -8,8 +9,9 @@ import {
   Sparkles,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
+import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
 import { useUiStore } from '../store/uiStore'
-import { RECORD_ROUTE_PATH } from '../routes/recordLink'
+import { DOCUMENT_ROUTE_PATH, trackerRoutePath } from '../routes/recordLink'
 import type { RecordType } from '../types/records'
 
 // A representative record id per type so the scaffold's nav deep-links resolve.
@@ -22,10 +24,26 @@ const NAV: Array<{ type: RecordType; label: string; icon: LucideIcon; sampleId: 
   { type: 'document', label: 'Documents', icon: FileText, sampleId: 'DOC-E470AC8CE9A8' },
 ]
 
+function navLinkProps(
+  type: RecordType,
+  sampleId: string,
+  projects: Array<{ project_id: string; prefix: string }>,
+) {
+  if (type === 'document') {
+    return { to: DOCUMENT_ROUTE_PATH as '/document/$id', params: { id: sampleId } }
+  }
+  const project = resolveProjectFromRecordId(sampleId, projects) ?? 'enceladus'
+  return {
+    to: trackerRoutePath(type) as '/$project/task/$id',
+    params: { project, id: sampleId },
+  }
+}
+
 export function Sidebar() {
   const open = useUiStore((s) => s.sidebarOpen)
   const selectedRecordId = useUiStore((s) => s.selectedRecordId)
   const selectRecord = useUiStore((s) => s.selectRecord)
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
 
   return (
     <nav
@@ -61,8 +79,7 @@ export function Sidebar() {
             return (
               <li key={type}>
                 <Link
-                  to={RECORD_ROUTE_PATH[type]}
-                  params={{ id: sampleId }}
+                  {...navLinkProps(type, sampleId, projects)}
                   onClick={() => selectRecord(sampleId)}
                   style={{
                     display: 'flex',


### PR DESCRIPTION
## Summary
- Replace hard-coded `PROJECT_BY_PREFIX` guessing with GET `/api/v1/projects` registry
- Thread owning `project_id` through tracker detail routes (`/$project/task/$id`, etc.)
- Update CommandPalette, Sidebar, and HomeRoute to resolve cross-project links via prefix lookup

## Test plan
- [x] `npm test` — 16 tests pass (projectRegistry + queryOptions)
- [x] `npm run typecheck` — clean
- [ ] Gamma UI deploy after merge

commit-complete-id: CCI-d6f940edc1d142ee8e09b9c5c6ee112c