### PR TITLE
ENC-TSK-L92: gate escalation approve/deny with explicit S3-maintained approver allowlist

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.6",
-  "updated_at": "2026-07-07T11:50:28Z",
-  "last_change_summary": "ENC-TSK-L89: FTR-122 retirement sweeps now atomically release task checkouts held by retiring sessions, add an account-wide retired-session checkout-release backfill action, and expose the action through the MCP coordination surface.",
+  "version": "2026-07-07.7",
+  "updated_at": "2026-07-07T12:45:00Z",
+  "last_change_summary": "ENC-TSK-L92 / ENC-ISS-501 (SEV-1): escalation approve/deny now requires the decider's Cognito email to be on a Console-edit-only S3 allowlist (ESCALATION_APPROVER_ALLOWLIST_BUCKET/_KEY), on top of the existing _is_cognito_session check, which was found to be a fail-open blocklist that let a non-human identity self-approve governance-bypass escalations.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7083,7 +7083,7 @@
       }
     },
     "coordination.escalations": {
-      "description": "ENC-FTR-121 Ph3 (ENC-TSK-J70, DOC-5B888FCA43B8 sections 5.7 + 6): io's escalation approval surface on coordination_api - the SOLE origin of override authorization in the platform. Every route verifies a genuine Cognito human session server-side per call (_is_cognito_session); internal-key, SCI, and managed-token credentials are structurally rejected with 403. No MCP action maps to approve or deny. Approve stamps approved_by {sub, email}, walks requested->approved under a ConditionExpression race guard, and drives applyEscalatedMutation (ENC-TSK-J69) in tracker_mutation via direct Lambda invoke (TRACKER_MUTATION_LAMBDA_NAME + X-Coordination-Internal-Key); the approval is durable even if the applier invoke fails (fail-soft: the escalation stays approved and the idempotent apply route can be re-driven - the agent never resubmits the cached mutation). Deny walks requested->denied, or requested->denied_with_guidance when a guidance_note is supplied; the note is stored on the item AND rides the denial event so watch polling (Ph4) delivers it to the agent.",
+      "description": "ENC-FTR-121 Ph3 (ENC-TSK-J70, DOC-5B888FCA43B8 sections 5.7 + 6): io's escalation approval surface on coordination_api - the SOLE origin of override authorization in the platform. Every route verifies a genuine Cognito session server-side per call (_is_cognito_session); internal-key and managed-token credentials are structurally rejected with 403. ENC-TSK-L92 / ENC-ISS-501 (SEV-1, 2026-07-07): _is_cognito_session alone was found to be a fail-open BLOCKLIST (it excludes only auth_mode in {internal-key, managed-token} -- any OTHER or absent auth_mode passed), which let a non-human Cognito-authenticated identity self-approve escalations within seconds of filing with no human review. The approve/deny routes now ALSO require the decider's Cognito email claim to appear in a positive allowlist (_is_allowlisted_escalation_decider) sourced from a Console-edit-only S3 document that no Lambda role -- including this one -- has write access to; the allowlist check fails CLOSED on any fetch/parse error. No MCP action maps to approve or deny. Approve stamps approved_by {sub, email}, walks requested->approved under a ConditionExpression race guard, and drives applyEscalatedMutation (ENC-TSK-J69) in tracker_mutation via direct Lambda invoke (TRACKER_MUTATION_LAMBDA_NAME + X-Coordination-Internal-Key); the approval is durable even if the applier invoke fails (fail-soft: the escalation stays approved and the idempotent apply route can be re-driven - the agent never resubmits the cached mutation). Deny walks requested->denied, or requested->denied_with_guidance when a guidance_note is supplied; the note is stored on the item AND rides the denial event so watch polling (Ph4) delivers it to the agent.",
       "fields": {
         "GET /api/v1/coordination/escalations": {
           "type": "route",
@@ -7091,11 +7091,19 @@
         },
         "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve": {
           "type": "route",
-          "definition": "Non-delegable approve: requested->approved + approved_by + event, then drives the applier. Returns applied:true|false with apply_result or apply_error+retry."
+          "definition": "Non-delegable approve: requested->approved + approved_by + event, then drives the applier. Returns applied:true|false with apply_result or apply_error+retry. ENC-TSK-L92: gated by _is_cognito_session AND _is_allowlisted_escalation_decider (both must pass); an allowlist-miss returns 403 before any DynamoDB write."
         },
         "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny": {
           "type": "route",
-          "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied."
+          "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied. ENC-TSK-L92: same dual gate as approve."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_BUCKET": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501. Env var (default 'jreese-net'). S3 bucket holding the escalation-approver allowlist document."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_KEY": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501. Env var (default 'security/escalation-approvers.md'). S3 key of the allowlist document. coordination_api's Lambda role is granted s3:GetObject ONLY on this exact key (EscalationApproverAllowlistRead statement, infrastructure/cloudformation/02-compute.yaml) -- no role in the account, including this Lambda's own, has PutObject/DeleteObject on it. The document is a markdown file with a fenced yaml block of `- email: \"...\"` list entries, parsed without a yaml dependency by _load_escalation_approver_allowlist (60s in-memory cache). Edits require an AWS Console-authenticated human; there is deliberately no programmatic write path."
         },
         "GET /api/v1/coordination/escalations/watch": {
           "type": "route",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -42,7 +42,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import boto3
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
@@ -8823,6 +8823,66 @@ def _is_assistant_request(event: Dict[str, Any]) -> bool:
     return key == CHECKOUT_ASSISTANT_KEY
 
 
+# ENC-TSK-L92 / ENC-ISS-501: escalation approve/deny decider allowlist.
+# _is_cognito_session is a fail-open blocklist (excludes only auth_mode in
+# {"internal-key", "managed-token"} -- any other or absent auth_mode passes),
+# which let a non-human Cognito-authenticated identity self-approve
+# governance-bypass escalations. This adds a positive allowlist on top: the
+# decider's claims.email must appear in a human-Console-only S3 document that
+# no Lambda role (including this one) has write access to -- only s3:GetObject.
+ESCALATION_APPROVER_ALLOWLIST_BUCKET = os.environ.get("ESCALATION_APPROVER_ALLOWLIST_BUCKET", "jreese-net")
+ESCALATION_APPROVER_ALLOWLIST_KEY = os.environ.get(
+    "ESCALATION_APPROVER_ALLOWLIST_KEY", "security/escalation-approvers.md"
+)
+_ESCALATION_ALLOWLIST_CACHE_TTL = 60.0
+_escalation_allowlist_cache: Dict[str, Any] = {"emails": None, "fetched_at": 0.0}
+
+
+def _load_escalation_approver_allowlist() -> Set[str]:
+    """Fetch and parse the escalation-approver allowlist S3 document, cached 60s.
+
+    Fails CLOSED: any fetch or parse error returns an empty set (nobody is
+    authorized) rather than silently falling back to "allow everyone" the way
+    the previous blocklist-only check did.
+    """
+    now = time.time()
+    cached = _escalation_allowlist_cache.get("emails")
+    fetched_at = _escalation_allowlist_cache.get("fetched_at") or 0.0
+    if cached is not None and (now - fetched_at) < _ESCALATION_ALLOWLIST_CACHE_TTL:
+        return cached
+    try:
+        s3 = boto3.client("s3", region_name=os.environ.get("SECRETS_REGION") or os.environ.get("AWS_REGION"))
+        obj = s3.get_object(Bucket=ESCALATION_APPROVER_ALLOWLIST_BUCKET, Key=ESCALATION_APPROVER_ALLOWLIST_KEY)
+        body = obj["Body"].read().decode("utf-8")
+        emails: Set[str] = set()
+        # Parsed without a yaml dependency: the document's fenced yaml block
+        # uses `- email: "..."` list entries; pull the value off any such
+        # line regardless of the leading "- " list marker.
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                stripped = stripped[2:].strip()
+            if stripped.startswith("email:"):
+                value = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+                if value:
+                    emails.add(value.lower())
+        _escalation_allowlist_cache["emails"] = emails
+        _escalation_allowlist_cache["fetched_at"] = now
+        return emails
+    except Exception as exc:  # noqa: BLE001 — fail closed on any fetch/parse error
+        logger.error(
+            "escalation approver allowlist fetch failed (fail-closed, denying all deciders): %s", exc
+        )
+        return set()
+
+
+def _is_allowlisted_escalation_decider(claims: Dict[str, Any]) -> bool:
+    email = str((claims or {}).get("email") or "").strip().lower()
+    if not email:
+        return False
+    return email in _load_escalation_approver_allowlist()
+
+
 def _ddb_to_py(item: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a DynamoDB low-level item dict to plain Python."""
     ds = TypeDeserializer()
@@ -10108,6 +10168,20 @@ def _handle_escalation_decision(
         return _error(403, (
             "Escalation approval/denial requires a Cognito session (human-only). "
             "Agent, SCI, and internal-key credentials are structurally rejected."
+        ))
+
+    # ENC-TSK-L92 / ENC-ISS-501: _is_cognito_session alone is insufficient --
+    # it is a fail-open blocklist, not a positive human check. Require the
+    # decider's email to be explicitly present in the Console-only allowlist.
+    if not _is_allowlisted_escalation_decider(claims):
+        logger.warning(
+            "escalation decision rejected: decider email %r not on approver allowlist "
+            "(escalation_id=%s, project_id=%s)",
+            claims.get("email"), escalation_id, project_id,
+        )
+        return _error(403, (
+            "Escalation approval/denial requires an explicitly allowlisted decider "
+            "email. This identity is not on the escalation approver allowlist."
         ))
 
     try:

--- a/backend/lambda/coordination_api/test_escalation_decision_j70.py
+++ b/backend/lambda/coordination_api/test_escalation_decision_j70.py
@@ -117,7 +117,8 @@ class TestNonDelegableGate(unittest.TestCase):
 
 
 class TestEscalationDecisions(unittest.TestCase):
-    def _decide(self, decision, ddb, body=None, apply_result=None, apply_raises=None):
+    def _decide(self, decision, ddb, body=None, apply_result=None, apply_raises=None,
+                claims=None, allowlist=None):
         patches = [mock.patch.object(coordination_lambda, "_get_ddb", return_value=ddb)]
         invoke = mock.MagicMock()
         if apply_raises is not None:
@@ -129,10 +130,17 @@ class TestEscalationDecisions(unittest.TestCase):
             }
         patches.append(mock.patch.object(
             coordination_lambda, "_invoke_tracker_mutation_api", invoke))
-        with patches[0], patches[1]:
+        # ENC-TSK-L92: the decider-allowlist check calls S3 in production; tests
+        # stub it directly rather than mocking boto3 so intent stays legible.
+        # Default allowlist matches COGNITO_CLAIMS's email, preserving every
+        # pre-L92 test's original pass-through behavior.
+        patches.append(mock.patch.object(
+            coordination_lambda, "_load_escalation_approver_allowlist",
+            return_value=allowlist if allowlist is not None else {"io@jreese.net"}))
+        with patches[0], patches[1], patches[2]:
             resp = coordination_lambda._handle_escalation_decision(
                 "enceladus", "ENC-ESC-001", decision,
-                _decision_event(body), COGNITO_CLAIMS)
+                _decision_event(body), claims or COGNITO_CLAIMS)
         return resp, ddb, invoke
 
     def test_approve_happy_path_stamps_identity_and_applies(self):
@@ -221,6 +229,94 @@ class TestEscalationDecisions(unittest.TestCase):
         self.assertEqual(409, resp["statusCode"])
         self.assertIn("concurrently", json.loads(resp["body"])["error"])
         invoke.assert_not_called()
+
+
+class TestEscalationApproverAllowlist(unittest.TestCase):
+    """ENC-TSK-L92 / ENC-ISS-501: positive allowlist on top of _is_cognito_session.
+
+    _is_cognito_session alone is a fail-open blocklist (excludes only
+    auth_mode in {"internal-key", "managed-token"}); it let a non-human
+    Cognito-authenticated identity self-approve escalations. These tests
+    cover the allowlist gate directly, independent of TestEscalationDecisions'
+    default-allowlisted fixture.
+    """
+
+    def test_cognito_identity_not_on_allowlist_gets_403(self):
+        not_allowlisted_claims = {
+            "auth_mode": "cognito", "sub": "c4b8e478-40e1-70ce-9f5d-caffd3e241df",
+            "email": "terminal-agent@enceladus.internal",
+        }
+        resp, ddb, invoke = self._decide_raw(
+            "approve", _fake_ddb(escalation=_escalation_item()),
+            claims=not_allowlisted_claims, allowlist={"io@jreese.net"})
+        self.assertEqual(403, resp["statusCode"])
+        self.assertIn("allowlist", json.loads(resp["body"])["error"])
+        ddb.update_item.assert_not_called()
+        invoke.assert_not_called()
+
+    def test_allowlisted_identity_still_passes(self):
+        resp, ddb, invoke = self._decide_raw(
+            "approve", _fake_ddb(escalation=_escalation_item()),
+            claims=COGNITO_CLAIMS, allowlist={"io@jreese.net"})
+        self.assertEqual(200, resp["statusCode"])
+        invoke.assert_called_once()
+
+    def test_missing_email_claim_gets_403(self):
+        no_email_claims = {"auth_mode": "cognito", "sub": "abc-123"}
+        resp, ddb, invoke = self._decide_raw(
+            "approve", _fake_ddb(escalation=_escalation_item()),
+            claims=no_email_claims, allowlist={"io@jreese.net"})
+        self.assertEqual(403, resp["statusCode"])
+        ddb.update_item.assert_not_called()
+
+    def test_parses_real_document_format(self):
+        """Regression lock for the S3 doc's actual fenced-yaml list-item shape."""
+        doc_body = (
+            "# Escalation Approver Allowlist\n\n"
+            "Some prose.\n\n"
+            "```yaml\n"
+            "approvers:\n"
+            "  - email: \"ai@jreese.net\"\n"
+            "    added_at: \"2026-07-07T12:00:00Z\"\n"
+            "    added_by: \"io (ENC-TSK-L92 initial provisioning)\"\n"
+            "    notes: \"test\"\n"
+            "```\n"
+        )
+        coordination_lambda._escalation_allowlist_cache["emails"] = None
+        coordination_lambda._escalation_allowlist_cache["fetched_at"] = 0.0
+        with mock.patch.object(coordination_lambda, "boto3") as fake_boto3:
+            fake_body = mock.MagicMock()
+            fake_body.read.return_value = doc_body.encode("utf-8")
+            fake_boto3.client.return_value.get_object.return_value = {"Body": fake_body}
+            emails = coordination_lambda._load_escalation_approver_allowlist()
+        self.assertEqual({"ai@jreese.net"}, emails)
+
+    def test_allowlist_fetch_failure_fails_closed(self):
+        """S3 GetObject error -> empty allowlist -> everyone denied, not everyone allowed."""
+        ddb = _fake_ddb(escalation=_escalation_item())
+        with mock.patch.object(coordination_lambda, "_get_ddb", return_value=ddb), \
+             mock.patch.object(coordination_lambda, "boto3") as fake_boto3:
+            fake_boto3.client.return_value.get_object.side_effect = RuntimeError("NoSuchKey")
+            coordination_lambda._escalation_allowlist_cache["emails"] = None
+            coordination_lambda._escalation_allowlist_cache["fetched_at"] = 0.0
+            resp = coordination_lambda._handle_escalation_decision(
+                "enceladus", "ENC-ESC-001", "approve", _decision_event(), COGNITO_CLAIMS)
+        self.assertEqual(403, resp["statusCode"])
+        ddb.update_item.assert_not_called()
+
+    def _decide_raw(self, decision, ddb, claims, allowlist, body=None):
+        invoke = mock.MagicMock()
+        invoke.return_value = {
+            "success": True, "status": "applied",
+            "result": {"before": {}, "after": {}}, "_status_code": 200,
+        }
+        with mock.patch.object(coordination_lambda, "_get_ddb", return_value=ddb), \
+             mock.patch.object(coordination_lambda, "_invoke_tracker_mutation_api", invoke), \
+             mock.patch.object(coordination_lambda, "_load_escalation_approver_allowlist",
+                                return_value=allowlist):
+            resp = coordination_lambda._handle_escalation_decision(
+                "enceladus", "ENC-ESC-001", decision, _decision_event(body), claims)
+        return resp, ddb, invoke
 
 
 class TestRenderDiff(unittest.TestCase):

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -347,6 +347,11 @@ Resources:
           TRAINING_HARD_DISABLED: "1"
           INTENT_TRAINING_BUCKET: !Ref S3Bucket
           INTENT_TRAINING_PREFIX: !Sub "${S3EnvPrefix}intent-training"
+          # ENC-TSK-L92 / ENC-ISS-501: escalation approve/deny decider allowlist.
+          # This role is granted s3:GetObject only on this exact key -- no Lambda
+          # role, including this one, has write access. Edits are Console-only.
+          ESCALATION_APPROVER_ALLOWLIST_BUCKET: !Ref S3Bucket
+          ESCALATION_APPROVER_ALLOWLIST_KEY: security/escalation-approvers.md
       Tags:
         - Key: Project
           Value: enceladus
@@ -3767,6 +3772,14 @@ Resources:
                   - s3:HeadBucket
                   - s3:GetBucketLocation
                 Resource: "arn:aws:s3:::jreese-net"
+              # ENC-TSK-L92 / ENC-ISS-501: escalation approver allowlist -- READ ONLY.
+              # Deliberately no s3:PutObject/DeleteObject grant here or anywhere else
+              # in this role; the allowlist document is Console-edit-only by design.
+              - Sid: EscalationApproverAllowlistRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/security/escalation-approvers.md"
               - Sid: SSMDispatch
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
Fixes ENC-ISS-501 (SEV-1): `_is_cognito_session` was a fail-open **blocklist** — it only excludes `auth_mode` values of `internal-key`/`managed-token`, so any other or absent `auth_mode` passed as "human." A distinct Cognito identity (`terminal-agent@enceladus.internal`) exploited this to self-approve governance-bypass escalations within 1-8 seconds of filing, with no human review, going back to the very first escalation ever created.

This PR adds a positive **allowlist** check on top of the existing guard: the decider's `claims.email` must appear in `s3://jreese-net/security/escalation-approvers.md` — a document no Lambda role (including `coordination_api`'s own execution role) has write access to. Fails closed on any S3 fetch/parse error (denies everyone rather than falling back to "allow everyone").

## Changes
- `backend/lambda/coordination_api/lambda_function.py`: `_load_escalation_approver_allowlist()` (60s-cached S3 fetch+parse) + `_is_allowlisted_escalation_decider()`, wired into `_handle_escalation_decision` immediately after the existing `_is_cognito_session` check.
- `infrastructure/cloudformation/02-compute.yaml`: new env vars (`ESCALATION_APPROVER_ALLOWLIST_BUCKET`/`_KEY`) + a read-only `s3:GetObject` IAM statement scoped to exactly this object. No `PutObject` grant added anywhere.
- `backend/lambda/coordination_api/test_escalation_decision_j70.py`: existing 15 tests updated to mock the allowlist (preserving original intent); +5 new tests covering not-allowlisted→403, allowlisted→pass, missing-email→403, fetch-failure→fail-closed, and real-document-format parsing.

## Test plan
- [x] `python3 -m pytest test_escalation_decision_j70.py -q` — 20/20 pass
- [x] `python3 -m pytest .` (full coordination_api suite) — 637 passed, 8 pre-existing unrelated failures (AWS-credential-dependent dispatch-plan/component-opacity tests, confirmed failing identically pre-change)
- [x] `tools/pre-deploy-health-gate.sh --stack enceladus-compute-gamma --template infrastructure/cloudformation/02-compute.yaml` — PASSED (7/7 checks, no drift)
- [ ] Post-merge: create the S3 allowlist doc, verify live 403 for a non-allowlisted identity and live success for `ai@jreese.net`, then apply the S3 object Deny lockout (ENC-TSK-L92 AC2-AC6, tracked separately in the task worklog)

CCI-8f7b6cf01fbe4efe9f6a49415401a24c

🤖 Generated with [Claude Code](https://claude.com/claude-code)