### PR TITLE
Fix gamma graphsearch SM timeout: VPC endpoint self-ingress

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -6061,6 +6061,19 @@ Resources:
         - Key: Component
           Value: search
 
+  # ENC-TSK-L43 follow-up: Secrets Manager interface endpoint ENIs share this SG;
+  # without self-ingress on :443, in-VPC Lambdas cannot reach the endpoint.
+  OpenSearchIndexerSecurityGroupVpcEndpointIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: IsGamma
+    Properties:
+      GroupId: !Ref OpenSearchIndexerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      SourceSecurityGroupId: !Ref OpenSearchIndexerSecurityGroup
+      Description: Lambda ENI to Secrets Manager VPC endpoint (shared SG)
+
   OpenSearchIndexerRole:
     Type: AWS::IAM::Role
     Condition: IsGamma


### PR DESCRIPTION
CCI-ca383e4f8d124926bcea5f7f673306ce

## Summary
- After L43 VPC attach, `graph_query_api-gamma` could not reach Secrets Manager — CloudWatch shows `ConnectTimeoutError` to `secretsmanager.us-west-2.amazonaws.com`
- The Secrets Manager interface endpoint shares `OpenSearchIndexerSecurityGroup` with the Lambdas but the SG had **no ingress** rules
- Adds self-referencing `:443` ingress so Lambda ENIs can reach endpoint ENIs on the same SG

## Test plan
- [ ] Merge + gamma compute deploy
- [ ] `/graphsearch/health` returns 200 quickly on `hi0dzmvqrc`
- [ ] Hybrid search returns results with `keyword_source=opensearch`


Made with [Cursor](https://cursor.com)