### PR TITLE
Fix OpenSearch L44 secret sync when bootstrap marker exists (ISS-496)

### DIFF
--- a/infrastructure/opensearch/bootstrap-node.sh
+++ b/infrastructure/opensearch/bootstrap-node.sh
@@ -15,8 +15,128 @@ JVM_HEAP="${OPENSEARCH_JVM_HEAP:-1g}"
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 
+_wait_green() {
+  local admin_password="$1"
+  log "Waiting for cluster health GREEN"
+  for i in $(seq 1 60); do
+    curl -ks -u "admin:${admin_password}" "https://127.0.0.1:9200/_cluster/health" | jq -e '.status=="green" or .status=="yellow"' >/dev/null 2>&1 && break
+    sleep 5
+  done
+}
+
+run_post_bootstrap_hooks() {
+  ADMIN_PASSWORD="$(tr -d '\n' < "${ADMIN_PASSWORD_FILE}")"
+  CFG="${OSH}/config/opensearch.yml"
+
+  # ENC-TSK-L44 audit logging via opensearch.yml post-bootstrap (L70 guard above); needs a restart.
+  if ! grep -q 'L44-audit' "${CFG}"; then
+    log "Enabling security-plugin audit logging"
+    cat >> "${CFG}" <<EOF
+
+# L44-audit
+plugins.security.audit.type: internal_opensearch
+plugins.security.audit.config.disabled_rest_categories: NONE
+plugins.security.audit.config.disabled_transport_categories: NONE
+# end-L44-audit
+EOF
+    systemctl restart opensearch
+    _wait_green "${ADMIN_PASSWORD}"
+  else
+    log "ENC-TSK-L44 audit config already present; skipping restart"
+  fi
+
+  # ENC-TSK-L44 fine-grained roles + Secrets Manager rotation; idempotent re-run.
+  log "Provisioning fine-grained security roles + Secrets Manager credentials"
+
+  RGN="${AWS_REGION:-$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null || echo us-west-2)}"
+  SECPFX="${OPENSEARCH_SECRET_PREFIX:-enceladus/opensearch}"
+  SECENV="${OPENSEARCH_SECRET_ENV:-gamma}"
+
+  if ! command -v aws &>/dev/null; then
+    dnf install -y awscli || pip3 install --quiet awscli
+  fi
+
+  _put_secret() {
+    local username="$1" password="$2"
+    local secret_id="${SECPFX}/${SECENV}-${username}"
+    local payload
+    payload="$(jq -n --arg u "${username}" --arg p "${password}" '{username:$u, password:$p}')"
+    if aws secretsmanager describe-secret --secret-id "${secret_id}" --region "${RGN}" >/dev/null 2>&1; then
+      aws secretsmanager put-secret-value --secret-id "${secret_id}" --secret-string "${payload}" --region "${RGN}" >/dev/null
+    else
+      aws secretsmanager create-secret --name "${secret_id}" --secret-string "${payload}" --region "${RGN}" >/dev/null
+    fi
+    log "Secrets Manager: synced ${secret_id}"
+  }
+
+  _put_secret "admin" "${ADMIN_PASSWORD}"
+
+  IPWF="/root/.opensearch-indexer-password"
+  QPWF="/root/.opensearch-query-password"
+  if [[ ! -f "${IPWF}" ]]; then
+    openssl rand -base64 24 > "${IPWF}"
+    chmod 0600 "${IPWF}"
+  fi
+  if [[ ! -f "${QPWF}" ]]; then
+    openssl rand -base64 24 > "${QPWF}"
+    chmod 0600 "${QPWF}"
+  fi
+  INDEXER_PASSWORD="$(tr -d '\n' < "${IPWF}")"
+  QUERY_PASSWORD="$(tr -d '\n' < "${QPWF}")"
+
+  _put_secret "indexer" "${INDEXER_PASSWORD}"
+  _put_secret "query" "${QUERY_PASSWORD}"
+
+  log "Applying indexer_role / query_role via Security REST API"
+  SEC="https://127.0.0.1:9200/_plugins/_security/api"
+  _sec_put() { curl -ks -u "admin:${ADMIN_PASSWORD}" -X PUT "${SEC}/$1" -H 'Content-Type: application/json' -d "$2"; }
+  _sec_put "roles/indexer_role" '{"cluster_permissions":["cluster_composite_ops","cluster:monitor/*"],"index_permissions":[{"index_patterns":["records_write","records_v*"],"allowed_actions":["indices:data/write/*","indices:admin/create","indices:admin/mapping/put","indices:admin/aliases","indices:monitor/*"]}]}'
+  _sec_put "roles/query_role" '{"cluster_permissions":["cluster:monitor/*"],"index_permissions":[{"index_patterns":["records_read","records_v*"],"allowed_actions":["indices:data/read/*","indices:monitor/*"]}]}'
+  _sec_put "internalusers/indexer" "$(jq -n --arg p "${INDEXER_PASSWORD}" '{password:$p, backend_roles:["indexer_backend"], description:"L44 write-only"}')"
+  _sec_put "internalusers/query" "$(jq -n --arg p "${QUERY_PASSWORD}" '{password:$p, backend_roles:["query_backend"], description:"L44 read-only"}')"
+  _sec_put "rolesmapping/indexer_role" '{"backend_roles":["indexer_backend"],"users":["indexer"]}'
+  _sec_put "rolesmapping/query_role" '{"backend_roles":["query_backend"],"users":["query"]}'
+
+  # ENC-TSK-L45 monitoring (AC-1): disk via CW Agent; JVM heap has no native
+  # metric, pushed by a cron polling OpenSearch's own stats API instead.
+  log "Configuring CloudWatch Agent + JVM heap heartbeat cron"
+  CW_NAMESPACE="Enceladus/OpenSearch"
+  mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+  cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<EOF
+{"metrics":{"namespace":"${CW_NAMESPACE}","append_dimensions":{"InstanceId":"\${aws:InstanceId}"},"aggregation_dimensions":[["InstanceId","path"],["InstanceId"]],"metrics_collected":{"disk":{"measurement":["used_percent"],"resources":["/"],"ignore_file_system_types":["sysfs","devtmpfs","tmpfs"],"drop_device":true},"mem":{"measurement":["mem_used_percent"]},"procstat":[{"pattern":"opensearch","measurement":["cpu_usage","memory_rss"]}]}}}
+EOF
+  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+  cat > /usr/local/bin/opensearch-jvm-heartbeat.sh <<'HEARTBEAT'
+#!/usr/bin/env bash
+set -euo pipefail
+ADMIN_PASSWORD_FILE="${OPENSEARCH_ADMIN_PASSWORD_FILE:-/root/.opensearch-admin-password}"
+NAMESPACE="${CW_NAMESPACE:-Enceladus/OpenSearch}"
+REGION="$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null || echo us-west-2)"
+IID="$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo unknown)"
+PW="$(tr -d '\n' < "${ADMIN_PASSWORD_FILE}" 2>/dev/null || true)"
+[[ -z "${PW}" ]] && exit 0
+STATS="$(curl -ks -m 5 -u "admin:${PW}" "https://127.0.0.1:9200/_nodes/stats/jvm" 2>/dev/null || true)"
+if [[ -z "${STATS}" ]]; then
+  # unreachable: push NodeUp=0 (not a JVMHeapPercent point -- missing data, not a false zero)
+  aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=NodeUp,Value=0,Unit=Count,Dimensions=[{Name=InstanceId,Value=${IID}}]"
+  exit 0
+fi
+HEAP="$(echo "${STATS}" | jq -r '.nodes | to_entries[0].value.jvm.mem.heap_used_percent // empty')"
+aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=NodeUp,Value=1,Unit=Count,Dimensions=[{Name=InstanceId,Value=${IID}}]"
+[[ -n "${HEAP}" ]] && aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=JVMHeapPercent,Value=${HEAP},Unit=Percent,Dimensions=[{Name=InstanceId,Value=${IID}}]"
+HEARTBEAT
+  chmod +x /usr/local/bin/opensearch-jvm-heartbeat.sh
+
+  cat > /etc/cron.d/opensearch-jvm-heartbeat <<EOF
+* * * * * root CW_NAMESPACE="${CW_NAMESPACE}" /usr/local/bin/opensearch-jvm-heartbeat.sh >> /var/log/opensearch-jvm-heartbeat.log 2>&1
+EOF
+  chmod 0644 /etc/cron.d/opensearch-jvm-heartbeat
+}
+
 if [[ -f "${MARKER}" ]]; then
-  log "Bootstrap already complete; exiting."
+  log "Bootstrap marker present; skipping core install, running post-bootstrap hooks (ENC-ISS-496)."
+  run_post_bootstrap_hooks
   exit 0
 fi
 
@@ -137,14 +257,7 @@ systemctl daemon-reload
 systemctl enable opensearch
 systemctl restart opensearch
 
-_wait_green() {
-  log "Waiting for cluster health GREEN"
-  for i in $(seq 1 60); do
-    curl -ks -u "admin:${ADMIN_PASSWORD}" "https://127.0.0.1:9200/_cluster/health" | jq -e '.status=="green" or .status=="yellow"' >/dev/null 2>&1 && break
-    sleep 5
-  done
-}
-_wait_green
+_wait_green "${ADMIN_PASSWORD}"
 curl -ks -u "admin:${ADMIN_PASSWORD}" "https://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=120s" | tee /var/log/opensearch-cluster-health.json
 
 log "Applying default index template (number_of_replicas: 0)"
@@ -152,110 +265,7 @@ curl -ks -u "admin:${ADMIN_PASSWORD}" -X PUT "https://127.0.0.1:9200/_index_temp
   -H 'Content-Type: application/json' \
   -d '{"index_patterns":["enceladus-*"],"template":{"settings":{"number_of_shards":1,"number_of_replicas":0}}}'
 
-# ENC-TSK-L44 audit logging via opensearch.yml post-bootstrap (L70 guard above); needs a restart.
-if ! grep -q 'L44-audit' "${CFG}"; then
-  log "Enabling security-plugin audit logging"
-  cat >> "${CFG}" <<EOF
-
-# L44-audit
-plugins.security.audit.type: internal_opensearch
-plugins.security.audit.config.disabled_rest_categories: NONE
-plugins.security.audit.config.disabled_transport_categories: NONE
-# end-L44-audit
-EOF
-  systemctl restart opensearch
-  _wait_green
-else
-  log "ENC-TSK-L44 audit config already present; skipping restart"
-fi
-
-# ENC-TSK-L44 fine-grained roles + Secrets Manager rotation; idempotent re-run.
-log "Provisioning fine-grained security roles + Secrets Manager credentials"
-
-RGN="${AWS_REGION:-$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null || echo us-west-2)}"
-SECPFX="${OPENSEARCH_SECRET_PREFIX:-enceladus/opensearch}"
-SECENV="${OPENSEARCH_SECRET_ENV:-gamma}"
-
-if ! command -v aws &>/dev/null; then
-  dnf install -y awscli || pip3 install --quiet awscli
-fi
-
-_put_secret() {
-  local username="$1" password="$2"
-  local secret_id="${SECPFX}/${SECENV}-${username}"
-  local payload
-  payload="$(jq -n --arg u "${username}" --arg p "${password}" '{username:$u, password:$p}')"
-  if aws secretsmanager describe-secret --secret-id "${secret_id}" --region "${RGN}" >/dev/null 2>&1; then
-    aws secretsmanager put-secret-value --secret-id "${secret_id}" --secret-string "${payload}" --region "${RGN}" >/dev/null
-  else
-    aws secretsmanager create-secret --name "${secret_id}" --secret-string "${payload}" --region "${RGN}" >/dev/null
-  fi
-  log "Secrets Manager: synced ${secret_id}"
-}
-
-_put_secret "admin" "${ADMIN_PASSWORD}"
-
-IPWF="/root/.opensearch-indexer-password"
-QPWF="/root/.opensearch-query-password"
-if [[ ! -f "${IPWF}" ]]; then
-  openssl rand -base64 24 > "${IPWF}"
-  chmod 0600 "${IPWF}"
-fi
-if [[ ! -f "${QPWF}" ]]; then
-  openssl rand -base64 24 > "${QPWF}"
-  chmod 0600 "${QPWF}"
-fi
-INDEXER_PASSWORD="$(tr -d '\n' < "${IPWF}")"
-QUERY_PASSWORD="$(tr -d '\n' < "${QPWF}")"
-
-_put_secret "indexer" "${INDEXER_PASSWORD}"
-_put_secret "query" "${QUERY_PASSWORD}"
-
-log "Applying indexer_role / query_role via Security REST API"
-SEC="https://127.0.0.1:9200/_plugins/_security/api"
-_sec_put() { curl -ks -u "admin:${ADMIN_PASSWORD}" -X PUT "${SEC}/$1" -H 'Content-Type: application/json' -d "$2"; }
-_sec_put "roles/indexer_role" '{"cluster_permissions":["cluster_composite_ops","cluster:monitor/*"],"index_permissions":[{"index_patterns":["records_write","records_v*"],"allowed_actions":["indices:data/write/*","indices:admin/create","indices:admin/mapping/put","indices:admin/aliases","indices:monitor/*"]}]}'
-_sec_put "roles/query_role" '{"cluster_permissions":["cluster:monitor/*"],"index_permissions":[{"index_patterns":["records_read","records_v*"],"allowed_actions":["indices:data/read/*","indices:monitor/*"]}]}'
-_sec_put "internalusers/indexer" "$(jq -n --arg p "${INDEXER_PASSWORD}" '{password:$p, backend_roles:["indexer_backend"], description:"L44 write-only"}')"
-_sec_put "internalusers/query" "$(jq -n --arg p "${QUERY_PASSWORD}" '{password:$p, backend_roles:["query_backend"], description:"L44 read-only"}')"
-_sec_put "rolesmapping/indexer_role" '{"backend_roles":["indexer_backend"],"users":["indexer"]}'
-_sec_put "rolesmapping/query_role" '{"backend_roles":["query_backend"],"users":["query"]}'
-
-# ENC-TSK-L45 monitoring (AC-1): disk via CW Agent; JVM heap has no native
-# metric, pushed by a cron polling OpenSearch's own stats API instead.
-log "Configuring CloudWatch Agent + JVM heap heartbeat cron"
-CW_NAMESPACE="Enceladus/OpenSearch"
-mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
-cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<EOF
-{"metrics":{"namespace":"${CW_NAMESPACE}","append_dimensions":{"InstanceId":"\${aws:InstanceId}"},"aggregation_dimensions":[["InstanceId","path"],["InstanceId"]],"metrics_collected":{"disk":{"measurement":["used_percent"],"resources":["/"],"ignore_file_system_types":["sysfs","devtmpfs","tmpfs"],"drop_device":true},"mem":{"measurement":["mem_used_percent"]},"procstat":[{"pattern":"opensearch","measurement":["cpu_usage","memory_rss"]}]}}}
-EOF
-/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-
-cat > /usr/local/bin/opensearch-jvm-heartbeat.sh <<'HEARTBEAT'
-#!/usr/bin/env bash
-set -euo pipefail
-ADMIN_PASSWORD_FILE="${OPENSEARCH_ADMIN_PASSWORD_FILE:-/root/.opensearch-admin-password}"
-NAMESPACE="${CW_NAMESPACE:-Enceladus/OpenSearch}"
-REGION="$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null || echo us-west-2)"
-IID="$(curl -fsS -m 2 http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo unknown)"
-PW="$(tr -d '\n' < "${ADMIN_PASSWORD_FILE}" 2>/dev/null || true)"
-[[ -z "${PW}" ]] && exit 0
-STATS="$(curl -ks -m 5 -u "admin:${PW}" "https://127.0.0.1:9200/_nodes/stats/jvm" 2>/dev/null || true)"
-if [[ -z "${STATS}" ]]; then
-  # unreachable: push NodeUp=0 (not a JVMHeapPercent point -- missing data, not a false zero)
-  aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=NodeUp,Value=0,Unit=Count,Dimensions=[{Name=InstanceId,Value=${IID}}]"
-  exit 0
-fi
-HEAP="$(echo "${STATS}" | jq -r '.nodes | to_entries[0].value.jvm.mem.heap_used_percent // empty')"
-aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=NodeUp,Value=1,Unit=Count,Dimensions=[{Name=InstanceId,Value=${IID}}]"
-[[ -n "${HEAP}" ]] && aws cloudwatch put-metric-data --region "${REGION}" --namespace "${NAMESPACE}" --metric-data "MetricName=JVMHeapPercent,Value=${HEAP},Unit=Percent,Dimensions=[{Name=InstanceId,Value=${IID}}]"
-HEARTBEAT
-chmod +x /usr/local/bin/opensearch-jvm-heartbeat.sh
-
-cat > /etc/cron.d/opensearch-jvm-heartbeat <<EOF
-* * * * * root CW_NAMESPACE="${CW_NAMESPACE}" /usr/local/bin/opensearch-jvm-heartbeat.sh >> /var/log/opensearch-jvm-heartbeat.log 2>&1
-EOF
-chmod 0644 /etc/cron.d/opensearch-jvm-heartbeat
+run_post_bootstrap_hooks
 
 touch "${MARKER}"
 log "Bootstrap complete"


### PR DESCRIPTION
CCI-8da8b400f85a4ddba09e53570cfb7a9f

## Summary
- **ENC-ISS-496 / ENC-TSK-L78:** `bootstrap-node.sh` exited early when `.bootstrap-complete` existed, so L44 never synced `enceladus/opensearch/gamma-{query,indexer,admin}` to Secrets Manager.
- Extract post-bootstrap hooks (`run_post_bootstrap_hooks`) and invoke them on marker-present re-runs (SSM/UserData) as well as first boot.

## Live remediation (already applied)
- Created SM secrets + query/indexer security-plugin users on gamma OpenSearch node via SSM.
- Hybrid graphsearch now returns `signal_availability.keyword=true`, `keyword_source=opensearch`.

## Test plan
- [x] Live gamma secrets exist
- [x] Hybrid graphsearch keyword arm verified
- [ ] Merge + future opensearch node UserData re-run idempotently re-syncs secrets


Made with [Cursor](https://cursor.com)