### PR TITLE
ENC-TSK-L54 — re-enable Rhythm Cycle on gamma compute deploy

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -367,10 +367,8 @@ jobs:
           # prod feature flags. Prod: 5t3sqte/bnwj3lj; gamma: fhhcl7m/zecfu42.
           if [ "${ENVIRONMENT_SUFFIX}" = "-gamma" ]; then
             APPCFG_APP="fhhcl7m"; APPCFG_ENV="zecfu42"
-            # ENC-PLN-068 / L14-L48 deploy unblock: Rhythm ScheduleGroups fail CREATE until
-            # CloudFormationDeployRole has scheduler:* (see iam-cfn-deploy-role-scheduler-patch.yml).
-            # Keep legacy gamma schedules active until IAM patch lands.
-            RHYTHM_CYCLE_ENABLED="false"
+            # ENC-TSK-L54: scheduler IAM landed (enceladus-cfn-deploy-scheduler-v1 on CFN deploy role).
+            RHYTHM_CYCLE_ENABLED="true"
           else
             APPCFG_APP="5t3sqte"; APPCFG_ENV="bnwj3lj"
             RHYTHM_CYCLE_ENABLED="true"


### PR DESCRIPTION
## Summary
- Set `RhythmCycleEnabled=true` for gamma compute stack deploys (reverts L49 temporary override)
- Scheduler IAM is live: `enceladus-cfn-deploy-scheduler-v1` attached to CFN deploy role (DOC-0A008E92E24D)

CCI-a305e42d1cc245438d7936385294da1a

## Test plan
- [ ] Merge to v4/main
- [ ] Gamma CloudFormation compute deploy succeeds with Rhythm ScheduleGroups

Made with [Cursor](https://cursor.com)