### PR TITLE
ENC-TSK-L51 — scheduler IAM as managed policy (inline quota fix)

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -189,26 +189,8 @@ Resources:
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/enceladus-*"
                   - !Sub "arn:aws:events:us-west-2:${AWS::AccountId}:rule/on-project-json-sync*"
 
-              # ENC-PLN-068: Rhythm Cycle EventBridge Scheduler groups/schedules
-              - Sid: EventBridgeSchedulerOps
-                Effect: Allow
-                Action:
-                  - scheduler:CreateScheduleGroup
-                  - scheduler:DeleteScheduleGroup
-                  - scheduler:GetScheduleGroup
-                  - scheduler:ListScheduleGroups
-                  - scheduler:CreateSchedule
-                  - scheduler:DeleteSchedule
-                  - scheduler:GetSchedule
-                  - scheduler:UpdateSchedule
-                  - scheduler:ListSchedules
-                  - scheduler:TagResource
-                  - scheduler:UntagResource
-                Resource:
-                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/rhythm-*"
-                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/rhythm-*/*"
-                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/enceladus-*"
-                  - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/enceladus-*/*"
+              # EventBridgeSchedulerOps moved to EventBridgeSchedulerOpsPolicy
+              # (managed attachment) — inline quota exhausted on this role.
 
               - Sid: PipesOps
                 Effect: Allow
@@ -437,6 +419,38 @@ Resources:
             Resource:
               - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:enceladus-mcp-code-gamma"
               - !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:enceladus-mcp-code-gamma:*"
+
+  # ENC-PLN-068 / ENC-TSK-L51 — Rhythm Cycle EventBridge Scheduler groups/schedules.
+  # Same failure class as CodeDeployStackOpsPolicy: inline CloudFormationDeployPolicy
+  # cannot grow (10,240-byte role inline quota exhausted by out-of-band patches).
+  EventBridgeSchedulerOpsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-scheduler-v1
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EventBridgeSchedulerOps
+            Effect: Allow
+            Action:
+              - scheduler:CreateScheduleGroup
+              - scheduler:DeleteScheduleGroup
+              - scheduler:GetScheduleGroup
+              - scheduler:ListScheduleGroups
+              - scheduler:CreateSchedule
+              - scheduler:DeleteSchedule
+              - scheduler:GetSchedule
+              - scheduler:UpdateSchedule
+              - scheduler:ListSchedules
+              - scheduler:TagResource
+              - scheduler:UntagResource
+            Resource:
+              - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/rhythm-*"
+              - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/rhythm-*/*"
+              - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/enceladus-*"
+              - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/enceladus-*/*"
 
   BackendDeployRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary
- Move `EventBridgeSchedulerOps` out of inline `CloudFormationDeployPolicy`
- Attach as `AWS::IAM::ManagedPolicy` `enceladus-cfn-deploy-scheduler-v1` (same pattern as CodeDeployStackOpsPolicy)
- Fixes github-roles stack UPDATE_ROLLBACK on 10 KiB inline limit

CCI-b804211525644ed798691c50c584f20a

## Test plan
- [ ] Re-dispatch CloudFormation GitHub Roles Stack Deploy; io approves v3-prod apply

Made with [Cursor](https://cursor.com)