### PR TITLE
feat(ui-v2): client cache engine — IndexedDB tiers + read-through (ENC-TSK-L24)

### DIFF
--- a/frontend/ui-v2/src/api/client.ts
+++ b/frontend/ui-v2/src/api/client.ts
@@ -14,6 +14,7 @@
 
 import type { HybridGraphsearchResponse, HybridSearchParams } from '../types/search'
 import type { UserPreferences } from '../types/userPreferences'
+import type { FeedCorpusPage } from '../sync/types'
 
 /**
  * Read API base URL. Defaults to `/api/v1`, matching the existing app's
@@ -186,4 +187,27 @@ export async function fetchHybridGraphsearch(
   }
   if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
   return (await res.json()) as HybridGraphsearchResponse
+}
+
+/**
+ * Feed corpus pagination (ENC-TSK-L23 / L24 seed). GET /api/v1/feed/corpus returns
+ * cursor-paginated Tier-1 identity rows for cache warm-start.
+ */
+export async function fetchFeedCorpusPage(
+  params: {
+    cursor?: string
+    limit?: number
+    sort?: string
+    q?: string
+  } = {},
+  init?: FetchInit,
+): Promise<FeedCorpusPage> {
+  const qs = new URLSearchParams()
+  if (params.limit != null) qs.set('limit', String(params.limit))
+  if (params.cursor) qs.set('cursor', params.cursor)
+  if (params.sort) qs.set('sort', params.sort)
+  if (params.q) qs.set('q', params.q)
+  const suffix = qs.toString()
+  const url = `${API_BASE}/feed/corpus${suffix ? `?${suffix}` : ''}`
+  return requestJson<FeedCorpusPage>(url, init)
 }

--- a/frontend/ui-v2/src/api/queryOptions.ts
+++ b/frontend/ui-v2/src/api/queryOptions.ts
@@ -13,7 +13,10 @@
  */
 
 import { queryOptions } from '@tanstack/react-query'
-import { fetchDocumentRecord, fetchTrackerRecord } from './client'
+import {
+  readThroughDocumentRecord,
+  readThroughTrackerRecord,
+} from '../sync/readThrough'
 import type {
   Document,
   Feature,
@@ -36,41 +39,41 @@ export const taskQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('task', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Task>('task', projectId, recordId, { signal }),
+      readThroughTrackerRecord<Task>('task', projectId, recordId, { signal }),
   })
 
 export const issueQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('issue', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Issue>('issue', projectId, recordId, { signal }),
+      readThroughTrackerRecord<Issue>('issue', projectId, recordId, { signal }),
   })
 
 export const featureQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('feature', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Feature>('feature', projectId, recordId, { signal }),
+      readThroughTrackerRecord<Feature>('feature', projectId, recordId, { signal }),
   })
 
 export const planQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('plan', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Plan>('plan', projectId, recordId, { signal }),
+      readThroughTrackerRecord<Plan>('plan', projectId, recordId, { signal }),
   })
 
 export const lessonQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('lesson', projectId, recordId),
     queryFn: ({ signal }) =>
-      fetchTrackerRecord<Lesson>('lesson', projectId, recordId, { signal }),
+      readThroughTrackerRecord<Lesson>('lesson', projectId, recordId, { signal }),
   })
 
 export const documentQueryOptions = (recordId: string, projectId = 'global') =>
   queryOptions({
     queryKey: recordKeys.detail('document', projectId, recordId),
-    queryFn: ({ signal }) => fetchDocumentRecord<Document>(recordId, { signal }),
+    queryFn: ({ signal }) => readThroughDocumentRecord<Document>(recordId, { signal }),
   })
 
 /**

--- a/frontend/ui-v2/src/main.tsx
+++ b/frontend/ui-v2/src/main.tsx
@@ -6,6 +6,7 @@ import { queryClient } from './api/queryClient'
 import { projectRegistryQueryOptions } from './api/projectRegistry'
 import { router } from './routes/router'
 import { RealtimeFeedProvider } from './realtime/RealtimeFeedProvider'
+import { CacheEngineProvider } from './sync/CacheEngineProvider'
 import { AuthGate } from './auth/AuthGate'
 import './styles.css'
 
@@ -18,9 +19,11 @@ createRoot(rootEl).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <AuthGate>
-        <RealtimeFeedProvider>
-          <RouterProvider router={router} />
-        </RealtimeFeedProvider>
+        <CacheEngineProvider>
+          <RealtimeFeedProvider>
+            <RouterProvider router={router} />
+          </RealtimeFeedProvider>
+        </CacheEngineProvider>
       </AuthGate>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -21,6 +21,7 @@ import {
 } from './feedEventReducer'
 import { useFeedConnectionStore } from '../store/feedConnectionStore'
 import type { FeedRealtimeEvent } from '../types/feedEvents'
+import { getCacheEngine, tier1FromFeedEvent } from '../sync/cacheEngine'
 
 interface RealtimeFeedContextValue {
   events: FeedRealtimeEvent[]
@@ -96,6 +97,23 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
           break
         case 'feed_event':
           recordLatency(event.latencyMs)
+          void (async () => {
+            const engine = getCacheEngine()
+            const feedEvent = event.event
+            const tier1 = tier1FromFeedEvent({
+              recordId: feedEvent.recordId,
+              recordType: feedEvent.record_type,
+              projectId: '',
+              title: feedEvent.summary,
+              status: feedEvent.action,
+            })
+            if (!tier1) return
+            if (feedEvent.action === 'removed') {
+              await engine.markTombstone(tier1.recordKey, tier1.recordId)
+            } else {
+              await engine.upsertTier1(tier1)
+            }
+          })()
           setEvents((prev) => {
             const merged = mergeFeedEvents(prev, [event.event])
             queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -30,6 +30,8 @@ import {
 import { buildSearchCorpus } from '../search/searchCorpus'
 import { sortSearchHits } from '../search/sortSearchHits'
 import { useTieredSearch } from '../search/useTieredSearch'
+import { getCacheEngine } from '../sync/cacheEngine'
+import { useCacheEngineState } from '../sync/CacheEngineProvider'
 import {
   useKeystrokeSuggestionTelemetry,
   useRequestFirstPageTelemetry,
@@ -81,7 +83,14 @@ export function FeedRoute() {
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
   const { events, isHydrating } = useRealtimeFeed()
-  const corpus = buildSearchCorpus(events, projects)
+  const { isWarm } = useCacheEngineState()
+  const corpus = useMemo(() => {
+    const fromEvents = buildSearchCorpus(events, projects)
+    if (!isWarm) return fromEvents
+    const byId = new Map(getCacheEngine().searchIndex.all().map((row) => [row.recordId, row]))
+    for (const row of fromEvents) byId.set(row.recordId, row)
+    return [...byId.values()]
+  }, [events, projects, isWarm])
   const projectId = projects[0]?.project_id ?? 'enceladus'
 
   const tiered = useTieredSearch({ projectId, query: q }, corpus)
@@ -95,22 +104,29 @@ export function FeedRoute() {
   const requestKey = `${q}|${f}|${op}|${sort}`
   useRequestFirstPageTelemetry(requestKey, hybridEnabled, tiered.hybridPending)
 
-  const searchSuggestions = useMemo(
-    () =>
-      corpus
-        .filter((row) => {
-          const needle = q.trim().toLowerCase()
-          if (!needle) return true
-          return row.recordId.toLowerCase().includes(needle) || row.title.toLowerCase().includes(needle)
-        })
-        .slice(0, 12)
+  const searchSuggestions = useMemo(() => {
+    if (isWarm) {
+      return getCacheEngine()
+        .searchIndex.suggest(q, 12)
         .map((row) => ({
           value: row.recordId,
           description: row.title,
           tag: row.recordType,
-        })),
-    [corpus, q],
-  )
+        }))
+    }
+    return corpus
+      .filter((row) => {
+        const needle = q.trim().toLowerCase()
+        if (!needle) return true
+        return row.recordId.toLowerCase().includes(needle) || row.title.toLowerCase().includes(needle)
+      })
+      .slice(0, 12)
+      .map((row) => ({
+        value: row.recordId,
+        description: row.title,
+        tag: row.recordType,
+      }))
+  }, [corpus, q, isWarm])
 
   const suggestionsKey = searchSuggestions.map((row) => row.value).join(',')
   const { markKeystroke } = useKeystrokeSuggestionTelemetry(suggestionsKey)

--- a/frontend/ui-v2/src/sync/CacheEngineProvider.tsx
+++ b/frontend/ui-v2/src/sync/CacheEngineProvider.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import { getCacheEngine } from './cacheEngine'
+import { seedCacheFromCorpus } from './corpusSeed'
+import { attachQueryClientPersist, restorePersistedQueryClient } from './queryPersist'
+import { queryClient } from '../api/queryClient'
+
+interface CacheEngineContextValue {
+  isWarm: boolean
+  warmDurationMs: number | null
+  seedError: string | null
+}
+
+const CacheEngineContext = createContext<CacheEngineContextValue>({
+  isWarm: false,
+  warmDurationMs: null,
+  seedError: null,
+})
+
+export function useCacheEngineState(): CacheEngineContextValue {
+  return useContext(CacheEngineContext)
+}
+
+export function CacheEngineProvider({ children }: { children: ReactNode }) {
+  const [isWarm, setIsWarm] = useState(getCacheEngine().isWarm)
+  const [warmDurationMs, setWarmDurationMs] = useState<number | null>(null)
+  const [seedError, setSeedError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const engine = getCacheEngine()
+
+    void (async () => {
+      await restorePersistedQueryClient(queryClient)
+      await engine.loadSearchSlice()
+      if (!cancelled) setIsWarm(engine.isWarm)
+
+      try {
+        const result = await seedCacheFromCorpus()
+        if (cancelled) return
+        setIsWarm(true)
+        setWarmDurationMs(result.durationMs)
+      } catch (error) {
+        if (cancelled) return
+        setSeedError(error instanceof Error ? error.message : 'Corpus seed failed')
+      }
+    })()
+
+    const detachPersist = attachQueryClientPersist(queryClient)
+    return () => {
+      cancelled = true
+      detachPersist()
+    }
+  }, [])
+
+  return (
+    <CacheEngineContext.Provider value={{ isWarm, warmDurationMs, seedError }}>
+      {children}
+    </CacheEngineContext.Provider>
+  )
+}

--- a/frontend/ui-v2/src/sync/cacheEngine.test.ts
+++ b/frontend/ui-v2/src/sync/cacheEngine.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  CacheEngine,
+  corpusItemToTier1,
+  resetCacheEngineForTests,
+  tier1FromFeedEvent,
+} from './cacheEngine'
+import type { FeedCorpusItem } from './types'
+
+describe('corpusItemToTier1', () => {
+  it('maps corpus items to tier1 rows', () => {
+    const item: FeedCorpusItem = {
+      record_id: 'ENC-TSK-99',
+      record_type: 'task',
+      project_id: 'enceladus',
+      title: 'Ship cache',
+      updated_at: '2026-07-05T12:00:00Z',
+      source: 'tracker',
+      record_key: 'tracker:enceladus:ENC-TSK-99',
+      attrs: { status: 'open', priority: 'high' },
+    }
+    const row = corpusItemToTier1(item)
+    expect(row).toMatchObject({
+      recordId: 'ENC-TSK-99',
+      recordType: 'task',
+      status: 'open',
+      priority: 'high',
+      versionSeq: '2026-07-05T12:00:00Z',
+    })
+  })
+
+  it('returns null for unsupported record types', () => {
+    expect(
+      corpusItemToTier1({
+        record_id: 'X',
+        record_type: 'unknown',
+        project_id: 'enceladus',
+        title: 'X',
+        source: 'tracker',
+        record_key: 'k',
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('CacheEngine', () => {
+  beforeEach(() => {
+    resetCacheEngineForTests()
+  })
+
+  it('ingests corpus pages and warms the search index', async () => {
+    const engine = new CacheEngine({ tier1Max: 100, tier2Max: 10, searchIndexMax: 100 })
+    const count = await engine.ingestCorpusPage([
+      {
+        record_id: 'ENC-TSK-1',
+        record_type: 'task',
+        project_id: 'enceladus',
+        title: 'One',
+        source: 'tracker',
+        record_key: 'tracker:enceladus:ENC-TSK-1',
+      },
+      {
+        record_id: 'DOC-1',
+        record_type: 'document',
+        project_id: 'global',
+        title: 'Doc',
+        source: 'document',
+        record_key: 'document::DOC-1',
+      },
+    ])
+    await engine.finalizeWarm()
+
+    expect(count).toBe(2)
+    expect(engine.searchIndex.all()).toHaveLength(2)
+    expect(engine.isWarm).toBe(true)
+  })
+
+  it('rejects stale tier2 writes and evicts LRU rows', async () => {
+    vi.useFakeTimers()
+    const engine = new CacheEngine({ tier1Max: 10, tier2Max: 2, searchIndexMax: 10 })
+
+    vi.setSystemTime(1_000)
+    await engine.upsertTier2('enceladus', 'A', { id: 'A' }, '2')
+    vi.setSystemTime(2_000)
+    await engine.upsertTier2('enceladus', 'B', { id: 'B' }, '2')
+    vi.setSystemTime(3_000)
+    await engine.getTier2Body('enceladus', 'A')
+    vi.setSystemTime(4_000)
+    await engine.upsertTier2('enceladus', 'C', { id: 'C' }, '2')
+
+    expect(await engine.getTier2Body('enceladus', 'B')).toBeNull()
+    expect(await engine.getTier2Body('enceladus', 'A')).toEqual({ id: 'A' })
+    expect(await engine.getTier2Body('enceladus', 'C')).toEqual({ id: 'C' })
+
+    vi.setSystemTime(5_000)
+    await engine.upsertTier2('enceladus', 'A', { id: 'A-old' }, '1')
+    expect(await engine.getTier2Body('enceladus', 'A')).toEqual({ id: 'A' })
+    vi.useRealTimers()
+  })
+
+  it('marks tombstones and removes search rows', async () => {
+    const engine = new CacheEngine()
+    const tier1 = tier1FromFeedEvent({
+      recordId: 'ENC-TSK-9',
+      recordType: 'task',
+      projectId: 'enceladus',
+      title: 'Gone',
+    })
+    expect(tier1).not.toBeNull()
+    await engine.upsertTier1(tier1!)
+    await engine.markTombstone(tier1!.recordKey, tier1!.recordId)
+
+    expect(engine.searchIndex.all()).toHaveLength(0)
+    await engine.upsertTier1(tier1!)
+    expect(engine.searchIndex.all()).toHaveLength(0)
+  })
+})

--- a/frontend/ui-v2/src/sync/cacheEngine.ts
+++ b/frontend/ui-v2/src/sync/cacheEngine.ts
@@ -1,0 +1,169 @@
+import type { RecordType } from '../types/records'
+import * as idb from './idbStore'
+import { CorpusSearchIndex } from './searchIndex'
+import { cacheKey, shouldAcceptVersion, versionSeqFromUpdatedAt } from './recordKey'
+import type { FeedCorpusItem, Tier1Record, Tier2Record } from './types'
+import { DEFAULT_CACHE_BUDGET } from './types'
+
+const VALID_TYPES: RecordType[] = ['task', 'issue', 'feature', 'plan', 'lesson', 'document']
+
+function normalizeRecordType(raw: string): RecordType | null {
+  const value = raw.toLowerCase() as RecordType
+  return VALID_TYPES.includes(value) ? value : null
+}
+
+export function corpusItemToTier1(item: FeedCorpusItem): Tier1Record | null {
+  const recordType = normalizeRecordType(item.record_type)
+  if (!recordType) return null
+  const versionSeq = versionSeqFromUpdatedAt(item.updated_at)
+  return {
+    projectId: item.project_id || (recordType === 'document' ? 'global' : 'enceladus'),
+    recordId: item.record_id,
+    recordType,
+    title: item.title || item.record_id,
+    status: typeof item.attrs?.status === 'string' ? item.attrs.status : undefined,
+    priority: typeof item.attrs?.priority === 'string' ? item.attrs.priority : undefined,
+    updatedAt: item.updated_at ?? null,
+    source: item.source,
+    recordKey: item.record_key,
+    versionSeq,
+    attrs: item.attrs ?? {},
+  }
+}
+
+export class CacheEngine {
+  readonly searchIndex: CorpusSearchIndex
+  private warmedAt: number | null = null
+  private warmDurationMsValue: number | null = null
+
+  constructor(private readonly budget = DEFAULT_CACHE_BUDGET) {
+    this.searchIndex = new CorpusSearchIndex(budget.searchIndexMax)
+  }
+
+  get isWarm(): boolean {
+    return this.warmedAt !== null
+  }
+
+  get warmDurationMs(): number | null {
+    return this.warmDurationMsValue
+  }
+
+  async upsertTier1(record: Tier1Record): Promise<void> {
+    if (await idb.hasTombstone(record.recordKey)) return
+    const existing = await idb.getTier1(record.projectId, record.recordId)
+    if (existing && !shouldAcceptVersion(existing.versionSeq, record.versionSeq)) return
+    await idb.putTier1(record)
+    this.searchIndex.upsert(record)
+  }
+
+  async upsertTier2(
+    projectId: string,
+    recordId: string,
+    body: unknown,
+    versionSeq: string,
+  ): Promise<void> {
+    const existing = await idb.getTier2(projectId, recordId)
+    if (existing && !shouldAcceptVersion(existing.versionSeq, versionSeq)) return
+    await idb.putTier2({
+      projectId,
+      recordId,
+      body,
+      versionSeq,
+      touchedAt: Date.now(),
+    })
+    await this.evictTier2IfNeeded()
+  }
+
+  async getTier2Body(projectId: string, recordId: string): Promise<unknown | null> {
+    const row = await idb.getTier2(projectId, recordId)
+    if (!row) return null
+    await idb.putTier2({ ...row, touchedAt: Date.now() })
+    return row.body
+  }
+
+  async markTombstone(recordKey: string, recordId: string): Promise<void> {
+    await idb.putTombstone({ recordKey, deletedAt: Date.now() })
+    this.searchIndex.remove(recordId)
+  }
+
+  async ingestCorpusPage(items: FeedCorpusItem[]): Promise<number> {
+    let count = 0
+    for (const item of items) {
+      const tier1 = corpusItemToTier1(item)
+      if (!tier1) continue
+      await this.upsertTier1(tier1)
+      count += 1
+    }
+    return count
+  }
+
+  async finalizeWarm(): Promise<void> {
+    const rows = await idb.listTier1(this.budget.tier1Max)
+    this.searchIndex.rebuild(rows.slice(0, this.budget.searchIndexMax))
+    this.warmedAt = Date.now()
+  }
+
+  markWarmComplete(startedAt: number): void {
+    this.warmedAt = Date.now()
+    this.warmDurationMsValue = this.warmedAt - startedAt
+  }
+
+  async loadSearchSlice(): Promise<void> {
+    const rows = await idb.listTier1(this.budget.searchIndexMax)
+    this.searchIndex.rebuild(rows)
+    if (rows.length > 0 && !this.warmedAt) {
+      this.warmedAt = Date.now()
+    }
+  }
+
+  private async evictTier2IfNeeded(): Promise<void> {
+    const rows = await idb.listTier2()
+    if (rows.length <= this.budget.tier2Max) return
+    const sorted = [...rows].sort((a, b) => a.touchedAt - b.touchedAt)
+    const evictCount = rows.length - this.budget.tier2Max
+    for (const row of sorted.slice(0, evictCount)) {
+      await idb.deleteTier2(row.projectId, row.recordId)
+    }
+  }
+}
+
+let singleton: CacheEngine | null = null
+
+export function getCacheEngine(): CacheEngine {
+  if (!singleton) singleton = new CacheEngine()
+  return singleton
+}
+
+export function resetCacheEngineForTests(): void {
+  singleton = null
+  idb.resetMemoryStoreForTests()
+}
+
+export function tier1FromFeedEvent(input: {
+  recordId: string
+  recordType: string
+  projectId: string
+  title: string
+  status?: string
+  updatedAt?: string | null
+}): Tier1Record | null {
+  const recordType = normalizeRecordType(input.recordType)
+  if (!recordType) return null
+  const projectId = input.projectId || (recordType === 'document' ? 'global' : 'enceladus')
+  const recordKey =
+    recordType === 'document'
+      ? `document::${input.recordId}`
+      : `tracker:${projectId}:${input.recordId}`
+  return {
+    projectId,
+    recordId: input.recordId,
+    recordType,
+    title: input.title,
+    status: input.status,
+    updatedAt: input.updatedAt ?? null,
+    source: recordType === 'document' ? 'document' : 'tracker',
+    recordKey,
+    versionSeq: versionSeqFromUpdatedAt(input.updatedAt),
+    attrs: { status: input.status },
+  }
+}

--- a/frontend/ui-v2/src/sync/corpusSeed.ts
+++ b/frontend/ui-v2/src/sync/corpusSeed.ts
@@ -1,0 +1,26 @@
+import { fetchFeedCorpusPage } from '../api/client'
+import { getCacheEngine } from './cacheEngine'
+
+export async function seedCacheFromCorpus(): Promise<{ pages: number; records: number; durationMs: number }> {
+  const engine = getCacheEngine()
+  const startedAt = performance.now()
+  let cursor: string | undefined
+  let pages = 0
+  let records = 0
+
+  for (;;) {
+    const page = await fetchFeedCorpusPage({ cursor, limit: 200 })
+    pages += 1
+    records += await engine.ingestCorpusPage(page.items)
+    if (!page.next_cursor) break
+    cursor = page.next_cursor
+  }
+
+  await engine.finalizeWarm()
+  engine.markWarmComplete(startedAt)
+  return {
+    pages,
+    records,
+    durationMs: Math.round(performance.now() - startedAt),
+  }
+}

--- a/frontend/ui-v2/src/sync/idbStore.ts
+++ b/frontend/ui-v2/src/sync/idbStore.ts
@@ -1,0 +1,210 @@
+import type { Tier1Record, Tier2Record, TombstoneRecord } from './types'
+import { cacheKey } from './recordKey'
+
+const DB_NAME = 'enceladus-ui-v2-sync'
+const DB_VERSION = 1
+
+type MemoryDb = {
+  tier1: Map<string, Tier1Record>
+  tier2: Map<string, Tier2Record>
+  tombstones: Map<string, TombstoneRecord>
+  queryCache: unknown | null
+}
+
+let memoryDb: MemoryDb | null = null
+
+function getMemoryDb(): MemoryDb {
+  if (!memoryDb) {
+    memoryDb = {
+      tier1: new Map(),
+      tier2: new Map(),
+      tombstones: new Map(),
+      queryCache: null,
+    }
+  }
+  return memoryDb
+}
+
+function openDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('indexedDB unavailable'))
+  }
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains('tier1')) db.createObjectStore('tier1')
+      if (!db.objectStoreNames.contains('tier2')) db.createObjectStore('tier2')
+      if (!db.objectStoreNames.contains('tombstones')) db.createObjectStore('tombstones')
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('indexedDB open failed'))
+  })
+}
+
+async function withStore<T>(
+  storeName: string,
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T> | void,
+): Promise<T | void> {
+  try {
+    const db = await openDb()
+    return await new Promise<T | void>((resolve, reject) => {
+      const tx = db.transaction(storeName, mode)
+      const store = tx.objectStore(storeName)
+      const request = fn(store)
+      tx.oncomplete = () => resolve(request ? request.result : undefined)
+      tx.onerror = () => reject(tx.error ?? new Error('indexedDB tx failed'))
+    })
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function putTier1(record: Tier1Record): Promise<void> {
+  const key = cacheKey(record.projectId, record.recordId)
+  try {
+    await withStore('tier1', 'readwrite', (store) => store.put(record, key))
+  } catch {
+    getMemoryDb().tier1.set(key, record)
+  }
+}
+
+export async function getTier1(projectId: string, recordId: string): Promise<Tier1Record | null> {
+  const key = cacheKey(projectId, recordId)
+  try {
+    const result = (await withStore('tier1', 'readonly', (store) => store.get(key))) as
+      | Tier1Record
+      | undefined
+    if (result) return result
+  } catch {
+    /* fall through */
+  }
+  return getMemoryDb().tier1.get(key) ?? null
+}
+
+export async function listTier1(limit: number): Promise<Tier1Record[]> {
+  const rows: Tier1Record[] = []
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('tier1', 'readonly')
+      const store = tx.objectStore('tier1')
+      const request = store.openCursor()
+      request.onsuccess = () => {
+        const cursor = request.result
+        if (!cursor || rows.length >= limit) {
+          resolve()
+          return
+        }
+        rows.push(cursor.value as Tier1Record)
+        cursor.continue()
+      }
+      request.onerror = () => reject(request.error ?? new Error('cursor failed'))
+    })
+    if (rows.length > 0) return rows
+  } catch {
+    /* fall through */
+  }
+  return [...getMemoryDb().tier1.values()].slice(0, limit)
+}
+
+export async function putTier2(record: Tier2Record): Promise<void> {
+  const key = cacheKey(record.projectId, record.recordId)
+  try {
+    await withStore('tier2', 'readwrite', (store) => store.put(record, key))
+  } catch {
+    getMemoryDb().tier2.set(key, record)
+  }
+}
+
+export async function deleteTier2(projectId: string, recordId: string): Promise<void> {
+  const key = cacheKey(projectId, recordId)
+  try {
+    await withStore('tier2', 'readwrite', (store) => store.delete(key))
+  } catch {
+    getMemoryDb().tier2.delete(key)
+  }
+}
+
+export async function getTier2(projectId: string, recordId: string): Promise<Tier2Record | null> {
+  const key = cacheKey(projectId, recordId)
+  try {
+    const result = (await withStore('tier2', 'readonly', (store) => store.get(key))) as
+      | Tier2Record
+      | undefined
+    if (result) return result
+  } catch {
+    /* fall through */
+  }
+  return getMemoryDb().tier2.get(key) ?? null
+}
+
+export async function listTier2(): Promise<Tier2Record[]> {
+  const rows: Tier2Record[] = []
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('tier2', 'readonly')
+      const store = tx.objectStore('tier2')
+      const request = store.openCursor()
+      request.onsuccess = () => {
+        const cursor = request.result
+        if (!cursor) {
+          resolve()
+          return
+        }
+        rows.push(cursor.value as Tier2Record)
+        cursor.continue()
+      }
+      request.onerror = () => reject(request.error ?? new Error('cursor failed'))
+    })
+    if (rows.length > 0) return rows
+  } catch {
+    /* fall through */
+  }
+  return [...getMemoryDb().tier2.values()]
+}
+
+export async function putTombstone(record: TombstoneRecord): Promise<void> {
+  try {
+    await withStore('tombstones', 'readwrite', (store) => store.put(record, record.recordKey))
+  } catch {
+    getMemoryDb().tombstones.set(record.recordKey, record)
+  }
+}
+
+export async function hasTombstone(recordKey: string): Promise<boolean> {
+  try {
+    const result = (await withStore('tombstones', 'readonly', (store) => store.get(recordKey))) as
+      | TombstoneRecord
+      | undefined
+    if (result) return true
+  } catch {
+    /* fall through */
+  }
+  return getMemoryDb().tombstones.has(recordKey)
+}
+
+export async function saveQueryCache(payload: unknown): Promise<void> {
+  try {
+    await withStore('meta', 'readwrite', (store) => store.put(payload, 'queryCache'))
+  } catch {
+    getMemoryDb().queryCache = payload
+  }
+}
+
+export async function loadQueryCache<T>(): Promise<T | null> {
+  try {
+    const result = (await withStore('meta', 'readonly', (store) => store.get('queryCache'))) as T | undefined
+    if (result) return result
+  } catch {
+    /* fall through */
+  }
+  return (getMemoryDb().queryCache as T | null) ?? null
+}
+
+export function resetMemoryStoreForTests(): void {
+  memoryDb = null
+}

--- a/frontend/ui-v2/src/sync/queryPersist.ts
+++ b/frontend/ui-v2/src/sync/queryPersist.ts
@@ -1,0 +1,35 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { dehydrate, hydrate } from '@tanstack/react-query'
+import * as idb from './idbStore'
+
+const PERSIST_KEY = 'queryCache'
+
+export async function restorePersistedQueryClient(client: QueryClient): Promise<void> {
+  const payload = await idb.loadQueryCache<{ clientState?: unknown }>()
+  if (!payload?.clientState) return
+  hydrate(client, payload as Parameters<typeof hydrate>[1])
+}
+
+export function attachQueryClientPersist(client: QueryClient): () => void {
+  let timer: number | null = null
+
+  const persist = () => {
+    if (timer !== null) window.clearTimeout(timer)
+    timer = window.setTimeout(() => {
+      const payload = dehydrate(client)
+      void idb.saveQueryCache({ clientState: payload })
+    }, 400)
+  }
+
+  const unsubscribe = client.getQueryCache().subscribe(persist)
+  return () => {
+    if (timer !== null) window.clearTimeout(timer)
+    unsubscribe()
+  }
+}
+
+export async function clearPersistedQueryClient(): Promise<void> {
+  await idb.saveQueryCache(null)
+}
+
+export { PERSIST_KEY }

--- a/frontend/ui-v2/src/sync/readThrough.test.ts
+++ b/frontend/ui-v2/src/sync/readThrough.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchDocumentRecord, fetchTrackerRecord } from '../api/client'
+import { resetCacheEngineForTests } from './cacheEngine'
+import { readThroughDocumentRecord, readThroughTrackerRecord } from './readThrough'
+
+vi.mock('../api/client', () => ({
+  fetchTrackerRecord: vi.fn(),
+  fetchDocumentRecord: vi.fn(),
+}))
+
+describe('readThrough fetchers', () => {
+  beforeEach(() => {
+    resetCacheEngineForTests()
+    vi.mocked(fetchTrackerRecord).mockReset()
+    vi.mocked(fetchDocumentRecord).mockReset()
+  })
+
+  it('returns cached tier2 without network', async () => {
+    vi.mocked(fetchTrackerRecord).mockResolvedValue({ record_id: 'ENC-TSK-1', updated_at: '2' })
+    const first = await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-1')
+    const second = await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-1')
+
+    expect(first).toEqual({ record_id: 'ENC-TSK-1', updated_at: '2' })
+    expect(second).toEqual(first)
+    expect(fetchTrackerRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('read-throughs document records into tier2', async () => {
+    vi.mocked(fetchDocumentRecord).mockResolvedValue({
+      document_id: 'DOC-1',
+      updated_at: '2026-07-05T00:00:00Z',
+    })
+
+    const body = await readThroughDocumentRecord<{ document_id: string }>('DOC-1')
+    expect(body.document_id).toBe('DOC-1')
+    expect(fetchDocumentRecord).toHaveBeenCalledTimes(1)
+
+    await readThroughDocumentRecord('DOC-1')
+    expect(fetchDocumentRecord).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/ui-v2/src/sync/readThrough.ts
+++ b/frontend/ui-v2/src/sync/readThrough.ts
@@ -1,0 +1,47 @@
+import {
+  fetchDocumentRecord,
+  fetchTrackerRecord,
+  type SessionExpiredError,
+} from '../api/client'
+import { getCacheEngine } from './cacheEngine'
+import { versionSeqFromUpdatedAt } from './recordKey'
+
+type FetchInit = { signal?: AbortSignal; headers?: HeadersInit }
+
+export async function readThroughTrackerRecord<T>(
+  recordType: 'task' | 'issue' | 'feature' | 'plan' | 'lesson',
+  projectId: string,
+  recordId: string,
+  init?: FetchInit,
+): Promise<T> {
+  const engine = getCacheEngine()
+  const cached = await engine.getTier2Body(projectId, recordId)
+  if (cached) return cached as T
+
+  const fresh = await fetchTrackerRecord<T>(recordType, projectId, recordId, init)
+  const updatedAt =
+    typeof fresh === 'object' && fresh && 'updated_at' in fresh
+      ? String((fresh as { updated_at?: string | null }).updated_at ?? '')
+      : ''
+  await engine.upsertTier2(projectId, recordId, fresh, versionSeqFromUpdatedAt(updatedAt))
+  return fresh
+}
+
+export async function readThroughDocumentRecord<T>(
+  documentId: string,
+  init?: FetchInit,
+): Promise<T> {
+  const engine = getCacheEngine()
+  const cached = await engine.getTier2Body('global', documentId)
+  if (cached) return cached as T
+
+  const fresh = await fetchDocumentRecord<T>(documentId, init)
+  const updatedAt =
+    typeof fresh === 'object' && fresh && 'updated_at' in fresh
+      ? String((fresh as { updated_at?: string | null }).updated_at ?? '')
+      : ''
+  await engine.upsertTier2('global', documentId, fresh, versionSeqFromUpdatedAt(updatedAt))
+  return fresh
+}
+
+export type { SessionExpiredError }

--- a/frontend/ui-v2/src/sync/recordKey.test.ts
+++ b/frontend/ui-v2/src/sync/recordKey.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { cacheKey, shouldAcceptVersion, versionSeqFromUpdatedAt } from './recordKey'
+
+describe('recordKey helpers', () => {
+  it('builds stable cache keys', () => {
+    expect(cacheKey('enceladus', 'ENC-TSK-1')).toBe('enceladus:ENC-TSK-1')
+    expect(cacheKey('', 'DOC-1')).toBe('global:DOC-1')
+  })
+
+  it('derives version seq from updated_at', () => {
+    expect(versionSeqFromUpdatedAt('2026-07-05T00:00:00Z')).toBe('2026-07-05T00:00:00Z')
+    expect(versionSeqFromUpdatedAt(null)).toBe('0')
+  })
+
+  it('accepts newer or equal version sequences', () => {
+    expect(shouldAcceptVersion(undefined, '2')).toBe(true)
+    expect(shouldAcceptVersion('2', '2')).toBe(true)
+    expect(shouldAcceptVersion('2', '3')).toBe(true)
+    expect(shouldAcceptVersion('3', '2')).toBe(false)
+  })
+})

--- a/frontend/ui-v2/src/sync/recordKey.ts
+++ b/frontend/ui-v2/src/sync/recordKey.ts
@@ -1,0 +1,13 @@
+export function cacheKey(projectId: string, recordId: string): string {
+  return `${projectId || 'global'}:${recordId}`
+}
+
+export function versionSeqFromUpdatedAt(updatedAt?: string | null): string {
+  return updatedAt?.trim() || '0'
+}
+
+export function shouldAcceptVersion(current: string | undefined, incoming: string): boolean {
+  if (!current) return true
+  if (current === incoming) return true
+  return incoming >= current
+}

--- a/frontend/ui-v2/src/sync/searchIndex.test.ts
+++ b/frontend/ui-v2/src/sync/searchIndex.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { CorpusSearchIndex } from './searchIndex'
+import type { Tier1Record } from './types'
+
+function tier1(overrides: Partial<Tier1Record> = {}): Tier1Record {
+  return {
+    projectId: 'enceladus',
+    recordId: 'ENC-TSK-1',
+    recordType: 'task',
+    title: 'Alpha task',
+    status: 'open',
+    source: 'tracker',
+    recordKey: 'tracker:enceladus:ENC-TSK-1',
+    versionSeq: '2026-07-05T00:00:00Z',
+    attrs: { status: 'open' },
+    ...overrides,
+  }
+}
+
+describe('CorpusSearchIndex', () => {
+  it('suggest filters by record id and title', () => {
+    const index = new CorpusSearchIndex(10)
+    index.rebuild([
+      tier1({ recordId: 'ENC-TSK-1', title: 'Alpha' }),
+      tier1({ recordId: 'ENC-TSK-2', title: 'Beta search' }),
+    ])
+
+    expect(index.suggest('beta').map((row) => row.recordId)).toEqual(['ENC-TSK-2'])
+    expect(index.suggest('enc-tsk-1').map((row) => row.recordId)).toEqual(['ENC-TSK-1'])
+  })
+
+  it('upsert replaces an existing row and respects maxRows', () => {
+    const index = new CorpusSearchIndex(2)
+    index.rebuild([tier1({ recordId: 'A' }), tier1({ recordId: 'B' })])
+    index.upsert(tier1({ recordId: 'A', title: 'Updated A' }))
+    index.upsert(tier1({ recordId: 'C', title: 'New C' }))
+
+    expect(index.all().map((row) => row.recordId)).toEqual(['C', 'A'])
+    expect(index.all().find((row) => row.recordId === 'A')?.title).toBe('Updated A')
+  })
+
+  it('facetCounts aggregates record types', () => {
+    const index = new CorpusSearchIndex(10)
+    index.rebuild([
+      tier1({ recordId: 'A', recordType: 'task' }),
+      tier1({ recordId: 'B', recordType: 'issue' }),
+      tier1({ recordId: 'C', recordType: 'task', status: 'closed' }),
+    ])
+
+    expect(index.facetCounts('recordType')).toEqual({ task: 2, issue: 1 })
+    expect(index.facetCounts('status')).toEqual({ open: 2, closed: 1 })
+  })
+})

--- a/frontend/ui-v2/src/sync/searchIndex.ts
+++ b/frontend/ui-v2/src/sync/searchIndex.ts
@@ -1,0 +1,69 @@
+import type { LocalSearchRecord } from '../types/search'
+import type { Tier1Record } from './types'
+
+/** Device-budgeted in-memory search index over the cached Tier-1 slice. */
+export class CorpusSearchIndex {
+  private rows: LocalSearchRecord[] = []
+  private maxRows: number
+
+  constructor(maxRows = 2_000) {
+    this.maxRows = maxRows
+  }
+
+  rebuild(records: Tier1Record[]): void {
+    const mapped = records.map(tier1ToLocalSearchRecord)
+    this.rows = mapped.slice(0, this.maxRows)
+  }
+
+  upsert(record: Tier1Record): void {
+    const next = tier1ToLocalSearchRecord(record)
+    this.rows = [next, ...this.rows.filter((row) => row.recordId !== next.recordId)].slice(
+      0,
+      this.maxRows,
+    )
+  }
+
+  remove(recordId: string): void {
+    this.rows = this.rows.filter((row) => row.recordId !== recordId)
+  }
+
+  all(): LocalSearchRecord[] {
+    return this.rows
+  }
+
+  suggest(query: string, limit = 12): LocalSearchRecord[] {
+    const needle = query.trim().toLowerCase()
+    const pool = needle
+      ? this.rows.filter(
+          (row) =>
+            row.recordId.toLowerCase().includes(needle) ||
+            row.title.toLowerCase().includes(needle),
+        )
+      : this.rows
+    return pool.slice(0, limit)
+  }
+
+  facetCounts(field: 'recordType' | 'status' | 'projectId'): Record<string, number> {
+    const counts: Record<string, number> = {}
+    for (const row of this.rows) {
+      const value =
+        field === 'recordType'
+          ? row.recordType
+          : field === 'status'
+            ? row.status ?? 'unknown'
+            : row.projectId
+      counts[value] = (counts[value] ?? 0) + 1
+    }
+    return counts
+  }
+}
+
+export function tier1ToLocalSearchRecord(record: Tier1Record): LocalSearchRecord {
+  return {
+    recordId: record.recordId,
+    recordType: record.recordType,
+    projectId: record.projectId,
+    title: record.title,
+    status: record.status,
+  }
+}

--- a/frontend/ui-v2/src/sync/types.ts
+++ b/frontend/ui-v2/src/sync/types.ts
@@ -1,0 +1,61 @@
+import type { RecordType } from '../types/records'
+
+/** Minimal Tier-1 index row keyed by (project_id, record_id). */
+export interface Tier1Record {
+  projectId: string
+  recordId: string
+  recordType: RecordType
+  title: string
+  status?: string
+  priority?: string
+  updatedAt?: string | null
+  source: 'tracker' | 'document'
+  recordKey: string
+  versionSeq: string
+  attrs: Record<string, unknown>
+}
+
+/** Tier-2 full-body cache entry with LRU metadata. */
+export interface Tier2Record {
+  projectId: string
+  recordId: string
+  body: unknown
+  versionSeq: string
+  touchedAt: number
+}
+
+export interface TombstoneRecord {
+  recordKey: string
+  deletedAt: number
+}
+
+export interface CacheBudget {
+  tier1Max: number
+  tier2Max: number
+  searchIndexMax: number
+}
+
+export const DEFAULT_CACHE_BUDGET: CacheBudget = {
+  tier1Max: 5_000,
+  tier2Max: 500,
+  searchIndexMax: 2_000,
+}
+
+export interface FeedCorpusItem {
+  record_id: string
+  record_type: string
+  project_id: string
+  title: string
+  updated_at?: string | null
+  source: 'tracker' | 'document'
+  record_key: string
+  attrs?: Record<string, unknown>
+}
+
+export interface FeedCorpusPage {
+  success: boolean
+  items: FeedCorpusItem[]
+  next_cursor: string | null
+  facets: Record<string, Record<string, number>>
+  total_matches: number
+}


### PR DESCRIPTION
## Summary
- Add `src/sync/` cache engine: IndexedDB Tier-1 identity index, Tier-2 LRU full-body cache, tombstones, and device-budgeted in-memory search index
- Seed warm-start from `GET /api/v1/feed/corpus` (L23); read-through record detail queryFns; TanStack Query dehydrate/hydrate persistence
- Wire AppSync WSS `feed_event` upserts/tombstones; FeedRoute uses warm cache for autosuggest + expanded local corpus

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 56 tests pass (includes cacheEngine/searchIndex/readThrough)
- [x] `npm run build` — clean
- [x] `npm run lint:adherence` — clean
- [ ] Gamma ui-v2 deploy after merge

commit-complete-id: CCI-334ac89ce72b4b2da218cfe9a8bbf812

Made with [Cursor](https://cursor.com)