### PR TITLE
ENC-TSK-L25 follow-up: fix gamma function_name_map for user_preferences_api

### DIFF
--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -101,3 +101,4 @@ function_name_map:
   rhythm_cycle: enceladus-rhythm-cycle-gamma
   corpus_entropy_engine: enceladus-corpus-entropy-engine-gamma
   corpus_entropy_gdmp_remediation: enceladus-corpus-entropy-gdmp-remediation-gamma
+  user_preferences_api: enceladus-user-preferences-api-gamma


### PR DESCRIPTION
## Summary
Gen2 deploy silently skipped `user_preferences_api`'s code push ("not in function_name_map"), leaving the Lambda on its CFN placeholder stub — confirmed live via CloudWatch: `Runtime.ImportModuleError: No module named 'lambda_function'`. `lambda_workflow_manifest.json` alone isn't sufficient; `envs/v4-gamma.yaml`'s `function_name_map` is the actual mapping Gen2's deploy script reads to know which functions to push code to and under what live name.

No lambda_function.py/handlers.py/server.py/coordination_api/config.py touched — pure env-manifest config, no governance dictionary bump needed.

CCI-3f316c395cf54ee89ed7a0b9dec9a77f

## Test plan
- [ ] Merge, gamma deploy, confirm `enceladus-user-preferences-api-gamma` code updates (CodeSize > 164 bytes, no more ImportModuleError in CloudWatch)
- [ ] curl round-trip on `/api/v1/user/preferences` returns 401 (not 500)