### PR TITLE
ENC-TSK-L82: add missing CFN deploy workflow for 09-appconfig-governance.yaml

### DIFF
--- a/.github/workflows/cloudformation-appconfig-governance-stack-deploy.yml
+++ b/.github/workflows/cloudformation-appconfig-governance-stack-deploy.yml
@@ -1,0 +1,218 @@
+name: CloudFormation AppConfig Governance Stack Deploy
+
+# ENC-TSK-L81: 09-appconfig-governance.yaml had no dedicated deploy workflow
+# since it was first stood up under ENC-TSK-K33 — every other CFN template in
+# this repo has one (see cloudformation-monitoring-stack-deploy.yml, which
+# this file mirrors), but this one was apparently applied once manually and
+# never wired into CI. Found while trying to ship the energy-function /
+# corroboration-function profile additions and hitting a real deploy gap:
+# no workflow watches this path, and the agent's own IAM identity is denied
+# cloudformation:CreateChangeSet against this stack (by design).
+#
+# Same plan/apply split with a GitHub Environment gate as the other
+# cloudformation-*-stack-deploy.yml workflows (ENC-TSK-J63 / ENC-FTR-120):
+# the plan job creates (but does not execute) the change-set; the apply job
+# runs inside a GitHub Environment — v3-prod (required reviewer: io) for
+# main, v4-gamma (no reviewer) for v4/**. AppConfigApplicationId /
+# AppConfigEnvironmentId are NOT passed here — CFN deploy reuses the
+# stack's already-stored parameter values (they never change post-creation).
+
+on:
+  push:
+    branches:
+      - main
+      - 'v4/**'
+    paths:
+      - "infrastructure/cloudformation/09-appconfig-governance.yaml"
+      - ".github/workflows/cloudformation-appconfig-governance-stack-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 09-appconfig-governance template"
+        type: string
+        required: false
+        default: "enceladus-appconfig-governance"
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual appconfig-governance stack deploy"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-appconfig-governance-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/09-appconfig-governance.yaml
+  ENVIRONMENT_SUFFIX: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
+  DEFAULT_STACK_NAME: enceladus-appconfig-governance
+
+jobs:
+  plan:
+    name: Plan AppConfig Governance stack change-set
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        run: |
+          set -euo pipefail
+          stack_name="${{ github.event.inputs.stack_name || env.DEFAULT_STACK_NAME }}${ENVIRONMENT_SUFFIX}"
+          echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Clean up ROLLBACK_COMPLETE stack if present (gamma self-heal, prod fail-closed)
+        run: |
+          set -euo pipefail
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${stack_name}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          if [ "${status}" = "ROLLBACK_COMPLETE" ]; then
+            if [ "${ENVIRONMENT_SUFFIX}" = "-gamma" ]; then
+              echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy (gamma self-heal)"
+              aws cloudformation delete-stack \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              aws cloudformation wait stack-delete-complete \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              echo "Stack deleted successfully"
+            else
+              echo "::error::Prod stack ${stack_name} is in ROLLBACK_COMPLETE — refusing to auto-delete a prod stack; remediate manually."
+              exit 1
+            fi
+          fi
+
+      - name: Create AppConfig Governance stack change-set (no execute)
+        id: changeset
+        run: |
+          set -euo pipefail
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 09-appconfig-governance/ \
+            --parameter-overrides \
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## AppConfig Governance stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## AppConfig Governance stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply AppConfig Governance stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          echo "=== Stack events (last 20) ==="
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"
+
+      - name: Report deployed stack state
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -85,6 +85,13 @@
       ],
       "notes": "ENC-TSK-J63 plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
     },
+    "cloudformation-appconfig-governance-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-L82; mirrors cloudformation-monitoring-stack-deploy.yml plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
+    },
     "cloudformation-ui-cdn-stack-deploy.yml": {
       "class": "conditional",
       "gated_jobs": [
@@ -119,7 +126,7 @@
       "gated_jobs": [
         "patch-role"
       ],
-      "notes": "ENC-PLN-068: environment: v3-prod — grant EventBridge Scheduler ops to CloudFormationDeployRole for Rhythm Cycle"
+      "notes": "ENC-PLN-068: environment: v3-prod \u2014 grant EventBridge Scheduler ops to CloudFormationDeployRole for Rhythm Cycle"
     },
     "iam-cfn-deploy-role-gamma-patch.yml": {
       "class": "prod-mutating",


### PR DESCRIPTION
## Summary
- Every other CFN template in this repo has a dedicated `cloudformation-*-stack-deploy.yml` (01-data/02-compute, 03-api, 05-monitoring, 07-codedeploy, 07-ui-cdn, 08-agent-auth, 10-opensearch-node) — except `09-appconfig-governance.yaml`, which was applied once manually under ENC-TSK-K33 and never wired into CI.
- This meant ENC-TSK-L81's `energy-function`/`corroboration-function` AppConfig profile additions (already merged to v4/main in #908) had no path to actually reach gamma: the agent's own IAM identity is correctly denied `cloudformation:CreateChangeSet` directly against this stack (by design, per this repo's IAM security model).
- Adds `cloudformation-appconfig-governance-stack-deploy.yml`, mirroring `cloudformation-monitoring-stack-deploy.yml`'s plan/apply split with a GitHub Environment gate (ENC-FTR-120): v4-gamma has no required reviewer (deploys automatically on merge to v4/main), v3-prod requires io review.
- `AppConfigApplicationId`/`AppConfigEnvironmentId` are intentionally left unspecified in the deploy step — `aws cloudformation deploy` reuses the stack's already-stored parameter values (they never change post-creation), same pattern the monitoring workflow relies on for its own unlisted params.

## Test plan
- [x] Mirrors an existing, working workflow pattern exactly (only template/stack-name identifiers changed)
- [ ] Post-merge: plan+apply jobs run automatically against `enceladus-appconfig-governance-gamma` and complete successfully
- [ ] Post-merge: `aws appconfig list-configuration-profiles --application-id fhhcl7m` shows `energy-function` and `corroboration-function`

CCI-9edd7d43c4964717afc799ca3516e1d9

🤖 Generated with [Claude Code](https://claude.com/claude-code)