### PR TITLE
Fix L41 search-index pipe drift (MessageGroupId + CFN recreate)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3021,7 +3021,7 @@ Resources:
         Fn::Sub: ${DataStackName}-SearchIndexQueueArn
       TargetParameters:
         SqsQueueParameters:
-          MessageGroupId: tracker
+          MessageGroupId: $.dynamodb.NewImage.project_id.S
           MessageDeduplicationId: $.dynamodb.Keys.record_id.S
 
   DocumentsToSearchIndexPipe:


### PR DESCRIPTION
## Summary
- Align `TrackerToSearchIndexPipe` FIFO `MessageGroupId` with `TrackerToGraphPipe` (`$.dynamodb.NewImage.project_id.S`).
- Live drifted pipes deleted out-of-band so the next compute deploy can recreate **both** `TrackerToSearchIndexPipe` (tracker stream) and `DocumentsToSearchIndexPipe` (documents stream) without `ResourceExistenceCheck` collision.

commit-complete-id: CCI-2396014756cb457f9466e1288903a249

## Test plan
- [ ] CloudFormation Compute Stack Deploy succeeds on v4/main
- [ ] Both search-index pipes RUNNING
- [ ] Tracker mutation visible in `records_read` within 5s


Made with [Cursor](https://cursor.com)