### PR TITLE
ENC-TSK-L19: feed as Search2.0 results (PropertyFilter + Cards)

### DIFF
--- a/frontend/ui-v2/src/design-system/index.d.ts
+++ b/frontend/ui-v2/src/design-system/index.d.ts
@@ -2,3 +2,8 @@ export { AppLayout } from '../../../design-system-2/v2/components/AppLayout/AppL
 export { SideNavigation } from '../../../design-system-2/v2/components/SideNavigation/SideNavigation.jsx'
 export { TopNavigation } from '../../../design-system-2/v2/components/TopNavigation/TopNavigation.jsx'
 export { Button } from '../../../design-system-2/v2/components/Button/Button.jsx'
+export { PropertyFilter } from '../../../design-system-2/v2/components/PropertyFilter/PropertyFilter.jsx'
+export { Cards } from '../../../design-system-2/v2/components/Cards/Cards.jsx'
+export { Autosuggest } from '../../../design-system-2/v2/components/Autosuggest/Autosuggest.jsx'
+export { ButtonDropdown } from '../../../design-system-2/v2/components/ButtonDropdown/ButtonDropdown.jsx'
+export { Input } from '../../../design-system-2/v2/components/Input/Input.jsx'

--- a/frontend/ui-v2/src/design-system/index.js
+++ b/frontend/ui-v2/src/design-system/index.js
@@ -3,3 +3,8 @@ export { AppLayout } from '../../../design-system-2/v2/components/AppLayout/AppL
 export { SideNavigation } from '../../../design-system-2/v2/components/SideNavigation/SideNavigation.jsx'
 export { TopNavigation } from '../../../design-system-2/v2/components/TopNavigation/TopNavigation.jsx'
 export { Button } from '../../../design-system-2/v2/components/Button/Button.jsx'
+export { PropertyFilter } from '../../../design-system-2/v2/components/PropertyFilter/PropertyFilter.jsx'
+export { Cards } from '../../../design-system-2/v2/components/Cards/Cards.jsx'
+export { Autosuggest } from '../../../design-system-2/v2/components/Autosuggest/Autosuggest.jsx'
+export { ButtonDropdown } from '../../../design-system-2/v2/components/ButtonDropdown/ButtonDropdown.jsx'
+export { Input } from '../../../design-system-2/v2/components/Input/Input.jsx'

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -1,0 +1,186 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { Autosuggest, ButtonDropdown, Cards } from '../design-system'
+import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
+import { SearchTierBadge } from '../components/SearchTierBadge'
+import { StatusChip } from '../components/StatusChip'
+import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
+import { applyPropertyFilter, type PropertyFilterQuery } from '../search/applyPropertyFilter'
+import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
+import {
+  deleteSavedSearch,
+  loadSavedSearches,
+  saveCurrentSearch,
+  type SavedSearch,
+} from '../search/savedSearches'
+import { buildSearchCorpus } from '../search/searchCorpus'
+import { useTieredSearch } from '../search/useTieredSearch'
+import { documentHref, recordHrefForType } from '../routes/recordLink'
+import type { SearchResultHit } from '../types/search'
+import './feed.css'
+
+const EMPTY_FILTER: PropertyFilterQuery = { tokens: [], operation: 'and' }
+
+export function FeedRoute() {
+  const [query, setQuery] = useState('')
+  const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>(EMPTY_FILTER)
+  const [savedSearches, setSavedSearches] = useState<SavedSearch[]>(() => loadSavedSearches())
+  const [cardColumns, setCardColumns] = useState(1)
+
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+  const { events, isHydrating } = useRealtimeFeed()
+  const corpus = buildSearchCorpus(events, projects)
+  const projectId = projects[0]?.project_id ?? 'enceladus'
+
+  const tiered = useTieredSearch({ projectId, query }, corpus)
+  const filteredHits = applyPropertyFilter(tiered.hits, filterQuery)
+
+  useEffect(() => {
+    const desktop = window.matchMedia('(min-width: 48rem)')
+    const sync = () => setCardColumns(desktop.matches ? 3 : 1)
+    sync()
+    desktop.addEventListener('change', sync)
+    return () => desktop.removeEventListener('change', sync)
+  }, [])
+
+  const savedItems = [
+    ...savedSearches.map((s) => ({
+      id: s.id,
+      text: s.name,
+      description: s.query || `${s.filterQuery.tokens.length} filters`,
+    })),
+    ...(savedSearches.length > 0 ? [{ id: '__divider', type: 'divider' as const }] : []),
+    { id: '__save', text: 'Save current search…' },
+    ...savedSearches.map((s) => ({
+      id: `__delete:${s.id}`,
+      text: `Delete “${s.name}”`,
+      danger: true,
+    })),
+  ]
+
+  const handleSavedClick = (id: string | undefined) => {
+    if (!id) return
+    if (id === '__save') {
+      const name = window.prompt('Name this search')
+      if (!name) return
+      setSavedSearches(saveCurrentSearch(savedSearches, name, query, filterQuery))
+      return
+    }
+    if (id.startsWith('__delete:')) {
+      const target = id.slice('__delete:'.length)
+      setSavedSearches(deleteSavedSearch(savedSearches, target))
+      return
+    }
+    const saved = savedSearches.find((s) => s.id === id)
+    if (!saved) return
+    setQuery(saved.query)
+    setFilterQuery(saved.filterQuery)
+  }
+
+  const searchSuggestions = corpus
+    .filter((row) => {
+      const q = query.trim().toLowerCase()
+      if (!q) return true
+      return row.recordId.toLowerCase().includes(q) || row.title.toLowerCase().includes(q)
+    })
+    .slice(0, 12)
+    .map((row) => ({
+      value: row.recordId,
+      description: row.title,
+      tag: row.recordType,
+    }))
+
+  return (
+    <div className="feed-route">
+      <header className="feed-route__header">
+        <p className="feed-route__eyebrow">Search 2.0 · Feed</p>
+        <h1 className="feed-route__title">Results</h1>
+        <p className="feed-route__subtitle">
+          Local tier paints instantly; hybrid merges async. Property pills refine the card
+          collection below.
+        </p>
+      </header>
+
+      <div className="feed-route__toolbar">
+        <div className="feed-route__search">
+          <Autosuggest
+            value={query}
+            options={searchSuggestions}
+            placeholder="Search records or saved name…"
+            ariaLabel="Feed search"
+            onChange={(event) => setQuery(event.detail.value)}
+          />
+        </div>
+        <ButtonDropdown items={savedItems} onItemClick={(event) => handleSavedClick(event.detail.id)}>
+          Saved searches
+        </ButtonDropdown>
+      </div>
+
+      <FeedPropertyFilter query={filterQuery} corpus={corpus} onChange={setFilterQuery} />
+
+      <div className="feed-route__meta">
+        <span>
+          {filteredHits.length} hit{filteredHits.length === 1 ? '' : 's'}
+          {tiered.hybridPending ? ' · hybrid loading…' : ''}
+        </span>
+        {tiered.hybridError && (
+          <span className="feed-route__meta-error">{tiered.hybridError.message}</span>
+        )}
+      </div>
+
+      {isHydrating && filteredHits.length === 0 && (
+        <p className="feed-route__empty">Loading feed snapshot…</p>
+      )}
+      {!isHydrating && filteredHits.length === 0 && (
+        <p className="feed-route__empty">No results — adjust search or filters.</p>
+      )}
+
+      <Cards
+        items={filteredHits}
+        trackBy="recordId"
+        columns={cardColumns}
+        cardDefinition={{
+          header: (hit) => <FeedCardTitle hit={hit} projects={projects} />,
+          sections: [
+            {
+              id: 'status',
+              header: 'Status',
+              content: (hit) => (hit.status ? <StatusChip status={hit.status} /> : '—'),
+            },
+            {
+              id: 'tier',
+              header: 'Tier',
+              content: (hit) => <SearchTierBadge tier={hit.tier} />,
+            },
+            {
+              id: 'project',
+              header: 'Project',
+              content: (hit) => hit.projectId,
+            },
+          ],
+        }}
+      />
+    </div>
+  )
+}
+
+function FeedCardTitle({
+  hit,
+  projects,
+}: {
+  hit: SearchResultHit
+  projects: Array<{ project_id: string; prefix: string }>
+}) {
+  const project =
+    hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
+  const href =
+    hit.recordType === 'document'
+      ? documentHref(hit.recordId)
+      : recordHrefForType(project, hit.recordType, hit.recordId)
+
+  return (
+    <a href={href} className="feed-route__card-link">
+      {hit.recordId}
+    </a>
+  )
+}

--- a/frontend/ui-v2/src/routes/feed.css
+++ b/frontend/ui-v2/src/routes/feed.css
@@ -1,0 +1,91 @@
+.feed-route {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: calc(var(--space-16) * 56);
+}
+
+.feed-route__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.feed-route__eyebrow {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--fg-muted);
+}
+
+.feed-route__title {
+  margin: var(--space-0);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
+  font-size: var(--text-3xl);
+  line-height: var(--lh-tight);
+  color: var(--fg-display);
+}
+
+.feed-route__subtitle {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--lh-relaxed);
+  color: var(--fg-muted);
+}
+
+.feed-route__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.feed-route__search {
+  flex: 1;
+  min-width: calc(var(--space-16) * 12);
+}
+
+.feed-property-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.feed-route__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.feed-route__meta-error {
+  color: var(--status-blocked);
+}
+
+.feed-route__empty {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+.feed-route__card-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.feed-route__card-link:hover {
+  color: var(--accent-hover);
+}
+
+@media (max-width: 48rem) {
+  .feed-route .ev2-cards__grid {
+    grid-template-columns: 1fr !important;
+  }
+}

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
 } from '@tanstack/react-router'
 import { AppShell } from '../shell/AppShell'
+import { FeedRoute } from './FeedRoute'
 import { HomeRoute } from './HomeRoute'
 import { PlaceholderRoute } from './PlaceholderRoute'
 import { createDocumentRecordRoute, createRecordRoute } from './recordRoute'
@@ -69,9 +70,14 @@ const documentRoute = createDocumentRecordRoute({
   queryOptionsFor: documentQueryOptions,
 })
 
+const feedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/feed',
+  component: FeedRoute,
+})
+
 const shellNavRoutes = [
   { path: '/projects', title: 'Projects' },
-  { path: '/feed', title: 'Feed' },
   { path: '/docs', title: 'Docs' },
   { path: '/coordination', title: 'Coordination' },
   { path: '/component-registry', title: 'Component registry' },
@@ -90,6 +96,7 @@ const placeholderRoutes = shellNavRoutes.map(({ path, title }) =>
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  feedRoute,
   ...placeholderRoutes,
   taskRoute,
   issueRoute,

--- a/frontend/ui-v2/src/search/FeedPropertyFilter.tsx
+++ b/frontend/ui-v2/src/search/FeedPropertyFilter.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { Autosuggest, PropertyFilter } from '../design-system'
+import {
+  buildAttributeRegistry,
+  suggestPropertyKeys,
+  suggestPropertyValues,
+} from './attributeRegistry'
+import type { PropertyFilterQuery } from './applyPropertyFilter'
+import type { LocalSearchRecord } from '../types/search'
+
+type ComposerMode = 'property' | 'value'
+
+interface FeedPropertyFilterProps {
+  query: PropertyFilterQuery
+  corpus: LocalSearchRecord[]
+  onChange: (query: PropertyFilterQuery) => void
+}
+
+/**
+ * PropertyFilter + attribute autosuggest composer (FTR-127 AC-6/7):
+ * type `sta` → pick `status` → Tab → value autosuggest → pill token.
+ */
+export function FeedPropertyFilter({ query, corpus, onChange }: FeedPropertyFilterProps) {
+  const properties = buildAttributeRegistry(corpus)
+  const [draft, setDraft] = useState('')
+  const [mode, setMode] = useState<ComposerMode>('property')
+  const [activeProperty, setActiveProperty] = useState<string | null>(null)
+
+  const propertyOptions =
+    mode === 'property'
+      ? suggestPropertyKeys(draft, properties).map((p) => ({
+          value: p.key,
+          description: 'filter property',
+          tag: (p.operators ?? ['=']).join(' '),
+        }))
+      : suggestPropertyValues(activeProperty ?? '', draft, corpus).map((v) => ({
+          value: v,
+          description: activeProperty ?? '',
+        }))
+
+  const addToken = (propertyKey: string, value: string) => {
+    onChange({
+      ...query,
+      tokens: [...(query.tokens ?? []), { propertyKey, operator: '=', value }],
+    })
+    setDraft('')
+    setMode('property')
+    setActiveProperty(null)
+  }
+
+  const handleComposerChange = (value: string) => {
+    if (mode === 'property') {
+      const exact = properties.find((p) => p.key === value)
+      if (exact) {
+        setActiveProperty(exact.key)
+        setMode('value')
+        setDraft('')
+        return
+      }
+      setDraft(value)
+      return
+    }
+
+    if (activeProperty) {
+      const values = observedValues(activeProperty, corpus)
+      if (values.includes(value)) {
+        addToken(activeProperty, value)
+        return
+      }
+    }
+    setDraft(value)
+  }
+
+  const handleTab = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Tab' || mode !== 'property') return
+    const match = suggestPropertyKeys(draft, properties, 1)[0]
+    if (!match) return
+    event.preventDefault()
+    setActiveProperty(match.key)
+    setMode('value')
+    setDraft('')
+  }
+
+  const placeholder =
+    mode === 'property'
+      ? 'Add filter — type property (e.g. sta → status), Tab to select'
+      : `Value for ${activeProperty} — pick or type`
+
+  return (
+    <div className="feed-property-filter">
+      <div onKeyDown={handleTab}>
+        <Autosuggest
+          value={draft}
+          options={propertyOptions}
+          placeholder={placeholder}
+          ariaLabel="Attribute filter composer"
+          emptyText={mode === 'property' ? 'No matching properties' : 'No matching values'}
+          onChange={(event) => handleComposerChange(event.detail.value)}
+        />
+      </div>
+      <PropertyFilter
+        query={query}
+        filteringProperties={properties}
+        placeholder="Or type field=value and press Enter"
+        hint="Filter pills apply above the result cards."
+        onChange={(event) => onChange(event.detail)}
+      />
+    </div>
+  )
+}
+
+function observedValues(propertyKey: string, corpus: LocalSearchRecord[]): string[] {
+  return suggestPropertyValues(propertyKey, '', corpus, 500)
+}

--- a/frontend/ui-v2/src/search/applyPropertyFilter.test.ts
+++ b/frontend/ui-v2/src/search/applyPropertyFilter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { applyPropertyFilter } from './applyPropertyFilter'
+import type { SearchResultHit } from '../types/search'
+
+const HITS: SearchResultHit[] = [
+  {
+    recordId: 'ENC-TSK-L19',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Feed search',
+    status: 'in-progress',
+    tier: 'local',
+  },
+  {
+    recordId: 'ENC-ISS-058',
+    recordType: 'issue',
+    projectId: 'enceladus',
+    title: 'Issue',
+    status: 'open',
+    tier: 'hybrid',
+  },
+]
+
+describe('applyPropertyFilter', () => {
+  it('returns all hits when no tokens', () => {
+    expect(applyPropertyFilter(HITS, { tokens: [] })).toHaveLength(2)
+  })
+
+  it('filters by status token pill', () => {
+    const filtered = applyPropertyFilter(HITS, {
+      tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }],
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.recordId).toBe('ENC-ISS-058')
+  })
+
+  it('filters by record_type token', () => {
+    const filtered = applyPropertyFilter(HITS, {
+      tokens: [{ propertyKey: 'record_type', operator: '=', value: 'task' }],
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.recordType).toBe('task')
+  })
+})

--- a/frontend/ui-v2/src/search/applyPropertyFilter.ts
+++ b/frontend/ui-v2/src/search/applyPropertyFilter.ts
@@ -1,0 +1,57 @@
+import { fieldValueForProperty } from './attributeRegistry'
+import type { LocalSearchRecord } from '../types/search'
+
+export interface PropertyFilterToken {
+  propertyKey: string
+  operator: string
+  value: string
+}
+
+export interface PropertyFilterQuery {
+  tokens: PropertyFilterToken[]
+  operation?: 'and' | 'or'
+}
+
+function compareToken(actual: string, operator: string, expected: string): boolean {
+  const a = actual.toLowerCase()
+  const e = expected.toLowerCase()
+  switch (operator) {
+    case '=':
+    case ':':
+      return a === e
+    case '!=':
+      return a !== e
+    case '>':
+      return a > e
+    case '<':
+      return a < e
+    case '>=':
+      return a >= e
+    case '<=':
+      return a <= e
+    default:
+      return a.includes(e)
+  }
+}
+
+function tokenMatches<T extends LocalSearchRecord>(hit: T, token: PropertyFilterToken): boolean {
+  const actual = fieldValueForProperty(hit, token.propertyKey)
+  if (actual === undefined) return false
+  return compareToken(actual, token.operator, token.value)
+}
+
+/** Apply PropertyFilter token pills to search hits (AND by default). */
+export function applyPropertyFilter<T extends LocalSearchRecord>(
+  hits: T[],
+  query: PropertyFilterQuery | undefined,
+): T[] {
+  const tokens = query?.tokens ?? []
+  if (tokens.length === 0) return hits
+  const op = query?.operation ?? 'and'
+  return hits.filter((hit) => {
+    if (op === 'or') {
+      return tokens.some((token) => tokenMatches(hit, token))
+    }
+    return tokens.every((token) => tokenMatches(hit, token))
+  })
+}

--- a/frontend/ui-v2/src/search/attributeRegistry.test.ts
+++ b/frontend/ui-v2/src/search/attributeRegistry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAttributeRegistry,
+  fieldValueForProperty,
+  suggestPropertyKeys,
+  suggestPropertyValues,
+} from './attributeRegistry'
+import type { LocalSearchRecord } from '../types/search'
+
+const CORPUS: LocalSearchRecord[] = [
+  {
+    recordId: 'ENC-TSK-L19',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Feed search wave A',
+    status: 'in-progress',
+  },
+  {
+    recordId: 'ENC-ISS-058',
+    recordType: 'issue',
+    projectId: 'enceladus',
+    title: 'Sample issue',
+    status: 'open',
+  },
+]
+
+describe('attributeRegistry', () => {
+  it('includes governance properties and observed keys', () => {
+    const props = buildAttributeRegistry(CORPUS)
+    expect(props.some((p) => p.key === 'status')).toBe(true)
+    expect(props.some((p) => p.key === 'record_type')).toBe(true)
+  })
+
+  it('suggests status from sta prefix within bounded set', () => {
+    const props = buildAttributeRegistry(CORPUS)
+    const keys = suggestPropertyKeys('sta', props).map((p) => p.key)
+    expect(keys).toContain('status')
+  })
+
+  it('suggests observed status values', () => {
+    const values = suggestPropertyValues('status', 'in', CORPUS)
+    expect(values).toContain('in-progress')
+  })
+
+  it('resolves hit fields for filter matching', () => {
+    expect(fieldValueForProperty(CORPUS[0], 'status')).toBe('in-progress')
+    expect(fieldValueForProperty(CORPUS[0], 'record_id')).toBe('ENC-TSK-L19')
+  })
+})

--- a/frontend/ui-v2/src/search/attributeRegistry.ts
+++ b/frontend/ui-v2/src/search/attributeRegistry.ts
@@ -1,0 +1,101 @@
+import type { LocalSearchRecord } from '../types/search'
+
+/** Governance dictionary ∪ observed feed fields (FTR-127 AC-6/7). */
+const GOVERNANCE_FILTER_PROPERTIES = [
+  { key: 'status', operators: ['=', '!=', ':'] },
+  { key: 'record_type', operators: ['=', '!=', ':'] },
+  { key: 'project_id', operators: ['=', '!=', ':'] },
+  { key: 'record_id', operators: ['=', '!=', ':'] },
+  { key: 'title', operators: ['=', '!=', ':'] },
+] as const
+
+export type FilteringProperty = {
+  key: string
+  operators?: string[]
+}
+
+export function buildAttributeRegistry(corpus: LocalSearchRecord[]): FilteringProperty[] {
+  const keys = new Map<string, Set<string>>()
+  for (const prop of GOVERNANCE_FILTER_PROPERTIES) {
+    keys.set(prop.key, new Set(prop.operators ?? ['=']))
+  }
+
+  for (const row of corpus) {
+    if (row.status) observe(keys, 'status', row.status)
+    observe(keys, 'record_type', row.recordType)
+    observe(keys, 'project_id', row.projectId)
+    observe(keys, 'record_id', row.recordId)
+    observe(keys, 'title', row.title)
+  }
+
+  return [...keys.entries()].map(([key, operators]) => ({
+    key,
+    operators: [...operators],
+  }))
+}
+
+function observe(map: Map<string, Set<string>>, key: string, _value: string) {
+  if (!map.has(key)) {
+    map.set(key, new Set(['=', '!=', ':']))
+  }
+}
+
+/** Resolve a hit field for property-filter token matching. */
+export function fieldValueForProperty(
+  hit: LocalSearchRecord,
+  propertyKey: string,
+): string | undefined {
+  switch (propertyKey) {
+    case 'status':
+      return hit.status
+    case 'record_type':
+      return hit.recordType
+    case 'project_id':
+      return hit.projectId
+    case 'record_id':
+      return hit.recordId
+    case 'title':
+      return hit.title
+    default:
+      return undefined
+  }
+}
+
+/** Distinct observed values for a property key (value autosuggest corpus). */
+export function observedValuesForProperty(
+  corpus: LocalSearchRecord[],
+  propertyKey: string,
+): string[] {
+  const values = new Set<string>()
+  for (const row of corpus) {
+    const v = fieldValueForProperty(row, propertyKey)
+    if (v) values.add(v)
+  }
+  return [...values].sort()
+}
+
+/** Prefix match property keys — intended to complete within 100ms (sync, bounded). */
+export function suggestPropertyKeys(
+  prefix: string,
+  properties: FilteringProperty[],
+  limit = 12,
+): FilteringProperty[] {
+  const q = prefix.trim().toLowerCase()
+  if (!q) return properties.slice(0, limit)
+  return properties
+    .filter((p) => p.key.toLowerCase().includes(q))
+    .slice(0, limit)
+}
+
+/** Prefix match observed values for the active property key. */
+export function suggestPropertyValues(
+  propertyKey: string,
+  prefix: string,
+  corpus: LocalSearchRecord[],
+  limit = 12,
+): string[] {
+  const q = prefix.trim().toLowerCase()
+  const values = observedValuesForProperty(corpus, propertyKey)
+  if (!q) return values.slice(0, limit)
+  return values.filter((v) => v.toLowerCase().includes(q)).slice(0, limit)
+}

--- a/frontend/ui-v2/src/search/savedSearches.test.ts
+++ b/frontend/ui-v2/src/search/savedSearches.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  deleteSavedSearch,
+  loadSavedSearches,
+  persistSavedSearches,
+  saveCurrentSearch,
+  type SavedSearch,
+} from './savedSearches'
+
+describe('savedSearches', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('persists and loads saved searches locally', () => {
+    const sample: SavedSearch[] = [
+      {
+        id: 'ss-1',
+        name: 'Open issues',
+        query: 'ENC',
+        filterQuery: { tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }] },
+      },
+    ]
+    persistSavedSearches(sample)
+    expect(loadSavedSearches()).toEqual(sample)
+  })
+
+  it('saves current search by name', () => {
+    const next = saveCurrentSearch([], 'My search', 'ENC', {
+      tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }],
+    })
+    expect(next).toHaveLength(1)
+    expect(next[0]?.name).toBe('My search')
+    expect(loadSavedSearches()[0]?.query).toBe('ENC')
+  })
+
+  it('deletes a saved search by id', () => {
+    const seeded = saveCurrentSearch([], 'Temp', '', { tokens: [] })
+    const updated = deleteSavedSearch(seeded, seeded[0]!.id)
+    expect(updated).toHaveLength(0)
+  })
+})

--- a/frontend/ui-v2/src/search/savedSearches.ts
+++ b/frontend/ui-v2/src/search/savedSearches.ts
@@ -1,0 +1,55 @@
+import type { PropertyFilterQuery } from './applyPropertyFilter'
+
+export interface SavedSearch {
+  id: string
+  name: string
+  query: string
+  filterQuery: PropertyFilterQuery
+}
+
+const STORAGE_KEY = 'enceladus-ui-v2:saved-searches'
+
+export function loadSavedSearches(): SavedSearch[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as SavedSearch[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function persistSavedSearches(searches: SavedSearch[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(searches))
+}
+
+export function saveCurrentSearch(
+  searches: SavedSearch[],
+  name: string,
+  query: string,
+  filterQuery: PropertyFilterQuery,
+): SavedSearch[] {
+  const trimmed = name.trim()
+  if (!trimmed) return searches
+  const next: SavedSearch = {
+    id: `ss-${Date.now()}`,
+    name: trimmed,
+    query,
+    filterQuery: {
+      tokens: [...(filterQuery.tokens ?? [])],
+      operation: filterQuery.operation ?? 'and',
+    },
+  }
+  const updated = [next, ...searches.filter((s) => s.name !== trimmed)]
+  persistSavedSearches(updated)
+  return updated
+}
+
+export function deleteSavedSearch(searches: SavedSearch[], id: string): SavedSearch[] {
+  const updated = searches.filter((s) => s.id !== id)
+  persistSavedSearches(updated)
+  return updated
+}

--- a/frontend/ui-v2/src/search/searchCorpus.ts
+++ b/frontend/ui-v2/src/search/searchCorpus.ts
@@ -1,0 +1,36 @@
+import type { ProjectSummary } from '../api/projects'
+import { resolveProjectFromRecordId } from '../api/projectRegistry'
+import type { FeedRealtimeEvent } from '../types/feedEvents'
+import type { RecordType } from '../types/records'
+import type { LocalSearchRecord } from '../types/search'
+
+const VALID_TYPES: RecordType[] = ['task', 'issue', 'feature', 'plan', 'lesson', 'document']
+
+function normalizeRecordType(raw: string): RecordType | null {
+  const t = raw.toLowerCase() as RecordType
+  return VALID_TYPES.includes(t) ? t : null
+}
+
+/** Build the local search corpus from feed snapshot / realtime events. */
+export function buildSearchCorpus(
+  events: FeedRealtimeEvent[],
+  projects: ProjectSummary[],
+): LocalSearchRecord[] {
+  const byId = new Map<string, LocalSearchRecord>()
+
+  for (const event of events) {
+    const recordType = normalizeRecordType(event.record_type)
+    if (!recordType) continue
+    const projectId =
+      resolveProjectFromRecordId(event.recordId, projects) ?? 'enceladus'
+    byId.set(event.recordId, {
+      recordId: event.recordId,
+      recordType,
+      projectId,
+      title: event.summary,
+      status: event.action,
+    })
+  }
+
+  return [...byId.values()]
+}


### PR DESCRIPTION
## Summary
- `/feed` is the search results page: Autosuggest query, PropertyFilter pill tokens + attribute autosuggest composer, Cards collection
- Tiered local/hybrid merge via `useTieredSearch`; saved searches local-first via ButtonDropdown
- All UI via design-system-2 components

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint:adherence`
- [x] `npm test` (30 passing)

commit-complete-id: CCI-9a7e5f3f4bc146b386df072345ca1301