### PR TITLE
ENC-TSK-L43: OpenSearch keyword arm + facet layer for graphsearch hybrid

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.22",
-  "updated_at": "2026-07-05T13:57:00Z",
-  "last_change_summary": "ENC-TSK-L44: devops-opensearch-indexer now authenticates to the OpenSearch node as the scoped 'indexer' security-plugin user (OPENSEARCH_USERNAME env var, default 'admin' for backward compat) instead of the admin superuser; OPENSEARCH_SECRET_NAME now points at enceladus/opensearch/gamma-indexer by default.",
+  "version": "2026-07-05.23",
+  "updated_at": "2026-07-05T14:06:00Z",
+  "last_change_summary": "ENC-TSK-L43: graph_query_api hybrid keyword arm reads OpenSearch records_read (multi_match fuzziness AUTO + bool_prefix) with within-search facet aggs; circuit-breaker falls back to Neo4j keyword + feed/corpus facets. feed/corpus accepts X-Coordination-Internal-Key for service facet fallback.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3467,11 +3467,11 @@
       }
     },
     "feed_query.corpus": {
-      "description": "ENC-TSK-L23 / FTR-127 AC-1..4/13: GET /api/v1/feed/corpus returns the full multi-project feed corpus from BOTH the tracker table and the documents table as a cursor-paginated stream. Minimal identity projection plus compact attrs map (status, priority, tags/keywords, document_subtype). Filter and sort pushdown via query params; facet counts are the browse/filter authority until ENC-TSK-L43 OpenSearch ships.",
+      "description": "ENC-TSK-L23 / FTR-127 AC-1..4/13: GET /api/v1/feed/corpus returns the full multi-project feed corpus from BOTH the tracker table and the documents table as a cursor-paginated stream. Minimal identity projection plus compact attrs map (status, priority, tags/keywords, document_subtype). Filter and sort pushdown via query params; facet counts are the browse-with-no-query facet authority and the graphsearch hybrid circuit-breaker fallback (ENC-TSK-L43). ENC-TSK-L43: also accepts X-Coordination-Internal-Key for service-to-service facet fallback from graph_query_api.",
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "GET /api/v1/feed/corpus \u2014 JWT-gated (401 unauthenticated). Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+          "definition": "GET /api/v1/feed/corpus \u2014 JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
         },
         "cursor": {
           "type": "string",
@@ -5807,7 +5807,7 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match \u2014 fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match \u2014 fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
       "fields": {
         "rrf_k": {
           "type": "integer",
@@ -7518,6 +7518,51 @@
       },
       "owner": "search",
       "source": "ENC-TSK-L41 / B67 Search2.0; credentials hardened by ENC-TSK-L44",
+      "telemetry_eligible": true
+    },
+    "graph_query_api.opensearch_keyword": {
+      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
+      "fields": {
+        "OPENSEARCH_ENDPOINT": {
+          "type": "string",
+          "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP)."
+        },
+        "OPENSEARCH_READ_ALIAS": {
+          "type": "string",
+          "definition": "Read alias locked to records_read per ENC-TSK-L40 naming contract.",
+          "default": "records_read"
+        },
+        "OPENSEARCH_SECRET_NAME": {
+          "type": "string",
+          "definition": "Secrets Manager secret holding {\"username\":\"query\",\"password\":\"...\"}.",
+          "default": "enceladus/opensearch/gamma-query"
+        },
+        "OPENSEARCH_USERNAME": {
+          "type": "string",
+          "definition": "Security-plugin username; defaults to query (read-only query_role).",
+          "default": "query"
+        },
+        "FEED_API_BASE": {
+          "type": "string",
+          "definition": "Base URL for feed/corpus facet fallback (service auth via COORDINATION_INTERNAL_API_KEY)."
+        },
+        "facets": {
+          "type": "object",
+          "definition": "Hybrid response field: facet counts {project_id, record_type, status, priority} over the active search."
+        },
+        "facets_source": {
+          "type": "enum",
+          "enum": ["opensearch", "feed_corpus"],
+          "definition": "Provenance of facets on hybrid responses."
+        },
+        "keyword_source": {
+          "type": "enum",
+          "enum": ["opensearch", "neo4j_fallback", "unavailable"],
+          "definition": "Provenance of the keyword RRF arm on hybrid responses."
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-L43",
       "telemetry_eligible": true
     },
     "opensearch_backfill.lambda": {

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -1762,13 +1762,24 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         return {"statusCode": 204, "headers": _cors_headers(), "body": ""}
 
     token = _extract_token(event)
-    if not token:
+    headers = event.get("headers") or {}
+    internal_key = headers.get("x-coordination-internal-key") or headers.get("X-Coordination-Internal-Key")
+    internal_ok = False
+    if internal_key:
+        expected = os.environ.get("COORDINATION_INTERNAL_API_KEY", "")
+        previous = os.environ.get("COORDINATION_INTERNAL_API_KEY_PREVIOUS", "")
+        valid = {k for k in (expected, previous) if k}
+        internal_ok = internal_key in valid
+
+    if not token and not internal_ok:
         return _error(401, "Authentication required. Please sign in.")
 
-    try:
-        claims = _verify_token(token)
-    except ValueError as exc:
-        return _error(401, str(exc))
+    claims: Dict[str, Any] = {"internal_service": True} if internal_ok and not token else {}
+    if token:
+        try:
+            claims = _verify_token(token)
+        except ValueError as exc:
+            return _error(401, str(exc))
 
     if method == "POST" and re.search(r"/api/v1/feed/refresh/?$", path):
         return _handle_feed_refresh()

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -22,6 +22,11 @@ Environment variables:
   COGNITO_CLIENT_ID           Cognito client ID
   CORS_ORIGIN                 CORS allowed origin (default: https://jreese.net)
   COORDINATION_INTERNAL_API_KEY  Internal API key for service-to-service auth
+  OPENSEARCH_ENDPOINT            Gamma OpenSearch HTTPS URL (ENC-TSK-L43)
+  OPENSEARCH_READ_ALIAS          Read alias (records_read)
+  OPENSEARCH_SECRET_NAME         Secrets Manager secret for query user
+  OPENSEARCH_USERNAME            OpenSearch security-plugin username (query)
+  FEED_API_BASE                  Base URL for feed/corpus facet fallback
   BEDROCK_REGION              AWS region for Bedrock (default: us-west-2)
 """
 
@@ -40,6 +45,7 @@ from urllib.parse import parse_qs
 import corroboration
 import dedup_convergence
 import energy_function
+import opensearch_keyword
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -2331,18 +2337,49 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         finally:
             _gex.shutdown(wait=False)
 
-    # ---- Keyword signal ----------------------------------------------------
+    # ---- Keyword signal (ENC-TSK-L43: OpenSearch primary, Neo4j fallback) --
     keyword_ranks: List[Dict[str, Any]] = []
     keyword_available = False
+    keyword_source = "unavailable"
+    facets: Dict[str, Dict[str, int]] = {}
+    facets_source: Optional[str] = None
     if query_text:
-        keyword_ranks = _hybrid_keyword_ranks(
-            driver,
+        os_ranks, os_facets, os_err = opensearch_keyword.hybrid_keyword_ranks(
             project_id,
             query_text,
             top_n=HYBRID_SIGNAL_TOP_N,
             record_type_filter=record_type_filter,
         )
-        keyword_available = bool(keyword_ranks)
+        if os_err is None:
+            keyword_ranks = os_ranks
+            keyword_available = bool(keyword_ranks)
+            keyword_source = "opensearch"
+            facets = os_facets
+            facets_source = "opensearch"
+        else:
+            logger.warning(
+                "[WARNING] OpenSearch keyword arm unavailable (%s) — Neo4j fallback",
+                os_err,
+            )
+            keyword_ranks = _hybrid_keyword_ranks(
+                driver,
+                project_id,
+                query_text,
+                top_n=HYBRID_SIGNAL_TOP_N,
+                record_type_filter=record_type_filter,
+            )
+            keyword_available = bool(keyword_ranks)
+            keyword_source = "neo4j_fallback"
+            fallback_facets, fb_err = opensearch_keyword.fetch_feed_corpus_facets(
+                project_id=project_id,
+                query_text=query_text,
+                record_type_filter=record_type_filter,
+            )
+            if fallback_facets:
+                facets = fallback_facets
+                facets_source = "feed_corpus"
+            elif fb_err:
+                logger.warning("[WARNING] feed/corpus facet fallback failed: %s", fb_err)
 
     # ---- RRF fusion --------------------------------------------------------
     signals: Dict[str, List[Dict[str, Any]]] = {}
@@ -2406,6 +2443,9 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
             # this call, surfaced even with zero candidates for observability
             # parity with energy_lambda_weights above.
             "corroboration_weber_k": corroboration_weber_k,
+            "facets": facets,
+            "facets_source": facets_source,
+            "keyword_source": keyword_source,
         }
 
     fused = _rrf_fuse(signals, k=RRF_K)
@@ -2641,10 +2681,10 @@ def _query_hybrid(driver, project_id: str, params: Dict) -> Dict:
         # call's corroboration bonus (see per_node_fusion[*].b_corr/k_corr and
         # nodes[*]._b_corr/_corroboration_count/_final_score/_final_rank).
         "corroboration_weber_k": corroboration_weber_k,
+        "facets": facets,
+        "facets_source": facets_source,
+        "keyword_source": keyword_source,
     }
-
-
-# Embedding property name must mirror graph_sync/embedding.py EMBEDDING_PROPERTY
 # without forcing an import at module load time (deploy packages the helper at
 # the top level, so the import is deferred to _compute_query_embedding).
 _EMBEDDING_PROPERTY = "embedding"
@@ -3029,6 +3069,9 @@ def _handle_search(event: Dict) -> Dict:
         "include_below_threshold",
         "edge_participation",
         "pathway",
+        "facets",
+        "facets_source",
+        "keyword_source",
         # ENC-TSK-I88: adjacency export pagination + corpus-size fields.
         "node_count",
         "edge_count",

--- a/backend/lambda/graph_query_api/opensearch_keyword.py
+++ b/backend/lambda/graph_query_api/opensearch_keyword.py
@@ -1,0 +1,264 @@
+"""OpenSearch keyword signal + within-search facets for hybrid graphsearch (ENC-TSK-L43).
+
+Reads exclusively via the records_read alias. When OpenSearch is unreachable the
+caller should fall back to Neo4j keyword ranks and feed/corpus facets.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+READ_ALIAS = os.environ.get("OPENSEARCH_READ_ALIAS", "records_read")
+OPENSEARCH_ENDPOINT = os.environ.get("OPENSEARCH_ENDPOINT", "").strip()
+OPENSEARCH_SECRET_NAME = os.environ.get("OPENSEARCH_SECRET_NAME", "").strip()
+OPENSEARCH_USERNAME = os.environ.get("OPENSEARCH_USERNAME", "query").strip() or "query"
+OPENSEARCH_PASSWORD = os.environ.get("OPENSEARCH_PASSWORD", "").strip()
+FEED_API_BASE = os.environ.get("FEED_API_BASE", "https://enceladus-gamma.jreese.net/api/v1/feed").rstrip("/")
+COORDINATION_INTERNAL_API_KEY = os.environ.get("COORDINATION_INTERNAL_API_KEY", "").strip()
+
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.check_hostname = False
+SSL_CONTEXT.verify_mode = ssl.CERT_NONE
+
+_secrets_client = None
+_cached_password: Optional[str] = None
+_cached_username: Optional[str] = None
+
+_FACET_FIELDS = ("project_id", "record_type", "status", "priority")
+
+_TEXT_FIELDS = [
+    "title",
+    "title._2gram",
+    "title._3gram",
+    "description",
+    "description._2gram",
+    "description._3gram",
+    "body",
+    "body._2gram",
+    "body._3gram",
+]
+
+_PREFIX_FIELDS = [
+    "title",
+    "title._2gram",
+    "title._3gram",
+    "description",
+    "description._2gram",
+    "description._3gram",
+]
+
+
+def opensearch_configured() -> bool:
+    return bool(OPENSEARCH_ENDPOINT)
+
+
+def _get_secrets_client():
+    global _secrets_client
+    if _secrets_client is None:
+        import boto3
+
+        _secrets_client = boto3.client("secretsmanager", region_name=os.environ.get("SECRETS_REGION", "us-west-2"))
+    return _secrets_client
+
+
+def _get_credentials() -> Tuple[str, str]:
+    global _cached_password, _cached_username
+    if _cached_password is not None:
+        return _cached_username or OPENSEARCH_USERNAME, _cached_password
+    if OPENSEARCH_PASSWORD:
+        _cached_password = OPENSEARCH_PASSWORD
+        _cached_username = OPENSEARCH_USERNAME
+        return _cached_username, _cached_password
+    if not OPENSEARCH_SECRET_NAME:
+        raise RuntimeError("OPENSEARCH_SECRET_NAME is not configured")
+    resp = _get_secrets_client().get_secret_value(SecretId=OPENSEARCH_SECRET_NAME)
+    payload = json.loads(resp["SecretString"])
+    password = payload.get("password") or payload.get("admin_password")
+    if not password:
+        raise RuntimeError(f"Secret {OPENSEARCH_SECRET_NAME} missing password key")
+    _cached_password = str(password)
+    _cached_username = str(payload.get("username") or OPENSEARCH_USERNAME)
+    return _cached_username, _cached_password
+
+
+def opensearch_request(method: str, path: str, body: Optional[Any] = None) -> Tuple[int, Any]:
+    if not OPENSEARCH_ENDPOINT:
+        raise RuntimeError("OPENSEARCH_ENDPOINT is not configured")
+    url = f"{OPENSEARCH_ENDPOINT}{path}"
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+    username, password = _get_credentials()
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    try:
+        with urllib.request.urlopen(req, context=SSL_CONTEXT, timeout=8) as resp:
+            raw = resp.read()
+            parsed = json.loads(raw) if raw else {}
+            return resp.status, parsed
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed
+
+
+def record_id_from_hit(hit: Dict[str, Any]) -> Optional[str]:
+    doc_id = str(hit.get("_id") or "").strip()
+    if doc_id.count("#") >= 2:
+        return doc_id.split("#", 2)[2]
+    source = hit.get("_source") or {}
+    project_id = str(source.get("project_id") or "").strip()
+    record_type = str(source.get("record_type") or "").strip()
+    if project_id and record_type:
+        return doc_id.split("#")[-1] if "#" in doc_id else doc_id
+    return doc_id or None
+
+
+def _build_search_body(
+    project_id: str,
+    query_text: str,
+    *,
+    top_n: int,
+    record_type_filter: Optional[str] = None,
+    include_facets: bool = True,
+) -> Dict[str, Any]:
+    filters: List[Dict[str, Any]] = [{"term": {"project_id": project_id}}]
+    if record_type_filter:
+        filters.append({"term": {"record_type": record_type_filter.lower()}})
+
+    should_clauses: List[Dict[str, Any]] = [
+        {
+            "multi_match": {
+                "query": query_text,
+                "fields": _TEXT_FIELDS,
+                "type": "best_fields",
+                "fuzziness": "AUTO",
+            }
+        },
+        {
+            "multi_match": {
+                "query": query_text,
+                "fields": _PREFIX_FIELDS,
+                "type": "bool_prefix",
+            }
+        },
+    ]
+
+    body: Dict[str, Any] = {
+        "size": top_n,
+        "query": {
+            "bool": {
+                "filter": filters,
+                "should": should_clauses,
+                "minimum_should_match": 1,
+            }
+        },
+    }
+    if include_facets:
+        body["size"] = top_n
+        body["aggs"] = {
+            field: {"terms": {"field": field, "size": 50}}
+            for field in _FACET_FIELDS
+        }
+    return body
+
+
+def _parse_facet_aggs(aggregations: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+    facets: Dict[str, Dict[str, int]] = {}
+    for field in _FACET_FIELDS:
+        buckets = (aggregations.get(field) or {}).get("buckets") or []
+        facets[field] = {
+            str(bucket.get("key")): int(bucket.get("doc_count") or 0)
+            for bucket in buckets
+            if bucket.get("key") is not None
+        }
+    return facets
+
+
+def hybrid_keyword_ranks(
+    project_id: str,
+    query_text: str,
+    top_n: int,
+    record_type_filter: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, int]], Optional[str]]:
+    """Return (keyword ranks, facets, error_message). error_message set on failure."""
+    if not query_text or not opensearch_configured():
+        return [], {}, "opensearch_not_configured" if not opensearch_configured() else None
+
+    body = _build_search_body(
+        project_id,
+        query_text,
+        top_n=top_n,
+        record_type_filter=record_type_filter,
+        include_facets=True,
+    )
+    try:
+        status, resp = opensearch_request("POST", f"/{READ_ALIAS}/_search", body)
+    except Exception as exc:
+        logger.warning("[WARNING] OpenSearch keyword search failed: %s", exc)
+        return [], {}, str(exc)
+
+    if status >= 400 or resp.get("error"):
+        message = str(resp.get("error") or status)
+        logger.warning("[WARNING] OpenSearch keyword search HTTP %s: %s", status, message)
+        return [], {}, message
+
+    hits = (resp.get("hits") or {}).get("hits") or []
+    ranked: List[Dict[str, Any]] = []
+    for idx, hit in enumerate(hits, start=1):
+        rid = record_id_from_hit(hit)
+        if not rid:
+            continue
+        score = float((hit.get("_score") or 0.0))
+        ranked.append({"record_id": rid, "score": score, "rank": idx})
+
+    facets = _parse_facet_aggs(resp.get("aggregations") or {})
+    return ranked, facets, None
+
+
+def fetch_feed_corpus_facets(
+    *,
+    project_id: str,
+    query_text: str = "",
+    record_type_filter: Optional[str] = None,
+) -> Tuple[Dict[str, Dict[str, int]], Optional[str]]:
+    """Circuit-breaker facet fallback via GET /feed/corpus (ENC-TSK-L23)."""
+    if not COORDINATION_INTERNAL_API_KEY:
+        return {}, "feed_internal_key_missing"
+
+    params: Dict[str, str] = {"limit": "1", "project_id": project_id}
+    if query_text:
+        params["q"] = query_text
+    if record_type_filter:
+        params["record_type"] = record_type_filter
+
+    url = f"{FEED_API_BASE}/corpus?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("X-Coordination-Internal-Key", COORDINATION_INTERNAL_API_KEY)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            payload = json.loads(resp.read())
+    except Exception as exc:
+        logger.warning("[WARNING] feed/corpus facet fallback failed: %s", exc)
+        return {}, str(exc)
+
+    facets = payload.get("facets")
+    if not isinstance(facets, dict):
+        return {}, "feed_corpus_missing_facets"
+    normalized: Dict[str, Dict[str, int]] = {}
+    for field in _FACET_FIELDS:
+        raw = facets.get(field)
+        if isinstance(raw, dict):
+            normalized[field] = {str(k): int(v) for k, v in raw.items()}
+    return normalized, None

--- a/backend/lambda/graph_query_api/test_opensearch_keyword.py
+++ b/backend/lambda/graph_query_api/test_opensearch_keyword.py
@@ -1,0 +1,103 @@
+"""Unit tests for ENC-TSK-L43 OpenSearch keyword arm helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import opensearch_keyword as okw  # noqa: E402
+
+
+class TestRecordIdFromHit(unittest.TestCase):
+    def test_parses_stable_doc_id(self):
+        hit = {"_id": "enceladus#task#ENC-TSK-001", "_source": {}}
+        self.assertEqual(okw.record_id_from_hit(hit), "ENC-TSK-001")
+
+
+class TestFacetParsing(unittest.TestCase):
+    def test_parse_facet_aggs(self):
+        aggs = {
+            "record_type": {"buckets": [{"key": "task", "doc_count": 3}]},
+            "status": {"buckets": [{"key": "open", "doc_count": 2}]},
+            "priority": {"buckets": []},
+            "project_id": {"buckets": [{"key": "enceladus", "doc_count": 3}]},
+        }
+        facets = okw._parse_facet_aggs(aggs)
+        self.assertEqual(facets["record_type"]["task"], 3)
+        self.assertEqual(facets["status"]["open"], 2)
+        self.assertEqual(facets["project_id"]["enceladus"], 3)
+
+
+class TestHybridKeywordRanks(unittest.TestCase):
+    def test_returns_ranks_and_facets_on_success(self):
+        search_resp = {
+            "hits": {
+                "hits": [
+                    {"_id": "enceladus#task#ENC-TSK-001", "_score": 4.2},
+                    {"_id": "enceladus#issue#ENC-ISS-002", "_score": 2.1},
+                ]
+            },
+            "aggregations": {
+                "project_id": {"buckets": [{"key": "enceladus", "doc_count": 2}]},
+                "record_type": {"buckets": [{"key": "task", "doc_count": 1}, {"key": "issue", "doc_count": 1}]},
+                "status": {"buckets": []},
+                "priority": {"buckets": []},
+            },
+        }
+        with mock.patch.object(okw, "opensearch_configured", return_value=True), mock.patch.object(
+            okw, "opensearch_request", return_value=(200, search_resp)
+        ):
+            ranks, facets, err = okw.hybrid_keyword_ranks("enceladus", "search test", 10)
+        self.assertIsNone(err)
+        self.assertEqual(len(ranks), 2)
+        self.assertEqual(ranks[0]["record_id"], "ENC-TSK-001")
+        self.assertEqual(ranks[0]["rank"], 1)
+        self.assertEqual(facets["record_type"]["task"], 1)
+
+    def test_returns_error_when_opensearch_fails(self):
+        with mock.patch.object(okw, "opensearch_configured", return_value=True), mock.patch.object(
+            okw, "opensearch_request", side_effect=RuntimeError("connection refused")
+        ):
+            ranks, facets, err = okw.hybrid_keyword_ranks("enceladus", "query", 5)
+        self.assertEqual(ranks, [])
+        self.assertEqual(facets, {})
+        self.assertIn("connection refused", err or "")
+
+
+class TestFeedCorpusFacetFallback(unittest.TestCase):
+    def test_parses_feed_corpus_facets(self):
+        payload = {
+            "facets": {
+                "record_type": {"task": 5},
+                "status": {"open": 4},
+                "priority": {"P1": 2},
+                "project_id": {"enceladus": 5},
+            }
+        }
+        body = json.dumps(payload).encode("utf-8")
+
+        class FakeResp:
+            def read(self):
+                return body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with mock.patch.object(okw, "COORDINATION_INTERNAL_API_KEY", "test-key"), mock.patch(
+            "urllib.request.urlopen", return_value=FakeResp()
+        ):
+            facets, err = okw.fetch_feed_corpus_facets(project_id="enceladus", query_text="foo")
+        self.assertIsNone(err)
+        self.assertEqual(facets["record_type"]["task"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -173,6 +173,14 @@ Parameters:
     Type: String
     Default: indexer
     Description: ENC-TSK-L44 security-plugin user bound to indexer_role (write-only).
+  OpenSearchQueryUsername:
+    Type: String
+    Default: query
+    Description: ENC-TSK-L44 security-plugin user bound to query_role (read-only).
+  OpenSearchQuerySecretName:
+    Type: String
+    Default: enceladus/opensearch/gamma-query
+    Description: ENC-TSK-L43 read-only OpenSearch credentials for graph_query_api hybrid keyword arm.
   OpenSearchIndexerVpcId:
     Type: AWS::EC2::VPC::Id
     Default: vpc-8ad4a8f2
@@ -681,6 +689,8 @@ Resources:
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
           APPCONFIG_CONFIGURATION: feature-flags
+          COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
       Tags:
         - Key: Project
           Value: enceladus
@@ -1536,6 +1546,18 @@ Resources:
           # env_drift_registry.json so the env-parity gate protects them.
           PATHWAY_TELEMETRY_BUCKET: !Ref S3Bucket
           PATHWAY_TELEMETRY_PREFIX: !Sub "${S3EnvPrefix}pathway-telemetry"
+          # ENC-TSK-L43 (B67 Search2.0): OpenSearch keyword arm + within-search facets.
+          OPENSEARCH_ENDPOINT: !If [IsGamma, !Ref OpenSearchHttpsEndpoint, !Ref "AWS::NoValue"]
+          OPENSEARCH_READ_ALIAS: !If [IsGamma, "records_read", !Ref "AWS::NoValue"]
+          OPENSEARCH_SECRET_NAME: !If [IsGamma, !Ref OpenSearchQuerySecretName, !Ref "AWS::NoValue"]
+          OPENSEARCH_USERNAME: !If [IsGamma, !Ref OpenSearchQueryUsername, !Ref "AWS::NoValue"]
+          FEED_API_BASE: !If [IsGamma, "https://enceladus-gamma.jreese.net/api/v1/feed", !Ref "AWS::NoValue"]
+      VpcConfig: !If
+        - IsGamma
+        - SecurityGroupIds:
+            - !Ref OpenSearchIndexerSecurityGroup
+          SubnetIds: !Ref OpenSearchIndexerSubnetIds
+        - !Ref "AWS::NoValue"
       Tags:
         - Key: Project
           Value: enceladus
@@ -5286,6 +5308,8 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       Policies:
         - PolicyName: AppConfigAccess
           PolicyDocument:
@@ -5337,6 +5361,16 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/neo4j/auradb-credentials${EnvironmentSuffix}*"
+        # ENC-TSK-L43: read-only OpenSearch query credentials (gamma).
+        - PolicyName: SecretsManagerOpenSearchQuery
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: SecretsManagerOpenSearchQuery
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:enceladus/opensearch/*"
         # ENC-FTR-087 Phase 1 (ENC-TSK-I85): write the per-wave drift-telemetry
         # record + read the per-project time series via the GSI.
         - PolicyName: DriftTelemetryTableAccess


### PR DESCRIPTION
CCI-92fbe5b7936343d2b7a9580a21402a9c

## Summary
- Add `opensearch_keyword.py` to query `records_read` with multi_match (fuzziness AUTO) + bool_prefix autocomplete for the hybrid keyword RRF arm
- Return within-search facet counts (`project_id`, `record_type`, `status`, `priority`) on hybrid graphsearch responses
- Circuit-breaker: fall back to Neo4j keyword ranks and `/feed/corpus` facets when OpenSearch is unreachable
- Gamma CFN: OpenSearch env + VPC on `graph_query_api`; internal-key auth for feed/corpus facet fallback

## Test plan
- [x] `pytest backend/lambda/graph_query_api/test_opensearch_keyword.py test_hybrid_retrieval.py`
- [x] `pytest backend/lambda/feed_query/test_corpus.py`
- [ ] Post-merge gamma deploy: verify hybrid `/graphsearch?search_type=hybrid` returns `keyword_source=opensearch` and facets when corpus indexed


Made with [Cursor](https://cursor.com)