### PR TITLE
feat(feed): version_seq GSI + /feed/delta incremental sync (ENC-TSK-L27)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.8",
-  "updated_at": "2026-07-05T08:19:00Z",
-  "last_change_summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29.",
+  "version": "2026-07-05.9",
+  "updated_at": "2026-07-05T08:27:00Z",
+  "last_change_summary": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): monotonic version_seq + version-seq-index GSI on devops-project-tracker; GET /api/v1/feed/delta?since=<version_seq> returns changed corpus items + delete tombstones; ui-v2 cache gap-heals incrementally.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3458,6 +3458,23 @@
         "attrs": {
           "type": "object",
           "definition": "Compact per-record attribute map: status, priority, category, severity (issues), tags (documents), document_subtype, subtypepattern."
+        }
+      }
+    },
+    "feed_query.delta": {
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
+      "fields": {
+        "since": {
+          "type": "integer",
+          "definition": "Non-negative integer version_seq watermark. Returns all tracker rows and feed_tombstone rows with version_seq strictly greater than since."
+        },
+        "latest_version_seq": {
+          "type": "integer",
+          "definition": "High-water version_seq observed in this response; clients persist and pass on the next delta poll."
+        },
+        "tombstones": {
+          "type": "array",
+          "definition": "Delete/evict hints: {record_key, record_id, record_type, project_id, version_seq} for feed_tombstone rows and stale-closed records."
         }
       }
     },

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,12 +1,7 @@
 {
-  "version": "2026-07-05.9",
-<<<<<<< HEAD
-  "updated_at": "2026-07-05T08:27:00Z",
-  "last_change_summary": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): monotonic version_seq + version-seq-index GSI on devops-project-tracker; GET /api/v1/feed/delta?since=<version_seq> returns changed corpus items + delete tombstones; ui-v2 cache gap-heals incrementally.",
-=======
-  "updated_at": "2026-07-05T08:26:00Z",
-  "last_change_summary": "ENC-TSK-L10 (B64 Ph3): new mcp_streaming_gateway Lambda (Lambda Web Adapter + Starlette/uvicorn, reusing server.py's MCP tool surface) + dedicated REST API Gateway v1 (McpStreamingRestApi) with responseTransferMode=STREAM, gamma-only. New entity mcp_streaming_gateway.lambda.",
->>>>>>> origin/v4/main
+  "version": "2026-07-05.10",
+  "updated_at": "2026-07-05T08:30:00Z",
+  "last_change_summary": "ENC-TSK-L27 (B67 WaveC): version_seq + version-seq-index GSI + GET /api/v1/feed/delta incremental sync. ENC-TSK-L10 (B64 Ph3): mcp_streaming_gateway Lambda + McpStreamingRestApi (gamma-only).",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/feed_query/corpus.py
+++ b/backend/lambda/feed_query/corpus.py
@@ -221,8 +221,9 @@ def build_tracker_entry(
     title: str,
     updated_at: Optional[str],
     attrs: Mapping[str, Any],
+    version_seq: Optional[int] = None,
 ) -> Dict[str, Any]:
-    return {
+    entry = {
         "record_id": record_id,
         "record_type": record_type,
         "project_id": project_id,
@@ -232,6 +233,9 @@ def build_tracker_entry(
         "record_key": tracker_record_key(project_id, record_id),
         "attrs": dict(attrs),
     }
+    if version_seq is not None:
+        entry["version_seq"] = int(version_seq)
+    return entry
 
 
 def build_document_entry(item: Mapping[str, Any]) -> Optional[Dict[str, Any]]:

--- a/backend/lambda/feed_query/delta.py
+++ b/backend/lambda/feed_query/delta.py
@@ -1,0 +1,151 @@
+"""Version-seq incremental feed delta for GET /api/v1/feed/delta (ENC-TSK-L27)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+try:
+    from enceladus_shared.version_seq import FEED_SCOPE, FEED_TOMBSTONE_RECORD_TYPE
+except ImportError:  # pragma: no cover - local tests without layer
+    FEED_SCOPE = "global"
+    FEED_TOMBSTONE_RECORD_TYPE = "feed_tombstone"
+
+VERSION_SEQ_INDEX = "version-seq-index"
+MAX_DELTA_ITEMS = 500
+
+
+def parse_since_version(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        value = int(text)
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _ddb_str(item: Mapping[str, Any], key: str) -> str:
+    field = item.get(key) or {}
+    if "S" in field:
+        return str(field["S"])
+    if "N" in field:
+        return str(field["N"])
+    return ""
+
+
+def query_version_delta(
+    ddb: Any,
+    table_name: str,
+    since: int,
+    *,
+    is_stale_closed: Callable[[Mapping[str, Any], Any], bool],
+    transform_record: Callable[[Mapping[str, Any], str], Optional[Dict[str, Any]]],
+    cutoff: Any,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], int]:
+    """Return (items, tombstones, latest_version_seq)."""
+    changed_keys: List[Dict[str, Dict[str, str]]] = []
+    tombstones: List[Dict[str, Any]] = []
+    latest = since
+
+    paginator = ddb.get_paginator("query")
+    for page in paginator.paginate(
+        TableName=table_name,
+        IndexName=VERSION_SEQ_INDEX,
+        KeyConditionExpression="feed_scope = :scope AND version_seq > :since",
+        ExpressionAttributeValues={
+            ":scope": {"S": FEED_SCOPE},
+            ":since": {"N": str(int(since))},
+        },
+        ProjectionExpression="project_id, record_id, record_type, item_id, version_seq, "
+        "target_project_id, target_record_id, target_record_type, updated_at",
+        ScanIndexForward=True,
+        Limit=MAX_DELTA_ITEMS,
+    ):
+        for item in page.get("Items", []):
+            seq_raw = _ddb_str(item, "version_seq")
+            try:
+                seq = int(seq_raw)
+            except (TypeError, ValueError):
+                continue
+            latest = max(latest, seq)
+            record_type = _ddb_str(item, "record_type")
+            if record_type == FEED_TOMBSTONE_RECORD_TYPE:
+                target_project = _ddb_str(item, "target_project_id")
+                target_record = _ddb_str(item, "target_record_id")
+                target_type = _ddb_str(item, "target_record_type")
+                item_id = _ddb_str(item, "item_id") or target_record.split("#", 1)[-1]
+                record_key = (
+                    f"document::{item_id}"
+                    if target_type == "document"
+                    else f"tracker:{target_project}:{item_id}"
+                )
+                tombstones.append(
+                    {
+                        "record_key": record_key,
+                        "record_id": item_id,
+                        "record_type": target_type or "task",
+                        "project_id": target_project,
+                        "version_seq": seq,
+                    }
+                )
+                continue
+            pid = _ddb_str(item, "project_id")
+            rid = _ddb_str(item, "record_id")
+            if pid and rid:
+                changed_keys.append(
+                    {"project_id": {"S": pid}, "record_id": {"S": rid}}
+                )
+
+    if not changed_keys and not tombstones:
+        return [], [], latest
+
+    items: List[Dict[str, Any]] = []
+    for batch_start in range(0, len(changed_keys), 100):
+        batch = changed_keys[batch_start : batch_start + 100]
+        resp = ddb.batch_get_item(
+            RequestItems={table_name: {"Keys": batch, "ConsistentRead": False}}
+        )
+        raw_items = resp.get("Responses", {}).get(table_name, [])
+        unprocessed = (
+            resp.get("UnprocessedKeys", {}).get(table_name, {}).get("Keys", [])
+        )
+        if unprocessed:
+            resp2 = ddb.batch_get_item(
+                RequestItems={table_name: {"Keys": unprocessed, "ConsistentRead": False}}
+            )
+            raw_items.extend(resp2.get("Responses", {}).get(table_name, []))
+
+        for raw_item in raw_items:
+            record_type = _ddb_str(raw_item, "record_type")
+            pid = _ddb_str(raw_item, "project_id")
+            item_id = _ddb_str(raw_item, "item_id")
+            seq_raw = _ddb_str(raw_item, "version_seq")
+            try:
+                seq = int(seq_raw)
+            except (TypeError, ValueError):
+                seq = latest
+            if is_stale_closed(raw_item, cutoff):
+                record_key = f"tracker:{pid}:{item_id}" if item_id else ""
+                if record_key:
+                    tombstones.append(
+                        {
+                            "record_key": record_key,
+                            "record_id": item_id,
+                            "record_type": record_type,
+                            "project_id": pid,
+                            "version_seq": seq,
+                        }
+                    )
+                continue
+            transformed = transform_record(raw_item, pid)
+            if transformed is None:
+                continue
+            transformed["version_seq"] = seq
+            items.append(transformed)
+
+    return items, tombstones, latest

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -5,6 +5,7 @@ Lambda API for Enceladus feed read and subscription lifecycle.
 Routes (via API Gateway proxy):
     GET     /api/v1/feed
     GET     /api/v1/feed/corpus
+    GET     /api/v1/feed/delta
     POST    /api/v1/feed/refresh
     POST    /api/v1/feed/subscriptions
     GET     /api/v1/feed/subscriptions/{subscriptionId}
@@ -43,6 +44,7 @@ from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 
 import corpus as feed_corpus
+import delta as feed_delta
 
 try:
     import jwt
@@ -1656,6 +1658,66 @@ def _handle_snapshot() -> Dict[str, Any]:
     }
 
 
+def _delta_corpus_entry(raw_item: Dict[str, Any], project_id: str) -> Optional[Dict[str, Any]]:
+    record_type = _ddb_str(raw_item, "record_type")
+    if record_type not in _TRANSFORM:
+        return None
+    transformed = _TRANSFORM[record_type](raw_item, project_id)
+    item_id = _ddb_str(raw_item, "item_id") or transformed.get(f"{record_type}_id", "")
+    attrs: Dict[str, Any] = {}
+    for key in ("status", "priority", "category", "severity"):
+        value = transformed.get(key)
+        if value:
+            attrs[key] = value
+    return feed_corpus.build_tracker_entry(
+        record_type,
+        str(item_id),
+        project_id,
+        str(transformed.get("title") or item_id),
+        transformed.get("updated_at"),
+        attrs,
+    )
+
+
+def _handle_delta(qs: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/feed/delta?since=<version_seq> — version-ordered incremental sync (ENC-TSK-L27)."""
+    since = feed_delta.parse_since_version((qs or {}).get("since"))
+    if since is None:
+        return _error(400, "'since' must be a non-negative integer version_seq")
+
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=CLOSED_ITEM_MAX_AGE_DAYS)
+    try:
+        items, tombstones, latest = feed_delta.query_version_delta(
+            _get_ddb(),
+            DYNAMODB_TABLE,
+            since,
+            is_stale_closed=_is_stale_closed,
+            transform_record=_delta_corpus_entry,
+            cutoff=cutoff,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("feed delta query failed: %s", exc)
+        return _error(500, "Failed to query feed delta. Please try again.")
+
+    body = {
+        "success": True,
+        "generated_at": _now_z(),
+        "since": since,
+        "latest_version_seq": latest,
+        "items": items,
+        "tombstones": tombstones,
+    }
+    return {
+        "statusCode": 200,
+        "headers": {
+            **_cors_headers(),
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+        },
+        "body": json.dumps(body),
+    }
+
+
 def _handle_corpus(qs: Dict[str, Any]) -> Dict[str, Any]:
     """GET /api/v1/feed/corpus — cursor-paginated multi-table feed corpus (ENC-TSK-L23)."""
     query = feed_corpus.parse_corpus_query(qs or {})
@@ -1760,6 +1822,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     if method == "GET" and re.search(r"/api/v1/feed/corpus/?$", path):
         return _handle_corpus(event.get("queryStringParameters") or {})
+
+    if method == "GET" and re.search(r"/api/v1/feed/delta/?$", path):
+        return _handle_delta(event.get("queryStringParameters") or {})
 
     if method != "GET" or not re.search(r"/api/v1/feed/?$", path):
         return _error(404, f"Unsupported route: {method} {path}")

--- a/backend/lambda/feed_query/test_delta_l27.py
+++ b/backend/lambda/feed_query/test_delta_l27.py
@@ -1,0 +1,93 @@
+"""Unit tests for feed delta version_seq queries (ENC-TSK-L27)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_DELTA_SPEC = importlib.util.spec_from_file_location(
+    "feed_delta",
+    os.path.join(os.path.dirname(__file__), "delta.py"),
+)
+delta = importlib.util.module_from_spec(_DELTA_SPEC)
+assert _DELTA_SPEC.loader is not None
+_DELTA_SPEC.loader.exec_module(delta)
+
+
+def test_parse_since_version():
+    assert delta.parse_since_version("0") == 0
+    assert delta.parse_since_version("42") == 42
+    assert delta.parse_since_version("") is None
+    assert delta.parse_since_version("-1") is None
+    assert delta.parse_since_version("abc") is None
+
+
+def test_query_version_delta_splits_items_and_tombstones():
+    class FakePaginator:
+        def paginate(self, **kwargs):
+            assert kwargs["IndexName"] == delta.VERSION_SEQ_INDEX
+            assert kwargs["ExpressionAttributeValues"][":since"]["N"] == "10"
+            yield {
+                "Items": [
+                    {
+                        "project_id": {"S": "enceladus"},
+                        "record_id": {"S": "task#ENC-TSK-001"},
+                        "record_type": {"S": "task"},
+                        "item_id": {"S": "ENC-TSK-001"},
+                        "version_seq": {"N": "11"},
+                    },
+                    {
+                        "record_type": {"S": delta.FEED_TOMBSTONE_RECORD_TYPE},
+                        "item_id": {"S": "ENC-TSK-002"},
+                        "target_project_id": {"S": "enceladus"},
+                        "target_record_id": {"S": "task#ENC-TSK-002"},
+                        "target_record_type": {"S": "task"},
+                        "version_seq": {"N": "12"},
+                    },
+                ]
+            }
+
+    class FakeDdb:
+        def get_paginator(self, name):
+            assert name == "query"
+            return FakePaginator()
+
+        def batch_get_item(self, **kwargs):
+            return {
+                "Responses": {
+                    "devops-project-tracker-gamma": [
+                        {
+                            "project_id": {"S": "enceladus"},
+                            "record_id": {"S": "task#ENC-TSK-001"},
+                            "record_type": {"S": "task"},
+                            "item_id": {"S": "ENC-TSK-001"},
+                            "version_seq": {"N": "11"},
+                            "status": {"S": "open"},
+                            "title": {"S": "Alpha"},
+                            "updated_at": {"S": "2026-07-05T08:00:00Z"},
+                        }
+                    ]
+                }
+            }
+
+    items, tombstones, latest = delta.query_version_delta(
+        FakeDdb(),
+        "devops-project-tracker-gamma",
+        10,
+        is_stale_closed=lambda _item, _cutoff: False,
+        transform_record=lambda raw, pid: {
+            "record_id": "ENC-TSK-001",
+            "record_type": "task",
+            "project_id": pid,
+            "title": "Alpha",
+            "record_key": f"tracker:{pid}:ENC-TSK-001",
+            "source": "tracker",
+            "attrs": {},
+        },
+        cutoff=None,
+    )
+    assert latest == 12
+    assert len(items) == 1
+    assert items[0]["version_seq"] == 11
+    assert tombstones[0]["record_id"] == "ENC-TSK-002"
+    assert tombstones[0]["version_seq"] == 12

--- a/backend/lambda/shared_layer/python/enceladus_shared/version_seq.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/version_seq.py
@@ -1,0 +1,77 @@
+"""Monotonic feed version_seq allocation (ENC-TSK-L27)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+FEED_SCOPE = "global"
+FEED_TOMBSTONE_PROJECT = "__feed__"
+FEED_TOMBSTONE_RECORD_TYPE = "feed_tombstone"
+VERSION_SEQ_COUNTER_PROJECT = "__feed__"
+VERSION_SEQ_COUNTER_RECORD = "counter#version_seq"
+
+
+def version_seq_attr(seq: int) -> Dict[str, Dict[str, str]]:
+    return {
+        "version_seq": {"N": str(int(seq))},
+        "feed_scope": {"S": FEED_SCOPE},
+    }
+
+
+def allocate_version_seq(ddb: Any, table_name: str) -> int:
+    """Atomically allocate the next monotonic version_seq."""
+    counter_key = {
+        "project_id": {"S": VERSION_SEQ_COUNTER_PROJECT},
+        "record_id": {"S": VERSION_SEQ_COUNTER_RECORD},
+    }
+    resp = ddb.update_item(
+        TableName=table_name,
+        Key=counter_key,
+        UpdateExpression=(
+            "SET next_num = if_not_exists(next_num, :zero) + :one, "
+            "feed_scope = :scope, record_type = :counter_type, "
+            "item_id = if_not_exists(item_id, :counter_item_id)"
+        ),
+        ExpressionAttributeValues={
+            ":zero": {"N": "0"},
+            ":one": {"N": "1"},
+            ":scope": {"S": FEED_SCOPE},
+            ":counter_type": {"S": "counter"},
+            ":counter_item_id": {"S": "COUNTER-VERSION-SEQ"},
+        },
+        ReturnValues="UPDATED_NEW",
+    )
+    attrs = resp.get("Attributes") or {}
+    return int(attrs.get("next_num", {"N": "0"})["N"])
+
+
+def version_seq_update_clause(seq: int) -> Tuple[str, Dict[str, Dict[str, str]]]:
+    expr = ", version_seq = :vseq, feed_scope = :fscope"
+    values = {
+        ":vseq": {"N": str(int(seq))},
+        ":fscope": {"S": FEED_SCOPE},
+    }
+    return expr, values
+
+
+def tombstone_item(
+    *,
+    seq: int,
+    project_id: str,
+    record_id: str,
+    item_id: str,
+    record_type: str,
+    updated_at: str,
+) -> Dict[str, Dict[str, str]]:
+    return {
+        "project_id": {"S": FEED_TOMBSTONE_PROJECT},
+        "record_id": {"S": f"tombstone#{seq}"},
+        "record_type": {"S": FEED_TOMBSTONE_RECORD_TYPE},
+        "feed_scope": {"S": FEED_SCOPE},
+        "version_seq": {"N": str(int(seq))},
+        "item_id": {"S": item_id or record_id.split("#", 1)[-1]},
+        "target_project_id": {"S": project_id},
+        "target_record_id": {"S": record_id},
+        "target_record_type": {"S": record_type},
+        "updated_at": {"S": updated_at},
+    }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -59,6 +59,12 @@ except ImportError:  # layer :7 lacks appconfig_flags — fall back to a direct 
     def _appconfig_flag(name, *, env_fallback=None, default=False):
         raw = os.environ.get(env_fallback, "") if env_fallback else ""
         return raw.strip().lower() == "true" if raw != "" else bool(default)
+try:
+    from enceladus_shared.version_seq import allocate_version_seq, version_seq_attr, version_seq_update_clause
+
+    _VERSION_SEQ_AVAILABLE = True
+except ImportError:
+    _VERSION_SEQ_AVAILABLE = False
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 
@@ -974,6 +980,20 @@ def _get_ddb():
             config=Config(retries={"max_attempts": 3, "mode": "standard"}),
         )
     return _ddb
+
+
+def _stamp_version_seq_on_create_item(item: Dict[str, Dict[str, str]]) -> None:
+    if not _VERSION_SEQ_AVAILABLE:
+        return
+    seq = allocate_version_seq(_get_ddb(), DYNAMODB_TABLE)
+    item.update(version_seq_attr(seq))
+
+
+def _version_seq_update_parts() -> Tuple[str, Dict[str, Dict[str, str]]]:
+    if not _VERSION_SEQ_AVAILABLE:
+        return "", {}
+    seq = allocate_version_seq(_get_ddb(), DYNAMODB_TABLE)
+    return version_seq_update_clause(seq)
 
 
 def _get_events():
@@ -3332,6 +3352,7 @@ def _handle_create_record(
             sk = f"{record_type}#{new_id}"
             item["record_id"] = _ser_s(sk)
             item["item_id"] = _ser_s(new_id)
+            _stamp_version_seq_on_create_item(item)
             try:
                 ddb.put_item(
                     TableName=DYNAMODB_TABLE, Item=item,
@@ -5223,6 +5244,10 @@ def _handle_update_field(
     if _optout_latch is not None:
         attr_values[":optout"] = {"BOOL": True}
     attr_values.update(extra_vals)
+
+    vseq_expr, vseq_vals = _version_seq_update_parts()
+    update_expr += vseq_expr
+    attr_values.update(vseq_vals)
 
     # ENC-TSK-L47: when the caller presented If-Match, guard the commit itself
     # (not just the pre-check above) against a write that landed in between —

--- a/frontend/ui-v2/src/api/client.ts
+++ b/frontend/ui-v2/src/api/client.ts
@@ -14,7 +14,7 @@
 
 import type { HybridGraphsearchResponse, HybridSearchParams } from '../types/search'
 import type { UserPreferences } from '../types/userPreferences'
-import type { FeedCorpusPage } from '../sync/types'
+import type { FeedCorpusPage, FeedDeltaPage } from '../sync/types'
 
 /**
  * Read API base URL. Defaults to `/api/v1`, matching the existing app's
@@ -210,4 +210,13 @@ export async function fetchFeedCorpusPage(
   const suffix = qs.toString()
   const url = `${API_BASE}/feed/corpus${suffix ? `?${suffix}` : ''}`
   return requestJson<FeedCorpusPage>(url, init)
+}
+
+/** Incremental feed delta (ENC-TSK-L27). */
+export async function fetchFeedDelta(
+  since: number,
+  init?: FetchInit,
+): Promise<FeedDeltaPage> {
+  const url = `${API_BASE}/feed/delta?since=${encodeURIComponent(String(since))}`
+  return requestJson<FeedDeltaPage>(url, init)
 }

--- a/frontend/ui-v2/src/sync/cacheEngine.ts
+++ b/frontend/ui-v2/src/sync/cacheEngine.ts
@@ -1,7 +1,7 @@
 import type { RecordType } from '../types/records'
 import * as idb from './idbStore'
 import { CorpusSearchIndex } from './searchIndex'
-import { cacheKey, shouldAcceptVersion, versionSeqFromUpdatedAt } from './recordKey'
+import { cacheKey, shouldAcceptVersion, versionSeqFromItem, versionSeqFromUpdatedAt } from './recordKey'
 import type { FeedCorpusItem, Tier1Record, Tier2Record } from './types'
 import { DEFAULT_CACHE_BUDGET } from './types'
 
@@ -15,7 +15,7 @@ function normalizeRecordType(raw: string): RecordType | null {
 export function corpusItemToTier1(item: FeedCorpusItem): Tier1Record | null {
   const recordType = normalizeRecordType(item.record_type)
   if (!recordType) return null
-  const versionSeq = versionSeqFromUpdatedAt(item.updated_at)
+  const versionSeq = versionSeqFromItem(item)
   return {
     projectId: item.project_id || (recordType === 'document' ? 'global' : 'enceladus'),
     recordId: item.record_id,

--- a/frontend/ui-v2/src/sync/corpusSeed.ts
+++ b/frontend/ui-v2/src/sync/corpusSeed.ts
@@ -1,5 +1,7 @@
 import { fetchFeedCorpusPage } from '../api/client'
 import { getCacheEngine } from './cacheEngine'
+import { healCacheFromDelta } from './deltaHeal'
+import { maxVersionSeqFromItems, setFeedVersionSeq } from './feedVersionMeta'
 
 export async function seedCacheFromCorpus(): Promise<{ pages: number; records: number; durationMs: number }> {
   const engine = getCacheEngine()
@@ -7,17 +9,23 @@ export async function seedCacheFromCorpus(): Promise<{ pages: number; records: n
   let cursor: string | undefined
   let pages = 0
   let records = 0
+  let versionSeq = 0
 
   for (;;) {
     const page = await fetchFeedCorpusPage({ cursor, limit: 200 })
     pages += 1
     records += await engine.ingestCorpusPage(page.items)
+    versionSeq = maxVersionSeqFromItems(page.items, versionSeq)
     if (!page.next_cursor) break
     cursor = page.next_cursor
   }
 
   await engine.finalizeWarm()
   engine.markWarmComplete(startedAt)
+  if (versionSeq > 0) {
+    await setFeedVersionSeq(versionSeq)
+  }
+  await healCacheFromDelta(engine, versionSeq)
   return {
     pages,
     records,

--- a/frontend/ui-v2/src/sync/deltaHeal.ts
+++ b/frontend/ui-v2/src/sync/deltaHeal.ts
@@ -1,0 +1,25 @@
+import { fetchFeedDelta } from '../api/client'
+import type { CacheEngine } from './cacheEngine'
+import { getFeedVersionSeq, setFeedVersionSeq } from './feedVersionMeta'
+
+export async function healCacheFromDelta(engine: CacheEngine, since?: number): Promise<number> {
+  let cursor = since ?? (await getFeedVersionSeq()) ?? 0
+  let latest = cursor
+
+  for (let pageNum = 0; pageNum < 20; pageNum += 1) {
+    const page = await fetchFeedDelta(cursor)
+    if (page.items.length > 0) {
+      await engine.ingestCorpusPage(page.items)
+    }
+    for (const tombstone of page.tombstones) {
+      await engine.markTombstone(tombstone.record_key, tombstone.record_id)
+    }
+    latest = Math.max(latest, page.latest_version_seq ?? cursor)
+    if (page.latest_version_seq <= cursor) break
+    if (page.items.length === 0 && page.tombstones.length === 0) break
+    cursor = page.latest_version_seq
+  }
+
+  await setFeedVersionSeq(latest)
+  return latest
+}

--- a/frontend/ui-v2/src/sync/feedVersionMeta.ts
+++ b/frontend/ui-v2/src/sync/feedVersionMeta.ts
@@ -1,0 +1,24 @@
+import { getMeta, setMeta } from './idbStore'
+
+const META_KEY = 'feed_version_seq'
+
+export async function getFeedVersionSeq(): Promise<number | null> {
+  const raw = await getMeta(META_KEY)
+  if (raw == null) return null
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : null
+}
+
+export async function setFeedVersionSeq(value: number): Promise<void> {
+  await setMeta(META_KEY, value)
+}
+
+export function maxVersionSeqFromItems(items: Array<{ version_seq?: number }>, current = 0): number {
+  let latest = current
+  for (const item of items) {
+    if (item.version_seq != null) {
+      latest = Math.max(latest, item.version_seq)
+    }
+  }
+  return latest
+}

--- a/frontend/ui-v2/src/sync/idbStore.ts
+++ b/frontend/ui-v2/src/sync/idbStore.ts
@@ -205,6 +205,23 @@ export async function loadQueryCache<T>(): Promise<T | null> {
   return (getMemoryDb().queryCache as T | null) ?? null
 }
 
+export async function getMeta(key: string): Promise<unknown | null> {
+  try {
+    const result = (await withStore('meta', 'readonly', (store) => store.get(key))) as unknown
+    return result ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function setMeta(key: string, value: unknown): Promise<void> {
+  try {
+    await withStore('meta', 'readwrite', (store) => store.put(value, key))
+  } catch {
+    /* memory fallback not needed for version watermark in tests */
+  }
+}
+
 export function resetMemoryStoreForTests(): void {
   memoryDb = null
 }

--- a/frontend/ui-v2/src/sync/recordKey.ts
+++ b/frontend/ui-v2/src/sync/recordKey.ts
@@ -6,6 +6,13 @@ export function versionSeqFromUpdatedAt(updatedAt?: string | null): string {
   return updatedAt?.trim() || '0'
 }
 
+export function versionSeqFromItem(item: { version_seq?: number; updated_at?: string | null }): string {
+  if (item.version_seq != null && Number.isFinite(item.version_seq)) {
+    return String(item.version_seq)
+  }
+  return versionSeqFromUpdatedAt(item.updated_at)
+}
+
 export function shouldAcceptVersion(current: string | undefined, incoming: string): boolean {
   if (!current) return true
   if (current === incoming) return true

--- a/frontend/ui-v2/src/sync/types.ts
+++ b/frontend/ui-v2/src/sync/types.ts
@@ -49,7 +49,24 @@ export interface FeedCorpusItem {
   updated_at?: string | null
   source: 'tracker' | 'document'
   record_key: string
+  version_seq?: number
   attrs?: Record<string, unknown>
+}
+
+export interface FeedDeltaTombstone {
+  record_key: string
+  record_id: string
+  record_type: string
+  project_id: string
+  version_seq: number
+}
+
+export interface FeedDeltaPage {
+  success: boolean
+  since: number
+  latest_version_seq: number
+  items: FeedCorpusItem[]
+  tombstones: FeedDeltaTombstone[]
 }
 
 export interface FeedCorpusPage {

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -92,12 +92,33 @@ Resources:
           AttributeType: S
         - AttributeName: updated_at
           AttributeType: S
+        - AttributeName: feed_scope
+          AttributeType: S
+        - AttributeName: version_seq
+          AttributeType: N
       KeySchema:
         - AttributeName: project_id
           KeyType: HASH
         - AttributeName: record_id
           KeyType: RANGE
       GlobalSecondaryIndexes:
+        - IndexName: version-seq-index
+          KeySchema:
+            - AttributeName: feed_scope
+              KeyType: HASH
+            - AttributeName: version_seq
+              KeyType: RANGE
+          Projection:
+            ProjectionType: INCLUDE
+            NonKeyAttributes:
+              - project_id
+              - record_id
+              - record_type
+              - item_id
+              - updated_at
+              - target_project_id
+              - target_record_id
+              - target_record_type
         - IndexName: type-updated-index
           KeySchema:
             - AttributeName: record_type

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -610,6 +610,13 @@ Resources:
       RouteKey: GET /api/v1/feed/corpus
       Target: !Sub integrations/${FeedQueryIntegration}
 
+  RouteFeedDelta:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/feed/delta
+      Target: !Sub integrations/${FeedQueryIntegration}
+
   RouteFeedRefresh:
     Type: AWS::ApiGatewayV2::Route
     Properties:

--- a/tools/backfill_tracker_version_seq.py
+++ b/tools/backfill_tracker_version_seq.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""One-shot backfill of version_seq on tracker records (ENC-TSK-L27).
+
+Usage:
+  AWS_PROFILE=enceladus-agent python3 tools/backfill_tracker_version_seq.py \\
+    --table devops-project-tracker-gamma [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import boto3
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "backend" / "lambda" / "shared_layer" / "python"))
+
+from enceladus_shared.version_seq import FEED_SCOPE, allocate_version_seq, version_seq_attr  # noqa: E402
+
+FEED_RECORD_TYPES = {"task", "issue", "feature", "lesson", "plan"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", required=True)
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    ddb = boto3.client("dynamodb", region_name=args.region)
+    updated = 0
+    paginator = ddb.get_paginator("scan")
+    for page in paginator.paginate(TableName=args.table):
+        for item in page.get("Items", []):
+            record_type = (item.get("record_type") or {}).get("S", "")
+            if record_type not in FEED_RECORD_TYPES:
+                continue
+            if item.get("version_seq"):
+                continue
+            seq = allocate_version_seq(ddb, args.table)
+            key = {
+                "project_id": item["project_id"],
+                "record_id": item["record_id"],
+            }
+            if args.dry_run:
+                print(f"would stamp {key} -> {seq}")
+            else:
+                ddb.update_item(
+                    TableName=args.table,
+                    Key=key,
+                    UpdateExpression="SET version_seq = :vseq, feed_scope = :scope",
+                    ExpressionAttributeValues={
+                        ":vseq": version_seq_attr(seq)["version_seq"],
+                        ":scope": {"S": FEED_SCOPE},
+                    },
+                )
+            updated += 1
+    print(f"backfill complete: {updated} records")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Monotonic `version_seq` + `feed_scope=global` stamped on tracker creates/patches via shared `enceladus_shared.version_seq`
- New `version-seq-index` GSI on `devops-project-tracker` (01-data stack)
- `GET /api/v1/feed/delta?since=<version_seq>` returns changed corpus items + tombstones + `latest_version_seq`
- ui-v2 cache gap-heals after corpus seed via `deltaHeal.ts`; version watermark in IDB meta
- Backfill tool: `tools/backfill_tracker_version_seq.py`

## Test plan
- [x] `pytest backend/lambda/feed_query/test_delta_l27.py test_lambda_function.py` — 36 passed
- [x] `npm test` + `npm run typecheck` in ui-v2 — 59 passed
- [ ] Post-merge: data stack (GSI) + api stack (route) + Gen2 feed_query/tracker_mutation + ui-v2 gamma
- [ ] Run backfill on gamma tracker table before live delta verification

commit-complete-id: CCI-f54c344fc8aa4cebbb41939de1b36a74