### PR TITLE
feat(deploy): blast-radius-scoped Gen2 Lambda deploys (ENC-TSK-J40)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -103,6 +103,8 @@ jobs:
       function_name_map_json: ${{ steps.manifest.outputs.function_name_map_json }}
       environment_suffix:    ${{ steps.manifest.outputs.environment_suffix }}
       codedeploy_app_name:   ${{ steps.manifest.outputs.codedeploy_app_name }}
+      full_scope:            ${{ steps.affected.outputs.full_scope }}
+      affected_functions_json: ${{ steps.affected.outputs.affected_functions_json }}
 
     steps:
       # ENC-TSK-I60: pin to the target SHA so the `find backend/lambda` probe
@@ -176,6 +178,28 @@ jobs:
           echo "Target=$TARGET  Arch=$ARCH  Runtime=$RUNTIME  Role=$ROLE"
           echo "function_name_map: $(echo "$FNMAP_JSON" | python3 -c 'import json,sys; m=json.load(sys.stdin); print(f"{len(m)} entries")')"
 
+      - name: Compute affected-set (ENC-TSK-J40)
+        id: affected
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.DM_GITHUB_READ_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          python3 tools/compute_affected_targets.py \
+            --environment "${{ steps.manifest.outputs.environment }}" \
+            --head-sha "${{ steps.sha.outputs.commit_sha }}" \
+            --repo "${{ github.repository }}"
+
+      - name: Assert component deploy_targets coverage (ENC-TSK-J40 AC-2)
+        if: steps.affected.outputs.full_scope == 'false'
+        shell: bash
+        env:
+          COORDINATION_INTERNAL_API_KEY: ${{ secrets.COORDINATION_INTERNAL_API_KEY }}
+        run: |
+          set -euo pipefail
+          python3 tools/assert_deploy_target_coverage.py \
+            --affected-functions-json '${{ steps.affected.outputs.affected_functions_json }}'
+
       - name: Configure AWS credentials (build role — S3 artifact probe)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -192,13 +216,40 @@ jobs:
           PY="${{ steps.manifest.outputs.py_version }}"
           KEY_PREFIX="${{ env.ARTIFACT_KEY_PREFIX }}/${ARCH}-py${PY}"
           BUCKET="${{ env.ARTIFACT_BUCKET }}"
+          FULL_SCOPE="${{ steps.affected.outputs.full_scope }}"
+          AFFECTED_JSON='${{ steps.affected.outputs.affected_functions_json }}'
 
-          mapfile -t FNS < <(find backend/lambda -maxdepth 2 -name lambda_function.py \
+          mapfile -t ALL_FNS < <(find backend/lambda -maxdepth 2 -name lambda_function.py \
             | sed -E 's|backend/lambda/([^/]+)/lambda_function.py|\1|' | sort -u)
 
           # mcp_code (enceladus-mcp-code) has no lambda_function.py — it is packaged
           # by _build.yml build-mcp-code from tools/enceladus-mcp-server/ (ENC-TSK-I39).
-          FNS+=("mcp_code")
+          ALL_FNS+=("mcp_code")
+
+          # ENC-TSK-J40 AC-1/AC-4: narrow to the affected set unless full_scope
+          # (no prior deployment, cross-cutting change, or diff failure --
+          # "ambiguity widens, never narrows", see tools/compute_affected_targets.py).
+          if [[ "$FULL_SCOPE" == "true" ]]; then
+            FNS=("${ALL_FNS[@]}")
+            echo "Full-scope deploy: probing all ${#FNS[@]} functions."
+          else
+            mapfile -t AFFECTED < <(echo "$AFFECTED_JSON" | python3 -c 'import json,sys; [print(f) for f in json.load(sys.stdin)]')
+            FNS=()
+            for fn in "${ALL_FNS[@]}"; do
+              for a in "${AFFECTED[@]}"; do
+                if [[ "$fn" == "$a" ]]; then
+                  FNS+=("$fn")
+                  break
+                fi
+              done
+            done
+            echo "Narrowed deploy: probing ${#FNS[@]} of ${#ALL_FNS[@]} functions (affected-set: ${AFFECTED[*]:-none})."
+            if [[ ${#FNS[@]} -eq 0 ]]; then
+              echo "No affected functions and not full_scope -- nothing to deploy."
+              echo "version_ids_json={}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
 
           # ENC-ISS-494: build-mcp-code always builds x86_64-py3.11 only (matches
           # v3-prod's arch by coincidence), regardless of the target environment's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
           set -euo pipefail
           python3 -m unittest tools.test_verify_lambda_package_arch -v
 
+      - name: Test blast-radius affected-target computation (ENC-TSK-J40)
+        run: |
+          set -euo pipefail
+          python3 -m unittest tools.test_compute_affected_targets -v
+
       # ENC-TSK-H22 (ENC-PLN-048 Obj 4.1): prove the env-parity gate catches a
       # template strip. Needs PyYAML (the gate's resolver parses CFN); no current
       # CI step imports yaml, so provision Python+PyYAML scoped to this step only.

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.1",
+  "version": "2026-07-05.2",
   "updated_at": "2026-07-05T00:00:00Z",
-  "last_change_summary": "ENC-TSK checkout_service fix: added tracker.task.github_repo per-task GitHub repo override field, checked by the new checkout_service._resolve_task_github_repo before falling back to project-level repo resolution at the committed/pr/merged-main/closed GitHub-validation gates (ENC-FTR-119 satellite-repo support).",
+  "last_change_summary": "ENC-TSK-J40: added component_registry.component.deploy_targets (stack names + function-name globs a component owns) to the ENC-TSK-E68 capability-declaration field set, consumed by tools/assert_deploy_target_coverage.py to fail closed when a component's declared targets are narrower than a merge's diff-inferred affected set.",
   "owners": [
     "enceladus-platform"
   ],
@@ -2561,7 +2561,7 @@
       }
     },
     "component_registry.component": {
-      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-J40 (PLN-060 Pile B): added a 6th field, deploy_targets, to the same capability-declaration set -- consumed by tools/assert_deploy_target_coverage.py to fail closed on blast-radius-scoped deploys when a component's declared targets are narrower than a merge's actual diff. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
       "fields": {
         "component_id": {
           "type": "string",
@@ -2777,6 +2777,15 @@
           "example": [
             "COORDINATION_INTERNAL_API_KEY",
             "DYNAMODB_REGION"
+          ]
+        },
+        "deploy_targets": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Stack names and/or backend/lambda function-name globs this component owns for deploy purposes. ENC-TSK-J40 (PLN-060 Pile B). Consumed by tools/assert_deploy_target_coverage.py as part of the blast-radius-scoped Gen2 deploy: when tools/compute_affected_targets.py diffs a merge against the last-deployed SHA and finds a changed backend/lambda/<dir> whose owning component (matched via source_paths.directory) HAS declared deploy_targets, that declaration must cover the changed dir or the deploy CI run fails closed. Components that have not declared deploy_targets are not gated (their functions ride the plain diff-inferred set, unaffected by this check) -- this field is opt-in, not retroactively enforced. Optional (empty-array default).",
+          "usage_guidance": "Populate with the exact backend/lambda directory name(s) (fnmatch glob supported, e.g. 'devops-*') this component is responsible for redeploying. A component that owns exactly one Lambda typically declares deploy_targets=[that lambda dir name]. Getting this wrong in the narrow direction (declaring less than you actually touch) fails the deploy CI run outright -- getting it wrong wide (declaring more) is safe and just means occasional non-narrowed deploys for that component's scope.",
+          "example": [
+            "tracker_mutation"
           ]
         },
         "source_paths": {

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -7818,12 +7818,17 @@ _COMPONENT_STATUSES = frozenset({"active", "deprecated", "archived"})
 # components_create / components_update / components_propose. All optional
 # List[str], empty-array default. Source-of-truth for the continuous deploy
 # capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70).
+# ENC-TSK-J40: deploy_targets added to the same extension point -- stack names
+# and function-name globs this component owns, consumed by
+# tools/assert_deploy_target_coverage.py to fail closed when a component's
+# declared targets are narrower than what a merge's diff actually touched.
 _COMPONENT_CAPABILITY_FIELDS = (
     "required_iam_actions",
     "required_env_secrets",
     "required_apigw_routes",
     "required_cfn_resources",
     "required_lambda_env_vars",
+    "deploy_targets",
 )
 _COMPONENT_STRICTNESS_RANK = {
     "github_pr_deploy": 0,

--- a/infrastructure/blast-radius-deploy-design.md
+++ b/infrastructure/blast-radius-deploy-design.md
@@ -1,0 +1,125 @@
+# ENC-TSK-J40: Blast-Radius-Scoped Gen2 Lambda Deploys
+
+PLN-060 Pile B / LCD-8b. Design doc for narrowing the Gen2 deploy pipeline
+(`.github/workflows/_deploy.yml`) from "push code to every Lambda on every
+merge" to "push code only to the Lambdas a merge actually touched."
+
+## Problem
+
+Every push to `v4/main` (and every `workflow_dispatch`/`workflow_call` to
+`v3-prod`) rebuilds and redeploys **all** ~30 Lambda functions, regardless of
+how small the actual change was. A one-line fix in `tracker_mutation` still
+triggers `update-function-code` + alias update (and CodeDeploy canary, where
+configured) for every other function too. This is wasted deploy time, wasted
+CodeDeploy canary windows, and unnecessary blast radius: a bug in the deploy
+pipeline itself, or a bad artifact for an unrelated function, can block or
+break a deploy that only needed to touch one Lambda.
+
+## Design
+
+### Phase 1 (this task) — Lambda-code push scoping only
+
+Scope is deliberately narrow: **only** which Lambda functions get
+`update-function-code` called in `_deploy.yml`'s `deploy` job. `_build.yml`
+still builds every function's artifact on every run (build-side selectivity
+has a different risk profile — stale/missing artifacts across partial
+rebuilds — and is left as a follow-up). CFN stack-level scoping (separate
+`cloudformation-*-stack-deploy.yml` workflows) is also out of scope; those
+already deploy independently per-stack.
+
+### AC-1 / AC-3 — Affected-set computation (`tools/compute_affected_targets.py`)
+
+Given `--environment` (the GitHub Deployments environment name, e.g.
+`v4-gamma`), the script:
+
+1. Resolves the **last successful GitHub Deployment SHA** for that
+   environment via `gh api /repos/{repo}/deployments?environment=X` +
+   `/statuses` (the existing deploy-state store — see `_deploy.yml`'s own
+   AC-2 comment: "GitHub Deployments API is the deploy-state store").
+2. `git diff --name-only <base>..<head>`.
+3. If any changed path matches a cross-cutting pattern — shared layer
+   source (`backend/lambda/shared_layer/`), IAM (`04-github-roles.yaml`),
+   CFN parameter files (`envs/*.yaml`), the deploy workflow files
+   themselves (`_build.yml`/`_deploy.yml`), or the build manifest
+   (`lambda_workflow_manifest.json`) — **or** the base SHA can't be
+   resolved, **or** the diff itself fails — output `full_scope=true` and an
+   empty affected list. The caller must treat `full_scope=true` as "deploy
+   everything," the current (safe) behavior.
+4. Otherwise, map every changed `backend/lambda/<dir>/...` path to its
+   `<dir>` and return that set as `affected_functions`.
+
+This is the "ambiguity widens, never narrows" contract (AC-3): any failure
+mode, any doubt, any cross-cutting touch produces the *wider* answer.
+
+### AC-2 — Component registry `deploy_targets` + fail-closed coverage (`tools/assert_deploy_target_coverage.py`)
+
+`deploy_targets` is added to the existing capability-declaration field set
+on `component_registry.component` (ENC-TSK-E68's `_COMPONENT_CAPABILITY_FIELDS`
+extension point in `coordination_api/lambda_function.py`) — a list of
+backend/lambda directory names (fnmatch globs supported) the component owns
+for deploy purposes.
+
+The assertion is **asymmetric by design**: for each function in the
+affected-set, find its owning component by `source_paths.directory`. If that
+component declared `deploy_targets` and the affected function is **not**
+covered by it, the deploy CI run fails closed — this is a real
+misconfiguration (the component's own maintainer said "I only touch X" and
+the diff proves otherwise). If the component has **not** declared
+`deploy_targets` at all, the function is not gated — it simply doesn't
+benefit from narrowing at the registry layer (it still gets deployed,
+because the plain diff-inferred set already includes it). This means
+enabling the feature does not retroactively block the ~27 of ~30 functions
+that don't yet have an owning component with `deploy_targets` declared;
+adoption is incremental, and getting it wrong can only ever widen (fail
+closed / block), never silently under-deploy.
+
+### AC-4 — Per-function selective push
+
+`_deploy.yml`'s `resolve` job's S3-artifact-probe step now takes the
+affected-set and narrows the probed (and therefore deployed) function list
+to the intersection of "what changed" and "what's built," unless
+`full_scope=true`. The `deploy` job's existing per-function push loop
+(`update-function-code` + `--s3-key`, already structured as one unit per
+target function) is untouched — it already only acts on whatever
+`version_ids_json` it's handed, so narrowing that input is sufficient.
+
+### AC-6 — Both lanes
+
+`main` and `v4/main` maintain **forked** copies of `_build.yml`/`_deploy.yml`
+(confirmed divergent — v4/main's `_build.yml` inlines MCP-server packaging
+differently). This change lands as two separate, hand-ported PRs: one to
+`main`, one to `v4/main`, each verified independently against that branch's
+actual workflow file.
+
+## Verification (AC-5)
+
+`tools/test_compute_affected_targets.py` exercises `compute()` directly
+(mocking `git diff`/`gh api` at the `_run` seam, no live AWS/GitHub calls
+needed) for the two scenarios the AC calls out by name:
+
+- A single changed file under one `backend/lambda/<dir>/` → `full_scope=False`,
+  `affected_functions == [<dir>]` only.
+- A changed file under `backend/lambda/shared_layer/` → `full_scope=True`
+  (fans out to everything).
+
+Run: `python3 tools/test_compute_affected_targets.py`
+
+## Guardrails
+
+- Every failure path (missing `gh`/git, malformed API response, no prior
+  deployment) resolves to `full_scope=true`, never to an empty/no-op deploy.
+- `assert_deploy_target_coverage.py` fails **open** (skips the check
+  entirely, doesn't block) if `COORDINATION_INTERNAL_API_KEY` isn't
+  configured or the registry API call itself fails — the coverage gate is a
+  defense-in-depth addition on top of the diff-based narrowing, not a hard
+  dependency for the base feature to function.
+- No existing behavior changes for components that haven't opted into
+  `deploy_targets`.
+
+## Follow-ups (explicitly out of scope here)
+
+- Build-side selectivity (skip building artifacts for unaffected functions).
+- CFN stack-level blast-radius scoping (separate deploy lane entirely).
+- Backfilling `deploy_targets` across the remaining component registry
+  entries (only the 3 pre-existing Enceladus Lambda components — checkout
+  service, coordination API, tracker mutation — are seeded in this PR).

--- a/tools/assert_deploy_target_coverage.py
+++ b/tools/assert_deploy_target_coverage.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""ENC-TSK-J40 AC-2: fail closed when a component's declared deploy_targets is
+narrower than what a merge's diff actually touched under that component's
+source_paths.
+
+Reads the component registry via `GET /coordination/components` (governed
+HTTP API, same auth pattern as tools/backfill_component_lifecycle_capabilities.py),
+and cross-checks each component that has BOTH source_paths.directory and a
+non-empty deploy_targets declared: if any changed backend/lambda/<dir> in
+`affected_functions` falls under that component's source_paths.directory,
+the function name (or a matching glob) must be present in deploy_targets.
+
+Deliberately asymmetric with tools/compute_affected_targets.py's safety
+contract: components that have NOT declared deploy_targets are skipped
+(warned, not failed) -- an undeclared component cannot be "narrower" than
+anything, so it never blocks. Only a component that HAS opted into
+deploy_targets and gets it wrong fails the build. This is the "fail-closed
+on shortfall" the AC asks for, without retroactively blocking every merge
+touching one of the ~30 Lambda functions that predate this task.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+from urllib import error as _urllib_error
+from urllib import request as _urllib_request
+
+DEFAULT_API_BASE = os.environ.get(
+    "COORDINATION_API_BASE",
+    "https://jreese.net/api/v1/coordination",
+)
+DEFAULT_API_KEY = os.environ.get("COORDINATION_INTERNAL_API_KEY", "")
+
+
+def _get(url: str, api_key: str) -> dict:
+    req = _urllib_request.Request(url, headers={"x-internal-api-key": api_key})
+    with _urllib_request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_components(api_base: str, api_key: str, project_id: str) -> list:
+    url = f"{api_base}/components?project_id={project_id}"
+    try:
+        data = _get(url, api_key)
+    except (_urllib_error.URLError, _urllib_error.HTTPError, TimeoutError) as exc:
+        print(f"::warning::could not fetch component registry ({exc}) -- skipping coverage assertion", file=sys.stderr)
+        return []
+    return data.get("components") or data.get("items") or []
+
+
+def owning_component(component: dict, function_dir: str) -> bool:
+    source_paths = component.get("source_paths") or {}
+    directory = (source_paths.get("directory") or "").strip().rstrip("/")
+    if not directory:
+        return False
+    return directory.endswith(f"backend/lambda/{function_dir}") or directory == f"backend/lambda/{function_dir}"
+
+
+def covered(function_dir: str, deploy_targets: list) -> bool:
+    return any(fnmatch.fnmatch(function_dir, pattern) for pattern in deploy_targets)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--affected-functions-json", required=True, help="JSON array of affected lambda dir names")
+    parser.add_argument("--project-id", default="enceladus")
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY)
+    args = parser.parse_args()
+
+    try:
+        affected = json.loads(args.affected_functions_json)
+    except json.JSONDecodeError:
+        print("::error::--affected-functions-json is not valid JSON", file=sys.stderr)
+        sys.exit(1)
+
+    if not affected:
+        print("No affected functions to check.")
+        return
+
+    if not args.api_key:
+        print("::warning::COORDINATION_INTERNAL_API_KEY not set -- skipping coverage assertion (fails open, per AC-3 'ambiguity widens')", file=sys.stderr)
+        return
+
+    components = fetch_components(args.api_base, args.api_key, args.project_id)
+
+    failures = []
+    for fn_dir in affected:
+        owner = next((c for c in components if owning_component(c, fn_dir)), None)
+        if owner is None:
+            print(f"[skip] {fn_dir}: no owning component declared -- not gated")
+            continue
+        deploy_targets = owner.get("deploy_targets") or []
+        if not deploy_targets:
+            print(f"[skip] {fn_dir}: owning component {owner.get('component_id')} has no deploy_targets declared -- not gated")
+            continue
+        if covered(fn_dir, deploy_targets):
+            print(f"[ok] {fn_dir}: covered by {owner.get('component_id')}.deploy_targets={deploy_targets}")
+        else:
+            failures.append((fn_dir, owner.get("component_id"), deploy_targets))
+
+    if failures:
+        print("::error::deploy_targets coverage shortfall -- these components declared deploy_targets narrower than the actual diff:", file=sys.stderr)
+        for fn_dir, comp_id, targets in failures:
+            print(f"::error::  {fn_dir} touched by this merge, but {comp_id}.deploy_targets={targets} does not cover it", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Coverage assertion passed for {len(affected)} affected function(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compute_affected_targets.py
+++ b/tools/compute_affected_targets.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""ENC-TSK-J40: compute the affected-set of Lambda functions for a deploy.
+
+Diffs the merge being deployed against the last successfully-deployed SHA for
+the target environment (via the GitHub Deployments API, the existing deploy-
+state store per _deploy.yml's AC-2), and maps changed files to affected
+Lambda function directories under backend/lambda/.
+
+Safety contract (AC-3, "ambiguity widens, never narrows"):
+  - Any failure to resolve a base SHA, run git diff, or parse output ->
+    full_scope=true (deploy everything, current behavior).
+  - Any changed path matching a cross-cutting pattern (shared layer source,
+    04-github-roles.yaml IAM, envs/*.yaml CFN parameter files, the deploy
+    workflow files themselves, or the build manifest) -> full_scope=true.
+  - Otherwise: affected_functions = the set of backend/lambda/<dir> whose
+    directory appears in the diff. Empty diff-under-backend/lambda with no
+    cross-cutting hit -> affected_functions=[] (a real no-op deploy, e.g. a
+    docs-only merge) -- callers must treat this as "skip", not "deploy none
+    of everything" (distinct from full_scope).
+
+Output: a single JSON object on stdout, and (if GITHUB_OUTPUT is set) the
+same fields written as step outputs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# AC-3: any changed path matching one of these forces full_scope=True.
+CROSS_CUTTING_PATTERNS = [
+    re.compile(r"^backend/lambda/shared_layer/"),
+    re.compile(r"^infrastructure/cloudformation/04-github-roles\.yaml$"),
+    re.compile(r"^envs/.*\.yaml$"),
+    re.compile(r"^\.github/workflows/_build\.yml$"),
+    re.compile(r"^\.github/workflows/_deploy\.yml$"),
+    re.compile(r"^infrastructure/lambda_workflow_manifest\.json$"),
+]
+
+LAMBDA_DIR_RE = re.compile(r"^backend/lambda/([^/]+)/")
+
+
+def _run(cmd: List[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=30)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def resolve_last_deployed_sha(environment: str, repo: str) -> Optional[str]:
+    """Last successful GitHub Deployment SHA for `environment`, via `gh api`.
+    Returns None on any failure -- caller must treat that as "can't diff,
+    go full_scope", never as "nothing changed"."""
+    out = _run([
+        "gh", "api",
+        f"/repos/{repo}/deployments?environment={environment}&per_page=30",
+    ])
+    if out is None:
+        return None
+    try:
+        deployments = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    for dep in deployments:
+        dep_id = dep.get("id")
+        if dep_id is None:
+            continue
+        statuses_out = _run([
+            "gh", "api", f"/repos/{repo}/deployments/{dep_id}/statuses?per_page=10",
+        ])
+        if statuses_out is None:
+            continue
+        try:
+            statuses = json.loads(statuses_out)
+        except json.JSONDecodeError:
+            continue
+        if any(s.get("state") == "success" for s in statuses):
+            sha = dep.get("sha")
+            if sha:
+                return sha
+    return None
+
+
+def diff_changed_files(base_sha: str, head_sha: str) -> Optional[List[str]]:
+    out = _run(["git", "diff", "--name-only", f"{base_sha}..{head_sha}"])
+    if out is None:
+        return None
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def compute(environment: str, repo: str, head_sha: str, base_sha_override: Optional[str] = None) -> dict:
+    base_sha = base_sha_override or resolve_last_deployed_sha(environment, repo)
+    if not base_sha:
+        return {
+            "full_scope": True,
+            "reason": "no prior successful deployment found for this environment (or GH API call failed) -- deploying everything",
+            "base_sha": None,
+            "head_sha": head_sha,
+            "affected_functions": [],
+        }
+
+    if base_sha == head_sha:
+        return {
+            "full_scope": False,
+            "reason": "base_sha == head_sha, nothing to diff",
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            "affected_functions": [],
+        }
+
+    changed = diff_changed_files(base_sha, head_sha)
+    if changed is None:
+        return {
+            "full_scope": True,
+            "reason": f"git diff {base_sha}..{head_sha} failed -- deploying everything",
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            "affected_functions": [],
+        }
+
+    for path in changed:
+        for pattern in CROSS_CUTTING_PATTERNS:
+            if pattern.match(path):
+                return {
+                    "full_scope": True,
+                    "reason": f"cross-cutting path changed: {path}",
+                    "base_sha": base_sha,
+                    "head_sha": head_sha,
+                    "affected_functions": [],
+                }
+
+    affected = set()
+    for path in changed:
+        m = LAMBDA_DIR_RE.match(path)
+        if m:
+            affected.add(m.group(1))
+
+    return {
+        "full_scope": False,
+        "reason": f"{len(changed)} file(s) changed, {len(affected)} lambda dir(s) affected",
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "affected_functions": sorted(affected),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--environment", required=True, help="GitHub Deployments environment name, e.g. v4-gamma, v3-prod")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "NX-2021-L/enceladus"))
+    parser.add_argument("--head-sha", default=os.environ.get("GITHUB_SHA", ""))
+    parser.add_argument("--base-sha", default="", help="Override auto-resolved base SHA (mainly for testing)")
+    args = parser.parse_args()
+
+    if not args.head_sha:
+        print("::error::--head-sha (or $GITHUB_SHA) is required", file=sys.stderr)
+        sys.exit(1)
+
+    result = compute(args.environment, args.repo, args.head_sha, args.base_sha or None)
+    print(json.dumps(result, indent=2))
+
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a") as f:
+            f.write(f"full_scope={'true' if result['full_scope'] else 'false'}\n")
+            f.write(f"affected_functions_json={json.dumps(result['affected_functions'])}\n")
+            f.write(f"reason={result['reason']}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/seed-component-registry.py
+++ b/tools/seed-component-registry.py
@@ -107,6 +107,7 @@ KNOWN_COMPONENTS = [
             "related": ["backend/lambda/shared_layer/"],
             "architecture_sections": ["4.17"],
         },
+        "deploy_targets": ["checkout_service"],
     },
     {
         "component_id": "comp-coordination-api",
@@ -129,6 +130,7 @@ KNOWN_COMPONENTS = [
             ],
             "architecture_sections": ["4.2", "5.1"],
         },
+        "deploy_targets": ["coordination_api"],
     },
     {
         "component_id": "comp-tracker-mutation",
@@ -148,6 +150,7 @@ KNOWN_COMPONENTS = [
             "related": ["backend/lambda/shared_layer/"],
             "architecture_sections": ["4.1", "5.1"],
         },
+        "deploy_targets": ["tracker_mutation"],
     },
     {
         "component_id": "comp-enceladus-mcp-server",

--- a/tools/test_compute_affected_targets.py
+++ b/tools/test_compute_affected_targets.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""ENC-TSK-J40 AC-5 verification: a single-function change deploys only that
+function, and a shared-layer change fans out to all. Mocks the `_run`
+subprocess seam in compute_affected_targets.py -- no live git/gh/AWS calls.
+
+Run: python3 tools/test_compute_affected_targets.py
+"""
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parent / "compute_affected_targets.py"
+spec = importlib.util.spec_from_file_location("compute_affected_targets", MODULE_PATH)
+cat = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cat)
+
+
+def _fake_run_factory(diff_lines, deployments_json="[]"):
+    def _fake_run(cmd):
+        if cmd[:2] == ["git", "diff"]:
+            return "\n".join(diff_lines) + "\n"
+        if cmd[:2] == ["gh", "api"] and "deployments?environment=" in cmd[2]:
+            return deployments_json
+        if cmd[:2] == ["gh", "api"] and "/statuses" in cmd[2]:
+            return '[{"state": "success"}]'
+        return None
+    return _fake_run
+
+
+class ComputeAffectedTargetsTest(unittest.TestCase):
+    def test_single_function_change_is_narrow(self):
+        with patch.object(cat, "_run", _fake_run_factory([
+            "backend/lambda/tracker_mutation/lambda_function.py",
+        ])):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertFalse(result["full_scope"], result["reason"])
+        self.assertEqual(result["affected_functions"], ["tracker_mutation"])
+
+    def test_multi_file_same_function_dedupes(self):
+        with patch.object(cat, "_run", _fake_run_factory([
+            "backend/lambda/tracker_mutation/lambda_function.py",
+            "backend/lambda/tracker_mutation/helpers.py",
+            "README.md",
+        ])):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertFalse(result["full_scope"])
+        self.assertEqual(result["affected_functions"], ["tracker_mutation"])
+
+    def test_shared_layer_change_forces_full_scope(self):
+        with patch.object(cat, "_run", _fake_run_factory([
+            "backend/lambda/shared_layer/python/enceladus_shared/appconfig_flags.py",
+            "backend/lambda/tracker_mutation/lambda_function.py",
+        ])):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertTrue(result["full_scope"], result["reason"])
+
+    def test_deploy_workflow_change_forces_full_scope(self):
+        with patch.object(cat, "_run", _fake_run_factory([
+            ".github/workflows/_deploy.yml",
+        ])):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertTrue(result["full_scope"])
+
+    def test_diff_failure_forces_full_scope(self):
+        with patch.object(cat, "_run", lambda cmd: None):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertTrue(result["full_scope"])
+
+    def test_no_prior_deployment_forces_full_scope(self):
+        with patch.object(cat, "resolve_last_deployed_sha", lambda env, repo: None):
+            result = cat.compute("v4-gamma", "org/repo", "headsha")
+        self.assertTrue(result["full_scope"])
+
+    def test_non_lambda_only_change_is_narrow_and_empty(self):
+        with patch.object(cat, "_run", _fake_run_factory([
+            "README.md",
+            "docs/foo.md",
+        ])):
+            result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
+        self.assertFalse(result["full_scope"])
+        self.assertEqual(result["affected_functions"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Narrows `_deploy.yml`'s per-function push to only the Lambdas a merge actually touched, instead of always redeploying all ~30 functions on every push/dispatch:

- `tools/compute_affected_targets.py`: diffs the merge against the last successful GitHub Deployment SHA per environment (the existing deploy-state store); any cross-cutting change (shared layer, IAM, `envs/*.yaml`, the deploy workflow files, the build manifest) or any resolution failure forces `full_scope=true` — **ambiguity widens, never narrows**.
- `tools/assert_deploy_target_coverage.py`: fail-closed gate for components that have declared a `deploy_targets` set narrower than what the diff shows. Components without a declaration are simply not gated (opt-in, not retroactive).
- `deploy_targets` added to the existing ENC-TSK-E68 capability-declaration field set on `component_registry.component`; seeded for the 3 existing Enceladus Lambda components (checkout_service, coordination_api, tracker_mutation).
- `_deploy.yml`'s artifact-probe step narrows to the affected set unless `full_scope`.
- `tools/test_compute_affected_targets.py` (+ new CI step) verifies both named scenarios from the AC: a single-function change stays narrow, a shared-layer change fans out to everything.
- `infrastructure/blast-radius-deploy-design.md` documents the design and explicit follow-ups (build-side selectivity, CFN stack-level scoping, full `deploy_targets` backfill) left out of this first increment.

This is the **main-lane (v3-prod)** half. `v4/main` maintains a forked copy of `_build.yml`/`_deploy.yml` (confirmed divergent), so a matching hand-ported PR follows separately for that lane — this task's AC6 ("merged both lanes") isn't satisfied until both land.

## Test plan
- [x] `python3 -m unittest tools.test_compute_affected_targets -v` — 7/7 pass, covering both AC-5-named scenarios plus edge cases (no prior deployment, diff failure, multi-file same-function dedup, non-lambda-only diff)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_deploy.yml'))"` / `ci.yml` — valid YAML
- [x] `python3 -c "import json; json.load(...)"` on the governance dictionary — valid JSON
- [ ] Live verification of a narrowed real deploy (will observe on the next v4/main push once the gamma-lane PR lands)

CCI-119de9f43da54a5b8830e12215ff3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)