### PR TITLE
Fix L41 TrackerToSearchIndexPipe CFN resource split

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3023,6 +3023,8 @@ Resources:
         SqsQueueParameters:
           MessageGroupId: tracker
           MessageDeduplicationId: $.dynamodb.Keys.record_id.S
+
+  DocumentsToSearchIndexPipe:
     Type: AWS::Pipes::Pipe
     Condition: IsGamma
     DeletionPolicy: Retain


### PR DESCRIPTION
## Summary
- Fixes YAML structure bug where `DocumentsToSearchIndexPipe` was nested inside `TrackerToSearchIndexPipe`, so gamma only got the documents pipe (tracker mutations never indexed).

commit-complete-id: CCI-2396014756cb457f9466e1288903a249

## Test plan
- [ ] CFN compute deploy creates both pipes
- [ ] `aws pipes describe-pipe --name devops-tracker-to-search-index-queue-gamma` succeeds