### PR TITLE
ENC-TSK-L14 — EventBridge Pipes replace tracker stream glue (B65 AC-5)

### DIFF
--- a/backend/lambda/convergence_telemetry/lambda_function.py
+++ b/backend/lambda/convergence_telemetry/lambda_function.py
@@ -1,9 +1,9 @@
 """enceladus-convergence-telemetry Lambda (ENC-FTR-086 Ph1 / ENC-TSK-I82).
 
 The Convergence Surface fan-out + increment Lambda. A single deployed function
-serves two event sources, dispatched on ``eventSource``:
+serves two event sources, dispatched on the normalized record shape:
 
-1. DynamoDB Stream (tracker table) -> FAN-OUT (AC-2)
+1. DynamoDB Stream (tracker table) via EventBridge Pipe -> FAN-OUT (AC-2)
    For each INSERT/MODIFY tracker record, canonicalize the open-taxonomy field
    values (category, priority, tags) and emit one SQS FIFO message per
    (attribute, canonical_value), partitioned by attribute_name (MessageGroupId)
@@ -222,15 +222,33 @@ def _handle_increment(records: List[Dict[str, Any]]) -> Dict[str, Any]:
 # Entry point
 # ---------------------------------------------------------------------------
 
+def _collect_records(event: Any) -> List[Dict[str, Any]]:
+    """Normalize records from SQS, direct stream, or EventBridge Pipe invokes."""
+    if isinstance(event, list):
+        return [item for item in event if isinstance(item, dict)]
+
+    if not isinstance(event, dict):
+        return []
+
+    records = event.get("Records", [])
+    if records:
+        return records
+
+    if "dynamodb" in event:
+        return [event]
+
+    return []
+
+
 def handler(event: Dict[str, Any], context: Any = None) -> Dict[str, Any]:
-    records = event.get("Records", []) if isinstance(event, dict) else []
+    records = _collect_records(event)
     if not records:
         return {"status": "noop", "reason": "no records"}
 
     source = records[0].get("eventSource") or records[0].get("EventSource") or ""
     if source == "aws:sqs":
         return _handle_increment(records)
-    if source == "aws:dynamodb":
+    if source == "aws:dynamodb" or "dynamodb" in records[0]:
         return _handle_fanout(records)
 
     logger.warning("convergence: unrecognized event source %r", source)

--- a/backend/lambda/convergence_telemetry/test_handler.py
+++ b/backend/lambda/convergence_telemetry/test_handler.py
@@ -88,6 +88,34 @@ class TestFanout(unittest.TestCase):
         # Every message carries an explicit FIFO dedup id.
         self.assertTrue(all(m.get("MessageDeduplicationId") for m in sent))
 
+    def test_pipe_direct_stream_record_fanout(self):
+        sent = []
+
+        class FakeSqs:
+            def send_message(self, **kw):
+                sent.append(kw)
+
+        orig_sqs, orig_url = lf._sqs, lf.QUEUE_URL
+        lf._sqs = FakeSqs()
+        lf.QUEUE_URL = "https://sqs.example/q.fifo"
+        try:
+            out = lf.handler(
+                _stream_record(
+                    {
+                        "project_id": {"S": "enceladus"},
+                        "record_type": {"S": "task"},
+                        "record_id": {"S": "ENC-TSK-L14"},
+                        "updated_at": {"S": "2026-07-05T06:00:00Z"},
+                        "category": {"S": "Implementation"},
+                    }
+                )
+            )
+        finally:
+            lf._sqs, lf.QUEUE_URL = orig_sqs, orig_url
+
+        self.assertEqual(out["fanned_out"], 1)
+        self.assertEqual(len(sent), 1)
+
 
 class TestIncrementDispatch(unittest.TestCase):
     def test_handle_increment_idempotent_across_batch(self):

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.1",
-  "updated_at": "2026-07-05T06:16:00Z",
-  "last_change_summary": "ENC-TSK-L11: provider_adapters package + dispatch registry wiring in coordination_api (Claude/Codex/Bedrock/A2A seam). No governed record schema or enum change; dictionary bump satisfies CI guard for handlers.py/lambda_function.py touch.",
+  "version": "2026-07-05.2",
+  "updated_at": "2026-07-05T06:35:00Z",
+  "last_change_summary": "ENC-TSK-L14: migrate governance-audit + convergence-telemetry tracker stream triggers to EventBridge Pipes (Pipe->Lambda). Handler touch only; no governed record schema change — dictionary bump satisfies CI guard.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/governance_audit/README.md
+++ b/backend/lambda/governance_audit/README.md
@@ -43,9 +43,8 @@ aws lambda get-function-configuration \
   --function-name enceladus-governance-audit \
   --region us-west-2
 
-aws lambda list-event-source-mappings \
-  --function-name enceladus-governance-audit \
-  --region us-west-2
+aws pipes list-pipes --region us-west-2 \
+  --query "Pipes[?contains(Name, 'governance-audit')].[Name,CurrentState,Source,Target]"
 ```
 
 Runtime smoke test:

--- a/backend/lambda/governance_audit/lambda_function.py
+++ b/backend/lambda/governance_audit/lambda_function.py
@@ -197,25 +197,41 @@ def _publish_alert(
 # Lambda handler
 # ---------------------------------------------------------------------------
 
-def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """Process DynamoDB Streams events and detect write-source anomalies.
+def _collect_stream_records(event: Any) -> List[Dict[str, Any]]:
+    """Normalize DynamoDB stream records from direct, SQS-wrapped, or Pipe invokes."""
+    if isinstance(event, list):
+        return [item for item in event if isinstance(item, dict) and item.get("dynamodb")]
 
-    Supports both direct DynamoDB Streams trigger and SQS-wrapped events.
-    """
-    records: List[Dict[str, Any]] = []
+    if not isinstance(event, dict):
+        return []
 
-    # Handle SQS-wrapped events (EventBridge Pipe -> SQS -> Lambda)
     if "Records" in event and event["Records"]:
         first = event["Records"][0]
         if first.get("eventSource") == "aws:sqs":
+            records: List[Dict[str, Any]] = []
             for sqs_record in event["Records"]:
                 body = json.loads(sqs_record.get("body", "{}"))
                 if isinstance(body, list):
                     records.extend(body)
                 elif isinstance(body, dict) and "dynamodb" in body:
                     records.append(body)
-        elif first.get("eventSource") == "aws:dynamodb":
-            records = event["Records"]
+            return records
+        if first.get("eventSource") == "aws:dynamodb":
+            return event["Records"]
+
+    if "dynamodb" in event:
+        return [event]
+
+    return []
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Process DynamoDB Streams events and detect write-source anomalies.
+
+    Supports direct DynamoDB Streams triggers, SQS-wrapped events, and
+    EventBridge Pipe -> Lambda invocations (ENC-TSK-L14).
+    """
+    records = _collect_stream_records(event)
 
     total = len(records)
     anomalies = 0

--- a/backend/lambda/governance_audit/test_lambda_function.py
+++ b/backend/lambda/governance_audit/test_lambda_function.py
@@ -116,3 +116,50 @@ def test_sqs_wrapped_unknown_channel_detected(monkeypatch):
     assert result == {"processed": 1, "clean": 0, "anomalies": 1}
     assert len(seen) == 1
     assert seen[0][0]["type"] == "UNKNOWN_CHANNEL"
+
+
+def test_pipe_direct_stream_record_detected(monkeypatch):
+    seen = []
+    monkeypatch.setattr(mod, "_publish_alert", lambda anomaly, image, event_name: seen.append((anomaly, image, event_name)))
+
+    event = _stream_record(
+        "INSERT",
+        _attr_map(
+            {
+                "project_id": "enceladus",
+                "record_id": "task#ENC-TSK-L14-TEST",
+                "item_id": "ENC-TSK-L14-TEST",
+                "record_type": "task",
+                "status": "open",
+            }
+        ),
+    )
+
+    result = mod.handler(event, None)
+
+    assert result == {"processed": 1, "clean": 0, "anomalies": 1}
+    assert len(seen) == 1
+
+
+def test_pipe_batch_list_detected(monkeypatch):
+    monkeypatch.setattr(mod, "_publish_alert", lambda anomaly, image, event_name: None)
+
+    event = [
+        _stream_record(
+            "MODIFY",
+            _attr_map(
+                {
+                    "project_id": "enceladus",
+                    "record_id": "task#ENC-TSK-L14-TEST-B",
+                    "item_id": "ENC-TSK-L14-TEST-B",
+                    "record_type": "task",
+                    "status": "open",
+                    "write_source": {"channel": "mcp_server"},
+                }
+            ),
+        )
+    ]
+
+    result = mod.handler(event, None)
+
+    assert result == {"processed": 1, "clean": 1, "anomalies": 0}

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2367,36 +2367,68 @@ Resources:
       Enabled: true
 
   # ---------------------------------------------------------------------------
-  # DynamoDB Stream -> Lambda (Governance Audit)
+  # EventBridge Pipes (Tracker Stream -> Lambda) — replace direct stream glue
+  # ENC-TSK-L14 / B65 AC-5: migrate GovernanceAudit + ConvergenceTelemetry
+  # DynamoDB Stream EventSourceMappings to EventBridge Pipes.
   # ---------------------------------------------------------------------------
 
-  GovernanceAuditStreamTrigger:
-    Type: AWS::Lambda::EventSourceMapping
+  TrackerToGovernanceAuditPipe:
+    Type: AWS::Pipes::Pipe
     DeletionPolicy: Retain
     Properties:
-      EventSourceArn: !ImportValue
+      Name: !Sub "enceladus-tracker-to-governance-audit${EnvironmentSuffix}"
+      RoleArn: !GetAtt GovernanceAuditPipeRole.Arn
+      Source: !ImportValue
         Fn::Sub: ${DataStackName}-TrackerStreamArn
-      FunctionName: !Ref GovernanceAuditFunction
-      BatchSize: 25
-      MaximumBatchingWindowInSeconds: 30
-      StartingPosition: LATEST
-      Enabled: true
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"],"dynamodb":{"NewImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+      Target: !GetAtt GovernanceAuditFunction.Arn
+      TargetParameters:
+        LambdaFunctionParameters:
+          InvocationType: FIRE_AND_FORGET
 
-  # ENC-FTR-086 Ph1 / ENC-TSK-I82: tracker DynamoDB Stream -> convergence fan-out.
-  ConvergenceStreamTrigger:
-    Type: AWS::Lambda::EventSourceMapping
+  GovernanceAuditPipeInvokePermission:
+    Type: AWS::Lambda::Permission
+    DependsOn: TrackerToGovernanceAuditPipe
+    Properties:
+      FunctionName: !Ref GovernanceAuditFunction
+      Action: lambda:InvokeFunction
+      Principal: pipes.amazonaws.com
+      SourceArn: !GetAtt TrackerToGovernanceAuditPipe.Arn
+
+  TrackerToConvergenceTelemetryPipe:
+    Type: AWS::Pipes::Pipe
     DeletionPolicy: Retain
     Properties:
-      EventSourceArn: !ImportValue
+      Name: !Sub "enceladus-tracker-to-convergence-telemetry${EnvironmentSuffix}"
+      RoleArn: !GetAtt ConvergenceTelemetryPipeRole.Arn
+      Source: !ImportValue
         Fn::Sub: ${DataStackName}-TrackerStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+      Target: !GetAtt ConvergenceTelemetryFunction.Arn
+      TargetParameters:
+        LambdaFunctionParameters:
+          InvocationType: FIRE_AND_FORGET
+
+  ConvergenceTelemetryPipeInvokePermission:
+    Type: AWS::Lambda::Permission
+    DependsOn: TrackerToConvergenceTelemetryPipe
+    Properties:
       FunctionName: !Ref ConvergenceTelemetryFunction
-      BatchSize: 25
-      MaximumBatchingWindowInSeconds: 30
-      StartingPosition: LATEST
-      FilterCriteria:
-        Filters:
-          - Pattern: '{"eventName":["INSERT","MODIFY"]}'
-      Enabled: true
+      Action: lambda:InvokeFunction
+      Principal: pipes.amazonaws.com
+      SourceArn: !GetAtt TrackerToConvergenceTelemetryPipe.Arn
 
   # ENC-FTR-086 Ph1 / ENC-TSK-I82: convergence SQS FIFO -> idempotent increment.
   ConvergenceSqsTrigger:
@@ -4280,19 +4312,6 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: DynamoDBStreamEventSource
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ConsumeTrackerStream
-                Effect: Allow
-                Action:
-                  - dynamodb:GetRecords
-                  - dynamodb:GetShardIterator
-                  - dynamodb:DescribeStream
-                  - dynamodb:ListStreams
-                Resource: !ImportValue
-                  Fn::Sub: ${DataStackName}-TrackerStreamArn
         - PolicyName: CloudWatchLogs
           PolicyDocument:
             Version: '2012-10-17'
@@ -4717,6 +4736,41 @@ Resources:
   # D1 architectural separation: read-only on the tracker STREAM (never the
   # governance tables) + read/write only on its own counter table + consume/send
   # on its own FIFO queue. Governance Lambdas have no access to the counter table.
+  ConvergenceTelemetryPipeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-convergence-telemetry-pipe-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: pipes.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PipeSourceTrackerStream
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+        - PolicyName: PipeTargetConvergenceTelemetryLambda
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeConvergenceTelemetry
+                Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt ConvergenceTelemetryFunction.Arn
+
   ConvergenceTelemetryRole:
     Type: AWS::IAM::Role
     DeletionPolicy: Retain
@@ -4730,19 +4784,6 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: ReadTrackerStream
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ConsumeTrackerStream
-                Effect: Allow
-                Action:
-                  - dynamodb:GetRecords
-                  - dynamodb:GetShardIterator
-                  - dynamodb:DescribeStream
-                  - dynamodb:ListStreams
-                Resource: !ImportValue
-                  Fn::Sub: ${DataStackName}-TrackerStreamArn
         - PolicyName: ConvergenceQueue
           PolicyDocument:
             Version: '2012-10-17'
@@ -5343,6 +5384,41 @@ Resources:
       Tags:
         - Key: Project
           Value: enceladus
+
+  GovernanceAuditPipeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-governance-audit-pipe-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: pipes.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PipeSourceTrackerStream
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+        - PolicyName: PipeTargetGovernanceAuditLambda
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeGovernanceAudit
+                Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt GovernanceAuditFunction.Arn
 
   GraphPipeRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary
- Replace direct DynamoDB Stream `EventSourceMapping` glue on `enceladus-governance-audit` and `enceladus-convergence-telemetry` with two EventBridge Pipes (`TrackerToGovernanceAuditPipe`, `TrackerToConvergenceTelemetryPipe`)
- Add pipe IAM roles + Lambda invoke permissions; drop stream-consumer IAM from the Lambda roles
- Update both handlers to accept Pipe -> Lambda payloads (single record or batch list); unit tests added

CCI-e8896d3c50ba4ac69bedb840a9e03761

## Test plan
- [x] `pytest backend/lambda/governance_audit/test_lambda_function.py`
- [x] `pytest backend/lambda/convergence_telemetry/test_handler.py`
- [ ] Merge + gamma deploy (`Deploy → v4-gamma`)
- [ ] Verify pipes RUNNING: `enceladus-tracker-to-governance-audit-gamma`, `enceladus-tracker-to-convergence-telemetry-gamma`
- [ ] Confirm no remaining tracker-stream EventSourceMappings on those Lambdas

Made with [Cursor](https://cursor.com)