### PR TITLE
fix(opensearch): handle empty response body in apply_records_index.py (ENC-TSK-L73)

### DIFF
--- a/infrastructure/opensearch/apply_records_index.py
+++ b/infrastructure/opensearch/apply_records_index.py
@@ -41,11 +41,17 @@ def _request(host, method, path, admin_password, body=None):
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
+    def _parse(raw):
+        # HEAD responses (and some error responses) have no body.
+        if not raw:
+            return {}
+        return json.loads(raw)
+
     try:
         with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
-            return resp.status, json.loads(resp.read())
+            return resp.status, _parse(resp.read())
     except urllib.error.HTTPError as exc:
-        return exc.code, json.loads(exc.read())
+        return exc.code, _parse(exc.read())
 
 
 def main():


### PR DESCRIPTION
## Summary
Found live-verifying ENC-TSK-L40 AC-3 against the now-healthy gamma OpenSearch node: `apply_records_index.py`'s HEAD `/{index_name}` existence-check has no response body, but `_request()` unconditionally called `json.loads()` on the raw response bytes, raising `JSONDecodeError` before the index/aliases were ever created.

Fixes `_request()` to return `{}` for an empty body instead of always parsing.

## Test plan
- [x] `python3 -m py_compile` — valid syntax
- [ ] Live re-run against the gamma OpenSearch node succeeds end-to-end (verifying immediately after merge)

CCI-cae8414f380f4c5cbdf83dac37ba1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)