### PR TITLE
ENC-TSK-L63: Bundle mcp_server package in MCP Lambda artifacts (ENC-ISS-492 hotfix)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -139,7 +139,15 @@ jobs:
                 esac
                 cp "$py" "$workdir/$base"
               done
-              echo "  [$fn] packaged tools/enceladus-mcp-server runtime modules"
+              # ENC-TSK-L63 / ENC-ISS-492: server.py imports the decomposed mcp_server
+              # package (ENC-TSK-L09). Root-level *.py copy alone is insufficient.
+              if [ ! -d tools/enceladus-mcp-server/mcp_server ]; then
+                echo "ERROR: $fn requires tools/enceladus-mcp-server/mcp_server package" >&2
+                exit 1
+              fi
+              rsync -a --exclude='__pycache__' --exclude='*.pyc' \
+                tools/enceladus-mcp-server/mcp_server/ "$workdir/mcp_server/"
+              echo "  [$fn] packaged tools/enceladus-mcp-server runtime modules + mcp_server/"
             fi
 
             # ENC-TSK-G43: cross-Lambda module sharing via .build_extras manifest.

--- a/tests/infrastructure/test_mcp_server_lambda_packaging.py
+++ b/tests/infrastructure/test_mcp_server_lambda_packaging.py
@@ -1,0 +1,58 @@
+"""ENC-TSK-L63 / ENC-ISS-492: MCP Lambda artifacts must include mcp_server package."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MCP_ROOT = REPO_ROOT / "tools" / "enceladus-mcp-server"
+
+
+def _simulate_mcp_lambda_packaging(workdir: Path) -> None:
+    """Mirror .github/workflows/_build.yml MCP runtime packaging block."""
+    for py in sorted(MCP_ROOT.glob("*.py")):
+        if py.name.startswith("test_"):
+            continue
+        shutil.copy2(py, workdir / py.name)
+
+    mcp_pkg_src = MCP_ROOT / "mcp_server"
+    assert mcp_pkg_src.is_dir(), "mcp_server package must exist in repo"
+    shutil.copytree(
+        mcp_pkg_src,
+        workdir / "mcp_server",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+
+
+def test_mcp_server_package_importable_after_simulated_lambda_packaging():
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        _simulate_mcp_lambda_packaging(workdir)
+        assert (workdir / "server.py").is_file()
+        assert (workdir / "mcp_server" / "actions.py").is_file()
+
+        env = {**os.environ, "PYTHONPATH": str(workdir)}
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import mcp_server.actions; import mcp_server.runtime; print('ok')",
+            ],
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+def test_build_yml_declares_mcp_server_rsync():
+    build_yml = (REPO_ROOT / ".github" / "workflows" / "_build.yml").read_text()
+    assert "mcp_server/" in build_yml
+    assert "ENC-TSK-L63" in build_yml or "ENC-ISS-492" in build_yml


### PR DESCRIPTION
## Summary
- Fix gamma MCP outage (`No module named 'mcp_server'`) after ENC-TSK-L09 by rsync-ing `tools/enceladus-mcp-server/mcp_server/` into Gen2 Lambda artifacts for `coordination_api`, `mcp_code`, `mcp_streamable`, and `mcp_streaming_gateway`.
- Add infrastructure regression test simulating packaged artifact layout and verifying `mcp_server` imports.

## Tracker
- Task: ENC-TSK-L63
- Issue: ENC-ISS-492
- CCI: CCI-9b4cbd738aa34a3f84e48e38e06a8d60

## Test plan
- [x] `pytest tests/infrastructure/test_mcp_server_lambda_packaging.py`
- [ ] CI green on PR
- [ ] Gamma deploy + MCP `connection_health` healthy post-merge


Made with [Cursor](https://cursor.com)