### PR TITLE
ENC-TSK-L51 — fix github-roles deploy S3 staging AccessDenied

### DIFF
--- a/.github/workflows/cloudformation-github-roles-stack-deploy.yml
+++ b/.github/workflows/cloudformation-github-roles-stack-deploy.yml
@@ -82,9 +82,7 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
-            --no-execute-changeset \
-            --s3-bucket enceladus-cfn-staging-us-west-2 \
-            --s3-prefix 04-github-roles/ 2>&1 | tee /tmp/plan.log
+            --no-execute-changeset 2>&1 | tee /tmp/plan.log
 
           if grep -q "No changes to deploy" /tmp/plan.log; then
             echo "has_changes=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- Drop S3 staging bucket from github-roles stack deploy (backend role lacks `s3:PutObject` on enceladus-cfn-staging-us-west-2)
- Template is ~44 KiB — within CFN direct-upload limit

CCI-b804211525644ed798691c50c584f20a

## Test plan
- [ ] Dispatch CloudFormation GitHub Roles Stack Deploy; plan succeeds; apply waits on v3-prod

Made with [Cursor](https://cursor.com)