### PR TITLE
Fix NAT IAM patch: merge into opensearch-ec2-v1 policy

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
@@ -1,7 +1,7 @@
 name: IAM CFN Deploy Role — NAT Gateway Patch
 
-# ENC-TSK-L43 Option A: grant the shared CFN deploy role EC2 permissions to
-# create NAT gateway + route table resources in the OpenSearch/Lambda VPC path.
+# ENC-TSK-L43 Option A: refresh enceladus-cfn-deploy-opensearch-ec2-v1 with NAT +
+# route-table grants (merged — do NOT add a separate inline policy; role is at cap).
 # io-gated: environment v3-prod (required reviewer).
 
 on:
@@ -11,7 +11,7 @@ on:
         description: "Why this patch is needed"
         type: string
         required: false
-        default: "Grant NAT gateway EC2 permissions for enceladus-compute-gamma (ENC-TSK-L43)"
+        default: "Refresh OpenSearch EC2 inline policy with NAT gateway grants (ENC-TSK-L43)"
 
 permissions:
   contents: read
@@ -33,19 +33,26 @@ jobs:
       - name: Verify caller identity
         run: aws sts get-caller-identity
 
-      - name: Apply inline policy — OpenSearch NAT gateway (gamma)
+      - name: Apply inline policy — OpenSearch EC2 + NAT (gamma)
         run: |
           set -euo pipefail
-          cat > /tmp/opensearch-nat-policy.json <<'JSON'
+          cat > /tmp/opensearch-ec2-policy.json <<'JSON'
           {
             "Version": "2012-10-17",
             "Statement": [
               {
-                "Sid": "OpenSearchNatEc2Describe",
+                "Sid": "OpenSearchNodeEc2Describe",
                 "Effect": "Allow",
                 "Action": [
                   "ec2:DescribeVpcs",
                   "ec2:DescribeSubnets",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceStatus",
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeVolumes",
+                  "ec2:DescribeAccountAttributes",
                   "ec2:DescribeRouteTables",
                   "ec2:DescribeNatGateways",
                   "ec2:DescribeAddresses"
@@ -53,9 +60,22 @@ jobs:
                 "Resource": "*"
               },
               {
-                "Sid": "OpenSearchNatEc2MutateGamma",
+                "Sid": "OpenSearchNodeEc2MutateGamma",
                 "Effect": "Allow",
                 "Action": [
+                  "ec2:RunInstances",
+                  "ec2:TerminateInstances",
+                  "ec2:StartInstances",
+                  "ec2:StopInstances",
+                  "ec2:CreateTags",
+                  "ec2:DeleteTags",
+                  "ec2:CreateSecurityGroup",
+                  "ec2:DeleteSecurityGroup",
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:AuthorizeSecurityGroupEgress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupEgress",
+                  "ec2:ModifyInstanceAttribute",
                   "ec2:AllocateAddress",
                   "ec2:ReleaseAddress",
                   "ec2:CreateNatGateway",
@@ -74,6 +94,17 @@ jobs:
                     "aws:RequestedRegion": "us-west-2"
                   }
                 }
+              },
+              {
+                "Sid": "OpenSearchNodePassInstanceProfile",
+                "Effect": "Allow",
+                "Action": "iam:PassRole",
+                "Resource": "arn:aws:iam::356364570033:role/enceladus-opensearch-node-role-gamma",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
+                }
               }
             ]
           }
@@ -81,13 +112,13 @@ jobs:
 
           aws iam put-role-policy \
             --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-opensearch-nat-v1" \
-            --policy-document "file:///tmp/opensearch-nat-policy.json"
+            --policy-name "enceladus-cfn-deploy-opensearch-ec2-v1" \
+            --policy-document "file:///tmp/opensearch-ec2-policy.json"
 
       - name: Verify inline policy attached
         run: |
           aws iam get-role-policy \
             --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-opensearch-nat-v1" \
-            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --policy-name "enceladus-cfn-deploy-opensearch-ec2-v1" \
+            --query 'PolicyDocument.Statement[*].Sid' \
             --output table


### PR DESCRIPTION
CCI-bd3621d3ced14538a720e53e516c7bcf

## Summary
Run 28838580298 failed: `Maximum policy size of 10240 bytes exceeded for role` when adding `enceladus-cfn-deploy-opensearch-nat-v1`.
Refresh existing `enceladus-cfn-deploy-opensearch-ec2-v1` with NAT + route-table grants instead.


Made with [Cursor](https://cursor.com)