### PR TITLE
ENC-TSK-L81: add missing energy-function + corroboration-function AppConfig profiles

### DIFF
--- a/infrastructure/cloudformation/09-appconfig-governance.yaml
+++ b/infrastructure/cloudformation/09-appconfig-governance.yaml
@@ -156,6 +156,124 @@ Resources:
       DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
       Description: "Initial activation - placeholder, ENC-TSK-K33"
 
+  # ---------------------------------------------------------------------------
+  # energy-function — graph_query_api retrieval-energy lambda weights
+  # (ENC-TSK-I98 / ENC-FTR-104). Activates energy_function.py::load_lambda_weights(),
+  # which has read this profile by convention since I98 but had no CFN resource
+  # behind it — every read fell through to the env-var/hardcoded-default path
+  # and logged a ConfigurationProfile-not-found error on every graph_query_api
+  # invocation (found live 2026-07-07 during ENC-TSK-B66 dashboard validation).
+  # ---------------------------------------------------------------------------
+
+  EnergyFunctionProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      Name: energy-function
+      LocationUri: hosted
+      Description: >-
+        Retrieval-energy lambda weights (lambda_graph, lambda_kw), live-
+        overridable per ENC-TSK-I98.
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "properties": {
+                "lambda_graph": { "type": "number", "minimum": 0 },
+                "lambda_kw":    { "type": "number", "minimum": 0 }
+              },
+              "additionalProperties": { "type": "number" }
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: energy-function
+
+  EnergyFunctionInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      ConfigurationProfileId: !Ref EnergyFunctionProfile
+      ContentType: application/json
+      Description: >-
+        Initial version - mirrors DEFAULT_LAMBDA_GRAPH/DEFAULT_LAMBDA_KW in
+        energy_function.py exactly, so activation is a no-op until someone
+        deliberately pushes a change.
+      Content: |
+        {
+          "lambda_graph": 1.0,
+          "lambda_kw": 0.1
+        }
+
+  EnergyFunctionInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      EnvironmentId: !Ref AppConfigEnvironmentId
+      ConfigurationProfileId: !Ref EnergyFunctionProfile
+      ConfigurationVersion: !Ref EnergyFunctionInitialVersion
+      DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
+      Description: "Initial activation - defaults match hardcoded fallback, closes missing-profile log noise"
+
+  # ---------------------------------------------------------------------------
+  # corroboration-function — graph_query_api corroboration Weber-Fechner
+  # constant (ENC-FTR-110). Same class of gap as energy-function above: read
+  # by convention since corroboration.py landed, no CFN resource behind it.
+  # ---------------------------------------------------------------------------
+
+  CorroborationFunctionProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      Name: corroboration-function
+      LocationUri: hosted
+      Description: >-
+        Corroboration Weber-Fechner constant (weber_k), live-overridable per
+        ENC-FTR-110.
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+              "properties": {
+                "weber_k": { "type": "number", "minimum": 0 }
+              },
+              "additionalProperties": { "type": "number" }
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: corroboration-function
+
+  CorroborationFunctionInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      ConfigurationProfileId: !Ref CorroborationFunctionProfile
+      ContentType: application/json
+      Description: >-
+        Initial version - mirrors DEFAULT_WEBER_K in corroboration.py exactly,
+        so activation is a no-op until someone deliberately pushes a change.
+      Content: |
+        {
+          "weber_k": 0.3
+        }
+
+  CorroborationFunctionInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      EnvironmentId: !Ref AppConfigEnvironmentId
+      ConfigurationProfileId: !Ref CorroborationFunctionProfile
+      ConfigurationVersion: !Ref CorroborationFunctionInitialVersion
+      DeploymentStrategyId: !Ref BudgetHierarchyDeploymentStrategy
+      Description: "Initial activation - defaults match hardcoded fallback, closes missing-profile log noise"
+
 Outputs:
   BudgetHierarchyProfileId:
     Value: !Ref BudgetHierarchyProfile
@@ -166,3 +284,13 @@ Outputs:
     Value: !Ref GovernanceDoctrineProfile
     Export:
       Name: !Sub "${AWS::StackName}-GovernanceDoctrineProfileId"
+
+  EnergyFunctionProfileId:
+    Value: !Ref EnergyFunctionProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-EnergyFunctionProfileId"
+
+  CorroborationFunctionProfileId:
+    Value: !Ref CorroborationFunctionProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-CorroborationFunctionProfileId"


### PR DESCRIPTION
## Summary
- `energy_function.py` and `corroboration.py` (graph_query_api) have read AppConfig configuration profiles `energy-function` and `corroboration-function` by convention since ENC-TSK-I98/ENC-FTR-110, but neither profile was ever CFN-codified.
- Every graph_query_api invocation logged an AppConfig-extension `ConfigurationProfile not found` ERROR (found live 2026-07-07 during ENC-TSK-B66 dashboard validation), even though both readers gracefully fall back to hard-coded defaults — functionally harmless but noisy.
- Adds both profiles to `09-appconfig-governance.yaml` mirroring the existing `budget-hierarchy`/`governance-doctrine` pattern, with initial hosted-config content matching each module's existing hard-coded fallback exactly (`lambda_graph=1.0`, `lambda_kw=0.1`, `weber_k=0.3`), so activation is a no-op behavior change.

## Test plan
- [x] CFN template validated via `aws cloudformation validate-template` and `cfn-lint` (clean)
- [ ] Post-merge: `aws appconfig list-configuration-profiles --application-id fhhcl7m` shows both new profiles
- [ ] Post-merge: CloudWatch Logs for `devops-graph-query-api-gamma` show zero `ConfigurationProfile not found` errors after deploy

CCI-44b405a36818440dab19e4583fa1db14

🤖 Generated with [Claude Code](https://claude.com/claude-code)