### PR TITLE
ENC-TSK-L47: If-Match/409 per-record revision contract (tracker_mutation + document_api)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.5",
-  "updated_at": "2026-07-05T07:24:00Z",
-  "last_change_summary": "ENC-TSK-L25 (B67 Search2.0 WaveB / FTR-127 AC-10/16/17): new user_preferences_api Lambda + user-preferences DynamoDB table (PK=sub) + GET/PUT /api/v1/user/preferences routes, gamma-only. New entity user_preferences_api.lambda.",
+  "version": "2026-07-05.6",
+  "updated_at": "2026-07-05T07:45:00Z",
+  "last_change_summary": "ENC-TSK-L47 (B67 backend / FTR-127 AC-19, K25 AC-3): If-Match / HTTP 409 per-record revision-conflict contract added to tracker_mutation's generic field-update path (sync_version) and document_api's PATCH path (version). Absent header preserves prior unconditional-write behavior. New entity api.if_match_revision_contract; new error_envelope.code value REVISION_CONFLICT.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7334,6 +7334,25 @@
           "type": "object"
         }
       }
+    },
+    "api.if_match_revision_contract": {
+      "description": "ENC-TSK-L47 (B67 AC-19 / K25 AC-3): optional client-driven optimistic-concurrency contract on tracker_mutation's generic field-update path (PATCH /{project}/{type}/{id}, keyed on the existing sync_version counter) and document_api's PATCH path (PATCH /documents/{id}, keyed on the existing version counter). Deliberately decoupled from ENC-TSK-L27's version_seq GSI work so it ships without escalated IAM. Absence of the header preserves pre-L47 unconditional-write behavior for every existing agent/PWA caller -- this is strictly additive.",
+      "fields": {
+        "If-Match": {
+          "type": "http_header",
+          "definition": "Optional request header carrying the revision the caller last read (sync_version for tracker records, version for documents). Quoted ETag-style values are accepted (quotes are stripped). When present, the server compares it against the current server-side revision before writing.",
+          "usage_guidance": "Read the revision from a prior GET/tracker.get response and echo it back as If-Match on the next mutation to get a 409 instead of a silent lost-update when another writer has landed a change in between. Omit entirely for today's unconditional-write behavior (no functional change)."
+        },
+        "REVISION_CONFLICT": {
+          "type": "error_envelope.code",
+          "definition": "New error_envelope.code value (HTTP 409). Returned when a supplied If-Match does not match the current server-side revision -- either at the pre-write check or (rarer) at the DynamoDB ConditionExpression guarding the commit itself if a write lands in the interim. The response body includes expected_revision, current_revision, and current (the full current server-side field values, deserialized) so callers -- notably ENC-TSK-K25's merge-conflict UI -- can resolve without a follow-up read.",
+          "usage_guidance": "On REVISION_CONFLICT, re-render the conflict from error_envelope.details.current and let the caller choose retry-with-fresh-revision or merge. Do not blind-retry with the same If-Match value."
+        },
+        "write_response_revision_echo": {
+          "type": "behavior",
+          "definition": "Every successful write on either path now echoes the post-write revision in the response body (sync_version on tracker_mutation, version on document_api) so the caller can update its local cache without an extra read."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda -- nightly EventBridge (gamma, cron 06:00 UTC, after K41's 05:00 CEE scan) consumes K41's Compliance/Semantic detector output and deterministically resolves a whitelist of compliance_warnings classes (fence_missing_language, metadata_field_missing) via document_api PATCH, advancing raw documents to compliant document_maturity_state with no agent session involvement. DATA-SAFETY: only the deterministic whitelist is auto-remediated; ambiguous/content-changing warnings are left for agent review; every auto-patch is logged with before/after compliance_score. Dry-run default-on (GDMP_DRY_RUN=1) plus a 3-run io-approval ramp (GDMP_IO_APPROVAL_RUNS=3, GDMP_MUTATION_ENABLED=0) reuse the FTR-106 / ENC-TSK-K03 unlearning Lambda's S3 run-counter pattern verbatim. CEE_GDMP_HARD_DISABLED=1 kill switch ships ON by default. Idempotent: is_already_compliant guards against re-patching already-compliant documents. New entity corpus_entropy_gdmp_remediation.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
@@ -7527,6 +7546,11 @@
       "version": "2026-07-02.34",
       "date": "2026-07-02",
       "summary": "ENC-TSK-K34 (ENC-ISS-477 cutover, DOC-F234A4E11DFD Option E): the DynamoDB governance-policies mirror of this dictionary is retired from the read path. coordination_api._load_governance_dictionary now serves this bundled file exclusively -- no DDB scan, no fallback branch. ENC-TSK-K31 found the DDB mirror had never once served as a live, independently-authored hot-patch target (every write only ever caught DynamoDB up to a prior git/S3 change), and it had been unwritable since 2026-06-29 (509KB item vs DynamoDB's 400KB cap). document_api's dictionary-specific DDB propagation is removed alongside it. This file (repo -> Lambda bundle -> deploy) is now the sole and always-authoritative source; check_governance_dictionary_sync.py remains the enforcement that this file stays current with schema-affecting code changes. No entity schema changed."
+    },
+    {
+      "version": "2026-07-05.6",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L47 (B67 backend / FTR-127 AC-19, K25 AC-3): If-Match / HTTP 409 per-record revision-conflict contract added to tracker_mutation's generic field-update path (sync_version) and document_api's PATCH path (version). Absent header preserves prior unconditional-write behavior. New entity api.if_match_revision_contract; new error_envelope.code value REVISION_CONFLICT."
     }
   ]
 }

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -491,6 +491,25 @@ def _verify_token(token: str) -> Dict[str, Any]:
     return claims
 
 
+def _extract_if_match(event: Optional[Dict]) -> Optional[str]:
+    """Extract the If-Match header value (ENC-TSK-L47 revision-conflict contract).
+
+    Returns the raw revision token as a string (quotes stripped per ETag convention),
+    or None if the header is absent. Absence preserves today's unconditional-PATCH
+    behavior for backward compatibility.
+    """
+    if not event:
+        return None
+    headers = event.get("headers") or {}
+    raw = headers.get("if-match") or headers.get("If-Match")
+    if raw is None:
+        return None
+    raw = str(raw).strip()
+    if raw.startswith('"') and raw.endswith('"') and len(raw) >= 2:
+        raw = raw[1:-1]
+    return raw or None
+
+
 def _extract_token(event: Dict) -> Optional[str]:
     headers = event.get("headers") or {}
     cookie_header = headers.get("cookie") or headers.get("Cookie") or ""
@@ -2203,6 +2222,22 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
     project_id = existing.get("project_id", {}).get("S", "")
     now = _now_z()
 
+    # ENC-TSK-L47: If-Match / HTTP 409 per-record revision contract. Own lightweight
+    # counter (version), decoupled from ENC-TSK-L27's version_seq. Absent header
+    # preserves today's unconditional-PATCH behavior (backward compatible).
+    if_match = _extract_if_match(event)
+    if if_match is not None and if_match != str(current_version):
+        return _error(
+            409,
+            f"If-Match revision mismatch: client expected revision '{if_match}', "
+            f"server is at revision {current_version}.",
+            code="REVISION_CONFLICT",
+            document_id=document_id,
+            expected_revision=if_match,
+            current_revision=current_version,
+            current=_deserialize_item(existing),
+        )
+
     # ENC-FTR-078 AC-3 / AC-19: determine final_subtype for subsequent validations.
     # existing_subtype is the pre-patch value (may be a legacy read-only value for
     # grandfathered records). final_subtype is the post-patch target — either the
@@ -2789,7 +2824,24 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
             ExpressionAttributeValues=attr_values,
         )
     except ddb.exceptions.ConditionalCheckFailedException:
-        return _error(409, "Document was modified concurrently. Please refresh and try again.")
+        try:
+            _refreshed_resp = ddb.get_item(
+                TableName=DOCUMENTS_TABLE,
+                Key={"document_id": {"S": document_id}},
+                ConsistentRead=True,
+            )
+            _refreshed = _deserialize_item(_refreshed_resp.get("Item") or existing)
+        except Exception:  # noqa: BLE001
+            _refreshed = _deserialize_item(existing)
+        return _error(
+            409,
+            "Document was modified concurrently. Please refresh and try again.",
+            code="REVISION_CONFLICT",
+            document_id=document_id,
+            expected_revision=str(current_version),
+            current_revision=_refreshed.get("version"),
+            current=_refreshed,
+        )
     except Exception as exc:
         logger.error("update_item failed: %s", exc)
         return _error(500, "Database write failed.")

--- a/backend/lambda/document_api/test_if_match_l47.py
+++ b/backend/lambda/document_api/test_if_match_l47.py
@@ -1,0 +1,149 @@
+"""test_if_match_l47.py — Tests for ENC-TSK-L47 If-Match / HTTP 409 revision contract.
+
+Covers the three ACs defined on ENC-TSK-L47:
+  AC-1: version is echoed on read/write (write case asserted here — read echo
+        already covered by the existing _get_single / _deserialize_item path).
+  AC-2: If-Match header, when present, is compared against the current
+        server-side version. Mismatch -> HTTP 409 with current server-side
+        field values in the body. Match -> the write proceeds and version
+        increments.
+  AC-3: concurrent-write simulation — a stale If-Match produces 409, a fresh
+        If-Match produces a successful write with an incremented revision.
+
+Absence of the If-Match header must leave today's unconditional-PATCH
+behavior fully intact.
+
+Run: python3 -m pytest test_if_match_l47.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "document_api_if_match",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+document_api = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(document_api)
+
+
+CLAIMS = {"auth_mode": "internal-key", "sub": "internal-key"}
+
+
+def _doc_item(version=3):
+    return {
+        "document_id": {"S": "DOC-L47TEST0001"},
+        "project_id": {"S": "enceladus"},
+        "document_subtype": {"S": "doc"},
+        "title": {"S": "Original title"},
+        "version": {"N": str(version)},
+    }
+
+
+def _event(body, if_match=None):
+    evt = {"body": json.dumps(body)}
+    if if_match is not None:
+        evt["headers"] = {"If-Match": if_match}
+    return evt
+
+
+class TestNoIfMatchHeaderUnchanged(unittest.TestCase):
+    @patch.object(document_api, "_get_ddb")
+    def test_write_succeeds_without_condition_on_expected(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _doc_item(version=3)}
+        resp = document_api._handle_patch(
+            _event({"title": "New title"}), CLAIMS, "DOC-L47TEST0001",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        kwargs = fake_ddb.update_item.call_args.kwargs
+        # Existing behavior preserved: ConditionExpression still guards against
+        # same-request races, keyed off the freshly-read version (unconditional
+        # from the caller's perspective since no If-Match was supplied).
+        self.assertEqual(kwargs["ExpressionAttributeValues"][":expected"], {"N": "3"})
+        body = json.loads(resp["body"])
+        self.assertTrue(body.get("success"))
+        self.assertEqual(body.get("version"), 4)
+
+
+class TestIfMatchFreshRevisionSucceeds(unittest.TestCase):
+    @patch.object(document_api, "_get_ddb")
+    def test_matching_if_match_writes(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _doc_item(version=3)}
+        resp = document_api._handle_patch(
+            _event({"title": "New title"}, if_match="3"), CLAIMS, "DOC-L47TEST0001",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body.get("success"))
+        self.assertEqual(body.get("version"), 4)
+
+    @patch.object(document_api, "_get_ddb")
+    def test_quoted_etag_style_if_match_is_accepted(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _doc_item(version=3)}
+        resp = document_api._handle_patch(
+            _event({"title": "New title"}, if_match='"3"'), CLAIMS, "DOC-L47TEST0001",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+
+
+class TestIfMatchStaleRevisionConflicts(unittest.TestCase):
+    @patch.object(document_api, "_get_ddb")
+    def test_stale_if_match_returns_409_with_current_document(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.return_value = {"Item": _doc_item(version=3)}
+        resp = document_api._handle_patch(
+            _event({"title": "New title"}, if_match="2"), CLAIMS, "DOC-L47TEST0001",
+        )
+        self.assertEqual(resp["statusCode"], 409)
+        fake_ddb.update_item.assert_not_called()
+        body = json.loads(resp["body"])
+        self.assertFalse(body.get("success"))
+        envelope = body.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "REVISION_CONFLICT")
+        details = envelope.get("details", {})
+        self.assertEqual(details.get("expected_revision"), "2")
+        self.assertEqual(details.get("current_revision"), 3)
+        self.assertEqual(details.get("current", {}).get("title"), "Original title")
+
+    @patch.object(document_api, "_get_ddb")
+    def test_race_between_precheck_and_commit_also_conflicts(self, mock_ddb):
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.get_item.side_effect = [
+            {"Item": _doc_item(version=3)},   # initial read (pre-check passes)
+            {"Item": _doc_item(version=4)},   # refetch after conflict
+        ]
+
+        class _FakeConditionalCheckFailedException(Exception):
+            pass
+
+        fake_ddb.exceptions.ConditionalCheckFailedException = _FakeConditionalCheckFailedException
+        fake_ddb.update_item.side_effect = _FakeConditionalCheckFailedException()
+
+        resp = document_api._handle_patch(
+            _event({"title": "New title"}, if_match="3"), CLAIMS, "DOC-L47TEST0001",
+        )
+        self.assertEqual(resp["statusCode"], 409)
+        body = json.loads(resp["body"])
+        envelope = body.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "REVISION_CONFLICT")
+        self.assertEqual(envelope.get("details", {}).get("current_revision"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -1527,6 +1527,25 @@ def _verify_token(token: str) -> Dict[str, Any]:
     return claims
 
 
+def _extract_if_match(event: Optional[Dict]) -> Optional[str]:
+    """Extract the If-Match header value (ENC-TSK-L47 revision-conflict contract).
+
+    Returns the raw revision token as a string (quotes stripped per ETag convention),
+    or None if the header is absent. Absence means "no concurrency check requested" —
+    callers must preserve today's unconditional-write behavior in that case.
+    """
+    if not event:
+        return None
+    headers = event.get("headers") or {}
+    raw = headers.get("if-match") or headers.get("If-Match")
+    if raw is None:
+        return None
+    raw = str(raw).strip()
+    if raw.startswith('"') and raw.endswith('"') and len(raw) >= 2:
+        raw = raw[1:-1]
+    return raw or None
+
+
 def _is_checkout_service_request(event: Optional[Dict]) -> bool:
     """Return True if request carries the CHECKOUT_SERVICE_KEY header (ENC-FTR-037).
 
@@ -4454,6 +4473,28 @@ def _handle_update_field(
     item_data = _deser_item(raw_item)
     warnings: List[str] = []
 
+    # --- ENC-TSK-L47: If-Match / HTTP 409 per-record revision contract ---
+    # Own lightweight counter (sync_version), decoupled from ENC-TSK-L27's version_seq.
+    # Absent header preserves today's unconditional-write behavior (backward compatible).
+    try:
+        _current_rev = int(item_data.get("sync_version", 0) or 0)
+    except (TypeError, ValueError):
+        _current_rev = 0
+    _if_match = _extract_if_match(event)
+    if _if_match is not None and _if_match != str(_current_rev):
+        return _error(
+            409,
+            f"If-Match revision mismatch: client expected revision '{_if_match}', "
+            f"server is at revision {_current_rev}.",
+            code="REVISION_CONFLICT",
+            field=field,
+            record_id=record_id,
+            record_type=record_type,
+            expected_revision=_if_match,
+            current_revision=_current_rev,
+            current=item_data,
+        )
+
     # --- ENC-ISS-092: user-initiated transitions (Cognito-only, bypass checkout gate) ---
     # Must be checked BEFORE session-ownership enforcement and the ENC-FTR-037 gate so
     # human operators can transition tasks that are checked out by another agent.
@@ -5183,13 +5224,41 @@ def _handle_update_field(
         attr_values[":optout"] = {"BOOL": True}
     attr_values.update(extra_vals)
 
+    # ENC-TSK-L47: when the caller presented If-Match, guard the commit itself
+    # (not just the pre-check above) against a write that landed in between —
+    # mirrors the existing sync_version CAS pattern used by _handle_pwa_action.
+    update_kwargs: Dict[str, Any] = {
+        "TableName": DYNAMODB_TABLE, "Key": key,
+        "UpdateExpression": update_expr,
+        "ExpressionAttributeNames": {"#fld": field},
+        "ExpressionAttributeValues": attr_values,
+    }
+    if _if_match is not None:
+        update_kwargs["ConditionExpression"] = "sync_version = :if_match_expected"
+        attr_values[":if_match_expected"] = {"N": str(_current_rev)}
+
     try:
-        ddb.update_item(
-            TableName=DYNAMODB_TABLE, Key=key,
-            UpdateExpression=update_expr,
-            ExpressionAttributeNames={"#fld": field},
-            ExpressionAttributeValues=attr_values,
-        )
+        ddb.update_item(**update_kwargs)
+    except ClientError as exc:
+        if _is_conditional_check_failed(exc):
+            try:
+                _refreshed_raw = _get_record_raw(project_id, record_type, record_id)
+                _refreshed = _deser_item(_refreshed_raw) if _refreshed_raw else item_data
+            except Exception:  # noqa: BLE001
+                _refreshed = item_data
+            return _error(
+                409,
+                "Record was modified concurrently: If-Match revision is no longer current.",
+                code="REVISION_CONFLICT",
+                field=field,
+                record_id=record_id,
+                record_type=record_type,
+                expected_revision=_if_match,
+                current_revision=_refreshed.get("sync_version"),
+                current=_refreshed,
+            )
+        logger.error("update_item failed: %s", exc)
+        return _error(500, "Database write failed.")
     except Exception as exc:
         logger.error("update_item failed: %s", exc)
         return _error(500, "Database write failed.")
@@ -5223,6 +5292,7 @@ def _handle_update_field(
     result: Dict[str, Any] = {
         "success": True, "record_id": record_id,
         "field": field, "value": value, "updated_at": now,
+        "sync_version": _current_rev + 1,
     }
     if warnings:
         result["warnings"] = warnings

--- a/backend/lambda/tracker_mutation/test_if_match_l47.py
+++ b/backend/lambda/tracker_mutation/test_if_match_l47.py
@@ -1,0 +1,167 @@
+"""test_if_match_l47.py — Tests for ENC-TSK-L47 If-Match / HTTP 409 revision contract.
+
+Covers the three ACs defined on ENC-TSK-L47:
+  AC-1: sync_version is echoed on read (already covered by test_counter_fields.py /
+        existing _deser_item behavior) and on write (this file: response body).
+  AC-2: If-Match header, when present, is compared against the current server-side
+        sync_version. Mismatch -> HTTP 409 with current server-side field values in
+        the body. Match -> the write proceeds and sync_version increments.
+  AC-3: concurrent-write simulation — a stale If-Match produces 409, a fresh
+        If-Match produces a successful write with an incremented revision.
+
+Absence of the If-Match header must leave today's unconditional-write behavior
+fully intact (backward compatibility for every existing agent/PWA caller that
+does not send the header).
+
+Run: python3 -m pytest test_if_match_l47.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "tracker_mutation",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+tracker_mutation = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tracker_mutation)
+
+
+def _mock_task_item(sync_version=3, **extra):
+    item = {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": "task#ENC-TSK-L47T"},
+        "item_id": {"S": "ENC-TSK-L47T"},
+        "status": {"S": "in-progress"},
+        "record_type": {"S": "task"},
+        "sync_version": {"N": str(sync_version)},
+        "history": {"L": []},
+        "checkout_count": {"N": "0"},
+        "closed_count": {"N": "0"},
+        "title": {"S": "Original title"},
+    }
+    item.update(extra)
+    return item
+
+
+def _event_with_if_match(value):
+    return {"headers": {"If-Match": value}}
+
+
+def _call(body, event=None):
+    return tracker_mutation._handle_update_field(
+        "enceladus", "task", "ENC-TSK-L47T", body, event=event,
+    )
+
+
+class TestNoIfMatchHeaderUnchanged(unittest.TestCase):
+    """Absent header: unconditional write, matching pre-L47 behavior exactly."""
+
+    def test_write_succeeds_without_condition_expression(self):
+        mock_ddb = MagicMock()
+        mock_ddb.get_item.return_value = {"Item": _mock_task_item(sync_version=3)}
+        mock_ddb.update_item.return_value = {}
+        with patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = _call({"field": "title", "value": "New title", "provider": "codex"})
+        self.assertEqual(result.get("statusCode"), 200)
+        kwargs = mock_ddb.update_item.call_args.kwargs
+        self.assertNotIn("ConditionExpression", kwargs)
+        body = json.loads(result["body"])
+        self.assertTrue(body.get("success"))
+        # AC-1: revision is echoed on write too.
+        self.assertEqual(body.get("sync_version"), 4)
+
+
+class TestIfMatchFreshRevisionSucceeds(unittest.TestCase):
+    """AC-2 / AC-3: a fresh If-Match proceeds and increments the revision."""
+
+    def test_matching_if_match_writes_and_guards_commit(self):
+        mock_ddb = MagicMock()
+        mock_ddb.get_item.return_value = {"Item": _mock_task_item(sync_version=3)}
+        mock_ddb.update_item.return_value = {}
+        with patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = _call(
+                {"field": "title", "value": "New title", "provider": "codex"},
+                event=_event_with_if_match("3"),
+            )
+        self.assertEqual(result.get("statusCode"), 200)
+        kwargs = mock_ddb.update_item.call_args.kwargs
+        self.assertEqual(kwargs.get("ConditionExpression"), "sync_version = :if_match_expected")
+        self.assertEqual(
+            kwargs["ExpressionAttributeValues"][":if_match_expected"], {"N": "3"},
+        )
+        body = json.loads(result["body"])
+        self.assertTrue(body.get("success"))
+        self.assertEqual(body.get("sync_version"), 4)
+
+    def test_quoted_etag_style_if_match_is_accepted(self):
+        mock_ddb = MagicMock()
+        mock_ddb.get_item.return_value = {"Item": _mock_task_item(sync_version=3)}
+        mock_ddb.update_item.return_value = {}
+        with patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = _call(
+                {"field": "title", "value": "New title", "provider": "codex"},
+                event=_event_with_if_match('"3"'),
+            )
+        self.assertEqual(result.get("statusCode"), 200)
+
+
+class TestIfMatchStaleRevisionConflicts(unittest.TestCase):
+    """AC-2 / AC-3: a stale If-Match is rejected with 409 + current field values."""
+
+    def test_stale_if_match_returns_409_with_current_record(self):
+        mock_ddb = MagicMock()
+        mock_ddb.get_item.return_value = {"Item": _mock_task_item(sync_version=3)}
+        with patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = _call(
+                {"field": "title", "value": "New title", "provider": "codex"},
+                event=_event_with_if_match("2"),
+            )
+        self.assertEqual(result.get("statusCode"), 409)
+        mock_ddb.update_item.assert_not_called()
+        body = json.loads(result["body"])
+        self.assertFalse(body.get("success"))
+        envelope = body.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "REVISION_CONFLICT")
+        details = envelope.get("details", {})
+        self.assertEqual(details.get("expected_revision"), "2")
+        self.assertEqual(details.get("current_revision"), 3)
+        self.assertEqual(details.get("current", {}).get("title"), "Original title")
+
+    def test_race_between_precheck_and_commit_also_conflicts(self):
+        """Simulates a write landing between the pre-check and the commit: the
+        ConditionExpression must catch it even though the early check passed."""
+        from botocore.exceptions import ClientError
+
+        mock_ddb = MagicMock()
+        mock_ddb.get_item.side_effect = [
+            {"Item": _mock_task_item(sync_version=3)},   # initial read (pre-check passes)
+            {"Item": _mock_task_item(sync_version=4)},    # refetch after conflict
+        ]
+        conflict = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": "x"}},
+            "UpdateItem",
+        )
+        mock_ddb.update_item.side_effect = conflict
+        with patch.object(tracker_mutation, "_get_ddb", return_value=mock_ddb):
+            result = _call(
+                {"field": "title", "value": "New title", "provider": "codex"},
+                event=_event_with_if_match("3"),
+            )
+        self.assertEqual(result.get("statusCode"), 409)
+        body = json.loads(result["body"])
+        envelope = body.get("error_envelope", {})
+        self.assertEqual(envelope.get("code"), "REVISION_CONFLICT")
+        self.assertEqual(envelope.get("details", {}).get("current_revision"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds an `If-Match` header check to `tracker_mutation`'s generic field-update path, keyed on the existing `sync_version` counter, and to `document_api`'s PATCH path, keyed on the existing `version` counter.
- Absent header preserves today's unconditional-write behavior (fully backward compatible for every existing agent/PWA caller).
- Mismatch returns HTTP 409 with the current server-side field values in the body (consumed by ENC-TSK-K25's merge-conflict UI). A fresh `If-Match` proceeds and the revision increments, guarded by a `ConditionExpression` at commit time against races between the pre-check and the write.
- Decoupled from ENC-TSK-L27's `version_seq` per B67 AC-19 / K25 AC-3 — no dependency on escalated IAM/GSI work.

## Test plan
- [x] `python3 -m pytest` in `backend/lambda/tracker_mutation/` — 450 passed (445 pre-existing + 5 new)
- [x] `python3 -m pytest` in `backend/lambda/document_api/` — 103 passed (98 pre-existing + 5 new)
- [x] `python3 -m py_compile` both `lambda_function.py` files
- [ ] Live gamma verification (concurrent-write 409 + fresh-If-Match success) — AC-3, to be run post-deploy and committed to the task worklog

CCI-2f1ef1b7d5c142b2b0ef9f542425356a

🤖 Generated with [Claude Code](https://claude.com/claude-code)