### PR TITLE
ENC-TSK-L15: Handoff Consolidation Engine (HCE) — finish C08/FTR-096

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -7514,10 +7514,41 @@
       "owner": "search",
       "source": "ENC-TSK-L41 / B67 Search2.0",
       "telemetry_eligible": true
+    },
+    "handoff_consolidation_engine.lambda": {
+      "description": "ENC-TSK-L15 / ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-096: Handoff Consolidation Engine (enceladus-handoff-consolidation-engine; gamma twin enceladus-handoff-consolidation-engine-gamma). Scheduled adaptive scan-cluster-propose cycle over Handoff documents; proposes lesson-candidate documents via governed Document API invoke (read-only DynamoDB, no direct writes). Emits OGTM CONSOLIDATED_FROM/PROPOSED_BY fields; GDMP Stage-2 provenance annotation; FSRS-6 stability seeding on candidates.",
+      "fields": {
+        "DOCUMENTS_TABLE": {
+          "definition": "Documents DynamoDB table name (read-only Query/Scan).",
+          "type": "string"
+        },
+        "DOCUMENT_API_LAMBDA_NAME": {
+          "definition": "Target devops-document-api Lambda for governed candidate create + provenance PATCH invokes.",
+          "type": "string"
+        },
+        "ADAPTIVE_TRIGGER_MIN_HANDOFFS": {
+          "definition": "Minimum new Handoffs since last cycle before a scheduled fire runs a full cycle.",
+          "default": "3",
+          "type": "string"
+        },
+        "HCE_GDMP_PROVENANCE_ENABLED": {
+          "definition": "When true, annotate compliant documents with informed_by context (contextualized maturity).",
+          "default": "true",
+          "type": "string"
+        }
+      },
+      "owner": "coordination",
+      "source": "ENC-TSK-L15 / ENC-FTR-096",
+      "telemetry_eligible": true
     }
   },
-  "change_summary": "ENC-TSK-K26 hotfix: tracker GET promotes item_id to typed {type}_id before record_extensions attach (detail pages lacked context_node while feed worked).",
+  "change_summary": "ENC-TSK-L15: register handoff_consolidation_engine.lambda entity for HCE Lambda (C08/L15).",
   "change_log": [
+    {
+      "version": "2026-07-05.20",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L15 (C08/FTR-096): new handoff_consolidation_engine.lambda entity for enceladus-handoff-consolidation-engine scheduled HCE Lambda (Document API write path, OGTM edges, GDMP Stage-2 provenance)."
+    },
     {
       "version": "2026-07-05.19",
       "date": "2026-07-05",

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -1023,6 +1023,36 @@ def _serialize_list(items: List[str]) -> Dict:
     return {"L": [{"S": s} for s in items]}
 
 
+def _extract_provenance_fields(body: Dict) -> Dict[str, Any]:
+    """Validate + serialize the optional HCE/GDMP provenance fields.
+
+    ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-065. Shared by PUT and PATCH so the
+    persisted shape stays identical. Returns {"item_fields": {...}} on success
+    (only keys actually present in `body` are returned) or {"error": msg}.
+    """
+    out: Dict[str, Dict] = {}
+    for list_field in ("informed_by", "consolidated_from"):
+        if list_field in body:
+            val = body[list_field]
+            if not isinstance(val, list):
+                return {"error": f"'{list_field}' must be an array of record IDs."}
+            cleaned = [str(v).strip() for v in val[:MAX_RELATED_ITEMS] if str(v).strip()]
+            out[list_field] = _serialize_list(cleaned)
+    if "proposed_by" in body:
+        proposer = str(body["proposed_by"]).strip()
+        if proposer:
+            out["proposed_by"] = {"S": proposer}
+    if "fsrs_initial_stability" in body:
+        try:
+            s0 = float(body["fsrs_initial_stability"])
+        except (TypeError, ValueError):
+            return {"error": "'fsrs_initial_stability' must be numeric."}
+        if s0 < 0:
+            return {"error": "'fsrs_initial_stability' must be non-negative."}
+        out["fsrs_initial_stability"] = {"N": str(s0)}
+    return {"item_fields": out}
+
+
 def _deserialize_list(attr: Dict) -> List[str]:
     if not attr or "L" not in attr:
         return []
@@ -2002,6 +2032,18 @@ def _handle_put(event: Dict, claims: Dict) -> Dict:
         "record_type": {"S": "document"},
     }
 
+    # ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-065: provenance fields used by the
+    # Handoff Consolidation Engine and GDMP. All optional and additive:
+    #   informed_by         -> GDMP ancestral context (INFORMED_BY edges)
+    #   consolidated_from   -> HCE source handoffs (CONSOLIDATED_FROM edges)
+    #   proposed_by         -> HCE proposer record (PROPOSED_BY edge)
+    #   fsrs_initial_stability -> FSRS-6 S_0 derived from recurrence (AC-5)
+    # graph_sync projects the edge fields; the Document API only persists them.
+    _provenance = _extract_provenance_fields(body)
+    if _provenance.get("error"):
+        return _error(400, _provenance["error"])
+    item.update(_provenance["item_fields"])
+
     # Add handoff-specific fields to DynamoDB item
     if handoff_fields:
         item["source_record_id"] = {"S": handoff_fields["source_record_id"]}
@@ -2322,6 +2364,20 @@ def _handle_patch(event: Dict, claims: Dict, document_id: str) -> Dict:
     if "description" in body:
         expr_parts.append("description = :desc")
         attr_values[":desc"] = {"S": str(body["description"]).strip()[:MAX_DESCRIPTION_LENGTH]}
+
+    # ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-065: provenance field patches. The HCE
+    # GDMP Stage 2 path PATCHes informed_by alongside document_maturity_state to
+    # advance compliant -> contextualized; consolidated_from / proposed_by /
+    # fsrs_initial_stability are set at candidate creation but patchable for
+    # backfill. Reuses the shared validator so PUT and PATCH stay in lockstep.
+    _provenance_patch = _extract_provenance_fields(body)
+    if _provenance_patch.get("error"):
+        return _error(400, _provenance_patch["error"])
+    for _pfield, _pval in _provenance_patch["item_fields"].items():
+        _alias = f"#prov_{_pfield}"
+        attr_names[_alias] = _pfield
+        expr_parts.append(f"{_alias} = :{_pfield}")
+        attr_values[f":{_pfield}"] = _pval
 
     if "related_items" in body:
         items = body["related_items"]

--- a/backend/lambda/document_api/test_provenance_fields_c08.py
+++ b/backend/lambda/document_api/test_provenance_fields_c08.py
@@ -1,0 +1,49 @@
+"""Tests for ENC-TSK-C08 / ENC-FTR-065: document_api provenance field handling.
+
+The HCE writes consolidated_from / proposed_by / fsrs_initial_stability at
+candidate creation and PATCHes informed_by for GDMP Stage 2. _extract_provenance_fields
+is the shared validator/serializer used by both PUT and PATCH.
+"""
+import unittest
+
+import lambda_function as da
+
+
+class TestExtractProvenanceFields(unittest.TestCase):
+    def test_empty_body_no_fields(self):
+        self.assertEqual(da._extract_provenance_fields({})["item_fields"], {})
+
+    def test_consolidated_from_serialized(self):
+        out = da._extract_provenance_fields({"consolidated_from": ["DOC-1", " DOC-2 ", ""]})
+        self.assertEqual(
+            out["item_fields"]["consolidated_from"],
+            {"L": [{"S": "DOC-1"}, {"S": "DOC-2"}]},
+        )
+
+    def test_informed_by_serialized(self):
+        out = da._extract_provenance_fields({"informed_by": ["DOC-A"]})
+        self.assertEqual(out["item_fields"]["informed_by"], {"L": [{"S": "DOC-A"}]})
+
+    def test_proposed_by_serialized(self):
+        out = da._extract_provenance_fields({"proposed_by": "ENC-FTR-064"})
+        self.assertEqual(out["item_fields"]["proposed_by"], {"S": "ENC-FTR-064"})
+
+    def test_fsrs_initial_stability_serialized(self):
+        out = da._extract_provenance_fields({"fsrs_initial_stability": 4.25})
+        self.assertEqual(out["item_fields"]["fsrs_initial_stability"], {"N": "4.25"})
+
+    def test_non_list_consolidated_from_errors(self):
+        out = da._extract_provenance_fields({"consolidated_from": "DOC-1"})
+        self.assertIn("error", out)
+
+    def test_non_numeric_stability_errors(self):
+        out = da._extract_provenance_fields({"fsrs_initial_stability": "high"})
+        self.assertIn("error", out)
+
+    def test_negative_stability_errors(self):
+        out = da._extract_provenance_fields({"fsrs_initial_stability": -1})
+        self.assertIn("error", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -602,6 +602,13 @@ _ALLOWED_EDGE_TYPES = frozenset({
     # graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL; labels must stay byte-identical
     # across both lambdas (ENC-ISS-178).
     "PATHWAY_TRAVERSED",
+    # ENC-TSK-C08 / ENC-FTR-064 (OGTM): Handoff Consolidation Engine provenance
+    # edges. CONSOLIDATED_FROM: Lesson-candidate Document -> source Handoff
+    # Documents. PROPOSED_BY: candidate -> proposer (the HCE feature/agent).
+    # Field-projected by graph_sync from the candidate's consolidated_from /
+    # proposed_by fields; labels must stay byte-identical across both lambdas.
+    "CONSOLIDATED_FROM", "CONSOLIDATES",
+    "PROPOSED_BY", "PROPOSES",
     "TRAVERSED_BY",
     # ENC-TSK-J04 / ENC-FTR-074 Ph3: agent identity/session/credential lifecycle edges.
     # Projected by graph_sync from the agent-store streams (_reconcile_agent_edges /

--- a/backend/lambda/graph_query_api/test_edge_allowlist_c08.py
+++ b/backend/lambda/graph_query_api/test_edge_allowlist_c08.py
@@ -1,0 +1,34 @@
+"""Tests for ENC-TSK-C08: graph_query_api _ALLOWED_EDGE_TYPES OGTM registration.
+
+AC-4: the HCE-introduced edge types CONSOLIDATED_FROM and PROPOSED_BY (plus their
+inverses) must be queryable via tracker.graphsearch, which gates on this allowlist.
+"""
+import unittest
+
+
+class TestAllowedEdgeTypesC08(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.allowed = lf._ALLOWED_EDGE_TYPES
+
+    def test_consolidated_from_in_allowlist(self):
+        self.assertIn("CONSOLIDATED_FROM", self.allowed)
+
+    def test_consolidates_inverse_in_allowlist(self):
+        self.assertIn("CONSOLIDATES", self.allowed)
+
+    def test_proposed_by_in_allowlist(self):
+        self.assertIn("PROPOSED_BY", self.allowed)
+
+    def test_proposes_inverse_in_allowlist(self):
+        self.assertIn("PROPOSES", self.allowed)
+
+    def test_existing_edge_types_preserved(self):
+        for edge in ("CONSOLIDATED_FROM", "INFORMED_BY", "HANDS_OFF", "RELATED_TO",
+                     "PATHWAY_TRAVERSED", "LEARNED_FROM"):
+            with self.subTest(edge=edge):
+                self.assertIn(edge, self.allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -369,6 +369,12 @@ def _collect_placeholder_target_refs(record: Dict[str, Any]) -> Set[PlaceholderR
             _add_placeholder_ref(refs, _infer_label_from_id(rid), rid)
         for source_id in record.get("informed_by", []) or []:
             _add_placeholder_ref(refs, "Document", source_id)
+        # ENC-TSK-C08 / ENC-FTR-064: HCE provenance placeholder targets.
+        for source_id in record.get("consolidated_from", []) or []:
+            _add_placeholder_ref(refs, "Document", source_id)
+        proposed_by = _bare_id(str(record.get("proposed_by") or "").strip())
+        if proposed_by:
+            _add_placeholder_ref(refs, _infer_label_from_id(proposed_by), proposed_by)
 
         doc_subtype = str(record.get("document_subtype") or "").strip()
         if doc_subtype == "coe":
@@ -1080,6 +1086,51 @@ def _reconcile_edges(tx, record: Dict[str, Any]) -> None:
                         doc_id, source_record_id,
                     )
 
+        # ENC-TSK-C08 / ENC-FTR-064 (OGTM): HCE provenance edges.
+        # CONSOLIDATED_FROM -> each source Handoff document a Lesson candidate was
+        # consolidated from; CONSOLIDATES is the inverse. Placeholder MERGE so the
+        # edge lands even if a source document has not yet been projected.
+        for source_id in record.get("consolidated_from", []) or []:
+            source_id = _bare_id(source_id) if source_id else ""
+            if not source_id:
+                continue
+            tx.run(
+                "MERGE (s:Document {record_id: $sid}) "
+                "ON CREATE SET s.is_placeholder = true",
+                sid=source_id,
+            )
+            tx.run(
+                "MATCH (d:Document), (s:Document) "
+                "WHERE d.record_id = $did AND s.record_id = $sid "
+                "MERGE (d)-[:CONSOLIDATED_FROM]->(s) "
+                "MERGE (s)-[:CONSOLIDATES]->(d)",
+                did=doc_id, sid=source_id,
+            )
+
+        # PROPOSED_BY -> the proposer record (HCE feature / agent); PROPOSES inverse.
+        proposed_by = _bare_id(str(record.get("proposed_by") or "").strip())
+        if proposed_by:
+            target_label = _infer_label_from_id(proposed_by)
+            if target_label:
+                tx.run(
+                    f"MERGE (t:{target_label} {{record_id: $pid}}) "
+                    "ON CREATE SET t.is_placeholder = true",
+                    pid=proposed_by,
+                )
+                tx.run(
+                    f"MATCH (d:Document), (t:{target_label}) "
+                    "WHERE d.record_id = $did AND t.record_id = $pid "
+                    "MERGE (d)-[:PROPOSED_BY]->(t) "
+                    "MERGE (t)-[:PROPOSES]->(d)",
+                    did=doc_id, pid=proposed_by,
+                )
+            else:
+                logger.warning(
+                    "[WARNING] Document %s proposed_by %s has unrecognised ID prefix; "
+                    "skipping PROPOSED_BY edge",
+                    doc_id, proposed_by,
+                )
+
     # ENC-FTR-098 / ENC-TSK-G35: MENTIONS edge auto-extraction from prose.
     # For every governed record_type with prose fields, strip fenced code
     # blocks, regex-extract Enceladus ID tokens via the Unit 2 extractor,
@@ -1273,6 +1324,15 @@ RELATIONSHIP_TYPE_TO_EDGE_LABEL = {
     "derived-from": "DERIVED_FROM",                    # AgentCredential -> parent AgentCredential
     "triggered-by": "TRIGGERED_BY",                    # AgentSession -> triggering session/routine
     "mutated": "MUTATED",                              # AgentSession -> any mutated record
+    # ENC-TSK-C08 / ENC-FTR-064 (OGTM): Handoff Consolidation Engine provenance.
+    # The operational path is field-projection from the candidate Document's
+    # consolidated_from / proposed_by fields (see _reconcile_edges document
+    # branch); these mapping entries also register the typed relationship-record
+    # path for parity. Labels stay byte-identical to graph_query_api.
+    "consolidated-from": "CONSOLIDATED_FROM",          # candidate -> source handoff
+    "consolidates": "CONSOLIDATES",                    # inverse
+    "proposed-by": "PROPOSED_BY",                      # candidate -> proposer
+    "proposes": "PROPOSES",                            # inverse
 }
 
 

--- a/backend/lambda/graph_sync/test_consolidation_edges_c08.py
+++ b/backend/lambda/graph_sync/test_consolidation_edges_c08.py
@@ -1,0 +1,75 @@
+"""Tests for ENC-TSK-C08: graph_sync HCE provenance edge projection.
+
+AC-4 (OGTM): the candidate Document's consolidated_from / proposed_by fields
+project to CONSOLIDATED_FROM / PROPOSED_BY edges (plus inverses), and the typed
+relationship-record path is registered in RELATIONSHIP_TYPE_TO_EDGE_LABEL.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestRelationshipTypeMappingC08(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.mapping = lf.RELATIONSHIP_TYPE_TO_EDGE_LABEL
+
+    def test_consolidated_from(self):
+        self.assertEqual(self.mapping["consolidated-from"], "CONSOLIDATED_FROM")
+
+    def test_consolidates(self):
+        self.assertEqual(self.mapping["consolidates"], "CONSOLIDATES")
+
+    def test_proposed_by(self):
+        self.assertEqual(self.mapping["proposed-by"], "PROPOSED_BY")
+
+    def test_proposes(self):
+        self.assertEqual(self.mapping["proposes"], "PROPOSES")
+
+
+class TestCandidateEdgeProjectionC08(unittest.TestCase):
+    def _reconcile(self, record):
+        import lambda_function as lf
+        tx = MagicMock()
+        lf._reconcile_edges(tx, record)
+        return [str(c) for c in tx.run.call_args_list]
+
+    def test_consolidated_from_projects_edge(self):
+        record = {
+            "record_type": "document",
+            "record_id": "DOC-CAND01",
+            "project_id": "enceladus",
+            "document_subtype": "doc",
+            "consolidated_from": ["DOC-SRC01", "DOC-SRC02"],
+        }
+        calls = self._reconcile(record)
+        self.assertTrue(any("CONSOLIDATED_FROM" in c for c in calls),
+                        f"no CONSOLIDATED_FROM edge; calls={calls}")
+        self.assertTrue(any("CONSOLIDATES" in c for c in calls))
+
+    def test_proposed_by_projects_edge(self):
+        record = {
+            "record_type": "document",
+            "record_id": "DOC-CAND02",
+            "project_id": "enceladus",
+            "document_subtype": "doc",
+            "proposed_by": "ENC-FTR-064",
+        }
+        calls = self._reconcile(record)
+        self.assertTrue(any("PROPOSED_BY" in c for c in calls),
+                        f"no PROPOSED_BY edge; calls={calls}")
+        self.assertTrue(any("PROPOSES" in c for c in calls))
+
+    def test_no_provenance_fields_no_edges(self):
+        record = {
+            "record_type": "document",
+            "record_id": "DOC-PLAIN",
+            "project_id": "enceladus",
+            "document_subtype": "doc",
+        }
+        calls = self._reconcile(record)
+        self.assertFalse(any("CONSOLIDATED_FROM" in c for c in calls))
+        self.assertFalse(any("PROPOSED_BY" in c for c in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/handoff_consolidation_engine/deploy.sh
+++ b/backend/lambda/handoff_consolidation_engine/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/handoff_consolidation_engine/lambda_function.py
+++ b/backend/lambda/handoff_consolidation_engine/lambda_function.py
@@ -79,6 +79,13 @@ GDMP_MIN_SHARED_REFS = int(os.environ.get("HCE_GDMP_MIN_SHARED_REFS", "1"))
 # edge lands on a real, traversable node.
 PROPOSER_ID = os.environ.get("HCE_PROPOSER_ID", "ENC-FTR-064")
 
+# AC-5 (ENC-TSK-L15): block candidate dispatch when the lesson primitive is disabled.
+_ENABLE_LESSON_RAW = os.environ.get("ENABLE_LESSON_PRIMITIVE", "true")
+
+
+def _lesson_primitive_enabled() -> bool:
+    return str(_ENABLE_LESSON_RAW).strip().lower() in ("1", "true", "yes", "on")
+
 # FSRS-6 initial-stability mapping bounds (see initial_stability_from_recurrence).
 FSRS_S0_FLOOR = float(os.environ.get("HCE_FSRS_S0_FLOOR", "2.0"))
 FSRS_S0_CEIL = float(os.environ.get("HCE_FSRS_S0_CEIL", "15.0"))
@@ -607,6 +614,19 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     since_iso = event.get("since")
     run_id = f"hce-{int(time.time())}"
     logger.info("[START] HCE cycle %s (force=%s dry_run=%s)", run_id, force, dry_run)
+
+    if not _lesson_primitive_enabled():
+        logger.info("[INFO] HCE cycle %s skipped: ENABLE_LESSON_PRIMITIVE disabled", run_id)
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "run_id": run_id,
+                    "skipped": True,
+                    "reason": "ENABLE_LESSON_PRIMITIVE disabled",
+                }
+            ),
+        }
 
     now = _now()
     cutoff = now - timedelta(days=LOOKBACK_DAYS)

--- a/backend/lambda/handoff_consolidation_engine/lambda_function.py
+++ b/backend/lambda/handoff_consolidation_engine/lambda_function.py
@@ -1,0 +1,699 @@
+"""Handoff Consolidation Engine (HCE) — ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-096.
+
+Closes the gap between Enceladus's short-term memory (Handoff documents, the
+episodic / hippocampal buffer) and its long-term knowledge (Lesson records, the
+semantic store). A scheduled, adaptive-triggered Lambda that runs a full
+scan-cluster-propose cycle against the Handoff document corpus and proposes
+Lesson candidates for coordination-lead review.
+
+Design lineage: DOC-450CE70D7BAC (Memory Consolidation Lambda design spec). This
+implementation operationalizes that design and adds, per ENC-TSK-C08:
+
+  * an adaptive trigger (run only when enough new episodic material has
+    accumulated since the last cycle, so the schedule is a ceiling not a floor),
+  * FSRS-6 stability initialization from Handoff recurrence count
+    (higher recurrence => higher initial stability S on the promoted Lesson),
+  * GDMP Stage 2 provenance annotation (compliant documents receive ancestral
+    session context via HCE semantic clustering and advance to `contextualized`),
+  * OGTM-traversable provenance edges CONSOLIDATED_FROM (candidate -> source
+    Handoffs) and PROPOSED_BY (candidate -> proposer) emitted as first-class
+    document fields that graph_sync projects to Neo4j.
+
+Governance model (mirrors the enceladus-agent-cli IAM posture):
+  * READS go straight to DynamoDB (the execution role is granted Query/Scan on
+    the documents table only).
+  * WRITES never touch DynamoDB/S3 directly — the engine invokes the governed
+    Document API Lambda with a synthetic API Gateway event and the internal
+    service key, exactly as coordination_api does for service-to-service writes.
+  * The engine NEVER promotes a candidate to a governed Lesson — that is an
+    io-only `tracker.create_lesson` action (DOC-450CE70D7BAC §6).
+
+The pure-function core (extractors, FSRS init, clustering, the adaptive-trigger
+decision, candidate assembly) is import-safe and side-effect-free so it can be
+unit-tested without AWS. The handler wires those functions to DynamoDB reads and
+Document API writes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# --- Configuration ---------------------------------------------------------
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "enceladus")
+DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+DOCUMENT_API_LAMBDA_NAME = os.environ.get("DOCUMENT_API_LAMBDA_NAME", "")
+
+# Adaptive trigger: a scheduled invoke runs a full cycle only when at least this
+# many Handoff documents were created since the lookback floor. The schedule is
+# therefore an upper bound on cadence; quiet periods are skipped cheaply.
+ADAPTIVE_TRIGGER_MIN_HANDOFFS = int(os.environ.get("ADAPTIVE_TRIGGER_MIN_HANDOFFS", "3"))
+LOOKBACK_DAYS = int(os.environ.get("HCE_LOOKBACK_DAYS", "90"))
+
+# Pattern-matching thresholds (DOC-450CE70D7BAC §4).
+COCITATION_MIN_PAIR_COUNT = int(os.environ.get("HCE_COCITATION_MIN_PAIR_COUNT", "3"))
+COCITATION_MIN_DISTINCT_WAVES = int(os.environ.get("HCE_COCITATION_MIN_WAVES", "2"))
+ERROR_MIN_DISTINCT_WAVES = int(os.environ.get("HCE_ERROR_MIN_WAVES", "2"))
+
+# GDMP Stage 2 provenance annotation budget per cycle.
+GDMP_PROVENANCE_ENABLED = os.environ.get("HCE_GDMP_PROVENANCE_ENABLED", "true").lower() == "true"
+GDMP_MAX_ANNOTATIONS = int(os.environ.get("HCE_GDMP_MAX_ANNOTATIONS", "10"))
+GDMP_MIN_SHARED_REFS = int(os.environ.get("HCE_GDMP_MIN_SHARED_REFS", "1"))
+
+# Proposer for the PROPOSED_BY edge. Defaults to the HCE feature record so the
+# edge lands on a real, traversable node.
+PROPOSER_ID = os.environ.get("HCE_PROPOSER_ID", "ENC-FTR-064")
+
+# FSRS-6 initial-stability mapping bounds (see initial_stability_from_recurrence).
+FSRS_S0_FLOOR = float(os.environ.get("HCE_FSRS_S0_FLOOR", "2.0"))
+FSRS_S0_CEIL = float(os.environ.get("HCE_FSRS_S0_CEIL", "15.0"))
+FSRS_S0_GROWTH = float(os.environ.get("HCE_FSRS_S0_GROWTH", "0.35"))
+
+DOC_SUBTYPES_IN_SCOPE = ("handoff", "wave")
+DOC_STATUSES_IN_SCOPE = ("active", "completed", "stale")
+
+CANDIDATE_KEYWORD = "lesson-candidate"
+
+_RATE_LIMIT_SLEEP_S = float(os.environ.get("HCE_RATE_LIMIT_SLEEP_S", "0.1"))
+
+# Enceladus record-id token (used for co-citation and error-class extraction).
+_ID_TOKEN_RE = re.compile(r"\b([A-Z]{2,5}-(?:TSK|ISS|FTR|PLN|LSN)-[0-9A-Z]+)\b")
+_ISS_TOKEN_RE = re.compile(r"\b([A-Z]{2,5}-ISS-[0-9A-Z]+)\b")
+_ERROR_TAG_RE = re.compile(r"\[(ERROR|WARN)\]", re.IGNORECASE)
+_SEV_RE = re.compile(r"\bSev([0-3])\b", re.IGNORECASE)
+
+_ddb_resource = None
+_lambda_client = None
+
+
+def _get_table():
+    global _ddb_resource
+    if _ddb_resource is None:
+        _ddb_resource = boto3.resource("dynamodb", region_name=REGION)
+    return _ddb_resource.Table(DOCUMENTS_TABLE)
+
+
+def _get_lambda_client():
+    global _lambda_client
+    if _lambda_client is None:
+        _lambda_client = boto3.client("lambda", region_name=REGION)
+    return _lambda_client
+
+
+def _internal_api_key() -> str:
+    for name in (
+        "ENCELADUS_COORDINATION_API_INTERNAL_API_KEY",
+        "ENCELADUS_COORDINATION_INTERNAL_API_KEY",
+        "COORDINATION_INTERNAL_API_KEY",
+    ):
+        val = (os.environ.get(name) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# FSRS-6 stability initialization (ENC-TSK-C08 AC-5)
+# ---------------------------------------------------------------------------
+
+def initial_stability_from_recurrence(
+    recurrence: int,
+    *,
+    floor: float = FSRS_S0_FLOOR,
+    ceil: float = FSRS_S0_CEIL,
+    growth: float = FSRS_S0_GROWTH,
+) -> float:
+    """Map a Handoff recurrence count to an initial FSRS-6 stability S_0.
+
+    Contract (ENC-TSK-C08 AC-5): the function is STRICTLY increasing in
+    `recurrence` for any growth > 0 — a pattern that recurred across more
+    sessions earns a higher initial stability, so the promoted Lesson decays
+    more slowly and surfaces longer in retrieval. The mapping saturates toward
+    `ceil` so a runaway recurrence count cannot mint an unbounded stability.
+
+    S_0(r) = floor + (ceil - floor) * (1 - exp(-growth * (r - 1)))
+
+    At r = 1 (a single occurrence) S_0 == floor — a normal new-Lesson stability.
+    As r -> inf, S_0 -> ceil. The curve is concave (diminishing returns), which
+    matches the FSRS-6 intuition that the first few corroborations matter most.
+    """
+    r = max(1, int(recurrence))
+    if ceil <= floor or growth <= 0:
+        return round(floor, 4)
+    span = ceil - floor
+    s0 = floor + span * (1.0 - math.exp(-growth * (r - 1)))
+    return round(s0, 4)
+
+
+# ---------------------------------------------------------------------------
+# Handoff corpus helpers
+# ---------------------------------------------------------------------------
+
+def wave_anchor(doc: Dict[str, Any]) -> str:
+    """Group key for a Handoff into a wave (DOC-450CE70D7BAC §7.3).
+
+    Prefer the explicit plan_anchor_id; otherwise the document is treated as its
+    own standalone wave (conservative grouping that never over-merges).
+    """
+    anchor = str(doc.get("plan_anchor_id") or "").strip()
+    return anchor or str(doc.get("document_id") or "").strip()
+
+
+def _doc_related_ids(doc: Dict[str, Any]) -> List[str]:
+    out: List[str] = []
+    for rid in doc.get("related_items", []) or []:
+        rid = str(rid).strip().upper()
+        if _ID_TOKEN_RE.fullmatch(rid):
+            out.append(rid)
+    return out
+
+
+def normalize_error_tokens(text: str) -> List[str]:
+    """Extract a normalized set of error-class tokens from Handoff prose.
+
+    ISS-NNN references are the preferred (structured) signal; [ERROR]/[WARN] log
+    tags and SevN markers are kept as coarse fallbacks for unstructured text.
+    """
+    text = text or ""
+    tokens = set(m.group(1).upper() for m in _ISS_TOKEN_RE.finditer(text))
+    for m in _ERROR_TAG_RE.finditer(text):
+        tokens.add(f"TAG:{m.group(1).upper()}")
+    for m in _SEV_RE.finditer(text):
+        tokens.add(f"SEV{m.group(1)}")
+    return sorted(tokens)
+
+
+def source_hash(ids: Sequence[str]) -> str:
+    """Stable content hash over a candidate's source set (dedup guard, §3.3)."""
+    norm = sorted({str(i).strip().upper() for i in ids if str(i).strip()})
+    return hashlib.sha256("|".join(norm).encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Pattern extractors (DOC-450CE70D7BAC §4) — pure functions
+# ---------------------------------------------------------------------------
+
+def extract_co_citation_candidates(
+    handoffs: Sequence[Dict[str, Any]],
+    *,
+    min_pair_count: int = COCITATION_MIN_PAIR_COUNT,
+    min_distinct_waves: int = COCITATION_MIN_DISTINCT_WAVES,
+) -> List[Dict[str, Any]]:
+    """Co-citation frequency extractor (§4.1, primary).
+
+    A record pair that is co-cited in the related_items of >= min_distinct_waves
+    distinct wave anchors AND reaches >= min_pair_count total co-citations within
+    the corpus becomes a candidate. Returns one candidate per qualifying pair.
+    """
+    pair_waves: Dict[Tuple[str, str], set] = defaultdict(set)
+    pair_docs: Dict[Tuple[str, str], set] = defaultdict(set)
+    for doc in handoffs:
+        anchor = wave_anchor(doc)
+        doc_id = str(doc.get("document_id") or "").strip()
+        ids = sorted(set(_doc_related_ids(doc)))
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                pair = (ids[i], ids[j])
+                pair_waves[pair].add(anchor)
+                pair_docs[pair].add(doc_id)
+
+    candidates: List[Dict[str, Any]] = []
+    for pair, waves in pair_waves.items():
+        docs = pair_docs[pair]
+        if len(waves) >= min_distinct_waves and len(docs) >= min_pair_count:
+            candidates.append({
+                "extractor": "co-citation",
+                "pattern_token": f"{pair[0]}+{pair[1]}",
+                "record_pair": list(pair),
+                "recurrence_count": len(docs),
+                "distinct_waves": sorted(waves),
+                "source_doc_ids": sorted(docs),
+            })
+    candidates.sort(key=lambda c: (-c["recurrence_count"], c["pattern_token"]))
+    return candidates
+
+
+def extract_error_recurrence_candidates(
+    handoffs: Sequence[Dict[str, Any]],
+    *,
+    min_distinct_waves: int = ERROR_MIN_DISTINCT_WAVES,
+) -> List[Dict[str, Any]]:
+    """Error-class recurrence extractor (§4.2, primary).
+
+    An error class recurring across >= min_distinct_waves distinct wave anchors
+    becomes a candidate.
+    """
+    class_waves: Dict[str, set] = defaultdict(set)
+    class_docs: Dict[str, set] = defaultdict(set)
+    class_first: Dict[str, str] = {}
+    class_last: Dict[str, str] = {}
+    for doc in handoffs:
+        anchor = wave_anchor(doc)
+        doc_id = str(doc.get("document_id") or "").strip()
+        created = str(doc.get("created_at") or "")
+        text = " ".join(str(doc.get(f) or "") for f in ("title", "description", "content"))
+        for token in normalize_error_tokens(text):
+            class_waves[token].add(anchor)
+            class_docs[token].add(doc_id)
+            if token not in class_first or created < class_first[token]:
+                class_first[token] = created
+            if token not in class_last or created > class_last[token]:
+                class_last[token] = created
+
+    candidates: List[Dict[str, Any]] = []
+    for token, waves in class_waves.items():
+        if len(waves) >= min_distinct_waves:
+            docs = class_docs[token]
+            candidates.append({
+                "extractor": "error-recurrence",
+                "pattern_token": token,
+                "error_class": token,
+                "recurrence_count": len(docs),
+                "distinct_waves": sorted(waves),
+                "source_doc_ids": sorted(docs),
+                "first_seen": class_first.get(token, ""),
+                "last_seen": class_last.get(token, ""),
+            })
+    candidates.sort(key=lambda c: (-c["recurrence_count"], c["pattern_token"]))
+    return candidates
+
+
+def run_extractors(handoffs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Run all primary extractors and return the merged candidate list."""
+    out: List[Dict[str, Any]] = []
+    out.extend(extract_co_citation_candidates(handoffs))
+    out.extend(extract_error_recurrence_candidates(handoffs))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Adaptive trigger (ENC-TSK-C08 AC-1)
+# ---------------------------------------------------------------------------
+
+def count_new_handoffs(handoffs: Sequence[Dict[str, Any]], since_iso: Optional[str]) -> int:
+    if not since_iso:
+        return len(handoffs)
+    return sum(1 for d in handoffs if str(d.get("created_at") or "") > since_iso)
+
+
+def should_run_cycle(
+    handoffs: Sequence[Dict[str, Any]],
+    *,
+    since_iso: Optional[str],
+    min_new_handoffs: int = ADAPTIVE_TRIGGER_MIN_HANDOFFS,
+    force: bool = False,
+) -> Tuple[bool, str]:
+    """Adaptive-trigger decision.
+
+    Returns (run, reason). A forced invoke always runs. Otherwise a full cycle
+    runs only when enough new episodic material accumulated since the last cycle,
+    making the schedule a ceiling on cadence rather than an unconditional floor.
+    """
+    if force:
+        return True, "forced"
+    if not handoffs:
+        return False, "no handoffs in scope"
+    new_count = count_new_handoffs(handoffs, since_iso)
+    if new_count >= min_new_handoffs:
+        return True, f"{new_count} new handoffs >= threshold {min_new_handoffs}"
+    return False, f"{new_count} new handoffs < threshold {min_new_handoffs}"
+
+
+# ---------------------------------------------------------------------------
+# GDMP Stage 2 provenance clustering (ENC-TSK-C08 AC-3)
+# ---------------------------------------------------------------------------
+
+def cluster_provenance_context(
+    compliant_docs: Sequence[Dict[str, Any]],
+    *,
+    min_shared_refs: int = GDMP_MIN_SHARED_REFS,
+) -> Dict[str, List[str]]:
+    """Semantic-clustering proxy for GDMP Stage 2 ancestral provenance.
+
+    For each compliant document, find sibling documents that share at least
+    `min_shared_refs` related-item references (the lightweight co-citation
+    proxy for semantic adjacency that needs no embedding round-trip). The shared
+    siblings become the document's ancestral session context (`informed_by`),
+    which graph_sync projects as INFORMED_BY edges, advancing the document from
+    `compliant` to `contextualized`.
+    """
+    ref_sets: Dict[str, set] = {}
+    for doc in compliant_docs:
+        doc_id = str(doc.get("document_id") or "").strip()
+        if doc_id:
+            ref_sets[doc_id] = set(_doc_related_ids(doc))
+
+    result: Dict[str, List[str]] = {}
+    for doc_id, refs in ref_sets.items():
+        if not refs:
+            continue
+        siblings: List[str] = []
+        for other_id, other_refs in ref_sets.items():
+            if other_id == doc_id:
+                continue
+            if len(refs & other_refs) >= min_shared_refs:
+                siblings.append(other_id)
+        if siblings:
+            result[doc_id] = sorted(siblings)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Candidate document assembly (DOC-450CE70D7BAC §5)
+# ---------------------------------------------------------------------------
+
+def build_candidate_document(
+    candidate: Dict[str, Any],
+    *,
+    lookback_start: str,
+    lookback_end: str,
+    proposer_id: str = PROPOSER_ID,
+) -> Dict[str, Any]:
+    """Assemble the Document API PUT body for a Lesson candidate.
+
+    The body carries the OGTM provenance fields the graph layer projects:
+      * consolidated_from -> the source Handoff document IDs (CONSOLIDATED_FROM)
+      * proposed_by       -> the proposer record (PROPOSED_BY)
+      * fsrs_initial_stability -> S_0 derived from recurrence (AC-5)
+    """
+    extractor = candidate["extractor"]
+    recurrence = int(candidate["recurrence_count"])
+    pattern_token = candidate["pattern_token"]
+    source_ids = list(candidate["source_doc_ids"])
+    distinct_waves = candidate.get("distinct_waves", [])
+    s0 = initial_stability_from_recurrence(recurrence)
+
+    if extractor == "co-citation":
+        pair = candidate["record_pair"]
+        short = f"co-citation of {pair[0]} & {pair[1]}"
+        observed = (
+            f"Records {pair[0]} and {pair[1]} were co-cited across "
+            f"{len(distinct_waves)} distinct waves ({recurrence} handoffs), "
+            "suggesting a recurring structural coupling worth a governed Lesson."
+        )
+    else:
+        short = f"recurring error class {candidate.get('error_class', pattern_token)}"
+        observed = (
+            f"Error class {candidate.get('error_class', pattern_token)} recurred "
+            f"across {len(distinct_waves)} distinct waves ({recurrence} handoffs)."
+        )
+
+    evidence_lines = "\n".join(f"- [{d}] source handoff" for d in source_ids)
+    content = f"""# LESSON CANDIDATE — {short}
+
+**Extractor**: {extractor}
+**Source Handoffs**: {', '.join(source_ids)} ({len(distinct_waves)} distinct waves)
+**Recurrence Count**: {recurrence}
+**FSRS-6 Initial Stability (S_0)**: {s0}
+**Lookback Window**: {lookback_start} to {lookback_end}
+**Generated**: {_iso(_now())}
+**Status**: DRAFT — awaiting coordination-lead review
+
+## Observed Pattern
+{observed}
+
+## Supporting Evidence
+{evidence_lines}
+
+## Proposed Lesson Statement
+<Draft — what should be learned and applied going forward, based on the
+recurring pattern above. Coordination lead refines before promotion.>
+
+## Suggested Tags
+{CANDIDATE_KEYWORD}, {pattern_token}
+
+---
+_Generated by the Handoff Consolidation Engine (ENC-TSK-C08). Not yet reviewed._
+_To promote: io calls tracker.create_lesson with this DOC as evidence_
+_(initial FSRS-6 stability S_0 = {s0}, derived from recurrence={recurrence})._
+_To discard: set document status to archived._
+"""
+
+    keywords = [CANDIDATE_KEYWORD, extractor, pattern_token.lower()]
+    return {
+        "title": f"LESSON CANDIDATE — {short}",
+        "document_subtype": "doc",
+        "document_maturity_state": "raw",
+        "content": content,
+        "related_items": source_ids,
+        "keywords": keywords[:10],
+        "consolidated_from": source_ids,
+        "proposed_by": proposer_id,
+        "fsrs_initial_stability": s0,
+        "_source_hash": source_hash(source_ids),
+        "_recurrence": recurrence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AWS-facing I/O
+# ---------------------------------------------------------------------------
+
+def _scan_documents(
+    subtypes: Sequence[str],
+    *,
+    statuses: Sequence[str],
+    cutoff_iso: str,
+) -> List[Dict[str, Any]]:
+    """Read documents in scope directly from DynamoDB (read-only IAM)."""
+    table = _get_table()
+    filt = (
+        Attr("record_type").eq("document")
+        & Attr("project_id").eq(PROJECT_ID)
+        & Attr("document_subtype").is_in(list(subtypes))
+        & Attr("created_at").gte(cutoff_iso)
+    )
+    items: List[Dict[str, Any]] = []
+    kwargs: Dict[str, Any] = {"FilterExpression": filt}
+    while True:
+        resp = table.scan(**kwargs)
+        for it in resp.get("Items", []):
+            if str(it.get("document_maturity_state") or "") == "archived":
+                continue
+            if statuses and str(it.get("status") or "active") not in statuses:
+                continue
+            items.append(it)
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            break
+        kwargs["ExclusiveStartKey"] = lek
+    return items
+
+
+def _scan_existing_candidate_hashes() -> set:
+    """Source hashes of already-proposed candidates (dedup guard, §3.3)."""
+    table = _get_table()
+    filt = (
+        Attr("record_type").eq("document")
+        & Attr("project_id").eq(PROJECT_ID)
+        & Attr("keywords").contains(CANDIDATE_KEYWORD)
+    )
+    hashes: set = set()
+    kwargs: Dict[str, Any] = {"FilterExpression": filt}
+    while True:
+        resp = table.scan(**kwargs)
+        for it in resp.get("Items", []):
+            consolidated = it.get("consolidated_from") or it.get("related_items") or []
+            hashes.add(source_hash(consolidated))
+        lek = resp.get("LastEvaluatedKey")
+        if not lek:
+            break
+        kwargs["ExclusiveStartKey"] = lek
+    return hashes
+
+
+def _invoke_document_api(method: str, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+    """Invoke the governed Document API Lambda with a synthetic API GW event."""
+    if not DOCUMENT_API_LAMBDA_NAME:
+        raise RuntimeError("DOCUMENT_API_LAMBDA_NAME not configured")
+    headers = {"Content-Type": "application/json"}
+    key = _internal_api_key()
+    if key:
+        headers["X-Coordination-Internal-Key"] = key
+    payload = {"project_id": PROJECT_ID, **body}
+    event = {
+        "version": "2.0",
+        "routeKey": f"{method} {path}",
+        "rawPath": path,
+        "requestContext": {"http": {"method": method, "path": path}},
+        "httpMethod": method,
+        "headers": headers,
+        "isBase64Encoded": False,
+        "body": json.dumps(payload),
+    }
+    resp = _get_lambda_client().invoke(
+        FunctionName=DOCUMENT_API_LAMBDA_NAME,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(event).encode("utf-8"),
+    )
+    raw = resp.get("Payload")
+    text = raw.read().decode("utf-8") if raw is not None else ""
+    envelope = json.loads(text) if text else {}
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"document API invoke error: {envelope}")
+    status = int(envelope.get("statusCode") or 0)
+    inner_raw = envelope.get("body")
+    inner: Dict[str, Any] = {}
+    if isinstance(inner_raw, str) and inner_raw:
+        try:
+            inner = json.loads(inner_raw)
+        except json.JSONDecodeError:
+            inner = {}
+    elif isinstance(inner_raw, dict):
+        inner = inner_raw
+    return {"status": status, "body": inner}
+
+
+def _create_candidate(spec: Dict[str, Any]) -> Optional[str]:
+    put_body = {k: v for k, v in spec.items() if not k.startswith("_")}
+    res = _invoke_document_api("PUT", "/api/v1/documents", put_body)
+    if res["status"] in (200, 201):
+        return res["body"].get("document_id")
+    logger.error("[ERROR] candidate create failed status=%s body=%s", res["status"], res["body"])
+    return None
+
+
+def _annotate_provenance(doc_id: str, informed_by: List[str]) -> bool:
+    body = {
+        "informed_by": informed_by,
+        "document_maturity_state": "contextualized",
+    }
+    res = _invoke_document_api("PATCH", f"/api/v1/documents/{doc_id}", body)
+    if res["status"] == 200:
+        return True
+    logger.error("[ERROR] provenance patch failed for %s status=%s body=%s",
+                 doc_id, res["status"], res["body"])
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Run one HCE scan-cluster-propose cycle.
+
+    Event knobs (all optional):
+      force      — bypass the adaptive trigger and always run.
+      dry_run    — run the full cycle but make no Document API writes.
+      since      — ISO timestamp for the adaptive new-handoff comparison.
+    """
+    event = event or {}
+    force = bool(event.get("force"))
+    dry_run = bool(event.get("dry_run"))
+    since_iso = event.get("since")
+    run_id = f"hce-{int(time.time())}"
+    logger.info("[START] HCE cycle %s (force=%s dry_run=%s)", run_id, force, dry_run)
+
+    now = _now()
+    cutoff = now - timedelta(days=LOOKBACK_DAYS)
+    cutoff_iso = _iso(cutoff)
+
+    summary: Dict[str, Any] = {
+        "run_id": run_id,
+        "lookback_start": cutoff_iso,
+        "lookback_end": _iso(now),
+        "handoffs_scanned": 0,
+        "candidates_detected": 0,
+        "candidates_proposed": 0,
+        "candidates_skipped_duplicate": 0,
+        "provenance_annotated": 0,
+        "dry_run": dry_run,
+        "errors": [],
+    }
+
+    try:
+        handoffs = _scan_documents(
+            DOC_SUBTYPES_IN_SCOPE, statuses=DOC_STATUSES_IN_SCOPE, cutoff_iso=cutoff_iso
+        )
+        summary["handoffs_scanned"] = len(handoffs)
+
+        run, reason = should_run_cycle(handoffs, since_iso=since_iso, force=force)
+        summary["adaptive_trigger"] = reason
+        if not run:
+            logger.info("[INFO] HCE cycle %s skipped by adaptive trigger: %s", run_id, reason)
+            summary["skipped"] = True
+            return {"statusCode": 200, "body": json.dumps(summary)}
+
+        candidates = run_extractors(handoffs)
+        summary["candidates_detected"] = len(candidates)
+
+        existing_hashes = set() if dry_run else _scan_existing_candidate_hashes()
+        proposed_ids: List[str] = []
+        for cand in candidates:
+            spec = build_candidate_document(
+                cand, lookback_start=cutoff_iso, lookback_end=_iso(now)
+            )
+            if spec["_source_hash"] in existing_hashes:
+                summary["candidates_skipped_duplicate"] += 1
+                continue
+            existing_hashes.add(spec["_source_hash"])
+            if dry_run:
+                proposed_ids.append(f"DRY-RUN:{spec['_source_hash']}")
+                continue
+            doc_id = _create_candidate(spec)
+            if doc_id:
+                proposed_ids.append(doc_id)
+            else:
+                summary["errors"].append(f"create failed: {spec['_source_hash']}")
+            time.sleep(_RATE_LIMIT_SLEEP_S)
+        summary["candidates_proposed"] = len(proposed_ids)
+        summary["proposed_document_ids"] = proposed_ids
+
+        # GDMP Stage 2 — provenance annotation of compliant documents.
+        if GDMP_PROVENANCE_ENABLED:
+            compliant = [
+                d for d in _scan_documents(
+                    ("doc", "handoff", "wave", "coe"),
+                    statuses=("active",),
+                    cutoff_iso=cutoff_iso,
+                )
+                if str(d.get("document_maturity_state") or "") == "compliant"
+            ]
+            provenance = cluster_provenance_context(compliant)
+            annotated = 0
+            for doc_id, informed_by in provenance.items():
+                if annotated >= GDMP_MAX_ANNOTATIONS:
+                    break
+                if dry_run:
+                    annotated += 1
+                    continue
+                if _annotate_provenance(doc_id, informed_by):
+                    annotated += 1
+                time.sleep(_RATE_LIMIT_SLEEP_S)
+            summary["provenance_annotated"] = annotated
+
+        logger.info("[SUCCESS] HCE cycle %s: %s", run_id, json.dumps(summary))
+        return {"statusCode": 200, "body": json.dumps(summary)}
+
+    except Exception as exc:  # noqa: BLE001 — surface as structured error
+        logger.error("[ERROR] HCE cycle %s failed: %s", run_id, exc, exc_info=True)
+        summary["errors"].append(str(exc))
+        return {"statusCode": 500, "body": json.dumps(summary)}
+
+
+# Alias for environments that expect lambda_handler.
+lambda_handler = handler

--- a/backend/lambda/handoff_consolidation_engine/requirements.txt
+++ b/backend/lambda/handoff_consolidation_engine/requirements.txt
@@ -1,0 +1,4 @@
+# Handoff Consolidation Engine (ENC-TSK-C08).
+# Runtime deps only — boto3 is provided by the Lambda runtime. The engine reads
+# documents via DynamoDB and writes via the governed Document API Lambda invoke,
+# so it needs no graph driver or third-party packages.

--- a/backend/lambda/handoff_consolidation_engine/test_lambda_function.py
+++ b/backend/lambda/handoff_consolidation_engine/test_lambda_function.py
@@ -1,0 +1,184 @@
+"""Unit tests for the Handoff Consolidation Engine (ENC-TSK-C08).
+
+Covers the pure-function core: FSRS-6 stability init monotonicity (AC-5), the
+co-citation and error-recurrence extractors (AC-1 scan-cluster-propose), the
+adaptive trigger (AC-1), GDMP Stage 2 provenance clustering (AC-3), and the
+candidate-document provenance fields that feed the OGTM edges (AC-4).
+"""
+import unittest
+
+import lambda_function as hce
+
+
+def _handoff(doc_id, anchor=None, related=None, content="", created="2026-06-01T00:00:00Z"):
+    return {
+        "document_id": doc_id,
+        "document_subtype": "handoff",
+        "plan_anchor_id": anchor or "",
+        "related_items": related or [],
+        "content": content,
+        "title": "",
+        "description": "",
+        "created_at": created,
+        "status": "active",
+    }
+
+
+class TestFsrsInitialStability(unittest.TestCase):
+    def test_strictly_increasing_in_recurrence(self):
+        prev = -1.0
+        for r in range(1, 30):
+            s = hce.initial_stability_from_recurrence(r)
+            self.assertGreater(s, prev, f"S_0 not increasing at recurrence={r}")
+            prev = s
+
+    def test_floor_at_single_occurrence(self):
+        self.assertAlmostEqual(
+            hce.initial_stability_from_recurrence(1, floor=2.0, ceil=15.0, growth=0.35),
+            2.0, places=4,
+        )
+
+    def test_saturates_at_or_below_ceiling(self):
+        # The mapping approaches but never exceeds the ceiling (it may round to
+        # the ceiling at very high recurrence, which is the intended bound).
+        for r in range(1, 200):
+            self.assertLessEqual(
+                hce.initial_stability_from_recurrence(r, floor=2.0, ceil=15.0, growth=0.35),
+                15.0,
+            )
+
+    def test_higher_recurrence_higher_stability(self):
+        # The headline AC-5 invariant.
+        self.assertLess(
+            hce.initial_stability_from_recurrence(2),
+            hce.initial_stability_from_recurrence(8),
+        )
+
+    def test_degenerate_params_return_floor(self):
+        self.assertEqual(hce.initial_stability_from_recurrence(5, floor=3.0, ceil=3.0, growth=0.3), 3.0)
+        self.assertEqual(hce.initial_stability_from_recurrence(5, floor=3.0, ceil=9.0, growth=0.0), 3.0)
+
+
+class TestCoCitationExtractor(unittest.TestCase):
+    def test_pair_across_distinct_waves(self):
+        handoffs = [
+            _handoff("DOC-1", anchor="ENC-PLN-006", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+            _handoff("DOC-2", anchor="ENC-PLN-007", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+            _handoff("DOC-3", anchor="ENC-PLN-008", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+        ]
+        cands = hce.extract_co_citation_candidates(handoffs)
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["recurrence_count"], 3)
+        self.assertEqual(sorted(cands[0]["record_pair"]), ["ENC-ISS-B2", "ENC-TSK-A1"])
+
+    def test_same_wave_does_not_qualify(self):
+        # Three docs but all in one wave -> distinct_waves=1 < 2.
+        handoffs = [
+            _handoff("DOC-1", anchor="ENC-PLN-006", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+            _handoff("DOC-2", anchor="ENC-PLN-006", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+            _handoff("DOC-3", anchor="ENC-PLN-006", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+        ]
+        self.assertEqual(hce.extract_co_citation_candidates(handoffs), [])
+
+    def test_below_pair_count_excluded(self):
+        handoffs = [
+            _handoff("DOC-1", anchor="ENC-PLN-006", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+            _handoff("DOC-2", anchor="ENC-PLN-007", related=["ENC-TSK-A1", "ENC-ISS-B2"]),
+        ]
+        # 2 docs / 2 waves but min_pair_count default is 3.
+        self.assertEqual(hce.extract_co_citation_candidates(handoffs), [])
+
+
+class TestErrorRecurrenceExtractor(unittest.TestCase):
+    def test_iss_token_recurs_across_waves(self):
+        handoffs = [
+            _handoff("DOC-1", anchor="ENC-PLN-006", content="hit ENC-ISS-197 again"),
+            _handoff("DOC-2", anchor="ENC-PLN-007", content="ENC-ISS-197 recurred [ERROR]"),
+        ]
+        cands = hce.extract_error_recurrence_candidates(handoffs)
+        tokens = {c["error_class"] for c in cands}
+        self.assertIn("ENC-ISS-197", tokens)
+
+    def test_single_wave_not_recurring(self):
+        handoffs = [_handoff("DOC-1", anchor="ENC-PLN-006", content="ENC-ISS-197")]
+        self.assertEqual(hce.extract_error_recurrence_candidates(handoffs), [])
+
+    def test_normalize_error_tokens(self):
+        toks = hce.normalize_error_tokens("[ERROR] boom ENC-ISS-001 Sev1 [WARN]")
+        self.assertIn("ENC-ISS-001", toks)
+        self.assertIn("TAG:ERROR", toks)
+        self.assertIn("TAG:WARN", toks)
+        self.assertIn("SEV1", toks)
+
+
+class TestAdaptiveTrigger(unittest.TestCase):
+    def test_force_always_runs(self):
+        run, reason = hce.should_run_cycle([], since_iso=None, force=True)
+        self.assertTrue(run)
+        self.assertEqual(reason, "forced")
+
+    def test_no_handoffs_does_not_run(self):
+        run, _ = hce.should_run_cycle([], since_iso=None, force=False)
+        self.assertFalse(run)
+
+    def test_threshold_gate(self):
+        handoffs = [_handoff(f"DOC-{i}", created="2026-06-10T00:00:00Z") for i in range(5)]
+        run, _ = hce.should_run_cycle(
+            handoffs, since_iso="2026-06-01T00:00:00Z", min_new_handoffs=3
+        )
+        self.assertTrue(run)
+        run2, _ = hce.should_run_cycle(
+            handoffs, since_iso="2026-06-09T00:00:00Z", min_new_handoffs=10
+        )
+        self.assertFalse(run2)
+
+
+class TestProvenanceClustering(unittest.TestCase):
+    def test_shared_refs_form_context(self):
+        docs = [
+            {"document_id": "DOC-A", "related_items": ["ENC-TSK-1", "ENC-ISS-2"]},
+            {"document_id": "DOC-B", "related_items": ["ENC-TSK-1", "ENC-FTR-3"]},
+            {"document_id": "DOC-C", "related_items": ["ENC-PLN-9"]},
+        ]
+        prov = hce.cluster_provenance_context(docs, min_shared_refs=1)
+        self.assertIn("DOC-A", prov)
+        self.assertIn("DOC-B", prov["DOC-A"])
+        self.assertNotIn("DOC-C", prov)
+
+    def test_no_shared_refs_no_context(self):
+        docs = [
+            {"document_id": "DOC-A", "related_items": ["ENC-TSK-1"]},
+            {"document_id": "DOC-B", "related_items": ["ENC-TSK-9"]},
+        ]
+        self.assertEqual(hce.cluster_provenance_context(docs, min_shared_refs=1), {})
+
+
+class TestCandidateAssembly(unittest.TestCase):
+    def test_candidate_carries_ogtm_fields(self):
+        cand = {
+            "extractor": "co-citation",
+            "pattern_token": "ENC-TSK-A1+ENC-ISS-B2",
+            "record_pair": ["ENC-TSK-A1", "ENC-ISS-B2"],
+            "recurrence_count": 4,
+            "distinct_waves": ["ENC-PLN-006", "ENC-PLN-007"],
+            "source_doc_ids": ["DOC-1", "DOC-2", "DOC-3", "DOC-4"],
+        }
+        spec = hce.build_candidate_document(
+            cand, lookback_start="2026-03-01T00:00:00Z", lookback_end="2026-06-01T00:00:00Z"
+        )
+        self.assertEqual(spec["consolidated_from"], cand["source_doc_ids"])
+        self.assertEqual(spec["proposed_by"], hce.PROPOSER_ID)
+        self.assertEqual(spec["fsrs_initial_stability"],
+                         hce.initial_stability_from_recurrence(4))
+        self.assertIn(hce.CANDIDATE_KEYWORD, spec["keywords"])
+        self.assertIn("LESSON CANDIDATE", spec["title"])
+
+    def test_source_hash_stable_and_order_independent(self):
+        self.assertEqual(
+            hce.source_hash(["DOC-1", "DOC-2"]),
+            hce.source_hash(["DOC-2", "DOC-1"]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -6052,6 +6052,9 @@ _RELATIONSHIP_TYPES = frozenset({
     "deploys", "deployed-by",
     # ENC-FTR-082 Phase A / AC-6: Pathway-telemetry traversal relationship.
     "pathway-traversed", "traversed-by",
+    # ENC-TSK-C08 / ENC-FTR-064: Handoff Consolidation Engine provenance edges.
+    "consolidated-from", "consolidates",
+    "proposed-by", "proposes",
 })
 
 _INVERSE_PAIRS: Dict[str, str] = {
@@ -6087,6 +6090,9 @@ _INVERSE_PAIRS: Dict[str, str] = {
     "deploys": "deployed-by", "deployed-by": "deploys",
     # ENC-FTR-082 Phase A / AC-6: Pathway-telemetry traversal relationship.
     "pathway-traversed": "traversed-by", "traversed-by": "pathway-traversed",
+    # ENC-TSK-C08 / ENC-FTR-064: Handoff Consolidation Engine provenance edges.
+    "consolidated-from": "consolidates", "consolidates": "consolidated-from",
+    "proposed-by": "proposes", "proposes": "proposed-by",
 }
 
 _OWL_CHARACTERISTICS: Dict[str, Dict[str, bool]] = {
@@ -6128,6 +6134,11 @@ _OWL_CHARACTERISTICS: Dict[str, Dict[str, bool]] = {
     # ENC-FTR-082 Phase A / AC-6: Pathway-telemetry traversal relationship.
     "pathway-traversed":  {"asymmetric": True, "irreflexive": True, "transitive": False},
     "traversed-by":       {"asymmetric": True, "irreflexive": True, "transitive": False},
+    # ENC-TSK-C08 / ENC-FTR-064: Handoff Consolidation Engine provenance edges.
+    "consolidated-from":  {"asymmetric": True, "irreflexive": True, "transitive": False},
+    "consolidates":       {"asymmetric": True, "irreflexive": True, "transitive": False},
+    "proposed-by":        {"asymmetric": True, "irreflexive": True, "transitive": False},
+    "proposes":           {"asymmetric": True, "irreflexive": True, "transitive": False},
 }
 
 # Domain/range constraints: {relationship_type: {source_types, target_types}}
@@ -6180,6 +6191,13 @@ _DOMAIN_RANGE_CONSTRAINTS: Dict[str, Dict[str, Optional[frozenset]]] = {
     # can be any governed record type (intent/anchor -> result node), so unconstrained.
     "pathway-traversed":  {"source": None, "target": None},
     "traversed-by":       {"source": None, "target": None},
+    # ENC-TSK-C08 / ENC-FTR-064: HCE provenance edges. Endpoints are document IDs
+    # (candidate / handoff) and the proposer record; documents are not a tracker
+    # record type, so source/target are unconstrained (mirrors hands-off).
+    "consolidated-from":  {"source": None, "target": None},
+    "consolidates":       {"source": None, "target": None},
+    "proposed-by":        {"source": None, "target": None},
+    "proposes":           {"source": None, "target": None},
 }
 
 _TRANSITIVE_TYPES = frozenset(

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The reasoning behind the system. Start here if you want to know *what was built 
 - [Governance as architecture](explanation/governance-as-architecture.md) — the central thesis: governance is the primary structure of the system, not a layer on top of it.
 - [The extended mind](explanation/extended-mind.md) — why the agents are given an external, ontological memory, and what that buys them.
 - [The v4 graph and hybrid retrieval](explanation/v4-graph-and-hybrid-retrieval.md) — the design of durable recall across vector, graph, and keyword signals.
+- [The Handoff Consolidation Engine](explanation/handoff-consolidation-engine.md) — the hippocampal-replay analog that consolidates recurring Handoff patterns into proposed Lessons (HCE + GDMP provenance + FSRS-6).
 - [About the MCP API boundary](explanation/about-the-mcp-api-boundary.md) — why tool handlers must go through service APIs and never touch the database directly.
 - [A governance incident, retrospected](explanation/governance-incident-2026-02-27.md) — what a real production incident taught the system about its own guardrails.
 - [JWT authentication forensics](explanation/jwt-authentication-forensics.md) — the analysis of a silent cross-platform build failure, and the prevention framework that came out of it.

--- a/docs/explanation/handoff-consolidation-engine.md
+++ b/docs/explanation/handoff-consolidation-engine.md
@@ -1,0 +1,96 @@
+# The Handoff Consolidation Engine
+
+Enceladus has two memory substrates with very different time constants. **Handoff
+documents** are the episodic buffer — the dense, session-scoped record of what one
+agent did and what the next should know. **Lesson records** are semantic memory —
+distilled, constitutionally-scored, append-only institutional knowledge. Between
+them sat a gap: recurring patterns accumulated across many Handoffs that *no single
+session ever inspected in aggregate*, and so were never promoted to durable
+knowledge. The Handoff Consolidation Engine (HCE, `ENC-FTR-064` / `ENC-TSK-C08`) is
+the hippocampal-replay analog that closes that gap.
+
+## What it does
+
+The HCE is a scheduled Lambda that runs a **scan → cluster → propose** cycle against
+the Handoff corpus:
+
+1. **Scan.** It reads Handoff and wave documents from the last lookback window
+   (90 days by default) directly from DynamoDB — read-only, matching the
+   `enceladus-agent-cli` security posture.
+2. **Cluster.** Two primary extractors mine recurring structure:
+   - **Co-citation frequency** — record pairs co-cited across multiple distinct
+     *wave anchors* (not merely multiple documents from one wave) surface a
+     recurring structural coupling.
+   - **Error-class recurrence** — `ENC-ISS-NNN` references, `[ERROR]`/`[WARN]`
+     tags, and `SevN` markers that recur across distinct waves surface a recurring
+     failure mode.
+3. **Propose.** Each qualifying pattern becomes a `LESSON CANDIDATE` document with
+   structured evidence, written through the governed Document API. The HCE **never**
+   promotes a candidate to a Lesson itself — promotion is an io-only
+   `tracker.create_lesson` action. The engine only ever proposes.
+
+A per-cycle deduplication guard hashes each candidate's source set so the same
+pattern is not re-proposed on consecutive runs.
+
+## The adaptive trigger
+
+The EventBridge schedule is an *upper bound* on cadence, not an unconditional floor.
+On each fire the engine counts how many new Handoffs accumulated since the last
+cycle; if fewer than a threshold (`ADAPTIVE_TRIGGER_MIN_HANDOFFS`, default 3), it
+skips the expensive cluster-and-propose work and returns cheaply. Consolidation
+happens when there is genuinely new episodic material to consolidate — the way
+memory replay is driven by accumulated experience rather than by the clock alone.
+
+## FSRS-6 stability from recurrence
+
+When a candidate is promoted, its initial FSRS-6 stability `S_0` should reflect how
+strongly the pattern was corroborated. The HCE derives `S_0` from the recurrence
+count with a strictly increasing, saturating map:
+
+```
+S_0(r) = floor + (ceil - floor) * (1 - exp(-growth * (r - 1)))
+```
+
+At a single occurrence (`r = 1`) `S_0` equals the floor — a normal new-Lesson
+stability. As recurrence grows, `S_0` rises toward the ceiling with diminishing
+returns. The invariant that matters (`ENC-TSK-C08` AC-5) is monotonic: **a pattern
+that recurred across more sessions earns a higher initial stability**, so the
+promoted Lesson decays more slowly and stays retrieval-visible longer.
+
+## GDMP Stage 2 provenance
+
+The same clustering that finds consolidation candidates also serves the Governed
+Document Maturation Protocol (GDMP, `ENC-FTR-065`). For documents already in the
+`compliant` state, the HCE finds siblings that share related-item references — a
+lightweight co-citation proxy for semantic adjacency — and writes those siblings
+as the document's `informed_by` ancestral context, advancing it from `compliant`
+to `contextualized`. This is GDMP Stage 2: documents receive ancestral session
+context via HCE semantic clustering, and the `INFORMED_BY` edges it implies become
+first-class graph structure.
+
+## Traversable provenance (OGTM)
+
+Two new edge types make the consolidation provenance traversable end-to-end, per
+the Ontological Graph Traversability Mandate (`ENC-FTR-066`):
+
+- **`CONSOLIDATED_FROM`** — a Lesson candidate to each source Handoff it was
+  consolidated from (inverse `CONSOLIDATES`).
+- **`PROPOSED_BY`** — a candidate to its proposer, the HCE feature record
+  (inverse `PROPOSES`).
+
+These are emitted as document fields (`consolidated_from`, `proposed_by`) that
+`graph_sync` projects to Neo4j, registered in the typed-relationship mapping, and
+added to the `graph_query_api` edge allowlist — so they are queryable via
+`tracker.graphsearch`. The chain *recurring pattern → candidate → source Handoffs →
+the records those Handoffs handed off* is one connected, walkable subgraph.
+
+## Where the code lives
+
+- `backend/lambda/handoff_consolidation_engine/` — the engine (pure extractor /
+  FSRS / clustering core plus the DynamoDB-read, Document-API-write handler).
+- `backend/lambda/graph_sync/` — `CONSOLIDATED_FROM` / `PROPOSED_BY` edge projection
+  and the relationship-type mapping.
+- `backend/lambda/graph_query_api/` — the edge-type allowlist that gates graphsearch.
+- `backend/lambda/document_api/` — persistence of the provenance fields.
+- `infrastructure/cloudformation/02-compute.yaml` — the Lambda, its read-only role,
+  the configurable EventBridge schedule, and the invoke permission.

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -84,6 +84,7 @@ function_name_map:
   graph_sync: devops-graph-sync-gamma
   opensearch_indexer: devops-opensearch-indexer-gamma
   memory_consolidation: enceladus-memory-consolidation-gamma
+  handoff_consolidation_engine: enceladus-handoff-consolidation-engine-gamma
   neo4j_backup: enceladus-neo4j-backup-gamma
   percolation_monitor: enceladus-percolation-monitor-gamma
   unlearning: enceladus-unlearning-gamma

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -174,6 +174,22 @@ Parameters:
     Default: subnet-0a27ee72
     Description: Subnet(s) for the indexer Lambda ENI (must route to OpenSearch :9200).
 
+  # ENC-TSK-C08 / ENC-FTR-064: configurable HCE cadence. The engine's adaptive
+  # trigger makes this an upper bound — a scheduled invoke runs a full
+  # scan-cluster-propose cycle only when enough new Handoffs accumulated.
+  HceScheduleExpression:
+    Type: String
+    Default: "cron(0 3 * * ? *)"
+    Description: >
+      EventBridge schedule for the Handoff Consolidation Engine (default 03:00 UTC
+      nightly). The adaptive trigger gates whether each fire does real work.
+  HceAdaptiveMinHandoffs:
+    Type: String
+    Default: "3"
+    Description: >
+      Adaptive-trigger threshold — minimum new Handoffs in the lookback window
+      before the HCE runs a full cycle on a scheduled fire.
+
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
   IsGamma: !Not [!Equals [!Ref EnvironmentSuffix, ""]]
@@ -1662,6 +1678,56 @@ Resources:
           Value: memory-consolidation
 
   # ---------------------------------------------------------------------------
+  # ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-096 (ENC-TSK-L15): Handoff Consolidation
+  # Engine (HCE). Scheduled + adaptive-triggered scan-cluster-propose cycle.
+  # Reads Handoff documents (DynamoDB, read-only) and proposes Lesson candidates
+  # via governed Document API invoke (writes never touch DynamoDB/S3 directly).
+  # ---------------------------------------------------------------------------
+  HandoffConsolidationEngineFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "enceladus-handoff-consolidation-engine${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.handler
+      MemorySize: 512
+      Timeout: 300
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      SnapStart: !If
+        - SnapStartEnabled
+        - ApplyOn: PublishedVersions
+        - !Ref AWS::NoValue
+      Role: !GetAtt HandoffConsolidationEngineRole.Arn
+      Layers:
+        - !Ref SharedLayerArn
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          PROJECT_ID: enceladus
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          ADAPTIVE_TRIGGER_MIN_HANDOFFS: !Ref HceAdaptiveMinHandoffs
+          HCE_LOOKBACK_DAYS: "90"
+          HCE_PROPOSER_ID: ENC-FTR-064
+          HCE_GDMP_PROVENANCE_ENABLED: "true"
+          AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          APPCONFIG_CONFIGURATION: feature-flags
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: handoff-consolidation-engine
+
+  # ---------------------------------------------------------------------------
   # ENC-FTR-106 / ENC-TSK-K03: Unlearning Lambda (Crick-Mitchison reverse-consolidation)
   # Nightly per-invocation pass: stigmergic-trace miss clusters + drift SAR waves ->
   # unlearning-candidate reports; optional archive of reference records via graph_sync.
@@ -2871,6 +2937,25 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt MemoryConsolidationSchedule.Arn
+
+  HandoffConsolidationEngineSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "enceladus-handoff-consolidation-engine-schedule${EnvironmentSuffix}"
+      Description: "HCE scan-cluster-propose cycle (ENC-TSK-C08 / ENC-TSK-L15)"
+      ScheduleExpression: !Ref HceScheduleExpression
+      State: !If [RhythmActive, DISABLED, ENABLED]
+      Targets:
+        - Arn: !GetAtt HandoffConsolidationEngineFunction.Arn
+          Id: handoff-consolidation-engine-target
+
+  HandoffConsolidationEnginePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref HandoffConsolidationEngineFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt HandoffConsolidationEngineSchedule.Arn
 
   # ENC-FTR-106 / ENC-TSK-K03: nightly unlearning trigger (04:00 UTC, after percolation)
   UnlearningSchedule:
@@ -5417,6 +5502,62 @@ Resources:
       Tags:
         - Key: Project
           Value: enceladus
+
+  HandoffConsolidationEngineRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "enceladus-handoff-consolidation-engine-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: handoff-consolidation-engine-inline
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Sid: DocumentsTableRead
+                Effect: Allow
+                Action:
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+              - Sid: InvokeDocumentApi
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-document-api${EnvironmentSuffix}"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: handoff-consolidation-engine
 
   # ENC-FTR-106 / ENC-TSK-K03: Unlearning Lambda IAM Role (gamma-only)
   UnlearningRole:

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -258,6 +258,12 @@
       "deploy_script": "backend/lambda/memory_consolidation/deploy.sh"
     },
     {
+      "function_name": "enceladus-handoff-consolidation-engine",
+      "lambda_dir": "backend/lambda/handoff_consolidation_engine",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/handoff_consolidation_engine/deploy.sh"
+    },
+    {
       "function_name": "enceladus-neo4j-backup",
       "lambda_dir": "backend/lambda/neo4j_backup",
       "workflow_file": ".github/workflows/_deploy.yml",


### PR DESCRIPTION
## Summary
- Finishes **ENC-TSK-L15** by landing the **ENC-TSK-C08** Handoff Consolidation Engine on `v4/main` (rebased from `claude/enc-tsk-c08`).
- **HCE Lambda** (`enceladus-handoff-consolidation-engine`): adaptive scheduled scan-cluster-propose over Handoffs; writes lesson-candidates via governed Document API invoke.
- **OGTM edges**: `CONSOLIDATED_FROM` / `PROPOSED_BY` wired in graph_sync, graph_query_api, tracker_mutation.
- **Document API**: provenance fields for HCE/GDMP Stage-2 (`consolidated_from`, `proposed_by`, FSRS stability seed).
- **Infra**: CFN function/role/schedule (03:00 UTC default), manifest + v4-gamma deploy registration.
- **AC-5**: `ENABLE_LESSON_PRIMITIVE` early-exit in handler.

commit-complete-id: CCI-b1c85b018d9a44ac94de96f8c291aca7

## Test plan
- [x] `handoff_consolidation_engine` — 18 tests
- [x] `graph_sync/test_consolidation_edges_c08` — 7 tests
- [x] `graph_query_api/test_edge_allowlist_c08` — 5 tests
- [x] `document_api/test_provenance_fields_c08` — 8 tests
- [ ] CloudFormation Compute Stack Deploy succeeds
- [ ] Gen2 Lambda deploy ships `enceladus-handoff-consolidation-engine-gamma`
- [ ] Manual invoke (dry_run) on gamma