### PR TITLE
ENC-TSK-L89: gamma agent.retire loopback + backfill APIGW routes

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -319,6 +319,23 @@ Resources:
           # ENC-ISS-441 / ENC-TSK-J92: SCI tokens share the checkout service's token table
           # (pk = token id, token_type=SCI). Env-suffixed so gamma writes the -gamma twin.
           CHECKOUT_TOKENS_TABLE: !Sub "enceladus-checkout-tokens${EnvironmentSuffix}"
+          # ENC-TSK-L89: embedded MCP server.py HTTP-loopbacks must target this
+          # stack's API Gateway host, not the hardcoded prod default. Without
+          # these, gamma agent.retire hits prod coordination_api while tracker
+          # checkout state lives in devops-project-tracker-gamma — retirement
+          # never releases gamma task checkouts.
+          ENCELADUS_COORDINATION_API_BASE: !If
+            - IsGamma
+            - "https://enceladus-gamma.jreese.net/api/v1/coordination"
+            - "https://jreese.net/api/v1/coordination"
+          ENCELADUS_TRACKER_API_BASE: !If
+            - IsGamma
+            - "https://enceladus-gamma.jreese.net/api/v1/tracker"
+            - "https://jreese.net/api/v1/tracker"
+          CHECKOUT_SERVICE_API_BASE: !If
+            - IsGamma
+            - "https://enceladus-gamma.jreese.net/api/v1/checkout"
+            - "https://jreese.net/api/v1/checkout"
           # ENC-TSK-F63 AC-1: AppConfig extension env vars (feature flag polling)
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -287,6 +287,46 @@ Resources:
       RouteKey: GET /api/v1/coordination/agents/types
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-L89 / ENC-FTR-122: agent session mutation routes were implemented in
+  # coordination_api (ENC-TSK-I38/J43) but only list GET routes were wired (L34).
+  # Gamma MCP embeds server.py inside CoordinationApiFunction and HTTP-loopbacks
+  # agent.retire / checkout-release-backfill — these routes must exist on the
+  # same gateway the function targets via ENCELADUS_COORDINATION_API_BASE.
+  RouteAgentSessionsRegister:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteAgentSessionsClaim:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions/claim
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteAgentSessionsCheckoutReleaseBackfill:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions/checkout-release-backfill
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteAgentSessionGet:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/agents/sessions/{sessionId}
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteAgentSessionRetire:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /api/v1/coordination/agents/sessions/{sessionId}/retire
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
   RouteComponentsGet:
     Type: AWS::ApiGatewayV2::Route
     Properties:


### PR DESCRIPTION
## Summary

- Wire missing API Gateway routes for agent session mutations (`register`, `claim`, `retire`, `checkout-release-backfill`, session GET) so L89 backfill and retire paths are reachable on the gamma gateway.
- Set `ENCELADUS_COORDINATION_API_BASE`, `ENCELADUS_TRACKER_API_BASE`, and `CHECKOUT_SERVICE_API_BASE` on `CoordinationApiFunction` so embedded MCP `server.py` HTTP loopbacks target the same stack (fixes live AC-3 failure where gamma MCP retired sessions via prod coordination_api while task checkouts live in `devops-project-tracker-gamma`).

Follow-up to merged PR #919. Root cause for failed live validation after deploy-success.

CCI-4dc0b0d96fa04b8cbcbf91b984b51991

## Test plan

- [x] Merge and gamma deploy (compute + api stacks)
- [ ] `POST /api/v1/coordination/agents/sessions/checkout-release-backfill` returns 200 on gamma (dry_run)
- [ ] Run backfill; confirm `ENC-TSK-L06`, `ENC-TSK-J10`, `ENC-TSK-L75` checkouts released
- [ ] Fresh session checkout + `agent.retire` releases checkout on gamma (AC-3)
- [ ] Set L89 acceptance evidence and close task