### PR TITLE
ENC-TSK-L06 hotfix: CFN deploy role secretsmanager:GetRandomPassword

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-secretsmanager-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-secretsmanager-patch.yml
@@ -1,0 +1,83 @@
+name: IAM CFN Deploy Role — Secrets Manager GetRandomPassword Patch
+
+# ENC-TSK-L06: CloudFormationDeployRole lacked secretsmanager:GetRandomPassword (and
+# scoped CreateSecret/TagResource/DescribeSecret on enceladus/id-service/*), blocking
+# the new IdServiceHmacSecret resource (AWS::SecretsManager::Secret with
+# GenerateSecretString) from being created on the enceladus-compute-gamma deploy
+# (UPDATE_ROLLBACK_COMPLETE 2026-07-07). GetRandomPassword is the action CFN's
+# GenerateSecretString calls internally to mint secret material server-side before
+# CreateSecret — it has no resource type in IAM and must be Resource: "*".
+# Durable fix in 04-github-roles.yaml; this one-off dispatch applies the grant live
+# ahead of the next github-roles stack deploy, mirroring the
+# iam-cfn-deploy-role-scheduler-patch.yml / iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+# precedent.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "ENC-TSK-L06 — grant secretsmanager:GetRandomPassword + scoped CreateSecret to CloudFormationDeployRole for IdServiceHmacSecret"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with Secrets Manager grants for ID Service secret
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — Secrets Manager (ID Service secret provisioning)
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          cat > /tmp/cfn-deploy-role-secretsmanager-idservice.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "SecretsManagerIdServiceProvision",
+                "Effect": "Allow",
+                "Action": [
+                  "secretsmanager:CreateSecret",
+                  "secretsmanager:TagResource",
+                  "secretsmanager:DescribeSecret"
+                ],
+                "Resource": "arn:aws:secretsmanager:us-west-2:${ACCOUNT_ID}:secret:enceladus/id-service/*"
+              },
+              {
+                "Sid": "SecretsManagerGetRandomPassword",
+                "Effect": "Allow",
+                "Action": "secretsmanager:GetRandomPassword",
+                "Resource": "*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-secretsmanager-idservice-v1" \
+            --policy-document "file:///tmp/cfn-deploy-role-secretsmanager-idservice.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-secretsmanager-idservice-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -599,6 +599,32 @@ Resources:
                 Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Sub "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:devops/coordination/*"
+              # ENC-TSK-L06 / B63 Phase 2 AC-6: the ID Service's HMAC provenance-signing
+              # secret is declared as a CFN-managed AWS::SecretsManager::Secret resource
+              # (02-compute.yaml IdServiceHmacSecret) using GenerateSecretString so no
+              # plaintext ever passes through a git commit or an agent session. CFN's
+              # GenerateSecretString mechanism calls secretsmanager:GetRandomPassword
+              # internally to generate the value BEFORE the CreateSecret call -- that
+              # action does not support resource-level scoping in IAM (AWS requires
+              # Resource: "*" for it; confirmed via the live rollback failure on
+              # enceladus-compute-gamma 2026-07-07: "not authorized to perform:
+              # secretsmanager:GetRandomPassword ... (Service: SecretsManager)").
+              # CreateSecret/TagResource are scoped to the enceladus/id-service/*
+              # secret path only.
+              - Sid: SecretsManagerIdServiceProvision
+                Effect: Allow
+                Action:
+                  - secretsmanager:CreateSecret
+                  - secretsmanager:TagResource
+                  - secretsmanager:DescribeSecret
+                Resource: !Sub "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:enceladus/id-service/*"
+              - Sid: SecretsManagerGetRandomPassword
+                Effect: Allow
+                # GetRandomPassword has no resource type in IAM (must be "*"); it is the
+                # mechanism CFN's GenerateSecretString calls internally to mint secret
+                # material server-side, never exposing plaintext to this role's caller.
+                Action: secretsmanager:GetRandomPassword
+                Resource: "*"
               - Sid: EC2Fleet
                 Effect: Allow
                 Action:

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -149,6 +149,13 @@
       ],
       "notes": "ENC-TSK-L83: environment: v3-prod -- despite the gamma-scoped grant, it patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml / iam-cfn-deploy-role-gamma-patch.yml)"
     },
+    "iam-cfn-deploy-role-secretsmanager-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L06: environment: v3-prod -- patches the SHARED CFN deploy role object with secretsmanager:GetRandomPassword (Resource: \"*\", required by CFN's GenerateSecretString mechanism) plus scoped CreateSecret/TagResource/DescribeSecret on enceladus/id-service/* (same shared-role pattern as iam-cfn-deploy-role-appconfig-patch.yml / iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml / iam-cfn-deploy-role-gamma-patch.yml)"
+    },
     "iam-cfn-deploy-role-opensearch-ec2-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary

Follow-up to #911 (ENC-TSK-L06 ID Service Lambda). The `enceladus-compute-gamma` CFN stack deploy triggered by #911 merging to `v4/main` rolled back:

```
IdServiceHmacSecret CREATE_FAILED: User: arn:aws:sts::...assumed-role/enceladus-cloudformation-deploy-github-role/GitHubActions
is not authorized to perform: secretsmanager:GetRandomPassword because no identity-based policy allows the
secretsmanager:GetRandomPassword action (Service: SecretsManager)
```

`IdServiceHmacSecret` is a CFN-managed `AWS::SecretsManager::Secret` resource using `GenerateSecretString` so the HMAC signing key is minted server-side — no plaintext ever passes through a git commit or an agent session. CFN's `GenerateSecretString` mechanism calls `secretsmanager:GetRandomPassword` internally before `CreateSecret`, and that action has no resource type in IAM (must be `Resource: "*"`).

## Changes
- `infrastructure/cloudformation/04-github-roles.yaml`: durable fix — new `SecretsManagerIdServiceProvision` (CreateSecret/TagResource/DescribeSecret scoped to `enceladus/id-service/*`) and `SecretsManagerGetRandomPassword` (`Resource: "*"`, required by the API) statements on `CloudFormationDeployRole`.
- `.github/workflows/iam-cfn-deploy-role-secretsmanager-patch.yml`: one-off `workflow_dispatch` patch (mirrors the `iam-cfn-deploy-role-scheduler-patch.yml` / `iam-cfn-deploy-role-eventbridge-listrules-patch.yml` precedent) to apply the grant live via `AWS_BACKEND_ROLE_TO_ASSUME`, ahead of the next full `04-github-roles.yaml` stack deploy picking it up.

## Test plan
- [x] YAML validation on both files
- [x] `cfn-lint` — no new errors (pre-existing unrelated `E3031` on the file, confirmed present on clean `v4/main` baseline too)
- [ ] Run the patch workflow via `workflow_dispatch` immediately after merge
- [ ] Re-trigger `enceladus-compute-gamma` deploy and confirm `IdServiceHmacSecret` + the rest of the ID Service stack create successfully

CCI-23bb2c14d35b4e16af7230fd95e8c041