### PR TITLE
feat(ui-v2): governance surfaces — live docs, plan graph, typed edges (ENC-TSK-K26)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.14",
-  "updated_at": "2026-07-05T09:35:00Z",
-  "last_change_summary": "ENC-TSK-L35: added coordination.agent_session.updated_at (unconditional session-activity bump) + .history (mirrored worklog entries) for the B67 PWA2.0 session detail page.",
+  "version": "2026-07-05.15",
+  "updated_at": "2026-07-05T11:25:00Z",
+  "last_change_summary": "ENC-TSK-K26: shared record_extensions module attaches typed_relationships + computed context_node (absolute structural_importance per DOC-310B93107B60) on feed_query and tracker_mutation GET; ui-v2 governance surfaces consume the extensions.",
   "owners": [
     "enceladus-platform"
   ],
@@ -4575,7 +4575,7 @@
       }
     },
     "feed_query.record_extensions": {
-      "description": "Feed query record extension fields added to task/issue/feature/lesson payloads in the /api/v1/feed response (ENC-TSK-A57). typed_relationships: typed relationship edges from rel# DynamoDB items. subtask_ids: plan tree hierarchy. context_node: context node scores (when ENABLE_CONTEXT_NODES active).",
+      "description": "Feed query record extension fields added to task/issue/feature/lesson/plan payloads in the /api/v1/feed response (ENC-TSK-A57, extended ENC-TSK-K26). Implemented in enceladus_shared.record_extensions and invoked from feed_query. typed_relationships: typed relationship edges from rel# DynamoDB items. context_node: computed scores (freshness, absolute-degree structural_importance, information_density, access_frequency).",
       "fields": {
         "typed_relationships": {
           "type": "array",
@@ -4590,8 +4590,34 @@
         },
         "context_node": {
           "type": "object",
-          "definition": "Context node metadata scores (freshness_score, structural_importance, information_density, access_frequency) joined from context node DynamoDB items when ENABLE_CONTEXT_NODES feature flag is active.",
-          "usage_guidance": "Used by ContextNodeBadges PWA component. Returns null/absent when feature flag is off or no context node exists."
+          "definition": "Context node metadata scores computed at read time by enceladus_shared.record_extensions.build_context_node_meta: freshness_score (half-life decay from updated_at), structural_importance (absolute degree normalized by project max per DOC-310B93107B60), information_density (text length / 2000), access_frequency (context_access_count). Always attached on feed records; not gated by ENABLE_CONTEXT_NODES.",
+          "usage_guidance": "Used by ui-v2 ContextNodeBadges on task/issue/feature/plan detail pages."
+        }
+      }
+    },
+    "tracker_mutation.get_record_extensions": {
+      "description": "ENC-TSK-K26: tracker_mutation GET /{project}/{type}/{id} enriches the deserialized record with the same typed_relationships + context_node extensions as feed_query via enceladus_shared.record_extensions.attach_record_extensions (query_typed_relationships_for_projects scoped to the record's project). Failures are logged and the bare record is still returned.",
+      "fields": {
+        "typed_relationships": {
+          "type": "array",
+          "definition": "Outgoing typed edges for the requested source record, same shape as feed_query.record_extensions.typed_relationships."
+        },
+        "context_node": {
+          "type": "object",
+          "definition": "Computed context node metadata for the requested record, same shape as feed_query.record_extensions.context_node."
+        }
+      }
+    },
+    "enceladus_shared.record_extensions": {
+      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py) centralizing typed-edge query + context-node score computation for feed_query and tracker_mutation GET handlers (ENC-TSK-K26 / ENC-TSK-A57).",
+      "fields": {
+        "compute_structural_importance": {
+          "type": "function",
+          "definition": "Absolute graph degree (in+out typed edges) for a record_id normalized by the project max degree; capped at 1.0. Implements DOC-310B93107B60 absolute metric (not stub/global PageRank)."
+        },
+        "attach_record_extensions": {
+          "type": "function",
+          "definition": "Mutates each record dict in-place: sets typed_relationships when edges exist and always sets context_node with the four score fields."
         }
       }
     },
@@ -7431,8 +7457,13 @@
       }
     }
   },
-  "change_summary": "ENC-TSK-L35 (B67 PWA2.0 session detail + worklog mirroring): coordination.agent_session gains updated_at (unconditional bump on every session-requiring call passing the SCI gate, including previously-untouched grandfathered/checkout-forwarded sessions) and history (best-effort mirror of every worklog entry the session appends to any governed record, via tracker_mutation._mirror_worklog_to_session). New GET /api/v1/coordination/agents/sessions/{id} single-session read route (coordination_api._handle_agent_session_get). Also wires the pre-existing agent-session-list/agent-type-list handlers (ENC-TSK-L34) to new API Gateway routes in 03-api.yaml. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED).",
+  "change_summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7 governance surfaces): enceladus_shared.record_extensions centralizes typed_relationships query + context_node score computation (absolute structural_importance per DOC-310B93107B60); feed_query attaches extensions on task/issue/feature/lesson/plan payloads; tracker_mutation GET enriches single-record reads with the same fields for ui-v2 TypedRelationshipSection + ContextNodeBadges.",
   "change_log": [
+    {
+      "version": "2026-07-05.15",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
     {
       "version": "2026-07-05.13",
       "date": "2026-07-05",

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -1883,18 +1883,29 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             logger.error("feed query failed: %s", exc)
             return _error(500, "Failed to query feed data. Please try again.")
 
-        # --- Attach typed relationship edges (ENC-ISS-137 / ENC-TSK-A57) ---
+        # --- Attach typed relationship edges + context node scores (ENC-TSK-A57/K26) ---
         try:
             project_ids = list({r.get("project_id", "") for r in tasks + issues + features + lessons + plans if r.get("project_id")})
             if project_ids:
-                edges_by_source = _query_typed_relationships(project_ids)
-                _attach_typed_relationships(tasks, "task_id", edges_by_source)
-                _attach_typed_relationships(issues, "issue_id", edges_by_source)
-                _attach_typed_relationships(features, "feature_id", edges_by_source)
-                _attach_typed_relationships(lessons, "lesson_id", edges_by_source)
-                _attach_typed_relationships(plans, "plan_id", edges_by_source)
+                from enceladus_shared.record_extensions import (
+                    attach_record_extensions,
+                    query_typed_relationships_for_projects,
+                )
+
+                edges_by_source = query_typed_relationships_for_projects(
+                    _get_ddb(),
+                    DYNAMODB_TABLE,
+                    project_ids,
+                    ddb_str=_ddb_str,
+                    ddb_float=_ddb_float,
+                )
+                attach_record_extensions(tasks, "task_id", "task", edges_by_source)
+                attach_record_extensions(issues, "issue_id", "issue", edges_by_source)
+                attach_record_extensions(features, "feature_id", "feature", edges_by_source)
+                attach_record_extensions(lessons, "lesson_id", "lesson", edges_by_source)
+                attach_record_extensions(plans, "plan_id", "plan", edges_by_source)
         except Exception as exc:
-            logger.warning("Failed to attach typed relationships: %s", exc)
+            logger.warning("Failed to attach record extensions: %s", exc)
 
         subscription_meta = {
             "subscription_id": None,

--- a/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
@@ -1,0 +1,216 @@
+"""Feed + tracker record extensions (ENC-TSK-K26 / ENC-TSK-A57).
+
+Attaches typed_relationships and computed context_node metadata to tracker
+records served by feed_query and tracker_mutation GET handlers.
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+HALF_LIFE_SECONDS = {
+    "task": 604800,
+    "issue": 259200,
+    "feature": 2592000,
+    "plan": 2592000,
+    "lesson": 15552000,
+    "document": 7776000,
+}
+
+
+def compute_freshness(updated_at_iso: Optional[str], record_type: str) -> float:
+    if not updated_at_iso:
+        return 0.5
+    try:
+        iso = updated_at_iso
+        if iso.endswith("Z"):
+            iso = iso[:-1] + "+00:00"
+        dt = datetime.fromisoformat(iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        age = max(0.0, datetime.now(timezone.utc).timestamp() - dt.timestamp())
+    except (ValueError, TypeError):
+        return 0.5
+    half_life = HALF_LIFE_SECONDS.get(record_type, 604800)
+    return math.exp(-math.log(2) * age / half_life)
+
+
+def _text_blob(record: Dict[str, Any]) -> str:
+    parts = [
+        str(record.get("title") or ""),
+        str(record.get("description") or ""),
+        str(record.get("observation") or ""),
+        str(record.get("insight") or ""),
+    ]
+    return " ".join(p for p in parts if p).strip()
+
+
+def compute_information_density(record: Dict[str, Any]) -> float:
+    blob = _text_blob(record)
+    if not blob:
+        return 0.0
+    # Normalize to [0,1] with 2k chars as saturation (ENC-FTR-050 scale).
+    return min(1.0, len(blob) / 2000.0)
+
+
+def compute_structural_importance(
+    record_id: str,
+    edges_by_source: Dict[str, List[Dict[str, Any]]],
+    max_degree: int,
+) -> float:
+    """Absolute degree normalized by project max (DOC-310B93107B60 absolute metric)."""
+    degree = len(edges_by_source.get(record_id, []))
+    for edges in edges_by_source.values():
+        for edge in edges:
+            if edge.get("target_id") == record_id:
+                degree += 1
+    if max_degree <= 0:
+        return 0.0
+    return min(1.0, degree / max_degree)
+
+
+def compute_max_degree(edges_by_source: Dict[str, List[Dict[str, Any]]]) -> int:
+    inbound: Dict[str, int] = {}
+    for source_id, edges in edges_by_source.items():
+        degree = len(edges)
+        for edge in edges:
+            target = edge.get("target_id")
+            if target:
+                inbound[target] = inbound.get(target, 0) + 1
+        degree += inbound.get(source_id, 0)
+        inbound[source_id] = max(inbound.get(source_id, 0), len(edges))
+    if not inbound:
+        return 1
+    return max(max(inbound.values()), 1)
+
+
+def build_context_node_meta(
+    record: Dict[str, Any],
+    record_type: str,
+    record_id: str,
+    edges_by_source: Dict[str, List[Dict[str, Any]]],
+    max_degree: int,
+) -> Dict[str, float]:
+    access_raw = record.get("context_access_count") or record.get("access_frequency") or 0
+    try:
+        access_frequency = int(access_raw)
+    except (TypeError, ValueError):
+        access_frequency = 0
+    return {
+        "freshness_score": round(compute_freshness(record.get("updated_at"), record_type), 4),
+        "structural_importance": round(
+            compute_structural_importance(record_id, edges_by_source, max_degree), 4
+        ),
+        "information_density": round(compute_information_density(record), 4),
+        "access_frequency": access_frequency,
+    }
+
+
+def attach_record_extensions(
+    records: List[Dict[str, Any]],
+    id_key: str,
+    record_type: str,
+    edges_by_source: Dict[str, List[Dict[str, Any]]],
+    max_degree: Optional[int] = None,
+) -> None:
+    if max_degree is None:
+        max_degree = compute_max_degree(edges_by_source)
+    for record in records:
+        record_id = str(record.get(id_key) or "")
+        if not record_id:
+            continue
+        edges = edges_by_source.get(record_id, [])
+        if edges:
+            record["typed_relationships"] = edges
+        record["context_node"] = build_context_node_meta(
+            record, record_type, record_id, edges_by_source, max_degree
+        )
+
+
+def query_typed_relationships_for_projects(
+    ddb,
+    table_name: str,
+    project_ids: List[str],
+    *,
+    ddb_str: Callable[[Dict[str, Any], str], str],
+    ddb_float: Callable[[Dict[str, Any], str], float],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Query all outgoing typed edges for the given projects."""
+    edges_by_source: Dict[str, List[Dict[str, Any]]] = {}
+    for pid in project_ids:
+        if not pid:
+            continue
+        paginator = ddb.get_paginator("query")
+        for page in paginator.paginate(
+            TableName=table_name,
+            KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
+            ExpressionAttributeValues={
+                ":pid": {"S": pid},
+                ":rel_prefix": {"S": "rel#"},
+            },
+        ):
+            for raw in page.get("Items", []):
+                sk = ddb_str(raw, "record_id")
+                if not sk or not sk.startswith("rel#"):
+                    continue
+                parts = sk.split("#", 4)
+                if len(parts) < 4:
+                    continue
+                _, source_id, rel_type, target_id = parts[0], parts[1], parts[2], parts[3]
+                if ddb_str(raw, "status") == "archived":
+                    continue
+                edge = {
+                    "relationship_type": rel_type,
+                    "target_id": target_id,
+                    "weight": ddb_float(raw, "weight"),
+                    "confidence": ddb_float(raw, "confidence"),
+                    "reason": ddb_str(raw, "reason") or None,
+                    "created_at": ddb_str(raw, "created_at") or None,
+                }
+                edges_by_source.setdefault(source_id, []).append(edge)
+    return edges_by_source
+
+
+def query_edges_for_record(
+    ddb,
+    table_name: str,
+    project_id: str,
+    source_id: str,
+    *,
+    ddb_str: Callable[[Dict[str, Any], str], str],
+    ddb_float: Callable[[Dict[str, Any], str], float],
+) -> List[Dict[str, Any]]:
+    """Query outgoing typed edges for a single source record."""
+    edges: List[Dict[str, Any]] = []
+    prefix = f"rel#{source_id}#"
+    paginator = ddb.get_paginator("query")
+    for page in paginator.paginate(
+        TableName=table_name,
+        KeyConditionExpression="project_id = :pid AND begins_with(record_id, :prefix)",
+        ExpressionAttributeValues={
+            ":pid": {"S": project_id},
+            ":prefix": {"S": prefix},
+        },
+    ):
+        for raw in page.get("Items", []):
+            sk = ddb_str(raw, "record_id")
+            if not sk or not sk.startswith("rel#"):
+                continue
+            parts = sk.split("#", 4)
+            if len(parts) < 4:
+                continue
+            _, _src, rel_type, target_id = parts
+            if ddb_str(raw, "status") == "archived":
+                continue
+            edges.append(
+                {
+                    "relationship_type": rel_type,
+                    "target_id": target_id,
+                    "weight": ddb_float(raw, "weight"),
+                    "confidence": ddb_float(raw, "confidence"),
+                    "reason": ddb_str(raw, "reason") or None,
+                    "created_at": ddb_str(raw, "created_at") or None,
+                }
+            )
+    return edges

--- a/backend/lambda/shared_layer/test_layer.py
+++ b/backend/lambda/shared_layer/test_layer.py
@@ -23,6 +23,12 @@ from enceladus_shared.auth import (
 from enceladus_shared.aws_clients import _get_ddb, _get_s3, _get_sqs
 from enceladus_shared.http_utils import _error, _parse_body, _path_method, _response
 from enceladus_shared.serialization import _deserialize, _now_z, _serialize, _unix_now
+from enceladus_shared.record_extensions import (
+    attach_record_extensions,
+    compute_freshness,
+    compute_max_degree,
+    compute_structural_importance,
+)
 
 
 class AuthTests(unittest.TestCase):
@@ -184,6 +190,35 @@ class AwsClientTests(unittest.TestCase):
         mock_boto3.client.assert_called_once()
 
         clients._ddb = None  # Clean up
+
+
+class RecordExtensionsTests(unittest.TestCase):
+    def test_structural_importance_absolute_degree(self):
+        edges = {
+            "A": [{"target_id": "B"}, {"target_id": "C"}],
+            "B": [{"target_id": "A"}],
+        }
+        max_degree = compute_max_degree(edges)
+        self.assertEqual(compute_structural_importance("A", edges, max_degree), 1.0)
+        self.assertEqual(compute_structural_importance("C", edges, max_degree), 1 / 3)
+
+    def test_attach_record_extensions_sets_context_node(self):
+        edges = {"ENC-TSK-001": [{"relationship_type": "relates-to", "target_id": "ENC-TSK-002"}]}
+        record = {
+            "task_id": "ENC-TSK-001",
+            "title": "Example",
+            "description": "x" * 100,
+            "updated_at": "2026-07-01T00:00:00Z",
+        }
+        attach_record_extensions([record], "task_id", "task", edges, max_degree=2)
+        self.assertEqual(len(record["typed_relationships"]), 1)
+        ctx = record["context_node"]
+        self.assertIn("freshness_score", ctx)
+        self.assertGreater(ctx["structural_importance"], 0)
+        self.assertGreater(ctx["information_density"], 0)
+
+    def test_compute_freshness_missing_timestamp_defaults(self):
+        self.assertEqual(compute_freshness(None, "task"), 0.5)
 
 
 if __name__ == "__main__":

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -2684,6 +2684,35 @@ def _handle_get_record(project_id: str, record_type: str, record_id: str) -> Dic
     if item is None:
         return _error(404, f"Record not found: {record_id}")
 
+    id_key = f"{record_type}_id"
+    try:
+        from enceladus_shared.record_extensions import (
+            attach_record_extensions,
+            query_typed_relationships_for_projects,
+        )
+
+        def _ddb_str(raw: Dict, key: str) -> str:
+            val = raw.get(key, {})
+            return val.get("S", "") if isinstance(val, dict) else ""
+
+        def _ddb_float(raw: Dict, key: str) -> float:
+            val = raw.get(key, {})
+            try:
+                return float(val.get("N", "0"))
+            except (TypeError, ValueError):
+                return 0.0
+
+        edges_by_source = query_typed_relationships_for_projects(
+            _get_ddb(),
+            DYNAMODB_TABLE,
+            [project_id],
+            ddb_str=_ddb_str,
+            ddb_float=_ddb_float,
+        )
+        attach_record_extensions([item], id_key, record_type, edges_by_source)
+    except Exception as exc:
+        logger.warning("Failed to attach record extensions for %s: %s", record_id, exc)
+
     return _response(200, {"success": True, "record": item})
 
 

--- a/frontend/ui-v2/package-lock.json
+++ b/frontend/ui-v2/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
+        "cytoscape": "^3.34.0",
         "lucide-react": "^1.23.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -29,7 +30,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^16.5.0",
         "jsdom": "^27.0.1",
-        "oxlint": "^1.22.0",
         "tailwindcss": "^4.3.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.62.1",
@@ -2575,329 +2575,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.72.0.tgz",
-      "integrity": "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.72.0.tgz",
-      "integrity": "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.72.0.tgz",
-      "integrity": "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.72.0.tgz",
-      "integrity": "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.72.0.tgz",
-      "integrity": "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.72.0.tgz",
-      "integrity": "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.72.0.tgz",
-      "integrity": "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.72.0.tgz",
-      "integrity": "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.72.0.tgz",
-      "integrity": "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.72.0.tgz",
-      "integrity": "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.72.0.tgz",
-      "integrity": "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.72.0.tgz",
-      "integrity": "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.72.0.tgz",
-      "integrity": "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.72.0.tgz",
-      "integrity": "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.72.0.tgz",
-      "integrity": "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.72.0.tgz",
-      "integrity": "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.72.0.tgz",
-      "integrity": "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.72.0.tgz",
-      "integrity": "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.72.0.tgz",
-      "integrity": "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4976,6 +4653,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/data-urls": {
       "version": "6.0.1",
@@ -7604,55 +7290,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/oxlint": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.72.0.tgz",
-      "integrity": "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "oxlint": "bin/oxlint"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.72.0",
-        "@oxlint/binding-android-arm64": "1.72.0",
-        "@oxlint/binding-darwin-arm64": "1.72.0",
-        "@oxlint/binding-darwin-x64": "1.72.0",
-        "@oxlint/binding-freebsd-x64": "1.72.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.72.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.72.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.72.0",
-        "@oxlint/binding-linux-arm64-musl": "1.72.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.72.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.72.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.72.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.72.0",
-        "@oxlint/binding-linux-x64-gnu": "1.72.0",
-        "@oxlint/binding-linux-x64-musl": "1.72.0",
-        "@oxlint/binding-openharmony-arm64": "1.72.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.72.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.72.0",
-        "@oxlint/binding-win32-x64-msvc": "1.72.0"
-      },
-      "peerDependencies": {
-        "oxlint-tsgolint": ">=0.22.1",
-        "vite-plus": "*"
-      },
-      "peerDependenciesMeta": {
-        "oxlint-tsgolint": {
-          "optional": true
-        },
-        "vite-plus": {
-          "optional": true
-        }
       }
     },
     "node_modules/p-limit": {

--- a/frontend/ui-v2/package.json
+++ b/frontend/ui-v2/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
+    "cytoscape": "^3.34.0",
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/frontend/ui-v2/src/api/documents.ts
+++ b/frontend/ui-v2/src/api/documents.ts
@@ -1,0 +1,90 @@
+import type { Document } from '../types/records'
+import { fetchDocumentRecord, SessionExpiredError } from './client'
+
+const API_BASE = '/api/v1/documents'
+const GOVERNANCE_PROJECT_ID = 'devops'
+const GOVERNANCE_KEYWORD = 'governance-file'
+const PROJECT_REFERENCE_KEYWORD = 'project-reference'
+
+export { SessionExpiredError }
+
+export const governanceDocKeys = {
+  primaryReference: (projectId: string) => ['governance', 'primary-reference', projectId] as const,
+  detail: (documentId: string) => ['governance', 'detail', documentId] as const,
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    credentials: 'include',
+    cache: 'no-store',
+  })
+  if (res.status === 401) throw new SessionExpiredError()
+  if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
+  return (await res.json()) as T
+}
+
+export async function searchDocuments(params: {
+  project?: string
+  keyword?: string
+  related?: string
+  title?: string
+}): Promise<Document[]> {
+  const qs = new URLSearchParams()
+  if (params.project) qs.set('project', params.project)
+  if (params.keyword) qs.set('keyword', params.keyword)
+  if (params.related) qs.set('related', params.related)
+  if (params.title) qs.set('title', params.title)
+  const data = await requestJson<{ documents?: Document[] }>(`${API_BASE}/search?${qs.toString()}`)
+  return data.documents ?? []
+}
+
+function dedupeByDocumentId(docs: Document[]): Document[] {
+  const deduped = new Map<string, Document>()
+  for (const doc of docs) deduped.set(doc.document_id, doc)
+  return [...deduped.values()]
+}
+
+function isCanonicalGovernanceDoc(doc: Document): boolean {
+  const keywords = new Set((doc.keywords ?? []).map((k) => k.toLowerCase()))
+  if (!keywords.has(GOVERNANCE_KEYWORD)) return false
+  const title = (doc.title ?? '').trim().toLowerCase()
+  if (title.startsWith('governance:')) return true
+  const fileName = (doc.file_name ?? '').trim().toLowerCase()
+  return fileName === 'agents.md' || fileName.startsWith('agents/')
+}
+
+function isCanonicalProjectReferenceDoc(doc: Document, projectId: string): boolean {
+  const keywords = new Set((doc.keywords ?? []).map((k) => k.toLowerCase()))
+  if (!keywords.has(PROJECT_REFERENCE_KEYWORD)) return false
+  const fileName = (doc.file_name ?? '').trim().toLowerCase()
+  if (fileName === `${projectId}-reference.md`) return true
+  return (doc.title ?? '').trim().toLowerCase().endsWith('project reference')
+}
+
+/** Live docstore governance + project reference docs (ENC-ISS-121 / ENC-TSK-K26). */
+export async function fetchGovernanceDocs(projectId: string): Promise<Document[]> {
+  const normalized = projectId.trim().toLowerCase()
+  if (!normalized) return []
+
+  const [projectReferenceDocs, governanceDocs] = await Promise.all([
+    searchDocuments({ project: normalized, keyword: PROJECT_REFERENCE_KEYWORD }),
+    searchDocuments({ project: GOVERNANCE_PROJECT_ID, keyword: GOVERNANCE_KEYWORD }),
+  ])
+
+  const fallbackProjectReferenceDocs =
+    projectReferenceDocs.length > 0
+      ? []
+      : await searchDocuments({ project: normalized, title: 'Project Reference' })
+
+  return dedupeByDocumentId([
+    ...[...projectReferenceDocs, ...fallbackProjectReferenceDocs].filter((d) =>
+      isCanonicalProjectReferenceDoc(d, normalized),
+    ),
+    ...governanceDocs.filter(isCanonicalGovernanceDoc),
+  ]).sort((a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
+}
+
+export async function fetchGovernanceDocument(documentId: string): Promise<Document> {
+  return fetchDocumentRecord<Document>(documentId)
+}

--- a/frontend/ui-v2/src/api/graph.ts
+++ b/frontend/ui-v2/src/api/graph.ts
@@ -1,0 +1,51 @@
+import { GraphUnavailableError, NotFoundError, SessionExpiredError } from './client'
+
+const API_BASE = '/api/v1'
+
+export interface GraphNode {
+  record_id?: string
+  title?: string
+  record_type?: string
+  [key: string]: unknown
+}
+
+export interface GraphEdge {
+  type: string
+  start: string
+  end: string
+}
+
+export interface GraphNeighborsResponse {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  summary?: string
+  error?: string
+}
+
+export const graphKeys = {
+  neighbors: (projectId: string, recordId: string, edgeTypes: string) =>
+    ['graph', 'neighbors', projectId, recordId, edgeTypes] as const,
+}
+
+export async function fetchGraphNeighbors(params: {
+  projectId: string
+  recordId: string
+  edgeTypes?: string[]
+  depth?: number
+}): Promise<GraphNeighborsResponse> {
+  const qs = new URLSearchParams({
+    search_type: 'neighbors',
+    project_id: params.projectId,
+    record_id: params.recordId,
+    depth: String(params.depth ?? 2),
+  })
+  if (params.edgeTypes?.length) qs.set('edge_types', params.edgeTypes.join(','))
+
+  const url = `${API_BASE}/tracker/graphsearch?${qs.toString()}`
+  const res = await fetch(url, { credentials: 'include', cache: 'no-store' })
+  if (res.status === 401) throw new SessionExpiredError()
+  if (res.status === 404) throw new NotFoundError(`Not found: ${url}`)
+  if (res.status === 503) throw new GraphUnavailableError('Graph index temporarily unavailable')
+  if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
+  return (await res.json()) as GraphNeighborsResponse
+}

--- a/frontend/ui-v2/src/components/ContextNodeBadges.tsx
+++ b/frontend/ui-v2/src/components/ContextNodeBadges.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import type { ContextNodeMeta } from '../types/records'
+
+function scoreColor(score: number): string {
+  if (score >= 0.7) return 'var(--status-success-fg, #6ee7b7)'
+  if (score >= 0.4) return 'var(--status-warning-fg, #fcd34d)'
+  return 'var(--status-danger-fg, #fca5a5)'
+}
+
+function ScoreBadge({ label, value }: { label: string; value: number }) {
+  return (
+    <span
+      title={`${label}: ${value.toFixed(3)}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--space-1)',
+        padding: '2px var(--space-2)',
+        borderRadius: 'var(--radius-sm)',
+        fontSize: 'var(--text-xs)',
+        fontFamily: 'var(--font-body)',
+        background: 'color-mix(in srgb, var(--bg-elevated) 80%, transparent)',
+        color: scoreColor(value),
+      }}
+    >
+      <span style={{ opacity: 0.7 }}>{label}</span>
+      {value.toFixed(2)}
+    </span>
+  )
+}
+
+export function ContextNodeBadges({ contextNode }: { contextNode?: ContextNodeMeta }) {
+  const [expanded, setExpanded] = useState(false)
+  if (!contextNode) return null
+
+  const { freshness_score, structural_importance, information_density, access_frequency } =
+    contextNode
+
+  if (freshness_score === 0 && structural_importance === 0 && information_density === 0) {
+    return null
+  }
+
+  return (
+    <section
+      style={{
+        marginTop: 'var(--space-5)',
+        padding: 'var(--space-4)',
+        borderRadius: 'var(--radius-md)',
+        border: 'var(--border-subtle)',
+        background: 'var(--bg-elevated)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-2)',
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          color: 'var(--fg-muted)',
+          fontFamily: 'var(--font-body)',
+          fontSize: 'var(--text-xs)',
+          textTransform: 'uppercase',
+          letterSpacing: 'var(--tracking-label)',
+        }}
+      >
+        Context scores
+        <span aria-hidden>{expanded ? '▾' : '▸'}</span>
+      </button>
+      {expanded ? (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 'var(--space-2)',
+            marginTop: 'var(--space-3)',
+          }}
+        >
+          <ScoreBadge label="Fresh" value={freshness_score} />
+          <ScoreBadge label="Struct" value={structural_importance} />
+          <ScoreBadge label="Dense" value={information_density} />
+          {access_frequency > 0 ? (
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--fg-muted)' }}>
+              Accessed {access_frequency}×
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/frontend/ui-v2/src/components/PlanGraphExplorer.tsx
+++ b/frontend/ui-v2/src/components/PlanGraphExplorer.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import cytoscape, { type Core } from 'cytoscape'
+import { fetchGraphNeighbors, graphKeys } from '../api/graph'
+import { recordHref } from '../routes/recordLink'
+import './plan-graph.css'
+
+const PLAN_EDGE_TYPES = ['PLAN_CONTAINS', 'INFORMED_BY', 'LEARNED_FROM', 'RELATED_TO', 'PLAN_ATTACHED_DOC']
+
+export function PlanGraphExplorer({
+  projectId,
+  planId,
+  objectiveIds = [],
+}: {
+  projectId: string
+  planId: string
+  objectiveIds?: string[]
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const cyRef = useRef<Core | null>(null)
+
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: graphKeys.neighbors(projectId, planId, PLAN_EDGE_TYPES.join(',')),
+    queryFn: () =>
+      fetchGraphNeighbors({
+        projectId,
+        recordId: planId,
+        edgeTypes: PLAN_EDGE_TYPES,
+        depth: 2,
+      }),
+    staleTime: 30_000,
+  })
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || !data?.nodes?.length) return
+
+    const nodeIds = new Set<string>([planId, ...objectiveIds])
+    for (const n of data.nodes) {
+      const id = String(n.record_id ?? '')
+      if (id) nodeIds.add(id)
+    }
+
+    const elements: cytoscape.ElementDefinition[] = []
+    for (const id of nodeIds) {
+      const hit = data.nodes.find((n) => n.record_id === id)
+      const label = String(hit?.title ?? id)
+      const isPlan = id === planId
+      const isObjective = objectiveIds.includes(id)
+      elements.push({
+        data: {
+          id,
+          label: label.length > 28 ? `${label.slice(0, 26)}…` : label,
+        },
+        classes: isPlan ? 'plan-root' : isObjective ? 'plan-objective' : 'plan-neighbor',
+      })
+    }
+
+    for (const edge of data.edges ?? []) {
+      const start = edge.start
+      const end = edge.end
+      if (!nodeIds.has(start) || !nodeIds.has(end)) continue
+      elements.push({
+        data: {
+          id: `${start}-${edge.type}-${end}`,
+          source: start,
+          target: end,
+          label: edge.type,
+        },
+      })
+    }
+
+    cyRef.current?.destroy()
+    const cy = cytoscape({
+      container: el,
+      elements,
+      style: [
+        {
+          selector: 'node',
+          style: {
+            label: 'data(label)',
+            'text-valign': 'center',
+            'text-halign': 'center',
+            'font-size': 10,
+            color: '#e2e8f0',
+            'background-color': '#334155',
+            width: 36,
+            height: 36,
+          },
+        },
+        {
+          selector: '.plan-root',
+          style: {
+            'background-color': '#0ea5a4',
+            width: 52,
+            height: 52,
+            'box-shadow': '0 0 16px rgba(14, 165, 164, 0.55)',
+          },
+        },
+        {
+          selector: '.plan-objective',
+          style: {
+            'background-color': '#0369a1',
+            'box-shadow': '0 0 10px rgba(3, 105, 161, 0.45)',
+          },
+        },
+        {
+          selector: 'edge',
+          style: {
+            width: 2,
+            'line-color': '#64748b',
+            'target-arrow-color': '#64748b',
+            'target-arrow-shape': 'triangle',
+            'curve-style': 'bezier',
+            label: 'data(label)',
+            'font-size': 8,
+            color: '#94a3b8',
+          },
+        },
+      ],
+      layout: { name: 'concentric', concentric: (node) => (node.id() === planId ? 2 : 1), levelWidth: () => 2 },
+    })
+
+    cy.on('tap', 'node', (evt) => {
+      const id = evt.target.id()
+      if (id === planId) return
+      const type = id.includes('-PLN-') ? 'plan' : 'task'
+      window.location.assign(recordHref(projectId, type, id))
+    })
+
+    cyRef.current = cy
+    return () => {
+      cy.destroy()
+      cyRef.current = null
+    }
+  }, [data, planId, projectId, objectiveIds])
+
+  return (
+    <section className="plan-graph" aria-label="Plan graph explorer">
+      <div className="plan-graph__header">
+        <h4 className="plan-graph__title">Plan graph</h4>
+        <p className="plan-graph__subtitle">
+          Cytoscape view of PLAN_CONTAINS and typed plan edges (ENC-PLN-006 objectives).
+        </p>
+      </div>
+      {isPending ? <p className="plan-graph__status">Loading graph…</p> : null}
+      {isError ? (
+        <p className="plan-graph__status plan-graph__status--error">
+          {error instanceof Error ? error.message : 'Graph unavailable'}
+        </p>
+      ) : null}
+      <div ref={containerRef} className="plan-graph__canvas" />
+      {data?.summary ? <p className="plan-graph__summary">{data.summary}</p> : null}
+    </section>
+  )
+}

--- a/frontend/ui-v2/src/components/TypedRelationshipSection.tsx
+++ b/frontend/ui-v2/src/components/TypedRelationshipSection.tsx
@@ -1,0 +1,92 @@
+import { Link } from '@tanstack/react-router'
+import type { TypedRelationshipEdge } from '../types/records'
+import { recordHrefForType } from '../routes/recordLink'
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  'blocks': 'Blocks',
+  'blocked-by': 'Blocked By',
+  'depends-on': 'Depends On',
+  'relates-to': 'Relates To',
+  'parent-of': 'Parent Of',
+  'child-of': 'Child Of',
+  'plan-contains': 'Plan Contains',
+  'informed-by': 'Informed By',
+  'learned-from': 'Learned From',
+  'related-to': 'Related To',
+}
+
+function detectRecordType(id: string): 'task' | 'issue' | 'feature' | 'lesson' | 'plan' {
+  if (id.includes('-PLN-')) return 'plan'
+  if (id.includes('-ISS-')) return 'issue'
+  if (id.includes('-FTR-')) return 'feature'
+  if (id.includes('-LSN-')) return 'lesson'
+  return 'task'
+}
+
+export function TypedRelationshipSection({
+  projectId,
+  edges,
+}: {
+  projectId: string
+  edges: TypedRelationshipEdge[]
+}) {
+  if (!edges.length) return null
+
+  const grouped = edges.reduce<Record<string, TypedRelationshipEdge[]>>((acc, edge) => {
+    const key = edge.relationship_type
+    acc[key] = acc[key] ?? []
+    acc[key].push(edge)
+    return acc
+  }, {})
+
+  return (
+    <section style={{ marginTop: 'var(--space-5)' }}>
+      <h4
+        style={{
+          margin: '0 0 var(--space-3)',
+          fontFamily: 'var(--font-heading)',
+          fontSize: 'var(--text-sm)',
+          color: 'var(--fg-display)',
+        }}
+      >
+        Typed relationships
+      </h4>
+      {Object.entries(grouped).map(([relType, relEdges]) => (
+        <div key={relType} style={{ marginBottom: 'var(--space-3)' }}>
+          <div
+            style={{
+              fontSize: 'var(--text-xs)',
+              textTransform: 'uppercase',
+              letterSpacing: 'var(--tracking-label)',
+              color: 'var(--accent)',
+              marginBottom: 'var(--space-2)',
+            }}
+          >
+            {RELATIONSHIP_LABELS[relType] ?? relType}
+          </div>
+          <ul style={{ margin: 0, paddingLeft: 'var(--space-5)' }}>
+            {relEdges.map((edge) => {
+              const targetType = detectRecordType(edge.target_id)
+              return (
+                <li key={`${relType}-${edge.target_id}`} style={{ marginBottom: 'var(--space-1)' }}>
+                  <Link
+                    to={recordHrefForType(projectId, targetType, edge.target_id)}
+                    style={{ color: 'var(--fg-body)', textDecoration: 'none' }}
+                  >
+                    {edge.target_id}
+                  </Link>
+                  {edge.reason ? (
+                    <span style={{ color: 'var(--fg-muted)', fontSize: 'var(--text-xs)' }}>
+                      {' '}
+                      — {edge.reason}
+                    </span>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/frontend/ui-v2/src/components/plan-graph.css
+++ b/frontend/ui-v2/src/components/plan-graph.css
@@ -1,0 +1,53 @@
+.plan-graph {
+  margin-top: var(--space-5);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  border: var(--border-subtle);
+  background: linear-gradient(
+    165deg,
+    color-mix(in srgb, var(--bg-elevated) 92%, #0ea5a4 8%) 0%,
+    var(--bg-elevated) 55%
+  );
+}
+
+.plan-graph__header {
+  margin-bottom: var(--space-3);
+}
+
+.plan-graph__title {
+  margin: var(--space-0);
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  color: var(--fg-display);
+}
+
+.plan-graph__subtitle {
+  margin: var(--space-1) var(--space-0) var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.plan-graph__canvas {
+  width: 100%;
+  min-height: calc(var(--space-16) * 14);
+  border-radius: var(--radius-sm);
+  border: var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-surface) 85%, #020617 15%);
+}
+
+.plan-graph__status {
+  margin: var(--space-0) var(--space-0) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+.plan-graph__status--error {
+  color: var(--status-blocked);
+}
+
+.plan-graph__summary {
+  margin: var(--space-3) var(--space-0) var(--space-0);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}

--- a/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
@@ -1,5 +1,7 @@
 import { Sparkles } from 'lucide-react'
 import type { Feature } from '../types/records'
+import { ContextNodeBadges } from '../components/ContextNodeBadges'
+import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
 import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
 
 export function FeaturePrimitive({ record }: { record: Feature }) {
@@ -23,6 +25,13 @@ export function FeaturePrimitive({ record }: { record: Feature }) {
       <MetaRow label="Related tasks">
         <Metric>{record.related_task_ids?.length ?? 0}</Metric>
       </MetaRow>
+      <ContextNodeBadges contextNode={record.context_node} />
+      {record.typed_relationships?.length ? (
+        <TypedRelationshipSection
+          projectId={record.project_id}
+          edges={record.typed_relationships}
+        />
+      ) : null}
     </PrimitiveCard>
   )
 }

--- a/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle } from 'lucide-react'
 import type { Issue } from '../types/records'
+import { ContextNodeBadges } from '../components/ContextNodeBadges'
+import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
 import { MetaRow, PrimitiveCard, Prose } from '../components/PrimitiveCard'
 
 export function IssuePrimitive({ record }: { record: Issue }) {
@@ -24,6 +26,13 @@ export function IssuePrimitive({ record }: { record: Issue }) {
       </MetaRow>
       {record.hypothesis ? (
         <MetaRow label="Hypothesis">{record.hypothesis}</MetaRow>
+      ) : null}
+      <ContextNodeBadges contextNode={record.context_node} />
+      {record.typed_relationships?.length ? (
+        <TypedRelationshipSection
+          projectId={record.project_id}
+          edges={record.typed_relationships}
+        />
       ) : null}
     </PrimitiveCard>
   )

--- a/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
@@ -1,5 +1,8 @@
 import { Map as MapIcon } from 'lucide-react'
 import type { Plan } from '../types/records'
+import { ContextNodeBadges } from '../components/ContextNodeBadges'
+import { PlanGraphExplorer } from '../components/PlanGraphExplorer'
+import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
 import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
 
 export function PlanPrimitive({ record }: { record: Plan }) {
@@ -22,6 +25,18 @@ export function PlanPrimitive({ record }: { record: Plan }) {
       <MetaRow label="Attached docs">
         <Metric>{record.attached_documents?.length ?? 0}</Metric>
       </MetaRow>
+      <PlanGraphExplorer
+        projectId={record.project_id}
+        planId={record.plan_id}
+        objectiveIds={record.objectives_set ?? []}
+      />
+      <ContextNodeBadges contextNode={record.context_node} />
+      {record.typed_relationships?.length ? (
+        <TypedRelationshipSection
+          projectId={record.project_id}
+          edges={record.typed_relationships}
+        />
+      ) : null}
     </PrimitiveCard>
   )
 }

--- a/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
@@ -1,5 +1,7 @@
 import { ListChecks } from 'lucide-react'
 import type { Task } from '../types/records'
+import { ContextNodeBadges } from '../components/ContextNodeBadges'
+import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
 import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
 
 export function TaskPrimitive({ record }: { record: Task }) {
@@ -29,6 +31,13 @@ export function TaskPrimitive({ record }: { record: Task }) {
         </Metric>{' '}
         edges
       </MetaRow>
+      <ContextNodeBadges contextNode={record.context_node} />
+      {record.typed_relationships?.length ? (
+        <TypedRelationshipSection
+          projectId={record.project_id}
+          edges={record.typed_relationships}
+        />
+      ) : null}
     </PrimitiveCard>
   )
 }

--- a/frontend/ui-v2/src/routes/GovernanceRoute.tsx
+++ b/frontend/ui-v2/src/routes/GovernanceRoute.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { Cards } from '../design-system'
+import { fetchGovernanceDocs, governanceDocKeys } from '../api/documents'
+import { projectRegistryQueryOptions } from '../api/projectRegistry'
+import { documentHref } from './recordLink'
+import type { Document } from '../types/records'
+import './governance.css'
+
+/**
+ * ENC-TSK-K26 / ENC-ISS-121 — Live governance docs from the docstore API.
+ * No stale mirror: every row is fetched via GET /api/v1/documents/search at
+ * read time (governance-file + project-reference keywords).
+ */
+export function GovernanceRoute() {
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+  const [projectId, setProjectId] = useState('enceladus')
+
+  const normalized = projectId.trim().toLowerCase()
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: governanceDocKeys.primaryReference(normalized),
+    queryFn: () => fetchGovernanceDocs(normalized),
+    enabled: normalized.length > 0,
+    staleTime: 60_000,
+  })
+
+  const docs = data ?? []
+
+  const cardDefinition = {
+    header: (doc: Document) => (
+      <Link to={documentHref(doc.document_id)} className="governance-route__card-link">
+        {doc.title || doc.document_id}
+      </Link>
+    ),
+    sections: [
+      {
+        id: 'documentId',
+        header: 'Document',
+        content: (doc: Document) => (
+          <span className="governance-route__card-id">{doc.document_id}</span>
+        ),
+      },
+      {
+        id: 'file',
+        header: 'File',
+        content: (doc: Document) => (
+          <span className="governance-route__card-file">{doc.file_name || '—'}</span>
+        ),
+      },
+      {
+        id: 'updated',
+        header: 'Updated',
+        content: (doc: Document) => doc.updated_at ?? '—',
+      },
+    ],
+  }
+
+  return (
+    <div className="governance-route">
+      <header className="governance-route__header">
+        <p className="governance-route__eyebrow">Governance · Live docstore</p>
+        <h1 className="governance-route__title">Governance documents</h1>
+        <p className="governance-route__subtitle">
+          agents.md, lifecycle-primer, dictionary, and project reference files — fetched from the
+          governed docstore on each load (ENC-ISS-121 / B67 AC-20).
+        </p>
+      </header>
+
+      <div className="governance-route__toolbar">
+        <label className="governance-route__project">
+          Project context
+          <select
+            value={projectId}
+            onChange={(e) => setProjectId(e.target.value)}
+            aria-label="Project for governance docs"
+          >
+            {projects.length > 0 ? (
+              projects.map((p) => (
+                <option key={p.project_id} value={p.project_id}>
+                  {p.project_id}
+                </option>
+              ))
+            ) : (
+              <option value="enceladus">enceladus</option>
+            )}
+          </select>
+        </label>
+        <p className="governance-route__meta">
+          {isPending ? 'Loading…' : `${docs.length} document${docs.length === 1 ? '' : 's'}`}
+        </p>
+      </div>
+
+      {isError ? (
+        <p className="governance-route__meta governance-route__meta-error">
+          {error instanceof Error ? error.message : 'Failed to load governance docs'}
+        </p>
+      ) : null}
+
+      {!isPending && !isError && docs.length === 0 ? (
+        <p className="governance-route__empty">No governance documents found for {normalized}.</p>
+      ) : null}
+
+      {!isPending && docs.length > 0 ? (
+        <Cards items={docs} cardDefinition={cardDefinition} trackBy="document_id" />
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/routes/governance.css
+++ b/frontend/ui-v2/src/routes/governance.css
@@ -1,0 +1,109 @@
+.governance-route {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: calc(var(--space-16) * 56);
+}
+
+.governance-route__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.governance-route__eyebrow {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--fg-muted);
+}
+
+.governance-route__title {
+  margin: var(--space-0);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
+  font-size: var(--text-3xl);
+  line-height: var(--lh-tight);
+  color: var(--fg-display);
+}
+
+.governance-route__subtitle {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--lh-relaxed);
+  color: var(--fg-muted);
+}
+
+.governance-route__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+}
+
+.governance-route__project {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.governance-route__project select {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--fg);
+}
+
+.governance-route__meta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.governance-route__meta-error {
+  color: var(--status-blocked);
+}
+
+.governance-route__empty {
+  margin: var(--space-0);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+.governance-route__card-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+}
+
+.governance-route__card-link:hover {
+  color: var(--accent-hover);
+}
+
+.governance-route__card-id {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.governance-route__card-file {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-body);
+}
+
+@media (max-width: 48rem) {
+  .governance-route .ev2-cards__grid {
+    grid-template-columns: 1fr !important;
+  }
+}

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -10,6 +10,7 @@ import { HomeRoute } from './HomeRoute'
 import { PlaceholderRoute } from './PlaceholderRoute'
 import { ProjectsRoute } from './ProjectsRoute'
 import { DocsRoute } from './DocsRoute'
+import { GovernanceRoute } from './GovernanceRoute'
 import { ChangelogRoute } from './ChangelogRoute'
 import { CoordinationRoute } from './CoordinationRoute'
 import { createSessionDetailRoute } from './SessionDetailRoute'
@@ -94,6 +95,11 @@ const docsRoute = createRoute({
   path: '/docs',
   component: DocsRoute,
 })
+const governanceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/governance',
+  component: GovernanceRoute,
+})
 const changelogRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/changelog',
@@ -129,6 +135,7 @@ const routeTree = rootRoute.addChildren([
   feedRoute,
   projectsRoute,
   docsRoute,
+  governanceRoute,
   changelogRoute,
   coordinationRoute,
   sessionRoute,

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -15,6 +15,7 @@ const SIDEBAR_ITEMS = [
   { type: 'link' as const, text: 'Projects', href: '/projects' },
   { type: 'link' as const, text: 'Feed', href: '/feed' },
   { type: 'link' as const, text: 'Docs', href: '/docs' },
+  { type: 'link' as const, text: 'Governance', href: '/governance' },
   { type: 'link' as const, text: 'Changelog', href: '/changelog' },
   { type: 'link' as const, text: 'Coordination', href: '/coordination' },
   { type: 'link' as const, text: 'Component registry', href: '/component-registry' },

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -21,6 +21,28 @@ export interface HistoryEntry {
   description: string
 }
 
+export interface TypedRelationshipEdge {
+  relationship_type: string
+  target_id: string
+  weight: number
+  confidence: number
+  reason: string | null
+  created_at: string | null
+}
+
+export interface ContextNodeMeta {
+  freshness_score: number
+  structural_importance: number
+  information_density: number
+  access_frequency: number
+}
+
+export interface RecordExtensions {
+  typed_relationships?: TypedRelationshipEdge[]
+  context_node?: ContextNodeMeta
+  subtask_ids?: string[]
+}
+
 export interface Task {
   task_id: string
   project_id: string
@@ -38,6 +60,9 @@ export interface Task {
   updated_at: string | null
   created_at: string | null
   sync_version?: number
+  typed_relationships?: TypedRelationshipEdge[]
+  context_node?: ContextNodeMeta
+  subtask_ids?: string[]
 }
 
 export interface Issue {
@@ -53,6 +78,8 @@ export interface Issue {
   history: HistoryEntry[]
   updated_at: string | null
   created_at: string | null
+  typed_relationships?: TypedRelationshipEdge[]
+  context_node?: ContextNodeMeta
 }
 
 export interface Feature {
@@ -67,6 +94,8 @@ export interface Feature {
   history: HistoryEntry[]
   updated_at: string | null
   created_at: string | null
+  typed_relationships?: TypedRelationshipEdge[]
+  context_node?: ContextNodeMeta
 }
 
 export interface Plan {
@@ -83,6 +112,8 @@ export interface Plan {
   history: HistoryEntry[]
   updated_at: string | null
   created_at: string | null
+  typed_relationships?: TypedRelationshipEdge[]
+  context_node?: ContextNodeMeta
 }
 
 export interface PillarScores {


### PR DESCRIPTION
CCI-f1776bc2fdad41e6b4361a4279a31de4

## Summary
- Add `/governance` route with live docstore fetch (ENC-ISS-121 / B67 AC-20)
- Embed Cytoscape plan graph on plan detail pages with PLAN_CONTAINS edges (AC-21)
- Wire context-node score badges and typed relationship sections on task/issue/feature/plan primitives (AC-22)
- Backend: shared `record_extensions` attaches typed edges + computed context_node on feed_query and tracker GET

## Test plan
- [x] `npm run typecheck` in frontend/ui-v2
- [x] ui-v2 vitest (143 tests)
- [x] shared_layer RecordExtensionsTests (3 tests)
- [ ] Gamma deploy + verify governance doc reload, ENC-PLN-006 graph, create_relationship feed latency, context badges


Made with [Cursor](https://cursor.com)