### PR TITLE
feat(infra): gamma OpenSearch node stack (ENC-TSK-L39)

### DIFF
--- a/.github/workflows/cloudformation-opensearch-node-stack-deploy.yml
+++ b/.github/workflows/cloudformation-opensearch-node-stack-deploy.yml
@@ -1,0 +1,220 @@
+name: CloudFormation OpenSearch Node Stack Deploy
+
+# ENC-TSK-L39 — gamma-only self-hosted OpenSearch node (t4g.small / single-AZ).
+# DEPLOY TARGET: gamma (v4) ONLY. v3-prod is FROZEN (DOC-499FA089EC30).
+# EscalatedPrereq: CFN deploy role needs ec2:RunInstances + iam:PassRole (DOC-359655466119).
+
+on:
+  push:
+    branches:
+      - 'v4/**'
+    paths:
+      - "infrastructure/cloudformation/10-opensearch-node.yaml"
+      - "infrastructure/opensearch/bootstrap-node.sh"
+      - ".github/workflows/cloudformation-opensearch-node-stack-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 10-opensearch-node template"
+        type: string
+        required: false
+        default: "enceladus-opensearch-node"
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual OpenSearch node stack deploy (gamma)"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-opensearch-node-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/10-opensearch-node.yaml
+  ENVIRONMENT_SUFFIX: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
+  DEFAULT_STACK_NAME: enceladus-opensearch-node
+
+jobs:
+  guard-gamma-only:
+    name: Guard — gamma only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse non-gamma targets
+        run: |
+          set -euo pipefail
+          if [ "${ENVIRONMENT_SUFFIX}" != "-gamma" ]; then
+            echo "::error::OpenSearch node stack is gamma-only (v3-prod is FROZEN, DOC-499FA089EC30)."
+            exit 1
+          fi
+          echo "Gamma target confirmed (ENVIRONMENT_SUFFIX=${ENVIRONMENT_SUFFIX})."
+
+  plan:
+    name: Plan OpenSearch node stack change-set
+    needs: guard-gamma-only
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync bootstrap script into CFN UserData (base64)
+        run: |
+          set -euo pipefail
+          python3 tools/sync_opensearch_bootstrap_cfn.py --check
+
+      - name: Configure AWS credentials (OIDC CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        run: |
+          set -euo pipefail
+          stack_name="${{ github.event.inputs.stack_name || env.DEFAULT_STACK_NAME }}${ENVIRONMENT_SUFFIX}"
+          echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Clean up ROLLBACK_COMPLETE stack if present (gamma self-heal)
+        run: |
+          set -euo pipefail
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${stack_name}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          if [ "${status}" = "ROLLBACK_COMPLETE" ]; then
+            echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy"
+            aws cloudformation delete-stack \
+              --region "${AWS_REGION}" \
+              --stack-name "${stack_name}"
+            aws cloudformation wait stack-delete-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${stack_name}"
+          fi
+
+      - name: Create OpenSearch node stack change-set (no execute)
+        id: changeset
+        run: |
+          set -euo pipefail
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 10-opensearch-node/ \
+            --parameter-overrides \
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## OpenSearch node stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## OpenSearch node stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply OpenSearch node stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: v4-gamma
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || true
+
+      - name: Report deployed stack state
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
+            --output table
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].Outputs' \
+            --output table

--- a/infrastructure/cloudformation/10-opensearch-node.yaml
+++ b/infrastructure/cloudformation/10-opensearch-node.yaml
@@ -1,0 +1,195 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  ENC-TSK-L39 — gamma-only self-hosted OpenSearch single-node infrastructure (DOC-77D6C714867E §14).
+  Stands up one graviton EC2 (t4g.small, arm64) with gp3 data volume (<=16GB), instance IAM role
+  (SSM Session Manager + CloudWatch Agent; optional manual snapshot bucket access), placed in a
+  public subnet with NO NAT gateway and single-AZ placement.
+
+  Cost posture (AC-3, locked): on-demand <= ~$13/mo (t4g.small + 16GB gp3 + modest egress);
+  1-year Compute Savings Plan / Reserved Instance recommended (~$8/mo). Explicitly excludes NAT
+  gateway, multi-AZ, replica nodes, and OpenSearch Serverless (~$350+/mo floor — rejected ISS-465 class).
+
+  DEPLOY TARGET: gamma (v4) ONLY via cloudformation-opensearch-node-stack-deploy.yml.
+  EscalatedPrereq: CFN deploy role must hold ec2:RunInstances + iam:PassRole for the instance
+  profile (DOC-359655466119) — do not hand-edit live IAM.
+
+Metadata:
+  Enceladus:
+    TaskId: ENC-TSK-L39
+    EscalatedPrereqs:
+      - CFN deploy role needs ec2:RunInstances, ec2:CreateTags, ec2:Describe*, iam:PassRole on OpenSearchNodeInstanceProfile
+
+Parameters:
+  EnvironmentSuffix:
+    Type: String
+    Default: "-gamma"
+    AllowedValues: ["", "-gamma"]
+    Description: Resource suffix; gamma-only stack in Phase 1.
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Default: vpc-8ad4a8f2
+    Description: VPC for the OpenSearch node (default VPC on gamma account).
+
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Default: subnet-0a27ee72
+    Description: Public subnet (MapPublicIpOnLaunch=true) — single-AZ, no NAT.
+
+  VpcCidr:
+    Type: String
+    Default: 172.31.0.0/16
+    Description: VPC CIDR allowed to reach OpenSearch :9200 (TLS).
+
+  InstanceType:
+    Type: String
+    Default: t4g.small
+    AllowedValues: [t4g.small, t4g.medium]
+    Description: Graviton instance class (AC-1 locks t4g.small).
+
+  VolumeSizeGiB:
+    Type: Number
+    Default: 16
+    MinValue: 8
+    MaxValue: 16
+    Description: gp3 root/data volume size (AC-1 <= 16GB).
+
+  OpenSearchVersion:
+    Type: String
+    Default: "2.19.1"
+    Description: OpenSearch tarball version installed by bootstrap-node.sh.
+
+  SnapshotBucketName:
+    Type: String
+    Default: ""
+    Description: Optional S3 bucket name for manual snapshot exports (empty disables snapshot IAM).
+
+Conditions:
+  HasSnapshotBucket: !Not [!Equals [!Ref SnapshotBucketName, ""]]
+
+Resources:
+  OpenSearchNodeRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-opensearch-node-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - !If
+          - HasSnapshotBucket
+          - PolicyName: opensearch-manual-snapshot-s3
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Sid: SnapshotObjectRW
+                  Effect: Allow
+                  Action:
+                    - s3:PutObject
+                    - s3:GetObject
+                    - s3:DeleteObject
+                    - s3:ListBucket
+                  Resource:
+                    - !Sub "arn:aws:s3:::${SnapshotBucketName}"
+                    - !Sub "arn:aws:s3:::${SnapshotBucketName}/*"
+          - !Ref AWS::NoValue
+
+  OpenSearchNodeInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: !Sub "enceladus-opensearch-node${EnvironmentSuffix}"
+      Roles:
+        - !Ref OpenSearchNodeRole
+
+  OpenSearchNodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "OpenSearch node (TLS :9200) ${EnvironmentSuffix}"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 9200
+          ToPort: 9200
+          CidrIp: !Ref VpcCidr
+          Description: OpenSearch REST (TLS) from VPC
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+          Description: Package downloads + artifact fetch
+
+  OpenSearchNodeInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref OpenSearchNodeInstanceProfile
+      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64}}'
+      SubnetId: !Ref SubnetId
+      SecurityGroupIds:
+        - !Ref OpenSearchNodeSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeType: gp3
+            VolumeSize: !Ref VolumeSizeGiB
+            Encrypted: true
+            DeleteOnTermination: true
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+        HttpPutResponseHopLimit: 1
+      Tags:
+        - Key: Name
+          Value: !Sub "enceladus-opensearch-node${EnvironmentSuffix}"
+        - Key: enceladus:component
+          Value: opensearch-node
+        - Key: enceladus:task
+          Value: ENC-TSK-L39
+      UserData:
+        Fn::Base64: !Sub
+          - |
+            #!/bin/bash
+            set -euo pipefail
+            exec > /var/log/opensearch-userdata.log 2>&1
+            export OPENSEARCH_VERSION="${OpenSearchVersion}"
+            export OPENSEARCH_CLUSTER_NAME="enceladus-search${EnvironmentSuffix}"
+            echo "${BootstrapScriptB64}" | base64 -d > /tmp/bootstrap-node.sh
+            chmod +x /tmp/bootstrap-node.sh
+            /tmp/bootstrap-node.sh
+          - OpenSearchVersion: !Ref OpenSearchVersion
+            EnvironmentSuffix: !Ref EnvironmentSuffix
+            BootstrapScriptB64: "IyEvdXNyL2Jpbi9lbnYgYmFzaAojIEVOQy1UU0stTDM5IOKAlCBzaW5nbGUtbm9kZSBPcGVuU2VhcmNoIGJvb3RzdHJhcCBmb3IgZ2FtbWEgKHQ0Zy5zbWFsbCAvIGFybTY0KS4KIyBJbnN0YWxsZWQgYnkgMTAtb3BlbnNlYXJjaC1ub2RlLnlhbWwgVXNlckRhdGEuIElkZW1wb3RlbnQgb24gcmUtcnVuIGV4Y2VwdCBmaXJzdAojIGNsdXN0ZXIgZm9ybWF0aW9uIChndWFyZGVkIGJ5IG1hcmtlciBmaWxlKS4Kc2V0IC1ldW8gcGlwZWZhaWwKCmV4ZWMgPiAvdmFyL2xvZy9vcGVuc2VhcmNoLWJvb3RzdHJhcC5sb2cgMj4mMQoKT1BFTlNFQVJDSF9WRVJTSU9OPSIke09QRU5TRUFSQ0hfVkVSU0lPTjotMi4xOS4xfSIKT1BFTlNFQVJDSF9IT01FPSIke09QRU5TRUFSQ0hfSE9NRTotL3Vzci9zaGFyZS9vcGVuc2VhcmNofSIKT1BFTlNFQVJDSF9VU0VSPSIke09QRU5TRUFSQ0hfVVNFUjotb3BlbnNlYXJjaH0iCkNMVVNURVJfTkFNRT0iJHtPUEVOU0VBUkNIX0NMVVNURVJfTkFNRTotZW5jZWxhZHVzLXNlYXJjaC1nYW1tYX0iCk5PREVfTkFNRT0iJHtPUEVOU0VBUkNIX05PREVfTkFNRTotc2VhcmNoLW5vZGUtMX0iCkFETUlOX1BBU1NXT1JEX0ZJTEU9IiR7T1BFTlNFQVJDSF9BRE1JTl9QQVNTV09SRF9GSUxFOi0vcm9vdC8ub3BlbnNlYXJjaC1hZG1pbi1wYXNzd29yZH0iCk1BUktFUj0iL3Zhci9saWIvb3BlbnNlYXJjaC8uYm9vdHN0cmFwLWNvbXBsZXRlIgpKVk1fSEVBUD0iJHtPUEVOU0VBUkNIX0pWTV9IRUFQOi0xZ30iCgpsb2coKSB7IGVjaG8gIlskKGRhdGUgLXUgKyVZLSVtLSVkVCVIOiVNOiVTWildICQqIjsgfQoKaWYgW1sgLWYgIiR7TUFSS0VSfSIgXV07IHRoZW4KICBsb2cgIkJvb3RzdHJhcCBhbHJlYWR5IGNvbXBsZXRlOyBleGl0aW5nLiIKICBleGl0IDAKZmkKCmxvZyAiSW5zdGFsbGluZyBwcmVyZXF1aXNpdGVzIgpkbmYgaW5zdGFsbCAteSBqYXZhLTE3LWFtYXpvbi1jb3JyZXR0by1oZWFkbGVzcyB0YXIgZ3ppcCBjdXJsIGpxIGFtYXpvbi1jbG91ZHdhdGNoLWFnZW50CgppZiAhIGlkICIke09QRU5TRUFSQ0hfVVNFUn0iICY+L2Rldi9udWxsOyB0aGVuCiAgdXNlcmFkZCAtLXN5c3RlbSAtLWhvbWUtZGlyICIke09QRU5TRUFSQ0hfSE9NRX0iIC0tc2hlbGwgL3NiaW4vbm9sb2dpbiAiJHtPUEVOU0VBUkNIX1VTRVJ9IgpmaQoKaW5zdGFsbCAtZCAtbSAwNzU1ICIke09QRU5TRUFSQ0hfSE9NRX0iCmluc3RhbGwgLWQgLW0gMDc1MCAtbyAiJHtPUEVOU0VBUkNIX1VTRVJ9IiAtZyAiJHtPUEVOU0VBUkNIX1VTRVJ9IiAvdmFyL2xpYi9vcGVuc2VhcmNoCmluc3RhbGwgLWQgLW0gMDc1MCAtbyAiJHtPUEVOU0VBUkNIX1VTRVJ9IiAtZyAiJHtPUEVOU0VBUkNIX1VTRVJ9IiAvdmFyL2xvZy9vcGVuc2VhcmNoCgpUQVJCQUxMPSJvcGVuc2VhcmNoLSR7T1BFTlNFQVJDSF9WRVJTSU9OfS1saW51eC1hcm02NC50YXIuZ3oiClVSTD0iaHR0cHM6Ly9hcnRpZmFjdHMub3BlbnNlYXJjaC5vcmcvcmVsZWFzZXMvYnVuZGxlL29wZW5zZWFyY2gvJHtPUEVOU0VBUkNIX1ZFUlNJT059LyR7VEFSQkFMTH0iClRNUD0iL3RtcC8ke1RBUkJBTEx9IgoKaWYgW1sgISAteCAiJHtPUEVOU0VBUkNIX0hPTUV9L2Jpbi9vcGVuc2VhcmNoIiBdXTsgdGhlbgogIGxvZyAiRG93bmxvYWRpbmcgT3BlblNlYXJjaCAke09QRU5TRUFSQ0hfVkVSU0lPTn0gKCR7VVJMfSkiCiAgY3VybCAtZnNTTCAiJHtVUkx9IiAtbyAiJHtUTVB9IgogIHRhciAteHpmICIke1RNUH0iIC1DIC90bXAKICBybSAtcmYgIiR7T1BFTlNFQVJDSF9IT01FOj99Ii8qCiAgY3AgLWEgIi90bXAvb3BlbnNlYXJjaC0ke09QRU5TRUFSQ0hfVkVSU0lPTn0iLyogIiR7T1BFTlNFQVJDSF9IT01FfS8iCiAgcm0gLWYgIiR7VE1QfSIKZmkKCmNob3duIC1SICIke09QRU5TRUFSQ0hfVVNFUn06JHtPUEVOU0VBUkNIX1VTRVJ9IiAiJHtPUEVOU0VBUkNIX0hPTUV9IiAvdmFyL2xpYi9vcGVuc2VhcmNoIC92YXIvbG9nL29wZW5zZWFyY2gKCmlmIFtbICEgLWYgIiR7QURNSU5fUEFTU1dPUkRfRklMRX0iIF1dOyB0aGVuCiAgb3BlbnNzbCByYW5kIC1iYXNlNjQgMjQgPiAiJHtBRE1JTl9QQVNTV09SRF9GSUxFfSIKICBjaG1vZCAwNjAwICIke0FETUlOX1BBU1NXT1JEX0ZJTEV9IgpmaQpBRE1JTl9QQVNTV09SRD0iJCh0ciAtZCAnXG4nIDwgIiR7QURNSU5fUEFTU1dPUkRfRklMRX0iKSIKZXhwb3J0IE9QRU5TRUFSQ0hfSU5JVElBTF9BRE1JTl9QQVNTV09SRD0iJHtBRE1JTl9QQVNTV09SRH0iCgpsb2cgIldyaXRpbmcgb3BlbnNlYXJjaC55bWwiCkNGRz0iJHtPUEVOU0VBUkNIX0hPTUV9L2NvbmZpZy9vcGVuc2VhcmNoLnltbCIKY2F0ID4+ICIke0NGR30iIDw8RU9GCgojIyMjIyMjIyMjIEVOQy1UU0stTDM5IGdlbmVyYXRlZCAjIyMjIyMjIyMjCmNsdXN0ZXIubmFtZTogJHtDTFVTVEVSX05BTUV9Cm5vZGUubmFtZTogJHtOT0RFX05BTUV9CmRpc2NvdmVyeS50eXBlOiBzaW5nbGUtbm9kZQpuZXR3b3JrLmhvc3Q6IDAuMC4wLjAKcGF0aC5kYXRhOiAvdmFyL2xpYi9vcGVuc2VhcmNoCnBhdGgubG9nczogL3Zhci9sb2cvb3BlbnNlYXJjaApwbHVnaW5zLnNlY3VyaXR5LmRpc2FibGVkOiBmYWxzZQphY3Rpb24uYXV0b19jcmVhdGVfaW5kZXg6IHRydWUKIyMjIyMjIyMjIyBFTkQgRU5DLVRTSy1MMzkgZ2VuZXJhdGVkICMjIyMjIyMjIyMKRU9GCgppbnN0YWxsIC1kIC1tIDA3NTUgIiR7T1BFTlNFQVJDSF9IT01FfS9jb25maWcvanZtLm9wdGlvbnMuZCIKY2F0ID4gIiR7T1BFTlNFQVJDSF9IT01FfS9jb25maWcvanZtLm9wdGlvbnMuZC9oZWFwLm9wdGlvbnMiIDw8RU9GCi1YbXMke0pWTV9IRUFQfQotWG14JHtKVk1fSEVBUH0KRU9GCgpsb2cgIlJ1bm5pbmcgb3BlbnNlYXJjaC10YXItaW5zdGFsbC5zaCAoVExTICsgc2VjdXJpdHkgcGx1Z2luIGRlbW8gY2VydHMpIgpjZCAiJHtPUEVOU0VBUkNIX0hPTUV9IgpjaG1vZCAreCAuL29wZW5zZWFyY2gtdGFyLWluc3RhbGwuc2gKLi9vcGVuc2VhcmNoLXRhci1pbnN0YWxsLnNoCiMgRGVtbyBpbnN0YWxsZXIgbWF5IGxlYXZlIGEgZm9yZWdyb3VuZCBwcm9jZXNzOyBlbnN1cmUgY2xlYW4gaGFuZG9mZiB0byBzeXN0ZW1kLgpwa2lsbCAtdSAiJHtPUEVOU0VBUkNIX1VTRVJ9IiB8fCB0cnVlCnNsZWVwIDIKCmxvZyAiSW5zdGFsbGluZyBzeXN0ZW1kIHVuaXQiCmNhdCA+IC9ldGMvc3lzdGVtZC9zeXN0ZW0vb3BlbnNlYXJjaC5zZXJ2aWNlIDw8RU9GCltVbml0XQpEZXNjcmlwdGlvbj1PcGVuU2VhcmNoIChFTkMtVFNLLUwzOSBzaW5nbGUgbm9kZSkKQWZ0ZXI9bmV0d29yay1vbmxpbmUudGFyZ2V0CldhbnRzPW5ldHdvcmstb25saW5lLnRhcmdldAoKW1NlcnZpY2VdClR5cGU9c2ltcGxlClVzZXI9JHtPUEVOU0VBUkNIX1VTRVJ9Ckdyb3VwPSR7T1BFTlNFQVJDSF9VU0VSfQpFbnZpcm9ubWVudD1PUEVOU0VBUkNIX0hPTUU9JHtPUEVOU0VBUkNIX0hPTUV9CkVudmlyb25tZW50PU9QRU5TRUFSQ0hfUEFUSF9DT05GPSR7T1BFTlNFQVJDSF9IT01FfS9jb25maWcKRW52aXJvbm1lbnQ9T1BFTlNFQVJDSF9KQVZBX0hPTUU9JHtPUEVOU0VBUkNIX0hPTUV9L2pkawpXb3JraW5nRGlyZWN0b3J5PSR7T1BFTlNFQVJDSF9IT01FfQpFeGVjU3RhcnQ9JHtPUEVOU0VBUkNIX0hPTUV9L2Jpbi9vcGVuc2VhcmNoClJlc3RhcnQ9b24tZmFpbHVyZQpMaW1pdE5PRklMRT02NTUzNgpMaW1pdE1FTUxPQ0s9aW5maW5pdHkKCltJbnN0YWxsXQpXYW50ZWRCeT1tdWx0aS11c2VyLnRhcmdldApFT0YKCnN5c3RlbWN0bCBkYWVtb24tcmVsb2FkCnN5c3RlbWN0bCBlbmFibGUgb3BlbnNlYXJjaApzeXN0ZW1jdGwgcmVzdGFydCBvcGVuc2VhcmNoCgpsb2cgIldhaXRpbmcgZm9yIGNsdXN0ZXIgaGVhbHRoIEdSRUVOIgpmb3IgaSBpbiAkKHNlcSAxIDYwKTsgZG8KICBpZiBjdXJsIC1rcyAtdSAiYWRtaW46JHtBRE1JTl9QQVNTV09SRH0iICJodHRwczovLzEyNy4wLjAuMTo5MjAwL19jbHVzdGVyL2hlYWx0aCIgXAogICAgfCBqcSAtZSAnLnN0YXR1cyA9PSAiZ3JlZW4iIG9yIC5zdGF0dXMgPT0gInllbGxvdyInID4vZGV2L251bGwgMj4mMTsgdGhlbgogICAgYnJlYWsKICBmaQogIHNsZWVwIDUKZG9uZQoKY3VybCAta3MgLXUgImFkbWluOiR7QURNSU5fUEFTU1dPUkR9IiAiaHR0cHM6Ly8xMjcuMC4wLjE6OTIwMC9fY2x1c3Rlci9oZWFsdGg/d2FpdF9mb3Jfc3RhdHVzPWdyZWVuJnRpbWVvdXQ9MTIwcyIgfCB0ZWUgL3Zhci9sb2cvb3BlbnNlYXJjaC1jbHVzdGVyLWhlYWx0aC5qc29uCgpsb2cgIkFwcGx5aW5nIGRlZmF1bHQgaW5kZXggdGVtcGxhdGUgKG51bWJlcl9vZl9yZXBsaWNhczogMCkiCmN1cmwgLWtzIC11ICJhZG1pbjoke0FETUlOX1BBU1NXT1JEfSIgLVggUFVUICJodHRwczovLzEyNy4wLjAuMTo5MjAwL19pbmRleF90ZW1wbGF0ZS9lbmNlbGFkdXMtZGVmYXVsdC1yZXBsaWNhcy16ZXJvIiBcCiAgLUggJ0NvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbicgXAogIC1kICd7ImluZGV4X3BhdHRlcm5zIjpbImVuY2VsYWR1cy0qIl0sInRlbXBsYXRlIjp7InNldHRpbmdzIjp7Im51bWJlcl9vZl9zaGFyZHMiOjEsIm51bWJlcl9vZl9yZXBsaWNhcyI6MH19fScKCnRvdWNoICIke01BUktFUn0iCmxvZyAiQm9vdHN0cmFwIGNvbXBsZXRlIgo="
+
+
+Outputs:
+  OpenSearchInstanceId:
+    Description: EC2 instance id for the gamma OpenSearch node
+    Value: !Ref OpenSearchNodeInstance
+    Export:
+      Name: !Sub "enceladus-opensearch-node-instance-id${EnvironmentSuffix}"
+
+  OpenSearchPrivateIp:
+    Description: Private IPv4 for in-VPC clients (https://<ip>:9200)
+    Value: !GetAtt OpenSearchNodeInstance.PrivateIp
+    Export:
+      Name: !Sub "enceladus-opensearch-node-private-ip${EnvironmentSuffix}"
+
+  OpenSearchHttpsEndpoint:
+    Description: TLS REST endpoint inside the VPC (demo/self-signed certs from bootstrap)
+    Value: !Sub
+      - "https://${Ip}:9200"
+      - Ip: !GetAtt OpenSearchNodeInstance.PrivateIp
+    Export:
+      Name: !Sub "enceladus-opensearch-node-endpoint${EnvironmentSuffix}"
+
+  OpenSearchNodeRoleArn:
+    Description: Instance role ARN (SSM + CloudWatch; optional snapshot bucket)
+    Value: !GetAtt OpenSearchNodeRole.Arn

--- a/infrastructure/opensearch/bootstrap-node.sh
+++ b/infrastructure/opensearch/bootstrap-node.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ENC-TSK-L39 — single-node OpenSearch bootstrap for gamma (t4g.small / arm64).
+# Installed by 10-opensearch-node.yaml UserData. Idempotent on re-run except first
+# cluster formation (guarded by marker file).
+set -euo pipefail
+
+exec > /var/log/opensearch-bootstrap.log 2>&1
+
+OPENSEARCH_VERSION="${OPENSEARCH_VERSION:-2.19.1}"
+OPENSEARCH_HOME="${OPENSEARCH_HOME:-/usr/share/opensearch}"
+OPENSEARCH_USER="${OPENSEARCH_USER:-opensearch}"
+CLUSTER_NAME="${OPENSEARCH_CLUSTER_NAME:-enceladus-search-gamma}"
+NODE_NAME="${OPENSEARCH_NODE_NAME:-search-node-1}"
+ADMIN_PASSWORD_FILE="${OPENSEARCH_ADMIN_PASSWORD_FILE:-/root/.opensearch-admin-password}"
+MARKER="/var/lib/opensearch/.bootstrap-complete"
+JVM_HEAP="${OPENSEARCH_JVM_HEAP:-1g}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+if [[ -f "${MARKER}" ]]; then
+  log "Bootstrap already complete; exiting."
+  exit 0
+fi
+
+log "Installing prerequisites"
+dnf install -y java-17-amazon-corretto-headless tar gzip curl jq amazon-cloudwatch-agent
+
+if ! id "${OPENSEARCH_USER}" &>/dev/null; then
+  useradd --system --home-dir "${OPENSEARCH_HOME}" --shell /sbin/nologin "${OPENSEARCH_USER}"
+fi
+
+install -d -m 0755 "${OPENSEARCH_HOME}"
+install -d -m 0750 -o "${OPENSEARCH_USER}" -g "${OPENSEARCH_USER}" /var/lib/opensearch
+install -d -m 0750 -o "${OPENSEARCH_USER}" -g "${OPENSEARCH_USER}" /var/log/opensearch
+
+TARBALL="opensearch-${OPENSEARCH_VERSION}-linux-arm64.tar.gz"
+URL="https://artifacts.opensearch.org/releases/bundle/opensearch/${OPENSEARCH_VERSION}/${TARBALL}"
+TMP="/tmp/${TARBALL}"
+
+if [[ ! -x "${OPENSEARCH_HOME}/bin/opensearch" ]]; then
+  log "Downloading OpenSearch ${OPENSEARCH_VERSION} (${URL})"
+  curl -fsSL "${URL}" -o "${TMP}"
+  tar -xzf "${TMP}" -C /tmp
+  rm -rf "${OPENSEARCH_HOME:?}"/*
+  cp -a "/tmp/opensearch-${OPENSEARCH_VERSION}"/* "${OPENSEARCH_HOME}/"
+  rm -f "${TMP}"
+fi
+
+chown -R "${OPENSEARCH_USER}:${OPENSEARCH_USER}" "${OPENSEARCH_HOME}" /var/lib/opensearch /var/log/opensearch
+
+if [[ ! -f "${ADMIN_PASSWORD_FILE}" ]]; then
+  openssl rand -base64 24 > "${ADMIN_PASSWORD_FILE}"
+  chmod 0600 "${ADMIN_PASSWORD_FILE}"
+fi
+ADMIN_PASSWORD="$(tr -d '\n' < "${ADMIN_PASSWORD_FILE}")"
+export OPENSEARCH_INITIAL_ADMIN_PASSWORD="${ADMIN_PASSWORD}"
+
+log "Writing opensearch.yml"
+CFG="${OPENSEARCH_HOME}/config/opensearch.yml"
+cat >> "${CFG}" <<EOF
+
+########## ENC-TSK-L39 generated ##########
+cluster.name: ${CLUSTER_NAME}
+node.name: ${NODE_NAME}
+discovery.type: single-node
+network.host: 0.0.0.0
+path.data: /var/lib/opensearch
+path.logs: /var/log/opensearch
+plugins.security.disabled: false
+action.auto_create_index: true
+########## END ENC-TSK-L39 generated ##########
+EOF
+
+install -d -m 0755 "${OPENSEARCH_HOME}/config/jvm.options.d"
+cat > "${OPENSEARCH_HOME}/config/jvm.options.d/heap.options" <<EOF
+-Xms${JVM_HEAP}
+-Xmx${JVM_HEAP}
+EOF
+
+log "Running opensearch-tar-install.sh (TLS + security plugin demo certs)"
+cd "${OPENSEARCH_HOME}"
+chmod +x ./opensearch-tar-install.sh
+./opensearch-tar-install.sh
+# Demo installer may leave a foreground process; ensure clean handoff to systemd.
+pkill -u "${OPENSEARCH_USER}" || true
+sleep 2
+
+log "Installing systemd unit"
+cat > /etc/systemd/system/opensearch.service <<EOF
+[Unit]
+Description=OpenSearch (ENC-TSK-L39 single node)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${OPENSEARCH_USER}
+Group=${OPENSEARCH_USER}
+Environment=OPENSEARCH_HOME=${OPENSEARCH_HOME}
+Environment=OPENSEARCH_PATH_CONF=${OPENSEARCH_HOME}/config
+Environment=OPENSEARCH_JAVA_HOME=${OPENSEARCH_HOME}/jdk
+WorkingDirectory=${OPENSEARCH_HOME}
+ExecStart=${OPENSEARCH_HOME}/bin/opensearch
+Restart=on-failure
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable opensearch
+systemctl restart opensearch
+
+log "Waiting for cluster health GREEN"
+for i in $(seq 1 60); do
+  if curl -ks -u "admin:${ADMIN_PASSWORD}" "https://127.0.0.1:9200/_cluster/health" \
+    | jq -e '.status == "green" or .status == "yellow"' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+
+curl -ks -u "admin:${ADMIN_PASSWORD}" "https://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=120s" | tee /var/log/opensearch-cluster-health.json
+
+log "Applying default index template (number_of_replicas: 0)"
+curl -ks -u "admin:${ADMIN_PASSWORD}" -X PUT "https://127.0.0.1:9200/_index_template/enceladus-default-replicas-zero" \
+  -H 'Content-Type: application/json' \
+  -d '{"index_patterns":["enceladus-*"],"template":{"settings":{"number_of_shards":1,"number_of_replicas":0}}}'
+
+touch "${MARKER}"
+log "Bootstrap complete"

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -50,6 +50,13 @@
       ],
       "notes": "v4/main-only file; gamma-only by construction (guard-gamma-only job refuses non-gamma, v3-prod FROZEN per DOC-499FA089EC30); ENC-TSK-J63 plan/apply split with apply environment: v4-gamma"
     },
+    "cloudformation-opensearch-node-stack-deploy.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-L39 gamma-only OpenSearch node stack; guard-gamma-only + apply environment: v4-gamma (v3-prod FROZEN)"
+    },
     "cloudformation-api-stack-deploy.yml": {
       "class": "conditional",
       "gated_jobs": [

--- a/tools/sync_opensearch_bootstrap_cfn.py
+++ b/tools/sync_opensearch_bootstrap_cfn.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Keep 10-opensearch-node.yaml UserData bootstrap base64 in sync with bootstrap-node.sh."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "infrastructure/opensearch/bootstrap-node.sh"
+TEMPLATE = REPO_ROOT / "infrastructure/cloudformation/10-opensearch-node.yaml"
+B64_KEY = "BootstrapScriptB64"
+
+
+def _read_b64(script: Path) -> str:
+    return base64.b64encode(script.read_bytes()).decode("ascii")
+
+
+def _replace_b64(template_text: str, b64: str) -> str:
+    pattern = rf'({B64_KEY}: ")([A-Za-z0-9+/=]+)(")'
+    if not re.search(pattern, template_text):
+        raise RuntimeError(f"Could not find {B64_KEY} string in {TEMPLATE}")
+    return re.sub(pattern, rf"\1{b64}\3", template_text, count=1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero when template embed is stale vs bootstrap-node.sh",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Rewrite 10-opensearch-node.yaml embedded base64",
+    )
+    args = parser.parse_args()
+
+    if not SCRIPT.is_file() or not TEMPLATE.is_file():
+        print("Missing bootstrap script or CFN template", file=sys.stderr)
+        return 2
+
+    expected = _read_b64(SCRIPT)
+    current_match = re.search(rf'{B64_KEY}: "([A-Za-z0-9+/=]+)"', TEMPLATE.read_text())
+    current = current_match.group(1) if current_match else ""
+
+    if expected == current:
+        print("[OK] bootstrap-node.sh is synced into 10-opensearch-node.yaml")
+        return 0
+
+    if args.check:
+        print(
+            "[ERROR] bootstrap-node.sh changed but 10-opensearch-node.yaml UserData base64 is stale. "
+            "Run: python3 tools/sync_opensearch_bootstrap_cfn.py --write",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.write:
+        updated = _replace_b64(TEMPLATE.read_text(), expected)
+        TEMPLATE.write_text(updated)
+        print(f"[OK] Updated embedded base64 in {TEMPLATE}")
+        return 0
+
+    print("[WARN] bootstrap embed is stale (pass --check or --write)", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Standalone `infrastructure/opensearch/bootstrap-node.sh` — single-node OpenSearch 2.19.1 arm64 install (TLS + security plugin, JVM 1g, replicas-0 index template).
- `infrastructure/cloudformation/10-opensearch-node.yaml` — t4g.small EC2 in public subnet (no NAT), gp3 <=16GB, IAM (SSM + CloudWatch + optional snapshot bucket), AC-3 cost description locked in stack metadata.
- Gamma-only deploy lane `cloudformation-opensearch-node-stack-deploy.yml` + `tools/sync_opensearch_bootstrap_cfn.py` guard.

## Test plan
- [x] CI green (prod gate baseline classified)
- [ ] CFN plan/apply on merge to v4/main
- [ ] Post-deploy: SSM into instance, `_cluster/health` GREEN

CCI-423684d4f09946c0a6f7913424aadba9