### PR TITLE
ENC-TSK-L06: add IAM patch workflow to main (workflow_dispatch discovery)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-secretsmanager-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-secretsmanager-patch.yml
@@ -1,0 +1,83 @@
+name: IAM CFN Deploy Role — Secrets Manager GetRandomPassword Patch
+
+# ENC-TSK-L06: CloudFormationDeployRole lacked secretsmanager:GetRandomPassword (and
+# scoped CreateSecret/TagResource/DescribeSecret on enceladus/id-service/*), blocking
+# the new IdServiceHmacSecret resource (AWS::SecretsManager::Secret with
+# GenerateSecretString) from being created on the enceladus-compute-gamma deploy
+# (UPDATE_ROLLBACK_COMPLETE 2026-07-07). GetRandomPassword is the action CFN's
+# GenerateSecretString calls internally to mint secret material server-side before
+# CreateSecret — it has no resource type in IAM and must be Resource: "*".
+# Durable fix in 04-github-roles.yaml; this one-off dispatch applies the grant live
+# ahead of the next github-roles stack deploy, mirroring the
+# iam-cfn-deploy-role-scheduler-patch.yml / iam-cfn-deploy-role-eventbridge-listrules-patch.yml
+# precedent.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "ENC-TSK-L06 — grant secretsmanager:GetRandomPassword + scoped CreateSecret to CloudFormationDeployRole for IdServiceHmacSecret"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with Secrets Manager grants for ID Service secret
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — Secrets Manager (ID Service secret provisioning)
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          cat > /tmp/cfn-deploy-role-secretsmanager-idservice.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "SecretsManagerIdServiceProvision",
+                "Effect": "Allow",
+                "Action": [
+                  "secretsmanager:CreateSecret",
+                  "secretsmanager:TagResource",
+                  "secretsmanager:DescribeSecret"
+                ],
+                "Resource": "arn:aws:secretsmanager:us-west-2:${ACCOUNT_ID}:secret:enceladus/id-service/*"
+              },
+              {
+                "Sid": "SecretsManagerGetRandomPassword",
+                "Effect": "Allow",
+                "Action": "secretsmanager:GetRandomPassword",
+                "Resource": "*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-secretsmanager-idservice-v1" \
+            --policy-document "file:///tmp/cfn-deploy-role-secretsmanager-idservice.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-secretsmanager-idservice-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -149,6 +149,13 @@
       ],
       "notes": "ENC-TSK-K09: environment: v3-prod — patches the SHARED CFN deploy role object with lambda:*FunctionUrlConfig on enceladus-mcp-code-gamma (ENC-TSK-K07 unblock)."
     },
+    "iam-cfn-deploy-role-secretsmanager-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-L06: environment v3-prod — patches the SHARED CFN deploy role object (SecretsManager GetSecretValue grant for the ID Service HMAC secret); same pattern as iam-cfn-deploy-role-gamma-patch.yml"
+    },
     "iam-cloudformation-unblock.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
- Same-content copy of the workflow already merged to v4/main in #914.
- GitHub only discovers `workflow_dispatch`-triggerable workflows from the **default branch** (main) — confirmed the sibling `iam-cfn-deploy-role-appconfig-patch.yml` case (ENC-TSK-L83 / PR #913) hit the exact same issue.
- No `push` trigger — merging this does not execute anything automatically. It only makes the workflow appear in the Actions dispatch list. The actual IAM patch still requires `workflow_dispatch` + io approval on the `v3-prod` required-reviewer gate, same as every sibling `iam-cfn-deploy-role-*-patch.yml`.

⚠️ Not auto-merging this one — it targets `main`, which is outside this session's gamma-only deploy authorization (DOC-499FA089EC30, v3-prod frozen pending final cutover). Flagging for explicit review, mirroring PR #913's own stated caution for the identical situation.

CCI-23bb2c14d35b4e16af7230fd95e8c041