### PR TITLE
ENC-TSK-L43: IAM permissions for NAT gateway CFN deploy

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-opensearch-ec2-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-opensearch-ec2-patch.yml
@@ -72,7 +72,21 @@ jobs:
                   "ec2:AuthorizeSecurityGroupEgress",
                   "ec2:RevokeSecurityGroupIngress",
                   "ec2:RevokeSecurityGroupEgress",
-                  "ec2:ModifyInstanceAttribute"
+                  "ec2:ModifyInstanceAttribute",
+                  "ec2:AllocateAddress",
+                  "ec2:ReleaseAddress",
+                  "ec2:CreateNatGateway",
+                  "ec2:DeleteNatGateway",
+                  "ec2:CreateRouteTable",
+                  "ec2:DeleteRouteTable",
+                  "ec2:CreateRoute",
+                  "ec2:ReplaceRoute",
+                  "ec2:DeleteRoute",
+                  "ec2:AssociateRouteTable",
+                  "ec2:DisassociateRouteTable",
+                  "ec2:DescribeNatGateways",
+                  "ec2:DescribeRouteTables",
+                  "ec2:DescribeAddresses"
                 ],
                 "Resource": "*",
                 "Condition": {

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -610,6 +610,22 @@ Resources:
                   - ec2:DescribeSecurityGroups
                   - ec2:DescribeLaunchTemplates
                   - ec2:DescribeLaunchTemplateVersions
+                  # ENC-TSK-L43 Option A: NAT gateway + route table for OpenSearch/Lambda subnet
+                  - ec2:AllocateAddress
+                  - ec2:ReleaseAddress
+                  - ec2:CreateNatGateway
+                  - ec2:DeleteNatGateway
+                  - ec2:CreateRouteTable
+                  - ec2:DeleteRouteTable
+                  - ec2:CreateRoute
+                  - ec2:ReplaceRoute
+                  - ec2:DeleteRoute
+                  - ec2:AssociateRouteTable
+                  - ec2:DisassociateRouteTable
+                  - ec2:DescribeNatGateways
+                  - ec2:DescribeRouteTables
+                  - ec2:DescribeAddresses
+                  - ec2:DescribeVpcs
                 Resource: "*"
               - Sid: SSM
                 Effect: Allow


### PR DESCRIPTION
CCI-ed2d8dc493e44d659bef453340697f6a

## Summary
- Compute deploy for #899 failed: `enceladus-cloudformation-deploy-github-role` lacks `ec2:AllocateAddress`, `ec2:CreateRouteTable`, NAT gateway actions
- Extends `enceladus-cfn-deploy-opensearch-ec2-v1` patch workflow + `04-github-roles` EC2Fleet sid

## Test plan
- [ ] Merge → run **IAM CFN Deploy Role — OpenSearch EC2 Patch** workflow (v3-prod approval)
- [ ] Re-run failed compute deploy for NAT resources
- [ ] Verify hybrid graphsearch on gamma