### PR TITLE
ENC-TSK-L10 follow-up: fix PYTHONPATH for enceladus_shared under Lambda Web Adapter

### DIFF
--- a/backend/lambda/mcp_streaming_gateway/run.sh
+++ b/backend/lambda/mcp_streaming_gateway/run.sh
@@ -3,4 +3,12 @@
 # launches this script once per execution environment (cold start), then proxies
 # subsequent invocations to it as HTTP requests on AWS_LWA_PORT.
 set -euo pipefail
+# AWS_LAMBDA_EXEC_WRAPPER fully replaces the native runtime bootstrap, which is
+# what normally sets PYTHONPATH=/opt/python so Lambda Layers (enceladus-shared,
+# providing enceladus_shared.appconfig_flags) are importable. That never
+# happens under the adapter, so set it explicitly (confirmed live: without
+# this, server.py's `from enceladus_shared.appconfig_flags import flag` AND
+# its `from appconfig_flags import flag` local-fallback both raise
+# ModuleNotFoundError at import time, crashing uvicorn's cold start -> 502).
+export PYTHONPATH="/opt/python:${PYTHONPATH:-}"
 exec python3 -m uvicorn asgi_app:application --host 0.0.0.0 --port "${AWS_LWA_PORT:-8080}"


### PR DESCRIPTION
## Summary
Live gamma verification of ENC-TSK-L10 (curl to the new McpStreamingRestApi /mcp endpoint) returned a 502 `InternalServerErrorException`. CloudWatch diagnosis: `Runtime.ExitError`, `ModuleNotFoundError: No module named 'appconfig_flags'` at uvicorn cold start — both server.py's primary `from enceladus_shared.appconfig_flags import flag` and its local-fallback `from appconfig_flags import flag` failed.

**Root cause**: `AWS_LAMBDA_EXEC_WRAPPER=/opt/bootstrap` (the Lambda Web Adapter) completely replaces the native Lambda runtime bootstrap — which is what normally sets `PYTHONPATH=/opt/python` so Lambda Layers are importable. Verified the `enceladus-shared` layer's actual zip structure directly (`aws lambda get-layer-version-by-arn` + download): `python/enceladus_shared/appconfig_flags.py`, i.e. it needs `/opt/python` on the path. `run.sh` now exports `PYTHONPATH` explicitly before exec'ing uvicorn.

Also found (not part of this PR, will clean up separately): two duplicate `McpStreamingRestApi` REST API Gateway resources exist in AWS (`8zcqe1jlk7` canonical per the CFN stack, `eoqogjjnu9` orphaned from an earlier failed-then-retried deploy attempt) — will delete the orphan directly via AWS CLI since it isn't CFN-managed.

CCI-15015673b822439cafae4a604945c942

## Test plan
- [ ] Merge, Gen2 deploy (code-only change, no CFN needed)
- [ ] curl the live /mcp endpoint again with a real MCP initialize payload, confirm streamed 200 response instead of 502