### PR TITLE
fix(tracker): promote item_id before record extension attach on GET (ENC-TSK-K26)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.18",
-  "updated_at": "2026-07-05T11:56:00Z",
-  "last_change_summary": "ENC-TSK-K26 hotfix: vendor record_extensions.py into feed_query/tracker_mutation function zips via .build_extras until enceladus-shared layer :11 ships.",
+  "version": "2026-07-05.19",
+  "updated_at": "2026-07-05T12:20:00Z",
+  "last_change_summary": "ENC-TSK-K26 hotfix: tracker GET promotes item_id to {type}_id before record_extensions attach so context_node and typed_relationships appear on detail pages.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7497,8 +7497,13 @@
       "telemetry_eligible": true
     }
   },
-  "change_summary": "ENC-TSK-K26 hotfix: feed_query + tracker_mutation vendor record_extensions.py via .build_extras (enceladus-shared:10 lacks the module); import path uses top-level record_extensions until layer :11.",
+  "change_summary": "ENC-TSK-K26 hotfix: tracker GET promotes item_id to typed {type}_id before record_extensions attach (detail pages lacked context_node while feed worked).",
   "change_log": [
+    {
+      "version": "2026-07-05.19",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions — gamma detail pages were missing context_node because _deser_item only exposes item_id."
+    },
     {
       "version": "2026-07-05.18",
       "date": "2026-07-05",

--- a/backend/lambda/shared_layer/test_layer.py
+++ b/backend/lambda/shared_layer/test_layer.py
@@ -217,6 +217,15 @@ class RecordExtensionsTests(unittest.TestCase):
         self.assertGreater(ctx["structural_importance"], 0)
         self.assertGreater(ctx["information_density"], 0)
 
+    def test_attach_record_extensions_requires_typed_id_key(self):
+        """Tracker GET deserializes item_id only; handler must promote to plan_id first."""
+        record = {"item_id": "ENC-PLN-006", "title": "Plan", "updated_at": "2026-07-01T00:00:00Z"}
+        attach_record_extensions([record], "plan_id", "plan", {}, max_degree=1)
+        self.assertNotIn("context_node", record)
+        record["plan_id"] = record["item_id"]
+        attach_record_extensions([record], "plan_id", "plan", {}, max_degree=1)
+        self.assertIn("context_node", record)
+
     def test_compute_freshness_missing_timestamp_defaults(self):
         self.assertEqual(compute_freshness(None, "task"), 0.5)
 

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -2685,6 +2685,11 @@ def _handle_get_record(project_id: str, record_type: str, record_id: str) -> Dic
         return _error(404, f"Record not found: {record_id}")
 
     id_key = f"{record_type}_id"
+    # _deser_item exposes item_id; feed_query maps that to {type}_id. Align GET
+    # responses so record_extensions can resolve the canonical id (ENC-TSK-K26).
+    canonical_id = str(item.get(id_key) or item.get("item_id") or record_id or "")
+    if canonical_id and not item.get(id_key):
+        item[id_key] = canonical_id
     try:
         from record_extensions import (
             attach_record_extensions,


### PR DESCRIPTION
## Summary
- Tracker GET responses deserialize DynamoDB as `item_id`, but `attach_record_extensions` keys off `{type}_id` (e.g. `plan_id`), so gamma detail pages lacked `context_node` / `typed_relationships` even after #879.
- Promote `item_id` → typed id before attach, matching feed_query shape.
- Governance dictionary bump to `2026-07-05.19`.

CCI-f1776bc2fdad41e6b4361a4279a31de4

## Test plan
- [x] `python3 backend/lambda/shared_layer/test_layer.py RecordExtensionsTests`
- [ ] Merge + Lambda Gen2 gamma deploy
- [ ] `GET /api/v1/tracker/enceladus/plan/ENC-PLN-006` returns `record.context_node`
- [ ] PWA plan detail badges render on gamma


Made with [Cursor](https://cursor.com)