### PR TITLE
fix(iam): feed_query BatchGetItem for /feed/delta (ENC-TSK-L27)

### DIFF
--- a/infrastructure/cloudformation/02-compute-import-stage-k44.yaml
+++ b/infrastructure/cloudformation/02-compute-import-stage-k44.yaml
@@ -3274,6 +3274,7 @@ Resources:
                   - dynamodb:Query
                   - dynamodb:Scan
                   - dynamodb:GetItem
+                  - dynamodb:BatchGetItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3763,6 +3763,7 @@ Resources:
                   - dynamodb:Query
                   - dynamodb:Scan
                   - dynamodb:GetItem
+                  - dynamodb:BatchGetItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"


### PR DESCRIPTION
Grants `dynamodb:BatchGetItem` on `devops-project-tracker` to `FeedQueryRole`. `/feed/delta` queries `version-seq-index` then batch-hydrates changed keys; without BatchGetItem gamma returns 500.

Follow-up to #847 / #852.

CCI-f54c344fc8aa4cebbb41939de1b36a74

Made with [Cursor](https://cursor.com)