### PR TITLE
ENC-TSK-L64: durable per-task GitHub repo override in checkout_service

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -894,6 +894,42 @@ def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]
         return None, None
 
 
+def _resolve_task_github_repo(task: dict, project_id: str) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the GitHub owner/repo to validate a task's commit/PR/merge against.
+
+    ENC-FTR-119: satellite repos (e.g. enceladus-support) host code for tasks
+    that still live under the primary project's project_id, so the
+    project-level ``repo`` field alone (``_resolve_github_repo``) cannot
+    express "this one task's code is in a different repo than its siblings."
+    Previously the only way to correct that per-call was for the caller to
+    remember to pass ``transition_evidence.owner``/``repo`` at every single
+    advance (committed, pr, merged-main, closed) -- forgetting any one of them
+    silently fell back to the project default and produced a confusing GitHub
+    404/422 far from the real cause.
+
+    A task-level ``github_repo`` field (a plain "owner/repo" string or a full
+    https://github.com/owner/repo URL, settable via the ordinary tracker.set
+    field-update path) is now checked first and, once set, durably overrides
+    the project default for every subsequent advance on that task -- no
+    per-call evidence required. Falls back to ``_resolve_github_repo`` when
+    the task has no override, so ordinary same-repo tasks are unaffected.
+    """
+    task_repo = (task.get("github_repo") or "").strip()
+    if task_repo:
+        if task_repo.startswith("http"):
+            owner, repo = _parse_github_url(task_repo)
+        else:
+            owner, _, repo = task_repo.partition("/")
+            owner, repo = (owner or None), (repo or None)
+        if owner and repo:
+            return owner, repo
+        logger.warning(
+            "Task github_repo override '%s' could not be parsed as owner/repo; "
+            "falling back to project-level resolution.", task_repo,
+        )
+    return _resolve_github_repo(project_id)
+
+
 # ---------------------------------------------------------------------------
 # Token management (DynamoDB)
 # ---------------------------------------------------------------------------
@@ -2458,7 +2494,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         owner = transition_evidence.get("owner")
         repo = transition_evidence.get("repo")
         if not owner or not repo:
-            resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+            resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
             owner = owner or resolved_owner
             repo = repo or resolved_repo
         if not owner or not repo:
@@ -2587,7 +2623,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         owner = transition_evidence.get("owner")
         repo = transition_evidence.get("repo")
         if not owner or not repo:
-            resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+            resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
             owner = owner or resolved_owner
             repo = repo or resolved_repo
         if not owner or not repo:
@@ -2710,7 +2746,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                     owner = transition_evidence.get("owner")
                     repo = transition_evidence.get("repo")
                     if not owner or not repo:
-                        resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+                        resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
                         owner = owner or resolved_owner
                         repo = repo or resolved_repo
                     if not owner or not repo:

--- a/backend/lambda/checkout_service/test_task_github_repo_override.py
+++ b/backend/lambda/checkout_service/test_task_github_repo_override.py
@@ -1,0 +1,99 @@
+"""Unit tests for _resolve_task_github_repo (per-task GitHub repo override).
+
+ENC-FTR-119: satellite repos (e.g. enceladus-support) host code for tasks
+that still live under the primary project's project_id, so the
+project-level ``repo`` field alone (_resolve_github_repo) cannot express
+"this one task's code is in a different repo than its siblings." Before this
+fix, the only way to correct that was for the caller to remember to pass
+transition_evidence.owner/repo at every single advance (committed, pr,
+merged-main, closed) -- forgetting any one of them silently fell back to the
+project default and produced a confusing GitHub 404/422 far from the real
+cause (this is what happened to ENC-TSK-J49: code lived in
+NX-2021-L/enceladus-support but committed/pr validation silently resolved to
+NX-2021-L/enceladus).
+
+These tests guard the new task-level ``github_repo`` override field, which
+once set on a task durably applies to every subsequent advance without
+per-call evidence.
+"""
+
+import importlib.util
+import os
+import unittest
+from unittest.mock import patch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_service",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_service = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(checkout_service)
+
+
+class ResolveTaskGithubRepoTests(unittest.TestCase):
+    def test_task_override_owner_slash_repo_wins_over_project_default(self):
+        task = {"github_repo": "NX-2021-L/enceladus-support"}
+        with patch.object(
+            checkout_service, "_resolve_github_repo"
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus-support"))
+        project_mock.assert_not_called()
+
+    def test_task_override_full_url_is_parsed(self):
+        task = {"github_repo": "https://github.com/NX-2021-L/enceladus-support"}
+        with patch.object(
+            checkout_service, "_resolve_github_repo"
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus-support"))
+        project_mock.assert_not_called()
+
+    def test_no_override_falls_back_to_project_resolution(self):
+        task = {}
+        with patch.object(
+            checkout_service, "_resolve_github_repo",
+            return_value=("NX-2021-L", "enceladus"),
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        project_mock.assert_called_once_with("enceladus")
+
+    def test_blank_override_falls_back_to_project_resolution(self):
+        task = {"github_repo": "   "}
+        with patch.object(
+            checkout_service, "_resolve_github_repo",
+            return_value=("NX-2021-L", "enceladus"),
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        project_mock.assert_called_once_with("enceladus")
+
+    def test_unparseable_override_falls_back_to_project_resolution(self):
+        """A malformed override (no slash, not a URL) should not silently
+        resolve to a broken (owner, None) pair -- fall back to the project
+        default and log a warning instead."""
+        task = {"github_repo": "not-a-valid-repo-string"}
+        with patch.object(
+            checkout_service, "_resolve_github_repo",
+            return_value=("NX-2021-L", "enceladus"),
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        project_mock.assert_called_once_with("enceladus")
+
+    def test_override_with_trailing_slash_segments_takes_first_two(self):
+        task = {"github_repo": "NX-2021-L/enceladus-support/extra"}
+        with patch.object(
+            checkout_service, "_resolve_github_repo"
+        ) as project_mock:
+            owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        # partition() on the first "/" -- repo captures everything after it.
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus-support/extra"))
+        project_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-01.02",
-  "updated_at": "2026-07-01T22:06:00Z",
-  "last_change_summary": "ENC-TSK-J41 v3-prod port (SEV-1 ENC-ISS-465 cost kill, via DOC-B716E8FB10B6 Channel A): graph_query_api adds GDS_HARD_DISABLED env gate (_check_gds_available->False; forces cypher_fallback, no Aura Graph Analytics session). 02-compute.yaml prefix->AWS::NoValue, GDS_HARD_DISABLED=1, StandingProjectionRefreshSchedule State=DISABLED. Env-gate only; no new record schema/edge types.",
+  "version": "2026-07-05.1",
+  "updated_at": "2026-07-05T00:00:00Z",
+  "last_change_summary": "ENC-TSK checkout_service fix: added tracker.task.github_repo per-task GitHub repo override field, checked by the new checkout_service._resolve_task_github_repo before falling back to project-level repo resolution at the committed/pr/merged-main/closed GitHub-validation gates (ENC-FTR-119 satellite-repo support).",
   "owners": [
     "enceladus-platform"
   ],
@@ -301,6 +301,11 @@
             "undeclared"
           ],
           "definition": "Deploy target for this task. 'prod' targets v3/main, 'gamma' targets v4/gamma stack, 'undeclared' (default) awaits labeling."
+        },
+        "github_repo": {
+          "type": "string",
+          "definition": "Optional per-task GitHub repo override, as \"owner/repo\" or a full https://github.com/owner/repo URL. ENC-FTR-119: satellite repos (e.g. enceladus-support) host code for tasks that still live under the primary project's project_id, so the project-level repo field alone (projects table / checkout_service._resolve_github_repo) cannot express \"this one task's code is in a different repo than its siblings.\" When set, checkout_service._resolve_task_github_repo checks this field BEFORE falling back to the project-level default, for every commit/PR/merged-main/closed gate that validates against GitHub -- no per-call transition_evidence.owner/repo required. Unset by default; ordinary same-repo tasks are unaffected.",
+          "usage_guidance": "Set via ordinary tracker.set field update (field=github_repo) any time prior to the first GitHub-validated advance (committed). Per-call transition_evidence.owner/repo still takes precedence over this field when both are present. A malformed value (no '/' and not an http(s) URL) is ignored with a warning and falls back to the project-level resolution rather than failing the advance."
         },
         "closed_count": {
           "type": "integer",
@@ -5838,6 +5843,11 @@
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
   "change_log": [
+    {
+      "version": "2026-07-05.1",
+      "date": "2026-07-05",
+      "summary": "Added tracker.task.github_repo optional field: durable per-task override of GitHub owner/repo for commit/PR/merge validation in checkout_service (new _resolve_task_github_repo helper), so ENC-FTR-119 satellite-repo tasks (e.g. code living in enceladus-support under the enceladus project_id) do not need transition_evidence.owner/repo passed on every advance."
+    },
     {
       "version": "2026-06-30.01",
       "date": "2026-06-30",


### PR DESCRIPTION
## Summary
- ENC-TSK-J49 (enceladus-support satellite repo pipeline port) stalled at coding-complete: checkout_service's committed/pr/merged-main/closed gates resolve GitHub owner/repo from the project's own `repo` field (`enceladus` -> `NX-2021-L/enceladus`), with no durable way for one task under that project_id to point at a different repo (`NX-2021-L/enceladus-support`). Validation silently checked the wrong repo and returned a confusing 404/422 far from the real cause.
- Adds a task-level `github_repo` override field (`owner/repo` string or full GitHub URL), checked by a new `_resolve_task_github_repo` helper before falling back to the existing project-level `_resolve_github_repo` default. Wired into all three GitHub-validation call sites (committed, merged-main, closed/code_on_main). Per-call `transition_evidence.owner`/`repo` still takes precedence when present, so ordinary same-repo tasks are unaffected.
- Documents `tracker.task.github_repo` in `governance_data_dictionary.json` (bumped to 2026-07-05.1) per the CI Governance Dictionary Guard.

CCI-97d4d3cc7ae841f891823f357407da28

## Test plan
- [x] New `test_task_github_repo_override.py` (6 tests): override wins over project default, full-URL override parsed, no-override falls back, blank-override falls back, malformed-override falls back with a warning (not a hard failure), multi-slash value takes first segment as owner.
- [x] Full existing `checkout_service` test suite (98 tests) passes unmodified against `origin/main` plus this change.
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check on the modified Lambda.
- [x] `governance_data_dictionary.json` validated as parseable JSON; diff is minimal (no reformatting noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)