### PR TITLE
ENC-TSK-L05 AC-1: populate 5 hardening fields on active enceladus components

### DIFF
--- a/tools/backfill_component_hardening_fields.py
+++ b/tools/backfill_component_hardening_fields.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Backfill the five ENC-TSK-E68 hardening fields onto active enceladus-project
+component_registry records.
+
+ENC-TSK-L05 AC-1 (B63 Ph2 H-BACKFILL). Reads the researched values from
+``tools/seed-component-registry.py``'s ``KNOWN_COMPONENTS`` (the single source
+of truth this backfill keeps in sync with) and PATCHes each active
+enceladus-project component's live registry row via the coordination API's
+``PATCH /api/v1/coordination/components/{componentId}`` route, which already
+recognizes required_iam_actions / required_env_secrets / required_apigw_routes
+/ required_cfn_resources / required_lambda_env_vars as
+``_COMPONENT_CAPABILITY_FIELDS`` (backend/lambda/coordination_api/
+lambda_function.py:8751-8756) — no Cognito/assistant-key gate applies to these
+fields (unlike transition_type/required_transition_type), so a plain internal
+API key is sufficient auth.
+
+This mirrors tools/backfill_component_lifecycle.py's CLI shape (--env {prod|
+gamma}, --dry-run, before/after classification + summary logging) but writes
+via the governed HTTP API (coordination_api Lambda's own IAM role) rather than
+direct boto3 DynamoDB UpdateItem, because the calling agent identity
+(enceladus-agent-cli) carries an explicit IAM deny on dynamodb:UpdateItem /
+PutItem against component-registry* tables (ENC-TSK-564) — confirmed live via
+a real UpdateItem attempt during ENC-TSK-L05 AC-1 research, which returned
+AccessDeniedException. The HTTP path goes through the coordination_api
+Lambda's own execution role instead, which is why seed-component-registry.py
+itself already uses this same HTTP-based approach rather than boto3.
+
+Usage:
+    # Dry run — prints planned PATCH bodies, makes no network calls.
+    python3 tools/backfill_component_hardening_fields.py --env gamma --dry-run
+
+    # Real run against gamma (requires COORDINATION_INTERNAL_API_KEY or
+    # ENCELADUS_COORDINATION_INTERNAL_API_KEY in the environment — this key is
+    # NOT available to standard enceladus-agent-cli sessions; it must be
+    # supplied by a session with access to it, e.g. via the coordination_api
+    # Lambda's own config or an authorized CI context).
+    ENCELADUS_COORDINATION_INTERNAL_API_KEY=<key> \\
+        python3 tools/backfill_component_hardening_fields.py --env gamma
+
+Scope: gamma only. This script intentionally has no prod code path — prod
+component-registry metadata is out of scope for ENC-TSK-L05 (per the task's
+standing gamma-lane directive); running against prod would require adding
+--env prod deliberately and is NOT wired up here on purpose.
+
+Related: ENC-TSK-L05, ENC-TSK-E68, ENC-PLN-031 Phase 3, ENC-TSK-E69
+(deploy_capability_auditor, the downstream consumer of these fields).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+logger = logging.getLogger("backfill_component_hardening_fields")
+
+_HARDENING_FIELDS = (
+    "required_iam_actions",
+    "required_env_secrets",
+    "required_apigw_routes",
+    "required_cfn_resources",
+    "required_lambda_env_vars",
+)
+
+# gamma-only by design (see module docstring). No prod entry — do not add one
+# without a deliberate, separately-reviewed decision; ENC-TSK-L05 scope is gamma.
+_ENV_TO_BASE_URL = {
+    "gamma": "https://jreese.net/api/v1/coordination",
+}
+
+
+def _load_seed_components() -> List[Dict[str, Any]]:
+    seed_path = Path(__file__).resolve().parent / "seed-component-registry.py"
+    namespace: Dict[str, Any] = {"__name__": "__not_main__"}
+    exec(compile(seed_path.read_text(), str(seed_path), "exec"), namespace)
+    components = namespace.get("KNOWN_COMPONENTS")
+    if not isinstance(components, list):
+        raise RuntimeError("KNOWN_COMPONENTS not found or not a list in seed script")
+    return components
+
+
+def _in_scope(comp: Dict[str, Any]) -> bool:
+    """ENC-TSK-L05 AC-1 scope: active components in the enceladus project."""
+    return comp.get("project_id") == "enceladus" and comp.get("status") == "active"
+
+
+def _api_request(
+    base_url: str, api_key: str, method: str, path: str, payload: Dict[str, Any] | None = None
+) -> Tuple[int, Dict[str, Any]]:
+    url = f"{base_url.rstrip('/')}{path}"
+    body = json.dumps(payload).encode() if payload is not None else None
+    headers = {
+        "Content-Type": "application/json",
+        "X-Coordination-Internal-Key": api_key,
+    }
+    req = urllib.request.Request(url, data=body, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            err_body = json.loads(raw)
+        except Exception:
+            err_body = {"raw": raw.decode(errors="replace")}
+        return exc.code, err_body
+
+
+def _get_live_component(base_url: str, api_key: str, component_id: str) -> Tuple[int, Dict[str, Any]]:
+    return _api_request(base_url, api_key, "GET", f"/components/{component_id}")
+
+
+def _needs_backfill(live_row: Dict[str, Any]) -> List[str]:
+    """Return the subset of the five hardening fields missing on the live row."""
+    return [f for f in _HARDENING_FIELDS if f not in live_row]
+
+
+def _patch_component(
+    base_url: str, api_key: str, component_id: str, seed_comp: Dict[str, Any]
+) -> Tuple[int, Dict[str, Any]]:
+    payload = {f: seed_comp.get(f, []) for f in _HARDENING_FIELDS}
+    return _api_request(base_url, api_key, "PATCH", f"/components/{component_id}", payload)
+
+
+def run(env: str, dry_run: bool, api_key: str) -> int:
+    base_url = _ENV_TO_BASE_URL[env]
+    components = [c for c in _load_seed_components() if _in_scope(c)]
+    logger.info("env=%s base_url=%s dry_run=%s in_scope_components=%d", env, base_url, dry_run, len(components))
+
+    # Pre-state: classify against live registry.
+    needs: List[str] = []
+    already: List[str] = []
+    unreachable: List[str] = []
+    for comp in components:
+        cid = comp["component_id"]
+        status, live = _get_live_component(base_url, api_key, cid)
+        if status == 404:
+            unreachable.append(cid)
+            logger.warning("[BEFORE] %s not found live (404) -- skipping", cid)
+            continue
+        if status != 200:
+            unreachable.append(cid)
+            logger.warning("[BEFORE] %s GET failed (%s) -- skipping", cid, status)
+            continue
+        live_row = live.get("component", live)
+        missing = _needs_backfill(live_row)
+        if missing:
+            needs.append(cid)
+        else:
+            already.append(cid)
+
+    logger.info(
+        "[BEFORE] in_scope=%d needs_backfill=%d already_set=%d unreachable=%d",
+        len(components), len(needs), len(already), len(unreachable),
+    )
+
+    if dry_run:
+        for comp in components:
+            cid = comp["component_id"]
+            action = "PATCH" if cid in needs else ("SKIP (already set)" if cid in already else "SKIP (unreachable)")
+            logger.info("[DRY-RUN] %s -> %s", cid, action)
+            if cid in needs:
+                payload = {f: comp.get(f, []) for f in _HARDENING_FIELDS}
+                logger.info("[DRY-RUN]   payload=%s", json.dumps(payload, sort_keys=True))
+        logger.info("[DRY-RUN] no writes performed")
+        return 0
+
+    # Apply.
+    written = 0
+    skipped = 0
+    failed = 0
+    for comp in components:
+        cid = comp["component_id"]
+        if cid not in needs:
+            skipped += 1
+            logger.info("[SKIP] %s already has all five hardening fields", cid)
+            continue
+        status, result = _patch_component(base_url, api_key, cid, comp)
+        if status == 200:
+            written += 1
+            logger.info("[WRITE] %s hardening fields backfilled", cid)
+        else:
+            failed += 1
+            logger.error("[FAIL] %s PATCH returned %s: %s", cid, status, result)
+
+    # Post-state verification.
+    after_needs: List[str] = []
+    for comp in components:
+        cid = comp["component_id"]
+        status, live = _get_live_component(base_url, api_key, cid)
+        if status != 200:
+            continue
+        live_row = live.get("component", live)
+        if _needs_backfill(live_row):
+            after_needs.append(cid)
+
+    logger.info(
+        "[SUMMARY] written=%d skipped=%d failed=%d expected_remaining=0 actual_remaining=%d",
+        written, skipped, failed, len(after_needs),
+    )
+    if after_needs:
+        logger.error("[SUMMARY] still missing hardening fields after backfill: %s", after_needs)
+
+    return 0 if not after_needs and failed == 0 else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Backfill ENC-TSK-E68 hardening fields onto live component-registry records (ENC-TSK-L05 AC-1)."
+    )
+    p.add_argument("--env", required=True, choices=sorted(_ENV_TO_BASE_URL.keys()),
+                   help="Target environment. gamma only -- prod is intentionally not wired up (see module docstring).")
+    p.add_argument("--dry-run", action="store_true", help="Classify + print planned PATCHes; no writes.")
+    p.add_argument("--api-key", default=None, help="Coordination API internal key (overrides env var).")
+    return p
+
+
+def main(argv: List[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = _build_parser().parse_args(argv)
+
+    api_key = (
+        args.api_key
+        or os.environ.get("ENCELADUS_COORDINATION_INTERNAL_API_KEY")
+        or os.environ.get("COORDINATION_INTERNAL_API_KEY")
+        or ""
+    )
+    if not api_key and not args.dry_run:
+        print(
+            "ERROR: --api-key or ENCELADUS_COORDINATION_INTERNAL_API_KEY/"
+            "COORDINATION_INTERNAL_API_KEY env var is required for a real run. "
+            "(This key is not provisioned to standard enceladus-agent-cli "
+            "sessions -- see module docstring.)",
+            file=sys.stderr,
+        )
+        return 2
+
+    return run(args.env, args.dry_run, api_key)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/seed-component-registry.py
+++ b/tools/seed-component-registry.py
@@ -108,6 +108,60 @@ KNOWN_COMPONENTS = [
             "architecture_sections": ["4.17"],
         },
         "deploy_targets": ["checkout_service"],
+        # ENC-TSK-L05 AC-1 (ENC-TSK-E68/PLN-031 Ph3 hardening fields).
+        # Role enceladus-checkout-service-role${EnvironmentSuffix} is deliberately
+        # NOT CFN-managed (02-compute.yaml:493-506 -- agent identity has an explicit
+        # IAM deny on iam:GetRole/ListRolePolicies, so the live policy document
+        # cannot be read). Actions below are derived from the actual boto3 calls
+        # in backend/lambda/checkout_service/lambda_function.py (dynamodb get_item/
+        # put_item/update_item/scan calls + secretsmanager get_secret_value for the
+        # GitHub App private key), not from a CFN Policy document.
+        "required_iam_actions": [
+            "dynamodb:GetItem",
+            "dynamodb:PutItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:Scan",
+            "secretsmanager:GetSecretValue",
+        ],
+        # _deploy.yml (Gen2 shared pipeline) is the only production-equivalent
+        # deploy path; it references exactly two secrets for every Lambda
+        # component it deploys (no per-component secret gating -- confirmed no
+        # matrix/strategy block, single `deploy` job, ThreadPoolExecutor fan-out).
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        # infrastructure/cloudformation/03-api.yaml: two Integrations target this
+        # function (CheckoutServiceIntegration lines 811-818 for the newer /plan/*
+        # routes; CheckoutApiIntegration lines 927-937, adopted out-of-band via
+        # ENC-TSK-J13 IMPORT, whose comment notes "live traffic uses this one" for
+        # the /task/* routes). Both integrations target the same live Lambda, so
+        # both route sets are declared here.
+        "required_apigw_routes": [
+            "POST /api/v1/checkout/{project}/plan/{planId}/checkout",
+            "DELETE /api/v1/checkout/{project}/plan/{planId}/checkout",
+            "POST /api/v1/checkout/{project}/plan/{planId}/advance",
+            "POST /api/v1/checkout/{project}/plan/{planId}/log",
+            "GET /api/v1/checkout/{project}/plan/{planId}/status",
+            "DELETE /api/v1/checkout/{project}/task/{taskId}/checkout",
+            "GET /api/v1/checkout/validate/commit-complete/{cciId}",
+            "GET /api/v1/checkout/{project}/task/{taskId}/status",
+            "POST /api/v1/checkout/{project}/task/{taskId}/advance",
+            "POST /api/v1/checkout/{project}/task/{taskId}/checkout",
+            "POST /api/v1/checkout/{project}/task/{taskId}/log",
+        ],
+        "required_cfn_resources": ["CheckoutServiceFunction", "CheckoutServiceIntegration", "CheckoutApiIntegration"],
+        "required_lambda_env_vars": [
+            "CHECKOUT_TOKENS_REGION",
+            "CHECKOUT_TOKENS_TABLE",
+            "COORDINATION_INTERNAL_API_KEY",
+            "ENCELADUS_COORDINATION_INTERNAL_API_KEY",
+            "GITHUB_PRIVATE_KEY_SECRET",
+            "GITHUB_APP_ID",
+            "GITHUB_INSTALLATION_ID",
+            "GITHUB_TOKEN",
+            "COGNITO_USER_POOL_ID",
+            "COGNITO_CLIENT_ID",
+            "CORS_ORIGIN",
+            "TRACKER_API_BASE",
+        ],
     },
     {
         "component_id": "comp-lifecycle-service",
@@ -131,6 +185,33 @@ KNOWN_COMPONENTS = [
             "architecture_sections": ["4.17"],
         },
         "deploy_targets": ["lifecycle_service"],
+        # ENC-TSK-L05 AC-1. Role LifecycleServiceRole is CFN-managed
+        # (02-compute.yaml:3749-3799, RoleName enceladus-lifecycle-service-lambda-role).
+        # Single inline policy grants read-only DynamoDB access (tracker,
+        # component-registry, projects tables) -- this service validates
+        # transitions, it does not invoke other Lambdas or publish events.
+        "required_iam_actions": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords",
+            "dynamodb:GetItem",
+            "dynamodb:Query",
+        ],
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        # No API Gateway Integration targets this function anywhere in
+        # 03-api.yaml -- it is invoked synchronously by tracker_mutation via
+        # lambda:InvokeFunction (TrackerMutationRole's invoke-lifecycle-service
+        # policy), never over HTTP. Empty is correct, not an oversight.
+        "required_apigw_routes": [],
+        "required_cfn_resources": ["LifecycleServiceFunction", "LifecycleServiceRole"],
+        "required_lambda_env_vars": [
+            "DYNAMODB_TABLE",
+            "DYNAMODB_REGION",
+            "COMPONENTS_TABLE",
+            "PROJECTS_TABLE",
+        ],
     },
     {
         "component_id": "comp-scoring-service",
@@ -154,6 +235,32 @@ KNOWN_COMPONENTS = [
             "architecture_sections": ["4.17"],
         },
         "deploy_targets": ["scoring_service"],
+        # ENC-TSK-L05 AC-1. Role ScoringServiceRole is CFN-managed
+        # (02-compute.yaml:3805-3841, RoleName enceladus-scoring-service-lambda-role).
+        # Pure SNS-triggered DynamoDB writer (lesson pillar_composite/resonance_score
+        # write-back on the tracker table) -- no other AWS API calls.
+        "required_iam_actions": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords",
+            "dynamodb:GetItem",
+            "dynamodb:UpdateItem",
+        ],
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        # No API Gateway Integration targets this function -- it subscribes to
+        # the enceladus-lesson-scoring SNS topic (ScoringServiceSubscription /
+        # ScoringServiceSnsPermission, 02-compute.yaml:603-617) and is never
+        # invoked over HTTP. Empty is correct, not an oversight.
+        "required_apigw_routes": [],
+        "required_cfn_resources": [
+            "ScoringServiceFunction",
+            "ScoringServiceRole",
+            "ScoringServiceSubscription",
+            "ScoringServiceSnsPermission",
+        ],
+        "required_lambda_env_vars": ["DYNAMODB_TABLE", "DYNAMODB_REGION"],
     },
     {
         "component_id": "comp-coordination-api",
@@ -177,6 +284,189 @@ KNOWN_COMPONENTS = [
             "architecture_sections": ["4.2", "5.1"],
         },
         "deploy_targets": ["coordination_api"],
+        # ENC-TSK-L05 AC-1. Role CoordinationApiRole is CFN-managed
+        # (02-compute.yaml:3302-3620, RoleName devops-coordination-api-lambda-role).
+        # Deduped action set across its Bedrock-dispatch + inline + AppConfig
+        # policies (this is the largest role in the stack -- coordination mode,
+        # governance, host-provisioning (EC2/SSM), Bedrock agent management, and
+        # Cognito client management all live in this one Lambda).
+        "required_iam_actions": [
+            "bedrock:InvokeAgent",
+            "lambda:InvokeFunction",
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords",
+            "dynamodb:GetItem",
+            "dynamodb:PutItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:DescribeTable",
+            "dynamodb:DeleteItem",
+            "s3:ListBucket",
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:HeadBucket",
+            "s3:GetBucketLocation",
+            "ssm:SendCommand",
+            "ssm:GetCommandInvocation",
+            "ssm:ListCommands",
+            "ssm:ListCommandInvocations",
+            "ssm:DescribeInstanceInformation",
+            "ec2:DescribeInstances",
+            "ec2:DescribeLaunchTemplates",
+            "ec2:DescribeLaunchTemplateVersions",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "ec2:CreateTags",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+            "sns:Publish",
+            "cognito-idp:InitiateAuth",
+            "cognito-idp:CreateUserPoolClient",
+            "cognito-idp:DeleteUserPoolClient",
+            "cognito-idp:DescribeUserPoolClient",
+            "cognito-idp:UpdateUserPoolClient",
+            "bedrock:CreateAgent",
+            "bedrock:GetAgent",
+            "bedrock:DeleteAgent",
+            "bedrock:PrepareAgent",
+            "bedrock:CreateAgentActionGroup",
+            "bedrock:GetAgentActionGroup",
+            "bedrock:DeleteAgentActionGroup",
+            "bedrock:CreateAgentAlias",
+            "bedrock:GetAgentAlias",
+            "bedrock:DeleteAgentAlias",
+            "bedrock:AssociateAgentKnowledgeBase",
+            "bedrock:DisassociateAgentKnowledgeBase",
+            "iam:PassRole",
+            "appconfig:GetConfiguration",
+            "appconfig:GetLatestConfiguration",
+            "appconfig:StartConfigurationSession",
+        ],
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        # infrastructure/cloudformation/03-api.yaml: CoordinationApiIntegration
+        # (lines 78-86) backs ~111 Route resources (many IsProduction/IsGamma
+        # twins of the same RouteKey). Deduped distinct RouteKeys below.
+        "required_apigw_routes": [
+            "POST /api/v1/coordination/requests",
+            "GET /api/v1/coordination/requests/{requestId}",
+            "POST /api/v1/coordination/requests/{requestId}/dispatch",
+            "POST /api/v1/coordination/requests/{requestId}/callback",
+            "POST /api/v1/cursor/webhook",
+            "GET /api/v1/coordination/capabilities",
+            "GET /api/v1/coordination/mcp",
+            "POST /api/v1/coordination/mcp",
+            "GET /api/v1/coordination/components",
+            "POST /api/v1/coordination/components",
+            "GET /api/v1/coordination/agents/sessions",
+            "GET /api/v1/coordination/agents/types",
+            "GET /api/v1/coordination/components/{componentId}",
+            "PATCH /api/v1/coordination/components/{componentId}",
+            "DELETE /api/v1/coordination/components/{componentId}",
+            "POST /api/v1/coordination/components/{componentId}/add_edge",
+            "POST /api/v1/coordination/components/{componentId}/remove_edge",
+            "POST /api/v1/coordination/components/{componentId}/deprecate",
+            "POST /api/v1/coordination/components/{componentId}/restore",
+            "POST /api/v1/coordination/components/{componentId}/revert",
+            "POST /api/v1/coordination/sessions/{sessionId}/message",
+            "DELETE /api/v1/coordination/auth/oauth-clients/{clientId}",
+            "DELETE /api/v1/coordination/auth/tokens/{tokenId}",
+            "GET /api/v1/coordination/auth/oauth-clients",
+            "GET /api/v1/coordination/auth/tokens",
+            "GET /api/v1/coordination/projects",
+            "GET /api/v1/coordination/projects/{projectId}",
+            "GET /api/v1/governance/dictionary",
+            "GET /api/v1/governance/hash",
+            "GET /api/v1/governance/{fileName+}",
+            "GET /api/v1/health",
+            "OPTIONS /api/v1/coordination/auth/cognito/session",
+            "OPTIONS /api/v1/coordination/auth/oauth-clients",
+            "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}",
+            "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/permissions",
+            "OPTIONS /api/v1/coordination/auth/oauth-clients/{clientId}/usage",
+            "OPTIONS /api/v1/coordination/auth/permissions/{tokenId}",
+            "OPTIONS /api/v1/coordination/auth/tokens",
+            "OPTIONS /api/v1/coordination/auth/tokens/{tokenId}",
+            "OPTIONS /api/v1/coordination/capabilities",
+            "OPTIONS /api/v1/coordination/mcp",
+            "OPTIONS /api/v1/coordination/projects",
+            "OPTIONS /api/v1/coordination/projects/{projectId}",
+            "OPTIONS /api/v1/coordination/requests",
+            "OPTIONS /api/v1/coordination/requests/{requestId}",
+            "OPTIONS /api/v1/coordination/requests/{requestId}/callback",
+            "OPTIONS /api/v1/coordination/requests/{requestId}/dispatch",
+            "PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/permissions",
+            "PATCH /api/v1/coordination/auth/oauth-clients/{clientId}/usage",
+            "PATCH /api/v1/coordination/auth/permissions/{tokenId}",
+            "POST /api/v1/coordination/auth/cognito/session",
+            "POST /api/v1/coordination/auth/oauth-clients",
+            "POST /api/v1/coordination/auth/tokens",
+            "POST /api/v1/coordination/components/propose",
+            "POST /api/v1/coordination/components/{componentId}/advance",
+            "POST /api/v1/coordination/components/{componentId}/approve",
+            "POST /api/v1/coordination/components/{componentId}/cloudwatch_event",
+            "POST /api/v1/coordination/components/{componentId}/reject",
+            "PUT /api/v1/governance/{fileName+}",
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/approve",
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/reject",
+            "GET /api/v1/coordination/escalations",
+            "GET /api/v1/coordination/escalations/watch",
+            "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve",
+            "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny",
+        ],
+        "required_cfn_resources": [
+            "CoordinationApiFunction",
+            "CoordinationApiRole",
+            "CoordinationBatchPollerRule",
+            "CoordinationBatchPollerPermission",
+            "AgentSessionIdleSweepSchedule",
+            "AgentSessionIdleSweepPermission",
+            "AgentSessionUnclaimSweepSchedule",
+            "AgentSessionUnclaimSweepPermission",
+            "IntentClassifierTrainingSchedule",
+            "IntentClassifierTrainingPermission",
+        ],
+        "required_lambda_env_vars": [
+            "COORDINATION_INTERNAL_API_KEY",
+            "COORDINATION_INTERNAL_API_KEY_PREVIOUS",
+            "COGNITO_USER_POOL_ID",
+            "COGNITO_CLIENT_ID",
+            "COORDINATION_TABLE",
+            "TRACKER_TABLE",
+            "RELATIONSHIPS_TABLE",
+            "PROJECTS_TABLE",
+            "DOCUMENTS_TABLE",
+            "DYNAMODB_REGION",
+            "SSM_REGION",
+            "SECRETS_REGION",
+            "CORS_ORIGIN",
+            "ENCELADUS_MCP_INTERFACE_MODE",
+            "DOCUMENT_API_LAMBDA_NAME",
+            "TRACKER_MUTATION_LAMBDA_NAME",
+            "CURSOR_WEBHOOK_SECRET",
+            "COMPONENTS_TABLE",
+            "GOVERNANCE_POLICIES_TABLE",
+            "AUTH_TOKENS_TABLE",
+            "GOVERNANCE_VERSION_TABLE",
+            "AGENT_SESSIONS_TABLE",
+            "AGENT_TYPES_TABLE",
+            "AGENT_CREDENTIALS_TABLE",
+            "AGENT_SESSIONS_IDLE_SWEEP_ENABLED",
+            "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS",
+            "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED",
+            "AGENT_SESSIONS_UNCLAIM_TTL_MINUTES",
+            "CHECKOUT_TOKENS_TABLE",
+            "AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS",
+            "APPCONFIG_APPLICATION",
+            "APPCONFIG_ENVIRONMENT",
+            "APPCONFIG_CONFIGURATION",
+            "TRAINING_HARD_DISABLED",
+            "INTENT_TRAINING_BUCKET",
+            "INTENT_TRAINING_PREFIX",
+        ],
     },
     {
         "component_id": "comp-tracker-mutation",
@@ -197,6 +487,76 @@ KNOWN_COMPONENTS = [
             "architecture_sections": ["4.1", "5.1"],
         },
         "deploy_targets": ["tracker_mutation"],
+        # ENC-TSK-L05 AC-1. Role TrackerMutationRole is CFN-managed
+        # (02-compute.yaml:3621-3745, RoleName devops-tracker-mutation-lambda-role).
+        # Deduped across its tracker-dynamodb, projects-read, eventbridge-put-events,
+        # AppConfig, invoke-lifecycle-service, and publish-lesson-scoring policies.
+        "required_iam_actions": [
+            "dynamodb:GetItem",
+            "dynamodb:PutItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:BatchWriteItem",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:DescribeTable",
+            "events:PutEvents",
+            "appconfig:GetConfiguration",
+            "appconfig:GetLatestConfiguration",
+            "appconfig:StartConfigurationSession",
+            "lambda:InvokeFunction",
+            "sns:Publish",
+        ],
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        # infrastructure/cloudformation/03-api.yaml: TrackerMutationIntegration
+        # (lines 87-94) plus a gamma-only TrackerMutationGammaLiveIntegration
+        # (lines 405-414, :live-alias-qualified, adopted for the gamma dedup/
+        # escalation surfaces). Deduped distinct RouteKeys across both.
+        "required_apigw_routes": [
+            "PATCH /{projectId}/{recordType}/{recordId}",
+            "PATCH /api/v1/tracker/{projectId}/{recordType}/{recordId}",
+            "DELETE /api/v1/tracker/{projectId}/relationship",
+            "DELETE /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout",
+            "GET /api/v1/tracker/pending-updates",
+            "GET /api/v1/tracker/{projectId}",
+            "GET /api/v1/tracker/{projectId}/relationship",
+            "GET /api/v1/tracker/{projectId}/{recordType}/{recordId}",
+            "OPTIONS /api/v1/tracker/pending-updates",
+            "OPTIONS /api/v1/tracker/{projectId}",
+            "OPTIONS /api/v1/tracker/{projectId}/relationship",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend",
+            "OPTIONS /api/v1/tracker/{projectId}/{recordType}/{recordId}/log",
+            "OPTIONS /{projectId}/{recordType}/{recordId}",
+            "POST /api/v1/tracker/{projectId}/{recordType}",
+            "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/acceptance-evidence",
+            "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/checkout",
+            "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/extend",
+            "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/log",
+            "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply",
+            "POST /api/v1/tracker/{projectId}/dedup-review",
+        ],
+        "required_cfn_resources": ["TrackerMutationFunction", "TrackerMutationRole"],
+        "required_lambda_env_vars": [
+            "COORDINATION_INTERNAL_API_KEY",
+            "COORDINATION_INTERNAL_API_KEY_PREVIOUS",
+            "COGNITO_USER_POOL_ID",
+            "COGNITO_CLIENT_ID",
+            "DYNAMODB_TABLE",
+            "RELATIONSHIPS_TABLE",
+            "DYNAMODB_REGION",
+            "PROJECTS_TABLE",
+            "AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS",
+            "APPCONFIG_APPLICATION",
+            "APPCONFIG_ENVIRONMENT",
+            "APPCONFIG_CONFIGURATION",
+            "LIFECYCLE_SERVICE_FUNCTION",
+            "LESSON_SCORING_TOPIC_ARN",
+            "ESCALATION_ALERTS_TOPIC_ARN",
+            "ENABLE_LESSON_PRIMITIVE",
+        ],
     },
     {
         "component_id": "comp-enceladus-mcp-server",
@@ -214,6 +574,27 @@ KNOWN_COMPONENTS = [
             "related": ["tools/enceladus-mcp-server/install_profile.sh"],
             "architecture_sections": ["8.1"],
         },
+        # ENC-TSK-L05 AC-1. This is a `library` component (server.py source), not
+        # a standalone deploy unit -- it has no `deploy_targets` entry (unlike the
+        # 5 lambda-category components above) and is architecturally different
+        # from them: the gamma runtime (EnceladusMcpCodeGammaFunction,
+        # 02-compute.yaml:6393-6501) is CFN-managed but Condition:IsProduction
+        # (created BY the prod stack, not gamma's own stack) and reuses the
+        # borrowed role devops-coordination-api-lambda-role-gamma rather than a
+        # role scoped to this component. The prod runtime (plain enceladus-mcp-code,
+        # no -gamma suffix) has NO CFN Function resource anywhere in the repo --
+        # it is entirely out-of-band/unmanaged and only appears as a literal ARN
+        # string in another component's (McpStreamingGatewayRole-adjacent
+        # DeployParityValidatorRole) IAM policy. Given this component owns neither
+        # a dedicated CFN-managed role nor a dedicated CFN Function resource of
+        # its own, all five fields are considered and left empty rather than
+        # attributing another component's borrowed/shared infrastructure to this
+        # one -- forcing values here would misrepresent drift-audit ownership.
+        "required_iam_actions": [],
+        "required_env_secrets": ["DM_GITHUB_READ_TOKEN", "COORDINATION_INTERNAL_API_KEY"],
+        "required_apigw_routes": [],
+        "required_cfn_resources": [],
+        "required_lambda_env_vars": [],
     },
     {
         "component_id": "comp-enceladus-pwa",
@@ -288,6 +669,22 @@ KNOWN_COMPONENTS = [
             },
             "architecture_sections": ["7.1", "7.2", "7.3", "7.4"],
         },
+        # ENC-TSK-L05 AC-1. Frontend component with no Lambda execution role of
+        # its own -- production-equivalent deploy path is .github/workflows/
+        # ui-backend-deploy.yml (job `deploy`, environment: v3-prod), which
+        # submits a DPL request via boto3/DynamoDB+SQS rather than calling
+        # S3/CloudFront APIs directly (the actual static-file publish executes
+        # in the devops-deployment-manager orchestrator, a different component's
+        # responsibility). required_iam_actions, required_apigw_routes,
+        # required_cfn_resources, and required_lambda_env_vars are considered
+        # and correctly empty: this component has no Lambda execution role, does
+        # not serve APIGW routes (it calls them, as a browser client), and has
+        # no dedicated CFN Function/resources of its own to track for drift.
+        "required_iam_actions": [],
+        "required_env_secrets": ["AWS_ROLE_TO_ASSUME", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+        "required_apigw_routes": [],
+        "required_cfn_resources": [],
+        "required_lambda_env_vars": [],
     },
     {
         "component_id": "comp-cloudformation-data",
@@ -304,6 +701,57 @@ KNOWN_COMPONENTS = [
             "directory": "infrastructure/cloudformation/",
             "architecture_sections": ["3.1", "3.2", "3.3"],
         },
+        # ENC-TSK-L05 AC-1. Infra-umbrella component -- this IS the entire
+        # 01-data.yaml template (no other component claims sub-resources within
+        # it), so listing its full logical-resource set is meaningful (unlike
+        # comp-cloudformation-app below, where 5 of ~35 Functions already have
+        # their own dedicated components). Deploy path: cloudformation-compute-
+        # stack-deploy.yml (data-stack change-set step; job-level
+        # AWS_CLOUDFORMATION_ROLE_TO_ASSUME secret, environment v3-prod/v4-gamma).
+        # required_iam_actions left empty: AWS_CLOUDFORMATION_ROLE_TO_ASSUME
+        # resolves to an externally-managed IAM role (GitHub secret, not a
+        # repo-declared CFN role) -- this agent's IAM identity is denied
+        # iam:GetRole/ListRolePolicies (per ENC-TSK-564), and no in-repo source
+        # enumerates that role's policy document, so this is a considered
+        # empty, not an oversight.
+        "required_iam_actions": [],
+        "required_env_secrets": ["AWS_CLOUDFORMATION_ROLE_TO_ASSUME"],
+        "required_apigw_routes": [],
+        "required_cfn_resources": [
+            "CoordinationRequestsTable",
+            "TrackerTable",
+            "RelationshipsTable",
+            "ProjectsTable",
+            "DocumentsTable",
+            "DriftTelemetryTable",
+            "StigmergicTraceTable",
+            "DeploymentManagerTable",
+            "GovernancePoliciesTable",
+            "ComponentRegistryTable",
+            "AgentComplianceViolationsTable",
+            "DeployQueue",
+            "FeedPublishQueue",
+            "GraphSyncQueue",
+            "GraphSyncDLQ",
+            "SearchIndexQueue",
+            "SearchIndexDLQ",
+            "ConvergenceTelemetryQueue",
+            "ConvergenceTelemetryDLQ",
+            "CoordinationDeadLetterTopic",
+            "FeedAlertsTopic",
+            "ParquetReadyTopic",
+            "ProjectJsonSyncTopic",
+            "ComponentRegistryEventsTopic",
+            "LessonScoringTopic",
+            "AgentSessionsTable",
+            "AgentTypesTable",
+            "AgentCredentialsTable",
+            "UserPreferencesTable",
+            "GovernanceVersionTable",
+            "PercolationTelemetryTable",
+            "ConvergenceTelemetryTable",
+        ],
+        "required_lambda_env_vars": [],
     },
     {
         "component_id": "comp-cloudformation-app",
@@ -321,6 +769,30 @@ KNOWN_COMPONENTS = [
             "related": ["infrastructure/lambda_workflow_manifest.json"],
             "architecture_sections": ["2.1", "4.0"],
         },
+        # ENC-TSK-L05 AC-1. Unlike comp-cloudformation-data, this umbrella's
+        # template (02-compute.yaml) already has 5 of its ~35 Lambda Functions
+        # registered as their OWN dedicated components (comp-checkout-service,
+        # comp-lifecycle-service, comp-scoring-service, comp-coordination-api,
+        # comp-tracker-mutation), each carrying its own required_cfn_resources
+        # now. Enumerating this umbrella's required_cfn_resources would mean
+        # either re-listing resources already owned/tracked by those dedicated
+        # components (double-booking drift ownership) or dumping the remaining
+        # ~30 unrelated Functions/Roles/EventBridge rules into a field with no
+        # scoping logic -- that re-scoping is explicitly ENC-TSK-L05 AC-4 (T4a,
+        # umbrella-per-CFn-file registration), which is out of scope for this
+        # AC-1-only pass and remains blocked on the same H-SCHEMA prerequisite
+        # as AC2-AC6. Left empty and considered, not force-filled, to avoid
+        # preempting AC-4's proper scoping decision.
+        "required_iam_actions": [],
+        "required_env_secrets": [
+            "AWS_CLOUDFORMATION_ROLE_TO_ASSUME",
+            "COORDINATION_INTERNAL_API_KEY",
+            "ENCELADUS_COGNITO_CLIENT_SECRET",
+            "CURSOR_WEBHOOK_SECRET",
+        ],
+        "required_apigw_routes": [],
+        "required_cfn_resources": [],
+        "required_lambda_env_vars": [],
     },
     # ── Harrisonfamily ───────────────────────────────────────────────────────
     {

--- a/tools/test_component_hardening_fields.py
+++ b/tools/test_component_hardening_fields.py
@@ -1,0 +1,136 @@
+"""Unit tests for the ENC-TSK-L05 AC-1 hardening-fields backfill.
+
+Covers tools/seed-component-registry.py's KNOWN_COMPONENTS (the five
+ENC-TSK-E68 fields on active enceladus-project entries) and the sibling
+verifier tools/verify_component_hardening_fields.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+MODULE_DIR = pathlib.Path(__file__).parent
+
+_HARDENING_FIELDS = (
+    "required_iam_actions",
+    "required_env_secrets",
+    "required_apigw_routes",
+    "required_cfn_resources",
+    "required_lambda_env_vars",
+)
+
+
+def _load_module(filename: str, module_name: str):
+    path = MODULE_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_seed():
+    return _load_module("seed-component-registry.py", "enceladus_seed_component_registry_under_test")
+
+
+def _active_enceladus_components(seed_module):
+    return [
+        c
+        for c in seed_module.KNOWN_COMPONENTS
+        if c.get("project_id") == "enceladus" and c.get("status") == "active"
+    ]
+
+
+def test_all_active_enceladus_components_declare_all_five_hardening_fields():
+    seed = _load_seed()
+    components = _active_enceladus_components(seed)
+    assert len(components) == 9, (
+        "Expected 9 active enceladus-project components at time of writing "
+        "(comp-checkout-service, comp-lifecycle-service, comp-scoring-service, "
+        "comp-coordination-api, comp-tracker-mutation, comp-enceladus-mcp-server, "
+        "comp-enceladus-pwa, comp-cloudformation-data, comp-cloudformation-app). "
+        "If this fails because a new component was added, extend this test's "
+        "expectations rather than deleting the assertion."
+    )
+    for comp in components:
+        cid = comp["component_id"]
+        for field in _HARDENING_FIELDS:
+            assert field in comp, f"{cid} is missing '{field}'"
+            assert isinstance(comp[field], list), f"{cid}.{field} must be a list"
+            assert all(isinstance(v, str) for v in comp[field]), (
+                f"{cid}.{field} must be a list of strings"
+            )
+
+
+def test_non_enceladus_components_are_untouched_by_this_backfill():
+    """AC-1 scope is enceladus-project active components only; this backfill
+    must not have added the hardening fields to other projects' entries."""
+    seed = _load_seed()
+    other_project_components = [
+        c for c in seed.KNOWN_COMPONENTS if c.get("project_id") != "enceladus"
+    ]
+    assert other_project_components, "sanity check: seed file should still have non-enceladus entries"
+    for comp in other_project_components:
+        for field in _HARDENING_FIELDS:
+            assert field not in comp, (
+                f"{comp['component_id']} (project={comp.get('project_id')}) "
+                f"unexpectedly has '{field}' -- ENC-TSK-L05 AC-1 scope is "
+                "enceladus-project components only"
+            )
+
+
+def test_lambda_components_have_nonempty_iam_actions_or_documented_reason():
+    """Every Lambda-category component either has a non-empty
+    required_iam_actions list, or is comp-checkout-service (whose role is
+    deliberately out-of-band / not CFN-managed, documented inline in the seed
+    file) -- an empty list must never be silently unconsidered."""
+    seed = _load_seed()
+    components = _active_enceladus_components(seed)
+    lambda_components = [c for c in components if c.get("category") == "lambda"]
+    assert len(lambda_components) == 5
+    for comp in lambda_components:
+        cid = comp["component_id"]
+        actions = comp["required_iam_actions"]
+        if cid == "comp-checkout-service":
+            # Out-of-band role; code-derived actions still populated (non-empty).
+            assert actions, f"{cid} should have code-derived IAM actions even though its role isn't CFN-managed"
+        else:
+            assert actions, f"{cid} (CFN-managed role) should have a non-empty required_iam_actions list"
+
+
+def test_apigw_routes_empty_for_non_http_lambdas():
+    """comp-lifecycle-service and comp-scoring-service are invoked
+    synchronously / via SNS respectively, never over HTTP -- their
+    required_apigw_routes must be empty, and non-empty for the three that do
+    serve routes."""
+    seed = _load_seed()
+    by_id = {c["component_id"]: c for c in _active_enceladus_components(seed)}
+
+    assert by_id["comp-lifecycle-service"]["required_apigw_routes"] == []
+    assert by_id["comp-scoring-service"]["required_apigw_routes"] == []
+
+    for cid in ("comp-checkout-service", "comp-coordination-api", "comp-tracker-mutation"):
+        assert by_id[cid]["required_apigw_routes"], f"{cid} should have non-empty required_apigw_routes"
+
+
+def test_required_transition_type_untouched():
+    """This backfill must not have disturbed the pre-existing F50
+    required_transition_type field on any entry."""
+    seed = _load_seed()
+    for comp in seed.KNOWN_COMPONENTS:
+        assert "required_transition_type" in comp, (
+            f"{comp['component_id']} lost its required_transition_type field"
+        )
+
+
+def test_verify_script_passes_against_current_seed_manifest():
+    """tools/verify_component_hardening_fields.py's seed-manifest audit
+    (no live probe) should exit 0 against the current KNOWN_COMPONENTS."""
+    verify = _load_module("verify_component_hardening_fields.py", "enceladus_verify_hardening_fields_under_test")
+    components = verify._load_seed_components()
+    failures, audited = verify._audit_seed(components)
+    assert audited == 9
+    assert failures == []

--- a/tools/verify_component_hardening_fields.py
+++ b/tools/verify_component_hardening_fields.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""ENC-TSK-L05 AC-1 — Pre-merge / spot-check guard for the five ENC-TSK-E68
+hardening fields on active enceladus-project component_registry entries.
+
+Runs two checks:
+
+1. **Seed manifest audit (always on).** Imports ``KNOWN_COMPONENTS`` from
+   ``tools/seed-component-registry.py`` and fails with exit code 1 if any
+   active enceladus-project entry is missing one of the five fields:
+   required_iam_actions, required_env_secrets, required_apigw_routes,
+   required_cfn_resources, required_lambda_env_vars. Per ENC-TSK-E68, each
+   field's *presence* (as a list, empty or not) is the bar — an empty list is
+   a valid, deliberate value (see comments in the seed file for the
+   per-component rationale on which fields are legitimately empty and why).
+   Only non-enceladus-project components and non-active components are
+   skipped, mirroring the AC-1 scope (this task never touched other
+   projects' entries).
+
+2. **Live registry probe (optional, gated by env var).** When
+   ``VERIFY_COMPONENT_HARDENING_LIVE=1`` is set, also queries the
+   coordination API and fails if any live enceladus-project component row is
+   missing one of the five fields.
+
+Usage:
+    # Default — audits the seed manifest only (used in PR CI / spot checks).
+    python3 tools/verify_component_hardening_fields.py
+
+    # Include live registry probe (run with Cognito/assistant creds).
+    VERIFY_COMPONENT_HARDENING_LIVE=1 \\
+        ENCELADUS_COORDINATION_INTERNAL_API_KEY=<key> \\
+        python3 tools/verify_component_hardening_fields.py
+
+Exit codes:
+    0 — all considered components pass
+    1 — one or more components missing a required field
+    2 — configuration error (e.g. seed import failed, API unreachable while
+        live probe requested)
+
+Related: ENC-TSK-L05 (B63 Ph2 H-BACKFILL AC-1), ENC-TSK-E68, ENC-PLN-031
+Phase 3, ENC-TSK-E69 (deploy_capability_auditor, the downstream consumer).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_HARDENING_FIELDS = (
+    "required_iam_actions",
+    "required_env_secrets",
+    "required_apigw_routes",
+    "required_cfn_resources",
+    "required_lambda_env_vars",
+)
+
+
+def _load_seed_components() -> list[dict[str, Any]]:
+    """Import KNOWN_COMPONENTS from the seed script without executing its CLI."""
+    seed_path = Path(__file__).resolve().parent / "seed-component-registry.py"
+    if not seed_path.exists():
+        print(f"FAIL(config): seed script not found at {seed_path}", file=sys.stderr)
+        sys.exit(2)
+    namespace: dict[str, Any] = {"__name__": "__not_main__"}
+    try:
+        exec(compile(seed_path.read_text(), str(seed_path), "exec"), namespace)
+    except Exception as exc:
+        print(f"FAIL(config): could not import seed script: {exc}", file=sys.stderr)
+        sys.exit(2)
+    components = namespace.get("KNOWN_COMPONENTS")
+    if not isinstance(components, list):
+        print("FAIL(config): KNOWN_COMPONENTS not a list in seed script", file=sys.stderr)
+        sys.exit(2)
+    return components
+
+
+def _in_scope(comp: dict[str, Any]) -> bool:
+    """ENC-TSK-L05 AC-1 scope: active components in the enceladus project."""
+    return comp.get("project_id") == "enceladus" and comp.get("status") == "active"
+
+
+def _audit_seed(components: list[dict[str, Any]]) -> tuple[list[str], int]:
+    """Return (failure reasons, count of in-scope components audited)."""
+    failures: list[str] = []
+    audited = 0
+    for comp in components:
+        if not _in_scope(comp):
+            continue
+        audited += 1
+        cid = comp.get("component_id") or "<unknown>"
+        missing_fields = [f for f in _HARDENING_FIELDS if f not in comp]
+        if missing_fields:
+            failures.append(
+                f"  - {cid}: missing field(s) {missing_fields} "
+                "(ENC-TSK-L05 AC-1 — every active enceladus component must "
+                "declare all five ENC-TSK-E68 hardening fields, even if the "
+                "considered value is an empty list)."
+            )
+            continue
+        non_list = [f for f in _HARDENING_FIELDS if not isinstance(comp.get(f), list)]
+        if non_list:
+            failures.append(f"  - {cid}: field(s) {non_list} present but not a list.")
+    return failures, audited
+
+
+def _live_probe(base_url: str, api_key: str, timeout_s: float = 10.0) -> list[str]:
+    url = f"{base_url.rstrip('/')}/components?project_id=enceladus"
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Content-Type": "application/json",
+            "X-Coordination-Internal-Key": api_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return [f"CONFIG_ERROR: coordination API returned HTTP {exc.code}: {exc.reason}"]
+    except Exception as exc:
+        return [f"CONFIG_ERROR: live probe failed: {exc}"]
+
+    items = body.get("components") or body.get("items") or []
+    if not isinstance(items, list):
+        return ["CONFIG_ERROR: API response missing 'components' array"]
+
+    failures: list[str] = []
+    for item in items:
+        if not _in_scope(item):
+            continue
+        cid = item.get("component_id") or "<unknown>"
+        missing_fields = [f for f in _HARDENING_FIELDS if f not in item]
+        if missing_fields:
+            failures.append(
+                f"  - {cid}: live registry row missing field(s) {missing_fields} "
+                "(run tools/backfill_component_hardening_fields.py)."
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enceladus component registry hardening-fields guard "
+            "(ENC-TSK-L05 AC-1 / ENC-TSK-E68)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--live-probe",
+        action="store_true",
+        help=(
+            "Probe the live coordination API in addition to auditing the seed "
+            "manifest. Overrides VERIFY_COMPONENT_HARDENING_LIVE. Requires "
+            "COORDINATION_API_BASE and ENCELADUS_COORDINATION_INTERNAL_API_KEY."
+        ),
+    )
+    args = parser.parse_args()
+
+    components = _load_seed_components()
+    failures, audited = _audit_seed(components)
+    print(f"Auditing {audited} active enceladus-project seed manifest entries "
+          "for the five ENC-TSK-E68 hardening fields…")
+    if failures:
+        print("\nFAIL: seed manifest audit", file=sys.stderr)
+        for line in failures:
+            print(line, file=sys.stderr)
+        return 1
+
+    print("PASS: every active enceladus-project seed manifest entry declares "
+          "all five hardening fields (required_iam_actions, "
+          "required_env_secrets, required_apigw_routes, "
+          "required_cfn_resources, required_lambda_env_vars).")
+
+    do_live = args.live_probe or os.environ.get("VERIFY_COMPONENT_HARDENING_LIVE") in {"1", "true", "yes"}
+    if not do_live:
+        print("(Live registry probe skipped. Set VERIFY_COMPONENT_HARDENING_LIVE=1 to enable.)")
+        return 0
+
+    base_url = os.environ.get("COORDINATION_API_BASE") or "https://jreese.net/api/v1/coordination"
+    api_key = os.environ.get("ENCELADUS_COORDINATION_INTERNAL_API_KEY") or os.environ.get(
+        "COORDINATION_INTERNAL_API_KEY"
+    )
+    if not api_key:
+        print(
+            "FAIL(config): live probe requested but no internal API key in env "
+            "(ENCELADUS_COORDINATION_INTERNAL_API_KEY or COORDINATION_INTERNAL_API_KEY).",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"Probing live registry at {base_url}…")
+    live_failures = _live_probe(base_url, api_key)
+    config_errors = [f for f in live_failures if f.startswith("CONFIG_ERROR")]
+    if config_errors:
+        for line in config_errors:
+            print(f"FAIL(config): {line}", file=sys.stderr)
+        return 2
+    if live_failures:
+        print("\nFAIL: live registry probe", file=sys.stderr)
+        for line in live_failures:
+            print(line, file=sys.stderr)
+        return 1
+
+    print("PASS: live registry rows all declare the five hardening fields.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Populates `required_iam_actions` / `required_env_secrets` / `required_apigw_routes` / `required_cfn_resources` / `required_lambda_env_vars` (ENC-TSK-E68 / ENC-PLN-031 Phase 3) on all 9 active enceladus-project components in `tools/seed-component-registry.py`, derived from `infrastructure/cloudformation/{01-data,02-compute,03-api}.yaml`, the GitHub Actions deploy workflows (`_deploy.yml`, `ui-backend-deploy.yml`, `cloudformation-compute-stack-deploy.yml`), and (for `comp-checkout-service`, whose IAM role is deliberately out-of-band per an explicit comment in `02-compute.yaml`) the actual boto3 calls in its Lambda source.
- Adds `tools/verify_component_hardening_fields.py`, a sibling to the existing `tools/verify_component_required_transition_type.py`, auditing presence of all five fields on active enceladus components.
- Adds `tools/backfill_component_hardening_fields.py`, a gamma-only backfill CLI (`--dry-run` supported) that PATCHes live `component-registry-gamma` rows via the coordination API — the only governed write path available, since direct DynamoDB writes are IAM-denied for `enceladus-agent-cli` (confirmed live during this task: a real `UpdateItem` attempt against `component-registry-gamma` returned `AccessDeniedException`).
- Adds `tools/test_component_hardening_fields.py` with unit coverage for the seed manifest shape and the verifier.

This is ENC-TSK-L05 **AC-1 only**. AC2-AC6 remain out of scope — they depend on the v3 component-registry schema (`component_address`/`component_repo_dir`/`component_address_class`/`component_class` + `required_transition_type` v3 enum) specified in DOC-157A790F9E8B, which was never shipped as its own task until a concurrent session picked it up moments ago as ENC-TSK-L77 ("H-SCHEMA"). This is documented on ENC-TSK-L05's worklog by three prior sessions (ENC-SES-040, ENC-SES-052, ENC-SES-057) and not re-litigated here.

**Known limitation surfaced by this PR**: the backfill script could not actually be run against live gamma in this session — the coordination API's internal API key is not provisioned to standard `enceladus-agent-cli` agent sessions, and Cognito PWA session auth is explicitly out of scope for MCP-adjacent mutations per governance. The script is dry-run-validated (correctly classifies live rows as unreachable without a key, does not crash or fabricate a write) and ready to run once a session with the internal key executes it.

CCI-c1c4be192e1a40dda1420bd691df9284

## Test plan

- [x] `python3 -m py_compile` on all 3 new/changed files
- [x] `python3 tools/verify_component_required_transition_type.py` — PASS (21/21, pre-existing check unaffected)
- [x] `python3 tools/verify_component_hardening_fields.py` — PASS (9/9 active enceladus components)
- [x] `python3 -m pytest tools/test_component_hardening_fields.py -v` — 6/6 passed
- [ ] Live gamma backfill run (`tools/backfill_component_hardening_fields.py --env gamma`) — blocked on coordination API internal key not being available to this agent session; documented as a known follow-up, not silently skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)