### PR TITLE
Add IAM NAT gateway patch workflow (ENC-TSK-L43 unblock)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
@@ -1,0 +1,93 @@
+name: IAM CFN Deploy Role — NAT Gateway Patch
+
+# ENC-TSK-L43 Option A: grant the shared CFN deploy role EC2 permissions to
+# create NAT gateway + route table resources in the OpenSearch/Lambda VPC path.
+# io-gated: environment v3-prod (required reviewer).
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant NAT gateway EC2 permissions for enceladus-compute-gamma (ENC-TSK-L43)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with NAT gateway EC2 permissions
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — OpenSearch NAT gateway (gamma)
+        run: |
+          set -euo pipefail
+          cat > /tmp/opensearch-nat-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "OpenSearchNatEc2Describe",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeSubnets",
+                  "ec2:DescribeRouteTables",
+                  "ec2:DescribeNatGateways",
+                  "ec2:DescribeAddresses"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "OpenSearchNatEc2MutateGamma",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:AllocateAddress",
+                  "ec2:ReleaseAddress",
+                  "ec2:CreateNatGateway",
+                  "ec2:DeleteNatGateway",
+                  "ec2:CreateRouteTable",
+                  "ec2:DeleteRouteTable",
+                  "ec2:CreateRoute",
+                  "ec2:ReplaceRoute",
+                  "ec2:DeleteRoute",
+                  "ec2:AssociateRouteTable",
+                  "ec2:DisassociateRouteTable"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "us-west-2"
+                  }
+                }
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-opensearch-nat-v1" \
+            --policy-document "file:///tmp/opensearch-nat-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-opensearch-nat-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -128,6 +128,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-nat-gateway-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L43: environment: v3-prod — NAT gateway EC2 grants on shared CFN deploy role for gamma OpenSearch/Lambda subnet"
+    },
     "iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
CCI-dcd149fe527640aba7b0893d326c0429

## Summary
- Adds `iam-cfn-deploy-role-nat-gateway-patch.yml` on **main** (workflow_dispatch registered)
- Classifies workflow in `prod_gate_baseline.json`
- Unblocks enceladus-compute-gamma NAT deploy (#899)

## Test plan
- [ ] Merge → dispatch NAT patch workflow (v3-prod)
- [ ] Re-run compute deploy on v4/main