### PR TITLE
Codify OpenSearch NAT managed policy in 04-github-roles (L43)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-nat-gateway-patch.yml
@@ -1,7 +1,11 @@
 name: IAM CFN Deploy Role — NAT Gateway Patch
 
 # ENC-TSK-L43 Option A: attach a managed policy with NAT + route-table grants.
-# The shared CFN deploy role is at inline-policy capacity (LimitExceeded on PutRolePolicy).
+# Durable fix: OpenSearchNatGatewayPolicy in 04-github-roles.yaml (deploy via
+# cloudformation-github-roles-stack-deploy.yml). This one-off dispatch applies
+# the grant live ahead of the next github-roles stack deploy. The backend deploy
+# role lacks iam:CreatePolicy — if this workflow fails AccessDenied, apply with
+# product-lead/admin credentials or dispatch github-roles stack deploy instead.
 # io-gated: environment v3-prod (required reviewer).
 
 on:

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -656,6 +656,49 @@ Resources:
               - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule-group/enceladus-*"
               - !Sub "arn:aws:scheduler:us-west-2:${AWS::AccountId}:schedule/enceladus-*/*"
 
+  # ENC-TSK-L43 Option A — NAT gateway + route table for OpenSearch/Lambda subnet (gamma).
+  # Same failure class as CodeDeployStackOpsPolicy: CloudFormationDeployRole inline quota
+  # exhausted; live grant applied out-of-band 2026-07-07 (product-lead) after patch workflow
+  # AccessDenied on iam:CreatePolicy (backend deploy role cannot create managed policies).
+  OpenSearchNatGatewayPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-opensearch-nat-gamma
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: OpenSearchNatEc2Describe
+            Effect: Allow
+            Action:
+              - ec2:DescribeVpcs
+              - ec2:DescribeSubnets
+              - ec2:DescribeRouteTables
+              - ec2:DescribeNatGateways
+              - ec2:DescribeAddresses
+            Resource: "*"
+          - Sid: OpenSearchNatEc2MutateGamma
+            Effect: Allow
+            Action:
+              - ec2:AllocateAddress
+              - ec2:ReleaseAddress
+              - ec2:CreateNatGateway
+              - ec2:DeleteNatGateway
+              - ec2:CreateRouteTable
+              - ec2:DeleteRouteTable
+              - ec2:CreateRoute
+              - ec2:ReplaceRoute
+              - ec2:DeleteRoute
+              - ec2:AssociateRouteTable
+              - ec2:DisassociateRouteTable
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:RequestedRegion: us-west-2
+
   # ENC-TSK-L55 codify: enceladus-ui-cdn-deploy was created out-of-band
   # (v4 UI CDN bootstrap, K54/ENC-TSK-K65 lineage) and attached to
   # CloudFormationDeployRole without ever being represented in this stack.


### PR DESCRIPTION
CCI-4585401cc0db40c18a9bac2db8fe50de

## Summary
- Add `OpenSearchNatGatewayPolicy` managed policy to `04-github-roles.yaml` (durable CFN owner for `enceladus-cfn-deploy-opensearch-nat-gamma`).
- Document that patch workflow is pre-stack-deploy only; github-roles stack deploy is the durable path.

## Test plan
- [ ] Merge to main
- [ ] Dispatch `cloudformation-github-roles-stack-deploy` (v3-prod approval)
- [ ] Confirm stack adopts existing managed policy without drift