### PR TITLE
fix(graph_sync): report SQS partial-batch failures to stop MENTIONS edge loss (ENC-TSK-L74)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.19",
+  "version": "2026-07-05.20",
   "updated_at": "2026-07-05T12:20:00Z",
-  "last_change_summary": "ENC-TSK-K26 hotfix: tracker GET promotes item_id to {type}_id before record_extensions attach so context_node and typed_relationships appear on detail pages.",
+  "last_change_summary": "ENC-TSK-L74: graph_sync SQS handler() now reports batchItemFailures (partial-batch-failure contract) instead of silently deleting the whole batch on any successful record, which was permanently losing MENTIONS graph edges for records that failed processing (root cause of ENC-ISS-486/488/493). No schema field changes -- dictionary bump is for the governance-guard gate on lambda_function.py edits.",
   "owners": [
     "enceladus-platform"
   ],

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -1535,20 +1535,40 @@ def _process_record(driver, stream_record: Dict) -> None:
 # ---------------------------------------------------------------------------
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """SQS-triggered handler. Processes DynamoDB stream records from EventBridge Pipe."""
+    """SQS-triggered handler. Processes DynamoDB stream records from EventBridge Pipe.
+
+    ENC-TSK-L74: reports the Lambda partial-batch-failure contract
+    (batchItemFailures) so SQS retries only the records that actually failed.
+    Without this, a batch response of plain HTTP 200 -- which is what a bare
+    `except Exception: continue` produces regardless of per-record errors --
+    tells SQS the WHOLE batch succeeded, so it deletes every message in it,
+    including the ones that raised. Those records' MENTIONS edges (and any
+    other graph writes from _process_record) are then silently and
+    permanently lost, with no retry and no DLQ delivery, despite this
+    function's prior comments claiming otherwise. Requires
+    FunctionResponseTypes: [ReportBatchItemFailures] on the event source
+    mapping (infrastructure/cloudformation/02-compute.yaml
+    GraphSyncSqsTrigger) for batchItemFailures to actually take effect."""
     records = event.get("Records", [])
     if not records:
         return {"statusCode": 200, "body": "no records"}
 
     driver = _get_neo4j_driver()
     if driver is None:
-        logger.error("[ERROR] Neo4j driver unavailable; returning success to avoid infinite SQS retry")
-        return {"statusCode": 200, "body": "neo4j unavailable - skipping"}
+        logger.error("[ERROR] Neo4j driver unavailable; failing whole batch for retry")
+        # Report every message as failed so SQS retries the whole batch once
+        # Neo4j is reachable again, instead of deleting it and losing every
+        # record's graph write.
+        return {"batchItemFailures": [
+            {"itemIdentifier": r.get("messageId")} for r in records if r.get("messageId")
+        ]}
 
     processed = 0
     errors = 0
+    failed_message_ids: List[str] = []
 
     for sqs_record in records:
+        message_id = sqs_record.get("messageId")
         try:
             body = sqs_record.get("body", "{}")
             if isinstance(body, str):
@@ -1561,14 +1581,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         except Exception:
             errors += 1
             logger.exception("[ERROR] Failed to process SQS record")
-            # Don't re-raise; let the batch continue.
-            # Failed messages will be retried via SQS visibility timeout
-            # and eventually land in DLQ after maxReceiveCount.
+            if message_id:
+                failed_message_ids.append(message_id)
 
     logger.info("[INFO] Batch complete: processed=%d, errors=%d, total=%d", processed, errors, len(records))
 
-    # If ALL records failed, raise to trigger SQS retry for the batch
-    if errors > 0 and processed == 0:
-        raise RuntimeError(f"All {errors} records in batch failed")
+    if failed_message_ids:
+        return {"batchItemFailures": [{"itemIdentifier": mid} for mid in failed_message_ids]}
 
     return {"statusCode": 200, "body": json.dumps({"processed": processed, "errors": errors})}

--- a/backend/lambda/graph_sync/test_partial_batch_failures_l74.py
+++ b/backend/lambda/graph_sync/test_partial_batch_failures_l74.py
@@ -1,0 +1,62 @@
+"""Tests for ENC-TSK-L74: handler() reports batchItemFailures instead of
+silently losing MENTIONS edges (and any other graph write) for records whose
+processing raised, when they share a batch with a successful record."""
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestHandlerPartialBatchFailures(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def _sqs_record(self, message_id, ok=True):
+        body = {
+            "dynamodb": {"Keys": {}, "NewImage": {}},
+        } if ok else {"not": "a stream record shape that raises"}
+        return {"messageId": message_id, "body": json.dumps(body)}
+
+    def test_one_failure_in_batch_reports_only_that_message_id(self):
+        good = self._sqs_record("msg-good")
+        bad = self._sqs_record("msg-bad")
+        event = {"Records": [good, bad]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=MagicMock()), \
+             patch.object(self.lf, "_extract_stream_record", side_effect=[
+                 {"dynamodb": {}}, {"dynamodb": {}},
+             ]), \
+             patch.object(self.lf, "_process_record", side_effect=[None, RuntimeError("boom")]):
+            result = self.lf.handler(event, None)
+
+        self.assertIn("batchItemFailures", result)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "msg-bad"}])
+
+    def test_all_success_returns_plain_200_no_failures(self):
+        event = {"Records": [self._sqs_record("msg-1"), self._sqs_record("msg-2")]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=MagicMock()), \
+             patch.object(self.lf, "_extract_stream_record", return_value={"dynamodb": {}}), \
+             patch.object(self.lf, "_process_record", return_value=None):
+            result = self.lf.handler(event, None)
+
+        self.assertNotIn("batchItemFailures", result)
+        self.assertEqual(result["statusCode"], 200)
+
+    def test_neo4j_unavailable_fails_entire_batch_for_retry(self):
+        event = {"Records": [self._sqs_record("msg-1"), self._sqs_record("msg-2")]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=None):
+            result = self.lf.handler(event, None)
+
+        self.assertIn("batchItemFailures", result)
+        ids = {f["itemIdentifier"] for f in result["batchItemFailures"]}
+        self.assertEqual(ids, {"msg-1", "msg-2"})
+
+    def test_empty_records_returns_plain_200(self):
+        result = self.lf.handler({"Records": []}, None)
+        self.assertEqual(result, {"statusCode": 200, "body": "no records"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2517,6 +2517,14 @@ Resources:
         Fn::Sub: ${DataStackName}-GraphSyncQueueArn
       FunctionName: !Ref GraphSyncFunction
       BatchSize: 10
+      # ENC-TSK-L74: without partial-batch-failure reporting, a batch with even
+      # one successful record returns HTTP 200 for the WHOLE batch and SQS
+      # deletes every message in it -- including ones whose _process_record
+      # raised -- permanently losing their MENTIONS edge writes with no retry.
+      # Matches the existing pattern on DeployOrchestratorSqsTrigger/
+      # FeedPublisherSqsTrigger above.
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
       Enabled: true
 
   SearchIndexSqsTrigger:


### PR DESCRIPTION
## Summary
Root cause of the recurring `mentions_drift_audit` findings (ENC-ISS-486, ENC-ISS-488, ENC-ISS-493 — same defect, worsening 44.79%→54.17% divergence over 3 days):

`graph_sync/lambda_function.py`'s `handler()` catches per-record exceptions with a bare `except Exception: continue`, never reporting them via the Lambda partial-batch-failure contract. A batch with even one successful record returns plain HTTP 200, which tells SQS the **whole batch** succeeded — deleting every message in it, including the ones whose `_process_record` raised. Those records' MENTIONS edges are then silently and permanently lost, with no retry and no DLQ delivery, despite the code's own prior comment claiming otherwise.

Ruled out regex/field-mismatch and create-only-write hypotheses first: `_reconcile_mentions_edges` and `mentions_extraction.py` are the literal same module imported by both the write path (`graph_sync`) and the audit's extractor (`deploy_parity_validator`), and `_reconcile_edges` fires on both `INSERT` and `MODIFY`. The failure mode is asymmetric by construction — it can only produce missing edges, never extra — matching every observed sample (`extra=[]` always).

## Fix
- `infrastructure/cloudformation/02-compute.yaml`: `GraphSyncSqsTrigger` gets `FunctionResponseTypes: [ReportBatchItemFailures]`, matching the existing `DeployOrchestratorSqsTrigger`/`FeedPublisherSqsTrigger` pattern that was simply missed for this queue.
- `backend/lambda/graph_sync/lambda_function.py`: `handler()` now tracks per-record `messageId`s and returns `{batchItemFailures: [...]}` for the ones that raised, so SQS retries only those. Also fixed the Neo4j-driver-unavailable branch, which previously discarded the entire batch as a false success — it now reports every message as failed so SQS retries once Neo4j is reachable again.
- `backend/lambda/graph_sync/test_partial_batch_failures_l74.py`: 4 tests (partial failure, all-success, Neo4j-unavailable, empty-batch).

Once deployed, `tools/backfill_graph.py` needs one run against gamma to repair the existing MENTIONS edge backlog (idempotent MERGE) — will do live post-merge and confirm the drift clears.

Closes ENC-ISS-486, ENC-ISS-488, ENC-ISS-493 (same defect, will close all three referencing this PR after live verification).

## Test plan
- [x] `python3 -m unittest test_partial_batch_failures_l74 -v` — 4/4 pass
- [x] `cfn-lint infrastructure/cloudformation/02-compute.yaml` — no new errors near the edited resource (pre-existing unrelated warnings only)
- [ ] Live: run `tools/backfill_graph.py` against gamma post-merge, confirm MENTIONS backlog clears

CCI-cdc8eaedb5ab47c4bb38733382bd55bb

🤖 Generated with [Claude Code](https://claude.com/claude-code)