### PR TITLE
ENC-TSK-L21: URL search state + scroll restore + search SLO telemetry (FTR-127)

### DIFF
--- a/frontend/ui-v2/src/components/RecordDetailBreadcrumbs.tsx
+++ b/frontend/ui-v2/src/components/RecordDetailBreadcrumbs.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from '@tanstack/react-router'
+import { BreadcrumbGroup } from '../design-system'
+import { loadFeedReturnSearch } from '../search/feedSearchParams'
+
+export function RecordDetailBreadcrumbs({ recordId }: { recordId: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <nav style={{ marginBottom: 'var(--space-5)' }}>
+      <BreadcrumbGroup
+        items={[
+          { text: 'Feed', href: '/feed' },
+          { text: recordId },
+        ]}
+        onFollow={(event) => {
+          if (event.detail.item.text !== 'Feed') return
+          navigate({ to: '/feed', search: loadFeedReturnSearch() })
+        }}
+      />
+    </nav>
+  )
+}

--- a/frontend/ui-v2/src/design-system/index.d.ts
+++ b/frontend/ui-v2/src/design-system/index.d.ts
@@ -12,3 +12,4 @@ export { Container } from '../../../design-system-2/v2/components/Container/Cont
 export { Header } from '../../../design-system-2/v2/components/Header/Header.jsx'
 export { Pagination } from '../../../design-system-2/v2/components/Pagination/Pagination.jsx'
 export { Box } from '../../../design-system-2/v2/components/Box/Box.jsx'
+export { BreadcrumbGroup } from '../../../design-system-2/v2/components/BreadcrumbGroup/BreadcrumbGroup.jsx'

--- a/frontend/ui-v2/src/design-system/index.js
+++ b/frontend/ui-v2/src/design-system/index.js
@@ -13,3 +13,4 @@ export { Container } from '../../../design-system-2/v2/components/Container/Cont
 export { Header } from '../../../design-system-2/v2/components/Header/Header.jsx'
 export { Pagination } from '../../../design-system-2/v2/components/Pagination/Pagination.jsx'
 export { Box } from '../../../design-system-2/v2/components/Box/Box.jsx'
+export { BreadcrumbGroup } from '../../../design-system-2/v2/components/BreadcrumbGroup/BreadcrumbGroup.jsx'

--- a/frontend/ui-v2/src/routes/FeedReadingPane.tsx
+++ b/frontend/ui-v2/src/routes/FeedReadingPane.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { Container, Header, Box } from '../design-system'
 import { SearchTierBadge } from '../components/SearchTierBadge'
 import { StatusChip } from '../components/StatusChip'
@@ -28,9 +29,9 @@ export function FeedReadingPane({ hit }: { hit: SearchResultHit | null }) {
         </Header>
       }
       footer={
-        <a href={href} className="feed-route__detail-link">
+        <Link to={href} className="feed-route__detail-link">
           Open full record →
-        </a>
+        </Link>
       }
     >
       <div className="feed-reading-pane__meta">

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -1,12 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useSearch } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Autosuggest, ButtonDropdown, Cards, ColumnLayout } from '../design-system'
 import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
 import { SearchTierBadge } from '../components/SearchTierBadge'
 import { StatusChip } from '../components/StatusChip'
 import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
-import { applyPropertyFilter, type PropertyFilterQuery } from '../search/applyPropertyFilter'
+import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
+import {
+  parseFilterQuery,
+  persistFeedReturnSearch,
+  serializeFilterQuery,
+  type FeedRouteSearch,
+  type FeedSort,
+} from '../search/feedSearchParams'
 import {
   deleteSavedSearch,
   loadSavedSearches,
@@ -20,20 +28,34 @@ import {
   type RecentlyViewedEntry,
 } from '../search/recentlyViewed'
 import { buildSearchCorpus } from '../search/searchCorpus'
+import { sortSearchHits } from '../search/sortSearchHits'
 import { useTieredSearch } from '../search/useTieredSearch'
+import {
+  useKeystrokeSuggestionTelemetry,
+  useRequestFirstPageTelemetry,
+} from '../search/useSearchTelemetry'
+import { useFeedConnectionStore } from '../store/feedConnectionStore'
 import { documentHref, recordHrefForType } from '../routes/recordLink'
 import type { SearchResultHit } from '../types/search'
 import { FeedReadingPane } from './FeedReadingPane'
 import { RecentlyViewedNav } from './RecentlyViewedNav'
+import { useFeedScrollRestore } from './useFeedScrollRestore'
 import './feed.css'
 
-const EMPTY_FILTER: PropertyFilterQuery = { tokens: [], operation: 'and' }
 const LIST_CHUNK = 24
 const WIDE_MEDIA = '(min-width: 64rem)'
+const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
+  { value: 'tier', label: 'Tier (default)' },
+  { value: 'id', label: 'Record ID' },
+  { value: 'title', label: 'Title' },
+  { value: 'status', label: 'Status' },
+]
 
 export function FeedRoute() {
-  const [query, setQuery] = useState('')
-  const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>(EMPTY_FILTER)
+  const feedSearch = useSearch({ from: '/feed' })
+  const navigate = useNavigate({ from: '/feed' })
+  const { q, f, op, sort, scroll } = feedSearch
+
   const [savedSearches, setSavedSearches] = useState<SavedSearch[]>(() => loadSavedSearches())
   const [isWide, setIsWide] = useState(false)
   const [selectedHit, setSelectedHit] = useState<SearchResultHit | null>(null)
@@ -41,20 +63,76 @@ export function FeedRoute() {
   const [recentItems, setRecentItems] = useState<RecentlyViewedEntry[]>([])
   const listRef = useRef<HTMLDivElement>(null)
 
+  const filterQuery = useMemo(() => parseFilterQuery(f, op), [f, op])
+
+  const patchFeedSearch = useCallback(
+    (patch: Partial<FeedRouteSearch>, replace = true) => {
+      navigate({
+        search: (prev) => {
+          const next = { ...prev, ...patch }
+          persistFeedReturnSearch(next)
+          return next
+        },
+        replace,
+      })
+    },
+    [navigate],
+  )
+
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
   const { events, isHydrating } = useRealtimeFeed()
   const corpus = buildSearchCorpus(events, projects)
   const projectId = projects[0]?.project_id ?? 'enceladus'
 
-  const tiered = useTieredSearch({ projectId, query }, corpus)
-  const filteredHits = applyPropertyFilter(tiered.hits, filterQuery)
+  const tiered = useTieredSearch({ projectId, query: q }, corpus)
+  const filteredHits = useMemo(
+    () => sortSearchHits(applyPropertyFilter(tiered.hits, filterQuery), sort),
+    [tiered.hits, filterQuery, sort],
+  )
   const visibleHits = filteredHits.slice(0, visibleCount)
+
+  const hybridEnabled = Boolean(q.trim())
+  const requestKey = `${q}|${f}|${op}|${sort}`
+  useRequestFirstPageTelemetry(requestKey, hybridEnabled, tiered.hybridPending)
+
+  const searchSuggestions = useMemo(
+    () =>
+      corpus
+        .filter((row) => {
+          const needle = q.trim().toLowerCase()
+          if (!needle) return true
+          return row.recordId.toLowerCase().includes(needle) || row.title.toLowerCase().includes(needle)
+        })
+        .slice(0, 12)
+        .map((row) => ({
+          value: row.recordId,
+          description: row.title,
+          tag: row.recordType,
+        })),
+    [corpus, q],
+  )
+
+  const suggestionsKey = searchSuggestions.map((row) => row.value).join(',')
+  const { markKeystroke } = useKeystrokeSuggestionTelemetry(suggestionsKey)
+
+  const keystrokeP50 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p50Ms)
+  const keystrokeP95 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p95Ms)
+  const localP50 = useFeedConnectionStore((s) => s.requestFirstPageLocal.p50Ms)
+  const localP95 = useFeedConnectionStore((s) => s.requestFirstPageLocal.p95Ms)
+  const serverP50 = useFeedConnectionStore((s) => s.requestFirstPageServer.p50Ms)
+  const serverP95 = useFeedConnectionStore((s) => s.requestFirstPageServer.p95Ms)
 
   const selectHit = (hit: SearchResultHit) => {
     setSelectedHit(hit)
     trackRecentlyViewed(hit)
     setRecentItems(getRecentlyViewed(hit.recordType))
   }
+
+  useFeedScrollRestore(scroll, isWide, listRef, (nextScroll) => patchFeedSearch({ scroll: nextScroll }), filteredHits.length > 0)
+
+  useEffect(() => {
+    persistFeedReturnSearch(feedSearch)
+  }, [feedSearch])
 
   useEffect(() => {
     const mq = window.matchMedia(WIDE_MEDIA)
@@ -66,7 +144,7 @@ export function FeedRoute() {
 
   useEffect(() => {
     setVisibleCount(LIST_CHUNK)
-  }, [query, filterQuery, filteredHits.length])
+  }, [q, f, op, sort, filteredHits.length])
 
   useEffect(() => {
     if (!isWide) {
@@ -129,7 +207,7 @@ export function FeedRoute() {
     if (id === '__save') {
       const name = window.prompt('Name this search')
       if (!name) return
-      setSavedSearches(saveCurrentSearch(savedSearches, name, query, filterQuery))
+      setSavedSearches(saveCurrentSearch(savedSearches, name, q, filterQuery))
       return
     }
     if (id.startsWith('__delete:')) {
@@ -139,25 +217,18 @@ export function FeedRoute() {
     }
     const saved = savedSearches.find((s) => s.id === id)
     if (!saved) return
-    setQuery(saved.query)
-    setFilterQuery(saved.filterQuery)
+    patchFeedSearch({
+      q: saved.query,
+      f: serializeFilterQuery(saved.filterQuery),
+      op: saved.filterQuery.operation ?? 'and',
+      scroll: 0,
+    })
   }
 
-  const searchSuggestions = corpus
-    .filter((row) => {
-      const q = query.trim().toLowerCase()
-      if (!q) return true
-      return row.recordId.toLowerCase().includes(q) || row.title.toLowerCase().includes(q)
-    })
-    .slice(0, 12)
-    .map((row) => ({
-      value: row.recordId,
-      description: row.title,
-      tag: row.recordType,
-    }))
-
   const cardDefinition = {
-    header: (hit: SearchResultHit) => <FeedCardTitle hit={hit} projects={projects} mobile={!isWide} />,
+    header: (hit: SearchResultHit) => (
+      <FeedCardTitle hit={hit} projects={projects} mobile={!isWide} feedSearch={feedSearch} />
+    ),
     sections: [
       {
         id: 'status',
@@ -207,12 +278,7 @@ export function FeedRoute() {
         </div>
       </ColumnLayout>
     ) : (
-      <Cards
-        items={visibleHits}
-        trackBy="recordId"
-        columns={1}
-        cardDefinition={cardDefinition}
-      />
+      <Cards items={visibleHits} trackBy="recordId" columns={1} cardDefinition={cardDefinition} />
     )
 
   return (
@@ -221,27 +287,55 @@ export function FeedRoute() {
         <p className="feed-route__eyebrow">Search 2.0 · Feed</p>
         <h1 className="feed-route__title">Results</h1>
         <p className="feed-route__subtitle">
-          Local tier paints instantly; hybrid merges async. Wide viewports open a reading pane;
-          mobile opens the full record page.
+          Local tier paints instantly; hybrid merges async. Search state lives in the URL so back
+          navigation and breadcrumb return restore filters and scroll.
         </p>
       </header>
 
       <div className="feed-route__toolbar">
         <div className="feed-route__search">
           <Autosuggest
-            value={query}
+            value={q}
             options={searchSuggestions}
             placeholder="Search records or saved name…"
             ariaLabel="Feed search"
-            onChange={(event) => setQuery(event.detail.value)}
+            onChange={(event) => {
+              markKeystroke()
+              patchFeedSearch({ q: event.detail.value, scroll: 0 })
+            }}
           />
         </div>
+        <label className="feed-route__sort">
+          <span>Sort</span>
+          <select
+            value={sort}
+            onChange={(event) =>
+              patchFeedSearch({ sort: event.target.value as FeedSort, scroll: 0 })
+            }
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
         <ButtonDropdown items={savedItems} onItemClick={(event) => handleSavedClick(event.detail.id)}>
           Saved searches
         </ButtonDropdown>
       </div>
 
-      <FeedPropertyFilter query={filterQuery} corpus={corpus} onChange={setFilterQuery} />
+      <FeedPropertyFilter
+        query={filterQuery}
+        corpus={corpus}
+        onChange={(next) =>
+          patchFeedSearch({
+            f: serializeFilterQuery(next),
+            op: next.operation ?? 'and',
+            scroll: 0,
+          })
+        }
+      />
 
       <div className="feed-route__meta">
         <span>
@@ -250,6 +344,30 @@ export function FeedRoute() {
         </span>
         {tiered.hybridError && (
           <span className="feed-route__meta-error">{tiered.hybridError.message}</span>
+        )}
+        {(keystrokeP50 !== null || localP50 !== null || serverP50 !== null) && (
+          <span className="feed-route__telemetry">
+            {keystrokeP50 !== null && (
+              <>
+                keystroke→suggest p50 {Math.round(keystrokeP50)}ms
+                {keystrokeP95 !== null ? ` / p95 ${Math.round(keystrokeP95)}ms` : ''}
+              </>
+            )}
+            {localP50 !== null && (
+              <>
+                {keystrokeP50 !== null ? ' · ' : ''}
+                request→page (local) p50 {Math.round(localP50)}ms
+                {localP95 !== null ? ` / p95 ${Math.round(localP95)}ms` : ''}
+              </>
+            )}
+            {serverP50 !== null && (
+              <>
+                {' · '}
+                request→page (server) p50 {Math.round(serverP50)}ms
+                {serverP95 !== null ? ` / p95 ${Math.round(serverP95)}ms` : ''}
+              </>
+            )}
+          </span>
         )}
       </div>
 
@@ -269,10 +387,12 @@ function FeedCardTitle({
   hit,
   projects,
   mobile,
+  feedSearch,
 }: {
   hit: SearchResultHit
   projects: Array<{ project_id: string; prefix: string }>
   mobile: boolean
+  feedSearch: FeedRouteSearch
 }) {
   const project =
     hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
@@ -283,9 +403,13 @@ function FeedCardTitle({
 
   if (mobile) {
     return (
-      <a href={href} className="feed-route__card-link">
+      <Link
+        to={href}
+        className="feed-route__card-link"
+        onClick={() => persistFeedReturnSearch(feedSearch)}
+      >
         {hit.recordId}
-      </a>
+      </Link>
     )
   }
 

--- a/frontend/ui-v2/src/routes/feed.css
+++ b/frontend/ui-v2/src/routes/feed.css
@@ -49,6 +49,31 @@
   min-width: calc(var(--space-16) * 12);
 }
 
+.feed-route__sort {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.feed-route__sort select {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--fg);
+}
+
+.feed-route__telemetry {
+  flex-basis: 100%;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
 .feed-property-filter {
   display: flex;
   flex-direction: column;

--- a/frontend/ui-v2/src/routes/recordRoute.tsx
+++ b/frontend/ui-v2/src/routes/recordRoute.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { useSuspenseQuery, type UseSuspenseQueryOptions } from '@tanstack/react-query'
 import { createRoute, type AnyRoute } from '@tanstack/react-router'
 import { queryClient } from '../api/queryClient'
+import { RecordDetailBreadcrumbs } from '../components/RecordDetailBreadcrumbs'
 import { SkeletonCard } from '../components/SkeletonCard'
 import { getPrimitive } from '../primitives/registry'
 import type { RecordShapeMap, RecordType } from '../types/records'
@@ -34,7 +35,12 @@ export function createRecordRoute<K extends TrackerRecordType>(config: {
     const { project, id } = route.useParams() as { project: string; id: string }
     const { data } = useSuspenseQuery(queryOptionsFor(project, id))
     const Primitive = getPrimitive(type)
-    return <Primitive record={data} />
+    return (
+      <>
+        <RecordDetailBreadcrumbs recordId={id} />
+        <Primitive record={data} />
+      </>
+    )
   }
 
   function RouteComponent() {
@@ -70,7 +76,12 @@ export function createDocumentRecordRoute(config: {
     const { id } = route.useParams() as { id: string }
     const { data } = useSuspenseQuery(queryOptionsFor(id))
     const Primitive = getPrimitive('document')
-    return <Primitive record={data} />
+    return (
+      <>
+        <RecordDetailBreadcrumbs recordId={id} />
+        <Primitive record={data} />
+      </>
+    )
   }
 
   function RouteComponent() {

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -8,6 +8,7 @@ import { AppShell } from '../shell/AppShell'
 import { FeedRoute } from './FeedRoute'
 import { HomeRoute } from './HomeRoute'
 import { PlaceholderRoute } from './PlaceholderRoute'
+import { parseFeedSearch } from '../search/feedSearchParams'
 import { createDocumentRecordRoute, createRecordRoute } from './recordRoute'
 import {
   documentQueryOptions,
@@ -73,6 +74,7 @@ const documentRoute = createDocumentRecordRoute({
 const feedRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/feed',
+  validateSearch: parseFeedSearch,
   component: FeedRoute,
 })
 

--- a/frontend/ui-v2/src/routes/useFeedScrollRestore.ts
+++ b/frontend/ui-v2/src/routes/useFeedScrollRestore.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+
+export function useFeedScrollRestore(
+  scroll: number,
+  isWide: boolean,
+  listRef: RefObject<HTMLDivElement | null>,
+  onScrollPersist: (nextScroll: number) => void,
+  ready: boolean,
+) {
+  const restoredFor = useRef<number | null>(null)
+  const persistTimer = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!ready || scroll <= 0) {
+      restoredFor.current = null
+      return
+    }
+    if (restoredFor.current === scroll) return
+
+    const restore = () => {
+      if (isWide && listRef.current) {
+        listRef.current.scrollTop = scroll
+      } else {
+        window.scrollTo({ top: scroll, behavior: 'auto' })
+      }
+      restoredFor.current = scroll
+    }
+
+    requestAnimationFrame(() => requestAnimationFrame(restore))
+  }, [scroll, isWide, listRef, ready])
+
+  useEffect(() => {
+    const persist = (value: number) => {
+      if (persistTimer.current !== null) window.clearTimeout(persistTimer.current)
+      persistTimer.current = window.setTimeout(() => onScrollPersist(Math.round(value)), 120)
+    }
+
+    if (isWide) {
+      const node = listRef.current
+      if (!node) return
+      const onScroll = () => persist(node.scrollTop)
+      node.addEventListener('scroll', onScroll, { passive: true })
+      return () => node.removeEventListener('scroll', onScroll)
+    }
+
+    const onScroll = () => persist(window.scrollY)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [isWide, listRef, onScrollPersist])
+}

--- a/frontend/ui-v2/src/search/feedSearchParams.test.ts
+++ b/frontend/ui-v2/src/search/feedSearchParams.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  FEED_SEARCH_DEFAULTS,
+  FEED_RETURN_STORAGE_KEY,
+  buildFeedPath,
+  loadFeedReturnSearch,
+  parseFeedSearch,
+  parseFilterQuery,
+  persistFeedReturnSearch,
+  serializeFilterQuery,
+} from './feedSearchParams'
+
+describe('feedSearchParams', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('parses defaults from empty search', () => {
+    expect(parseFeedSearch({})).toEqual(FEED_SEARCH_DEFAULTS)
+  })
+
+  it('round-trips query, filters, sort, and scroll', () => {
+    const parsed = parseFeedSearch({
+      q: 'ENC',
+      f: 'status|%3D|open',
+      op: 'or',
+      sort: 'title',
+      scroll: '240',
+    })
+    expect(parsed.q).toBe('ENC')
+    expect(parsed.sort).toBe('title')
+    expect(parsed.scroll).toBe(240)
+    expect(parseFilterQuery(parsed.f, parsed.op).tokens).toEqual([
+      { propertyKey: 'status', operator: '=', value: 'open' },
+    ])
+    expect(buildFeedPath(parsed)).toContain('q=ENC')
+    expect(buildFeedPath(parsed)).toContain('scroll=240')
+  })
+
+  it('serializes and parses multi-token filters', () => {
+    const serialized = serializeFilterQuery({
+      tokens: [
+        { propertyKey: 'status', operator: '=', value: 'open' },
+        { propertyKey: 'priority', operator: '!=', value: 'P0' },
+      ],
+      operation: 'and',
+    })
+    expect(parseFilterQuery(serialized, 'and').tokens).toEqual([
+      { propertyKey: 'status', operator: '=', value: 'open' },
+      { propertyKey: 'priority', operator: '!=', value: 'P0' },
+    ])
+  })
+
+  it('persists feed return search for breadcrumb navigation', () => {
+    persistFeedReturnSearch({
+      q: 'hybrid',
+      f: '',
+      op: 'and',
+      sort: 'tier',
+      scroll: 88,
+    })
+    expect(sessionStorage.getItem(FEED_RETURN_STORAGE_KEY)).toContain('scroll=88')
+    expect(loadFeedReturnSearch().q).toBe('hybrid')
+    expect(loadFeedReturnSearch().scroll).toBe(88)
+  })
+})

--- a/frontend/ui-v2/src/search/feedSearchParams.ts
+++ b/frontend/ui-v2/src/search/feedSearchParams.ts
@@ -1,0 +1,117 @@
+import type { PropertyFilterQuery } from './applyPropertyFilter'
+
+export type FeedSort = 'tier' | 'id' | 'status' | 'title'
+
+export interface FeedRouteSearch {
+  q: string
+  f: string
+  op: 'and' | 'or'
+  sort: FeedSort
+  scroll: number
+}
+
+export const FEED_SEARCH_DEFAULTS: FeedRouteSearch = {
+  q: '',
+  f: '',
+  op: 'and',
+  sort: 'tier',
+  scroll: 0,
+}
+
+export const FEED_RETURN_STORAGE_KEY = 'enc.feed.returnSearch'
+
+const FEED_SORTS: FeedSort[] = ['tier', 'id', 'status', 'title']
+
+function isFeedSort(value: unknown): value is FeedSort {
+  return typeof value === 'string' && FEED_SORTS.includes(value as FeedSort)
+}
+
+export function parseFeedSearch(raw: Record<string, unknown>): FeedRouteSearch {
+  const q = typeof raw.q === 'string' ? raw.q : ''
+  const f = typeof raw.f === 'string' ? raw.f : ''
+  const op = raw.op === 'or' ? 'or' : 'and'
+  const sort = isFeedSort(raw.sort) ? raw.sort : 'tier'
+  const scrollRaw = raw.scroll
+  const scroll =
+    typeof scrollRaw === 'number'
+      ? scrollRaw
+      : typeof scrollRaw === 'string'
+        ? Number.parseInt(scrollRaw, 10)
+        : 0
+
+  return {
+    q,
+    f,
+    op,
+    sort,
+    scroll: Number.isFinite(scroll) && scroll > 0 ? Math.round(scroll) : 0,
+  }
+}
+
+export function serializeFilterQuery(query: PropertyFilterQuery): string {
+  if (query.tokens.length === 0) return ''
+  return query.tokens
+    .map(
+      (token) =>
+        `${encodeURIComponent(token.propertyKey)}|${encodeURIComponent(token.operator)}|${encodeURIComponent(token.value)}`,
+    )
+    .join(';')
+}
+
+export function parseFilterQuery(f: string, op: 'and' | 'or'): PropertyFilterQuery {
+  if (!f.trim()) return { tokens: [], operation: op }
+  const tokens = f
+    .split(';')
+    .map((part) => {
+      const segments = part.split('|')
+      if (segments.length < 3) return null
+      const [propertyKey, operator, ...rest] = segments
+      const value = rest.join('|')
+      return {
+        propertyKey: decodeURIComponent(propertyKey ?? ''),
+        operator: decodeURIComponent(operator ?? ''),
+        value: decodeURIComponent(value),
+      }
+    })
+    .filter(
+      (token): token is PropertyFilterQuery['tokens'][number] =>
+        Boolean(token?.propertyKey && token.operator),
+    )
+
+  return { tokens, operation: op }
+}
+
+export function feedSearchToParams(search: FeedRouteSearch): URLSearchParams {
+  const params = new URLSearchParams()
+  if (search.q) params.set('q', search.q)
+  if (search.f) params.set('f', search.f)
+  if (search.op !== 'and') params.set('op', search.op)
+  if (search.sort !== 'tier') params.set('sort', search.sort)
+  if (search.scroll > 0) params.set('scroll', String(search.scroll))
+  return params
+}
+
+export function buildFeedPath(search: FeedRouteSearch): string {
+  const qs = feedSearchToParams(search).toString()
+  return qs ? `/feed?${qs}` : '/feed'
+}
+
+export function persistFeedReturnSearch(search: FeedRouteSearch): void {
+  try {
+    const qs = feedSearchToParams(search).toString()
+    sessionStorage.setItem(FEED_RETURN_STORAGE_KEY, qs ? `?${qs}` : '')
+  } catch {
+    // sessionStorage unavailable (SSR/tests)
+  }
+}
+
+export function loadFeedReturnSearch(): FeedRouteSearch {
+  try {
+    const stored = sessionStorage.getItem(FEED_RETURN_STORAGE_KEY)
+    if (!stored) return FEED_SEARCH_DEFAULTS
+    const params = new URLSearchParams(stored.startsWith('?') ? stored.slice(1) : stored)
+    return parseFeedSearch(Object.fromEntries(params.entries()))
+  } catch {
+    return FEED_SEARCH_DEFAULTS
+  }
+}

--- a/frontend/ui-v2/src/search/sortSearchHits.test.ts
+++ b/frontend/ui-v2/src/search/sortSearchHits.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { sortSearchHits } from './sortSearchHits'
+import type { SearchResultHit } from '../types/search'
+
+const hits: SearchResultHit[] = [
+  {
+    recordId: 'ENC-TSK-BBB',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Bravo',
+    status: 'open',
+    tier: 'local',
+  },
+  {
+    recordId: 'ENC-TSK-AAA',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Alpha',
+    status: 'closed',
+    tier: 'hybrid',
+  },
+]
+
+describe('sortSearchHits', () => {
+  it('preserves tier order by default', () => {
+    expect(sortSearchHits(hits, 'tier').map((h) => h.recordId)).toEqual([
+      'ENC-TSK-BBB',
+      'ENC-TSK-AAA',
+    ])
+  })
+
+  it('sorts by record id', () => {
+    expect(sortSearchHits(hits, 'id').map((h) => h.recordId)).toEqual([
+      'ENC-TSK-AAA',
+      'ENC-TSK-BBB',
+    ])
+  })
+
+  it('sorts by title', () => {
+    expect(sortSearchHits(hits, 'title').map((h) => h.title)).toEqual(['Alpha', 'Bravo'])
+  })
+})

--- a/frontend/ui-v2/src/search/sortSearchHits.ts
+++ b/frontend/ui-v2/src/search/sortSearchHits.ts
@@ -1,0 +1,22 @@
+import type { FeedSort } from './feedSearchParams'
+import type { SearchResultHit } from '../types/search'
+
+export function sortSearchHits(hits: SearchResultHit[], sort: FeedSort): SearchResultHit[] {
+  if (sort === 'tier') return hits
+
+  const copy = [...hits]
+  switch (sort) {
+    case 'id':
+      copy.sort((a, b) => a.recordId.localeCompare(b.recordId))
+      break
+    case 'title':
+      copy.sort((a, b) => a.title.localeCompare(b.title))
+      break
+    case 'status':
+      copy.sort((a, b) => (a.status ?? '').localeCompare(b.status ?? ''))
+      break
+    default:
+      break
+  }
+  return copy
+}

--- a/frontend/ui-v2/src/search/useSearchTelemetry.ts
+++ b/frontend/ui-v2/src/search/useSearchTelemetry.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+import { useFeedConnectionStore } from '../store/feedConnectionStore'
+
+/** Record keystroke → suggestion panel refresh latency (p50/p95 in feedConnectionStore). */
+export function useKeystrokeSuggestionTelemetry(suggestionsKey: string) {
+  const record = useFeedConnectionStore((s) => s.recordKeystrokeSuggestion)
+  const pendingAt = useRef<number | null>(null)
+
+  const markKeystroke = () => {
+    pendingAt.current = performance.now()
+  }
+
+  useEffect(() => {
+    if (pendingAt.current === null) return
+    record(performance.now() - pendingAt.current)
+    pendingAt.current = null
+  }, [suggestionsKey, record])
+
+  return { markKeystroke }
+}
+
+/** Record request → first-page latency split by local (sync tier) vs server (hybrid tier). */
+export function useRequestFirstPageTelemetry(
+  requestKey: string,
+  hybridEnabled: boolean,
+  hybridPending: boolean,
+) {
+  const recordLocal = useFeedConnectionStore((s) => s.recordRequestFirstPageLocal)
+  const recordServer = useFeedConnectionStore((s) => s.recordRequestFirstPageServer)
+  const startedAt = useRef<number | null>(null)
+  const localKey = useRef<string | null>(null)
+  const serverKey = useRef<string | null>(null)
+
+  useEffect(() => {
+    startedAt.current = performance.now()
+    localKey.current = null
+    serverKey.current = null
+  }, [requestKey])
+
+  useEffect(() => {
+    if (!startedAt.current || localKey.current === requestKey) return
+    recordLocal(performance.now() - startedAt.current)
+    localKey.current = requestKey
+  }, [requestKey, recordLocal])
+
+  useEffect(() => {
+    if (!hybridEnabled || !startedAt.current || serverKey.current === requestKey) return
+    if (hybridPending) return
+    recordServer(performance.now() - startedAt.current)
+    serverKey.current = requestKey
+  }, [requestKey, hybridEnabled, hybridPending, recordServer])
+}

--- a/frontend/ui-v2/src/shell/FeedPane.tsx
+++ b/frontend/ui-v2/src/shell/FeedPane.tsx
@@ -32,6 +32,12 @@ export function FeedPane() {
   const reconnectAttempt = useFeedConnectionStore((s) => s.reconnectAttempt)
   const p50LatencyMs = useFeedConnectionStore((s) => s.p50LatencyMs)
   const p99LatencyMs = useFeedConnectionStore((s) => s.p99LatencyMs)
+  const keystrokeP50 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p50Ms)
+  const keystrokeP95 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p95Ms)
+  const localP50 = useFeedConnectionStore((s) => s.requestFirstPageLocal.p50Ms)
+  const localP95 = useFeedConnectionStore((s) => s.requestFirstPageLocal.p95Ms)
+  const serverP50 = useFeedConnectionStore((s) => s.requestFirstPageServer.p50Ms)
+  const serverP95 = useFeedConnectionStore((s) => s.requestFirstPageServer.p95Ms)
   const errorMessage = useFeedConnectionStore((s) => s.errorMessage)
 
   const { events, isHydrating, isSnapshotError, refetchSnapshot, manualReconnect } =
@@ -83,8 +89,32 @@ export function FeedPane() {
         </p>
         {p50LatencyMs !== null && (
           <p style={{ margin: 'var(--space-1) 0 0', fontSize: 'var(--text-xs)', color: 'var(--fg-muted)' }}>
-            P50 {Math.round(p50LatencyMs)}ms
+            WSS P50 {Math.round(p50LatencyMs)}ms
             {p99LatencyMs !== null ? ` · P99 ${Math.round(p99LatencyMs)}ms` : ''}
+          </p>
+        )}
+        {(keystrokeP50 !== null || localP50 !== null || serverP50 !== null) && (
+          <p style={{ margin: 'var(--space-1) 0 0', fontSize: 'var(--text-xs)', color: 'var(--fg-muted)' }}>
+            {keystrokeP50 !== null && (
+              <>
+                Key→suggest P50 {Math.round(keystrokeP50)}ms
+                {keystrokeP95 !== null ? ` · P95 ${Math.round(keystrokeP95)}ms` : ''}
+              </>
+            )}
+            {localP50 !== null && (
+              <>
+                {keystrokeP50 !== null ? ' · ' : ''}
+                Req→page local P50 {Math.round(localP50)}ms
+                {localP95 !== null ? ` · P95 ${Math.round(localP95)}ms` : ''}
+              </>
+            )}
+            {serverP50 !== null && (
+              <>
+                {' · '}
+                Req→page server P50 {Math.round(serverP50)}ms
+                {serverP95 !== null ? ` · P95 ${Math.round(serverP95)}ms` : ''}
+              </>
+            )}
           </p>
         )}
       </div>

--- a/frontend/ui-v2/src/store/feedConnectionStore.ts
+++ b/frontend/ui-v2/src/store/feedConnectionStore.ts
@@ -7,6 +7,13 @@
 import { create } from 'zustand'
 import type { RealtimeConnectionPhase } from '../types/feedEvents'
 
+export interface LatencyBucket {
+  lastMs: number | null
+  p50Ms: number | null
+  p95Ms: number | null
+  samples: number[]
+}
+
 interface FeedConnectionState {
   phase: RealtimeConnectionPhase
   reconnectAttempt: number
@@ -16,12 +23,18 @@ interface FeedConnectionState {
   p99LatencyMs: number | null
   latencySamples: number[]
   errorMessage: string | null
+  keystrokeSuggestion: LatencyBucket
+  requestFirstPageLocal: LatencyBucket
+  requestFirstPageServer: LatencyBucket
 
   setPhase: (phase: RealtimeConnectionPhase) => void
   setReconnectAttempt: (attempt: number) => void
   incrementFailedReconnects: () => void
   resetFailedReconnects: () => void
   recordLatency: (latencyMs: number) => void
+  recordKeystrokeSuggestion: (latencyMs: number) => void
+  recordRequestFirstPageLocal: (latencyMs: number) => void
+  recordRequestFirstPageServer: (latencyMs: number) => void
   setErrorMessage: (message: string | null) => void
   resetLatency: () => void
 }
@@ -33,6 +46,20 @@ function percentile(values: number[], p: number): number | null {
   return sorted[index] ?? null
 }
 
+function emptyBucket(): LatencyBucket {
+  return { lastMs: null, p50Ms: null, p95Ms: null, samples: [] }
+}
+
+function recordBucket(bucket: LatencyBucket, latencyMs: number): LatencyBucket {
+  const samples = [...bucket.samples, latencyMs].slice(-200)
+  return {
+    lastMs: latencyMs,
+    samples,
+    p50Ms: percentile(samples, 50),
+    p95Ms: percentile(samples, 95),
+  }
+}
+
 export const useFeedConnectionStore = create<FeedConnectionState>((set, get) => ({
   phase: 'idle',
   reconnectAttempt: 0,
@@ -42,6 +69,9 @@ export const useFeedConnectionStore = create<FeedConnectionState>((set, get) => 
   p99LatencyMs: null,
   latencySamples: [],
   errorMessage: null,
+  keystrokeSuggestion: emptyBucket(),
+  requestFirstPageLocal: emptyBucket(),
+  requestFirstPageServer: emptyBucket(),
 
   setPhase: (phase) => set({ phase }),
   setReconnectAttempt: (attempt) => set({ reconnectAttempt: attempt }),
@@ -57,6 +87,18 @@ export const useFeedConnectionStore = create<FeedConnectionState>((set, get) => 
       p99LatencyMs: percentile(samples, 99),
     })
   },
+  recordKeystrokeSuggestion: (latencyMs) =>
+    set((state) => ({
+      keystrokeSuggestion: recordBucket(state.keystrokeSuggestion, latencyMs),
+    })),
+  recordRequestFirstPageLocal: (latencyMs) =>
+    set((state) => ({
+      requestFirstPageLocal: recordBucket(state.requestFirstPageLocal, latencyMs),
+    })),
+  recordRequestFirstPageServer: (latencyMs) =>
+    set((state) => ({
+      requestFirstPageServer: recordBucket(state.requestFirstPageServer, latencyMs),
+    })),
   setErrorMessage: (message) => set({ errorMessage: message }),
   resetLatency: () =>
     set({
@@ -64,5 +106,8 @@ export const useFeedConnectionStore = create<FeedConnectionState>((set, get) => 
       p50LatencyMs: null,
       p99LatencyMs: null,
       latencySamples: [],
+      keystrokeSuggestion: emptyBucket(),
+      requestFirstPageLocal: emptyBucket(),
+      requestFirstPageServer: emptyBucket(),
     }),
 }))


### PR DESCRIPTION
## Summary
- Feed search state (query, PropertyFilter tokens, sort, scroll) encoded in TanStack Router `/feed` search params
- Browser back and record-detail `BreadcrumbGroup` “Feed” restore prior filtered view + scroll via URL + sessionStorage snapshot
- Extended `feedConnectionStore` with keystroke→suggestion and request→first-page p50/p95 metrics (local vs server tier), surfaced in feed meta and FeedPane

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint:adherence`
- [x] `npm test` (39 passing)
- [ ] Gamma ui-v2 deploy after merge

commit-complete-id: CCI-854fd98ccc8741dc861810a7cda1e1cd