### PR TITLE
Fix gamma graphsearch 503: allow Neo4j Bolt egress from OpenSearch SG

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -6048,6 +6048,13 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
           Description: Secrets Manager / AWS API egress when subnet routes public
+        # ENC-TSK-L43 follow-up: graph_query_api shares this SG in-VPC for
+        # OpenSearch :9200; hybrid search still needs Neo4j Aura Bolt (:7687).
+        - IpProtocol: tcp
+          FromPort: 7687
+          ToPort: 7687
+          CidrIp: 0.0.0.0/0
+          Description: Neo4j Aura Bolt TLS for graph_query_api hybrid path
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
CCI-16a333414c8a4d71bbd823da4d5e9aae

## Summary
- L43 attached `graph_query_api-gamma` to `OpenSearchIndexerSecurityGroup` for private OpenSearch `:9200` access
- That SG only allowed egress on `:443` and `:9200`; Neo4j Aura hybrid search uses Bolt on `:7687`, so requests hung until the 180s Lambda timeout (API Gateway 503)
- Adds `:7687` egress to `OpenSearchIndexerSecurityGroup` (gamma-only)

## Root cause evidence
- `devops-graph-query-api-gamma` START log lines with no END after VPC deploy (~14:12 UTC)
- SG `sg-05c87a5fa9010b400` egress: only tcp/443 + tcp/9200
- Health/hybrid curl to `hi0dzmvqrc` times out at 30s

## Test plan
- [ ] Merge and let gamma compute stack deploy succeed
- [ ] `curl -H "X-Coordination-Internal-Key: …" https://hi0dzmvqrc.execute-api.us-west-2.amazonaws.com/api/v1/tracker/graphsearch/health` returns 200 quickly
- [ ] Hybrid search returns `keyword_source=opensearch` and populated `facets`
- [ ] Confirm indexer Lambda still healthy (unchanged egress needs)