### PR TITLE
fix(cfn): pin AL2023 AMI for OpenSearch node deploy (ENC-TSK-L39)

### DIFF
--- a/infrastructure/cloudformation/10-opensearch-node.yaml
+++ b/infrastructure/cloudformation/10-opensearch-node.yaml
@@ -59,6 +59,13 @@ Parameters:
     Default: "2.19.1"
     Description: OpenSearch tarball version installed by bootstrap-node.sh.
 
+  AmiId:
+    Type: AWS::EC2::Image::Id
+    Default: ami-0aca5422add5908e3
+    Description: >
+      Amazon Linux 2023 arm64 AMI (t4g). Pin updated manually; avoids SSM dynamic
+      reference which requires ssm:GetParameters on the CFN deploy role at plan time.
+
   SnapshotBucketName:
     Type: String
     Default: ""
@@ -131,7 +138,7 @@ Resources:
     Properties:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref OpenSearchNodeInstanceProfile
-      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64}}'
+      ImageId: !Ref AmiId
       SubnetId: !Ref SubnetId
       SecurityGroupIds:
         - !Ref OpenSearchNodeSecurityGroup


### PR DESCRIPTION
CFN deploy role lacks `ssm:GetParameters` for dynamic AMI resolve at change-set creation.

CCI-423684d4f09946c0a6f7913424aadba9

Made with [Cursor](https://cursor.com)