### PR TITLE
Fix DPL deployment_type in _ui_deploy.yml (ENC-ISS-451 telemetry 400)

### DIFF
--- a/.github/workflows/_ui_deploy.yml
+++ b/.github/workflows/_ui_deploy.yml
@@ -415,7 +415,14 @@ jobs:
           print(json.dumps({
               "project_id": "enceladus",
               "change_type": "patch",
-              "deployment_type": "ui_update",
+              # ENC-ISS-451: "ui_update" is not a member of VALID_DEPLOYMENT_TYPES
+              # in backend/lambda/deploy_intake (every submission 400s). This is
+              # also deploy_intake's own default deployment_type for exactly this
+              # case (a UI deploy) -- picking it means the non_ui_config block
+              # below stays inert (github_public_static is not in
+              # NON_UI_SERVICE_GROUP_BY_TYPE, so no service_group/target_arn
+              # validation applies), so no other field needs to change.
+              "deployment_type": "github_public_static",
               "summary": f"ui-v2 PWA deploy to {env} @ {sha[:7]} (PR #{pr_id})",
               "changes": [
                   f"commit_sha: {sha}",


### PR DESCRIPTION
## Summary
- "ui_update" is not a member of `deploy_intake`'s `VALID_DEPLOYMENT_TYPES` enum, so the "Record deploy → DPL" step has 400'd on every ui-v2 gamma deploy since it was added — confirmed on run 28732528696 (PR #838/ENC-TSK-L18) and run 28734192109 (PR #841/ENC-TSK-L37). This never blocked the actual deploy (the step has `continue-on-error: true`, and the S3 sync + CloudFront invalidation are unaffected) — it's a pure telemetry gap.
- `deploy_intake`'s own default `deployment_type` is `"github_public_static"` for exactly this case (a UI deploy submitted with no explicit type). Picking it also means the `non_ui_config` block already in the payload stays inert — `github_public_static` is not in `NON_UI_SERVICE_GROUP_BY_TYPE`, so no `service_group`/`target_arn` validation applies, and no other field needs to change.
- `.github/workflows/_deploy.yml`'s equivalent step (for Lambda deploys) already uses the valid `"lambda_update"` value — only the UI workflow had the typo.

## Test plan
- [x] `yaml.safe_load` on the modified workflow file — parses clean
- [x] Extracted and executed the embedded Python payload-building block standalone — produces valid JSON with `"deployment_type": "github_public_static"`
- [x] Traced `deploy_intake/lambda_function.py`'s validation path by hand: `github_public_static` passes `VALID_DEPLOYMENT_TYPES` and is not in `NON_UI_SERVICE_GROUP_BY_TYPE`, so the `non_ui_config` validation block is skipped entirely
- [ ] Live verification: this workflow's `paths:` filter includes `.github/workflows/_ui_deploy.yml` itself, so merging this PR will trigger a real "Deploy UI (ui-v2 PWA)" run — will confirm the "Record deploy → DPL" step returns 200/201 post-merge

CCI-33a13178d8f94da9a4f67577ac71533e

🤖 Generated with [Claude Code](https://claude.com/claude-code)