### PR TITLE
ENC-TSK-L51 — io-gated enceladus-github-roles stack deploy workflow

### DIFF
--- a/.github/workflows/cloudformation-github-roles-stack-deploy.yml
+++ b/.github/workflows/cloudformation-github-roles-stack-deploy.yml
@@ -1,0 +1,166 @@
+name: CloudFormation GitHub Roles Stack Deploy
+
+# ENC-TSK-L50 / ENC-PLN-068: 04-github-roles.yaml has no push-deploy lane.
+# Durable IAM fixes (EventBridge Scheduler for Rhythm Cycle) require updating the
+# live enceladus-github-roles stack. Plan/apply split with v3-prod gate per
+# DOC-B716E8FB10B6 Channel C + ENC-FTR-120 (ENC-TSK-J62/J64).
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 04-github-roles template"
+        type: string
+        required: false
+        default: "enceladus-github-roles"
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "Apply 04-github-roles.yaml to live IAM (scheduler grant / ENC-PLN-068)"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-github-roles-stack-deploy
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/04-github-roles.yaml
+  DEFAULT_STACK_NAME: enceladus-github-roles
+
+jobs:
+  plan:
+    name: Plan github-roles stack change-set
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify backend deploy role secret is set
+        run: |
+          if [ -z "${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}" ]; then
+            echo "::error::AWS_BACKEND_ROLE_TO_ASSUME secret is not set or empty."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (BackendDeployRole)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        env:
+          INPUT_STACK_NAME: ${{ github.event.inputs.stack_name }}
+        run: |
+          set -euo pipefail
+          stack_name="${INPUT_STACK_NAME:-${DEFAULT_STACK_NAME}}"
+          echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create github-roles stack change-set (no execute)
+        id: changeset
+        run: |
+          set -euo pipefail
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 04-github-roles/ 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## github-roles stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## github-roles stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply github-roles stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: v3-prod
+
+    steps:
+      - name: Configure AWS credentials (BackendDeployRole)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Verify stack status
+        run: |
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{Name:StackName,Status:StackStatus}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -4,7 +4,9 @@ Description: >
   Part of ENC-ISS-056: Provision the missing CloudFormation deploy role so
   the cloudformation-api-stack-deploy workflow can authenticate.
 
-  Deploy manually once with admin credentials:
+  Deploy via GitHub Actions (io-gated):
+    workflow_dispatch: cloudformation-github-roles-stack-deploy.yml
+  Or manually once with admin credentials:
     aws cloudformation deploy --stack-name enceladus-github-roles \
       --template-file infrastructure/cloudformation/04-github-roles.yaml \
       --capabilities CAPABILITY_NAMED_IAM --region us-west-2

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -50,6 +50,13 @@
       ],
       "notes": "v4/main-only file; gamma-only by construction (guard-gamma-only job refuses non-gamma, v3-prod FROZEN per DOC-499FA089EC30); ENC-TSK-J63 plan/apply split with apply environment: v4-gamma"
     },
+    "cloudformation-github-roles-stack-deploy.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-L51 / DOC-B716E8FB10B6 Channel C: dispatch-only enceladus-github-roles stack deploy; apply job environment: v3-prod"
+    },
     "cloudformation-api-stack-deploy.yml": {
       "class": "conditional",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
- Add `cloudformation-github-roles-stack-deploy.yml` (workflow_dispatch, plan/apply split)
- Apply job pauses on **v3-prod** for io approval (DOC-B716E8FB10B6 Channel C)
- Durable path to land EventBridge Scheduler IAM from `04-github-roles.yaml` (ENC-PLN-068 / L50)

CCI-b804211525644ed798691c50c584f20a

## Test plan
- [ ] Merge to main
- [ ] Dispatch workflow; io approves v3-prod apply job
- [ ] Re-dispatch scheduler patch or redeploy gamma compute with Rhythm enabled

Made with [Cursor](https://cursor.com)