### PR TITLE
ENC-TSK-L90: arm GDMP Stage-1 mutation-ramp (gamma) per io directive #2

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2477,8 +2477,10 @@ Resources:
   # Compliance/Semantic detector output and deterministically resolves a
   # whitelist of compliance_warnings classes via documents.patch, advancing
   # raw documents to compliant maturity_state with no agent involvement.
-  # DATA-SAFETY: GDMP_DRY_RUN=1, GDMP_MUTATION_ENABLED=0, GDMP_IO_APPROVAL_RUNS=3
+  # DATA-SAFETY: GDMP_DRY_RUN=0, GDMP_MUTATION_ENABLED=1, GDMP_IO_APPROVAL_RUNS=3
   # (FTR-106 AC-4 io-approval-ramp pattern, same shape as UnlearningFunction).
+  # Stage-1 mutation-ramp ARMED 2026-07-07 per io directive #2 (ENC-TSK-L90);
+  # code-enforced ramp still holds the next 3 live nightly runs candidate-only.
   # CEE_GDMP_HARD_DISABLED is the mandatory kill switch (ISS-465 cost-preflight
   # precedent), checked first thing in the handler. Gamma-only (Condition:
   # IsGamma): v3-prod is frozen (DOC-499FA089EC30).
@@ -2518,19 +2520,24 @@ Resources:
           GDMP_STATE_BUCKET: !Ref S3Bucket
           GDMP_STATE_PREFIX: !Sub "${S3EnvPrefix}gdmp-remediation-state"
           GDMP_MAX_DOCS_PER_RUN: "200"
-          # DATA-SAFETY defaults -- io clears CEE_GDMP_HARD_DISABLED and later
-          # flips GDMP_MUTATION_ENABLED only after IO_APPROVAL_RUNS candidate
-          # reports have been reviewed. Mirrors UNLEARNING_* (K03) convention.
-          GDMP_DRY_RUN: "1"
-          GDMP_MUTATION_ENABLED: "0"
+          # DATA-SAFETY: Stage-1 mutation-ramp ARMED 2026-07-07 per io directive
+          # #2 (ENC-TSK-L90). After the initial IO_APPROVAL_RUNS candidate
+          # reports were reviewed, io flipped GDMP_DRY_RUN "1"->"0" and
+          # GDMP_MUTATION_ENABLED "0"->"1". Mirrors UNLEARNING_* (K03) convention.
+          # Mutation remains gated by the code-enforced io-approval ramp: the
+          # handler's mutation_allowed() keeps the next 3 live nightly runs
+          # candidate-report-only (run_count < GDMP_IO_APPROVAL_RUNS; the counter
+          # increments only on non-dry runs and is currently 0) before the 4th
+          # live run performs real documents.patch remediation.
+          GDMP_DRY_RUN: "0"
+          GDMP_MUTATION_ENABLED: "1"
           GDMP_IO_APPROVAL_RUNS: "3"
           # ISS-465-style kill switch -- installed disabled by default; io
           # clears to "0" to enable. Mirrors CEE_HARD_DISABLED (K41) /
           # UNLEARNING_MUTATION_ENABLED (K03) sibling convention.
-          # Cleared 2026-07-02 per io: lets the Lambda run on its initial
-          # nightly schedule. GDMP_DRY_RUN stays "1" / GDMP_MUTATION_ENABLED
-          # stays "0" -- this produces real candidate reports without
-          # mutating any documents yet (ENC-TSK-K42).
+          # Cleared 2026-07-02 per io; remains "0" through the 2026-07-07
+          # mutation-ramp flip -- the io-approval ramp (not this kill switch)
+          # now governs when live mutation begins (ENC-TSK-K42 / ENC-TSK-L90).
           CEE_GDMP_HARD_DISABLED: "0"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]


### PR DESCRIPTION
## ENC-TSK-L90 — GDMP Stage-1 mutation-ramp enable (io directive #2, 2026-07-07)

Flips two env vars on `CorpusEntropyGdmpRemediationFunction` (`Condition: IsGamma`) in `infrastructure/cloudformation/02-compute.yaml`:

- `GDMP_DRY_RUN` `"1"` → `"0"`
- `GDMP_MUTATION_ENABLED` `"0"` → `"1"`

Left unchanged: `GDMP_IO_APPROVAL_RUNS="3"`, `CEE_GDMP_HARD_DISABLED="0"`. The `IsGamma` condition is **unaltered**, so v3-prod is structurally untouched (gamma-only). DATA-SAFETY comments updated to record the flip.

### DATA-SAFETY — ramp is code-enforced
`mutation_allowed()` = `not dry_run AND mutation_enabled AND run_count >= GDMP_IO_APPROVAL_RUNS(3)`. The persisted run counter increments **only on non-dry runs** (`lambda_function.py:279-280`) and is currently **0** (every nightly run since 2026-07-02 was dry). So this flip **arms** the ramp but keeps the next **3 live nightly runs candidate-report-only**; the **4th** live run is the first to perform real `documents.patch` remediation. Matches the directive's DONE-WHEN.

Feeds ENC-TSK-K42 / ENC-TSK-B66 (PLN-006 Phase 5). Deploys to the gamma compute stack via v4/main.

CCI-715b3d75876747d9845a1a297f8637cd