### PR TITLE
ENC-TSK-L22: hybrid graphsearch fetcher + tiered search merge (FTR-127)

### DIFF
--- a/frontend/ui-v2/src/api/client.ts
+++ b/frontend/ui-v2/src/api/client.ts
@@ -12,6 +12,8 @@
  *   - 401 -> SessionExpiredError, 404 -> NotFoundError.
  */
 
+import type { HybridGraphsearchResponse, HybridSearchParams } from '../types/search'
+
 /**
  * Read API base URL. Defaults to `/api/v1`, matching the existing app's
  * `normalizeApiBaseUrl(import.meta.env.VITE_API_BASE_URL)` default in
@@ -39,6 +41,17 @@ export class NotFoundError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'NotFoundError'
+  }
+}
+
+/** Graph index unavailable (503 GRAPH_UNAVAILABLE) — fall back to local/tracker reads. */
+export class GraphUnavailableError extends Error {
+  readonly status = 503
+  readonly fallbackHint?: string
+  constructor(message: string, fallbackHint?: string) {
+    super(message)
+    this.name = 'GraphUnavailableError'
+    this.fallbackHint = fallbackHint
   }
 }
 
@@ -108,4 +121,42 @@ export async function fetchDocumentRecord<T>(
   const url = `${API_BASE}/documents/${encodeURIComponent(documentId)}`
   const body = await requestJson<{ document?: T } & Record<string, unknown>>(url, init)
   return (body.document ?? (body as unknown)) as T
+}
+
+/**
+ * Hybrid graphsearch (FTR-127 / ENC-TSK-L22). Live gamma endpoint:
+ * GET /api/v1/tracker/graphsearch?search_type=hybrid&project_id=...
+ */
+export async function fetchHybridGraphsearch(
+  params: HybridSearchParams,
+  init?: FetchInit,
+): Promise<HybridGraphsearchResponse> {
+  const qs = new URLSearchParams({
+    search_type: 'hybrid',
+    project_id: params.projectId,
+  })
+  if (params.query?.trim()) qs.set('query', params.query.trim())
+  if (params.anchorRecordId?.trim()) qs.set('anchor_record_id', params.anchorRecordId.trim())
+  if (params.recordType) qs.set('record_type', params.recordType)
+  if (params.topN != null) qs.set('top_n', String(params.topN))
+  if (params.includeBelowThreshold) qs.set('include_below_threshold', 'true')
+
+  const url = `${API_BASE}/tracker/graphsearch?${qs.toString()}`
+  const res = await fetch(url, {
+    signal: init?.signal,
+    headers: withDefaultHeaders(init?.headers),
+    credentials: 'include',
+    cache: 'no-store',
+  })
+  if (res.status === 401) throw new SessionExpiredError()
+  if (res.status === 404) throw new NotFoundError(`Not found: ${url}`)
+  if (res.status === 503) {
+    const body = (await res.json().catch(() => ({}))) as { message?: string; fallback_hint?: string }
+    throw new GraphUnavailableError(
+      body.message ?? 'Graph index temporarily unavailable',
+      body.fallback_hint,
+    )
+  }
+  if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
+  return (await res.json()) as HybridGraphsearchResponse
 }

--- a/frontend/ui-v2/src/api/searchQueryOptions.ts
+++ b/frontend/ui-v2/src/api/searchQueryOptions.ts
@@ -1,0 +1,33 @@
+import { queryOptions } from '@tanstack/react-query'
+import { fetchHybridGraphsearch, GraphUnavailableError } from './client'
+import type { HybridSearchParams } from '../types/search'
+
+/** Stable key namespace for hybrid graphsearch reads (ENC-TSK-L22). */
+export const searchKeys = {
+  all: ['search'] as const,
+  hybrid: (params: HybridSearchParams) =>
+    [
+      'search',
+      'hybrid',
+      {
+        projectId: params.projectId,
+        query: params.query ?? '',
+        anchorRecordId: params.anchorRecordId ?? '',
+        recordType: params.recordType ?? '',
+        topN: params.topN ?? 20,
+        includeBelowThreshold: params.includeBelowThreshold ?? false,
+      },
+    ] as const,
+}
+
+export const hybridSearchQueryOptions = (params: HybridSearchParams) =>
+  queryOptions({
+    queryKey: searchKeys.hybrid(params),
+    queryFn: ({ signal }) => fetchHybridGraphsearch(params, { signal }),
+    staleTime: 30_000,
+    // Hybrid is enrichment — never retry aggressively; local tier stands alone.
+    retry: (failureCount, error) => {
+      if (error instanceof GraphUnavailableError) return false
+      return failureCount < 1
+    },
+  })

--- a/frontend/ui-v2/src/components/SearchTierBadge.tsx
+++ b/frontend/ui-v2/src/components/SearchTierBadge.tsx
@@ -1,0 +1,35 @@
+import type { SearchTier } from '../types/search'
+
+const TIER_LABEL: Record<SearchTier, string> = {
+  local: 'Local',
+  hybrid: 'Hybrid',
+}
+
+const TIER_COLOR: Record<SearchTier, string> = {
+  local: 'var(--status-open)',
+  hybrid: 'var(--accent)',
+}
+
+/** Tier label for merged search results (FTR-127 — local vs hybrid semantic tier). */
+export function SearchTierBadge({ tier }: { tier: SearchTier }) {
+  const color = TIER_COLOR[tier]
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        fontFamily: 'var(--font-heading)',
+        fontSize: 'var(--text-xs)',
+        fontWeight: 'var(--fw-medium)',
+        textTransform: 'uppercase',
+        letterSpacing: 'var(--tracking-label)',
+        color,
+        border: `1px solid ${color}`,
+        borderRadius: 'var(--radius-sm)',
+        padding: '1px var(--space-2)',
+      }}
+    >
+      {TIER_LABEL[tier]}
+    </span>
+  )
+}

--- a/frontend/ui-v2/src/search/localKeywordSearch.ts
+++ b/frontend/ui-v2/src/search/localKeywordSearch.ts
@@ -1,0 +1,31 @@
+import type { LocalSearchRecord, SearchResultHit } from '../types/search'
+
+/**
+ * Tier-0 local keyword search — synchronous, bounded, intended to complete
+ * within the <100ms autosuggest SLO (FTR-127). No network I/O.
+ */
+export function searchLocalKeyword(
+  corpus: LocalSearchRecord[],
+  query: string,
+  limit = 20,
+): SearchResultHit[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+
+  const hits: SearchResultHit[] = []
+  for (const row of corpus) {
+    const idMatch = row.recordId.toLowerCase().includes(q)
+    const titleMatch = row.title.toLowerCase().includes(q)
+    if (!idMatch && !titleMatch) continue
+    hits.push({
+      recordId: row.recordId,
+      recordType: row.recordType,
+      projectId: row.projectId,
+      title: row.title,
+      status: row.status,
+      tier: 'local',
+    })
+    if (hits.length >= limit) break
+  }
+  return hits
+}

--- a/frontend/ui-v2/src/search/mergeSearchResults.test.ts
+++ b/frontend/ui-v2/src/search/mergeSearchResults.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { searchKeys } from '../api/searchQueryOptions'
+import { searchLocalKeyword } from './localKeywordSearch'
+import { hybridNodesToHits, mergeSearchResults } from './mergeSearchResults'
+import type { HybridGraphsearchResponse, LocalSearchRecord } from '../types/search'
+
+const CORPUS: LocalSearchRecord[] = [
+  {
+    recordId: 'ENC-TSK-H68',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Gamma monitoring task',
+  },
+  {
+    recordId: 'ENC-ISS-058',
+    recordType: 'issue',
+    projectId: 'enceladus',
+    title: 'Auth regression',
+  },
+]
+
+describe('searchLocalKeyword', () => {
+  it('matches title substring instantly', () => {
+    const hits = searchLocalKeyword(CORPUS, 'auth')
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.recordId).toBe('ENC-ISS-058')
+    expect(hits[0]?.tier).toBe('local')
+  })
+})
+
+describe('mergeSearchResults', () => {
+  const hybridResponse: HybridGraphsearchResponse = {
+    success: true,
+    nodes: [
+      {
+        record_id: 'ENC-TSK-K21',
+        title: 'PWA scaffold',
+        _labels: ['Task'],
+        status: 'open',
+      },
+      {
+        record_id: 'ENC-ISS-058',
+        title: 'Auth regression (graph)',
+        _labels: ['Issue'],
+      },
+    ],
+    edges: [],
+    paths: [],
+    summary: 'Hybrid: 2 nodes',
+    query_cypher: 'hybrid/multi-signal-rrf',
+    duration_ms: 42,
+    per_node_fusion: {
+      'ENC-TSK-K21': { fused_rank: 1, per_signal_ranks: { vector: 1 } },
+      'ENC-ISS-058': { fused_rank: 2 },
+    },
+  }
+
+  it('preserves local hits and adds hybrid-only rows', () => {
+    const local = searchLocalKeyword(CORPUS, 'auth')
+    const { hits, localCount, hybridCount } = mergeSearchResults(
+      local,
+      hybridResponse,
+      'enceladus',
+    )
+    expect(localCount).toBe(1)
+    expect(hybridCount).toBe(2)
+    expect(hits.map((h) => h.recordId).sort()).toEqual(['ENC-ISS-058', 'ENC-TSK-K21'])
+    const enriched = hits.find((h) => h.recordId === 'ENC-ISS-058')
+    expect(enriched?.tier).toBe('local')
+    expect(enriched?.fusion?.fused_rank).toBe(2)
+  })
+
+  it('maps hybrid nodes to hits with tier hybrid', () => {
+    const hits = hybridNodesToHits('enceladus', hybridResponse)
+    expect(hits[0]?.tier).toBe('hybrid')
+    expect(hits[0]?.recordType).toBe('task')
+  })
+})
+
+describe('searchKeys.hybrid', () => {
+  it('uses the search/hybrid namespace', () => {
+    expect(
+      searchKeys.hybrid({ projectId: 'enceladus', query: 'deploy' }),
+    ).toEqual([
+      'search',
+      'hybrid',
+      {
+        projectId: 'enceladus',
+        query: 'deploy',
+        anchorRecordId: '',
+        recordType: '',
+        topN: 20,
+        includeBelowThreshold: false,
+      },
+    ])
+  })
+})

--- a/frontend/ui-v2/src/search/mergeSearchResults.ts
+++ b/frontend/ui-v2/src/search/mergeSearchResults.ts
@@ -1,0 +1,83 @@
+import type { RecordType } from '../types/records'
+import type {
+  HybridGraphsearchNode,
+  HybridGraphsearchResponse,
+  SearchResultHit,
+  SearchTier,
+} from '../types/search'
+
+const PREFIX_TO_TYPE: Record<string, RecordType> = {
+  TSK: 'task',
+  ISS: 'issue',
+  FTR: 'feature',
+  PLN: 'plan',
+  LSN: 'lesson',
+  DOC: 'document',
+}
+
+export function inferRecordTypeFromNode(node: HybridGraphsearchNode): RecordType {
+  for (const label of node._labels ?? []) {
+    const lower = label.toLowerCase()
+    if (['task', 'issue', 'feature', 'plan', 'lesson', 'document'].includes(lower)) {
+      return lower as RecordType
+    }
+  }
+  if (node.record_id.startsWith('DOC-')) return 'document'
+  const mid = node.record_id.split('-')[1]
+  return (mid && PREFIX_TO_TYPE[mid]) ?? 'task'
+}
+
+export function hybridNodesToHits(
+  projectId: string,
+  response: HybridGraphsearchResponse,
+): SearchResultHit[] {
+  const fusion = response.per_node_fusion ?? {}
+  return (response.nodes ?? []).map((node) => {
+    const recordId = node.record_id
+    return {
+      recordId,
+      recordType: inferRecordTypeFromNode(node),
+      projectId: node.project_id ?? projectId,
+      title: node.title ?? recordId,
+      status: typeof node.status === 'string' ? node.status : undefined,
+      tier: 'hybrid' as SearchTier,
+      fusion: fusion[recordId],
+    }
+  })
+}
+
+/**
+ * Merge local (instant) and hybrid (async) tiers without blocking the local
+ * paint path. Local hits are preserved; hybrid adds unseen record_ids and
+ * attaches fusion metadata when the same id appears in both tiers.
+ */
+export function mergeSearchResults(
+  localHits: SearchResultHit[],
+  hybridResponse: HybridGraphsearchResponse | undefined,
+  projectId: string,
+): { hits: SearchResultHit[]; localCount: number; hybridCount: number } {
+  const hybridHits = hybridResponse ? hybridNodesToHits(projectId, hybridResponse) : []
+  const byId = new Map<string, SearchResultHit>()
+
+  for (const hit of localHits) {
+    byId.set(hit.recordId, hit)
+  }
+
+  for (const hit of hybridHits) {
+    const existing = byId.get(hit.recordId)
+    if (existing) {
+      byId.set(hit.recordId, {
+        ...existing,
+        fusion: hit.fusion,
+        // Keep tier=local for rows that painted instantly; fusion enriches them.
+      })
+    } else {
+      byId.set(hit.recordId, hit)
+    }
+  }
+
+  const hits = [...byId.values()]
+  const localCount = hits.filter((h) => h.tier === 'local').length
+  const hybridCount = hybridHits.length
+  return { hits, localCount, hybridCount }
+}

--- a/frontend/ui-v2/src/search/useTieredSearch.ts
+++ b/frontend/ui-v2/src/search/useTieredSearch.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { hybridSearchQueryOptions } from '../api/searchQueryOptions'
+import { searchLocalKeyword } from './localKeywordSearch'
+import { mergeSearchResults } from './mergeSearchResults'
+import type { HybridSearchParams, LocalSearchRecord, TieredSearchSnapshot } from '../types/search'
+
+/**
+ * Two-tier search hook (ENC-TSK-L22 / FTR-127 AC-14):
+ *   - Tier `local` paints synchronously from the provided corpus.
+ *   - Tier `hybrid` loads async via the live graphsearch endpoint and merges in
+ *     without blocking the local result set.
+ */
+export function useTieredSearch(
+  params: HybridSearchParams,
+  corpus: LocalSearchRecord[],
+): TieredSearchSnapshot {
+  const localHits = useMemo(
+    () => searchLocalKeyword(corpus, params.query ?? ''),
+    [corpus, params.query],
+  )
+
+  const hybridEnabled =
+    Boolean(params.projectId) &&
+    Boolean((params.query ?? '').trim() || params.anchorRecordId)
+
+  const hybridQuery = useQuery({
+    ...hybridSearchQueryOptions(params),
+    enabled: hybridEnabled,
+  })
+
+  const merged = useMemo(
+    () => mergeSearchResults(localHits, hybridQuery.data, params.projectId),
+    [localHits, hybridQuery.data, params.projectId],
+  )
+
+  return {
+    hits: merged.hits,
+    localCount: merged.localCount,
+    hybridCount: merged.hybridCount,
+    hybridPending: hybridEnabled && hybridQuery.isFetching,
+    hybridError: hybridQuery.error instanceof Error ? hybridQuery.error : null,
+    signalAvailability: hybridQuery.data?.signal_availability,
+    summary: hybridQuery.data?.summary,
+  }
+}

--- a/frontend/ui-v2/src/types/search.ts
+++ b/frontend/ui-v2/src/types/search.ts
@@ -1,0 +1,78 @@
+import type { RecordType } from './records'
+
+/** Client-side instant tier (keyword/facet over local corpus). */
+export type SearchTier = 'local' | 'hybrid'
+
+export interface HybridSearchParams {
+  projectId: string
+  query?: string
+  anchorRecordId?: string
+  recordType?: RecordType
+  topN?: number
+  includeBelowThreshold?: boolean
+}
+
+export interface HybridGraphsearchNode {
+  record_id: string
+  project_id?: string
+  title?: string
+  status?: string
+  _labels?: string[]
+  [key: string]: unknown
+}
+
+export interface HybridGraphsearchResponse {
+  success: boolean
+  nodes: HybridGraphsearchNode[]
+  edges: unknown[]
+  paths: unknown[]
+  summary: string
+  query_cypher: string
+  duration_ms: number
+  signal_availability?: { vector: boolean; graph: boolean; keyword: boolean }
+  graph_algorithm?: string
+  rrf_k?: number
+  per_node_fusion?: Record<
+    string,
+    {
+      fused_rank?: number
+      fused_score?: number
+      per_signal_ranks?: Record<string, number>
+      final_rank?: number
+      final_score?: number
+    }
+  >
+  fallback_hint?: string
+}
+
+export interface SearchResultHit {
+  recordId: string
+  recordType: RecordType
+  projectId: string
+  title: string
+  status?: string
+  tier: SearchTier
+  fusion?: HybridGraphsearchResponse['per_node_fusion'] extends Record<string, infer V>
+    ? V
+    : never
+}
+
+/** Minimal row the local keyword tier searches (feed snapshot, cache index, etc.). */
+export interface LocalSearchRecord {
+  recordId: string
+  recordType: RecordType
+  projectId: string
+  title: string
+  status?: string
+}
+
+export interface TieredSearchSnapshot {
+  /** Merged view — local hits first, then hybrid-only additions. */
+  hits: SearchResultHit[]
+  localCount: number
+  hybridCount: number
+  hybridPending: boolean
+  hybridError: Error | null
+  signalAvailability?: HybridGraphsearchResponse['signal_availability']
+  summary?: string
+}


### PR DESCRIPTION
## Summary
- Add `fetchHybridGraphsearch` against live `GET /api/v1/tracker/graphsearch?search_type=hybrid`
- TanStack queryOptions under `['search','hybrid', params]`
- Local keyword tier (sync) + async hybrid merge with tier labels via `useTieredSearch`

## Test plan
- [x] 20 vitest tests pass (including merge + query key coverage)
- [x] `npm run typecheck` clean
- [ ] Gamma ui-v2 deploy after merge

commit-complete-id: CCI-5aeabc17e7ec43cc9fdc8fe025b30422

Made with [Cursor](https://cursor.com)