### PR TITLE
ENC-TSK-L83: add IAM patch workflow to main (workflow_dispatch discovery)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-appconfig-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appconfig-patch.yml
@@ -1,0 +1,100 @@
+name: IAM CFN Deploy Role — AppConfig Governance Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant appconfig:Create*/Get*/Tag*/Delete* on the fhhcl7m application to the CFN deploy role (ENC-TSK-L83, enceladus-appconfig-governance-gamma UPDATE_ROLLBACK_COMPLETE due to missing appconfig:CreateConfigurationProfile permission)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with AppConfig governance-stack permissions
+    # ENC-TSK-K59 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule, same as the sibling iam-cfn-deploy-role-*-patch.yml workflows.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — AppConfig governance stack bootstrap
+        run: |
+          set -euo pipefail
+          cat > /tmp/appconfig-governance-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AppConfigGovernanceApplicationScope",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:CreateConfigurationProfile",
+                  "appconfig:GetConfigurationProfile",
+                  "appconfig:UpdateConfigurationProfile",
+                  "appconfig:DeleteConfigurationProfile",
+                  "appconfig:ListConfigurationProfiles",
+                  "appconfig:TagResource",
+                  "appconfig:UntagResource",
+                  "appconfig:ListTagsForResource"
+                ],
+                "Resource": [
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m",
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/configurationprofile/*"
+                ]
+              },
+              {
+                "Sid": "AppConfigGovernanceHostedVersionsAndDeployments",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:CreateHostedConfigurationVersion",
+                  "appconfig:GetHostedConfigurationVersion",
+                  "appconfig:DeleteHostedConfigurationVersion",
+                  "appconfig:ListHostedConfigurationVersions",
+                  "appconfig:StartDeployment",
+                  "appconfig:GetDeployment",
+                  "appconfig:StopDeployment",
+                  "appconfig:ListDeployments"
+                ],
+                "Resource": [
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/configurationprofile/*",
+                  "arn:aws:appconfig:us-west-2:356364570033:application/fhhcl7m/environment/*"
+                ]
+              },
+              {
+                "Sid": "AppConfigGovernanceDeploymentStrategy",
+                "Effect": "Allow",
+                "Action": [
+                  "appconfig:GetDeploymentStrategy",
+                  "appconfig:ListDeploymentStrategies"
+                ],
+                "Resource": "arn:aws:appconfig:us-west-2:356364570033:deploymentstrategy/*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-appconfig-governance-v1" \
+            --policy-document "file:///tmp/appconfig-governance-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-appconfig-governance-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -247,6 +247,13 @@
         "execute"
       ],
       "notes": "ENC-TSK-M98 / ENC-ISS-538 canonical->gamma tracker mirror. Mutates ONLY -gamma DynamoDB tables (in-tool direction lock: source hard-coded to devops-project-tracker read-only, every write target must end -gamma). dry_run job is read-only; execute job requires typed confirm phrase OVERWRITE-GAMMA AND environment: gamma-mirror (io one-time setup: add required_reviewers to gamma-mirror before first execute, ENC-TSK-N01)."
+    },
+    "iam-cfn-deploy-role-appconfig-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L83: environment: v3-prod — grants appconfig profile/hosted-version/deployment ops on application fhhcl7m to the SHARED CFN deploy role (rhythm-tenants + appconfig-governance stack unblock)"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Same-content copy of the workflow already merged to v4/main in #912.
- GitHub only discovers `workflow_dispatch`-triggerable workflows from the **default branch** (main) — confirmed the sibling `iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml` already lives on `main` for exactly this reason.
- No `push` trigger — merging this does not execute anything automatically. It only makes the workflow appear in the Actions dispatch list. The actual IAM patch still requires `workflow_dispatch` + io approval on the `v3-prod` required-reviewer gate, same as every sibling `iam-cfn-deploy-role-*-patch.yml`.

⚠️ Not auto-merging this one — it targets `main`, which is outside this session's gamma-only deploy authorization. Flagging for explicit review.

CCI-3d659ddf11094d57a2e70ce86fbd2c5c

🤖 Generated with [Claude Code](https://claude.com/claude-code)