### PR TITLE
feat(opensearch): records_v{n} index template + aliases (ENC-TSK-L40)

### DIFF
--- a/infrastructure/opensearch/README.md
+++ b/infrastructure/opensearch/README.md
@@ -1,0 +1,74 @@
+# ENC-TSK-L40 Records Index (OpenSearch)
+
+Index schema, mappings, and alias contract for the `records_v{n}` index
+backing Search2.0 (ENC-FTR-127 / ENC-TSK-B67). Applied against the gamma
+single-node OpenSearch cluster provisioned by ENC-TSK-L39
+(`infrastructure/cloudformation/10-opensearch-node.yaml`).
+
+## Naming contract
+
+- The physical index is always **versioned**: `records_v1`, `records_v2`, ...
+  Never create a bare `records` index or alias — OpenSearch forbids an alias
+  sharing a name with a physical index, which would block the exact
+  zero-downtime reindex this scheme exists for.
+- `records_read` and `records_write` are aliases, always pointing at the
+  current physical index. `records_write` is the alias's `is_write_index`.
+- **L41** (indexer, not yet built) must write exclusively via `records_write`.
+- **L43** (query layer, not yet built) must read exclusively via `records_read`.
+- To reindex (mapping change, etc.): create `records_v{n+1}`, backfill, then
+  atomically repoint both aliases via `_aliases` (as `apply_records_index.py`
+  does for the initial version) and delete the old physical index once
+  traffic has drained.
+
+## Schema (`index-templates/records-v1.json`)
+
+Composable index template on pattern `records_v*`, priority 200 (above the
+bootstrap-time `enceladus-default-replicas-zero` template on `enceladus-*`
+from `bootstrap-node.sh`, which this deliberately does not depend on).
+
+- Keyword facets: `project_id`, `record_type`, `status`, `priority`, `tags`.
+- Text fields (`title`, `description`, `body`): `search_as_you_type` mapping
+  type gives the `._2gram` / `._3gram` / `._index_prefix` subfields needed for
+  prefix/autocomplete `bool_prefix` queries, analyzed with a custom
+  `enceladus_text_analyzer` (standard tokenizer + lowercase + asciifolding)
+  for accent-insensitive matching.
+- Dates: `created_at`, `updated_at`.
+- `version_seq` (long): **interim contract is `updated_at` epoch-millis**,
+  written by whatever indexes into `records_write`. Cut over to a real
+  monotonic sequence once ENC-TSK-L27 ships an authoritative version source;
+  the field name does not need to change, only what populates it.
+- 1 primary shard, 0 replicas (single-node cluster, matches L39 sizing).
+
+## Applying (VPC/SSM-only reachable — no GitHub Actions path)
+
+The node has no public ingress (security group only allows :9200 from the
+VPC CIDR); there is no existing "apply to a private EC2 instance via SSM"
+GitHub Actions pattern in this repo; the same precedent as
+`tools/neo4j-migrations/` (`README.md` there) applies: ship the schema as a
+versioned artifact + idempotent apply script, run manually by whoever has
+AWS + SSM access, with results captured as tracker evidence rather than
+piped through CI.
+
+Run directly on the instance (session via `aws ssm start-session`, or an
+`aws ssm send-command` shell-script document) using the AWS profile
+sanctioned for gamma OpenSearch node access:
+
+```bash
+# From an operator session with SSM access to the gamma OpenSearch instance:
+ADMIN_PASSWORD="$(tr -d '\n' < /root/.opensearch-admin-password)" \
+  python3 infrastructure/opensearch/apply_records_index.py --version 1
+
+ADMIN_PASSWORD="$(tr -d '\n' < /root/.opensearch-admin-password)" \
+  python3 infrastructure/opensearch/smoke_test_records_index.py
+```
+
+After running, capture the smoke test's JSON output (exact-term hit count,
+prefix/autocomplete hit count, fuzzy hit count, faceted aggregation buckets)
+and attach it to ENC-TSK-L40's `live_validation_evidence`.
+
+## Governance
+
+This directory is not under a registered component in the component
+registry (ENC-FTR-041); it pairs with `comp-search` once L41/L43 (indexer /
+query layer Lambdas) are scoped, similar to how `tools/neo4j-migrations/`
+pairs with `comp-graph-sync`.

--- a/infrastructure/opensearch/apply_records_index.py
+++ b/infrastructure/opensearch/apply_records_index.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""ENC-TSK-L40 — apply the records_v{n} index template + read/write aliases.
+
+Idempotent: safe to re-run. Creates the versioned physical index if absent,
+applies the index template (composable, pattern records_v*), and points
+records_read / records_write aliases at it. Never creates or writes to a
+bare "records" index/alias -- OpenSearch forbids an alias sharing a name
+with a physical index (see README.md).
+
+Run on the OpenSearch node itself (VPC/SSM-only reachable -- no public
+ingress, see infrastructure/cloudformation/10-opensearch-node.yaml):
+
+    ADMIN_PASSWORD="$(tr -d '\\n' < /root/.opensearch-admin-password)" \\
+      python3 apply_records_index.py --version 1
+
+Or via SSM send-command from an operator machine with AWS creds -- see
+README.md for the exact invocation.
+"""
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+TEMPLATE_PATH = Path(__file__).parent / "index-templates" / "records-v1.json"
+TEMPLATE_NAME = "records-index-template"
+
+
+def _request(host, method, path, admin_password, body=None):
+    url = f"{host}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    import base64
+
+    auth = base64.b64encode(f"admin:{admin_password}".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", type=int, required=True, help="Physical index version n (records_v{n})")
+    parser.add_argument("--host", default="https://127.0.0.1:9200")
+    parser.add_argument("--admin-password", default=os.environ.get("ADMIN_PASSWORD"))
+    args = parser.parse_args()
+
+    if not args.admin_password:
+        print("ADMIN_PASSWORD env var or --admin-password required", file=sys.stderr)
+        sys.exit(1)
+
+    index_name = f"records_v{args.version}"
+    template_body = json.loads(TEMPLATE_PATH.read_text())
+
+    status, resp = _request(args.host, "PUT", f"/_index_template/{TEMPLATE_NAME}", args.admin_password, template_body)
+    print(f"[template] PUT /_index_template/{TEMPLATE_NAME} -> {status} {resp}")
+    if status not in (200, 201):
+        sys.exit(f"Failed to apply index template: {resp}")
+
+    status, resp = _request(args.host, "HEAD", f"/{index_name}", args.admin_password)
+    if status == 200:
+        print(f"[index] {index_name} already exists, skipping create")
+    else:
+        status, resp = _request(args.host, "PUT", f"/{index_name}", args.admin_password)
+        print(f"[index] PUT /{index_name} -> {status} {resp}")
+        if status not in (200, 201):
+            sys.exit(f"Failed to create index {index_name}: {resp}")
+
+    alias_actions = {
+        "actions": [
+            {"add": {"index": index_name, "alias": "records_read"}},
+            {"add": {"index": index_name, "alias": "records_write", "is_write_index": True}},
+        ]
+    }
+    status, resp = _request(args.host, "POST", "/_aliases", args.admin_password, alias_actions)
+    print(f"[aliases] POST /_aliases -> {status} {resp}")
+    if status not in (200, 201):
+        sys.exit(f"Failed to apply aliases: {resp}")
+
+    print(f"records_read / records_write now point at {index_name}. Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/infrastructure/opensearch/index-templates/records-v1.json
+++ b/infrastructure/opensearch/index-templates/records-v1.json
@@ -1,0 +1,45 @@
+{
+  "index_patterns": ["records_v*"],
+  "priority": 200,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "analysis": {
+        "analyzer": {
+          "enceladus_text_analyzer": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["lowercase", "asciifolding"]
+          }
+        }
+      }
+    },
+    "mappings": {
+      "properties": {
+        "project_id": { "type": "keyword" },
+        "record_type": { "type": "keyword" },
+        "status": { "type": "keyword" },
+        "priority": { "type": "keyword" },
+        "tags": { "type": "keyword" },
+        "title": {
+          "type": "search_as_you_type",
+          "analyzer": "enceladus_text_analyzer"
+        },
+        "description": {
+          "type": "search_as_you_type",
+          "analyzer": "enceladus_text_analyzer"
+        },
+        "body": {
+          "type": "search_as_you_type",
+          "analyzer": "enceladus_text_analyzer"
+        },
+        "created_at": { "type": "date" },
+        "updated_at": { "type": "date" },
+        "version_seq": {
+          "type": "long"
+        }
+      }
+    }
+  }
+}

--- a/infrastructure/opensearch/smoke_test_records_index.py
+++ b/infrastructure/opensearch/smoke_test_records_index.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""ENC-TSK-L40 AC-3 smoke test: indexes one sample record via records_write and
+queries it back via records_read for exact-term, prefix/autocomplete, fuzzy,
+and faceted-aggregation. Prints a JSON evidence blob suitable for
+live_validation_evidence.
+
+    ADMIN_PASSWORD="$(tr -d '\\n' < /root/.opensearch-admin-password)" \\
+      python3 smoke_test_records_index.py
+"""
+import argparse
+import base64
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SAMPLE_DOC = {
+    "project_id": "enceladus",
+    "record_type": "task",
+    "status": "open",
+    "priority": "P1",
+    "tags": ["search", "opensearch"],
+    "title": "B67 Search2.0 OpenSearch smoke test record",
+    "description": "Synthetic record used to verify records_v1 mappings and analyzers.",
+    "body": "Exact term, prefix autocomplete, and fuzzy matching should all resolve this document.",
+    "created_at": "2026-07-05T00:00:00Z",
+    "updated_at": "2026-07-05T00:00:00Z",
+    "version_seq": 1751673600000,
+}
+
+
+def _request(host, method, path, admin_password, body=None):
+    url = f"{host}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    auth = base64.b64encode(f"admin:{admin_password}".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="https://127.0.0.1:9200")
+    parser.add_argument("--admin-password", default=os.environ.get("ADMIN_PASSWORD"))
+    args = parser.parse_args()
+    if not args.admin_password:
+        print("ADMIN_PASSWORD env var or --admin-password required", file=sys.stderr)
+        sys.exit(1)
+
+    host, pw = args.host, args.admin_password
+    evidence = {}
+
+    status, resp = _request(host, "POST", "/records_write/_doc/smoke-l40-1?refresh=true", pw, SAMPLE_DOC)
+    evidence["index"] = {"status": status, "result": resp.get("result", resp)}
+    if status not in (200, 201):
+        sys.exit(f"Index failed: {resp}")
+
+    time.sleep(1)
+
+    status, resp = _request(host, "GET", "/records_read/_search", pw, {"query": {"term": {"record_type": "task"}}})
+    evidence["exact_term"] = {"status": status, "hits": resp.get("hits", {}).get("total", {})}
+
+    status, resp = _request(
+        host, "GET", "/records_read/_search", pw,
+        {"query": {"multi_match": {"query": "smok", "type": "bool_prefix", "fields": ["title", "title._2gram", "title._3gram"]}}},
+    )
+    evidence["prefix_autocomplete"] = {"status": status, "hits": resp.get("hits", {}).get("total", {})}
+
+    status, resp = _request(
+        host, "GET", "/records_read/_search", pw,
+        {"query": {"match": {"title": {"query": "smoke tset", "fuzziness": "AUTO"}}}},
+    )
+    evidence["fuzzy"] = {"status": status, "hits": resp.get("hits", {}).get("total", {})}
+
+    status, resp = _request(
+        host, "GET", "/records_read/_search", pw,
+        {"size": 0, "aggs": {"by_status": {"terms": {"field": "status"}}, "by_priority": {"terms": {"field": "priority"}}}},
+    )
+    evidence["faceted_aggregation"] = {"status": status, "aggregations": resp.get("aggregations", {})}
+
+    print(json.dumps(evidence, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds the versioned `records_v{n}` OpenSearch index template (keyword facets, `search_as_you_type` autocomplete subfields with an asciifolding+lowercase analyzer, date fields, interim `version_seq` = `updated_at` epoch-millis per the AC's contract until ENC-TSK-L27 ships a real sequence).
- Adds an idempotent apply script that creates `records_v1` and points `records_read`/`records_write` aliases at it — never a bare `records` index/alias, since OpenSearch forbids an alias sharing a name with a physical index.
- Adds a smoke test covering exact-term, prefix/autocomplete, fuzzy, and faceted-aggregation queries (AC-3).

No CFN/Lambda changes — the OpenSearch node (ENC-TSK-L39) has no public/CI-reachable ingress, so this mirrors the `tools/neo4j-migrations/` precedent: ship a versioned schema artifact + manual apply script, run via SSM against the instance, evidence captured on the tracker task rather than piped through CI.

**Note:** Live application (AC-3 verification) is currently blocked — ENC-TSK-L39's OpenSearch node bootstrap script has an unresolved bug (disk space exhaustion during package extraction, being fixed by ENC-SES-04Q). This PR ships the schema/tooling; live verification will follow once the node is up.

## Test plan
- [x] `python3 -m json.tool` on the index template — valid JSON
- [x] `python3 -m py_compile` on both scripts — valid syntax
- [ ] Live apply + smoke test against the gamma OpenSearch node (blocked on ENC-TSK-L39 bootstrap fix)

CCI-d81476251bfd482e99bf09dd7700cf12

🤖 Generated with [Claude Code](https://claude.com/claude-code)