### PR TITLE
Restore S3 staging for github-roles CFN deploy (template >51KB)

### DIFF
--- a/.github/workflows/cloudformation-github-roles-stack-deploy.yml
+++ b/.github/workflows/cloudformation-github-roles-stack-deploy.yml
@@ -75,6 +75,10 @@ jobs:
         id: changeset
         run: |
           set -euo pipefail
+          # 04-github-roles.yaml exceeds the 51,200-byte direct-upload limit since
+          # ENC-TSK-L55 (~58 KiB). BackendDeployRole must hold S3CfnStagingAccess
+          # on enceladus-cfn-staging-us-west-2 (ENC-TSK-L61); PR #837's no-S3 path
+          # is obsolete. Same bucket/prefix convention as compute/api/monitoring CFN workflows.
 
           aws cloudformation deploy \
             --region "${AWS_REGION}" \
@@ -82,7 +86,9 @@ jobs:
             --template-file "${TEMPLATE_FILE}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset \
-            --no-execute-changeset 2>&1 | tee /tmp/plan.log
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 04-github-roles/ 2>&1 | tee /tmp/plan.log
 
           if grep -q "No changes to deploy" /tmp/plan.log; then
             echo "has_changes=false" >> "${GITHUB_OUTPUT}"

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -839,6 +839,18 @@ Resources:
                   - s3:GetObject
                   - s3:PutObject
                 Resource: "arn:aws:s3:::jreese-net/deploy/*"
+              # S3 staging for `aws cloudformation deploy --s3-bucket` (ENC-TSK-L61).
+              # Required since 04-github-roles.yaml crossed the 51,200-byte inline
+              # limit after ENC-TSK-L55 drift reconciliation (~58 KiB). Mirrors
+              # CloudFormationDeployRole S3CfnStagingAccess. PR #837 removed
+              # workflow S3 staging when the template was ~44 KiB; that path is
+              # obsolete — restore both grant and workflow staging together.
+              - Sid: S3CfnStagingAccess
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${CfnStagingBucket}/*"
               - Sid: SecretsRead
                 Effect: Allow
                 Action: secretsmanager:GetSecretValue


### PR DESCRIPTION
CCI-5710a314b66e41c2915f659939c3e7db

## Summary
- `04-github-roles.yaml` is ~58 KiB after ENC-TSK-L55 reconciliation — exceeds CFN direct-upload limit (51,200 bytes).
- PR #837 removed workflow S3 staging when template was ~44 KiB; that path is now obsolete.
- Grant `BackendDeployRole` `S3CfnStagingAccess` on `enceladus-cfn-staging-us-west-2` (mirrors `CloudFormationDeployRole`).
- Restore `--s3-bucket` / `--s3-prefix 04-github-roles/` in `cloudformation-github-roles-stack-deploy.yml`.

## Test plan
- [ ] Merge to `main`
- [ ] One-time admin/product-lead deploy lands the BackendDeployRole S3 grant
- [ ] Dispatch CloudFormation GitHub Roles Stack Deploy; plan succeeds
- [ ] Per DOC-499FA089EC30: apply only if changes exist (v3-prod gate)


Made with [Cursor](https://cursor.com)