### PR TITLE
fix(opensearch): apply_records_index empty HTTP bodies (ENC-TSK-L40)

### DIFF
--- a/infrastructure/opensearch/apply_records_index.py
+++ b/infrastructure/opensearch/apply_records_index.py
@@ -43,9 +43,18 @@ def _request(host, method, path, admin_password, body=None):
     ctx.verify_mode = ssl.CERT_NONE
     try:
         with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
-            return resp.status, json.loads(resp.read())
+            raw = resp.read()
+            if raw:
+                return resp.status, json.loads(raw)
+            return resp.status, {}
     except urllib.error.HTTPError as exc:
-        return exc.code, json.loads(exc.read())
+        raw = exc.read()
+        if raw:
+            try:
+                return exc.code, json.loads(raw)
+            except json.JSONDecodeError:
+                return exc.code, {"error": raw.decode("utf-8", errors="replace")}
+        return exc.code, {}
 
 
 def main():


### PR DESCRIPTION
## Summary
Fix `apply_records_index.py` to tolerate empty bodies on HEAD/existence checks (OpenSearch returns no JSON on HEAD 200/404).

## Test plan
- [x] SSM apply + smoke on gamma OpenSearch node after fix

CCI-d81476251bfd482e99bf09dd7700cf12

Made with [Cursor](https://cursor.com)