### PR TITLE
B65 Ph4: enceladus-relationships table + dual-write (ENC-TSK-L13)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.20",
-  "updated_at": "2026-07-05T12:20:00Z",
-  "last_change_summary": "ENC-TSK-L74: graph_sync SQS handler() now reports batchItemFailures (partial-batch-failure contract) instead of silently deleting the whole batch on any successful record, which was permanently losing MENTIONS graph edges for records that failed processing (root cause of ENC-ISS-486/488/493). No schema field changes -- dictionary bump is for the governance-guard gate on lambda_function.py edits.",
+  "version": "2026-07-05.21",
+  "updated_at": "2026-07-05T12:53:00Z",
+  "last_change_summary": "ENC-TSK-L13: enceladus-relationships dedicated table + enceladus_shared.relationship_store dual-write/read-merge migration off devops-project-tracker rel# rows.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3814,7 +3814,7 @@
       "field_count": 2
     },
     "tracker.relationship": {
-      "description": "First-class governed typed relationship edge between tracker records (ENC-FTR-049). Stored in devops-project-tracker with rel# SK prefix. Each relationship creates an atomic forward+inverse pair. DynamoDB is system of record; Neo4j receives MERGE projections via DynamoDB Streams.",
+      "description": "First-class governed typed relationship edge between tracker records (ENC-FTR-049). Primary store is enceladus-relationships (ENC-TSK-L13 / B65 Ph4); devops-project-tracker rel# rows remain during dual-write migration. Each relationship creates an atomic forward+inverse pair. DynamoDB is system of record; Neo4j receives MERGE projections via devops-project-tracker DynamoDB Streams until rel# cleanup (AC5).",
       "fields": {
         "relationship_type": {
           "type": "enum",
@@ -4059,7 +4059,9 @@
         "pk": "project_id",
         "sk_pattern": "rel#{source_id}#{relationship_type}#{target_id}",
         "inverse_sk_pattern": "rel#{target_id}#{inverse_type}#{source_id}",
-        "table": "devops-project-tracker",
+        "table": "enceladus-relationships",
+        "legacy_table": "devops-project-tracker",
+        "dual_write_env": "RELATIONSHIPS_TABLE",
         "delete_method": "soft-delete via UpdateItem (status=archived). No DeleteItem permission needed. Data preserved for audit."
       },
       "covered_lambdas": [
@@ -4627,6 +4629,23 @@
         "attach_record_extensions": {
           "type": "function",
           "definition": "Mutates each record dict in-place: sets typed_relationships when edges exist and always sets context_node with the four score fields."
+        }
+      }
+    },
+    "enceladus_shared.relationship_store": {
+      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py) for B65 Ph4 typed-relationship table extraction (ENC-TSK-L13). When RELATIONSHIPS_TABLE is set, writes dual-put forward+inverse pairs to enceladus-relationships and devops-project-tracker; reads merge the relationships table first with legacy tracker fallback on SK conflicts.",
+      "fields": {
+        "write_target_tables": {
+          "type": "function",
+          "definition": "Returns [relationships_table, tracker_table] when RELATIONSHIPS_TABLE is configured, else [tracker_table] only."
+        },
+        "query_relationship_raw_items": {
+          "type": "function",
+          "definition": "Prefix query with relationships-table-first merge; pagination cursor follows the primary (relationships) table."
+        },
+        "iter_project_relationship_items": {
+          "type": "function",
+          "definition": "Full-project rel# scan for feed/extensions; relationships table keys win over tracker duplicates."
         }
       }
     },

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -9287,31 +9287,19 @@ def _handle_components_propose(event: Dict[str, Any], claims: Dict[str, Any]) ->
 
     ddb = _get_ddb()
     try:
-        ddb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": COMPONENTS_TABLE,
-                        "Item": _py_to_ddb(component_item),
-                        "ConditionExpression": "attribute_not_exists(component_id)",
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": TRACKER_TABLE,
-                        "Item": forward_rel,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": TRACKER_TABLE,
-                        "Item": inverse_rel,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-            ]
-        )
+        from enceladus_shared.relationship_store import build_create_transact_puts
+
+        transact_items = [
+            {
+                "Put": {
+                    "TableName": COMPONENTS_TABLE,
+                    "Item": _py_to_ddb(component_item),
+                    "ConditionExpression": "attribute_not_exists(component_id)",
+                }
+            },
+            *build_create_transact_puts(TRACKER_TABLE, forward_rel, inverse_rel),
+        ]
+        ddb.transact_write_items(TransactItems=transact_items)
     except ddb.exceptions.TransactionCanceledException as exc:
         reasons = getattr(exc, "response", {}).get("CancellationReasons") or []
         if any((r or {}).get("Code") == "ConditionalCheckFailed" for r in reasons):
@@ -11076,23 +11064,10 @@ def _handle_components_add_edge(
 
     ddb = _get_ddb()
     try:
+        from enceladus_shared.relationship_store import build_create_transact_puts
+
         ddb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": TRACKER_TABLE,
-                        "Item": forward,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": TRACKER_TABLE,
-                        "Item": inverse,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-            ]
+            TransactItems=build_create_transact_puts(TRACKER_TABLE, forward, inverse)
         )
     except ddb.exceptions.TransactionCanceledException as exc:
         reasons = getattr(exc, "response", {}).get("CancellationReasons") or []
@@ -11200,29 +11175,15 @@ def _handle_components_remove_edge(
 
     ddb = _get_ddb()
     try:
+        from enceladus_shared.relationship_store import build_delete_transact_deletes
+
         ddb.transact_write_items(
-            TransactItems=[
-                {
-                    "Delete": {
-                        "TableName": TRACKER_TABLE,
-                        "Key": {
-                            "project_id": {"S": project_id},
-                            "record_id": {"S": forward_sk},
-                        },
-                        "ConditionExpression": "attribute_exists(record_id)",
-                    }
-                },
-                {
-                    "Delete": {
-                        "TableName": TRACKER_TABLE,
-                        "Key": {
-                            "project_id": {"S": project_id},
-                            "record_id": {"S": inverse_sk},
-                        },
-                        "ConditionExpression": "attribute_exists(record_id)",
-                    }
-                },
-            ]
+            TransactItems=build_delete_transact_deletes(
+                TRACKER_TABLE,
+                project_id_attr={"S": project_id},
+                forward_sk=forward_sk,
+                inverse_sk=inverse_sk,
+            )
         )
     except ddb.exceptions.TransactionCanceledException as exc:
         reasons = getattr(exc, "response", {}).get("CancellationReasons") or []

--- a/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
@@ -137,38 +137,33 @@ def query_typed_relationships_for_projects(
     ddb_float: Callable[[Dict[str, Any], str], float],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Query all outgoing typed edges for the given projects."""
+    from enceladus_shared.relationship_store import iter_project_relationship_items
+
     edges_by_source: Dict[str, List[Dict[str, Any]]] = {}
-    for pid in project_ids:
-        if not pid:
+    for raw in iter_project_relationship_items(
+        ddb,
+        table_name,
+        project_ids,
+        ser_s=lambda value: {"S": value},
+    ):
+        sk = ddb_str(raw, "record_id")
+        if not sk or not sk.startswith("rel#"):
             continue
-        paginator = ddb.get_paginator("query")
-        for page in paginator.paginate(
-            TableName=table_name,
-            KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
-            ExpressionAttributeValues={
-                ":pid": {"S": pid},
-                ":rel_prefix": {"S": "rel#"},
-            },
-        ):
-            for raw in page.get("Items", []):
-                sk = ddb_str(raw, "record_id")
-                if not sk or not sk.startswith("rel#"):
-                    continue
-                parts = sk.split("#", 4)
-                if len(parts) < 4:
-                    continue
-                _, source_id, rel_type, target_id = parts[0], parts[1], parts[2], parts[3]
-                if ddb_str(raw, "status") == "archived":
-                    continue
-                edge = {
-                    "relationship_type": rel_type,
-                    "target_id": target_id,
-                    "weight": ddb_float(raw, "weight"),
-                    "confidence": ddb_float(raw, "confidence"),
-                    "reason": ddb_str(raw, "reason") or None,
-                    "created_at": ddb_str(raw, "created_at") or None,
-                }
-                edges_by_source.setdefault(source_id, []).append(edge)
+        parts = sk.split("#", 4)
+        if len(parts) < 4:
+            continue
+        _, source_id, rel_type, target_id = parts[0], parts[1], parts[2], parts[3]
+        if ddb_str(raw, "status") == "archived":
+            continue
+        edge = {
+            "relationship_type": rel_type,
+            "target_id": target_id,
+            "weight": ddb_float(raw, "weight"),
+            "confidence": ddb_float(raw, "confidence"),
+            "reason": ddb_str(raw, "reason") or None,
+            "created_at": ddb_str(raw, "created_at") or None,
+        }
+        edges_by_source.setdefault(source_id, []).append(edge)
     return edges_by_source
 
 
@@ -182,35 +177,35 @@ def query_edges_for_record(
     ddb_float: Callable[[Dict[str, Any], str], float],
 ) -> List[Dict[str, Any]]:
     """Query outgoing typed edges for a single source record."""
-    edges: List[Dict[str, Any]] = []
+    from enceladus_shared.relationship_store import query_relationship_raw_items
+
     prefix = f"rel#{source_id}#"
-    paginator = ddb.get_paginator("query")
-    for page in paginator.paginate(
-        TableName=table_name,
-        KeyConditionExpression="project_id = :pid AND begins_with(record_id, :prefix)",
-        ExpressionAttributeValues={
-            ":pid": {"S": project_id},
-            ":prefix": {"S": prefix},
-        },
-    ):
-        for raw in page.get("Items", []):
-            sk = ddb_str(raw, "record_id")
-            if not sk or not sk.startswith("rel#"):
-                continue
-            parts = sk.split("#", 4)
-            if len(parts) < 4:
-                continue
-            _, _src, rel_type, target_id = parts
-            if ddb_str(raw, "status") == "archived":
-                continue
-            edges.append(
-                {
-                    "relationship_type": rel_type,
-                    "target_id": target_id,
-                    "weight": ddb_float(raw, "weight"),
-                    "confidence": ddb_float(raw, "confidence"),
-                    "reason": ddb_str(raw, "reason") or None,
-                    "created_at": ddb_str(raw, "created_at") or None,
-                }
-            )
+    raw_items, _ = query_relationship_raw_items(
+        ddb,
+        table_name,
+        project_id,
+        prefix,
+        ser_s=lambda value: {"S": value},
+    )
+    edges: List[Dict[str, Any]] = []
+    for raw in raw_items:
+        sk = ddb_str(raw, "record_id")
+        if not sk or not sk.startswith("rel#"):
+            continue
+        parts = sk.split("#", 4)
+        if len(parts) < 4:
+            continue
+        _, _src, rel_type, target_id = parts
+        if ddb_str(raw, "status") == "archived":
+            continue
+        edges.append(
+            {
+                "relationship_type": rel_type,
+                "target_id": target_id,
+                "weight": ddb_float(raw, "weight"),
+                "confidence": ddb_float(raw, "confidence"),
+                "reason": ddb_str(raw, "reason") or None,
+                "created_at": ddb_str(raw, "created_at") or None,
+            }
+        )
     return edges

--- a/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
@@ -1,0 +1,228 @@
+"""Typed relationship edge storage (ENC-TSK-L13 / B65 Ph4).
+
+Dual-write migration from devops-project-tracker rel# rows to the dedicated
+enceladus-relationships table. Reads merge the relationships table first and
+fall back to the tracker table for keys not yet present in the new store.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+PutItem = Dict[str, Any]
+TransactItem = Dict[str, Any]
+
+
+def relationships_table_name() -> Optional[str]:
+    raw = os.environ.get("RELATIONSHIPS_TABLE", "").strip()
+    return raw or None
+
+
+def dual_write_enabled() -> bool:
+    return relationships_table_name() is not None
+
+
+def write_target_tables(tracker_table: str) -> List[str]:
+    rel_table = relationships_table_name()
+    if rel_table and rel_table != tracker_table:
+        return [rel_table, tracker_table]
+    return [tracker_table]
+
+
+def build_create_transact_puts(
+    tracker_table: str,
+    forward_item: PutItem,
+    inverse_item: PutItem,
+) -> List[TransactItem]:
+    items: List[TransactItem] = []
+    for table in write_target_tables(tracker_table):
+        items.extend(
+            [
+                {
+                    "Put": {
+                        "TableName": table,
+                        "Item": forward_item,
+                        "ConditionExpression": "attribute_not_exists(record_id)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table,
+                        "Item": inverse_item,
+                        "ConditionExpression": "attribute_not_exists(record_id)",
+                    }
+                },
+            ]
+        )
+    return items
+
+
+def build_archive_transact_updates(
+    tracker_table: str,
+    *,
+    project_id_attr: PutItem,
+    forward_sk: str,
+    inverse_sk: str,
+    archived_at_attr: PutItem,
+) -> List[TransactItem]:
+    items: List[TransactItem] = []
+    for table in write_target_tables(tracker_table):
+        for sk in (forward_sk, inverse_sk):
+            items.append(
+                {
+                    "Update": {
+                        "TableName": table,
+                        "Key": {
+                            "project_id": project_id_attr,
+                            "record_id": {"S": sk},
+                        },
+                        "UpdateExpression": "SET #st = :archived, archived_at = :now",
+                        "ExpressionAttributeNames": {"#st": "status"},
+                        "ExpressionAttributeValues": {
+                            ":archived": {"S": "archived"},
+                            ":now": archived_at_attr,
+                        },
+                        "ConditionExpression": "attribute_exists(record_id)",
+                    }
+                }
+            )
+    return items
+
+
+def build_delete_transact_deletes(
+    tracker_table: str,
+    *,
+    project_id_attr: PutItem,
+    forward_sk: str,
+    inverse_sk: str,
+) -> List[TransactItem]:
+    items: List[TransactItem] = []
+    for table in write_target_tables(tracker_table):
+        for sk in (forward_sk, inverse_sk):
+            items.append(
+                {
+                    "Delete": {
+                        "TableName": table,
+                        "Key": {
+                            "project_id": project_id_attr,
+                            "record_id": {"S": sk},
+                        },
+                        "ConditionExpression": "attribute_exists(record_id)",
+                    }
+                }
+            )
+    return items
+
+
+def _paginate_prefix(
+    ddb,
+    table_name: str,
+    project_id: str,
+    sk_prefix: str,
+    *,
+    ser_s: Callable[[str], PutItem],
+    limit: Optional[int] = None,
+    exclusive_start_key: Optional[Dict[str, Any]] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    kwargs: Dict[str, Any] = {
+        "TableName": table_name,
+        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
+        "ExpressionAttributeValues": {
+            ":pid": ser_s(project_id),
+            ":prefix": ser_s(sk_prefix),
+        },
+    }
+    if limit is not None:
+        kwargs["Limit"] = limit
+    if exclusive_start_key:
+        kwargs["ExclusiveStartKey"] = exclusive_start_key
+    resp = ddb.query(**kwargs)
+    return resp.get("Items", []), resp.get("LastEvaluatedKey")
+
+
+def query_relationship_raw_items(
+    ddb,
+    tracker_table: str,
+    project_id: str,
+    sk_prefix: str,
+    *,
+    ser_s: Callable[[str], PutItem],
+    limit: Optional[int] = None,
+    exclusive_start_key: Optional[Dict[str, Any]] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Query relationship rows; relationships table wins on SK conflicts."""
+    rel_table = relationships_table_name()
+    if not rel_table:
+        return _paginate_prefix(
+            ddb,
+            tracker_table,
+            project_id,
+            sk_prefix,
+            ser_s=ser_s,
+            limit=limit,
+            exclusive_start_key=exclusive_start_key,
+        )
+
+    primary_items, primary_cursor = _paginate_prefix(
+        ddb,
+        rel_table,
+        project_id,
+        sk_prefix,
+        ser_s=ser_s,
+        limit=limit,
+        exclusive_start_key=exclusive_start_key,
+    )
+    merged: Dict[str, Dict[str, Any]] = {}
+    for raw in primary_items:
+        sk = raw.get("record_id", {}).get("S", "")
+        if sk:
+            merged[sk] = raw
+
+    if exclusive_start_key is None:
+        legacy_items, _ = _paginate_prefix(
+            ddb,
+            tracker_table,
+            project_id,
+            sk_prefix,
+            ser_s=ser_s,
+        )
+        for raw in legacy_items:
+            sk = raw.get("record_id", {}).get("S", "")
+            if sk and sk not in merged:
+                merged[sk] = raw
+
+    return list(merged.values()), primary_cursor
+
+
+def iter_project_relationship_items(
+    ddb,
+    tracker_table: str,
+    project_ids: Iterable[str],
+    *,
+    ser_s: Callable[[str], PutItem],
+    rel_prefix: str = "rel#",
+) -> Iterable[Dict[str, Any]]:
+    """Yield all relationship raw items for projects (feed/extensions path)."""
+    rel_table = relationships_table_name()
+    for pid in project_ids:
+        if not pid:
+            continue
+        merged: Dict[str, Dict[str, Any]] = {}
+        tables = [rel_table, tracker_table] if rel_table else [tracker_table]
+        for table in tables:
+            if not table:
+                continue
+            paginator = ddb.get_paginator("query")
+            for page in paginator.paginate(
+                TableName=table,
+                KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
+                ExpressionAttributeValues={
+                    ":pid": ser_s(pid),
+                    ":rel_prefix": ser_s(rel_prefix),
+                },
+            ):
+                for raw in page.get("Items", []):
+                    sk = raw.get("record_id", {}).get("S", "")
+                    if sk.startswith("rel#") and sk not in merged:
+                        merged[sk] = raw
+        yield from merged.values()

--- a/backend/lambda/shared_layer/test_layer.py
+++ b/backend/lambda/shared_layer/test_layer.py
@@ -7,6 +7,7 @@ Run from shared_layer directory:
 from __future__ import annotations
 
 import json
+import os
 import sys
 import unittest
 from decimal import Decimal
@@ -28,6 +29,10 @@ from enceladus_shared.record_extensions import (
     compute_freshness,
     compute_max_degree,
     compute_structural_importance,
+)
+from enceladus_shared.relationship_store import (
+    build_create_transact_puts,
+    write_target_tables,
 )
 
 
@@ -228,6 +233,36 @@ class RecordExtensionsTests(unittest.TestCase):
 
     def test_compute_freshness_missing_timestamp_defaults(self):
         self.assertEqual(compute_freshness(None, "task"), 0.5)
+
+
+class RelationshipStoreTests(unittest.TestCase):
+    def test_write_target_tables_dual_write(self):
+        with patch.dict(
+            os.environ,
+            {"RELATIONSHIPS_TABLE": "enceladus-relationships-gamma"},
+            clear=False,
+        ):
+            targets = write_target_tables("devops-project-tracker-gamma")
+        self.assertEqual(
+            targets,
+            ["enceladus-relationships-gamma", "devops-project-tracker-gamma"],
+        )
+
+    def test_build_create_transact_puts_dual_write(self):
+        forward = {"project_id": {"S": "enceladus"}, "record_id": {"S": "rel#A#relates-to#B"}}
+        inverse = {"project_id": {"S": "enceladus"}, "record_id": {"S": "rel#B#related-to#A"}}
+        with patch.dict(
+            os.environ,
+            {"RELATIONSHIPS_TABLE": "enceladus-relationships-gamma"},
+            clear=False,
+        ):
+            items = build_create_transact_puts("devops-project-tracker-gamma", forward, inverse)
+        self.assertEqual(len(items), 4)
+        tables = {item["Put"]["TableName"] for item in items}
+        self.assertEqual(
+            tables,
+            {"enceladus-relationships-gamma", "devops-project-tracker-gamma"},
+        )
 
 
 if __name__ == "__main__":

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -6368,23 +6368,12 @@ def _handle_create_relationship(project_id: str, body: Dict) -> Dict:
 
     ddb = _get_ddb()
     try:
+        from enceladus_shared.relationship_store import build_create_transact_puts
+
         ddb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": DYNAMODB_TABLE,
-                        "Item": forward_item,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": DYNAMODB_TABLE,
-                        "Item": inverse_item,
-                        "ConditionExpression": "attribute_not_exists(record_id)",
-                    }
-                },
-            ]
+            TransactItems=build_create_transact_puts(
+                DYNAMODB_TABLE, forward_item, inverse_item
+            )
         )
     except ClientError as exc:
         if exc.response["Error"]["Code"] == "TransactionCanceledException":
@@ -6442,35 +6431,16 @@ def _handle_archive_relationship(project_id: str, params: Dict) -> Dict:
 
     ddb = _get_ddb()
     try:
+        from enceladus_shared.relationship_store import build_archive_transact_updates
+
         ddb.transact_write_items(
-            TransactItems=[
-                {
-                    "Update": {
-                        "TableName": DYNAMODB_TABLE,
-                        "Key": {"project_id": _ser_s(project_id), "record_id": _ser_s(forward_sk)},
-                        "UpdateExpression": "SET #st = :archived, archived_at = :now",
-                        "ExpressionAttributeNames": {"#st": "status"},
-                        "ExpressionAttributeValues": {
-                            ":archived": _ser_s("archived"),
-                            ":now": _ser_s(now),
-                        },
-                        "ConditionExpression": "attribute_exists(record_id)",
-                    }
-                },
-                {
-                    "Update": {
-                        "TableName": DYNAMODB_TABLE,
-                        "Key": {"project_id": _ser_s(project_id), "record_id": _ser_s(inverse_sk)},
-                        "UpdateExpression": "SET #st = :archived, archived_at = :now",
-                        "ExpressionAttributeNames": {"#st": "status"},
-                        "ExpressionAttributeValues": {
-                            ":archived": _ser_s("archived"),
-                            ":now": _ser_s(now),
-                        },
-                        "ConditionExpression": "attribute_exists(record_id)",
-                    }
-                },
-            ]
+            TransactItems=build_archive_transact_updates(
+                DYNAMODB_TABLE,
+                project_id_attr=_ser_s(project_id),
+                forward_sk=forward_sk,
+                inverse_sk=inverse_sk,
+                archived_at_attr=_ser_s(now),
+            )
         )
     except ClientError as exc:
         if exc.response["Error"]["Code"] == "TransactionCanceledException":
@@ -6521,26 +6491,29 @@ def _handle_list_relationships(project_id: str, query_params: Dict) -> Dict:
         sk_prefix = "rel#"
 
     kwargs: Dict[str, Any] = {
-        "TableName": DYNAMODB_TABLE,
-        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
-        "ExpressionAttributeValues": {
-            ":pid": _ser_s(project_id),
-            ":prefix": _ser_s(sk_prefix),
-        },
         "Limit": page_size,
     }
 
     cursor = query_params.get("cursor", "")
+    exclusive_start_key = None
     if cursor:
         try:
             import base64
-            decoded = json.loads(base64.b64decode(cursor))
-            kwargs["ExclusiveStartKey"] = decoded
+            exclusive_start_key = json.loads(base64.b64decode(cursor))
         except Exception:
             pass
 
-    resp = ddb.query(**kwargs)
-    items = resp.get("Items", [])
+    from enceladus_shared.relationship_store import query_relationship_raw_items
+
+    items, last_key = query_relationship_raw_items(
+        ddb,
+        DYNAMODB_TABLE,
+        project_id,
+        sk_prefix,
+        ser_s=_ser_s,
+        limit=page_size,
+        exclusive_start_key=exclusive_start_key,
+    )
 
     results = []
     for item in items:
@@ -6579,7 +6552,6 @@ def _handle_list_relationships(project_id: str, query_params: Dict) -> Dict:
         "count": len(results),
     }
 
-    last_key = resp.get("LastEvaluatedKey")
     if last_key:
         import base64
         response_body["next_cursor"] = base64.b64encode(

--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -147,6 +147,33 @@ Resources:
         - Key: Component
           Value: tracker
 
+  # ENC-TSK-L13 / B65 Ph4: dedicated typed-relationship edge store (rel# rows).
+  # Dual-write migration from devops-project-tracker; graph_sync continues to
+  # consume tracker-table streams until rel# cleanup (AC5).
+  RelationshipsTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub "enceladus-relationships${EnvironmentSuffix}"
+      BillingMode: PAY_PER_REQUEST
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+      AttributeDefinitions:
+        - AttributeName: project_id
+          AttributeType: S
+        - AttributeName: record_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: project_id
+          KeyType: HASH
+        - AttributeName: record_id
+          KeyType: RANGE
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: relationships
+
   ProjectsTable:
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Retain
@@ -887,6 +914,18 @@ Outputs:
     Value: !GetAtt TrackerTable.StreamArn
     Export:
       Name: !Sub ${AWS::StackName}-TrackerStreamArn
+  RelationshipsTableName:
+    Value: !Ref RelationshipsTable
+    Export:
+      Name: !Sub ${AWS::StackName}-RelationshipsTable
+  RelationshipsTableArn:
+    Value: !GetAtt RelationshipsTable.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-RelationshipsTableArn
+  RelationshipsStreamArn:
+    Value: !GetAtt RelationshipsTable.StreamArn
+    Export:
+      Name: !Sub ${AWS::StackName}-RelationshipsStreamArn
   ProjectsTableName:
     Value: !Ref ProjectsTable
     Export:

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -230,6 +230,7 @@ Resources:
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
           TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          RELATIONSHIPS_TABLE: !Sub "enceladus-relationships${EnvironmentSuffix}"
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           # ENC-TSK-J57: DocumentsTableRead/DocumentsTableCandidateDecisionWrite grant
           # access to documents${EnvironmentSuffix}, but this env var was never wired
@@ -328,6 +329,7 @@ Resources:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          RELATIONSHIPS_TABLE: !Sub "enceladus-relationships${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
@@ -646,6 +648,7 @@ Resources:
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          RELATIONSHIPS_TABLE: !Sub "enceladus-relationships${EnvironmentSuffix}"
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           FEED_PUBLISHER_FUNCTION: !Sub "devops-feed-publisher${EnvironmentSuffix}"
@@ -3219,6 +3222,18 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: RelationshipsTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}/index/*"
               - Sid: ProjectsTableRead
                 Effect: Allow
                 Action:
@@ -3489,6 +3504,19 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              - Sid: RelationshipsTableAccess
+                Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}/index/*"
         - PolicyName: projects-read
           PolicyDocument:
             Version: '2012-10-17'
@@ -3897,6 +3925,8 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-relationships${EnvironmentSuffix}/index/*"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects${EnvironmentSuffix}/index/*"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"

--- a/tools/relationship_table_backfill.py
+++ b/tools/relationship_table_backfill.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Copy existing rel# rows from devops-project-tracker to enceladus-relationships.
+
+ENC-TSK-L13 (B65 Ph4). Idempotent: each PutItem uses
+attribute_not_exists(record_id) so a second run against an already-copied
+corpus reports skipped rows instead of overwriting.
+
+Usage:
+
+    python3 tools/relationship_table_backfill.py --env gamma [--dry-run] [--region us-west-2]
+
+Emits JSON summary to stdout: {env, dry_run, scanned, copied, skipped, errors}.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any, Dict, Iterable, List
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger("relationship_table_backfill")
+
+_ENV_TO_TABLE_SUFFIX = {"prod": "", "gamma": "-gamma"}
+
+
+def _tracker_table(env: str) -> str:
+    return f"devops-project-tracker{_ENV_TO_TABLE_SUFFIX[env]}"
+
+
+def _relationships_table(env: str) -> str:
+    return f"enceladus-relationships{_ENV_TO_TABLE_SUFFIX[env]}"
+
+
+def _scan_rel_rows(ddb, table_name: str) -> Iterable[Dict[str, Any]]:
+    kwargs: Dict[str, Any] = {
+        "TableName": table_name,
+        "FilterExpression": "begins_with(record_id, :rel_prefix)",
+        "ExpressionAttributeValues": {":rel_prefix": {"S": "rel#"}},
+    }
+    while True:
+        resp = ddb.scan(**kwargs)
+        for item in resp.get("Items", []):
+            yield item
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+
+def _copy_item(
+    ddb,
+    dest_table: str,
+    item: Dict[str, Any],
+    *,
+    dry_run: bool,
+) -> str:
+    sk = item.get("record_id", {}).get("S", "")
+    if not sk.startswith("rel#"):
+        return "skipped"
+    if dry_run:
+        return "copied"
+    try:
+        ddb.put_item(
+            TableName=dest_table,
+            Item=item,
+            ConditionExpression="attribute_not_exists(record_id)",
+        )
+        return "copied"
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code == "ConditionalCheckFailedException":
+            return "skipped"
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env", choices=["prod", "gamma"], required=True)
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--dry-run", action="store_true", help="Report only; make no writes.")
+    parser.add_argument("--report-out", help="Also write the JSON summary to this file path.")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    ddb = boto3.client("dynamodb", region_name=args.region)
+    source_table = _tracker_table(args.env)
+    dest_table = _relationships_table(args.env)
+
+    scanned = 0
+    copied = 0
+    skipped = 0
+    errors: List[str] = []
+
+    logger.info(
+        "Copying rel# rows %s -> %s (dry_run=%s)",
+        source_table,
+        dest_table,
+        args.dry_run,
+    )
+
+    for item in _scan_rel_rows(ddb, source_table):
+        scanned += 1
+        try:
+            outcome = _copy_item(ddb, dest_table, item, dry_run=args.dry_run)
+        except ClientError as exc:
+            sk = item.get("record_id", {}).get("S", "")
+            errors.append(f"{sk}: {exc}")
+            continue
+        if outcome == "copied":
+            copied += 1
+        else:
+            skipped += 1
+
+    summary = {
+        "env": args.env,
+        "dry_run": args.dry_run,
+        "source_table": source_table,
+        "dest_table": dest_table,
+        "scanned": scanned,
+        "copied": copied,
+        "skipped": skipped,
+        "errors": errors,
+    }
+
+    output = json.dumps(summary, indent=2)
+    print(output)
+    if args.report_out:
+        with open(args.report_out, "w", encoding="utf-8") as handle:
+            handle.write(output + "\n")
+        logger.info("Report written to %s", args.report_out)
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add dedicated `enceladus-relationships` DynamoDB table (CFN 01-data) with stream exports.
- Introduce `enceladus_shared.relationship_store` for dual-write transacts and read-merge (new table wins, tracker fallback).
- Wire tracker_mutation, coordination_api, and record_extensions; add idempotent backfill tool.
- Bump governance dictionary to `2026-07-05.21`.

Commit: `408bc79b3478bea5cda067ad103c7d8b8bc311d1`

CCI-489fa39027ef462186432f6147ed39a0

## Test plan
- [x] `PYTHONPATH=python python3 -m pytest backend/lambda/shared_layer/test_layer.py -q` (23 passed)
- [ ] Deploy 01-data stack on gamma (creates table)
- [ ] Deploy lambdas (RELATIONSHIPS_TABLE env)
- [ ] Run `python3 tools/relationship_table_backfill.py --env gamma`
- [ ] Verify create/list relationships dual-write + merged reads

AC3–AC5 (read cutover metrics, zero rel# reads, cleanup) follow after deploy/backfill soak.