### PR TITLE
ENC-TSK-L83: add IAM patch workflow for AppConfig governance deploy role

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-appconfig-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appconfig-patch.yml
@@ -1,0 +1,100 @@
+name: IAM CFN Deploy Role — AppConfig Governance Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant appconfig:Create*/Get*/Tag*/Delete* on the fhhcl7m application to the CFN deploy role (ENC-TSK-L83, enceladus-appconfig-governance-gamma UPDATE_ROLLBACK_COMPLETE due to missing appconfig:CreateConfigurationProfile permission)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with AppConfig governance-stack permissions
+    # ENC-TSK-K59 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule, same as the sibling iam-cfn-deploy-role-*-patch.yml workflows.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — AppConfig governance stack bootstrap
+        run: |
+          set -euo pipefail
+          cat > /tmp/appconfig-governance-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AppConfigGovernanceApplicationScope",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:CreateConfigurationProfile",
+                  "appconfig:GetConfigurationProfile",
+                  "appconfig:UpdateConfigurationProfile",
+                  "appconfig:DeleteConfigurationProfile",
+                  "appconfig:ListConfigurationProfiles",
+                  "appconfig:TagResource",
+                  "appconfig:UntagResource",
+                  "appconfig:ListTagsForResource"
+                ],
+                "Resource": [
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m",
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/configurationprofile/*"
+                ]
+              },
+              {
+                "Sid": "AppConfigGovernanceHostedVersionsAndDeployments",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:CreateHostedConfigurationVersion",
+                  "appconfig:GetHostedConfigurationVersion",
+                  "appconfig:DeleteHostedConfigurationVersion",
+                  "appconfig:ListHostedConfigurationVersions",
+                  "appconfig:StartDeployment",
+                  "appconfig:GetDeployment",
+                  "appconfig:StopDeployment",
+                  "appconfig:ListDeployments"
+                ],
+                "Resource": [
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/configurationprofile/*",
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/environment/*"
+                ]
+              },
+              {
+                "Sid": "AppConfigGovernanceDeploymentStrategy",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:GetDeploymentStrategy",
+                  "appconfig:ListDeploymentStrategies"
+                ],
+                "Resource": "arn:aws:appconfig:us-west-2:356364570033:deploymentstrategy/*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-appconfig-governance-v1" \
+            --policy-document "file:///tmp/appconfig-governance-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-appconfig-governance-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -142,6 +142,13 @@
       ],
       "notes": "ENC-TSK-K59: environment: v3-prod \u2014 despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml)"
     },
+    "iam-cfn-deploy-role-appconfig-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L83: environment: v3-prod -- despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml / iam-cfn-deploy-role-gamma-patch.yml)"
+    },
     "iam-cfn-deploy-role-opensearch-ec2-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
- `enceladus-appconfig-governance-gamma`'s update (triggered by the new ENC-TSK-L82 deploy workflow, #910) rolled back to `UPDATE_ROLLBACK_COMPLETE`: `enceladus-cloudformation-deploy-github-role` lacks `appconfig:CreateConfigurationProfile`, confirmed via CFN stack events (`HandlerErrorCode: AccessDenied`).
- The existing `budget-hierarchy`/`governance-doctrine` profiles were evidently created via a different, more privileged path (manual, pre-CI) than this automated role has ever needed to exercise — this is genuinely the first time an automated deploy has tried to create AppConfig profiles.
- Adds `iam-cfn-deploy-role-appconfig-patch.yml`, `workflow_dispatch`-only, `environment: v3-prod` — mirroring the existing `iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml` pattern exactly, since this is a shared-role IAM mutation (ENC-FTR-120) that requires io review regardless of the gamma-only blast radius of the resource it unblocks.
- Scoped to the `fhhcl7m` application ARN only, not account-wide `*`.

This PR only *adds* a dispatch-gated workflow file — it does not itself mutate any IAM policy. Running it (a separate step, after merge) will pause on the v3-prod required-reviewer gate for explicit approval.

## Test plan
- [x] Mirrors an existing, working IAM-patch workflow pattern exactly (only policy statements/resource ARNs changed)
- [ ] Post-merge: `workflow_dispatch` this workflow, io approves the v3-prod gate, inline policy `enceladus-cfn-deploy-appconfig-governance-v1` attached
- [ ] Re-run ENC-TSK-L82's deploy workflow; `enceladus-appconfig-governance-gamma` reaches `UPDATE_COMPLETE`

CCI-3d659ddf11094d57a2e70ce86fbd2c5c

🤖 Generated with [Claude Code](https://claude.com/claude-code)