### PR TITLE
Fix gamma deploy blocker for enceladus-relationships table (ENC-TSK-L13)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -222,11 +222,12 @@ jobs:
             fi
           done
 
-          # --- DynamoDB tables (new tables added by ENC-TSK-I27/I28 that can be orphaned) ---
+          # --- DynamoDB tables (new tables added by ENC-TSK-I27/I28/L13 that can be orphaned) ---
           candidate_tables=(
             "governance-version${suffix}"
             "agent-sessions${suffix}"
             "agent-types${suffix}"
+            "enceladus-relationships${suffix}"
           )
           tracked_tables=$(aws cloudformation list-stack-resources \
             --stack-name "${stack_name}" --region "${region}" \

--- a/infrastructure/cloudformation/resource-import-relationships-gamma-l13.json
+++ b/infrastructure/cloudformation/resource-import-relationships-gamma-l13.json
@@ -1,0 +1,7 @@
+[
+  {
+    "ResourceType": "AWS::DynamoDB::Table",
+    "LogicalResourceId": "RelationshipsTable",
+    "ResourceIdentifier": { "TableName": "enceladus-relationships-gamma" }
+  }
+]


### PR DESCRIPTION
## Summary
- Add `enceladus-relationships-gamma` to the data-stack orphan self-heal list so failed 01-data rollbacks no longer wedge `ResourceExistenceCheck`.
- Add import manifest fallback for manual CFN adoption if needed.

Follow-up to #885 — unblocks gamma 01-data + 02-compute deploy for L13 AC0–AC2.

Commit: `776d0b2`

CCI-489fa39027ef462186432f6147ed39a0

## Test plan
- [ ] Merge and re-run CloudFormation Compute Stack Deploy on v4/main
- [ ] Confirm `RelationshipsTable` is stack-managed and compute deploy applies RELATIONSHIPS_TABLE env