### PR TITLE
feat(ui-v2): offline layer — Workbox, mutation queue, If-Match/409 (ENC-TSK-K25)

### DIFF
--- a/frontend/ui-v2/src/api/mutations.ts
+++ b/frontend/ui-v2/src/api/mutations.ts
@@ -1,0 +1,212 @@
+/**
+ * Tracker mutation API — If-Match revision contract (ENC-TSK-L47 / K25 AC-3).
+ * Offline queue integration (K25 AC-18).
+ */
+
+import { API_BASE, SessionExpiredError } from './client'
+import {
+  enqueueMutation,
+  type QueuedMutation,
+} from '../offline/mutationQueue'
+import { useOfflineStore } from '../store/offlineStore'
+
+export const GOVERNANCE_CRITICAL_FIELDS = [
+  'status',
+  'priority',
+  'transition_type',
+  'acceptance_criteria',
+] as const
+
+export interface MutationResult {
+  success: boolean
+  record_id: string
+  updated_at: string
+  updated_status?: string
+  sync_version?: number
+}
+
+export interface RevisionConflictDetails {
+  code: 'REVISION_CONFLICT'
+  field?: string
+  record_id: string
+  record_type?: string
+  expected_revision?: string
+  current_revision?: number
+  current?: Record<string, unknown>
+}
+
+export class RevisionConflictError extends Error {
+  readonly status = 409
+  readonly details: RevisionConflictDetails
+
+  constructor(message: string, details: RevisionConflictDetails) {
+    super(message)
+    this.name = 'RevisionConflictError'
+    this.details = details
+  }
+}
+
+export function isRevisionConflictError(error: unknown): error is RevisionConflictError {
+  return error instanceof RevisionConflictError
+}
+
+export function readSyncVersion(record: unknown): number | undefined {
+  if (!record || typeof record !== 'object') return undefined
+  const raw = (record as { sync_version?: unknown }).sync_version
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  if (typeof raw === 'string' && raw.trim()) {
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+interface PatchOptions {
+  ifMatchRevision?: number
+  skipOfflineQueue?: boolean
+}
+
+async function parseErrorBody(res: Response): Promise<Record<string, unknown>> {
+  try {
+    return (await res.json()) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+async function sendMutationRequest(
+  url: string,
+  method: 'PATCH' | 'POST' | 'DELETE',
+  body: Record<string, unknown>,
+  headers: Record<string, string>,
+): Promise<MutationResult> {
+  const res = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: {
+      'content-type': 'application/json',
+      'x-requested-with': 'XMLHttpRequest',
+      accept: 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  })
+
+  if (res.status === 401) throw new SessionExpiredError()
+
+  const data = await parseErrorBody(res)
+
+  if (res.status === 409 && data.code === 'REVISION_CONFLICT') {
+    throw new RevisionConflictError(
+      String(data.error ?? 'Revision conflict'),
+      {
+        code: 'REVISION_CONFLICT',
+        field: typeof data.field === 'string' ? data.field : undefined,
+        record_id: String(data.record_id ?? ''),
+        record_type: typeof data.record_type === 'string' ? data.record_type : undefined,
+        expected_revision:
+          typeof data.expected_revision === 'string' ? data.expected_revision : undefined,
+        current_revision:
+          typeof data.current_revision === 'number' ? data.current_revision : undefined,
+        current:
+          typeof data.current === 'object' && data.current
+            ? (data.current as Record<string, unknown>)
+            : undefined,
+      },
+    )
+  }
+
+  if (!res.ok) {
+    throw new Error(String(data.error ?? `Mutation failed (${res.status})`))
+  }
+
+  return data as MutationResult
+}
+
+export async function patchTrackerRecord(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan' | 'lesson',
+  recordId: string,
+  body: Record<string, unknown>,
+  options: PatchOptions = {},
+): Promise<MutationResult> {
+  const url = `${API_BASE}/tracker/${encodeURIComponent(projectId)}/${recordType}/${encodeURIComponent(recordId)}`
+  const headers: Record<string, string> = {}
+  if (options.ifMatchRevision !== undefined) {
+    headers['If-Match'] = String(options.ifMatchRevision)
+  }
+
+  if (typeof navigator !== 'undefined' && !navigator.onLine && !options.skipOfflineQueue) {
+    await enqueueMutation({ url, method: 'PATCH', body, headers })
+    await useOfflineStore.getState().refreshPendingCount()
+    return {
+      success: true,
+      record_id: recordId,
+      updated_at: new Date().toISOString(),
+    }
+  }
+
+  return sendMutationRequest(url, 'PATCH', body, headers)
+}
+
+export async function replayQueuedMutation(entry: QueuedMutation): Promise<boolean> {
+  try {
+    await sendMutationRequest(entry.url, entry.method, entry.body, entry.headers)
+    return true
+  } catch (error) {
+    if (error instanceof RevisionConflictError) return false
+    if (error instanceof SessionExpiredError) return false
+    return false
+  }
+}
+
+export async function closeRecord(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan',
+  recordId: string,
+  ifMatchRevision?: number,
+): Promise<MutationResult> {
+  return patchTrackerRecord(projectId, recordType, recordId, { action: 'close' }, { ifMatchRevision })
+}
+
+export async function submitNote(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan',
+  recordId: string,
+  note: string,
+  ifMatchRevision?: number,
+): Promise<MutationResult> {
+  return patchTrackerRecord(projectId, recordType, recordId, { action: 'note', note }, { ifMatchRevision })
+}
+
+export async function setField(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan' | 'lesson',
+  recordId: string,
+  field: string,
+  value: string,
+  ifMatchRevision?: number,
+): Promise<MutationResult> {
+  return patchTrackerRecord(
+    projectId,
+    recordType,
+    recordId,
+    { field, value },
+    { ifMatchRevision },
+  )
+}
+
+export function mergeConflictFields(
+  clientField: string,
+  clientValue: unknown,
+  serverRecord: Record<string, unknown> | undefined,
+): 'server-wins' | 'side-by-side' {
+  if (GOVERNANCE_CRITICAL_FIELDS.includes(clientField as (typeof GOVERNANCE_CRITICAL_FIELDS)[number])) {
+    return 'server-wins'
+  }
+  if (!serverRecord) return 'side-by-side'
+  const serverValue = serverRecord[clientField]
+  if (serverValue === clientValue) return 'server-wins'
+  return 'side-by-side'
+}

--- a/frontend/ui-v2/src/components/OfflineLayer.tsx
+++ b/frontend/ui-v2/src/components/OfflineLayer.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { Alert, Button, Flashbar, Modal } from '../design-system'
+import { useOfflineStore } from '../store/offlineStore'
+import { replayQueuedMutation } from '../api/mutations'
+import {
+  mergeConflictFields,
+  type RevisionConflictError,
+} from '../api/mutations'
+import type { ConflictMergeState } from '../hooks/useRecordMutation'
+import { registerConflictMergeHandler } from '../hooks/useRecordMutation'
+
+export function OfflinePendingFlashbar() {
+  const pendingCount = useOfflineStore((s) => s.pendingCount)
+  const swUpdateReady = useOfflineStore((s) => s.swUpdateReady)
+  const refreshPendingCount = useOfflineStore((s) => s.refreshPendingCount)
+  const replayQueue = useOfflineStore((s) => s.replayQueue)
+  const setSwUpdateReady = useOfflineStore((s) => s.setSwUpdateReady)
+
+  useEffect(() => {
+    void refreshPendingCount()
+    const onOnline = () => {
+      void replayQueue(replayQueuedMutation).then(() => refreshPendingCount())
+    }
+    window.addEventListener('online', onOnline)
+    return () => window.removeEventListener('online', onOnline)
+  }, [refreshPendingCount, replayQueue])
+
+  const items = []
+  if (pendingCount > 0) {
+    items.push({
+      id: 'offline-pending',
+      type: 'in-progress' as const,
+      header: `${pendingCount} change${pendingCount === 1 ? '' : 's'} pending sync`,
+      content: 'Saved locally while offline. Mutations replay automatically when connectivity returns.',
+      loading: true,
+    })
+  }
+  if (swUpdateReady) {
+    items.push({
+      id: 'sw-update',
+      type: 'info' as const,
+      header: 'App update available',
+      content: 'A new version is ready. Reload when your current edits are complete.',
+      dismissible: true,
+      onDismiss: () => setSwUpdateReady(false),
+    })
+  }
+
+  if (items.length === 0) return null
+  return <Flashbar items={items} />
+}
+
+export function ConflictMergeModal() {
+  const [state, setState] = useState<ConflictMergeState>({ open: false, error: null, vars: null })
+
+  useEffect(() => {
+    registerConflictMergeHandler(setState)
+    return () => registerConflictMergeHandler(() => {})
+  }, [])
+
+  if (!state.open || !state.error || !state.vars) return null
+
+  const server = state.error.details.current ?? {}
+  const field = state.vars.field ?? 'status'
+  const clientValue = state.vars.value
+  const serverValue = server[field]
+  const mode = mergeConflictFields(field, clientValue, server)
+
+  return (
+    <Modal
+      visible
+      header="Revision conflict — merge required"
+      onDismiss={() => setState({ open: false, error: null, vars: null })}
+      footer={
+        <Button variant="primary" onClick={() => setState({ open: false, error: null, vars: null })}>
+          Acknowledge
+        </Button>
+      }
+    >
+      <Alert type="warning" header="409 If-Match mismatch">
+        {mode === 'server-wins'
+          ? `Governance-critical field "${field}" — server value is authoritative.`
+          : `Field "${field}" changed concurrently — review both values.`}
+      </Alert>
+      <div className="mt-4 grid gap-3 text-sm">
+        <div>
+          <strong>Your change</strong>
+          <pre className="mt-1 rounded bg-slate-900/40 p-2 font-mono text-xs">{String(clientValue ?? '—')}</pre>
+        </div>
+        <div>
+          <strong>Server state</strong>
+          <pre className="mt-1 rounded bg-slate-900/40 p-2 font-mono text-xs">{String(serverValue ?? '—')}</pre>
+        </div>
+        <p className="text-slate-400">
+          Expected revision {state.error.details.expected_revision ?? '—'}, server at{' '}
+          {state.error.details.current_revision ?? '—'}.
+        </p>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/ui-v2/src/design-system/index.d.ts
+++ b/frontend/ui-v2/src/design-system/index.d.ts
@@ -24,3 +24,5 @@ export { Select } from '../../../design-system-2/v2/components/Select/Select.jsx
 export { Table } from '../../../design-system-2/v2/components/Table/Table.jsx'
 export { Tabs } from '../../../design-system-2/v2/components/Tabs/Tabs.jsx'
 export { StatusIndicator } from '../../../design-system-2/v2/components/StatusIndicator/StatusIndicator.jsx'
+export { Flashbar } from '../../../design-system-2/v2/components/Flashbar/Flashbar.jsx'
+export { Alert } from '../../../design-system-2/v2/components/Alert/Alert.jsx'

--- a/frontend/ui-v2/src/design-system/index.js
+++ b/frontend/ui-v2/src/design-system/index.js
@@ -25,3 +25,5 @@ export { Select } from '../../../design-system-2/v2/components/Select/Select.jsx
 export { Table } from '../../../design-system-2/v2/components/Table/Table.jsx'
 export { Tabs } from '../../../design-system-2/v2/components/Tabs/Tabs.jsx'
 export { StatusIndicator } from '../../../design-system-2/v2/components/StatusIndicator/StatusIndicator.jsx'
+export { Flashbar } from '../../../design-system-2/v2/components/Flashbar/Flashbar.jsx'
+export { Alert } from '../../../design-system-2/v2/components/Alert/Alert.jsx'

--- a/frontend/ui-v2/src/hooks/useRecordMutation.ts
+++ b/frontend/ui-v2/src/hooks/useRecordMutation.ts
@@ -1,0 +1,96 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  closeRecord,
+  mergeConflictFields,
+  readSyncVersion,
+  setField,
+  submitNote,
+  type MutationResult,
+  type RevisionConflictError,
+  isRevisionConflictError,
+} from '../api/mutations'
+import { recordKeys } from '../api/queryOptions'
+
+type RecordType = 'task' | 'issue' | 'feature' | 'plan'
+
+interface MutationVars {
+  projectId: string
+  recordType: RecordType
+  recordId: string
+  action: 'close' | 'note' | 'set_field'
+  note?: string
+  field?: string
+  value?: string
+  syncVersion?: number
+}
+
+export interface ConflictMergeState {
+  open: boolean
+  error: RevisionConflictError | null
+  vars: MutationVars | null
+}
+
+let conflictHandler: ((state: ConflictMergeState) => void) | null = null
+
+export function registerConflictMergeHandler(handler: (state: ConflictMergeState) => void): void {
+  conflictHandler = handler
+}
+
+/**
+ * Optimistic tracker mutations with If-Match revision headers (K25 / K23 pattern).
+ */
+export function useRecordMutation() {
+  const qc = useQueryClient()
+
+  return useMutation<MutationResult, Error, MutationVars>({
+    mutationFn: async (vars) => {
+      const revision = vars.syncVersion ?? undefined
+      if (vars.action === 'close') {
+        return closeRecord(vars.projectId, vars.recordType, vars.recordId, revision)
+      }
+      if (vars.action === 'note') {
+        return submitNote(vars.projectId, vars.recordType, vars.recordId, vars.note ?? '', revision)
+      }
+      return setField(
+        vars.projectId,
+        vars.recordType,
+        vars.recordId,
+        vars.field!,
+        vars.value!,
+        revision,
+      )
+    },
+    onMutate: async (vars) => {
+      if (vars.action !== 'set_field' || vars.field !== 'status' || !vars.value) {
+        return { snapshot: undefined }
+      }
+      const key = recordKeys.detail(vars.recordType, vars.projectId, vars.recordId)
+      await qc.cancelQueries({ queryKey: key })
+      const snapshot = qc.getQueryData(key)
+      return { snapshot }
+    },
+    onError: (error, vars, context) => {
+      if (isRevisionConflictError(error)) {
+        conflictHandler?.({ open: true, error, vars })
+        return
+      }
+      if (context?.snapshot !== undefined && vars) {
+        qc.setQueryData(
+          recordKeys.detail(vars.recordType, vars.projectId, vars.recordId),
+          context.snapshot,
+        )
+      }
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({
+        queryKey: recordKeys.detail(vars.recordType, vars.projectId, vars.recordId),
+      })
+    },
+  })
+}
+
+export function extractRevisionFromRecord(record: unknown): number | undefined {
+  return readSyncVersion(record)
+}
+
+export { mergeConflictFields, isRevisionConflictError }

--- a/frontend/ui-v2/src/main.tsx
+++ b/frontend/ui-v2/src/main.tsx
@@ -2,18 +2,32 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
+import { registerSW } from 'virtual:pwa-register'
 import { queryClient } from './api/queryClient'
 import { projectRegistryQueryOptions } from './api/projectRegistry'
 import { router } from './routes/router'
 import { RealtimeFeedProvider } from './realtime/RealtimeFeedProvider'
 import { CacheEngineProvider } from './sync/CacheEngineProvider'
 import { AuthGate } from './auth/AuthGate'
+import { useOfflineStore } from './store/offlineStore'
 import './styles.css'
 
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element #root not found')
 
 void queryClient.prefetchQuery(projectRegistryQueryOptions)
+
+if ('serviceWorker' in navigator) {
+  registerSW({
+    immediate: true,
+    onNeedRefresh() {
+      useOfflineStore.getState().setSwUpdateReady(true)
+    },
+    onOfflineReady() {
+      /* precache warm — no auto reload (registerType: prompt) */
+    },
+  })
+}
 
 createRoot(rootEl).render(
   <StrictMode>

--- a/frontend/ui-v2/src/offline/mutationQueue.ts
+++ b/frontend/ui-v2/src/offline/mutationQueue.ts
@@ -1,0 +1,127 @@
+/**
+ * Application-layer offline mutation queue (B67 AC-18 / DOC-E470AC8CE9A8 §7.2).
+ * Complements Workbox BackgroundSync with UI-visible pendingCount.
+ */
+
+const DB_NAME = 'enceladus-ui-v2-offline'
+const STORE = 'pendingMutations'
+
+export interface QueuedMutation {
+  id: string
+  url: string
+  method: 'PATCH' | 'POST' | 'DELETE'
+  body: Record<string, unknown>
+  headers: Record<string, string>
+  enqueuedAt: string
+}
+
+type MemoryQueue = QueuedMutation[]
+
+let memoryQueue: MemoryQueue = []
+
+function openDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('indexedDB unavailable'))
+  }
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('indexedDB open failed'))
+  })
+}
+
+async function listAll(): Promise<QueuedMutation[]> {
+  try {
+    const db = await openDb()
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly')
+      const store = tx.objectStore(STORE)
+      const req = store.getAll()
+      req.onsuccess = () => resolve((req.result as QueuedMutation[]) ?? [])
+      req.onerror = () => reject(req.error ?? new Error('indexedDB read failed'))
+    })
+  } catch {
+    return [...memoryQueue]
+  }
+}
+
+async function put(entry: QueuedMutation): Promise<void> {
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).put(entry)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('indexedDB write failed'))
+    })
+  } catch {
+    memoryQueue = [...memoryQueue.filter((m) => m.id !== entry.id), entry]
+  }
+}
+
+async function remove(id: string): Promise<void> {
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).delete(id)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('indexedDB delete failed'))
+    })
+  } catch {
+    memoryQueue = memoryQueue.filter((m) => m.id !== id)
+  }
+}
+
+export async function getPendingMutationCount(): Promise<number> {
+  const rows = await listAll()
+  return rows.length
+}
+
+export async function enqueueMutation(
+  input: Omit<QueuedMutation, 'id' | 'enqueuedAt'>,
+): Promise<QueuedMutation> {
+  const entry: QueuedMutation = {
+    ...input,
+    id: crypto.randomUUID(),
+    enqueuedAt: new Date().toISOString(),
+  }
+  await put(entry)
+  return entry
+}
+
+export async function drainMutationQueue(
+  send: (entry: QueuedMutation) => Promise<boolean>,
+): Promise<number> {
+  const rows = await listAll()
+  let replayed = 0
+  for (const entry of rows.sort((a, b) => a.enqueuedAt.localeCompare(b.enqueuedAt))) {
+    const ok = await send(entry)
+    if (!ok) break
+    await remove(entry.id)
+    replayed += 1
+  }
+  return replayed
+}
+
+/** Test-only reset */
+export async function clearMutationQueueForTests(): Promise<void> {
+  memoryQueue = []
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).clear()
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error ?? new Error('indexedDB clear failed'))
+    })
+  } catch {
+    /* memory fallback already cleared */
+  }
+}

--- a/frontend/ui-v2/src/offline/offlineLayer.test.ts
+++ b/frontend/ui-v2/src/offline/offlineLayer.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearMutationQueueForTests,
+  enqueueMutation,
+  getPendingMutationCount,
+} from './mutationQueue'
+import {
+  GOVERNANCE_CRITICAL_FIELDS,
+  mergeConflictFields,
+  readSyncVersion,
+  RevisionConflictError,
+} from '../api/mutations'
+
+describe('mutationQueue', () => {
+  afterEach(async () => {
+    await clearMutationQueueForTests()
+  })
+
+  it('tracks pending offline mutations', async () => {
+    expect(await getPendingMutationCount()).toBe(0)
+    await enqueueMutation({
+      url: '/api/v1/tracker/enceladus/task/ENC-TSK-1',
+      method: 'PATCH',
+      body: { field: 'status', value: 'closed' },
+      headers: { 'If-Match': '3' },
+    })
+    expect(await getPendingMutationCount()).toBe(1)
+  })
+})
+
+describe('If-Match / 409 merge policy (K25 AC-3)', () => {
+  it('reads sync_version from tracker records', () => {
+    expect(readSyncVersion({ sync_version: 7 })).toBe(7)
+    expect(readSyncVersion({ sync_version: '4' })).toBe(4)
+  })
+
+  it('server-wins on governance-critical fields', () => {
+    for (const field of GOVERNANCE_CRITICAL_FIELDS) {
+      expect(mergeConflictFields(field, 'open', { [field]: 'closed' })).toBe('server-wins')
+    }
+  })
+
+  it('side-by-side on independent fields when values differ', () => {
+    expect(mergeConflictFields('title', 'A', { title: 'B' })).toBe('side-by-side')
+  })
+
+  it('RevisionConflictError carries structured details', () => {
+    const err = new RevisionConflictError('conflict', {
+      code: 'REVISION_CONFLICT',
+      record_id: 'ENC-TSK-1',
+      expected_revision: '2',
+      current_revision: 3,
+    })
+    expect(err.status).toBe(409)
+    expect(err.details.current_revision).toBe(3)
+  })
+})
+
+describe('offline enqueue when navigator offline', () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    await clearMutationQueueForTests()
+  })
+
+  it('queues PATCH when offline', async () => {
+    vi.stubGlobal('navigator', { onLine: false })
+    const { patchTrackerRecord } = await import('../api/mutations')
+    const result = await patchTrackerRecord('enceladus', 'task', 'ENC-TSK-9', {
+      action: 'note',
+      note: 'offline note',
+    })
+    expect(result.success).toBe(true)
+    expect(await getPendingMutationCount()).toBe(1)
+  })
+})

--- a/frontend/ui-v2/src/offline/workboxStrategies.test.ts
+++ b/frontend/ui-v2/src/offline/workboxStrategies.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APP_SHELL_NETWORK_TIMEOUT_SECONDS,
+  WORKBOX_STRATEGY_MAP,
+} from './workboxStrategies'
+
+describe('WORKBOX_STRATEGY_MAP (B67 AC-17)', () => {
+  it('defines exactly six strategy entries', () => {
+    expect(WORKBOX_STRATEGY_MAP).toHaveLength(6)
+  })
+
+  it('covers CacheFirst, StaleWhileRevalidate, NetworkFirst, NetworkOnly, BackgroundSync', () => {
+    const handlers = WORKBOX_STRATEGY_MAP.map((e) => e.handler)
+    expect(handlers).toContain('CacheFirst')
+    expect(handlers).toContain('StaleWhileRevalidate')
+    expect(handlers.filter((h) => h.startsWith('NetworkFirst'))).toHaveLength(1)
+    expect(handlers).toContain('NetworkOnly')
+    expect(handlers).toContain('NetworkOnly+BackgroundSync')
+  })
+
+  it('uses 3s app-shell network timeout per DOC-E470AC8CE9A8', () => {
+    expect(APP_SHELL_NETWORK_TIMEOUT_SECONDS).toBe(3)
+  })
+})

--- a/frontend/ui-v2/src/offline/workboxStrategies.ts
+++ b/frontend/ui-v2/src/offline/workboxStrategies.ts
@@ -1,0 +1,25 @@
+/**
+ * B67 AC-17 — canonical Workbox strategy map (DOC-E470AC8CE9A8 §7.1).
+ * vite.config.ts runtimeCaching must stay aligned with these six entries.
+ */
+export const WORKBOX_STRATEGY_MAP = [
+  { id: 'static-assets', handler: 'CacheFirst', routes: 'Vite content-hashed JS/CSS (precache + media)' },
+  { id: 's3-payloads', handler: 'CacheFirst', routes: '/mobile/v1/reference/*' },
+  { id: 'feed-api', handler: 'StaleWhileRevalidate', routes: '/api/v1/feed*, /feed/corpus*, /mobile/v1/*.json' },
+  {
+    id: 'record-detail',
+    handler: 'NetworkFirst',
+    routes: 'GET /api/v1/tracker/*/{type}/{id}, GET /api/v1/documents/*',
+    timeoutSeconds: 5,
+  },
+  { id: 'auth', handler: 'NetworkOnly', routes: '/api/v1/auth*, /callback, /mobile/v1/auth*' },
+  {
+    id: 'mutations',
+    handler: 'NetworkOnly+BackgroundSync',
+    routes: 'PATCH|POST|DELETE /api/v1/tracker/*, /api/v1/documents/*',
+  },
+] as const
+
+export const APP_SHELL_NETWORK_TIMEOUT_SECONDS = 3
+
+export type WorkboxStrategyId = (typeof WORKBOX_STRATEGY_MAP)[number]['id']

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { performLogout } from '../auth/logout'
 import { useUiStore } from '../store/uiStore'
 import { CommandPalette } from './CommandPalette'
 import { FeedPane } from './FeedPane'
+import { ConflictMergeModal, OfflinePendingFlashbar } from '../components/OfflineLayer'
 import './shell.css'
 
 const LOGOUT_HREF = '__logout__'
@@ -152,6 +153,8 @@ export function AppShell({ children }: { children: ReactNode }) {
         toolsOpen={toolsOpen}
       />
       <CommandPalette />
+      <OfflinePendingFlashbar />
+      <ConflictMergeModal />
     </div>
   )
 }

--- a/frontend/ui-v2/src/store/offlineStore.ts
+++ b/frontend/ui-v2/src/store/offlineStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand'
+import { drainMutationQueue, getPendingMutationCount } from '../offline/mutationQueue'
+import type { QueuedMutation } from '../offline/mutationQueue'
+
+interface OfflineState {
+  pendingCount: number
+  swUpdateReady: boolean
+  refreshPendingCount: () => Promise<void>
+  setSwUpdateReady: (ready: boolean) => void
+  replayQueue: (send: (entry: QueuedMutation) => Promise<boolean>) => Promise<number>
+}
+
+export const useOfflineStore = create<OfflineState>((set) => ({
+  pendingCount: 0,
+  swUpdateReady: false,
+  refreshPendingCount: async () => {
+    const pendingCount = await getPendingMutationCount()
+    set({ pendingCount })
+  },
+  setSwUpdateReady: (ready) => set({ swUpdateReady: ready }),
+  replayQueue: async (send) => {
+    const replayed = await drainMutationQueue(send)
+    const pendingCount = await getPendingMutationCount()
+    set({ pendingCount })
+    return replayed
+  },
+}))

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -37,6 +37,7 @@ export interface Task {
   history: HistoryEntry[]
   updated_at: string | null
   created_at: string | null
+  sync_version?: number
 }
 
 export interface Issue {

--- a/frontend/ui-v2/vite.config.ts
+++ b/frontend/ui-v2/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { APP_SHELL_NETWORK_TIMEOUT_SECONDS } from './src/offline/workboxStrategies'
 
 const uiRoot = path.dirname(fileURLToPath(import.meta.url))
 
@@ -53,14 +54,94 @@ export default defineConfig({
       },
     }),
     tailwindcss(),
-    // K25 owns the offline/caching story. Here we ship a manifest only — no
-    // runtime caching strategies, no Workbox precache of app routes.
+    // ENC-TSK-K25 · B67 AC-17/18/19 offline layer (DOC-E470AC8CE9A8 §7)
     VitePWA({
       registerType: 'prompt',
-      injectRegister: null,
+      injectRegister: false,
       workbox: {
-        // Manifest-only: do not precache anything. Caching lands in K25.
-        globPatterns: [],
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,woff}'],
+        navigateFallback: '/index.html',
+        navigateFallbackDenylist: [/^\/api\//, /\/callback/, /^\/mobile\/v1\/auth/],
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) =>
+              request.destination === 'image' || request.destination === 'font',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'static-media',
+              expiration: { maxAgeSeconds: 60 * 60 * 24 * 30 },
+            },
+          },
+          {
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'app-shell',
+              networkTimeoutSeconds: APP_SHELL_NETWORK_TIMEOUT_SECONDS,
+            },
+          },
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/api/v1/feed') || url.pathname.startsWith('/feed/'),
+            handler: 'StaleWhileRevalidate',
+            options: { cacheName: 'feed-api' },
+          },
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/mobile/v1/') && url.pathname.endsWith('.json'),
+            handler: 'StaleWhileRevalidate',
+            options: { cacheName: 'mobile-feed-swr' },
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/mobile/v1/reference/'),
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 's3-reference',
+              expiration: { maxAgeSeconds: 60 * 60 * 24 * 7 },
+            },
+          },
+          {
+            urlPattern: ({ url, request }) =>
+              request.method === 'GET' &&
+              (Boolean(
+                url.pathname.match(
+                  /^\/api\/v1\/tracker\/[^/]+\/(task|issue|feature|plan|lesson)\//,
+                ),
+              ) ||
+                (url.pathname.startsWith('/api/v1/documents/') &&
+                  !url.pathname.includes('/search'))),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'record-detail',
+              networkTimeoutSeconds: 5,
+            },
+          },
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/api/v1/auth') ||
+              url.pathname.includes('/callback') ||
+              url.pathname.startsWith('/mobile/v1/auth'),
+            handler: 'NetworkOnly',
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
+            handler: 'NetworkOnly',
+          },
+          ...(['PATCH', 'POST', 'DELETE'] as const).map((method) => ({
+            urlPattern: ({ url }: { url: URL }) =>
+              (url.pathname.startsWith('/api/v1/tracker/') ||
+                url.pathname.startsWith('/api/v1/documents/')) &&
+              !url.pathname.includes('/graphsearch'),
+            handler: 'NetworkOnly' as const,
+            method,
+            options: {
+              backgroundSync: {
+                name: 'enceladus-mutation-queue',
+                options: { maxRetentionTime: 24 * 60 },
+              },
+            },
+          })),
+        ],
       },
       manifest: {
         name: 'Enceladus Governance Cockpit',


### PR DESCRIPTION
## Summary
- Implements B67 AC-17/18/19 offline layer for `frontend/ui-v2` per DOC-E470AC8CE9A8 §7
- Six-entry Workbox runtime map (CacheFirst/SWR/NetworkFirst/NetworkOnly/BackgroundSync) with `registerType: prompt`
- IDB offline mutation queue + Flashbar pending count; If-Match revision headers + governance-aware 409 merge modal

CCI-1f593aafa0ca43b9b30bc6334686f3ef

## Test plan
- [x] `cd frontend/ui-v2 && npm test` (143 tests)
- [x] `npm run typecheck`
- [ ] Merge → ui-gamma-deploy workflow green on v4/main


Made with [Cursor](https://cursor.com)