### PR TITLE
ENC-TSK-L41: OpenSearch CDC indexer (dedicated search-index FIFO)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -425,6 +425,7 @@ jobs:
               'enceladus-bedrock-agent-actions': 'bedrock-agent-actions',
               'devops-changelog-api':           'changelog-api',
               'devops-graph-sync':              'graph-sync',
+              'devops-opensearch-indexer':      'opensearch-indexer',
               'enceladus-neo4j-backup':         'neo4j-backup',
               'enceladus-graph-health-metrics': 'graph-health-metrics',
               'devops-env-drift-auditor':       'env-drift-auditor',

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.16",
-  "updated_at": "2026-07-05T11:25:00Z",
-  "last_change_summary": "ENC-TSK-J40: added component_registry.component.deploy_targets (stack names + function-name globs a component owns) to the ENC-TSK-E68 capability-declaration field set, consumed by tools/assert_deploy_target_coverage.py to fail closed when a component's declared targets are narrower than a merge's diff-inferred affected set.",
+  "version": "2026-07-05.17",
+  "updated_at": "2026-07-05T11:50:00Z",
+  "last_change_summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity — devops-opensearch-indexer CDC Lambda fed by dedicated SearchIndexQueue FIFO (Tracker/Documents EventBridge Pipes), bulk-upserting tracker/document mutations to OpenSearch records_write with external-version idempotency.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7464,10 +7464,46 @@
           "usage_guidance": "Client subscribes to /records/{recordId} (ENC-TSK-L29 AppSyncRealtimeClient.watchRecord) only while that record's detail page is open, and upserts event.record directly into the Tier-2 cache + the live query cache -- never re-fetches on receipt of this event."
         }
       }
+    },
+    "opensearch_indexer.lambda": {
+      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync \u2014 consumes a DEDICATED devops-search-index-queue.fifo fed by TrackerToSearchIndexPipe + DocumentsToSearchIndexPipe (second DynamoDB-stream reader group on tracker + documents tables). Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. SQS trigger uses ReportBatchItemFailures + DLQ redrive. Runs in VPC to reach the gamma single-node OpenSearch cluster (TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-admin). Skips reference and relationship record_types. Provisioned by infrastructure/cloudformation/01-data.yaml (SearchIndexQueue) + 02-compute.yaml (pipes, function, role, event source mapping).",
+      "fields": {
+        "OPENSEARCH_ENDPOINT": {
+          "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP, e.g. https://172.31.28.54:9200).",
+          "type": "string"
+        },
+        "OPENSEARCH_WRITE_ALIAS": {
+          "definition": "OpenSearch write alias; locked to records_write per ENC-TSK-L40 naming contract.",
+          "default": "records_write",
+          "type": "string"
+        },
+        "OPENSEARCH_ADMIN_PASSWORD": {
+          "definition": "Admin basic-auth password when set; takes precedence over Secrets Manager lookup.",
+          "type": "string"
+        },
+        "OPENSEARCH_SECRET_NAME": {
+          "definition": "Secrets Manager secret id holding {\"password\":\"...\"} when OPENSEARCH_ADMIN_PASSWORD is empty.",
+          "default": "enceladus/opensearch/gamma-admin",
+          "type": "string"
+        },
+        "SECRETS_REGION": {
+          "definition": "Region for Secrets Manager client.",
+          "default": "us-west-2",
+          "type": "string"
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-L41 / B67 Search2.0",
+      "telemetry_eligible": true
     }
   },
-  "change_summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7 governance surfaces): enceladus_shared.record_extensions centralizes typed_relationships query + context_node score computation (absolute structural_importance per DOC-310B93107B60); feed_query attaches extensions on task/issue/feature/lesson/plan payloads; tracker_mutation GET enriches single-record reads with the same fields for ui-v2 TypedRelationshipSection + ContextNodeBadges.",
+  "change_summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): opensearch_indexer.lambda — CDC indexer on dedicated SearchIndexQueue FIFO projecting tracker/document mutations to OpenSearch records_write with external-version idempotency; graph_sync queue untouched.",
   "change_log": [
+    {
+      "version": "2026-07-05.17",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
     {
       "version": "2026-07-05.15",
       "date": "2026-07-05",

--- a/backend/lambda/opensearch_indexer/deploy.sh
+++ b/backend/lambda/opensearch_indexer/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/opensearch_indexer/lambda_function.py
+++ b/backend/lambda/opensearch_indexer/lambda_function.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""devops-opensearch-indexer — CDC indexer for B67 Search2.0 (ENC-TSK-L41).
+
+Consumes DynamoDB stream records from a dedicated SQS FIFO queue fed by
+TrackerToSearchIndexPipe + DocumentsToSearchIndexPipe. Bulk-upserts tracker and
+document mutations into OpenSearch via the records_write alias; REMOVE deletes
+by stable natural key.
+
+Idempotency (interim until ENC-TSK-L27 version_seq):
+  _id = {project_id}#{record_type}#{bare_record_id}
+  external version = updated_at epoch milliseconds (version_seq field)
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+WRITE_ALIAS = os.environ.get("OPENSEARCH_WRITE_ALIAS", "records_write")
+OPENSEARCH_ENDPOINT = os.environ.get("OPENSEARCH_ENDPOINT", "").rstrip("/")
+OPENSEARCH_SECRET_NAME = os.environ.get("OPENSEARCH_SECRET_NAME", "")
+SECRETS_REGION = os.environ.get("SECRETS_REGION", os.environ.get("AWS_REGION", "us-west-2"))
+
+SKIP_RECORD_TYPES = frozenset({"reference", "relationship"})
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.check_hostname = False
+SSL_CONTEXT.verify_mode = ssl.CERT_NONE
+
+_admin_password: Optional[str] = None
+_secrets_client = None
+
+
+def _get_secrets_client():
+    global _secrets_client
+    if _secrets_client is None:
+        _secrets_client = boto3.client("secretsmanager", region_name=SECRETS_REGION)
+    return _secrets_client
+
+
+def _get_admin_password() -> str:
+    global _admin_password
+    if _admin_password is not None:
+        return _admin_password
+    override = os.environ.get("OPENSEARCH_ADMIN_PASSWORD")
+    if override:
+        _admin_password = override
+        return _admin_password
+    if not OPENSEARCH_SECRET_NAME:
+        raise RuntimeError("OPENSEARCH_SECRET_NAME is not configured")
+    resp = _get_secrets_client().get_secret_value(SecretId=OPENSEARCH_SECRET_NAME)
+    payload = json.loads(resp["SecretString"])
+    password = payload.get("password") or payload.get("admin_password")
+    if not password:
+        raise RuntimeError(f"Secret {OPENSEARCH_SECRET_NAME} missing password key")
+    _admin_password = str(password)
+    return _admin_password
+
+
+def _deser_value(ddb_val: Dict[str, Any]) -> Any:
+    if "S" in ddb_val:
+        return ddb_val["S"]
+    if "N" in ddb_val:
+        return ddb_val["N"]
+    if "BOOL" in ddb_val:
+        return ddb_val["BOOL"]
+    if "NULL" in ddb_val:
+        return None
+    if "L" in ddb_val:
+        return [_deser_value(v) for v in ddb_val["L"]]
+    if "M" in ddb_val:
+        return {k: _deser_value(v) for k, v in ddb_val["M"].items()}
+    if "SS" in ddb_val:
+        return list(ddb_val["SS"])
+    return str(ddb_val)
+
+
+def _deser_image(image: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: _deser_value(v) for k, v in image.items()}
+
+
+def _normalize_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = dict(record or {})
+    record_type = str(normalized.get("record_type") or "").strip()
+    if not record_type and normalized.get("document_id"):
+        record_type = "document"
+        normalized["record_type"] = record_type
+    if record_type == "document" and not normalized.get("record_id"):
+        normalized["record_id"] = normalized.get("document_id", "")
+    return normalized
+
+
+def _bare_record_id(record_id: str) -> str:
+    record_id = str(record_id or "").strip()
+    return record_id.split("#", 1)[-1] if "#" in record_id else record_id
+
+
+def _extract_remove_record_id(keys: Dict[str, Any], old_record: Dict[str, Any]) -> str:
+    for key_name in ("record_id", "document_id"):
+        typed = keys.get(key_name) or {}
+        value = str(typed.get("S") or "").strip()
+        if value:
+            return value
+    for key_name in ("record_id", "document_id"):
+        value = str(old_record.get(key_name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _parse_epoch_ms(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if text.isdigit():
+        return int(text)
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        dt = datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        return 0
+
+
+def _stable_doc_id(project_id: str, record_type: str, record_id: str) -> str:
+    return f"{project_id}#{record_type}#{_bare_record_id(record_id)}"
+
+
+def _build_search_document(record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    record = _normalize_record(record)
+    project_id = str(record.get("project_id") or "").strip()
+    record_type = str(record.get("record_type") or "").strip()
+    record_id = str(record.get("record_id") or "").strip()
+    if not project_id or not record_type or not record_id:
+        return None
+    if record_type in SKIP_RECORD_TYPES:
+        return None
+
+    title = str(record.get("title") or "").strip()
+    description = str(record.get("description") or "").strip()
+    body = str(record.get("body") or record.get("full_description") or record.get("content") or "").strip()
+    if record_type == "document" and not description:
+        description = title
+
+    updated_at = record.get("updated_at") or record.get("created_at")
+    created_at = record.get("created_at") or updated_at
+    version_ms = _parse_epoch_ms(updated_at)
+
+    tags = record.get("tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    elif not isinstance(tags, list):
+        tags = []
+
+    doc = {
+        "project_id": project_id,
+        "record_type": record_type,
+        "status": str(record.get("status") or "").strip(),
+        "priority": str(record.get("priority") or "").strip(),
+        "tags": [str(t) for t in tags if t],
+        "title": title,
+        "description": description,
+        "body": body,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "version_seq": version_ms,
+    }
+    return doc
+
+
+def _extract_stream_record(sqs_body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if isinstance(sqs_body, str):
+        try:
+            sqs_body = json.loads(sqs_body)
+        except json.JSONDecodeError:
+            return None
+    if "dynamodb" in sqs_body:
+        return sqs_body
+    return sqs_body
+
+
+def _opensearch_request(method: str, path: str, body: Optional[Any] = None) -> Tuple[int, Any]:
+    if not OPENSEARCH_ENDPOINT:
+        raise RuntimeError("OPENSEARCH_ENDPOINT is not configured")
+    url = f"{OPENSEARCH_ENDPOINT}{path}"
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8") if not isinstance(body, (bytes, bytearray)) else body
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    auth = base64.b64encode(f"admin:{_get_admin_password()}".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    try:
+        with urllib.request.urlopen(req, context=SSL_CONTEXT, timeout=30) as resp:
+            raw = resp.read()
+            parsed = json.loads(raw) if raw else {}
+            return resp.status, parsed
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed
+
+
+def _stream_record_to_action(stream_record: Dict[str, Any]) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Return ('index', meta+doc) or ('delete', meta) or None to skip."""
+    event_name = stream_record.get("eventName", "")
+    dynamodb = stream_record.get("dynamodb", {})
+
+    if event_name in ("INSERT", "MODIFY"):
+        new_image = dynamodb.get("NewImage", {})
+        if not new_image:
+            return None
+        record = _normalize_record(_deser_image(new_image))
+        search_doc = _build_search_document(record)
+        if not search_doc:
+            return None
+        doc_id = _stable_doc_id(
+            search_doc["project_id"],
+            search_doc["record_type"],
+            record.get("record_id", ""),
+        )
+        version_ms = search_doc["version_seq"]
+        meta = {
+            "index": {
+                "_index": WRITE_ALIAS,
+                "_id": doc_id,
+                "version": version_ms,
+                "version_type": "external",
+            }
+        }
+        return ("index", {"meta": meta, "doc": search_doc})
+
+    if event_name == "REMOVE":
+        old_image = dynamodb.get("OldImage", {})
+        old_record = _normalize_record(_deser_image(old_image)) if old_image else {}
+        raw_id = _extract_remove_record_id(dynamodb.get("Keys", {}), old_record)
+        if not raw_id:
+            return None
+        record_type = str(old_record.get("record_type") or "").strip()
+        if not record_type and old_record.get("document_id"):
+            record_type = "document"
+        if record_type in SKIP_RECORD_TYPES:
+            return None
+        project_id = str(old_record.get("project_id") or "").strip()
+        if not project_id or not record_type:
+            return None
+        doc_id = _stable_doc_id(project_id, record_type, raw_id)
+        meta = {"delete": {"_index": WRITE_ALIAS, "_id": doc_id}}
+        return ("delete", {"meta": meta})
+
+    return None
+
+
+def _bulk_execute(actions: List[Tuple[str, Dict[str, Any]]]) -> List[Tuple[int, Dict[str, Any]]]:
+    if not actions:
+        return []
+    lines: List[str] = []
+    for _kind, payload in actions:
+        lines.append(json.dumps(payload["meta"]))
+        if "doc" in payload:
+            lines.append(json.dumps(payload["doc"]))
+    body = "\n".join(lines) + "\n"
+    status, resp = _opensearch_request("POST", f"/{WRITE_ALIAS}/_bulk", body.encode("utf-8"))
+    if status != 200:
+        raise RuntimeError(f"Bulk request failed: status={status} resp={resp}")
+    items = resp.get("items") or []
+    results: List[Tuple[int, Dict[str, Any]]] = []
+    for item in items:
+        op_result = item.get("index") or item.get("delete") or {}
+        results.append((op_result.get("status", 500), op_result))
+    if len(results) != len(actions):
+        raise RuntimeError(
+            f"Bulk item count mismatch: expected {len(actions)} got {len(results)}"
+        )
+    return results
+
+
+def _is_success_status(status: int) -> bool:
+    if 200 <= status < 300:
+        return True
+    # External version conflict: stale write is idempotent success.
+    if status == 409:
+        return True
+    return False
+
+
+def _batch_failure_response(message_ids: List[str]) -> Dict[str, Any]:
+    failures = []
+    seen = set()
+    for message_id in message_ids:
+        if not message_id or message_id in seen:
+            continue
+        seen.add(message_id)
+        failures.append({"itemIdentifier": message_id})
+    if not failures:
+        return {}
+    return {"batchItemFailures": failures}
+
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    records = event.get("Records") or []
+    if not records:
+        return {}
+
+    parsed: List[Tuple[str, Optional[Tuple[str, Dict[str, Any]]]]] = []
+    failed_message_ids: List[str] = []
+    bulk_actions: List[Tuple[str, Dict[str, Any]]] = []
+    bulk_message_indexes: List[int] = []
+
+    for idx, sqs_record in enumerate(records):
+        message_id = sqs_record.get("messageId") or sqs_record.get("messageID")
+        try:
+            body_raw = sqs_record.get("body", "{}")
+            body = json.loads(body_raw) if isinstance(body_raw, str) else body_raw
+            stream_record = _extract_stream_record(body)
+            if not stream_record or "dynamodb" not in stream_record:
+                parsed.append((message_id, None))
+                continue
+            action = _stream_record_to_action(stream_record)
+            parsed.append((message_id, action))
+            if action is not None:
+                bulk_message_indexes.append(idx)
+                bulk_actions.append(action)
+        except Exception:
+            logger.exception("[ERROR] Failed to parse SQS record messageId=%s", message_id)
+            if message_id:
+                failed_message_ids.append(message_id)
+
+    if bulk_actions:
+        try:
+            bulk_results = _bulk_execute(bulk_actions)
+            for bulk_idx, (status, _result) in enumerate(bulk_results):
+                if _is_success_status(status):
+                    continue
+                msg_idx = bulk_message_indexes[bulk_idx]
+                message_id = records[msg_idx].get("messageId") or records[msg_idx].get("messageID")
+                if message_id:
+                    failed_message_ids.append(message_id)
+        except Exception:
+            logger.exception("[ERROR] OpenSearch bulk execute failed")
+            for msg_idx in bulk_message_indexes:
+                message_id = records[msg_idx].get("messageId") or records[msg_idx].get("messageID")
+                if message_id:
+                    failed_message_ids.append(message_id)
+
+    logger.info(
+        "[INFO] Batch complete: total=%d bulk=%d failures=%d",
+        len(records),
+        len(bulk_actions),
+        len(failed_message_ids),
+    )
+    return _batch_failure_response(failed_message_ids)

--- a/backend/lambda/opensearch_indexer/test_lambda_function.py
+++ b/backend/lambda/opensearch_indexer/test_lambda_function.py
@@ -1,0 +1,175 @@
+"""Unit tests for devops-opensearch-indexer (ENC-TSK-L41)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+def _load_module():
+    if "boto3" not in sys.modules:
+        fake_boto3 = types.ModuleType("boto3")
+        fake_boto3.client = lambda *a, **k: None
+        sys.modules["boto3"] = fake_boto3
+    if "botocore.exceptions" not in sys.modules:
+        fake_botocore = types.ModuleType("botocore.exceptions")
+        fake_botocore.ClientError = Exception
+        sys.modules["botocore.exceptions"] = fake_botocore
+
+    here = pathlib.Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location("opensearch_indexer_under_test", here / "lambda_function.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+IDX = _load_module()
+
+
+class TestRecordMapping(unittest.TestCase):
+    def test_tracker_document_fields(self):
+        record = {
+            "project_id": "enceladus",
+            "record_type": "task",
+            "record_id": "task#ENC-TSK-123",
+            "title": "Fix search",
+            "description": "Details here",
+            "status": "open",
+            "priority": "P1",
+            "tags": ["search"],
+            "created_at": "2026-07-05T00:00:00Z",
+            "updated_at": "2026-07-05T01:00:00Z",
+        }
+        doc = IDX._build_search_document(record)
+        self.assertEqual(doc["title"], "Fix search")
+        self.assertEqual(doc["version_seq"], IDX._parse_epoch_ms(record["updated_at"]))
+        doc_id = IDX._stable_doc_id("enceladus", "task", record["record_id"])
+        self.assertEqual(doc_id, "enceladus#task#ENC-TSK-123")
+
+    def test_document_uses_full_description_as_body(self):
+        record = {
+            "document_id": "DOC-ABC",
+            "record_type": "document",
+            "project_id": "enceladus",
+            "title": "Architecture note",
+            "full_description": "Long body text",
+            "status": "active",
+            "updated_at": "2026-07-05T02:00:00Z",
+        }
+        doc = IDX._build_search_document(record)
+        self.assertEqual(doc["body"], "Long body text")
+        self.assertEqual(doc["record_type"], "document")
+
+    def test_reference_records_skipped(self):
+        self.assertIsNone(
+            IDX._build_search_document(
+                {"project_id": "enceladus", "record_type": "reference", "record_id": "ref#1"}
+            )
+        )
+
+
+class TestStreamActions(unittest.TestCase):
+    def test_modify_builds_index_action(self):
+        stream = {
+            "eventName": "MODIFY",
+            "dynamodb": {
+                "NewImage": {
+                    "project_id": {"S": "enceladus"},
+                    "record_type": {"S": "task"},
+                    "record_id": {"S": "ENC-TSK-999"},
+                    "title": {"S": "Hello"},
+                    "updated_at": {"S": "2026-07-05T03:00:00Z"},
+                }
+            },
+        }
+        kind, payload = IDX._stream_record_to_action(stream)
+        self.assertEqual(kind, "index")
+        self.assertEqual(payload["meta"]["index"]["_id"], "enceladus#task#ENC-TSK-999")
+
+    def test_remove_builds_delete_action(self):
+        stream = {
+            "eventName": "REMOVE",
+            "dynamodb": {
+                "Keys": {"document_id": {"S": "DOC-REMOVE-1"}},
+                "OldImage": {
+                    "document_id": {"S": "DOC-REMOVE-1"},
+                    "record_type": {"S": "document"},
+                    "project_id": {"S": "enceladus"},
+                },
+            },
+        }
+        kind, payload = IDX._stream_record_to_action(stream)
+        self.assertEqual(kind, "delete")
+        self.assertEqual(payload["meta"]["delete"]["_id"], "enceladus#document#DOC-REMOVE-1")
+
+
+class TestHandler(unittest.TestCase):
+    @patch.dict(
+        IDX.__dict__,
+        {"OPENSEARCH_ENDPOINT": "https://127.0.0.1:9200", "_admin_password": "secret"},
+    )
+    @patch.object(IDX, "_bulk_execute")
+    def test_report_batch_item_failures(self, bulk_execute):
+        bulk_execute.return_value = [(500, {"error": "boom"})]
+        event = {
+            "Records": [
+                {
+                    "messageId": "good-1",
+                    "body": json.dumps(
+                        {
+                            "eventName": "MODIFY",
+                            "dynamodb": {
+                                "NewImage": {
+                                    "project_id": {"S": "enceladus"},
+                                    "record_type": {"S": "task"},
+                                    "record_id": {"S": "ENC-TSK-1"},
+                                    "title": {"S": "A"},
+                                    "updated_at": {"S": "2026-07-05T00:00:00Z"},
+                                }
+                            },
+                        }
+                    ),
+                }
+            ]
+        }
+        result = IDX.handler(event, None)
+        self.assertEqual(result, {"batchItemFailures": [{"itemIdentifier": "good-1"}]})
+
+    @patch.dict(
+        IDX.__dict__,
+        {"OPENSEARCH_ENDPOINT": "https://127.0.0.1:9200", "_admin_password": "secret"},
+    )
+    @patch.object(IDX, "_bulk_execute")
+    def test_version_conflict_is_success(self, bulk_execute):
+        bulk_execute.return_value = [(409, {"error": {"type": "version_conflict_engine_exception"}})]
+        event = {
+            "Records": [
+                {
+                    "messageId": "ok-1",
+                    "body": json.dumps(
+                        {
+                            "eventName": "MODIFY",
+                            "dynamodb": {
+                                "NewImage": {
+                                    "project_id": {"S": "enceladus"},
+                                    "record_type": {"S": "task"},
+                                    "record_id": {"S": "ENC-TSK-2"},
+                                    "title": {"S": "B"},
+                                    "updated_at": {"S": "2026-07-05T00:00:00Z"},
+                                }
+                            },
+                        }
+                    ),
+                }
+            ]
+        }
+        result = IDX.handler(event, None)
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -82,6 +82,7 @@ function_name_map:
   arc_walk_metrics: enceladus-arc-walk-metrics-gamma
   graph_query_api: devops-graph-query-api-gamma
   graph_sync: devops-graph-sync-gamma
+  opensearch_indexer: devops-opensearch-indexer-gamma
   memory_consolidation: enceladus-memory-consolidation-gamma
   neo4j_backup: enceladus-neo4j-backup-gamma
   percolation_monitor: enceladus-percolation-monitor-gamma

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -507,6 +507,44 @@ Resources:
         - Key: Component
           Value: graph
 
+  # ENC-TSK-L41 / B67 Search2.0: dedicated FIFO for the OpenSearch CDC indexer.
+  # Fed by TrackerToSearchIndexPipe + DocumentsToSearchIndexPipe (02-compute.yaml)
+  # — NOT graph_sync's GraphSyncQueue (SQS would split messages across consumers).
+  SearchIndexQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    Properties:
+      QueueName: !Sub "devops-search-index-queue${EnvironmentSuffix}.fifo"
+      FifoQueue: true
+      ContentBasedDeduplication: true
+      VisibilityTimeout: 120
+      MessageRetentionPeriod: 86400
+      ReceiveMessageWaitTimeSeconds: 20
+      SqsManagedSseEnabled: true
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt SearchIndexDLQ.Arn
+        maxReceiveCount: 3
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: search
+
+  SearchIndexDLQ:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    Properties:
+      QueueName: !Sub "devops-search-index-dlq${EnvironmentSuffix}.fifo"
+      FifoQueue: true
+      ContentBasedDeduplication: true
+      MessageRetentionPeriod: 1209600
+      SqsManagedSseEnabled: true
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: search
+
   # ENC-FTR-086 Ph1 / ENC-TSK-I82: write buffer between the convergence fan-out
   # (DynamoDB-stream-triggered) and the idempotent counter increment. FIFO with
   # per-attribute MessageGroupId so increments to one attribute are ordered while
@@ -901,6 +939,18 @@ Outputs:
     Value: !GetAtt GraphSyncDLQ.Arn
     Export:
       Name: !Sub ${AWS::StackName}-GraphSyncDLQArn
+  SearchIndexQueueUrl:
+    Value: !Ref SearchIndexQueue
+    Export:
+      Name: !Sub ${AWS::StackName}-SearchIndexQueueUrl
+  SearchIndexQueueArn:
+    Value: !GetAtt SearchIndexQueue.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-SearchIndexQueueArn
+  SearchIndexDLQArn:
+    Value: !GetAtt SearchIndexDLQ.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-SearchIndexDLQArn
   ComponentRegistryEventsTopicArn:
     Value: !Ref ComponentRegistryEventsTopic
     Export:

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1408,12 +1408,12 @@ Resources:
       FunctionName: !Sub "devops-opensearch-indexer${EnvironmentSuffix}"
       Code:
         ZipFile: "# managed outside CloudFormation"
-      Runtime: python3.12
+      Runtime: !If [IsGamma, python3.12, python3.11]
       Handler: lambda_function.handler
       MemorySize: 256
       Timeout: 60
       Architectures:
-        - arm64
+        - !If [IsGamma, arm64, x86_64]
       Role: !GetAtt OpenSearchIndexerRole.Arn
       VpcConfig:
         SecurityGroupIds:

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -149,6 +149,31 @@ Parameters:
       ENC-PLN-068: gamma rhythm tier schedules; when true, legacy superseded
       gamma EventBridge rules are disabled (K91).
 
+  # ENC-TSK-L41 / B67 Search2.0: gamma OpenSearch CDC indexer (VPC-private node).
+  OpenSearchHttpsEndpoint:
+    Type: String
+    Default: https://172.31.28.54:9200
+    Description: HTTPS endpoint for the gamma OpenSearch node (private VPC IP).
+  OpenSearchAdminSecretName:
+    Type: String
+    Default: enceladus/opensearch/gamma-admin
+    Description: Optional Secrets Manager secret with {"password":"..."} when env var unset.
+  OpenSearchAdminPassword:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: >
+      Gamma OpenSearch admin password for basic auth. Prefer passing via deploy
+      --parameter-overrides; when empty the Lambda falls back to Secrets Manager.
+  OpenSearchIndexerVpcId:
+    Type: AWS::EC2::VPC::Id
+    Default: vpc-8ad4a8f2
+    Description: VPC hosting the gamma OpenSearch node and indexer Lambda ENI.
+  OpenSearchIndexerSubnetIds:
+    Type: CommaDelimitedList
+    Default: subnet-0a27ee72
+    Description: Subnet(s) for the indexer Lambda ENI (must route to OpenSearch :9200).
+
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
   IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
@@ -1374,6 +1399,39 @@ Resources:
         - Key: Component
           Value: graph
 
+  # ENC-TSK-L41 / B67 Search2.0: CDC indexer Lambda (gamma-only until prod OpenSearch).
+  OpenSearchIndexerFunction:
+    Type: AWS::Lambda::Function
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-opensearch-indexer${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: python3.12
+      Handler: lambda_function.handler
+      MemorySize: 256
+      Timeout: 60
+      Architectures:
+        - arm64
+      Role: !GetAtt OpenSearchIndexerRole.Arn
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref OpenSearchIndexerSecurityGroup
+        SubnetIds: !Ref OpenSearchIndexerSubnetIds
+      Environment:
+        Variables:
+          OPENSEARCH_ENDPOINT: !Ref OpenSearchHttpsEndpoint
+          OPENSEARCH_WRITE_ALIAS: records_write
+          OPENSEARCH_ADMIN_PASSWORD: !Ref OpenSearchAdminPassword
+          OPENSEARCH_SECRET_NAME: !Ref OpenSearchAdminSecretName
+          SECRETS_REGION: !Ref AWS::Region
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: search
+
   GraphQueryApiFunction:
     Type: AWS::Lambda::Function
     DeletionPolicy: Retain
@@ -2461,6 +2519,19 @@ Resources:
       BatchSize: 10
       Enabled: true
 
+  SearchIndexSqsTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-SearchIndexQueueArn
+      FunctionName: !Ref OpenSearchIndexerFunction
+      BatchSize: 10
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      Enabled: true
+
   # ---------------------------------------------------------------------------
   # EventBridge Pipes (Tracker Stream -> Lambda) — replace direct stream glue
   # ENC-TSK-L14 / B65 AC-5: migrate GovernanceAudit + ConvergenceTelemetry
@@ -2923,6 +2994,52 @@ Resources:
             - Pattern: '{"eventName":["INSERT","MODIFY"]}'
       Target: !ImportValue
         Fn::Sub: ${DataStackName}-GraphSyncQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: document
+          MessageDeduplicationId: $.dynamodb.Keys.document_id.S
+
+  # ENC-TSK-L41 / B67 Search2.0: dedicated search-index FIFO (NOT GraphSyncQueue).
+  TrackerToSearchIndexPipe:
+    Type: AWS::Pipes::Pipe
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-tracker-to-search-index-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt SearchIndexPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY"],"dynamodb":{"NewImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+            - Pattern: '{"eventName":["REMOVE"],"dynamodb":{"OldImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-SearchIndexQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: tracker
+          MessageDeduplicationId: $.dynamodb.Keys.record_id.S
+    Type: AWS::Pipes::Pipe
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-documents-to-search-index-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt SearchIndexPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-DocumentsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY","REMOVE"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-SearchIndexQueueArn
       TargetParameters:
         SqsQueueParameters:
           MessageGroupId: document
@@ -5596,6 +5713,137 @@ Resources:
                 Effect: Allow
                 Action: lambda:InvokeFunction
                 Resource: !GetAtt GovernanceAuditFunction.Arn
+
+  # ENC-TSK-L41: EventBridge Pipes role for tracker/documents -> SearchIndexQueue.
+  SearchIndexPipeRole:
+    Type: AWS::IAM::Role
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-search-index-pipe-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: pipes.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PipeSourceStreams
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+              - Sid: ReadDocumentsStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-DocumentsStreamArn
+        - PolicyName: PipeTargetSearchIndexQueue
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: WriteSearchIndexQueue
+                Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:GetQueueUrl
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-SearchIndexQueueArn
+      Tags:
+        - Key: Project
+          Value: enceladus
+
+  OpenSearchIndexerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      GroupDescription: !Sub "OpenSearch CDC indexer Lambda ${EnvironmentSuffix}"
+      VpcId: !Ref OpenSearchIndexerVpcId
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 9200
+          ToPort: 9200
+          CidrIp: 172.31.0.0/16
+          Description: OpenSearch REST (TLS) within VPC
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: Secrets Manager / AWS API egress when subnet routes public
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: search
+
+  OpenSearchIndexerRole:
+    Type: AWS::IAM::Role
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-opensearch-indexer-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      Policies:
+        - PolicyName: SqsEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ConsumeSearchIndexQueue
+                Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-SearchIndexQueueArn
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: SecretsManagerOpenSearch
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: SecretsManagerOpenSearch
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/opensearch/*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: search
 
   GraphPipeRole:
     Type: AWS::IAM::Role

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -129,6 +129,12 @@
       "deploy_script": "backend/lambda/graph_sync/deploy.sh"
     },
     {
+      "function_name": "devops-opensearch-indexer",
+      "lambda_dir": "backend/lambda/opensearch_indexer",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/opensearch_indexer/deploy.sh"
+    },
+    {
       "function_name": "devops-project-service",
       "lambda_dir": "backend/lambda/project_service",
       "workflow_file": ".github/workflows/_deploy.yml",


### PR DESCRIPTION
## Summary
- Adds `devops-search-index-queue` FIFO + DLQ in `01-data.yaml`, with `TrackerToSearchIndexPipe` and `DocumentsToSearchIndexPipe` targeting it (graph_sync queue unchanged per AC-1).
- Implements `devops-opensearch-indexer` Lambda (VPC, gamma-only): bulk upsert/delete to `records_write` with `_id={project_id}#{record_type}#{record_id}` and external version = `updated_at` epoch-ms; `ReportBatchItemFailures` + DLQ redrive.
- Registers function in deploy manifest / v4-gamma function map; 7 unit tests.

commit-complete-id: CCI-2396014756cb457f9466e1288903a249

## Deploy notes
1. Deploy **data** stack first (new queue exports), then **compute** stack (pipes + Lambda + event source mapping).
2. Pass `OpenSearchAdminPassword` via `--parameter-overrides` on gamma compute deploy (or populate Secrets Manager `enceladus/opensearch/gamma-admin` with `{"password":"..."}`).
3. After deploy, verify AC-3 freshness (tracker mutation → searchable ≤5s p95) and graph_sync metrics unchanged.

## Test plan
- [x] `pytest backend/lambda/opensearch_indexer/test_lambda_function.py`
- [x] `python3 tools/verify_lambda_workflow_coverage.py`
- [ ] Merge + gamma data/compute CFN deploy
- [ ] Live: mutate tracker record, query `records_read` within 5s
- [ ] Live: confirm graph_sync queue depth / Neo4j projection unaffected