### PR TITLE
ENC-TSK-L23: GET /api/v1/feed/corpus cursor-paginated multi-table corpus (FTR-127)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.3",
-  "updated_at": "2026-07-05T06:50:00Z",
-  "last_change_summary": "ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional relation enforcement -- tracker_mutation PATCH now atomically mirrors newly-added related_task_ids/related_issue_ids/related_feature_ids onto each target's reverse field; document_api PUT/PATCH mirrors related_items onto each named tracker record's new related_document_ids field; new tracker.relate(source_id, target_id) MCP convenience action performs the append under one governance hash check. inverse_of declared across tracker.task/issue/feature/lesson and docstore.document.",
+  "version": "2026-07-05.4",
+  "updated_at": "2026-07-05T07:20:00Z",
+  "last_change_summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus — cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3437,6 +3437,27 @@
         "response_error": {
           "type": "object",
           "definition": "Error response (502): returned when feed_publisher invoke fails or returns a function error."
+        }
+      }
+    },
+    "feed_query.corpus": {
+      "description": "ENC-TSK-L23 / FTR-127 AC-1..4/13: GET /api/v1/feed/corpus returns the full multi-project feed corpus from BOTH the tracker table and the documents table as a cursor-paginated stream. Minimal identity projection plus compact attrs map (status, priority, tags/keywords, document_subtype). Filter and sort pushdown via query params; facet counts are the browse/filter authority until ENC-TSK-L43 OpenSearch ships.",
+      "fields": {
+        "endpoint": {
+          "type": "string",
+          "definition": "GET /api/v1/feed/corpus — JWT-gated (401 unauthenticated). Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+        },
+        "cursor": {
+          "type": "string",
+          "definition": "Base64url-encoded composite cursor over (sort_value, record_key). record_key is source-tagged: tracker:{project_id}:{record_id} or document::{document_id}."
+        },
+        "facets": {
+          "type": "object",
+          "definition": "Facet counts for record_type, status, priority, and project_id over the filtered corpus slice."
+        },
+        "attrs": {
+          "type": "object",
+          "definition": "Compact per-record attribute map: status, priority, category, severity (issues), tags (documents), document_subtype, subtypepattern."
         }
       }
     },

--- a/backend/lambda/feed_query/corpus.py
+++ b/backend/lambda/feed_query/corpus.py
@@ -1,0 +1,303 @@
+"""Feed corpus pagination for GET /api/v1/feed/corpus (ENC-TSK-L23 / FTR-127)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+VALID_SORTS = {
+    "updated_at_desc",
+    "record_id_asc",
+    "title_asc",
+    "status_asc",
+    "priority_asc",
+}
+
+_FACET_FIELDS = ("record_type", "status", "priority", "project_id")
+
+
+def _clamp_limit(raw: Any) -> int:
+    try:
+        value = int(str(raw or DEFAULT_LIMIT))
+    except (TypeError, ValueError):
+        value = DEFAULT_LIMIT
+    return max(1, min(MAX_LIMIT, value))
+
+
+def _split_csv(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    return [part.strip().lower() for part in str(raw).split(",") if part.strip()]
+
+
+def parse_corpus_query(qs: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "limit": _clamp_limit(qs.get("limit")),
+        "cursor": str(qs.get("cursor") or "").strip(),
+        "sort": str(qs.get("sort") or "updated_at_desc").strip().lower(),
+        "q": str(qs.get("q") or "").strip().lower(),
+        "record_type": _split_csv(qs.get("record_type")),
+        "status": _split_csv(qs.get("status")),
+        "project_id": _split_csv(qs.get("project_id")),
+        "priority": _split_csv(qs.get("priority")),
+    }
+
+
+def encode_cursor(sort_value: str, record_key: str) -> str:
+    payload = {"sort_value": sort_value, "record_key": record_key}
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_cursor(raw: str) -> Optional[Tuple[str, str]]:
+    if not raw:
+        return None
+    try:
+        padded = raw + "=" * (-len(raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8"))
+        sort_value = str(payload.get("sort_value") or "")
+        record_key = str(payload.get("record_key") or "")
+        if not sort_value or not record_key:
+            return None
+        return sort_value, record_key
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, TypeError):
+        return None
+
+
+def _sort_key(entry: Mapping[str, Any], sort: str) -> Tuple:
+    if sort == "record_id_asc":
+        primary = str(entry.get("record_id") or "").lower()
+    elif sort == "title_asc":
+        primary = str(entry.get("title") or "").lower()
+    elif sort == "status_asc":
+        primary = str((entry.get("attrs") or {}).get("status") or "").lower()
+    elif sort == "priority_asc":
+        primary = str((entry.get("attrs") or {}).get("priority") or "").lower()
+    else:
+        primary = str(entry.get("updated_at") or "")
+        sort = "updated_at_desc"
+    record_key = str(entry.get("record_key") or "")
+    if sort == "updated_at_desc":
+        return (primary, record_key)
+    return (primary, record_key)
+
+
+def sort_entries(entries: Sequence[Mapping[str, Any]], sort: str) -> List[Dict[str, Any]]:
+    normalized_sort = sort if sort in VALID_SORTS else "updated_at_desc"
+    if normalized_sort == "updated_at_desc":
+        ordered = sorted(
+            entries,
+            key=lambda entry: (
+                str(entry.get("updated_at") or ""),
+                str(entry.get("record_key") or ""),
+            ),
+            reverse=True,
+        )
+    else:
+        ordered = sorted(entries, key=lambda entry: _sort_key(entry, normalized_sort))
+    result: List[Dict[str, Any]] = []
+    for entry in ordered:
+        row = dict(entry)
+        row["sort_value"] = _sort_key(row, normalized_sort)[0]
+        result.append(row)
+    return result
+
+
+def _matches_filters(entry: Mapping[str, Any], query: Mapping[str, Any]) -> bool:
+    needle = str(query.get("q") or "")
+    if needle:
+        hay = f"{entry.get('record_id', '')} {entry.get('title', '')}".lower()
+        if needle not in hay:
+            return False
+
+    attrs = entry.get("attrs") or {}
+    for field, values in (
+        ("record_type", query.get("record_type")),
+        ("status", query.get("status")),
+        ("project_id", query.get("project_id")),
+        ("priority", query.get("priority")),
+    ):
+        selected = values or []
+        if not selected:
+            continue
+        actual = str(entry.get(field if field != "priority" else "record_type") or "")
+        if field == "status":
+            actual = str(attrs.get("status") or "").lower()
+        elif field == "priority":
+            actual = str(attrs.get("priority") or "").lower()
+        elif field == "record_type":
+            actual = str(entry.get("record_type") or "").lower()
+        elif field == "project_id":
+            actual = str(entry.get("project_id") or "").lower()
+        if actual not in selected:
+            return False
+    return True
+
+
+def compute_facets(entries: Iterable[Mapping[str, Any]]) -> Dict[str, Dict[str, int]]:
+    facets: Dict[str, Dict[str, int]] = {field: {} for field in _FACET_FIELDS}
+    for entry in entries:
+        attrs = entry.get("attrs") or {}
+        pairs = {
+            "record_type": str(entry.get("record_type") or "unknown"),
+            "status": str(attrs.get("status") or "unknown"),
+            "priority": str(attrs.get("priority") or "unknown"),
+            "project_id": str(entry.get("project_id") or "unknown"),
+        }
+        for field, value in pairs.items():
+            bucket = facets[field]
+            bucket[value] = bucket.get(value, 0) + 1
+    return facets
+
+
+def paginate_corpus(
+    entries: Sequence[Mapping[str, Any]],
+    query: Mapping[str, Any],
+) -> Dict[str, Any]:
+    sort = str(query.get("sort") or "updated_at_desc")
+    if sort not in VALID_SORTS:
+        sort = "updated_at_desc"
+
+    filtered = [dict(entry) for entry in entries if _matches_filters(entry, query)]
+    sorted_rows = sort_entries(filtered, sort)
+    facets = compute_facets(sorted_rows)
+
+    cursor = decode_cursor(str(query.get("cursor") or ""))
+    start_index = 0
+    if cursor is not None:
+        _cursor_sort, cursor_key = cursor
+        for idx, row in enumerate(sorted_rows):
+            if str(row.get("record_key") or "") == cursor_key:
+                start_index = idx + 1
+                break
+
+    limit = int(query.get("limit") or DEFAULT_LIMIT)
+    page = sorted_rows[start_index : start_index + limit]
+    next_cursor = None
+    if start_index + limit < len(sorted_rows) and page:
+        last = page[-1]
+        next_cursor = encode_cursor(str(last.get("sort_value") or ""), str(last.get("record_key") or ""))
+
+    public_items = []
+    for row in page:
+        public_items.append(
+            {
+                "record_id": row.get("record_id"),
+                "record_type": row.get("record_type"),
+                "project_id": row.get("project_id"),
+                "title": row.get("title"),
+                "updated_at": row.get("updated_at"),
+                "source": row.get("source"),
+                "record_key": row.get("record_key"),
+                "attrs": row.get("attrs") or {},
+            }
+        )
+
+    return {
+        "items": public_items,
+        "next_cursor": next_cursor,
+        "facets": facets,
+        "total_matches": len(sorted_rows),
+        "sort": sort,
+    }
+
+
+def tracker_record_key(project_id: str, record_id: str) -> str:
+    return f"tracker:{project_id}:{record_id}"
+
+
+def document_record_key(document_id: str) -> str:
+    return f"document::{document_id}"
+
+
+def build_tracker_entry(
+    record_type: str,
+    record_id: str,
+    project_id: str,
+    title: str,
+    updated_at: Optional[str],
+    attrs: Mapping[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "record_id": record_id,
+        "record_type": record_type,
+        "project_id": project_id,
+        "title": title or record_id,
+        "updated_at": updated_at,
+        "source": "tracker",
+        "record_key": tracker_record_key(project_id, record_id),
+        "attrs": dict(attrs),
+    }
+
+
+def build_document_entry(item: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    document_id = str(item.get("document_id") or "").strip()
+    if not document_id:
+        return None
+    status = str(item.get("status") or "active").lower()
+    if status in {"deleted", "archived"}:
+        return None
+    keywords = item.get("keywords") or []
+    tags = [str(tag).strip() for tag in keywords if str(tag).strip()]
+    attrs = {
+        "status": status,
+        "tags": tags,
+        "document_subtype": str(item.get("document_subtype") or "general"),
+    }
+    subtypepattern = str(item.get("subtypepattern") or "").strip()
+    if subtypepattern:
+        attrs["subtypepattern"] = subtypepattern
+    return {
+        "record_id": document_id,
+        "record_type": "document",
+        "project_id": str(item.get("project_id") or ""),
+        "title": str(item.get("title") or document_id),
+        "updated_at": item.get("updated_at") or item.get("created_at"),
+        "source": "document",
+        "record_key": document_record_key(document_id),
+        "attrs": attrs,
+    }
+
+
+def build_tracker_entries_from_records(
+    tasks: Sequence[Mapping[str, Any]],
+    issues: Sequence[Mapping[str, Any]],
+    features: Sequence[Mapping[str, Any]],
+    lessons: Sequence[Mapping[str, Any]],
+    plans: Sequence[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    entries: List[Dict[str, Any]] = []
+
+    def append_many(records: Sequence[Mapping[str, Any]], record_type: str, id_key: str) -> None:
+        for record in records:
+            record_id = str(record.get(id_key) or "")
+            if not record_id:
+                continue
+            attrs = {
+                "status": record.get("status"),
+                "priority": record.get("priority"),
+                "category": record.get("category"),
+            }
+            if record_type == "issue":
+                attrs["severity"] = record.get("severity")
+            entries.append(
+                build_tracker_entry(
+                    record_type,
+                    record_id,
+                    str(record.get("project_id") or ""),
+                    str(record.get("title") or record_id),
+                    record.get("updated_at"),
+                    attrs,
+                )
+            )
+
+    append_many(tasks, "task", "task_id")
+    append_many(issues, "issue", "issue_id")
+    append_many(features, "feature", "feature_id")
+    append_many(lessons, "lesson", "lesson_id")
+    append_many(plans, "plan", "plan_id")
+    return entries

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -4,6 +4,7 @@ Lambda API for Enceladus feed read and subscription lifecycle.
 
 Routes (via API Gateway proxy):
     GET     /api/v1/feed
+    GET     /api/v1/feed/corpus
     POST    /api/v1/feed/refresh
     POST    /api/v1/feed/subscriptions
     GET     /api/v1/feed/subscriptions/{subscriptionId}
@@ -22,6 +23,7 @@ Environment variables:
     COORDINATION_TABLE        default: coordination-requests
     DYNAMODB_REGION           default: us-west-2
     PROJECTS_TABLE            default: projects
+    DOCUMENTS_TABLE           default: documents
 """
 
 from __future__ import annotations
@@ -39,6 +41,8 @@ import urllib.request
 import boto3
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
+
+import corpus as feed_corpus
 
 try:
     import jwt
@@ -68,6 +72,7 @@ SUBSCRIPTIONS_TABLE = os.environ.get("SUBSCRIPTIONS_TABLE", "feed-subscriptions"
 COORDINATION_TABLE = os.environ.get("COORDINATION_TABLE", "coordination-requests")
 DYNAMODB_REGION = os.environ.get("DYNAMODB_REGION", "us-west-2")
 PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
+DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
 COGNITO_USER_POOL_ID = os.environ.get("COGNITO_USER_POOL_ID", "")
 COGNITO_CLIENT_ID = os.environ.get("COGNITO_CLIENT_ID", "")
 FEED_PUBLISHER_FUNCTION = os.environ.get("FEED_PUBLISHER_FUNCTION", "devops-feed-publisher")
@@ -111,6 +116,10 @@ _JWKS_TTL = 3600.0
 _project_cache: Optional[List[Dict[str, str]]] = None
 _project_cache_at: float = 0.0
 _PROJECT_CACHE_TTL = 300.0
+
+_corpus_cache_entries: Optional[List[Dict[str, Any]]] = None
+_corpus_cache_at: float = 0.0
+_CORPUS_CACHE_TTL = 30.0
 
 _ddb = None
 
@@ -1226,6 +1235,125 @@ def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Li
     return all_tasks, all_issues, all_features, all_lessons, all_plans
 
 
+def _query_corpus_tracker_records() -> Tuple[
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+]:
+    """Load the full tracker corpus without per-type refresh caps (ENC-TSK-L23)."""
+    ddb = _get_ddb()
+    projects = _get_active_projects()
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=CLOSED_ITEM_MAX_AGE_DAYS)
+
+    all_tasks: List[Dict[str, Any]] = []
+    all_issues: List[Dict[str, Any]] = []
+    all_features: List[Dict[str, Any]] = []
+    all_lessons: List[Dict[str, Any]] = []
+    all_plans: List[Dict[str, Any]] = []
+
+    for proj in projects:
+        pid = proj["project_id"]
+        paginator = ddb.get_paginator("query")
+        try:
+            for page in paginator.paginate(
+                TableName=DYNAMODB_TABLE,
+                IndexName="project-type-index",
+                KeyConditionExpression="project_id = :pid",
+                ExpressionAttributeValues={":pid": {"S": pid}},
+            ):
+                for raw_item in page.get("Items", []):
+                    record_type = _ddb_str(raw_item, "record_type")
+                    if record_type not in _TRANSFORM:
+                        continue
+                    try:
+                        if _is_stale_closed(raw_item, cutoff):
+                            continue
+                        transformed = _TRANSFORM[record_type](raw_item, pid)
+                    except Exception as rec_exc:  # noqa: BLE001
+                        logger.error(
+                            "feed_query corpus: skipping record_type=%s item_id=%s project=%s: %s",
+                            record_type,
+                            _ddb_str(raw_item, "item_id") or "?",
+                            pid,
+                            rec_exc,
+                        )
+                        continue
+                    if record_type == "task":
+                        all_tasks.append(transformed)
+                    elif record_type == "issue":
+                        all_issues.append(transformed)
+                    elif record_type == "feature":
+                        all_features.append(transformed)
+                    elif record_type == "lesson":
+                        all_lessons.append(transformed)
+                    elif record_type == "plan":
+                        all_plans.append(transformed)
+        except (BotoCoreError, ClientError) as exc:
+            logger.error("Corpus tracker query failed for project %s: %s", pid, exc)
+            continue
+
+    return all_tasks, all_issues, all_features, all_lessons, all_plans
+
+
+def _deserialize_document_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "document_id": _ddb_str(item, "document_id"),
+        "project_id": _ddb_str(item, "project_id"),
+        "title": _ddb_str(item, "title"),
+        "status": _ddb_str(item, "status") or "active",
+        "updated_at": _ddb_str(item, "updated_at") or None,
+        "created_at": _ddb_str(item, "created_at") or None,
+        "document_subtype": _ddb_str(item, "document_subtype") or "general",
+        "subtypepattern": _ddb_str(item, "subtypepattern") or "",
+        "keywords": _ddb_str_set(item, "keywords"),
+    }
+
+
+def _scan_documents_for_corpus() -> List[Dict[str, Any]]:
+    ddb = _get_ddb()
+    items: List[Dict[str, Any]] = []
+    scan_params: Dict[str, Any] = {"TableName": DOCUMENTS_TABLE}
+    try:
+        while True:
+            resp = ddb.scan(**scan_params)
+            for raw_item in resp.get("Items", []):
+                try:
+                    items.append(_deserialize_document_item(raw_item))
+                except Exception as exc:  # noqa: BLE001
+                    logger.error("feed_query corpus: skipping document item: %s", exc)
+            last_key = resp.get("LastEvaluatedKey")
+            if not isinstance(last_key, dict) or not last_key:
+                break
+            scan_params["ExclusiveStartKey"] = last_key
+    except (BotoCoreError, ClientError) as exc:
+        logger.error("Corpus documents scan failed: %s", exc)
+    return items
+
+
+def _get_corpus_entries() -> List[Dict[str, Any]]:
+    global _corpus_cache_entries, _corpus_cache_at
+    now = time.time()
+    if _corpus_cache_entries is not None and now - _corpus_cache_at < _CORPUS_CACHE_TTL:
+        return _corpus_cache_entries
+
+    tasks, issues, features, lessons, plans = _query_corpus_tracker_records()
+    tracker_entries = feed_corpus.build_tracker_entries_from_records(
+        tasks, issues, features, lessons, plans
+    )
+    document_entries = [
+        entry
+        for entry in (
+            feed_corpus.build_document_entry(doc) for doc in _scan_documents_for_corpus()
+        )
+        if entry
+    ]
+    _corpus_cache_entries = tracker_entries + document_entries
+    _corpus_cache_at = now
+    return _corpus_cache_entries
+
+
 # ---------------------------------------------------------------------------
 # Typed relationship edges (ENC-ISS-137 / ENC-FTR-049 / ENC-TSK-A57)
 # ---------------------------------------------------------------------------
@@ -1528,6 +1656,39 @@ def _handle_snapshot() -> Dict[str, Any]:
     }
 
 
+def _handle_corpus(qs: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/feed/corpus — cursor-paginated multi-table feed corpus (ENC-TSK-L23)."""
+    query = feed_corpus.parse_corpus_query(qs or {})
+    if query["sort"] not in feed_corpus.VALID_SORTS:
+        return _error(400, f"Invalid sort '{query['sort']}'")
+
+    if query["cursor"] and feed_corpus.decode_cursor(query["cursor"]) is None:
+        return _error(400, "Invalid cursor")
+
+    try:
+        entries = _get_corpus_entries()
+        page = feed_corpus.paginate_corpus(entries, query)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("feed corpus query failed: %s", exc)
+        return _error(500, "Failed to query feed corpus. Please try again.")
+
+    body = {
+        "success": True,
+        "generated_at": _now_z(),
+        "version": "1.0",
+        **page,
+    }
+    return {
+        "statusCode": 200,
+        "headers": {
+            **_cors_headers(),
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+        },
+        "body": json.dumps(body),
+    }
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     method = (
         (event.get("requestContext") or {}).get("http", {}).get("method")
@@ -1596,6 +1757,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # /mobile/v1/tasks.json S3 object. JWT already enforced above.
     if method == "GET" and re.search(r"/api/v1/feed/tasks\.json/?$", path):
         return _handle_snapshot()
+
+    if method == "GET" and re.search(r"/api/v1/feed/corpus/?$", path):
+        return _handle_corpus(event.get("queryStringParameters") or {})
 
     if method != "GET" or not re.search(r"/api/v1/feed/?$", path):
         return _error(404, f"Unsupported route: {method} {path}")

--- a/backend/lambda/feed_query/test_corpus.py
+++ b/backend/lambda/feed_query/test_corpus.py
@@ -1,0 +1,88 @@
+"""Unit tests for feed corpus pagination (ENC-TSK-L23)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_CORPUS_SPEC = importlib.util.spec_from_file_location(
+    "feed_corpus",
+    os.path.join(os.path.dirname(__file__), "corpus.py"),
+)
+corpus = importlib.util.module_from_spec(_CORPUS_SPEC)
+assert _CORPUS_SPEC.loader is not None
+_CORPUS_SPEC.loader.exec_module(corpus)
+
+
+def _entry(
+    record_id: str,
+    *,
+    record_type: str = "task",
+    project_id: str = "enceladus",
+    title: str = "Alpha",
+    updated_at: str = "2026-07-05T10:00:00Z",
+    status: str = "open",
+    priority: str = "P1",
+) -> dict:
+    return corpus.build_tracker_entry(
+        record_type,
+        record_id,
+        project_id,
+        title,
+        updated_at,
+        {"status": status, "priority": priority},
+    )
+
+
+def test_paginate_returns_next_cursor_and_facets():
+    entries = [
+        _entry("ENC-TSK-BBB", updated_at="2026-07-05T11:00:00Z"),
+        _entry("ENC-TSK-AAA", updated_at="2026-07-05T10:00:00Z"),
+        corpus.build_document_entry(
+            {
+                "document_id": "DOC-123",
+                "project_id": "enceladus",
+                "title": "Doc",
+                "status": "active",
+                "updated_at": "2026-07-05T09:00:00Z",
+                "keywords": ["wave-b"],
+            }
+        ),
+    ]
+    entries = [entry for entry in entries if entry]
+
+    first = corpus.paginate_corpus(entries, {"limit": 2, "sort": "updated_at_desc"})
+    assert len(first["items"]) == 2
+    assert first["items"][0]["record_id"] == "ENC-TSK-BBB"
+    assert first["next_cursor"]
+    assert first["facets"]["record_type"]["task"] == 2
+    assert first["facets"]["record_type"]["document"] == 1
+
+    second = corpus.paginate_corpus(
+        entries,
+        {"limit": 2, "sort": "updated_at_desc", "cursor": first["next_cursor"]},
+    )
+    assert len(second["items"]) == 1
+    assert second["items"][0]["record_id"] == "DOC-123"
+    assert second["next_cursor"] is None
+
+
+def test_filter_by_record_type_and_query():
+    entries = [
+        _entry("ENC-TSK-AAA", title="Search alpha"),
+        _entry("ENC-ISS-BBB", record_type="issue", title="Other"),
+    ]
+    page = corpus.paginate_corpus(
+        entries,
+        {"limit": 10, "record_type": ["task"], "q": "search"},
+    )
+    assert page["total_matches"] == 1
+    assert page["items"][0]["record_id"] == "ENC-TSK-AAA"
+
+
+def test_invalid_cursor_decode_returns_none():
+    assert corpus.decode_cursor("not-valid") is None
+
+
+def test_document_entry_skips_deleted():
+    assert corpus.build_document_entry({"document_id": "DOC-1", "status": "deleted"}) is None

--- a/backend/lambda/feed_query/test_lambda_function.py
+++ b/backend/lambda/feed_query/test_lambda_function.py
@@ -62,6 +62,56 @@ def test_invalid_since_returns_400(monkeypatch):
     assert "since" in payload["error"]
 
 
+def _corpus_get_event(**params: str) -> dict:
+    return {
+        "requestContext": {"http": {"method": "GET"}},
+        "rawPath": "/api/v1/feed/corpus",
+        "headers": {"Cookie": "enceladus_id_token=test-token"},
+        "queryStringParameters": params or None,
+    }
+
+
+def test_corpus_requires_auth():
+    resp = feed_query.lambda_handler(
+        {
+            "requestContext": {"http": {"method": "GET"}},
+            "rawPath": "/api/v1/feed/corpus",
+            "headers": {},
+        },
+        None,
+    )
+    assert resp["statusCode"] == 401
+
+
+def test_corpus_returns_paginated_payload(monkeypatch):
+    monkeypatch.setattr(feed_query, "_verify_token", lambda _token: {"sub": "u-1"})
+    monkeypatch.setattr(
+        feed_query,
+        "_get_corpus_entries",
+        lambda: feed_query.feed_corpus.build_tracker_entries_from_records(
+            [{"task_id": "ENC-TSK-1", "project_id": "enceladus", "title": "One", "status": "open", "priority": "P1", "updated_at": "2026-07-05T10:00:00Z"}],
+            [],
+            [],
+            [],
+            [],
+        ),
+    )
+
+    resp = feed_query.lambda_handler(_corpus_get_event(limit="10"), None)
+    assert resp["statusCode"] == 200
+    payload = json.loads(resp["body"])
+    assert payload["success"] is True
+    assert payload["items"][0]["record_id"] == "ENC-TSK-1"
+    assert "facets" in payload
+    assert payload["total_matches"] == 1
+
+
+def test_corpus_invalid_cursor_returns_400(monkeypatch):
+    monkeypatch.setattr(feed_query, "_verify_token", lambda _token: {"sub": "u-1"})
+    resp = feed_query.lambda_handler(_corpus_get_event(cursor="bad-cursor"), None)
+    assert resp["statusCode"] == 400
+
+
 # ---------------------------------------------------------------------------
 # _ddb_history defensive behavior (ENC-TSK-C31)
 #

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -624,6 +624,7 @@ Resources:
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           FEED_PUBLISHER_FUNCTION: !Sub "devops-feed-publisher${EnvironmentSuffix}"
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
@@ -3678,6 +3679,8 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -603,6 +603,13 @@ Resources:
       RouteKey: GET /api/v1/feed/tasks.json
       Target: !Sub integrations/${FeedQueryIntegration}
 
+  RouteFeedCorpus:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/feed/corpus
+      Target: !Sub integrations/${FeedQueryIntegration}
+
   RouteFeedRefresh:
     Type: AWS::ApiGatewayV2::Route
     Properties:


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/feed/corpus` to feed_query: merges tracker + documents tables into a source-tagged corpus with minimal identity projection + compact `attrs` map
- Cursor pagination via composite `(sort_value, record_key)` cursors; filter/sort pushdown query params; facet counts for browse/filter authority
- JWT-gated (401 unauthenticated); documents-table IAM + env on feed_query; API Gateway route in 03-api

## Test plan
- [x] `pytest backend/lambda/feed_query/test_corpus.py backend/lambda/feed_query/test_lambda_function.py` — 38 passed
- [ ] Gen2 feed-query lambda deploy + api-stack deploy to v4-gamma after merge

commit-complete-id: CCI-eaa91c7405734a1b84c9064134e2d695