### PR TITLE
fix(tracker): bundle version_seq for feed/delta stamps (ENC-TSK-L27)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.10",
-  "updated_at": "2026-07-05T08:30:00Z",
-  "last_change_summary": "ENC-TSK-L27 (B67 WaveC): version_seq + version-seq-index GSI + GET /api/v1/feed/delta incremental sync. ENC-TSK-L10 (B64 Ph3): mcp_streaming_gateway Lambda + McpStreamingRestApi (gamma-only).",
+  "version": "2026-07-05.11",
+  "updated_at": "2026-07-05T08:42:00Z",
+  "last_change_summary": "ENC-TSK-L27 follow-up: tracker_mutation bundles version_seq_util fallback so writes stamp version_seq before shared layer ships enceladus_shared.version_seq.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -64,7 +64,12 @@ try:
 
     _VERSION_SEQ_AVAILABLE = True
 except ImportError:
-    _VERSION_SEQ_AVAILABLE = False
+    try:
+        from version_seq_util import allocate_version_seq, version_seq_attr, version_seq_update_clause
+
+        _VERSION_SEQ_AVAILABLE = True
+    except ImportError:
+        _VERSION_SEQ_AVAILABLE = False
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 

--- a/backend/lambda/tracker_mutation/version_seq_util.py
+++ b/backend/lambda/tracker_mutation/version_seq_util.py
@@ -1,0 +1,52 @@
+"""Bundled version_seq helpers for tracker_mutation (ENC-TSK-L27)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+FEED_SCOPE = "global"
+VERSION_SEQ_COUNTER_PROJECT = "__feed__"
+VERSION_SEQ_COUNTER_RECORD = "counter#version_seq"
+
+
+def version_seq_attr(seq: int) -> Dict[str, Dict[str, str]]:
+    return {
+        "version_seq": {"N": str(int(seq))},
+        "feed_scope": {"S": FEED_SCOPE},
+    }
+
+
+def allocate_version_seq(ddb: Any, table_name: str) -> int:
+    counter_key = {
+        "project_id": {"S": VERSION_SEQ_COUNTER_PROJECT},
+        "record_id": {"S": VERSION_SEQ_COUNTER_RECORD},
+    }
+    resp = ddb.update_item(
+        TableName=table_name,
+        Key=counter_key,
+        UpdateExpression=(
+            "SET next_num = if_not_exists(next_num, :zero) + :one, "
+            "feed_scope = :scope, record_type = :counter_type, "
+            "item_id = if_not_exists(item_id, :counter_item_id)"
+        ),
+        ExpressionAttributeValues={
+            ":zero": {"N": "0"},
+            ":one": {"N": "1"},
+            ":scope": {"S": FEED_SCOPE},
+            ":counter_type": {"S": "counter"},
+            ":counter_item_id": {"S": "COUNTER-VERSION-SEQ"},
+        },
+        ReturnValues="UPDATED_NEW",
+    )
+    attrs = resp.get("Attributes") or {}
+    return int(attrs.get("next_num", {"N": "0"})["N"])
+
+
+def version_seq_update_clause(seq: int) -> Tuple[str, Dict[str, Dict[str, str]]]:
+    return (
+        ", version_seq = :vseq, feed_scope = :fscope",
+        {
+            ":vseq": {"N": str(int(seq))},
+            ":fscope": {"S": FEED_SCOPE},
+        },
+    )


### PR DESCRIPTION
Follow-up to #847: shared layer :10 does not yet ship `enceladus_shared.version_seq`. Bundle `version_seq_util.py` in tracker_mutation with import fallback so tracker writes stamp `version_seq` for `/feed/delta`.

CCI-f54c344fc8aa4cebbb41939de1b36a74