### PR TITLE
L41: add DocumentsToSearchIndexPipe (step 2/2)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3027,6 +3027,29 @@ Resources:
           MessageGroupId: $.dynamodb.NewImage.project_id.S
           MessageDeduplicationId: $.dynamodb.Keys.record_id.S
 
+  DocumentsToSearchIndexPipe:
+    Type: AWS::Pipes::Pipe
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      Name: !Sub "devops-documents-to-search-index-queue${EnvironmentSuffix}"
+      RoleArn: !GetAtt SearchIndexPipeRole.Arn
+      Source: !ImportValue
+        Fn::Sub: ${DataStackName}-DocumentsStreamArn
+      SourceParameters:
+        DynamoDBStreamParameters:
+          BatchSize: 10
+          StartingPosition: LATEST
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"eventName":["INSERT","MODIFY","REMOVE"]}'
+      Target: !ImportValue
+        Fn::Sub: ${DataStackName}-SearchIndexQueueArn
+      TargetParameters:
+        SqsQueueParameters:
+          MessageGroupId: document
+          MessageDeduplicationId: $.dynamodb.Keys.document_id.S
+
   # ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-identity graph projection pipes. Three more
   # EventBridge Pipes modeled on TrackerToGraphPipe/DocumentsToGraphPipe, each sourcing a
   # distinct agent-store DynamoDB Stream and targeting the SAME GraphSyncQueue. graph_sync


### PR DESCRIPTION
## Summary
Step 2 of 2 — adds `DocumentsToSearchIndexPipe` now that `TrackerToSearchIndexPipe` no longer holds the documents pipe name in stack.

commit-complete-id: CCI-2396014756cb457f9466e1288903a249


Made with [Cursor](https://cursor.com)