### PR TITLE
fix(ui-v2): design-system-2 CSS import (L17 deploy unblock)

### DIFF
--- a/frontend/ui-v2/src/styles.css
+++ b/frontend/ui-v2/src/styles.css
@@ -1,6 +1,6 @@
 /* ENC-TSK-K21 · Global styles for PWA 2.0.
  *
- * Design contract (see frontend/design-system/README.md + SKILL.md "Five Laws"):
+ * Design contract (see frontend/design-system-2/README.md + SKILL.md "Five Laws"):
  *   - Void canvas via var(--enc-void); content emerges like starlight.
  *   - Teal-alpha borders; 8px card radii (var(--radius-lg)).
  *   - cubic-bezier(0.4,0,0.2,1) "orbital" easing (var(--ease-orbit)).
@@ -10,7 +10,7 @@
 
 /* Design-system tokens: the canonical --enc-* palette, type scale, radii,
  * easing and the semantic element styles. Imported, never copied. */
-@import '../../design-system/colors_and_type.css';
+@import '../../design-system-2/colors_and_type.css';
 
 /* Tailwind v4 — utilities layered on top of the token system. */
 @import 'tailwindcss';


### PR DESCRIPTION
## Summary
Fix broken `@import` in ui-v2 styles.css — `colors_and_type.css` lives under `frontend/design-system-2/`, unblocking the ui-v2 PWA deploy workflow for ENC-TSK-L17.

## Test plan
- [x] `npm run build` passes locally

commit-complete-id: CCI-d6f940edc1d142ee8e09b9c5c6ee112c

Made with [Cursor](https://cursor.com)