### PR TITLE
ENC-TSK-L80: bind project_id in graph_query_api adjacency count queries

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-05.23",
-  "updated_at": "2026-07-05T14:06:00Z",
-  "last_change_summary": "ENC-TSK-L43: graph_query_api hybrid keyword arm reads OpenSearch records_read (multi_match fuzziness AUTO + bool_prefix) with within-search facet aggs; circuit-breaker falls back to Neo4j keyword + feed/corpus facets. feed/corpus accepts X-Coordination-Internal-Key for service facet fallback.",
+  "version": "2026-07-07.1",
+  "updated_at": "2026-07-07T04:07:54Z",
+  "last_change_summary": "ENC-TSK-L80: graph_query_api._query_adjacency bound project_id on its node_count/edge_count Cypher queries (previously referenced $project_id in the query text but never passed it as a session.run() parameter, causing ParameterMissing on every offset=0 call). No schema/entity change — bugfix only, repo-file version bump per CI guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7631,8 +7631,13 @@
       "telemetry_eligible": true
     }
   },
-  "change_summary": "ENC-TSK-L42: register opensearch_backfill.lambda; merge L44 scoped indexer auth into search_index_core.",
+  "change_summary": "ENC-TSK-L80: bugfix, no schema change — graph_query_api._query_adjacency now binds project_id on its count queries.",
   "change_log": [
+    {
+      "version": "2026-07-07.1",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call — the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
+    },
     {
       "version": "2026-07-05.23",
       "date": "2026-07-05",

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -2750,13 +2750,15 @@ def _query_adjacency(driver, project_id: str, params: Dict) -> Dict:
         if offset == 0:
             node_count = int(
                 session.run(
-                    f"MATCH (n) WHERE {node_filter} RETURN count(n) AS c"
+                    f"MATCH (n) WHERE {node_filter} RETURN count(n) AS c",
+                    project_id=project_id,
                 ).single()["c"]
             )
             edge_count = int(
                 session.run(
                     f"{edge_match} "
-                    "RETURN count(DISTINCT [a.record_id, b.record_id]) AS c"
+                    "RETURN count(DISTINCT [a.record_id, b.record_id]) AS c",
+                    project_id=project_id,
                 ).single()["c"]
             )
         page = session.run(

--- a/backend/lambda/graph_query_api/test_spurious_attractor_ftr105.py
+++ b/backend/lambda/graph_query_api/test_spurious_attractor_ftr105.py
@@ -42,6 +42,10 @@ class _FakeAdjacencySession:
         return False
 
     def run(self, cypher, **params):
+        if "$project_id" in cypher:
+            assert "project_id" in params, (
+                f"cypher references $project_id but no project_id was bound: {cypher!r}"
+            )
         if "RETURN count(n) AS c" in cypher:
             return _FakeSingleResult(self._node_count)
         if "RETURN count(DISTINCT" in cypher:


### PR DESCRIPTION
## Summary
- `_query_adjacency`'s node_count/edge_count `session.run()` calls referenced `$project_id` in their Cypher text but never bound it as a parameter, so every `offset=0` adjacency call failed with `Neo.ClientError.Statement.ParameterMissing`.
- This is the exact call shape ENC-TSK-K41's CEE Lambda makes every night for its relational-entropy detector — the detector has been silently running against an empty edge list since deploy (not just logging an error).
- Strengthened the FTR-105 adjacency test fake session to assert any `$project_id` reference has a bound `project_id` param, so this regression class fails loudly in CI going forward.

## Test plan
- [x] `pytest backend/lambda/graph_query_api/test_spurious_attractor_ftr105.py` — 8/8 pass (verified failing against pre-fix code, passing against the fix)
- [x] `pytest backend/lambda/graph_query_api/` (full package) — 303 passed, 14 subtests passed
- [x] `tools/verify_lambda_workflow_coverage.py` / `tools/verify_lambda_arch_parity.py` — both pass
- [ ] Post-merge: live `curl` of gamma `/api/v1/tracker/graphsearch?search_type=adjacency` returns 200 with real node_count/edge_count
- [ ] Post-merge: tonight's K41 CEE Lambda cron run completes with zero graph_query_api errors

CCI-64df6ae154154155a9f5eac1bcbeb729

🤖 Generated with [Claude Code](https://claude.com/claude-code)