### PR TITLE
ENC-TSK-L37: Lesson detail page surfaces real constitutional-scoring math

### DIFF
--- a/frontend/ui-v2/src/design-system/index.d.ts
+++ b/frontend/ui-v2/src/design-system/index.d.ts
@@ -13,3 +13,5 @@ export { Header } from '../../../design-system-2/v2/components/Header/Header.jsx
 export { Pagination } from '../../../design-system-2/v2/components/Pagination/Pagination.jsx'
 export { Box } from '../../../design-system-2/v2/components/Box/Box.jsx'
 export { BreadcrumbGroup } from '../../../design-system-2/v2/components/BreadcrumbGroup/BreadcrumbGroup.jsx'
+export { KeyValuePairs } from '../../../design-system-2/v2/components/KeyValuePairs/KeyValuePairs.jsx'
+export { BarChart } from '../../../design-system-2/v2/components/BarChart/BarChart.jsx'

--- a/frontend/ui-v2/src/design-system/index.js
+++ b/frontend/ui-v2/src/design-system/index.js
@@ -14,3 +14,5 @@ export { Header } from '../../../design-system-2/v2/components/Header/Header.jsx
 export { Pagination } from '../../../design-system-2/v2/components/Pagination/Pagination.jsx'
 export { Box } from '../../../design-system-2/v2/components/Box/Box.jsx'
 export { BreadcrumbGroup } from '../../../design-system-2/v2/components/BreadcrumbGroup/BreadcrumbGroup.jsx'
+export { KeyValuePairs } from '../../../design-system-2/v2/components/KeyValuePairs/KeyValuePairs.jsx'
+export { BarChart } from '../../../design-system-2/v2/components/BarChart/BarChart.jsx'

--- a/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
@@ -1,6 +1,14 @@
 import { Lightbulb } from 'lucide-react'
 import type { Lesson } from '../types/records'
-import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { BarChart, KeyValuePairs } from '../design-system'
+
+const PILLAR_LABELS: { key: keyof Lesson['pillar_scores']; label: string }[] = [
+  { key: 'efficiency', label: 'Efficiency' },
+  { key: 'human_protection', label: 'Human Protection' },
+  { key: 'intention', label: 'Intention' },
+  { key: 'alignment', label: 'Alignment' },
+]
 
 export function LessonPrimitive({ record }: { record: Lesson }) {
   return (
@@ -45,12 +53,28 @@ export function LessonPrimitive({ record }: { record: Lesson }) {
       >
         {record.insight}
       </blockquote>
-      <MetaRow label="Confidence">
-        <Metric>{(record.confidence ?? 0).toFixed(2)}</Metric>
-      </MetaRow>
-      <MetaRow label="Resonance">
-        <Metric>{(record.resonance_score ?? 0).toFixed(2)}</Metric>
-      </MetaRow>
+      <div style={{ marginBottom: 'var(--space-4)' }}>
+        <KeyValuePairs
+          columns={3}
+          items={[
+            { label: 'Confidence', value: (record.confidence ?? 0).toFixed(2), mono: true },
+            { label: 'Pillar Composite', value: (record.pillar_composite ?? 0).toFixed(3), mono: true },
+            { label: 'Resonance', value: (record.resonance_score ?? 0).toFixed(3), mono: true },
+          ]}
+        />
+      </div>
+      <BarChart
+        title="Constitutional Pillar Scores"
+        subtitle="DOC-6EFD5DB32CD8 — efficiency / human_protection / intention / alignment"
+        xDomain={PILLAR_LABELS.map((p) => p.label)}
+        series={[
+          {
+            title: 'Pillar Scores',
+            data: PILLAR_LABELS.map((p) => record.pillar_scores?.[p.key] ?? 0),
+          },
+        ]}
+        height={220}
+      />
       <MetaRow label="Provenance">{record.provenance}</MetaRow>
     </PrimitiveCard>
   )

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -101,6 +101,7 @@ export interface Lesson {
   provenance: string
   confidence: number
   pillar_scores: PillarScores
+  pillar_composite: number
   resonance_score: number
   category: string
   status: string


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc confidence/resonance MetaRow display in `LessonPrimitive.tsx` with design-system-2 `KeyValuePairs` (confidence, pillar_composite, resonance) and adds a `BarChart` of the four `pillar_scores` (efficiency / human_protection / intention / alignment) per DOC-6EFD5DB32CD8.
- Exports `KeyValuePairs` and `BarChart` from the ui-v2 design-system barrel (both existed in `design-system-2` already but were unused/unexported).
- Adds `pillar_composite` to the `Lesson` TypeScript type — the backend (`tracker_mutation` `_compute_lesson_pillar_composite`) already computes and persists this field alongside `pillar_scores`/`resonance_score`; it just wasn't surfaced in the type or the UI.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` (incl. `_adherence.oxlintrc.json` design-system-2 guard) — 18 pre-existing errors elsewhere in the repo, none in touched files; adherence guard passes standalone with exit 0
- [x] `npx vitest run` — 56/56 passing
- [x] `npm run build` — succeeds
- [ ] Visual gamma verification post-deploy

CCI-cfb779ef20214096a82fc354d93da8d7

🤖 Generated with [Claude Code](https://claude.com/claude-code)