### PR TITLE
ENC-TSK-L89 release stale checkouts on session retirement

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -50,6 +50,7 @@ from config import (
     AGENT_SESSIONS_UNCLAIM_TTL_MINUTES,
     AGENT_TYPES_TABLE,
     CHECKOUT_TOKENS_TABLE,
+    TRACKER_TABLE,
     logger,
 )
 from aws_clients import _get_ddb
@@ -79,6 +80,7 @@ __all__ = [
     "get_credential",
     "claim_session",
     "retire_session",
+    "retire_session_with_checkout_release",
     "SCI_PREFIX",
     "SCI_TTL_SECONDS",
     "mint_sci",
@@ -88,6 +90,7 @@ __all__ = [
     "revoke_credential",
     "sweep_idle_sessions",
     "sweep_unclaimed_sessions",
+    "release_checkouts_for_retired_sessions",
     "list_sessions",
     "list_agent_types",
     "list_credentials",
@@ -460,34 +463,199 @@ def claim_session(
     return updated
 
 
-def retire_session(session_id: str) -> Dict[str, Any]:
-    """Flip a session to retired from any live state (allocated or claimed → retired).
+_MAX_RETIREMENT_TRANSACTION_ITEMS = 100
 
-    Append-only: once retired a session cannot be un-retired. Returns the
-    updated session item.
 
-    Raises ValueError when the session is missing or already retired.
+def _task_display_id(task: Mapping[str, Any]) -> str:
+    item_id = str(task.get("item_id") or "").strip()
+    if item_id:
+        return item_id
+    record_id = str(task.get("record_id") or "").strip()
+    return record_id.split("#", 1)[-1] if "#" in record_id else record_id
+
+
+def _checked_out_tasks_for_session(session_id: str) -> List[Dict[str, Any]]:
+    """Return task records whose checkout is currently held by ``session_id``."""
+    if not session_id:
+        return []
+    ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "FilterExpression": (
+            "active_agent_session_id = :sid AND begins_with(#rid, :task_pfx) "
+            "AND (#active = :true OR checkout_state = :checked_out)"
+        ),
+        "ExpressionAttributeNames": {
+            "#rid": "record_id",
+            "#active": "active_agent_session",
+        },
+        "ExpressionAttributeValues": {
+            ":sid": _serialize(session_id),
+            ":task_pfx": _serialize("task#"),
+            ":true": _serialize(True),
+            ":checked_out": _serialize("checked_out"),
+        },
+    }
+
+    tasks: List[Dict[str, Any]] = []
+    scan = ddb.scan(**scan_kwargs)
+    while True:
+        tasks.extend(_deserialize(raw) for raw in scan.get("Items", []))
+        last_key = scan.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        scan = ddb.scan(ExclusiveStartKey=last_key, **scan_kwargs)
+    return tasks
+
+
+def _sci_revoke_transact_item(
+    session: Mapping[str, Any], *, reason: str, now: str
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    token_id = str(session.get("sci_token_id") or "").strip()
+    if not token_id:
+        return None, None
+
+    ddb = _get_ddb()
+    raw = ddb.get_item(
+        TableName=CHECKOUT_TOKENS_TABLE,
+        Key={"pk": _serialize(token_id)},
+    ).get("Item")
+    if not raw:
+        return None, None
+    token = _deserialize(raw)
+    if bool(token.get("revoked")):
+        return None, None
+
+    return {
+        "Update": {
+            "TableName": CHECKOUT_TOKENS_TABLE,
+            "Key": {"pk": _serialize(token_id)},
+            "UpdateExpression": (
+                "SET revoked = :t, revoked_at = :now, revocation_reason = :reason"
+            ),
+            "ConditionExpression": (
+                "attribute_exists(pk) AND (attribute_not_exists(revoked) OR revoked = :f)"
+            ),
+            "ExpressionAttributeValues": {
+                ":t": _serialize(True),
+                ":f": _serialize(False),
+                ":now": _serialize(now),
+                ":reason": _serialize(reason),
+            },
+        }
+    }, token_id
+
+
+def _checkout_release_transact_items(
+    session_id: str, tasks: List[Mapping[str, Any]], *, reason: str, now: str
+) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    note = f"Checkout released because agent session {session_id} retired ({reason})"
+    history_entry = {"M": {
+        "timestamp": _serialize(now),
+        "status": _serialize("worklog"),
+        "description": _serialize(f"[RETIREMENT-RELEASE] {note}"),
+    }}
+    for task in tasks:
+        project_id = str(task.get("project_id") or "").strip()
+        record_id = str(task.get("record_id") or "").strip()
+        if not project_id or not record_id:
+            continue
+        items.append({
+            "Update": {
+                "TableName": TRACKER_TABLE,
+                "Key": {
+                    "project_id": _serialize(project_id),
+                    "record_id": _serialize(record_id),
+                },
+                "UpdateExpression": (
+                    "SET active_agent_session = :f, "
+                    "active_agent_session_id = :empty_s, "
+                    "active_agent_session_parent = :f, "
+                    "checkout_state = :checked_in, "
+                    "checked_in_by = :sid, checked_in_at = :now, "
+                    "updated_at = :now, last_update_note = :note, "
+                    "sync_version = if_not_exists(sync_version, :zero) + :one, "
+                    "history = list_append(if_not_exists(history, :empty_l), :hentry)"
+                ),
+                "ConditionExpression": (
+                    "attribute_exists(#rid) AND active_agent_session_id = :sid"
+                ),
+                "ExpressionAttributeNames": {"#rid": "record_id"},
+                "ExpressionAttributeValues": {
+                    ":f": _serialize(False),
+                    ":empty_s": _serialize(""),
+                    ":checked_in": _serialize("checked_in"),
+                    ":sid": _serialize(session_id),
+                    ":now": _serialize(now),
+                    ":note": _serialize(note),
+                    ":zero": {"N": "0"},
+                    ":one": {"N": "1"},
+                    ":empty_l": {"L": []},
+                    ":hentry": {"L": [history_entry]},
+                },
+            }
+        })
+    return items
+
+
+def retire_session_with_checkout_release(
+    session_id: str, *, reason: str = "explicit_retire"
+) -> Dict[str, Any]:
+    """Retire a live session and atomically release task checkouts it owns.
+
+    The transaction includes the append-only session retirement, SCI revocation
+    when an unrevoked SCI exists, and every task checkout release currently held
+    by the session. A failure leaves all three surfaces untouched.
     """
     if not session_id:
         raise ValueError("session_id is required")
 
+    session = get_session(session_id)
+    if session is None:
+        raise ValueError(f"Session {session_id!r} not found")
+    status = str(session.get("status") or "").strip()
+    if status == "retired":
+        raise ValueError(f"Session {session_id!r} is already retired")
+    if status not in {"allocated", "claimed"}:
+        raise ValueError(f"Session {session_id!r} cannot be retired from status={status!r}")
+
     ddb = _get_ddb()
-    try:
-        resp = ddb.update_item(
-            TableName=AGENT_SESSIONS_TABLE,
-            Key={"session_id": _serialize(session_id)},
-            UpdateExpression="SET #st = :retired",
-            ConditionExpression="#st = :allocated OR #st = :claimed",
-            ExpressionAttributeNames={"#st": "status"},
-            ExpressionAttributeValues={
+    now = _now_z()
+    tasks = _checked_out_tasks_for_session(session_id)
+    task_ids = [_task_display_id(task) for task in tasks]
+
+    transact_items: List[Dict[str, Any]] = [{
+        "Update": {
+            "TableName": AGENT_SESSIONS_TABLE,
+            "Key": {"session_id": _serialize(session_id)},
+            "UpdateExpression": "SET #st = :retired",
+            "ConditionExpression": "#st = :allocated OR #st = :claimed",
+            "ExpressionAttributeNames": {"#st": "status"},
+            "ExpressionAttributeValues": {
                 ":retired": _serialize("retired"),
                 ":allocated": _serialize("allocated"),
                 ":claimed": _serialize("claimed"),
             },
-            ReturnValues="ALL_NEW",
+        }
+    }]
+    sci_item, sci_token_id = _sci_revoke_transact_item(session, reason=reason, now=now)
+    if sci_item:
+        transact_items.append(sci_item)
+    transact_items.extend(_checkout_release_transact_items(session_id, tasks, reason=reason, now=now))
+    if len(transact_items) > _MAX_RETIREMENT_TRANSACTION_ITEMS:
+        raise ValueError(
+            f"Session {session_id!r} has too many checkout releases for one atomic "
+            f"transaction ({len(transact_items)} items)."
         )
+
+    try:
+        ddb.transact_write_items(TransactItems=transact_items)
     except ClientError as exc:
-        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+        if exc.response.get("Error", {}).get("Code") in {
+            "ConditionalCheckFailedException",
+            "TransactionCanceledException",
+        }:
             existing = get_session(session_id)
             if existing is None:
                 raise ValueError(f"Session {session_id!r} not found") from exc
@@ -498,8 +666,39 @@ def retire_session(session_id: str) -> Dict[str, Any]:
             ) from exc
         raise
 
-    updated = _deserialize(resp.get("Attributes", {}))
+    updated = get_session(session_id) or {**session, "status": "retired"}
     logger.info("[INFO] Retired session %s", session_id)
+    if task_ids:
+        logger.info(
+            "[INFO] Released %d checkout(s) for retired session %s: %s",
+            len(task_ids), session_id, task_ids,
+        )
+    if sci_token_id:
+        logger.info(
+            "[INFO] Revoked SCI %s for session %s (reason=%s)",
+            sci_token_id, session_id, reason,
+        )
+    return {
+        "session": updated,
+        "released_task_count": len(task_ids),
+        "released_tasks": task_ids,
+        "released_task_records": [
+            {
+                "project_id": str(task.get("project_id") or ""),
+                "record_id": str(task.get("record_id") or ""),
+                "task_id": _task_display_id(task),
+            }
+            for task in tasks
+        ],
+        "sci_revoked": bool(sci_token_id),
+        "sci_token_id": sci_token_id or "",
+    }
+
+
+def retire_session(session_id: str) -> Dict[str, Any]:
+    """Flip a session to retired from any live state and release its checkouts."""
+    result = retire_session_with_checkout_release(session_id, reason="explicit_retire")
+    updated = result["session"]
     return updated
 
 
@@ -764,20 +963,25 @@ def sweep_idle_sessions(
     retired: List[str] = []
     skipped: List[Dict[str, str]] = []
     revoked_scis: List[str] = []
+    released_tasks: List[str] = []
+    released_by_session: Dict[str, List[str]] = {}
     if not dry_run:
         for sid in candidate_ids:
             try:
-                retire_session(sid)
+                result = retire_session_with_checkout_release(
+                    sid, reason="idle_ttl_exceeded"
+                )
                 retired.append(sid)
             except ValueError as exc:
                 # Concurrently retired/transitioned between scan and update — idempotent skip.
                 skipped.append({"session_id": sid, "reason": str(exc)})
                 continue
-            # ENC-ISS-441 / ENC-TSK-J94: a swept session's SCI must never mutate again.
-            # Revocation failure is non-fatal (logged; the next sweep re-revokes).
-            token = _revoke_sci_after_sweep(sid, reason="idle_ttl_exceeded")
-            if token:
-                revoked_scis.append(token)
+            if result.get("sci_revoked") and result.get("sci_token_id"):
+                revoked_scis.append(str(result["sci_token_id"]))
+            task_ids = [str(t) for t in result.get("released_tasks", [])]
+            if task_ids:
+                released_tasks.extend(task_ids)
+                released_by_session[sid] = task_ids
 
     summary: Dict[str, Any] = {
         "enabled": True,
@@ -793,6 +997,9 @@ def sweep_idle_sessions(
         "skipped": skipped,
         "revoked_sci_count": len(revoked_scis),
         "revoked_scis": revoked_scis,
+        "released_task_count": len(released_tasks),
+        "released_tasks": released_tasks,
+        "released_by_session": released_by_session,
     }
     logger.info("[INFO] Agent-session idle-sweep: %s", json.dumps(summary, default=str))
     return summary
@@ -885,18 +1092,25 @@ def sweep_unclaimed_sessions(
     retired: List[str] = []
     skipped: List[Dict[str, str]] = []
     revoked_scis: List[str] = []
+    released_tasks: List[str] = []
+    released_by_session: Dict[str, List[str]] = {}
     if not dry_run:
         for sid in candidate_ids:
             try:
-                retire_session(sid)
+                result = retire_session_with_checkout_release(
+                    sid, reason="unclaim_ttl_exceeded"
+                )
                 retired.append(sid)
             except ValueError as exc:
                 # Claimed or retired between scan and update — idempotent skip.
                 skipped.append({"session_id": sid, "reason": str(exc)})
                 continue
-            token = _revoke_sci_after_sweep(sid, reason="unclaim_ttl_exceeded")
-            if token:
-                revoked_scis.append(token)
+            if result.get("sci_revoked") and result.get("sci_token_id"):
+                revoked_scis.append(str(result["sci_token_id"]))
+            task_ids = [str(t) for t in result.get("released_tasks", [])]
+            if task_ids:
+                released_tasks.extend(task_ids)
+                released_by_session[sid] = task_ids
 
     summary: Dict[str, Any] = {
         "enabled": True,
@@ -912,8 +1126,161 @@ def sweep_unclaimed_sessions(
         "skipped": skipped,
         "revoked_sci_count": len(revoked_scis),
         "revoked_scis": revoked_scis,
+        "released_task_count": len(released_tasks),
+        "released_tasks": released_tasks,
+        "released_by_session": released_by_session,
     }
     logger.info("[INFO] Agent-session unclaim-sweep: %s", json.dumps(summary, default=str))
+    return summary
+
+
+def _checked_out_session_task_candidates() -> List[Dict[str, Any]]:
+    ddb = _get_ddb()
+    scan_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "FilterExpression": (
+            "begins_with(#rid, :task_pfx) AND active_agent_session_id <> :empty_s "
+            "AND (#active = :true OR checkout_state = :checked_out)"
+        ),
+        "ExpressionAttributeNames": {
+            "#rid": "record_id",
+            "#active": "active_agent_session",
+        },
+        "ExpressionAttributeValues": {
+            ":task_pfx": _serialize("task#"),
+            ":empty_s": _serialize(""),
+            ":true": _serialize(True),
+            ":checked_out": _serialize("checked_out"),
+        },
+    }
+    tasks: List[Dict[str, Any]] = []
+    scan = ddb.scan(**scan_kwargs)
+    while True:
+        tasks.extend(_deserialize(raw) for raw in scan.get("Items", []))
+        last_key = scan.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        scan = ddb.scan(ExclusiveStartKey=last_key, **scan_kwargs)
+    return tasks
+
+
+def _release_retired_session_checkouts(
+    session_id: str, tasks: List[Mapping[str, Any]], *, reason: str
+) -> Dict[str, Any]:
+    session = get_session(session_id)
+    if session is None:
+        return {
+            "session_id": session_id,
+            "released_task_count": 0,
+            "released_tasks": [],
+            "skipped": True,
+            "reason": "session_not_found",
+        }
+    if session.get("status") != "retired":
+        return {
+            "session_id": session_id,
+            "released_task_count": 0,
+            "released_tasks": [],
+            "skipped": True,
+            "reason": f"session_status_{session.get('status')}",
+        }
+
+    now = _now_z()
+    transact_items: List[Dict[str, Any]] = []
+    sci_item, sci_token_id = _sci_revoke_transact_item(session, reason=reason, now=now)
+    if sci_item:
+        transact_items.append(sci_item)
+    transact_items.extend(_checkout_release_transact_items(session_id, tasks, reason=reason, now=now))
+    if not transact_items:
+        return {
+            "session_id": session_id,
+            "released_task_count": 0,
+            "released_tasks": [],
+            "sci_revoked": False,
+        }
+    if len(transact_items) > _MAX_RETIREMENT_TRANSACTION_ITEMS:
+        raise ValueError(
+            f"Retired session {session_id!r} has too many checkout releases for one "
+            f"atomic transaction ({len(transact_items)} items)."
+        )
+
+    _get_ddb().transact_write_items(TransactItems=transact_items)
+    task_ids = [_task_display_id(task) for task in tasks]
+    return {
+        "session_id": session_id,
+        "released_task_count": len(task_ids),
+        "released_tasks": task_ids,
+        "released_task_records": [
+            {
+                "project_id": str(task.get("project_id") or ""),
+                "record_id": str(task.get("record_id") or ""),
+                "task_id": _task_display_id(task),
+            }
+            for task in tasks
+        ],
+        "sci_revoked": bool(sci_token_id),
+        "sci_token_id": sci_token_id or "",
+    }
+
+
+def release_checkouts_for_retired_sessions(
+    *, dry_run: bool = False, session_ids: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """One-time backfill: release task checkouts held by already-retired sessions."""
+    requested = {str(sid).strip() for sid in (session_ids or []) if str(sid).strip()}
+    checked_out = _checked_out_session_task_candidates()
+    by_session: Dict[str, List[Dict[str, Any]]] = {}
+    skipped_live: List[Dict[str, str]] = []
+    for task in checked_out:
+        sid = str(task.get("active_agent_session_id") or "").strip()
+        if not sid or (requested and sid not in requested):
+            continue
+        session = get_session(sid)
+        if session and session.get("status") == "retired":
+            by_session.setdefault(sid, []).append(task)
+        else:
+            skipped_live.append({
+                "session_id": sid,
+                "task_id": _task_display_id(task),
+                "reason": "session_not_retired" if session else "session_not_found",
+            })
+
+    released_tasks: List[str] = []
+    released_by_session: Dict[str, List[str]] = {}
+    session_results: List[Dict[str, Any]] = []
+    if not dry_run:
+        for sid, tasks in sorted(by_session.items()):
+            result = _release_retired_session_checkouts(
+                sid, tasks, reason="retired_session_backfill"
+            )
+            session_results.append(result)
+            task_ids = [str(t) for t in result.get("released_tasks", [])]
+            if task_ids:
+                released_tasks.extend(task_ids)
+                released_by_session[sid] = task_ids
+
+    candidates_by_session = {
+        sid: [_task_display_id(task) for task in tasks]
+        for sid, tasks in sorted(by_session.items())
+    }
+    summary = {
+        "success": True,
+        "dry_run": dry_run,
+        "candidate_session_count": len(by_session),
+        "candidate_task_count": sum(len(tasks) for tasks in by_session.values()),
+        "candidates_by_session": candidates_by_session,
+        "released_session_count": len(released_by_session),
+        "released_task_count": len(released_tasks),
+        "released_tasks": released_tasks,
+        "released_by_session": released_by_session,
+        "session_results": session_results,
+        "skipped_live_count": len(skipped_live),
+        "skipped_live": skipped_live,
+    }
+    logger.info(
+        "[INFO] Retired-session checkout backfill: %s",
+        json.dumps(summary, default=str),
+    )
     return summary
 
 

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.4",
-  "updated_at": "2026-07-07T05:41:00Z",
-  "last_change_summary": "ENC-TSK-L84: opensearch_indexer.lambda CDC transport swapped from EventBridge Pipes (DynamoDB-stream source, confirmed account-wide non-functional per ENC-ISS-497) to a direct Lambda EventSourceMapping on the tracker + documents DynamoDB streams. Handler now accepts both the legacy SQS-wrapped shape and the native direct-stream shape. Legacy SQS trigger + Pipes disabled, not deleted.",
+  "version": "2026-07-07.5",
+  "updated_at": "2026-07-07T11:35:33Z",
+  "last_change_summary": "ENC-TSK-L89: FTR-122 retirement sweeps now atomically release task checkouts held by retiring sessions, add an account-wide retired-session checkout-release backfill action, and expose the action through the MCP coordination surface.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7106,7 +7106,7 @@
       "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
     },
     "coordination.agent_session_idle_sweep": {
-      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep. ENC-TSK-J94: the sweep now also revokes each retired session's SCI (revocation_reason=idle_ttl_exceeded) and the default threshold is 7200s.",
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep. ENC-TSK-J94: the sweep now also revokes each retired session's SCI (revocation_reason=idle_ttl_exceeded) and the default threshold is 7200s. ENC-TSK-L89: retirement now uses one DynamoDB transaction per session to retire the session, revoke any unrevoked SCI, and release all task checkouts held by that session (active_agent_session=false, active_agent_session_id='', checkout_state=checked_in) so a dead session cannot strand a task lock.",
       "fields": {
         "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
           "type": "boolean",
@@ -7122,7 +7122,7 @@
         },
         "summary": {
           "type": "object",
-          "definition": "Return value (CloudWatch only - no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+          "definition": "Return value (CloudWatch only - no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis, released_task_count, released_tasks, released_by_session}."
         },
         "revoked_scis": {
           "type": "array",
@@ -7168,7 +7168,7 @@
       }
     },
     "coordination.agent_session_unclaim_sweep": {
-      "description": "ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep - retirement lifecycle part 1 from the io design decision on ENC-ISS-441. The AgentSessionUnclaimSweepSchedule EventBridge rule (02-compute.yaml, rate(10 minutes)) invokes coordination_api with Input {\"action\":\"agent_session_unclaim_sweep\"}; lambda_handler dispatches to _handle_agent_session_unclaim_sweep -> agent_id_alloc.sweep_unclaimed_sessions. Sessions in status=allocated (registered via agent.register but never claimed) whose created_at is older than AGENT_SESSIONS_UNCLAIM_TTL_MINUTES are flipped to 'retired' via the same append-only conditional UpdateItem as agent.retire, and any bound SCI is revoked (revocation_reason=unclaim_ttl_exceeded; defense-in-depth - allocated sessions normally have no SCI since SCIs mint at claim). Reference timestamp is strictly created_at. Idempotent; dry_run-capable; master-flag guarded. Closes the ghost-registration gap (10 of 24 prod sessions were unclaimed, the ENC-ISS-441 evidence).",
+      "description": "ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep - retirement lifecycle part 1 from the io design decision on ENC-ISS-441. The AgentSessionUnclaimSweepSchedule EventBridge rule (02-compute.yaml, rate(10 minutes)) invokes coordination_api with Input {\"action\":\"agent_session_unclaim_sweep\"}; lambda_handler dispatches to _handle_agent_session_unclaim_sweep -> agent_id_alloc.sweep_unclaimed_sessions. Sessions in status=allocated (registered via agent.register but never claimed) whose created_at is older than AGENT_SESSIONS_UNCLAIM_TTL_MINUTES are flipped to 'retired' via the same append-only conditional UpdateItem as agent.retire, and any bound SCI is revoked (revocation_reason=unclaim_ttl_exceeded; defense-in-depth - allocated sessions normally have no SCI since SCIs mint at claim). Reference timestamp is strictly created_at. Idempotent; dry_run-capable; master-flag guarded. Closes the ghost-registration gap (10 of 24 prod sessions were unclaimed, the ENC-ISS-441 evidence). ENC-TSK-L89: the same retirement transaction also releases all task checkouts held by the retiring session, clearing active_agent_session and active_agent_session_id and marking checkout_state=checked_in.",
       "fields": {
         "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED": {
           "type": "boolean",
@@ -7184,7 +7184,24 @@
         },
         "summary": {
           "type": "object",
-          "definition": "Return value (CloudWatch only): {enabled, dry_run, unclaim_ttl_minutes, cutoff, scanned_allocated, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis}."
+          "definition": "Return value (CloudWatch only): {enabled, dry_run, unclaim_ttl_minutes, cutoff, scanned_allocated, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis, released_task_count, released_tasks, released_by_session}."
+        }
+      }
+    },
+    "coordination.agent_session_checkout_release_backfill": {
+      "description": "ENC-TSK-L89 / ENC-FTR-122: one-time and on-demand repair surface for stale task checkouts held by already-retired ENC-SES sessions. coordination_api exposes POST /api/v1/coordination/agents/sessions/checkout-release-backfill and direct Lambda Input {\"action\":\"agent_session_checkout_release_backfill\"}; the MCP code-mode surface exposes coordination(action=\"agent.checkout_release_backfill\"). The helper scans checked-out task records account-wide, filters to owners whose agent-session row is status=retired, and releases those task locks per retired session in an atomic DynamoDB transaction. This is status-neutral: it does NOT advance, close, or override task lifecycle status, and is explicitly separate from direct_state_override.",
+      "fields": {
+        "dry_run": {
+          "type": "boolean",
+          "definition": "When true, reports candidate retired-session checkout locks without mutating tasks or SCI tokens."
+        },
+        "session_ids": {
+          "type": "array",
+          "definition": "Optional list of ENC-SES ids to restrict the backfill scan. Omit for account-wide repair."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Response: {success, dry_run, candidate_session_count, candidate_task_count, candidates_by_session, released_session_count, released_task_count, released_tasks, released_by_session, session_results, skipped_live_count, skipped_live}."
         }
       }
     },
@@ -7233,6 +7250,15 @@
         "sci": {
           "type": "string",
           "definition": "Optional on checkout_task / advance_task_status / append_worklog (and honored on plan/tracker mutation paths). Session Claim ID issued by coordination agent.claim (ENC-ISS-441). Required by the backend for agent sessions claimed after SCI_ENFORCEMENT_EPOCH; strip-and-forwarded, never validated at the MCP layer."
+        }
+      }
+    },
+    "mcp_server.agent_checkout_release_backfill": {
+      "description": "ENC-TSK-L89: code-mode coordination action agent.checkout_release_backfill maps to the coordination_api retired-session checkout-release backfill route. Args: dry_run? and session_ids?. Returns the coordination.agent_session_checkout_release_backfill summary unchanged so an agent can evidence the one-time L06/orphan release without direct DynamoDB access.",
+      "fields": {
+        "action": {
+          "type": "string",
+          "definition": "coordination(action=\"agent.checkout_release_backfill\", arguments={dry_run?: boolean, session_ids?: string[]})"
         }
       }
     },
@@ -7675,8 +7701,13 @@
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
     }
   },
-  "change_summary": "ENC-TSK-L06: new ID Service Lambda extraction (B63 Phase 2 AC-6) with IAM-isolated counter allocation, idempotency contract, HMAC provenance signing, and trust-score feedback loop.",
+  "change_summary": "ENC-TSK-L89: FTR-122 retirement sweeps now atomically release task checkouts held by retired sessions, add an account-wide retired-session checkout-release backfill action, and expose the action through the MCP coordination surface.",
   "change_log": [
+    {
+      "version": "2026-07-07.5",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L89 / FTR-122: agent-session retirement now atomically releases task checkouts held by the retiring session in the same DynamoDB transaction as session retire + SCI revocation for both the idle and unclaim sweeps. Added coordination.agent_session_checkout_release_backfill plus MCP coordination action agent.checkout_release_backfill for the one-time retired-session stale-lock repair, including the ENC-TSK-L06 / ENC-SES-057 class."
+    },
     {
       "version": "2026-07-07.3",
       "date": "2026-07-07",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -14971,27 +14971,51 @@ def _handle_agent_session_retire(
     if not session_id:
         return _error(400, "session_id is required", retryable=False)
     try:
-        item = _agent_id_alloc.retire_session(session_id)
+        result = _agent_id_alloc.retire_session_with_checkout_release(
+            session_id, reason="explicit_retire"
+        )
     except ValueError as exc:
         return _error(400, str(exc), retryable=False)
     except (BotoCoreError, ClientError) as exc:
         logger.exception("[ERROR] retire_session failed: %s", exc)
         return _error(500, "DynamoDB error during session retire")
-    # ENC-ISS-441 / ENC-TSK-J92: retirement revokes the session's SCI. The retire itself
-    # is already durable (append-only flip above); a revocation failure is surfaced but
-    # non-fatal — the ENC-TSK-J94 sweeps re-revoke as a backstop.
-    payload: Dict[str, Any] = {"session": item}
-    try:
-        revoked = _agent_id_alloc.revoke_sci_for_session(session_id, reason="explicit_retire")
-    except (ValueError, BotoCoreError, ClientError) as exc:
-        logger.exception("[ERROR] SCI revocation failed on retire of %s: %s", session_id, exc)
-        payload["sci_revoked"] = False
-        payload["sci_revocation_error"] = "SCI revocation failed — the idle/unclaim sweep will re-revoke"
-    else:
-        payload["sci_revoked"] = bool(revoked)
-        if revoked:
-            payload["sci_token_id"] = revoked.get("token_id") or revoked.get("pk")
+    payload: Dict[str, Any] = {
+        "session": result["session"],
+        "sci_revoked": bool(result.get("sci_revoked")),
+        "released_task_count": int(result.get("released_task_count") or 0),
+        "released_tasks": result.get("released_tasks", []),
+    }
+    if result.get("sci_token_id"):
+        payload["sci_token_id"] = result["sci_token_id"]
     return _response(200, payload)
+
+
+def _handle_agent_session_checkout_release_backfill(event: Dict[str, Any]) -> Dict[str, Any]:
+    """POST /api/v1/coordination/agents/sessions/checkout-release-backfill.
+
+    One-time operational repair for tasks whose checkout owner is an already-retired
+    ENC-SES session. It is status-neutral: only checkout ownership fields are released.
+    """
+    body = _json_body(event) or {
+        key: event[key] for key in ("dry_run", "session_ids") if key in event
+    }
+    raw_session_ids = body.get("session_ids")
+    session_ids = None
+    if raw_session_ids is not None:
+        if not isinstance(raw_session_ids, list):
+            return _error(400, "session_ids must be a list when supplied", retryable=False)
+        session_ids = [str(sid).strip() for sid in raw_session_ids if str(sid).strip()]
+    try:
+        summary = _agent_id_alloc.release_checkouts_for_retired_sessions(
+            dry_run=bool(body.get("dry_run", False)),
+            session_ids=session_ids,
+        )
+    except ValueError as exc:
+        return _error(400, str(exc), retryable=False)
+    except (BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] checkout-release backfill failed: %s", exc)
+        return _error(500, "DynamoDB error during checkout-release backfill")
+    return _response(200, summary)
 
 
 def _handle_agent_type_list(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -16070,6 +16094,10 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         logger.info("[INFO] Scheduled agent-session unclaim-sweep invoked")
         return _handle_agent_session_unclaim_sweep(event)
 
+    if event.get("action") == "agent_session_checkout_release_backfill":
+        logger.info("[INFO] Agent-session checkout-release backfill invoked")
+        return _handle_agent_session_checkout_release_backfill(event)
+
     # --- ENC-TSK-K02 / FTR-084 Ph2: weekly intent-classifier training ---
     if event.get("action") == "intent_classifier_training":
         logger.info("[INFO] Scheduled intent-classifier training invoked")
@@ -16297,6 +16325,10 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     # POST /api/v1/coordination/agents/sessions/claim
     if method == "POST" and path == "/api/v1/coordination/agents/sessions/claim":
         return _handle_agent_session_claim(event, claims or {})
+
+    # POST /api/v1/coordination/agents/sessions/checkout-release-backfill
+    if method == "POST" and path == "/api/v1/coordination/agents/sessions/checkout-release-backfill":
+        return _handle_agent_session_checkout_release_backfill(event)
 
     # GET /api/v1/coordination/agents/sessions/{id} (ENC-TSK-L35 session detail page)
     match_session_get = re.fullmatch(

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -21,6 +21,30 @@ import config  # noqa: E402
 import agent_id_alloc as alloc  # noqa: E402
 
 
+def _create_simple_table(ddb, table, key):
+    ddb.create_table(
+        TableName=table,
+        AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _create_tracker_table(ddb):
+    ddb.create_table(
+        TableName=config.TRACKER_TABLE,
+        AttributeDefinitions=[
+            {"AttributeName": "project_id", "AttributeType": "S"},
+            {"AttributeName": "record_id", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "project_id", "KeyType": "HASH"},
+            {"AttributeName": "record_id", "KeyType": "RANGE"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
 class EncodeSeqTest(unittest.TestCase):
     def test_encoding_is_min_width_3_and_unbounded(self):
         self.assertEqual(alloc.encode_seq(1), "001")
@@ -56,12 +80,8 @@ class MintingTest(unittest.TestCase):
             (config.AGENT_SESSIONS_TABLE, "session_id"),
             (config.AGENT_TYPES_TABLE, "agent_type_id"),
         ):
-            self.ddb.create_table(
-                TableName=table,
-                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
-                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
+            _create_simple_table(self.ddb, table, key)
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -178,12 +198,8 @@ class AgentMutationTest(unittest.TestCase):
             (config.AGENT_SESSIONS_TABLE, "session_id"),
             (config.AGENT_TYPES_TABLE, "agent_type_id"),
         ):
-            self.ddb.create_table(
-                TableName=table,
-                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
-                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
+            _create_simple_table(self.ddb, table, key)
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -371,6 +387,7 @@ class IdleSweepTest(unittest.TestCase):
                 KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
                 BillingMode="PAY_PER_REQUEST",
             )
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -520,12 +537,8 @@ class CredentialLifecycleTest(unittest.TestCase):
             (config.AGENT_TYPES_TABLE, "agent_type_id"),
             (config.AGENT_CREDENTIALS_TABLE, "credential_id"),
         ):
-            self.ddb.create_table(
-                TableName=table,
-                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
-                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
+            _create_simple_table(self.ddb, table, key)
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -709,12 +722,8 @@ class SciTokenTest(unittest.TestCase):
             (config.AGENT_TYPES_TABLE, "agent_type_id"),
             (config.CHECKOUT_TOKENS_TABLE, "pk"),
         ):
-            self.ddb.create_table(
-                TableName=table,
-                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
-                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
-                BillingMode="PAY_PER_REQUEST",
-            )
+            _create_simple_table(self.ddb, table, key)
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -824,6 +833,7 @@ class UnclaimAndRevocationSweepTest(unittest.TestCase):
                 KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
                 BillingMode="PAY_PER_REQUEST",
             )
+        _create_tracker_table(self.ddb)
         patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -839,6 +849,44 @@ class UnclaimAndRevocationSweepTest(unittest.TestCase):
             TableName=config.CHECKOUT_TOKENS_TABLE, Key={"pk": {"S": token_id}}
         )
         return resp.get("Item")
+
+    def _put_checked_out_task(self, task_id, session_id):
+        self.ddb.put_item(
+            TableName=config.TRACKER_TABLE,
+            Item={
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": f"task#{task_id}"},
+                "item_id": {"S": task_id},
+                "record_type": {"S": "task"},
+                "status": {"S": "in-progress"},
+                "active_agent_session": {"BOOL": True},
+                "active_agent_session_id": {"S": session_id},
+                "active_agent_session_parent": {"BOOL": False},
+                "checkout_state": {"S": "checked_out"},
+                "history": {"L": []},
+            },
+        )
+
+    def _get_task(self, task_id):
+        resp = self.ddb.get_item(
+            TableName=config.TRACKER_TABLE,
+            Key={"project_id": {"S": "enceladus"}, "record_id": {"S": f"task#{task_id}"}},
+        )
+        return resp.get("Item")
+
+    def _put_retired_session(self, session_id):
+        self.ddb.put_item(
+            TableName=config.AGENT_SESSIONS_TABLE,
+            Item={
+                "session_id": {"S": session_id},
+                "agent_type_id": {"S": "ENC-AGT-001"},
+                "parent_session_id": {"S": "root"},
+                "runtime": {"S": "dead-test-session"},
+                "created_at": {"S": "2026-07-01T00:00:00Z"},
+                "claimed_at": {"S": "2026-07-01T00:00:01Z"},
+                "status": {"S": "retired"},
+            },
+        )
 
     # -- config defaults per the io design decision on ENC-ISS-441 -----------
     def test_defaults_are_two_hours_and_ten_minutes(self):
@@ -894,12 +942,59 @@ class UnclaimAndRevocationSweepTest(unittest.TestCase):
         self.assertTrue(item["revoked"]["BOOL"])
         self.assertEqual(item["revocation_reason"]["S"], "idle_ttl_exceeded")
 
+    def test_idle_sweep_releases_checked_out_task_in_same_pass(self):
+        minted = self._mint(status="allocated")
+        session = alloc.claim_session(minted["session_id"])
+        sci = alloc.mint_sci(session)
+        self._put_checked_out_task("ENC-TSK-IDLE", session["session_id"])
+
+        summary = alloc.sweep_idle_sessions(idle_threshold_seconds=3600, now=self._future)
+
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertEqual(summary["revoked_sci_count"], 1)
+        self.assertIn(sci["token_id"], summary["revoked_scis"])
+        self.assertEqual(summary["released_task_count"], 1)
+        self.assertIn("ENC-TSK-IDLE", summary["released_tasks"])
+        task = self._get_task("ENC-TSK-IDLE")
+        self.assertFalse(task["active_agent_session"]["BOOL"])
+        self.assertEqual(task["active_agent_session_id"]["S"], "")
+        self.assertEqual(task["checkout_state"]["S"], "checked_in")
+
     def test_unclaim_sweep_without_sci_reports_zero_revocations(self):
         self._mint(status="allocated")
         summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
         self.assertEqual(summary["retired_count"], 1)
         self.assertEqual(summary["revoked_sci_count"], 0)
         self.assertEqual(summary["revoked_scis"], [])
+
+    def test_unclaim_sweep_releases_checked_out_task(self):
+        minted = self._mint(status="allocated")
+        self._put_checked_out_task("ENC-TSK-UNCLAIM", minted["session_id"])
+
+        summary = alloc.sweep_unclaimed_sessions(unclaim_ttl_minutes=10, now=self._future)
+
+        self.assertEqual(summary["retired_count"], 1)
+        self.assertEqual(summary["released_task_count"], 1)
+        self.assertIn("ENC-TSK-UNCLAIM", summary["released_tasks"])
+        task = self._get_task("ENC-TSK-UNCLAIM")
+        self.assertFalse(task["active_agent_session"]["BOOL"])
+        self.assertEqual(task["active_agent_session_id"]["S"], "")
+        self.assertEqual(task["checkout_state"]["S"], "checked_in")
+
+    def test_backfill_releases_l06_from_already_retired_session(self):
+        self._put_retired_session("ENC-SES-057")
+        self._put_checked_out_task("ENC-TSK-L06", "ENC-SES-057")
+
+        summary = alloc.release_checkouts_for_retired_sessions()
+
+        self.assertEqual(summary["candidate_session_count"], 1)
+        self.assertEqual(summary["candidate_task_count"], 1)
+        self.assertEqual(summary["released_task_count"], 1)
+        self.assertEqual(summary["released_by_session"], {"ENC-SES-057": ["ENC-TSK-L06"]})
+        task = self._get_task("ENC-TSK-L06")
+        self.assertFalse(task["active_agent_session"]["BOOL"])
+        self.assertEqual(task["active_agent_session_id"]["S"], "")
+        self.assertEqual(task["checkout_state"]["S"], "checked_in")
 
     def test_unclaim_sweep_is_idempotent_on_rerun(self):
         self._mint(status="allocated")

--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -653,6 +653,71 @@ class CoordinationLambdaUnitTests(unittest.TestCase):
         self.assertEqual(resp["statusCode"], 200)
         mock_route_handler.assert_called_once()
 
+    @patch.object(coordination_lambda._agent_id_alloc, "release_checkouts_for_retired_sessions")
+    def test_handle_agent_session_checkout_release_backfill_accepts_direct_event(
+        self,
+        mock_release,
+    ):
+        mock_release.return_value = {
+            "success": True,
+            "dry_run": True,
+            "released_task_count": 0,
+            "released_tasks": [],
+            "candidates_by_session": {"ENC-SES-057": ["ENC-TSK-L06"]},
+        }
+
+        resp = coordination_lambda._handle_agent_session_checkout_release_backfill({
+            "dry_run": True,
+            "session_ids": ["ENC-SES-057"],
+        })
+
+        self.assertEqual(resp["statusCode"], 200)
+        mock_release.assert_called_once_with(
+            dry_run=True,
+            session_ids=["ENC-SES-057"],
+        )
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        self.assertEqual(body["candidates_by_session"], {"ENC-SES-057": ["ENC-TSK-L06"]})
+
+    @patch.object(coordination_lambda, "_handle_agent_session_checkout_release_backfill")
+    def test_lambda_handler_routes_checkout_release_backfill_direct_action(self, mock_route_handler):
+        mock_route_handler.return_value = coordination_lambda._response(
+            200,
+            {"success": True, "released_task_count": 1},
+        )
+        event = {
+            "action": "agent_session_checkout_release_backfill",
+            "session_ids": ["ENC-SES-057"],
+        }
+
+        resp = coordination_lambda.lambda_handler(event, None)
+
+        self.assertEqual(resp["statusCode"], 200)
+        mock_route_handler.assert_called_once_with(event)
+
+    @patch.object(coordination_lambda, "_authenticate", return_value=({"auth_mode": "internal-key"}, None))
+    @patch.object(coordination_lambda, "_handle_agent_session_checkout_release_backfill")
+    def test_lambda_handler_routes_checkout_release_backfill_http(
+        self,
+        mock_route_handler,
+        _mock_auth,
+    ):
+        mock_route_handler.return_value = coordination_lambda._response(
+            200,
+            {"success": True, "released_task_count": 1},
+        )
+        event = {
+            "requestContext": {"http": {"method": "POST"}},
+            "rawPath": "/api/v1/coordination/agents/sessions/checkout-release-backfill",
+            "body": "{}",
+        }
+
+        resp = coordination_lambda.lambda_handler(event, None)
+
+        self.assertEqual(resp["statusCode"], 200)
+        mock_route_handler.assert_called_once_with(event)
+
     @patch.object(coordination_lambda, "DISPATCH_TIMEOUT_CEILING_SECONDS", 1800)
     @patch.object(coordination_lambda, "HOST_V2_TIMEOUT_SECONDS", 9999)
     @patch.object(coordination_lambda, "_build_ssm_commands", return_value=["echo ok"])

--- a/tools/enceladus-mcp-server/mcp_server/actions.py
+++ b/tools/enceladus-mcp-server/mcp_server/actions.py
@@ -77,6 +77,7 @@ def build_action_registries(flags: ActionFeatureFlags) -> Tuple[
         "agent.claim": {"tool": "agent_claim"},
         "agent.list": {"tool": "agent_list"},
         "agent.retire": {"tool": "agent_retire"},
+        "agent.checkout_release_backfill": {"tool": "agent_checkout_release_backfill"},
         "agent.type.list": {"tool": "agent_type_list"},
         "agent.type.register": {"tool": "agent_type_register"},
     }

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3357,8 +3357,8 @@ def _code_mode_tool_catalog() -> list[Tool]:
                             "Coordination action identifier. Orchestration: capabilities.get, "
                             "request.get, dispatch_plan.generate, dispatch_plan.dry_run, "
                             "auth.cognito_session. Agent identity (ENC-TSK-I38): agent.register, "
-                            "agent.claim, agent.list, agent.retire, agent.type.list, "
-                            "agent.type.register."
+                            "agent.claim, agent.list, agent.retire, "
+                            "agent.checkout_release_backfill, agent.type.list, agent.type.register."
                         ),
                     },
                     "arguments": {
@@ -8768,6 +8768,19 @@ async def _agent_retire(args: dict) -> list[TextContent]:
     return _result_text(result)
 
 
+async def _agent_checkout_release_backfill(args: dict) -> list[TextContent]:
+    """Release task checkouts held by already-retired ENC-SES sessions."""
+    payload: Dict[str, Any] = {}
+    if args.get("dry_run") is not None:
+        payload["dry_run"] = bool(args["dry_run"])
+    if args.get("session_ids") is not None:
+        payload["session_ids"] = args["session_ids"]
+    result = _coordination_api_request(
+        "POST", "/agents/sessions/checkout-release-backfill", payload=payload
+    )
+    return _result_text(result)
+
+
 async def _agent_type_list(args: dict) -> list[TextContent]:
     """List entries in the ENC-AGT agent-type directory (agent.type.list)."""
     query: Dict[str, Any] = {}
@@ -9786,6 +9799,7 @@ _TOOL_HANDLERS = {
     "agent_claim": _agent_claim,
     "agent_list": _agent_list,
     "agent_retire": _agent_retire,
+    "agent_checkout_release_backfill": _agent_checkout_release_backfill,
     "agent_type_list": _agent_type_list,
     "agent_type_register": _agent_type_register,
     "governance_update": _governance_update,


### PR DESCRIPTION
## Summary
- Add atomic session retirement that retires the session, revokes any unrevoked SCI, and releases held task checkouts in one DynamoDB transaction.
- Route both idle and unclaim sweeps through the atomic checkout-release path and expose released-task summaries.
- Add retired-session checkout-release backfill plus Lambda/MCP entrypoints for the one-time orphan repair.
- Update governance_data_dictionary.json for the schema-affecting Lambda/MCP changes.

## Validation
- `PYTHONPATH=.:../shared_layer/python python3 -m pytest test_agent_id_alloc.py test_lambda_function.py::CoordinationLambdaUnitTests::test_handle_agent_session_checkout_release_backfill_accepts_direct_event test_lambda_function.py::CoordinationLambdaUnitTests::test_lambda_handler_routes_checkout_release_backfill_direct_action test_lambda_function.py::CoordinationLambdaUnitTests::test_lambda_handler_routes_checkout_release_backfill_http -q --tb=short` => 86 passed
- `python3 -m py_compile backend/lambda/coordination_api/agent_id_alloc.py backend/lambda/coordination_api/lambda_function.py backend/lambda/coordination_api/test_agent_id_alloc.py backend/lambda/coordination_api/test_lambda_function.py tools/enceladus-mcp-server/server.py tools/enceladus-mcp-server/mcp_server/actions.py`
- `python3 -m json.tool backend/lambda/coordination_api/governance_data_dictionary.json >/tmp/l89-governance-dict.json`
- `python3 tools/check_governance_dictionary_sync.py --base origin/v4/main --head HEAD`

Full `test_lambda_function.py` was attempted locally; unrelated dispatch/provider tests fail in this sandbox because AWS endpoints are unreachable.

Commit gate: CCI-31990ce69d06409bb3f980ab0be3e7af