### PR TITLE
fix(cfn): codify missing changelog_api Lambda invoke permission (ENC-TSK-L65)

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -948,6 +948,19 @@ Resources:
       IntegrationMethod: POST
       PayloadFormatVersion: '2.0'
 
+  # ENC-TSK-L65: neither prod nor gamma ever had an AWS::Lambda::Permission for
+  # this integration -- discovered when GET /api/v1/changelog/history returned
+  # a generic API-Gateway 500 with zero Lambda invocations (no resource policy
+  # existed at all). Applies unconditionally (both envs), matching the
+  # unconditional ChangelogApiIntegration above.
+  ChangelogApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub "devops-changelog-api${EnvironmentSuffix}"
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*/api/v1/changelog/*"
+
   # ---------------------------------------------------------------------------
   # ENC-TSK-L10 (B64 Ph3): REST API Gateway (v1) for Lambda response streaming.
   # A SEPARATE API from HttpApi above -- HTTP API v2 (AWS::ApiGatewayV2) does not


### PR DESCRIPTION
## Summary
- Neither prod nor gamma ever declared an `AWS::Lambda::Permission` for `devops-changelog-api`, despite the HTTP API route being correctly wired — discovered when `GET /api/v1/changelog/history` returned a generic API-Gateway 500 with zero Lambda invocations during ENC-TSK-L33 live verification (`lambda get-policy` returned `ResourceNotFoundException` — no resource policy existed at all). A manual CLI grant unblocked that verification at the time, but any CFN drift-reconciliation or stack redeploy recreating this Lambda would silently drop it.
- Adds `ChangelogApiInvokePermission`, mirroring the existing `GraphQueryApiInvokePermission` pattern, scoped to `/api/v1/changelog/*`, applied unconditionally (both prod and gamma) to match the unconditional `ChangelogApiIntegration` it backs.

## Test plan
- [x] `cfn-lint infrastructure/cloudformation/03-api.yaml` — no new errors/warnings introduced by this change (pre-existing W3011/W2001 warnings unrelated)
- [ ] `aws cloudformation detect-stack-drift` shows the permission as `IN_SYNC` post-deploy (AC-2)
- [ ] `GET /api/v1/changelog/history` continues returning a structured Lambda response post-deploy (AC-3)

CCI-426259b983724919bae5f37452f73296

🤖 Generated with [Claude Code](https://claude.com/claude-code)