### PR TITLE
ENC-TSK-L29: full-body AppSync events on /records/{recordId} (WaveC)

### DIFF
--- a/backend/lambda/appsync_feed_publisher/lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/lambda_function.py
@@ -355,6 +355,22 @@ def channel_targets(payload: Dict[str, Any]) -> List[str]:
     return list(payload.get("channels", []))
 
 
+def build_full_record_body(record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Full record body for the /records/{recordId} channel only (ENC-TSK-L29).
+
+    Returns the deserialized NewImage (current field values) for INSERT/MODIFY
+    events so the client's Tier-1/Tier-2 mirror (ENC-TSK-L24) can upsert
+    directly with no follow-up fetch. Returns None for REMOVE events (and when
+    there is no NewImage) — the client instead reacts to the lightweight
+    payload's action='removed' and marks a tombstone. Deliberately a SEPARATE
+    function from build_event_payload so the /feed/updates and /projects/{id}
+    channels (B67 AC-23 fixed ~500-byte budget) are never touched by this.
+    """
+    ddb = record.get("dynamodb", {}) or {}
+    new_image = _deserialize_image(ddb.get("NewImage"))
+    return new_image or None
+
+
 # ---------------------------------------------------------------------------
 # AppSync Events HTTP publish (stdlib urllib; SigV4 documented alternative)
 # ---------------------------------------------------------------------------
@@ -394,12 +410,17 @@ def _sigv4_headers(body: bytes, host: str) -> Dict[str, str]:
     return headers
 
 
-def publish_to_appsync(payload: Dict[str, Any]) -> None:
+def publish_to_appsync(payload: Dict[str, Any], full_body: Optional[Dict[str, Any]] = None) -> None:
     """POST one event as an AppSync Events publish frame to its channels.
 
     AppSync Events HTTP publish shape: {"channel": <path>, "events": [<json str>]}.
     We publish to each target channel (global, per-record, per-project). Raises
     on HTTP/transport failure so the caller can mark the record for retry.
+
+    ENC-TSK-L29: when full_body is provided, the /records/{recordId} channel's
+    event carries an additional "record" field with the complete current
+    record body — /feed/updates and /projects/{id} always get the lightweight
+    payload unchanged (AC-23 budget).
     """
     url = _endpoint_url()
     if not url:
@@ -407,9 +428,18 @@ def publish_to_appsync(payload: Dict[str, Any]) -> None:
 
     host = url.split("://", 1)[-1].split("/", 1)[0]
     event_json = json.dumps(payload, separators=(",", ":"))
+    detail_event_json = (
+        json.dumps({**payload, "record": full_body}, separators=(",", ":"))
+        if full_body is not None
+        else event_json
+    )
 
     for channel in channel_targets(payload):
-        body_obj = {"channel": channel, "events": [event_json]}
+        is_record_channel = channel.startswith("/records/")
+        body_obj = {
+            "channel": channel,
+            "events": [detail_event_json if is_record_channel else event_json],
+        }
         body = json.dumps(body_obj, separators=(",", ":")).encode("utf-8")
 
         headers = {"Content-Type": "application/json", "host": host}
@@ -481,15 +511,19 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 )
                 continue
 
+            full_body = build_full_record_body(record)
+
             if DRY_RUN:
                 logger.info(
-                    "appsync_feed_publisher: DRY_RUN — would publish event=%s action=%s channels=%s",
+                    "appsync_feed_publisher: DRY_RUN — would publish event=%s action=%s channels=%s "
+                    "full_body=%s",
                     payload["eventId"],
                     payload["action"],
                     payload["channels"],
+                    full_body is not None,
                 )
             else:
-                publish_to_appsync(payload)
+                publish_to_appsync(payload, full_body)
             published += 1
         except Exception as exc:  # noqa: BLE001 — isolate per-record failure
             logger.error(

--- a/backend/lambda/appsync_feed_publisher/test_lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/test_lambda_function.py
@@ -334,3 +334,124 @@ def test_composite_record_id_without_item_id_falls_back_to_suffix():
     assert payload is not None
     assert payload["recordId"] == "ENC-LSN-057"
     assert "/records/ENC-LSN-057" in payload["channels"]
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-L29: full record body on /records/{recordId} only (not /feed/updates
+# or /projects/{id}), so the client's Tier-1/Tier-2 mirror (ENC-TSK-L24) can
+# upsert directly with no follow-up fetch.
+# ---------------------------------------------------------------------------
+
+
+def test_build_full_record_body_returns_new_image_for_insert():
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={
+            "record_id": "task#ENC-TSK-L29T",
+            "item_id": "ENC-TSK-L29T",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "title": "Full body row",
+            "status": "open",
+        },
+    )
+    full_body = mod.build_full_record_body(rec)
+    assert full_body is not None
+    assert full_body["item_id"] == "ENC-TSK-L29T"
+    assert full_body["title"] == "Full body row"
+    assert full_body["status"] == "open"
+
+
+def test_build_full_record_body_returns_new_image_for_modify():
+    rec = _stream_record(
+        event_name="MODIFY",
+        new_image={"record_id": "task#ENC-TSK-L29T", "item_id": "ENC-TSK-L29T", "status": "closed"},
+        old_image={"record_id": "task#ENC-TSK-L29T", "item_id": "ENC-TSK-L29T", "status": "open"},
+    )
+    full_body = mod.build_full_record_body(rec)
+    assert full_body is not None
+    assert full_body["status"] == "closed"
+
+
+def test_build_full_record_body_returns_none_for_remove():
+    rec = _stream_record(
+        event_name="REMOVE",
+        old_image={"record_id": "task#ENC-TSK-L29T", "item_id": "ENC-TSK-L29T", "status": "open"},
+    )
+    full_body = mod.build_full_record_body(rec)
+    assert full_body is None
+
+
+class _FakeResponse:
+    def __init__(self, status=200):
+        self.status = status
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_publish_to_appsync_attaches_record_only_to_records_channel():
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={
+            "record_id": "task#ENC-TSK-L29T",
+            "item_id": "ENC-TSK-L29T",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "title": "Full body row",
+        },
+    )
+    payload = mod.build_event_payload(rec, 0)
+    full_body = mod.build_full_record_body(rec)
+    assert payload is not None and full_body is not None
+
+    sent_bodies = {}
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ARG001
+        body = json.loads(req.data.decode("utf-8"))
+        sent_bodies[body["channel"]] = json.loads(body["events"][0])
+        return _FakeResponse(200)
+
+    with patch.object(mod.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        mod.publish_to_appsync(payload, full_body)
+
+    assert set(sent_bodies.keys()) == {"/feed/updates", "/records/ENC-TSK-L29T", "/projects/enceladus"}
+    assert "record" not in sent_bodies["/feed/updates"]
+    assert "record" not in sent_bodies["/projects/enceladus"]
+    assert sent_bodies["/records/ENC-TSK-L29T"]["record"] == full_body
+    # AC-23: the lightweight channels must stay exactly as small as before —
+    # no accidental leakage of the full body onto the fixed-budget channels.
+    assert sent_bodies["/feed/updates"] == payload
+
+
+def test_publish_to_appsync_without_full_body_is_unchanged():
+    rec = _stream_record(
+        event_name="REMOVE",
+        old_image={
+            "record_id": "task#ENC-TSK-L29T",
+            "item_id": "ENC-TSK-L29T",
+            "record_type": "task",
+            "project_id": "enceladus",
+        },
+    )
+    payload = mod.build_event_payload(rec, 0)
+    assert payload is not None
+
+    sent_bodies = {}
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ARG001
+        body = json.loads(req.data.decode("utf-8"))
+        sent_bodies[body["channel"]] = json.loads(body["events"][0])
+        return _FakeResponse(200)
+
+    with patch.object(mod.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        mod.publish_to_appsync(payload)
+
+    for body in sent_bodies.values():
+        assert "record" not in body

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.7",
-  "updated_at": "2026-07-05T08:12:00Z",
-  "last_change_summary": "ENC-TSK-L53 / ENC-ISS-489: graph_query_api._authenticate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] (parity with feed_query/user_preferences/tracker_mutation); fixes cookie-only 401 on hybrid graphsearch for ui-v2.",
+  "version": "2026-07-05.8",
+  "updated_at": "2026-07-05T08:19:00Z",
+  "last_change_summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7353,6 +7353,16 @@
           "definition": "Every successful write on either path now echoes the post-write revision in the response body (sync_version on tracker_mutation, version on document_api) so the caller can update its local cache without an extra read."
         }
       }
+    },
+    "appsync_feed_publisher.full_record_body_l29": {
+      "description": "ENC-TSK-L29 (B67 Search2.0 WaveC): the appsync_feed_publisher Lambda (backend/lambda/appsync_feed_publisher, DISTINCT from the legacy backend/lambda/feed_publisher v1 S3 mobile-feed publisher) attaches the full current record body to the event delivered on a record's /records/{recordId} AppSync Events channel only. The /feed/updates (global firehose) and /projects/{projectId} channels are never given a body -- their payload stays exactly the pre-existing B67 AC-10 lightweight envelope (fixed ~500-byte AC-23 budget). Purpose: an open record-detail page's client-side Tier-1/Tier-2 mirror (ENC-TSK-L24) can upsert directly from a /records/{recordId} event with no follow-up GET.",
+      "fields": {
+        "record": {
+          "type": "object",
+          "definition": "Present only on /records/{recordId} channel events, for INSERT/MODIFY stream records. Deserialized DynamoDB NewImage -- every current field on the record, plain JSON (no {S:...}/{N:...} typed wrappers). Absent on /feed/updates and /projects/{id} events, and absent for REMOVE events (the client instead reacts to the existing lightweight envelope's action='removed' and marks a tombstone).",
+          "usage_guidance": "Client subscribes to /records/{recordId} (ENC-TSK-L29 AppSyncRealtimeClient.watchRecord) only while that record's detail page is open, and upserts event.record directly into the Tier-2 cache + the live query cache -- never re-fetches on receipt of this event."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda -- nightly EventBridge (gamma, cron 06:00 UTC, after K41's 05:00 CEE scan) consumes K41's Compliance/Semantic detector output and deterministically resolves a whitelist of compliance_warnings classes (fence_missing_language, metadata_field_missing) via document_api PATCH, advancing raw documents to compliant document_maturity_state with no agent session involvement. DATA-SAFETY: only the deterministic whitelist is auto-remediated; ambiguous/content-changing warnings are left for agent review; every auto-patch is logged with before/after compliance_score. Dry-run default-on (GDMP_DRY_RUN=1) plus a 3-run io-approval ramp (GDMP_IO_APPROVAL_RUNS=3, GDMP_MUTATION_ENABLED=0) reuse the FTR-106 / ENC-TSK-K03 unlearning Lambda's S3 run-counter pattern verbatim. CEE_GDMP_HARD_DISABLED=1 kill switch ships ON by default. Idempotent: is_already_compliant guards against re-patching already-compliant documents. New entity corpus_entropy_gdmp_remediation.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
@@ -7551,6 +7561,11 @@
       "version": "2026-07-05.6",
       "date": "2026-07-05",
       "summary": "ENC-TSK-L47 (B67 backend / FTR-127 AC-19, K25 AC-3): If-Match / HTTP 409 per-record revision-conflict contract added to tracker_mutation's generic field-update path (sync_version) and document_api's PATCH path (version). Absent header preserves prior unconditional-write behavior. New entity api.if_match_revision_contract; new error_envelope.code value REVISION_CONFLICT."
+    },
+    {
+      "version": "2026-07-05.8",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
     }
   ]
 }

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -29,6 +29,12 @@ interface RealtimeFeedContextValue {
   isSnapshotError: boolean
   refetchSnapshot: () => void
   manualReconnect: () => void
+  /**
+   * ENC-TSK-L29: subscribe to full-body events for a single record over the
+   * shared realtime connection. No-op (safe, returns a no-op unsubscribe) if
+   * realtime is disabled or not yet connected.
+   */
+  watchRecord: (recordId: string, onEvent: (event: FeedRealtimeEvent) => void) => () => void
 }
 
 const RealtimeFeedContext = createContext<RealtimeFeedContextValue | null>(null)
@@ -171,6 +177,10 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
       clientRef.current?.manualRetry()
       resetFailedReconnects()
       setPhase('connecting')
+    },
+    watchRecord: (recordId, onRecordEvent) => {
+      if (!clientRef.current) return () => {}
+      return clientRef.current.watchRecord(recordId, onRecordEvent)
     },
   }
 

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
@@ -164,3 +164,124 @@ describe('AppSyncRealtimeClient', () => {
     client.stop()
   })
 })
+
+describe('AppSyncRealtimeClient — per-record watch (ENC-TSK-L29)', () => {
+  afterEach(() => {
+    MockWebSocket.instances = []
+  })
+
+  it('subscribes to /records/{recordId} and routes matching data frames to the watch handler only', () => {
+    const globalEvents: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => globalEvents.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+
+    const recordEvents: unknown[] = []
+    client.watchRecord('ENC-TSK-L29T', (event) => recordEvents.push(event))
+
+    const subscribeFrame = socket.sent
+      .map((raw) => JSON.parse(raw))
+      .find((frame) => frame.type === 'subscribe' && frame.channel === '/records/ENC-TSK-L29T')
+    expect(subscribeFrame).toBeDefined()
+
+    const detailPayload = {
+      eventId: 'evt-detail-1',
+      recordId: 'ENC-TSK-L29T',
+      record_type: 'task',
+      action: 'updated',
+      actorType: 'agent',
+      actorId: 'ENC-SES-1',
+      summary: 'updated task',
+      cursor: 1_700_000_000_001,
+      channels: ['/records/ENC-TSK-L29T'],
+      record: { item_id: 'ENC-TSK-L29T', title: 'Full body' },
+    }
+    socket.emit({ type: 'data', id: subscribeFrame.id, event: JSON.stringify(detailPayload) })
+
+    expect(recordEvents).toHaveLength(1)
+    expect((recordEvents[0] as { record?: { title?: string } }).record?.title).toBe('Full body')
+    // Per-record events never reach the global feed_event handler.
+    expect(globalEvents).not.toContain('feed_event')
+    client.stop()
+  })
+
+  it('unsubscribe stops routing further events and sends an unsubscribe frame', () => {
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: () => {},
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+
+    const recordEvents: unknown[] = []
+    const unsubscribe = client.watchRecord('ENC-TSK-L29T', (event) => recordEvents.push(event))
+    const subscribeFrame = socket.sent
+      .map((raw) => JSON.parse(raw))
+      .find((frame) => frame.type === 'subscribe' && frame.channel === '/records/ENC-TSK-L29T')
+
+    unsubscribe()
+    expect(
+      socket.sent.map((raw) => JSON.parse(raw)).some((f) => f.type === 'unsubscribe' && f.id === subscribeFrame.id),
+    ).toBe(true)
+
+    socket.emit({
+      type: 'data',
+      id: subscribeFrame.id,
+      event: JSON.stringify({
+        eventId: 'evt-detail-2',
+        recordId: 'ENC-TSK-L29T',
+        record_type: 'task',
+        action: 'updated',
+        actorType: 'agent',
+        actorId: 'ENC-SES-1',
+        summary: 'updated task',
+        cursor: 1_700_000_000_002,
+        channels: ['/records/ENC-TSK-L29T'],
+        record: { item_id: 'ENC-TSK-L29T' },
+      }),
+    })
+    expect(recordEvents).toHaveLength(0)
+    client.stop()
+  })
+
+  it('resubscribes watched records after a reconnect', () => {
+    vi.useFakeTimers()
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: () => {},
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    let socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+    client.watchRecord('ENC-TSK-L29T', () => {})
+
+    socket.close()
+    vi.advanceTimersByTime(BACKOFF_BASE_MS * 4)
+    socket = MockWebSocket.instances.at(-1)!
+    socket.open()
+    socket.emit({ type: 'connection_ack' })
+
+    const resubscribed = socket.sent
+      .map((raw) => JSON.parse(raw))
+      .some((frame) => frame.type === 'subscribe' && frame.channel === '/records/ENC-TSK-L29T')
+    expect(resubscribed).toBe(true)
+    client.stop()
+  })
+})

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
@@ -71,6 +71,14 @@ export class AppSyncRealtimeClient {
   private disposed = false
   private lastCursor: number
   private seenEventIds = new Set<string>()
+  // ENC-TSK-L29: per-record `/records/{recordId}` subscriptions, multiplexed
+  // on the same socket as the primary feed subscription. Keyed by the
+  // client-chosen subscription id so incoming `data` frames route to the
+  // right handler (matched via frame.id) instead of the global feed reducer.
+  private extraSubscriptions = new Map<
+    string,
+    { channel: string; onEvent: (event: FeedRealtimeEvent) => void }
+  >()
 
   constructor(options: AppSyncRealtimeClientOptions) {
     this.config = options.config
@@ -109,6 +117,43 @@ export class AppSyncRealtimeClient {
 
   getLastCursor(): number {
     return this.lastCursor
+  }
+
+  /**
+   * ENC-TSK-L29: subscribe to a single record's `/records/{recordId}` channel
+   * on the SAME socket as the primary feed subscription. `onEvent` receives
+   * only events for this record (full-body events per the backend contract).
+   * Returns an unsubscribe function; safe to call even before the socket
+   * connects (auto (re)subscribes once `connection_ack` arrives).
+   */
+  watchRecord(recordId: string, onEvent: (event: FeedRealtimeEvent) => void): () => void {
+    const channel = `/records/${recordId}`
+    const id = crypto.randomUUID()
+    this.extraSubscriptions.set(id, { channel, onEvent })
+    this.sendSubscribeFrame(id, channel)
+    return () => {
+      this.extraSubscriptions.delete(id)
+      this.sendUnsubscribeFrame(id)
+    }
+  }
+
+  private sendSubscribeFrame(id: string, channel: string): void {
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    socket.send(
+      JSON.stringify({
+        type: 'subscribe',
+        id,
+        channel,
+        authorization: { host: this.config.httpHost, 'x-api-key': this.config.apiKey },
+      }),
+    )
+  }
+
+  private sendUnsubscribeFrame(id: string): void {
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    socket.send(JSON.stringify({ type: 'unsubscribe', id }))
   }
 
   private connect(): void {
@@ -158,6 +203,11 @@ export class AppSyncRealtimeClient {
     if (frame.type === 'connection_ack') {
       this.reconnectAttempt = 0
       this.subscribe()
+      // ENC-TSK-L29: re-establish any per-record watches after (re)connect —
+      // AppSync subscriptions do not survive a socket replacement.
+      for (const [id, sub] of this.extraSubscriptions) {
+        this.sendSubscribeFrame(id, sub.channel)
+      }
       this.startHeartbeat()
       this.onEvent({ type: 'connected' })
       return
@@ -169,6 +219,23 @@ export class AppSyncRealtimeClient {
 
     if (frame.type === 'error') {
       this.onEvent({ type: 'disconnected', reason: JSON.stringify(frame.errors ?? frame) })
+      return
+    }
+
+    // ENC-TSK-L29: a data frame from a per-record subscription routes to that
+    // watch's own handler — full-body events never touch the global feed
+    // dedup/cursor/gap bookkeeping below, which is scoped to the primary
+    // /feed/updates subscription.
+    if (frame.type === 'data' && frame.event && frame.id && this.extraSubscriptions.has(frame.id)) {
+      const sub = this.extraSubscriptions.get(frame.id)!
+      try {
+        const payload =
+          typeof frame.event === 'string' ? (JSON.parse(frame.event) as unknown) : frame.event
+        const feedEvent = parseFeedEvent(payload)
+        if (feedEvent) sub.onEvent(feedEvent)
+      } catch {
+        // malformed per-record event — drop silently, same as the primary path
+      }
       return
     }
 

--- a/frontend/ui-v2/src/realtime/useRecordRealtimeSync.ts
+++ b/frontend/ui-v2/src/realtime/useRecordRealtimeSync.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { recordKeys } from '../api/queryOptions'
+import { getCacheEngine } from '../sync/cacheEngine'
+import { versionSeqFromUpdatedAt } from '../sync/recordKey'
+import type { RecordType } from '../types/records'
+import { useRealtimeFeed } from './RealtimeFeedProvider'
+
+/**
+ * ENC-TSK-L29: while a tracker-record detail page is open, subscribe to its
+ * `/records/{recordId}` full-body events and upsert them directly into the
+ * Tier-2 mirror (ENC-TSK-L24) AND the live TanStack Query cache — no
+ * follow-up fetch, and the open page updates in place. No-op if realtime is
+ * disabled (RealtimeFeedProvider.watchRecord degrades to a safe no-op).
+ */
+export function useRecordRealtimeSync(
+  recordType: Exclude<RecordType, 'document'>,
+  projectId: string,
+  recordId: string,
+): void {
+  const { watchRecord } = useRealtimeFeed()
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    return watchRecord(recordId, (event) => {
+      if (event.action === 'removed' || !event.record) return
+      const body = event.record
+      const updatedAt = typeof body.updated_at === 'string' ? body.updated_at : ''
+      queryClient.setQueryData(recordKeys.detail(recordType, projectId, recordId), body)
+      void getCacheEngine().upsertTier2(projectId, recordId, body, versionSeqFromUpdatedAt(updatedAt))
+    })
+  }, [watchRecord, queryClient, recordType, projectId, recordId])
+}

--- a/frontend/ui-v2/src/routes/recordRoute.tsx
+++ b/frontend/ui-v2/src/routes/recordRoute.tsx
@@ -5,6 +5,7 @@ import { queryClient } from '../api/queryClient'
 import { RecordDetailBreadcrumbs } from '../components/RecordDetailBreadcrumbs'
 import { SkeletonCard } from '../components/SkeletonCard'
 import { getPrimitive } from '../primitives/registry'
+import { useRecordRealtimeSync } from '../realtime/useRecordRealtimeSync'
 import type { RecordShapeMap, RecordType } from '../types/records'
 
 type TrackerRecordType = Exclude<RecordType, 'document'>
@@ -34,6 +35,7 @@ export function createRecordRoute<K extends TrackerRecordType>(config: {
   function RecordComponent() {
     const { project, id } = route.useParams() as { project: string; id: string }
     const { data } = useSuspenseQuery(queryOptionsFor(project, id))
+    useRecordRealtimeSync(type, project, id)
     const Primitive = getPrimitive(type)
     return (
       <>

--- a/frontend/ui-v2/src/types/feedEvents.ts
+++ b/frontend/ui-v2/src/types/feedEvents.ts
@@ -13,6 +13,14 @@ export interface FeedRealtimeEvent {
   summary: string
   cursor: number
   channels: string[]
+  /**
+   * ENC-TSK-L29: the full current record body, present ONLY on events
+   * delivered over a per-record `/records/{recordId}` subscription (never on
+   * the `/feed/updates` or `/projects/{id}` channels, which keep the fixed
+   * AC-23 payload budget). Lets the client mirror (ENC-TSK-L24) upsert
+   * directly with no follow-up fetch.
+   */
+  record?: Record<string, unknown>
 }
 
 export interface FeedSnapshot {


### PR DESCRIPTION
## Summary
- **Backend** (`appsync_feed_publisher`): new `build_full_record_body()` returns the deserialized `NewImage` for INSERT/MODIFY stream records; `publish_to_appsync` attaches it as a `record` field ONLY on the `/records/{recordId}` channel's event. `/feed/updates` and `/projects/{id}` are byte-for-byte unchanged (fixed B67 AC-23 payload budget). REMOVE events carry no body — clients already react to `action='removed'`.
- **Frontend**: `AppSyncRealtimeClient` now multiplexes per-record subscriptions on the same socket as the primary feed subscription (`watchRecord`/unsubscribe, resubscribed automatically after a reconnect, routed by `frame.id` so they never touch the global feed's dedup/cursor/gap bookkeeping). A new `useRecordRealtimeSync` hook, wired into every tracker record-detail route (`recordRoute.tsx`), upserts incoming full bodies directly into the Tier-2 mirror (ENC-TSK-L24) and the live TanStack Query cache — an open detail page updates in place, no follow-up GET.

## Test plan
- [x] `python3 -m pytest` in `backend/lambda/appsync_feed_publisher/` — 27 passed (22 pre-existing + 5 new)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` (incl. adherence guard) — pre-existing errors elsewhere untouched by this change; adherence guard exits 0 standalone
- [x] `npx vitest run` — 59/59 passing (56 pre-existing + 3 new)
- [x] `npm run build` — succeeds
- [ ] Live gamma verification post-deploy

CCI-f78c9f5c821c435f8a3e5c52945949f2

🤖 Generated with [Claude Code](https://claude.com/claude-code)