### PR TITLE
ENC-TSK-L85: swap dead graph-sync EventBridge Pipes for direct Lambda ESM (gamma)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.4",
-  "updated_at": "2026-07-07T05:41:00Z",
-  "last_change_summary": "ENC-TSK-L84: opensearch_indexer.lambda CDC transport swapped from EventBridge Pipes (DynamoDB-stream source, confirmed account-wide non-functional per ENC-ISS-497) to a direct Lambda EventSourceMapping on the tracker + documents DynamoDB streams. Handler now accepts both the legacy SQS-wrapped shape and the native direct-stream shape. Legacy SQS trigger + Pipes disabled, not deleted.",
+  "version": "2026-07-07.5",
+  "updated_at": "2026-07-07T11:35:12Z",
+  "last_change_summary": "ENC-TSK-L85: graph_sync.lambda CDC transport swapped from EventBridge Pipes (DynamoDB-stream source, confirmed account-wide non-functional per ENC-ISS-497, same fix pattern as ENC-TSK-L84) to a direct Lambda EventSourceMapping on the tracker + documents DynamoDB streams, gamma only. Handler now accepts both the legacy SQS-wrapped shape and the native direct-stream shape. Legacy SQS trigger disabled on gamma only (Fn::If, v3-prod unchanged), not deleted; Pipes left in place.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7675,8 +7675,13 @@
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
     }
   },
-  "change_summary": "ENC-TSK-L06: new ID Service Lambda extraction (B63 Phase 2 AC-6) with IAM-isolated counter allocation, idempotency contract, HMAC provenance signing, and trust-score feedback loop.",
+  "change_summary": "ENC-TSK-L85: graph_sync CDC transport swapped from dead EventBridge Pipes to direct Lambda EventSourceMapping, gamma only.",
   "change_log": [
+    {
+      "version": "2026-07-07.5",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L85: graph_sync.lambda CDC transport swapped from EventBridge Pipes (DynamoDB-stream source, confirmed account-wide non-functional per ENC-ISS-497, same fix pattern as ENC-TSK-L84) to a direct Lambda EventSourceMapping (GraphSyncTrackerStreamTrigger / GraphSyncDocumentsStreamTrigger) on the tracker + documents DynamoDB streams. Gamma only: GraphSyncFunction/GraphSyncRole/GraphSyncSqsTrigger are shared prod(v3)+gamma resources with no Condition, so every change is scoped via Fn::If or a new Condition: IsGamma resource -- v3-prod's deployed behavior is unchanged even on a future redeploy of this template. Handler now accepts both the legacy SQS-wrapped shape and the native direct-stream shape (correct messageId vs SequenceNumber failure identifiers). Legacy GraphSyncSqsTrigger disabled on gamma only, left enabled on prod/v3, not deleted; Pipes left in place."
+    },
     {
       "version": "2026-07-07.3",
       "date": "2026-07-07",

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -4,8 +4,27 @@ Triggered by SQS FIFO queue (devops-graph-sync-queue.fifo) which receives
 events from an EventBridge Pipe connected to the devops-project-tracker
 DynamoDB Stream.
 
-Flow:
+ENC-TSK-L85: EventBridge Pipes with a DynamoDB Streams source were confirmed
+account-wide non-functional (StateReason=No records processed, zero
+throughput -- see ENC-ISS-497, same root cause already fixed for
+search-index via ENC-TSK-L84). On gamma, CDC now runs via direct
+AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB
+streams (GraphSyncTrackerStreamTrigger / GraphSyncDocumentsStreamTrigger).
+This handler accepts BOTH event shapes so the old SQS-fed path
+(GraphSyncSqsTrigger, disabled on gamma but left enabled on prod/v3, not
+deleted) and the new direct-stream path can coexist during rollback windows:
+  - SQS-wrapped: event.Records[].body is a JSON string containing the raw
+    DynamoDB stream record. Failure identifier = SQS messageId.
+  - Direct DynamoDB Streams ESM: event.Records[] IS the raw stream record
+    (eventName/dynamodb at the top level, no body/messageId). Failure
+    identifier = dynamodb.SequenceNumber per the DynamoDB Streams
+    ReportBatchItemFailures contract (NOT eventID).
+
+Flow (prod/v3, unchanged):
   DynamoDB Streams -> EventBridge Pipe -> SQS FIFO -> This Lambda
+  -> MERGE/DELETE Cypher operations against AuraDB Free
+Flow (gamma):
+  DynamoDB Streams -> Lambda EventSourceMapping (direct) -> This Lambda
   -> MERGE/DELETE Cypher operations against AuraDB Free
 
 The graph is a READ-ONLY derived index. DynamoDB remains the sole source
@@ -1491,6 +1510,18 @@ def _delete_node(tx, record_id: str) -> None:
 # SQS event processing
 # ---------------------------------------------------------------------------
 
+def _record_source_and_identifier(raw_record: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+    """Classify a Records[] entry as 'sqs' or 'ddb_stream' and return its
+    ReportBatchItemFailures identifier (messageId for SQS, SequenceNumber for
+    a direct DynamoDB Streams ESM). See ENC-TSK-L85 / ENC-TSK-L84."""
+    if "body" in raw_record or "messageId" in raw_record or "messageID" in raw_record:
+        message_id = raw_record.get("messageId") or raw_record.get("messageID")
+        return "sqs", message_id
+    # Direct DynamoDB Streams ESM: the record itself has eventName/dynamodb.
+    sequence_number = (raw_record.get("dynamodb") or {}).get("SequenceNumber")
+    return "ddb_stream", sequence_number
+
+
 def _extract_stream_record(sqs_body: Dict) -> Optional[Dict]:
     """Extract the DynamoDB stream record from an SQS message body."""
     # EventBridge Pipe wraps stream records in the SQS body
@@ -1676,20 +1707,26 @@ def _process_record(driver, stream_record: Dict) -> None:
 # ---------------------------------------------------------------------------
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """SQS-triggered handler. Processes DynamoDB stream records from EventBridge Pipe.
+    """Processes DynamoDB stream records, from either the legacy SQS-fed path
+    (GraphSyncSqsTrigger, prod/v3) or the direct DynamoDB Streams
+    EventSourceMapping (GraphSyncTrackerStreamTrigger /
+    GraphSyncDocumentsStreamTrigger, gamma -- ENC-TSK-L85). See
+    _record_source_and_identifier for the shape-classification contract.
 
     ENC-TSK-L74: reports the Lambda partial-batch-failure contract
-    (batchItemFailures) so SQS retries only the records that actually failed.
-    Without this, a batch response of plain HTTP 200 -- which is what a bare
-    `except Exception: continue` produces regardless of per-record errors --
-    tells SQS the WHOLE batch succeeded, so it deletes every message in it,
-    including the ones that raised. Those records' MENTIONS edges (and any
-    other graph writes from _process_record) are then silently and
-    permanently lost, with no retry and no DLQ delivery, despite this
-    function's prior comments claiming otherwise. Requires
+    (batchItemFailures) so the source retries only the records that actually
+    failed. Without this, a batch response of plain HTTP 200 -- which is what
+    a bare `except Exception: continue` produces regardless of per-record
+    errors -- tells the source the WHOLE batch succeeded, so it deletes every
+    message/record in it, including the ones that raised. Those records'
+    MENTIONS edges (and any other graph writes from _process_record) are then
+    silently and permanently lost, with no retry and no DLQ delivery, despite
+    this function's prior comments claiming otherwise. Requires
     FunctionResponseTypes: [ReportBatchItemFailures] on the event source
     mapping (infrastructure/cloudformation/02-compute.yaml
-    GraphSyncSqsTrigger) for batchItemFailures to actually take effect."""
+    GraphSyncSqsTrigger / GraphSyncTrackerStreamTrigger /
+    GraphSyncDocumentsStreamTrigger) for batchItemFailures to actually take
+    effect."""
     records = event.get("Records", [])
     if not records:
         return {"statusCode": 200, "body": "no records"}
@@ -1697,37 +1734,44 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     driver = _get_neo4j_driver()
     if driver is None:
         logger.error("[ERROR] Neo4j driver unavailable; failing whole batch for retry")
-        # Report every message as failed so SQS retries the whole batch once
-        # Neo4j is reachable again, instead of deleting it and losing every
-        # record's graph write.
-        return {"batchItemFailures": [
-            {"itemIdentifier": r.get("messageId")} for r in records if r.get("messageId")
-        ]}
+        # Report every record as failed so the source retries the whole batch
+        # once Neo4j is reachable again, instead of deleting it and losing
+        # every record's graph write. Identifier depends on event shape
+        # (ENC-TSK-L85): SQS messageId, or direct-ESM SequenceNumber.
+        failures = []
+        for r in records:
+            _source, identifier = _record_source_and_identifier(r)
+            if identifier:
+                failures.append({"itemIdentifier": identifier})
+        return {"batchItemFailures": failures}
 
     processed = 0
     errors = 0
-    failed_message_ids: List[str] = []
+    failed_identifiers: List[str] = []
 
-    for sqs_record in records:
-        message_id = sqs_record.get("messageId")
+    for raw_record in records:
+        source, identifier = _record_source_and_identifier(raw_record)
         try:
-            body = sqs_record.get("body", "{}")
-            if isinstance(body, str):
-                body = json.loads(body)
+            if source == "sqs":
+                body = raw_record.get("body", "{}")
+                if isinstance(body, str):
+                    body = json.loads(body)
+                stream_record = _extract_stream_record(body)
+            else:
+                stream_record = raw_record
 
-            stream_record = _extract_stream_record(body)
             if stream_record and "dynamodb" in stream_record:
                 _process_record(driver, stream_record)
                 processed += 1
         except Exception:
             errors += 1
-            logger.exception("[ERROR] Failed to process SQS record")
-            if message_id:
-                failed_message_ids.append(message_id)
+            logger.exception("[ERROR] Failed to process %s record identifier=%s", source, identifier)
+            if identifier:
+                failed_identifiers.append(identifier)
 
     logger.info("[INFO] Batch complete: processed=%d, errors=%d, total=%d", processed, errors, len(records))
 
-    if failed_message_ids:
-        return {"batchItemFailures": [{"itemIdentifier": mid} for mid in failed_message_ids]}
+    if failed_identifiers:
+        return {"batchItemFailures": [{"itemIdentifier": fid} for fid in failed_identifiers]}
 
     return {"statusCode": 200, "body": json.dumps({"processed": processed, "errors": errors})}

--- a/backend/lambda/graph_sync/test_partial_batch_failures_l74.py
+++ b/backend/lambda/graph_sync/test_partial_batch_failures_l74.py
@@ -1,6 +1,10 @@
 """Tests for ENC-TSK-L74: handler() reports batchItemFailures instead of
 silently losing MENTIONS edges (and any other graph write) for records whose
-processing raised, when they share a batch with a successful record."""
+processing raised, when they share a batch with a successful record.
+
+ENC-TSK-L85: also covers the direct DynamoDB Streams EventSourceMapping event
+shape (gamma), alongside the legacy SQS-wrapped shape (prod/v3), and the
+correct SequenceNumber-vs-messageId failure-identifier semantics for each."""
 import json
 import unittest
 from unittest.mock import MagicMock, patch
@@ -16,6 +20,18 @@ class TestHandlerPartialBatchFailures(unittest.TestCase):
             "dynamodb": {"Keys": {}, "NewImage": {}},
         } if ok else {"not": "a stream record shape that raises"}
         return {"messageId": message_id, "body": json.dumps(body)}
+
+    def _ddb_stream_record(self, sequence_number, event_name="INSERT"):
+        """Native DynamoDB Streams ESM shape (no body/messageId wrapper)."""
+        return {
+            "eventID": "unused-not-the-failure-identifier",
+            "eventName": event_name,
+            "dynamodb": {
+                "SequenceNumber": sequence_number,
+                "Keys": {},
+                "NewImage": {},
+            },
+        }
 
     def test_one_failure_in_batch_reports_only_that_message_id(self):
         good = self._sqs_record("msg-good")
@@ -56,6 +72,61 @@ class TestHandlerPartialBatchFailures(unittest.TestCase):
     def test_empty_records_returns_plain_200(self):
         result = self.lf.handler({"Records": []}, None)
         self.assertEqual(result, {"statusCode": 200, "body": "no records"})
+
+    def test_direct_ddb_stream_shape_classified_correctly(self):
+        """ENC-TSK-L85: event.Records[] entries with no body/messageId are the
+        raw stream record itself; failure identifier must be SequenceNumber,
+        never eventID (the DynamoDB Streams ReportBatchItemFailures contract
+        keys off SequenceNumber, not eventID)."""
+        rec = self._ddb_stream_record("seq-1")
+        source, identifier = self.lf._record_source_and_identifier(rec)
+        self.assertEqual(source, "ddb_stream")
+        self.assertEqual(identifier, "seq-1")
+
+    def test_sqs_shape_still_classified_as_sqs(self):
+        rec = self._sqs_record("msg-1")
+        source, identifier = self.lf._record_source_and_identifier(rec)
+        self.assertEqual(source, "sqs")
+        self.assertEqual(identifier, "msg-1")
+
+    def test_direct_ddb_stream_failure_reports_sequence_number(self):
+        good = self._ddb_stream_record("seq-good")
+        bad = self._ddb_stream_record("seq-bad")
+        event = {"Records": [good, bad]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=MagicMock()), \
+             patch.object(self.lf, "_process_record", side_effect=[None, RuntimeError("boom")]):
+            result = self.lf.handler(event, None)
+
+        self.assertIn("batchItemFailures", result)
+        self.assertEqual(result["batchItemFailures"], [{"itemIdentifier": "seq-bad"}])
+
+    def test_mixed_sqs_and_direct_ddb_stream_batch(self):
+        """A rollback window can have both event sources wired simultaneously
+        (old SQS trigger left enabled on prod/v3, new direct ESM on gamma) --
+        handler must classify and process each record independently."""
+        sqs_good = self._sqs_record("msg-good")
+        ddb_good = self._ddb_stream_record("seq-good")
+        event = {"Records": [sqs_good, ddb_good]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=MagicMock()), \
+             patch.object(self.lf, "_extract_stream_record", return_value={"dynamodb": {}}), \
+             patch.object(self.lf, "_process_record", return_value=None):
+            result = self.lf.handler(event, None)
+
+        self.assertNotIn("batchItemFailures", result)
+        self.assertEqual(result["statusCode"], 200)
+        self.assertEqual(json.loads(result["body"])["processed"], 2)
+
+    def test_neo4j_unavailable_fails_entire_batch_direct_ddb_stream_shape(self):
+        event = {"Records": [self._ddb_stream_record("seq-1"), self._ddb_stream_record("seq-2")]}
+
+        with patch.object(self.lf, "_get_neo4j_driver", return_value=None):
+            result = self.lf.handler(event, None)
+
+        self.assertIn("batchItemFailures", result)
+        ids = {f["itemIdentifier"] for f in result["batchItemFailures"]}
+        self.assertEqual(ids, {"seq-1", "seq-2"})
 
 
 if __name__ == "__main__":

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2745,6 +2745,17 @@ Resources:
         - ReportBatchItemFailures
       Enabled: true
 
+  # ENC-TSK-L85: TrackerToGraphPipe/DocumentsToGraphPipe (EventBridge Pipes,
+  # DynamoDB Streams source) were confirmed account-wide non-functional
+  # (ENC-ISS-497, same root cause already fixed for search-index via
+  # ENC-TSK-L84). This SQS trigger was the downstream leg of that dead path.
+  # On gamma, CDC now runs via GraphSyncTrackerStreamTrigger /
+  # GraphSyncDocumentsStreamTrigger below, a direct Lambda
+  # EventSourceMapping on the same streams. GraphSyncFunction/GraphSyncRole
+  # are shared prod(v3)+gamma resources (no Condition), so the disable is
+  # scoped with Fn::If rather than a resource-level Condition -- v3-prod
+  # keeps Enabled: true unchanged; only gamma flips to false. Left defined
+  # (not removed) for rollback.
   GraphSyncSqsTrigger:
     Type: AWS::Lambda::EventSourceMapping
     DeletionPolicy: Retain
@@ -2761,6 +2772,61 @@ Resources:
       # FeedPublisherSqsTrigger above.
       FunctionResponseTypes:
         - ReportBatchItemFailures
+      Enabled: !If [IsGamma, false, true]
+
+  # ---------------------------------------------------------------------------
+  # ENC-TSK-L85: DynamoDB Stream -> Lambda EventSourceMapping (direct, no
+  # SQS/Pipes intermediary), gamma only. Replaces TrackerToGraphPipe /
+  # DocumentsToGraphPipe after EventBridge Pipes with a DynamoDB Streams
+  # source were confirmed account-wide non-functional (ENC-ISS-497:
+  # StateReason=No records processed, zero throughput -- same root cause
+  # already fixed for search-index via ENC-TSK-L84). Mirrors the
+  # already-proven-working AppSyncFeedTrackerStreamTrigger pattern in
+  # 06-appsync-events.yaml and the ENC-TSK-L84 SearchIndex*StreamTrigger
+  # pattern above. FilterCriteria preserves the retired Pipes' record_type
+  # scoping, and additionally splits INSERT/MODIFY (NewImage-based filter)
+  # from REMOVE (OldImage-based filter) so REMOVE events -- which have no
+  # NewImage -- are no longer silently dropped by a NewImage-only filter
+  # (a latent gap in the original Pipes' filter design, independent of the
+  # account-wide outage).
+  # ---------------------------------------------------------------------------
+
+  GraphSyncTrackerStreamTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-TrackerStreamArn
+      FunctionName: !Ref GraphSyncFunction
+      BatchSize: 10
+      MaximumBatchingWindowInSeconds: 0
+      StartingPosition: LATEST
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"eventName":["INSERT","MODIFY"],"dynamodb":{"NewImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+          - Pattern: '{"eventName":["REMOVE"],"dynamodb":{"OldImage":{"record_type":{"S":[{"anything-but":"reference"}]}}}}'
+      Enabled: true
+
+  GraphSyncDocumentsStreamTrigger:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsGamma
+    DeletionPolicy: Retain
+    Properties:
+      EventSourceArn: !ImportValue
+        Fn::Sub: ${DataStackName}-DocumentsStreamArn
+      FunctionName: !Ref GraphSyncFunction
+      BatchSize: 10
+      MaximumBatchingWindowInSeconds: 0
+      StartingPosition: LATEST
+      FunctionResponseTypes:
+        - ReportBatchItemFailures
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"eventName":["INSERT","MODIFY"]}'
+          - Pattern: '{"eventName":["REMOVE"]}'
       Enabled: true
 
   # ENC-TSK-L84: disabled, not deleted. TrackerToSearchIndexPipe /
@@ -5497,6 +5563,35 @@ Resources:
                   - bedrock:InvokeModel
                 Resource:
                   - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.titan-embed-text-v2:0"
+        # ENC-TSK-L85: direct DynamoDB Streams EventSourceMapping replacing the
+        # dead Pipes-DynamoDB-source path (ENC-ISS-497), gamma only for now
+        # (v3-prod frozen). Added unconditionally on this shared role (like
+        # the policies above) since it's an inert read-only grant with no new
+        # ESM configured against it in prod under this template -- SqsEventSource
+        # above is retained (not removed) since GraphSyncSqsTrigger stays
+        # defined, just disabled on gamma, for rollback.
+        - PolicyName: DynamoDbStreamEventSource
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ReadTrackerStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-TrackerStreamArn
+              - Sid: ReadDocumentsStream
+                Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !ImportValue
+                  Fn::Sub: ${DataStackName}-DocumentsStreamArn
       Tags:
         - Key: Project
           Value: enceladus


### PR DESCRIPTION
## Summary
- `TrackerToGraphPipe`/`DocumentsToGraphPipe` (EventBridge Pipes, DynamoDB Streams source) confirmed account-wide non-functional (ENC-ISS-497) -- same root cause already fixed for search-index via ENC-TSK-L84.
- Gamma only: `GraphSyncFunction`/`GraphSyncRole`/`GraphSyncSqsTrigger` are shared prod(v3)+gamma resources with no `Condition`, so every change here is scoped via `Fn::If` (on `Enabled`) or a new `Condition: IsGamma` resource -- v3-prod's deployed behavior is unchanged even on a future redeploy of this same template.
- `graph_sync` handler now accepts both the legacy SQS-wrapped shape and the native direct DynamoDB Streams ESM shape, with correct `ReportBatchItemFailures` identifiers for each (`messageId` vs `SequenceNumber`).
- New `GraphSyncTrackerStreamTrigger` / `GraphSyncDocumentsStreamTrigger` EventSourceMappings (gamma only), `FilterCriteria` matching the retired Pipes' `record_type` scoping, plus a genuine fix: split INSERT/MODIFY (NewImage-based filter) from REMOVE (OldImage-based filter) so REMOVE events -- which have no NewImage -- are no longer silently dropped (a latent gap in the original Pipes' filter design, independent of the account-wide outage).
- Old `GraphSyncSqsTrigger` disabled on gamma only (`Enabled: !If [IsGamma, false, true]`), left enabled on prod/v3, not deleted, for rollback.
- `GraphSyncRole` gains DynamoDB Streams read permissions.

## Test plan
- [x] `pytest backend/lambda/graph_sync/test_partial_batch_failures_l74.py` -- 9/9 pass, including new direct-ESM-shape and mixed-batch tests
- [x] `pytest backend/lambda/graph_sync/` (full package) -- 105/105 pass
- [x] `tools/verify_lambda_workflow_coverage.py` / `tools/verify_lambda_arch_parity.py` -- both pass
- [x] `cfn-lint` -- no new findings vs baseline (only the expected +2 pre-existing `W3011` DeletionPolicy convention warnings, same as every other resource in this file)
- [ ] Post-merge: live write to `devops-project-tracker-gamma`/`documents-gamma` triggers the new ESM and lands in Neo4j within the freshness window

CCI-f97d0be1af8b42a4b9431795e2343f7f

🤖 Generated with [Claude Code](https://claude.com/claude-code)