### PR TITLE
chore(iam): EC2 deploy-role patch for OpenSearch node (ENC-TSK-L39)

### DIFF
--- a/.github/workflows/cloudformation-opensearch-node-stack-deploy.yml
+++ b/.github/workflows/cloudformation-opensearch-node-stack-deploy.yml
@@ -183,10 +183,14 @@ jobs:
             --region "${AWS_REGION}" \
             --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
             --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          stack_status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NONE")
           aws cloudformation execute-change-set \
             --region "${AWS_REGION}" \
             --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
-          if [ "${changeset_type}" = "CREATE" ]; then
+          if [ "${changeset_type}" = "CREATE" ] || [ "${stack_status}" = "REVIEW_IN_PROGRESS" ] || [ "${stack_status}" = "NONE" ]; then
             aws cloudformation wait stack-create-complete \
               --region "${AWS_REGION}" \
               --stack-name "${{ needs.plan.outputs.stack_name }}"

--- a/.github/workflows/iam-cfn-deploy-role-opensearch-ec2-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-opensearch-ec2-patch.yml
@@ -1,0 +1,110 @@
+name: IAM CFN Deploy Role — OpenSearch EC2 Patch
+
+# ENC-TSK-L39 / DOC-359655466119 — grant the shared CFN deploy role the minimum EC2
+# permissions to stand up enceladus-opensearch-node-gamma (t4g.small in default VPC).
+# io-gated: environment v3-prod (required reviewer).
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant EC2+PassRole for enceladus-opensearch-node-gamma CFN stack (ENC-TSK-L39)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with OpenSearch EC2 permissions
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — OpenSearch node EC2 bootstrap (gamma)
+        run: |
+          set -euo pipefail
+          cat > /tmp/opensearch-ec2-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "OpenSearchNodeEc2Describe",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeSubnets",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceStatus",
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeVolumes",
+                  "ec2:DescribeAccountAttributes"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "OpenSearchNodeEc2MutateGamma",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:TerminateInstances",
+                  "ec2:StartInstances",
+                  "ec2:StopInstances",
+                  "ec2:CreateTags",
+                  "ec2:DeleteTags",
+                  "ec2:CreateSecurityGroup",
+                  "ec2:DeleteSecurityGroup",
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:AuthorizeSecurityGroupEgress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupEgress",
+                  "ec2:ModifyInstanceAttribute"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "us-west-2"
+                  }
+                }
+              },
+              {
+                "Sid": "OpenSearchNodePassInstanceProfile",
+                "Effect": "Allow",
+                "Action": "iam:PassRole",
+                "Resource": "arn:aws:iam::356364570033:role/enceladus-opensearch-node-role-gamma",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
+                }
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-opensearch-ec2-v1" \
+            --policy-document "file:///tmp/opensearch-ec2-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-opensearch-ec2-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -135,6 +135,13 @@
       ],
       "notes": "ENC-TSK-K59: environment: v3-prod \u2014 despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
     },
+    "iam-cfn-deploy-role-opensearch-ec2-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L39 / DOC-359655466119: environment v3-prod \u2014 EC2+PassRole for enceladus-opensearch-node-gamma CFN stack"
+    },
     "iam-cloudformation-unblock.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
Adds io-gated `iam-cfn-deploy-role-opensearch-ec2-patch.yml` (DOC-359655466119) and fixes OpenSearch CFN apply waiter for initial CREATE stacks.

After merge, dispatch the IAM patch workflow (requires v3-prod approval), delete `enceladus-opensearch-node-gamma` if ROLLBACK_COMPLETE, then re-run the OpenSearch CFN deploy workflow.

CCI-423684d4f09946c0a6f7913424aadba9

Made with [Cursor](https://cursor.com)