### PR TITLE
ENC-TSK-L77: component registry v3 schema + required_transition_type v3 enum migration

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -41,6 +41,7 @@ Environment variables:
     CORS_ORIGIN                   default: https://jreese.net
     TOKEN_TTL_DAYS                token expiry in days (default: 90)
     COMPONENTS_TABLE              component registry DynamoDB table (default: component-registry)
+    DOCUMENT_API_BASE             document API base URL (defaults from TRACKER_API_BASE sibling)
     CHECKOUT_ASSISTANT_KEY        secret key for checkout-service-assistant auto-remediation
     COORDINATION_API_BASE         base URL for coordination API (default: https://jreese.net/api/v1/coordination)
 
@@ -55,11 +56,12 @@ identically to before.
 ENC-FTR-041: Added component registry enforcement. Tasks must declare ``components``
 (list of component_ids from component-registry table) before agent-initiated advances.
 The checkout service enforces that task.transition_type is at least as strict as the
-most restrictive component's transition_type (STRICTNESS_RANK ordering). Added
-``lambda_deploy`` transition_type arc (same as web_deploy but uses lambda_deploy_evidence
-at deploy-success). Added checkout-service-assistant inline auto-remediation: after 3
-consecutive deploy-success failures, the assistant infers the intended deploy method and
-loosens component registration if safe to do so.
+most restrictive component's artifact policy. Legacy component policy values are
+normalized to the v3 enum code|external_deploy|documentation at read time. Added
+``lambda_deploy`` task transition_type arc (same as web_deploy but uses
+lambda_deploy_evidence at deploy-success). Added checkout-service-assistant inline
+auto-remediation: after 3 consecutive deploy-success failures, the assistant infers
+the intended component policy if safe to do so.
 
 ENC-ISS-106: Added subtask lifecycle gate. Parent tasks (those with non-empty
 subtask_ids) cannot advance from coding-complete onward unless all direct children
@@ -86,6 +88,7 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple
+import urllib.parse
 import urllib.request
 import urllib.error
 from urllib.parse import unquote
@@ -156,6 +159,10 @@ CHECKOUT_ASSISTANT_KEY = os.environ.get("CHECKOUT_ASSISTANT_KEY", "")
 COORDINATION_API_BASE = os.environ.get(
     "COORDINATION_API_BASE", "https://jreese.net/api/v1/coordination"
 )
+DOCUMENT_API_BASE = os.environ.get(
+    "DOCUMENT_API_BASE",
+    TRACKER_API_BASE.rsplit("/", 1)[0] + "/documents",
+).rstrip("/")
 # ENC-ISS-441 / ENC-TSK-J93: agent-sessions store (ENC-FTR-117 / ENC-TSK-I37)
 # read by the SCI enforcement gate for the grandfather-epoch check and the
 # last_activity_at heartbeat touch (J83 pattern).
@@ -422,6 +429,8 @@ def _error(
             code = "NOT_FOUND"
         elif status == 409:
             code = "CONFLICT"
+        elif status == 422:
+            code = "INVALID_INPUT"
         elif status >= 500:
             code = "INTERNAL_ERROR"
         else:
@@ -556,6 +565,29 @@ def _tracker_request(
     except Exception as exc:
         logger.error("Tracker API request failed (%s %s): %s", method, path, exc)
         return 503, {"error": f"Tracker API unavailable: {exc}"}
+
+
+def _document_api_request(method: str, path: str) -> Tuple[int, dict]:
+    """Make a read-only request to document API using the coordination internal key."""
+    url = f"{DOCUMENT_API_BASE}{path}"
+    headers: dict = {
+        "Content-Type": "application/json",
+        "X-Coordination-Internal-Key": _PRIMARY_INTERNAL_KEY,
+    }
+    req = urllib.request.Request(url, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode())
+            return resp.status, body
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read().decode())
+        except Exception:
+            body = {"error": str(exc)}
+        return exc.code, body
+    except Exception as exc:
+        logger.error("Document API request failed (%s %s): %s", method, path, exc)
+        return 503, {"error": f"Document API unavailable: {exc}"}
 
 
 def _get_task(project_id: str, task_id: str) -> Tuple[int, dict]:
@@ -1311,8 +1343,8 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
             return _component_misconfigured_response(exc)
         if required_type is not None:
             task_rank = STRICTNESS_RANK.get(pre_transition_type, 99)
-            required_rank = STRICTNESS_RANK.get(required_type, 0)
-            if task_rank > required_rank:
+            required_rank = _COMPONENT_POLICY_TASK_MAX_RANK.get(required_type, -1)
+            if not _task_transition_satisfies_component_requirement(pre_transition_type, required_type):
                 # Identify the specific conflicting component for the error message.
                 # F50/AC-3: read required_transition_type, not the legacy transition_type.
                 conflicting_component = None
@@ -1325,15 +1357,15 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
                         item = resp.get("Item")
                         if not item:
                             continue
-                        comp_type = (
+                        raw_comp_type = (
                             item.get("required_transition_type", {}).get("S") or ""
                         ).strip()
-                        if not comp_type:
+                        if not raw_comp_type:
                             # Should be unreachable after _get_required_transition_type
                             # succeeded for this component; skip defensively.
                             continue
-                        comp_rank = STRICTNESS_RANK.get(comp_type, 0)
-                        if comp_rank < task_rank:
+                        comp_type = _normalize_component_required_transition_type(raw_comp_type, item)
+                        if not _task_transition_satisfies_component_requirement(pre_transition_type, comp_type):
                             conflicting_component = cid
                             break
                     except Exception:
@@ -1341,10 +1373,11 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
                 return _validation_error(
                     400,
                     (
-                        f"Task transition_type '{pre_transition_type}' (rank {task_rank}) is less strict "
-                        f"than required '{required_type}' (rank {required_rank}) enforced by component "
-                        f"'{conflicting_component or pre_components[0]}'. Update task.transition_type "
-                        f"to at least '{required_type}' before checking out."
+                        f"Task transition_type '{pre_transition_type}' (rank {task_rank}) cannot satisfy "
+                        f"component required_transition_type '{required_type}' (max task rank {required_rank}) "
+                        f"enforced by component '{conflicting_component or pre_components[0]}'. Update "
+                        "task.transition_type to a lifecycle arc that produces the required artifact class "
+                        "before checking out."
                     ),
                     task_id=task_id,
                     target_status="in-progress",
@@ -1361,7 +1394,7 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
                         "arguments": {
                             "record_id": task_id,
                             "field": "transition_type",
-                            "value": required_type,
+                            "value": _recommended_task_transition_for_component_policy(required_type),
                             "governance_hash": "<governance_hash>",
                         },
                     },
@@ -1663,6 +1696,45 @@ _NO_CODE_EVIDENCE_SCHEMA: Dict[str, Any] = {
     "example": {
         "no_code_evidence": "Updated governance metadata and confirmed the new rules are visible to agents.",
     },
+}
+
+_EXTERNAL_DEPLOY_EVIDENCE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required_fields": {
+        "comp_external_id": {
+            "type": "string",
+            "format": "non-empty string",
+            "description": "Stable identifier retrieved from the external system for the live component resource.",
+        },
+        "retrieval_steps": {
+            "type": "string",
+            "format": "non-empty string, minimum 20 characters",
+            "description": "Concrete steps a future operator can follow to re-retrieve comp_external_id.",
+        },
+    },
+    "example": {
+        "external_deploy_evidence": {
+            "comp_external_id": "90df28c1",
+            "retrieval_steps": "Open the external console, select the production resource, and copy its instance identifier from the details panel.",
+        }
+    },
+}
+
+_DOCUMENTATION_EVIDENCE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required_fields": {
+        "documentation_evidence": {
+            "type": "array[string]",
+            "format": "non-empty DOC-* identifiers",
+            "description": "At least one DOC id must resolve to an extant document and be novel or fresh at close.",
+        },
+    },
+    "close_gate": {
+        "fresh_window_minutes": 15,
+        "novel": "not referenced by another closed task's documentation_evidence",
+        "fresh": "document.updated_at is within 15 minutes of the close attempt",
+    },
+    "example": {"documentation_evidence": ["DOC-EDEFF7CD0BD5"]},
 }
 
 
@@ -2006,6 +2078,184 @@ def _validate_code_on_main_evidence(
     return True, ""
 
 
+def _validate_external_deploy_evidence(evidence: Any) -> Tuple[bool, str]:
+    if not evidence or not isinstance(evidence, dict):
+        return False, "transition_evidence.external_deploy_evidence must be a JSON object"
+    comp_external_id = evidence.get("comp_external_id")
+    if not isinstance(comp_external_id, str) or not comp_external_id.strip():
+        return False, "external_deploy_evidence.comp_external_id is required and must be a non-empty string"
+    retrieval_steps = evidence.get("retrieval_steps")
+    if not isinstance(retrieval_steps, str) or not retrieval_steps.strip():
+        return False, "external_deploy_evidence.retrieval_steps is required and must be a non-empty string"
+    if len(retrieval_steps.strip()) < 20:
+        return False, "external_deploy_evidence.retrieval_steps must be at least 20 characters"
+    evidence["comp_external_id"] = comp_external_id.strip()
+    evidence["retrieval_steps"] = retrieval_steps.strip()
+    return True, ""
+
+
+_DOC_ID_RE = re.compile(r"^DOC-[0-9A-F]+$")
+_DOCUMENTATION_FRESH_WINDOW_SECONDS = 15 * 60
+
+
+def _parse_documentation_evidence(raw: Any) -> Tuple[list[str], Optional[str]]:
+    if not isinstance(raw, list) or not raw:
+        return [], "documentation_evidence must be a non-empty array of DOC-* strings"
+    doc_ids: list[str] = []
+    for value in raw:
+        if not isinstance(value, str) or not value.strip():
+            return [], "documentation_evidence entries must be non-empty strings"
+        doc_id = value.strip().upper()
+        if not _DOC_ID_RE.match(doc_id):
+            return [], f"documentation_evidence entry '{value}' must match DOC-*"
+        doc_ids.append(doc_id)
+    return doc_ids, None
+
+
+def _parse_jsonish_evidence(raw: Any) -> Any:
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return stripped
+    return raw
+
+
+def _extract_documentation_evidence_doc_ids(record: Dict[str, Any]) -> set[str]:
+    doc_ids: set[str] = set()
+    candidates = [
+        record.get("documentation_evidence"),
+        record.get("transition_evidence"),
+    ]
+    for candidate in candidates:
+        parsed = _parse_jsonish_evidence(candidate)
+        if isinstance(parsed, dict):
+            parsed = parsed.get("documentation_evidence")
+        if isinstance(parsed, list):
+            ids, err = _parse_documentation_evidence(parsed)
+            if not err:
+                doc_ids.update(ids)
+    return doc_ids
+
+
+def _closed_documentation_evidence_doc_ids(project_id: str, current_task_id: str) -> set[str]:
+    used: set[str] = set()
+    cursor = ""
+    for _ in range(25):
+        path = f"/{project_id}?type=task&status=closed&page_size=200"
+        if cursor:
+            path += "&next_cursor=" + urllib.parse.quote(cursor, safe="")
+        status, body = _tracker_request("GET", path)
+        if status != 200:
+            raise RuntimeError(body.get("error", f"tracker list failed with HTTP {status}"))
+        for record in body.get("records") or body.get("items") or []:
+            if not isinstance(record, dict):
+                continue
+            rid = str(record.get("id") or record.get("record_id") or record.get("task_id") or "").strip()
+            if rid == current_task_id:
+                continue
+            used.update(_extract_documentation_evidence_doc_ids(record))
+        cursor = str(body.get("next_cursor") or "").strip()
+        if not cursor:
+            break
+    return used
+
+
+def _get_document_metadata(doc_id: str) -> Tuple[int, Dict[str, Any]]:
+    status, body = _document_api_request("GET", f"/{doc_id}")
+    if status != 200:
+        return status, body
+    if isinstance(body.get("document"), dict):
+        return status, body["document"]
+    return status, body if isinstance(body, dict) else {}
+
+
+def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_documentation_close_evidence(
+    *,
+    project_id: str,
+    task_id: str,
+    evidence: Any,
+    now: Optional[datetime] = None,
+) -> Tuple[bool, str, Dict[str, Any], list[str]]:
+    doc_ids, err = _parse_documentation_evidence(evidence)
+    if err:
+        return False, err, {"required_evidence_schema": _DOCUMENTATION_EVIDENCE_SCHEMA}, []
+
+    now_dt = now or datetime.now(timezone.utc)
+    try:
+        previously_used = _closed_documentation_evidence_doc_ids(project_id, task_id)
+    except Exception as exc:
+        return (
+            False,
+            f"documentation_evidence novelty check failed: {exc}",
+            {"policy": "P7 novelty-or-freshness close gate"},
+            doc_ids,
+        )
+
+    details: Dict[str, Any] = {
+        "policy": "P7 documentation close gate: at least one DOC id must be novel or fresh.",
+        "fresh_window_minutes": 15,
+        "doc_results": [],
+    }
+    qualifying: list[str] = []
+    non_qualifying: list[str] = []
+    for doc_id in doc_ids:
+        status, doc = _get_document_metadata(doc_id)
+        if status != 200:
+            details["doc_results"].append({
+                "document_id": doc_id,
+                "qualifies": False,
+                "reason": f"document lookup returned HTTP {status}",
+            })
+            non_qualifying.append(doc_id)
+            continue
+        updated_at = _parse_iso_datetime(doc.get("updated_at"))
+        is_fresh = (
+            updated_at is not None
+            and 0 <= (now_dt - updated_at).total_seconds() <= _DOCUMENTATION_FRESH_WINDOW_SECONDS
+        )
+        is_novel = doc_id not in previously_used
+        qualifies = is_novel or is_fresh
+        if qualifies:
+            qualifying.append(doc_id)
+        else:
+            non_qualifying.append(doc_id)
+        details["doc_results"].append({
+            "document_id": doc_id,
+            "qualifies": qualifies,
+            "novel": is_novel,
+            "fresh": is_fresh,
+            "updated_at": doc.get("updated_at", ""),
+        })
+
+    details["qualifying_doc_ids"] = qualifying
+    details["non_qualifying_doc_ids"] = non_qualifying
+    if not qualifying:
+        return (
+            False,
+            "documentation_evidence close gate failed: at least one DOC id must be novel or fresh.",
+            details,
+            doc_ids,
+        )
+    return True, "", details, doc_ids
+
+
 # ---------------------------------------------------------------------------
 # ENC-FTR-059: Matrix-driven deploy-success validator registry
 # Maps transition_type → validator function for deploy-success evidence.
@@ -2096,13 +2346,79 @@ def _validate_subtask_gate(
 
 # ---------------------------------------------------------------------------
 # ENC-FTR-041: Component registry enforcement helpers
-# ENC-TSK-F50 / ENC-ISS-270: required_transition_type is now the governed
-# enforcement field (see DOC-240A67973B13). The legacy `transition_type`
-# field on component records is NOT read here post-F50 — it is retained on
-# the record for back-compat and deploy-style documentation only. A missing
-# or invalid `required_transition_type` is an invariant violation and fails
-# loud with COMPONENT_MISCONFIGURED; no silent default remains.
+# DOC-157A790F9E8B v3: component.required_transition_type is now the component
+# policy enum {code, external_deploy, documentation}. Task.transition_type keeps
+# the existing lifecycle-arc enum in transition_type_matrix.py. This layer maps
+# legacy component rows at read time, then checks whether the task arc can
+# produce the artifact class required by the component policy.
 # ---------------------------------------------------------------------------
+
+_COMPONENT_REQUIRED_TRANSITION_TYPES = frozenset({
+    "code",
+    "external_deploy",
+    "documentation",
+})
+_LEGACY_COMPONENT_REQUIRED_TRANSITION_TYPE_MAP = {
+    "github_pr_deploy": "code",
+    "lambda_deploy": "code",
+    "web_deploy": "code",
+    "code_only": "code",
+    "data_only": "code",
+}
+_COMPONENT_POLICY_TASK_MAX_RANK = {
+    # Code components may use any code-producing lifecycle arc, including
+    # code_only. no_code remains too weak because it produces no repo artifact.
+    "code": STRICTNESS_RANK["code_only"],
+    # External deploy components need a deploy-success stage for P6 evidence.
+    "external_deploy": STRICTNESS_RANK["web_deploy"],
+    # Documentation components are satisfied by any task arc, but receive the
+    # P7 doc-evidence close gate below when the policy is present.
+    "documentation": STRICTNESS_RANK["no_code"],
+}
+_COMPONENT_POLICY_ORDER = {
+    name: rank for name, rank in sorted(
+        _COMPONENT_POLICY_TASK_MAX_RANK.items(),
+        key=lambda item: (item[1], item[0]),
+    )
+}
+
+
+def _component_looks_documentation_authored(item: Dict[str, Any]) -> bool:
+    address_class = (item.get("component_address_class", {}).get("S") or "").strip().lower()
+    component_class = (item.get("component_class", {}).get("S") or "").strip().lower()
+    address = (item.get("component_address", {}).get("S") or "").strip().lower()
+    repo_dir = (item.get("component_repo_dir", {}).get("S") or "").strip().lower()
+    return (
+        address_class == "meta"
+        or component_class == "meta"
+        or address.startswith("meta:")
+        or repo_dir.startswith("meta:")
+    )
+
+
+def _normalize_component_required_transition_type(raw_value: str, item: Optional[Dict[str, Any]] = None) -> str:
+    value = (raw_value or "").strip().lower()
+    if value in _COMPONENT_REQUIRED_TRANSITION_TYPES:
+        return value
+    if value == "no_code":
+        return "documentation" if _component_looks_documentation_authored(item or {}) else "code"
+    return _LEGACY_COMPONENT_REQUIRED_TRANSITION_TYPE_MAP.get(value, "")
+
+
+def _task_transition_satisfies_component_requirement(
+    task_transition_type: str,
+    required_policy: str,
+) -> bool:
+    task_rank = STRICTNESS_RANK.get(task_transition_type, 99)
+    return task_rank <= _COMPONENT_POLICY_TASK_MAX_RANK.get(required_policy, -1)
+
+
+def _recommended_task_transition_for_component_policy(required_policy: str) -> str:
+    if required_policy == "external_deploy":
+        return "github_pr_deploy"
+    if required_policy == "documentation":
+        return "no_code"
+    return "code_only"
 
 
 class ComponentMisconfiguredError(Exception):
@@ -2130,7 +2446,8 @@ class ComponentMisconfiguredError(Exception):
         if reason == "invalid_value":
             message = (
                 f"Component '{component_id}' has invalid required_transition_type="
-                f"'{bad_value}'; this is an invariant violation. Contact platform admin."
+                f"'{bad_value}'; expected one of code|external_deploy|documentation "
+                "or a recognized legacy value for read-time migration. Contact platform admin."
             )
         else:
             message = (
@@ -2156,12 +2473,12 @@ def _component_misconfigured_response(exc: ComponentMisconfiguredError) -> dict:
         "remediation_guidance": (
             "Set the component's `required_transition_type` in the registry "
             "(DynamoDB enceladus-component-registry) via the PWA /components "
-            "edit surface or via a product-lead terminal update-item. Valid "
-            "values: github_pr_deploy|lambda_deploy|web_deploy|code_only|no_code. "
+            "edit surface or via a product-lead terminal update-item. V3 valid "
+            "values: code|external_deploy|documentation. "
             "After the field is populated, retry the checkout."
         ),
         "rule_citation": (
-            "ENC-TSK-F50 / ENC-ISS-270 / DOC-240A67973B13 (AC-1 review document)"
+            "ENC-TSK-L77 / DOC-157A790F9E8B (v3 component hardening)"
         ),
     }
     if exc.bad_value is not None:
@@ -2181,14 +2498,12 @@ _BLOCKED_LIFECYCLE_STATUSES = frozenset({"proposed", "deprecated"})
 
 
 def _get_required_transition_type(component_ids: list) -> Optional[str]:
-    """Return the most restrictive ``required_transition_type`` across the
-    given component IDs.
+    """Return the most restrictive v3 component policy across component IDs.
 
-    F50/AC-3: reads the governed ``required_transition_type`` field on each
-    component registry record — NOT the legacy ``transition_type`` field.
-    If a component record exists but has no ``required_transition_type``
-    attribute, or the value is not a valid member of STRICTNESS_RANK,
-    raises :class:`ComponentMisconfiguredError` (no silent default).
+    DOC-157A790F9E8B / ENC-TSK-L77: reads the governed
+    ``required_transition_type`` field and normalizes legacy component enum
+    values at read time. Missing values still fail loud; the compatibility path
+    is for existing populated rows, not silent fallback.
 
     Missing components (component_id absent from the registry entirely)
     continue to fail-open with a WARNING log, preserving the ENC-FTR-041
@@ -2214,24 +2529,25 @@ def _get_required_transition_type(component_ids: list) -> Optional[str]:
                 )
                 continue
             required_attr = item.get("required_transition_type") or {}
-            comp_type = (required_attr.get("S") or "").strip()
-            if not comp_type:
+            raw_comp_type = (required_attr.get("S") or "").strip()
+            if not raw_comp_type:
                 logger.error(
                     "[F50/AC-3] Component '%s' is missing required_transition_type "
-                    "in the registry (see DOC-240A67973B13 for governance contract)",
+                    "in the registry (see DOC-157A790F9E8B for governance contract)",
                     cid,
                 )
                 raise ComponentMisconfiguredError(cid, reason="missing")
-            if comp_type not in STRICTNESS_RANK:
+            comp_type = _normalize_component_required_transition_type(raw_comp_type, item)
+            if comp_type not in _COMPONENT_REQUIRED_TRANSITION_TYPES:
                 logger.error(
                     "[F50/AC-3] Component '%s' has invalid required_transition_type='%s' "
-                    "(not in STRICTNESS_RANK)",
-                    cid, comp_type,
+                    "(not in v3 enum and not a recognized legacy value)",
+                    cid, raw_comp_type,
                 )
                 raise ComponentMisconfiguredError(
-                    cid, reason="invalid_value", bad_value=comp_type
+                    cid, reason="invalid_value", bad_value=raw_comp_type
                 )
-            rank = STRICTNESS_RANK[comp_type]
+            rank = _COMPONENT_POLICY_TASK_MAX_RANK[comp_type]
             if rank < min_rank:
                 min_rank = rank
                 required = comp_type
@@ -2240,6 +2556,37 @@ def _get_required_transition_type(component_ids: list) -> Optional[str]:
         except Exception as exc:
             logger.error("[FTR-041] Failed to fetch component '%s': %s", cid, exc)
     return required
+
+
+def _get_component_required_transition_types(component_ids: list) -> set[str]:
+    """Return all normalized v3 component policies present on the task."""
+    policies: set[str] = set()
+    if not component_ids:
+        return policies
+    for cid in component_ids:
+        try:
+            resp = _ddb.get_item(
+                TableName=COMPONENTS_TABLE,
+                Key={"component_id": {"S": str(cid)}},
+            )
+            item = resp.get("Item")
+            if not item:
+                continue
+            required_attr = item.get("required_transition_type") or {}
+            raw_comp_type = (required_attr.get("S") or "").strip()
+            if not raw_comp_type:
+                raise ComponentMisconfiguredError(cid, reason="missing")
+            comp_type = _normalize_component_required_transition_type(raw_comp_type, item)
+            if comp_type not in _COMPONENT_REQUIRED_TRANSITION_TYPES:
+                raise ComponentMisconfiguredError(
+                    cid, reason="invalid_value", bad_value=raw_comp_type
+                )
+            policies.add(comp_type)
+        except ComponentMisconfiguredError:
+            raise
+        except Exception as exc:
+            logger.error("[FTR-041] Failed to fetch component '%s': %s", cid, exc)
+    return policies
 
 
 def _get_components_lifecycle(component_ids: list) -> Dict[str, Dict[str, str]]:
@@ -2280,17 +2627,22 @@ def _get_components_lifecycle(component_ids: list) -> Dict[str, Dict[str, str]]:
 
 
 def _get_component_transition_type(component_id: str) -> str:
-    """Fetch current transition_type for a component from registry. Defaults to github_pr_deploy."""
+    """Fetch the current v3 component policy for assistant compatibility."""
     try:
         resp = _ddb.get_item(
             TableName=COMPONENTS_TABLE,
             Key={"component_id": {"S": str(component_id)}},
         )
         item = resp.get("Item") or {}
-        return item.get("transition_type", {}).get("S", "github_pr_deploy")
+        raw = (
+            item.get("required_transition_type", {}).get("S")
+            or item.get("transition_type", {}).get("S")
+            or "code"
+        )
+        return _normalize_component_required_transition_type(raw, item) or "code"
     except Exception as exc:
         logger.error("[ASSISTANT] Failed to fetch component '%s': %s", component_id, exc)
-        return "github_pr_deploy"
+        return "code"
 
 
 def _update_component_transition_type_via_api(
@@ -2300,6 +2652,7 @@ def _update_component_transition_type_via_api(
     url = f"{COORDINATION_API_BASE.rstrip('/')}/components/{component_id}"
     payload = json.dumps({
         "transition_type": new_type,
+        "required_transition_type": new_type,
         "assistant_reason": reason,
     }).encode()
     req = urllib.request.Request(
@@ -2374,19 +2727,14 @@ def _invoke_assistant(
         )
         return
 
-    inferred_type = (
-        "github_pr_deploy" if has_gha else
-        "web_deploy" if has_web else
-        "lambda_deploy" if has_lambda else
-        None
-    )
+    inferred_type = "code" if (has_gha or has_web or has_lambda) else None
     if not inferred_type:
         return
 
     for cid in components:
         current = _get_component_transition_type(cid)
-        current_rank = STRICTNESS_RANK.get(current, 0)
-        inferred_rank = STRICTNESS_RANK.get(inferred_type, 0)
+        current_rank = _COMPONENT_POLICY_TASK_MAX_RANK.get(current, 0)
+        inferred_rank = _COMPONENT_POLICY_TASK_MAX_RANK.get(inferred_type, 0)
         if inferred_rank >= current_rank:
             logger.info(
                 "[ASSISTANT] NOT loosening component '%s' (inferred=%s rank=%d >= current=%s rank=%d)",
@@ -2522,6 +2870,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
     # Human operators via the PWA UI (user_initiated=true) bypass this check to allow
     # closing legacy tasks that pre-date the component registry.
     components = task.get("components") or []
+    component_required_policies: set[str] = set()
     is_user_initiated = bool(body.get("user_initiated", False))
     if not components and not is_user_initiated:
         return _validation_error(
@@ -2614,16 +2963,18 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         except ComponentMisconfiguredError as exc:
             return _component_misconfigured_response(exc)
         if required_type is not None:
+            component_required_policies = {required_type}
             task_rank = STRICTNESS_RANK.get(transition_type, 99)
-            required_rank = STRICTNESS_RANK.get(required_type, 0)
-            if task_rank > required_rank:
+            required_rank = _COMPONENT_POLICY_TASK_MAX_RANK.get(required_type, -1)
+            if not _task_transition_satisfies_component_requirement(transition_type, required_type):
                 return _validation_error(
                     400,
                     (
-                        f"Task transition_type '{transition_type}' (rank {task_rank}) is less strict "
-                        f"than required '{required_type}' (rank {required_rank}) enforced by the "
-                        f"component registry (ENC-FTR-041). Update task.transition_type to at least "
-                        f"'{required_type}', or fix the component registration."
+                        f"Task transition_type '{transition_type}' (rank {task_rank}) cannot satisfy "
+                        f"component required_transition_type '{required_type}' (max task rank {required_rank}) "
+                        "enforced by the component registry (ENC-FTR-041). Update task.transition_type "
+                        "to a lifecycle arc that produces the required artifact class, or fix the "
+                        "component registration."
                     ),
                     task_id=task_id,
                     current_status=current_status,
@@ -2638,7 +2989,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                             "arguments": {
                                 "record_id": task_id,
                                 "field": "transition_type",
-                                "value": required_type,
+                                "value": _recommended_task_transition_for_component_policy(required_type),
                                 "governance_hash": "<governance_hash>",
                             },
                         },
@@ -2646,7 +2997,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                             task_id,
                             target_status,
                             provider or session_id or "<provider>",
-                            required_type,
+                            _recommended_task_transition_for_component_policy(required_type),
                         ),
                     ],
                 )
@@ -2939,6 +3290,40 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                     required_fields=[ev_label],
                 )
         transition_evidence[ev_key] = evidence_obj
+        if components:
+            try:
+                component_required_policies = (
+                    _get_component_required_transition_types(components)
+                    or component_required_policies
+                )
+            except ComponentMisconfiguredError as exc:
+                return _component_misconfigured_response(exc)
+        if "external_deploy" in component_required_policies:
+            external_evidence = (
+                transition_evidence.get("external_deploy_evidence")
+                or body.get("external_deploy_evidence")
+            )
+            valid, reason = _validate_external_deploy_evidence(external_evidence)
+            if not valid:
+                return _error(
+                    422,
+                    f"external_deploy_evidence validation failed: {reason}",
+                    code="INVALID_INPUT",
+                    retryable=False,
+                    details={
+                        "task_id": task_id,
+                        "current_status": current_status,
+                        "target_status": target_status,
+                        "transition_type": transition_type,
+                        "component_required_transition_types": sorted(component_required_policies),
+                        "required_fields": [
+                            "transition_evidence.external_deploy_evidence.comp_external_id",
+                            "transition_evidence.external_deploy_evidence.retrieval_steps",
+                        ],
+                        "required_evidence_schema": _EXTERNAL_DEPLOY_EVIDENCE_SCHEMA,
+                    },
+                )
+            transition_evidence["external_deploy_evidence"] = external_evidence
         logger.info(
             "deploy-success gate passed for %s (type=%s, matrix_version=%d)",
             task_id, transition_type, MATRIX_VERSION,
@@ -3014,6 +3399,43 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                 "closed gate passed for %s (type=%s, matrix_version=%d)",
                 task_id, transition_type, MATRIX_VERSION,
             )
+
+        if components:
+            try:
+                component_required_policies = (
+                    _get_component_required_transition_types(components)
+                    or component_required_policies
+                )
+            except ComponentMisconfiguredError as exc:
+                return _component_misconfigured_response(exc)
+        if "documentation" in component_required_policies:
+            documentation_evidence = (
+                transition_evidence.get("documentation_evidence")
+                or body.get("documentation_evidence")
+            )
+            valid, reason, details, doc_ids = _validate_documentation_close_evidence(
+                project_id=project_id,
+                task_id=task_id,
+                evidence=documentation_evidence,
+            )
+            if not valid:
+                return _error(
+                    422,
+                    reason,
+                    code="INVALID_INPUT",
+                    retryable=False,
+                    details={
+                        "task_id": task_id,
+                        "current_status": current_status,
+                        "target_status": target_status,
+                        "transition_type": transition_type,
+                        "component_required_transition_types": sorted(component_required_policies),
+                        "required_fields": ["transition_evidence.documentation_evidence"],
+                        "required_evidence_schema": _DOCUMENTATION_EVIDENCE_SCHEMA,
+                        **details,
+                    },
+                )
+            transition_evidence["documentation_evidence"] = doc_ids
 
         # ENC-FTR-048: Gate task closure on structured acceptance criteria evidence.
         # Only applies when the task has structured AC (object form with evidence_acceptance).

--- a/backend/lambda/checkout_service/test_checkout_error_context.py
+++ b/backend/lambda/checkout_service/test_checkout_error_context.py
@@ -29,7 +29,7 @@ class CheckoutServiceErrorContextTests(unittest.TestCase):
         self.assertEqual(details["example_fix"][0]["tool"], "tracker_set")
         self.assertEqual(details["example_fix"][-1]["tool"], "checkout_task")
 
-    @patch.object(checkout_service, "_get_required_transition_type", return_value="github_pr_deploy")
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="code")
     @patch.object(checkout_service, "_get_task")
     def test_advance_missing_deploy_evidence_includes_full_schema(self, mock_get_task, _mock_required_type):
         mock_get_task.return_value = (
@@ -137,7 +137,7 @@ class CheckoutServiceErrorContextTests(unittest.TestCase):
 
     @patch.object(checkout_service, "_validate_commit", return_value=(True, ""))
     @patch.object(checkout_service, "_resolve_github_repo", return_value=("NX-2021-L", "enceladus"))
-    @patch.object(checkout_service, "_get_required_transition_type", return_value="github_pr_deploy")
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="code")
     @patch.object(checkout_service, "_get_task")
     def test_cai_missing_includes_token_semantics(
         self, mock_get_task, _mock_required_type, _mock_resolve, _mock_validate,
@@ -179,7 +179,7 @@ class CheckoutServiceErrorContextTests(unittest.TestCase):
         self.assertEqual(prereq["arguments"]["record_id"], "ENC-TSK-840")
         self.assertEqual(prereq["arguments"]["target_status"], "coding-complete")
 
-    @patch.object(checkout_service, "_get_required_transition_type", return_value="github_pr_deploy")
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="code")
     @patch.object(checkout_service, "_get_task")
     def test_cci_missing_includes_token_semantics(self, mock_get_task, _mock_required_type):
         """CCI gate error includes token_type, token_purpose, prerequisite_call."""

--- a/backend/lambda/checkout_service/test_component_misconfig_failure.py
+++ b/backend/lambda/checkout_service/test_component_misconfig_failure.py
@@ -88,8 +88,8 @@ class ComponentMisconfiguredHelperTests(unittest.TestCase):
         def fake_get_item(**kwargs):
             cid = kwargs["Key"]["component_id"]["S"]
             mapping = {
-                "comp-checkout-service": "github_pr_deploy",
-                "comp-governance-docs": "no_code",
+                "comp-checkout-service": "code",
+                "comp-governance-docs": "documentation",
             }
             return _registry_item(component_id=cid, required_value=mapping[cid])
 
@@ -97,8 +97,8 @@ class ComponentMisconfiguredHelperTests(unittest.TestCase):
             result = checkout_service._get_required_transition_type(
                 ["comp-checkout-service", "comp-governance-docs"]
             )
-        # github_pr_deploy has rank 0 (strictest) and wins.
-        self.assertEqual(result, "github_pr_deploy")
+        # code is stricter than documentation and wins.
+        self.assertEqual(result, "code")
 
     def test_missing_component_id_fails_open_with_warning(self):
         """A stale task.components entry (no registry row) must not hard block."""
@@ -150,7 +150,7 @@ class CheckoutHandlerCOMPONENT_MISCONFIGUREDTests(unittest.TestCase):
             "jreese.net/components/comp-checkout-service", details["remediation_url"]
         )
         self.assertIn("required_transition_type", details["remediation_guidance"])
-        self.assertIn("DOC-240A67973B13", details["rule_citation"])
+        self.assertIn("DOC-157A790F9E8B", details["rule_citation"])
 
     @patch.object(checkout_service, "_get_task")
     def test_handle_advance_surfaces_component_misconfigured_envelope(self, mock_get_task):

--- a/backend/lambda/checkout_service/test_component_v3_evidence_gates.py
+++ b/backend/lambda/checkout_service/test_component_v3_evidence_gates.py
@@ -1,0 +1,175 @@
+"""ENC-TSK-L77 — v3 component policy evidence gates."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_service",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_service = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(checkout_service)
+
+
+def _deploy_evidence() -> dict:
+    return {
+        "id": 123,
+        "name": "Deploy Lambda Artifacts (Gen2)",
+        "run_id": 456,
+        "head_sha": "a" * 40,
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-07-07T04:00:00Z",
+        "completed_at": "2026-07-07T04:01:00Z",
+    }
+
+
+class ExternalDeployEvidenceGateTests(unittest.TestCase):
+    @patch.object(checkout_service, "_get_components_lifecycle", return_value={"comp-external": {"lifecycle_status": "active"}})
+    @patch.object(checkout_service, "_get_component_required_transition_types", return_value={"external_deploy"})
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="external_deploy")
+    @patch.object(checkout_service, "_get_task")
+    def test_deploy_success_requires_external_deploy_evidence(self, mock_get_task, _required, _policies, _lifecycle):
+        mock_get_task.return_value = (
+            200,
+            {
+                "status": "deploy-init",
+                "transition_type": "github_pr_deploy",
+                "active_agent_session": True,
+                "active_agent_session_id": "test-session",
+                "components": ["comp-external"],
+            },
+        )
+
+        resp = checkout_service._handle_advance(
+            "enceladus",
+            "ENC-TSK-EXT",
+            {
+                "target_status": "deploy-success",
+                "provider": "test-session",
+                "transition_evidence": {"deploy_evidence": _deploy_evidence()},
+            },
+        )
+
+        self.assertEqual(resp["statusCode"], 422)
+        envelope = json.loads(resp["body"])["error_envelope"]
+        self.assertIn("external_deploy_evidence", envelope["message"])
+        self.assertIn("comp_external_id", envelope["details"]["required_fields"][0])
+
+    @patch.object(checkout_service, "_get_components_lifecycle", return_value={"comp-external": {"lifecycle_status": "active"}})
+    @patch.object(checkout_service, "_get_component_required_transition_types", return_value={"external_deploy"})
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="external_deploy")
+    @patch.object(checkout_service, "_get_task")
+    def test_deploy_success_rejects_short_retrieval_steps(self, mock_get_task, _required, _policies, _lifecycle):
+        mock_get_task.return_value = (
+            200,
+            {
+                "status": "deploy-init",
+                "transition_type": "github_pr_deploy",
+                "active_agent_session": True,
+                "active_agent_session_id": "test-session",
+                "components": ["comp-external"],
+            },
+        )
+
+        resp = checkout_service._handle_advance(
+            "enceladus",
+            "ENC-TSK-EXT",
+            {
+                "target_status": "deploy-success",
+                "provider": "test-session",
+                "transition_evidence": {
+                    "deploy_evidence": _deploy_evidence(),
+                    "external_deploy_evidence": {
+                        "comp_external_id": "cf-resource-1",
+                        "retrieval_steps": "too short",
+                    },
+                },
+            },
+        )
+
+        self.assertEqual(resp["statusCode"], 422)
+        self.assertIn("at least 20", json.loads(resp["body"])["error_envelope"]["message"])
+
+
+class DocumentationEvidenceGateTests(unittest.TestCase):
+    def _task_sequence(self):
+        initial = {
+            "status": "coding-complete",
+            "transition_type": "no_code",
+            "active_agent_session": True,
+            "active_agent_session_id": "test-session",
+            "components": ["comp-docs"],
+        }
+        updated = {**initial, "status": "closed"}
+        return [(200, initial), (200, updated)]
+
+    @patch.object(checkout_service, "_get_components_lifecycle", return_value={"comp-docs": {"lifecycle_status": "active"}})
+    @patch.object(checkout_service, "_get_component_required_transition_types", return_value={"documentation"})
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="documentation")
+    @patch.object(checkout_service, "_closed_documentation_evidence_doc_ids", return_value={"DOC-ABC123"})
+    @patch.object(checkout_service, "_get_document_metadata", return_value=(200, {"updated_at": "2026-07-07T03:00:00Z"}))
+    @patch.object(checkout_service, "_get_task")
+    def test_closed_rejects_stale_reused_doc_id(
+        self, mock_get_task, _doc, _used, _required, _policies, _lifecycle
+    ):
+        mock_get_task.return_value = self._task_sequence()[0]
+
+        resp = checkout_service._handle_advance(
+            "enceladus",
+            "ENC-TSK-DOC",
+            {
+                "target_status": "closed",
+                "provider": "test-session",
+                "transition_evidence": {
+                    "no_code_evidence": "Verified the docstore update path.",
+                    "documentation_evidence": ["DOC-ABC123"],
+                },
+            },
+        )
+
+        self.assertEqual(resp["statusCode"], 422)
+        details = json.loads(resp["body"])["error_envelope"]["details"]
+        self.assertEqual(details["non_qualifying_doc_ids"], ["DOC-ABC123"])
+
+    @patch.object(checkout_service, "_get_components_lifecycle", return_value={"comp-docs": {"lifecycle_status": "active"}})
+    @patch.object(checkout_service, "_release_task")
+    @patch.object(checkout_service, "_set_task_field", return_value=(200, {"success": True}))
+    @patch.object(checkout_service, "_get_component_required_transition_types", return_value={"documentation"})
+    @patch.object(checkout_service, "_get_required_transition_type", return_value="documentation")
+    @patch.object(checkout_service, "_closed_documentation_evidence_doc_ids", return_value=set())
+    @patch.object(checkout_service, "_get_document_metadata", return_value=(200, {"updated_at": "2026-07-07T03:00:00Z"}))
+    @patch.object(checkout_service, "_get_task")
+    def test_closed_accepts_novel_doc_id(
+        self, mock_get_task, _doc, _used, _required, _policies, mock_set, mock_release, _lifecycle
+    ):
+        mock_get_task.side_effect = self._task_sequence()
+
+        resp = checkout_service._handle_advance(
+            "enceladus",
+            "ENC-TSK-DOC",
+            {
+                "target_status": "closed",
+                "provider": "test-session",
+                "transition_evidence": {
+                    "no_code_evidence": "Verified the docstore update path.",
+                    "documentation_evidence": ["DOC-DEF123"],
+                },
+            },
+        )
+
+        self.assertEqual(resp["statusCode"], 200)
+        transition_evidence = mock_set.call_args.kwargs["transition_evidence"]
+        self.assertEqual(transition_evidence["documentation_evidence"], ["DOC-DEF123"])
+        mock_release.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,40 +1,40 @@
 {
-  "version": "2026-07-07.7",
-  "updated_at": "2026-07-07T12:45:00Z",
-  "last_change_summary": "ENC-TSK-L92 / ENC-ISS-501 (SEV-1): escalation approve/deny now requires the decider's Cognito email to be on a Console-edit-only S3 allowlist (ESCALATION_APPROVER_ALLOWLIST_BUCKET/_KEY), on top of the existing _is_cognito_session check, which was found to be a fail-open blocklist that let a non-human identity self-approve governance-bypass escalations.",
+  "version": "2026-07-07.8",
+  "updated_at": "2026-07-07T12:53:00Z",
+  "last_change_summary": "ENC-TSK-L77: component registry v3 hardening adds component_address/component_repo_dir/component_address_class/component_class, migrates component required_transition_type to code|external_deploy|documentation with legacy read-time mapping, and documents external_deploy_evidence plus documentation_evidence advance gates.",
   "owners": [
     "enceladus-platform"
   ],
   "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
   "entities": {
     "tracker.dedup_auto_merge": {
-      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 \u00a7P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL \u2014 judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
       "fields": {
         "enable_dedup_auto_merge": {
           "type": "feature_flag",
-          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 \u00a74.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
           "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
         },
         "dedup_auto_merge_kill_switch": {
           "type": "feature_flag",
-          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} \u2014 auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 \u00a78).",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
           "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
         },
         "precision_lcb_floor": {
           "type": "number",
           "default": 0.999,
-          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 \u00a74.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 \u2014 auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, \u00a74.4).",
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
           "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
         },
         "auto_walk_opt_out_latch": {
           "type": "behavior",
-          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge \u2014 un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source \u2014 PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
-          "usage_guidance": "No manual action required \u2014 the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
         },
         "audit_feed": {
           "type": "event",
           "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
-          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 \u00a710)."
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
         }
       }
     },
@@ -57,8 +57,8 @@
             "deployed",
             "superseded"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -110,8 +110,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -120,7 +120,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -146,14 +146,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -244,7 +244,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -254,12 +254,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -273,7 +273,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -289,7 +289,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -297,8 +297,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -346,7 +346,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -358,9 +358,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         },
         "auto_walk_opt_out": {
@@ -375,7 +375,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -433,7 +433,7 @@
             "closed",
             "superseded"
           ],
-          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
+          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
         },
         "priority": {
           "type": "enum",
@@ -505,7 +505,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -525,7 +525,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -746,7 +746,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
         }
       }
     },
@@ -782,7 +782,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -902,7 +902,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -927,7 +927,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -1035,7 +1035,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -1144,7 +1144,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -1173,7 +1173,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1281,7 +1281,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1413,7 +1413,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1439,7 +1439,7 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
           "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
@@ -1827,18 +1827,18 @@
           ],
           "default": "ci_triggered",
           "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
-          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field \u2014 including enceladus \u2014 are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier \u2014 never from evidence-field emptiness (DOC-078C57FC1BE6 \u00a77.2). seed value: enceladus = ci_triggered."
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
         }
       }
     },
     "lifecycle_service.arc_walker_walk": {
-      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 \u00a76.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (\u00a73.1/\u00a711): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) \u2014 distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the \u00a77.2 coding-complete trap).",
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
       "governing_feature": "ENC-FTR-111",
       "governing_task": "ENC-TSK-H85",
       "fields": {
         "feature_flag": {
           "type": "string",
-          "definition": "enable_arc_walker \u2014 independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 \u00a711).",
+          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
           "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
         },
         "phase1_legs": {
@@ -1848,19 +1848,19 @@
         },
         "idempotent_conditional_write": {
           "type": "object",
-          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly \u2014 no double-step, no lost update (DOC-078C57FC1BE6 \u00a78 idempotency / \u00a79 concurrent-advance mitigation)."
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
         },
         "safety_invariants": {
           "type": "object",
-          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity \u2014 a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning \u2014 if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
         },
         "write_source": {
           "type": "string",
-          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the \u00a713 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
         },
         "artifact_genesis": {
           "type": "string",
-          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 \u00a78/\u00a710): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
         }
       }
     },
@@ -2289,7 +2289,7 @@
       "fields": {
         "package_root": {
           "type": "string",
-          "definition": "tools/enceladus-mcp-server/mcp_server/ \u2014 sibling package imported by server.py."
+          "definition": "tools/enceladus-mcp-server/mcp_server/ — sibling package imported by server.py."
         },
         "handler_modules": {
           "type": "object",
@@ -2433,7 +2433,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2460,7 +2460,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2531,7 +2531,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2688,7 +2688,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2710,12 +2710,38 @@
         },
         "transition_evidence": {
           "type": "object",
-          "definition": "Evidence payload; required fields vary by target_status (see gate_matrix)."
+          "definition": "Evidence payload; required fields vary by target_status and by component_registry.component.required_transition_type policy (see gate_matrix plus v3_component_policy_evidence)."
+        },
+        "v3_component_policy_evidence": {
+          "type": "object",
+          "definition": "Additional evidence overlays introduced by ENC-TSK-L77 / DOC-157A790F9E8B. These are evaluated by checkout_service based on the task's declared components and their normalized component required_transition_type values.",
+          "properties": {
+            "external_deploy_evidence": {
+              "type": "object",
+              "required_when": "Any task component resolves to required_transition_type=external_deploy and target_status=deploy-success.",
+              "required_fields": {
+                "comp_external_id": "non-empty string",
+                "retrieval_steps": "string, minimum 20 characters"
+              },
+              "definition": "Structured external-system proof. comp_external_id is the live external resource identifier; retrieval_steps must be concrete enough for a future agent/io session to re-derive the same identifier."
+            },
+            "documentation_evidence": {
+              "type": "array[string]",
+              "required_when": "Any task component resolves to required_transition_type=documentation and target_status=closed.",
+              "constraints": [
+                "non-empty array",
+                "each item matches DOC-* and resolves through document API",
+                "at least one item is novel or fresh"
+              ],
+              "fresh_window_minutes": 15,
+              "definition": "Docstore artifact-genesis proof. Novel means not referenced by another closed task's documentation_evidence; fresh means document.updated_at is within 15 minutes of the close attempt. Stale re-references are permitted as supporting context when at least one array member qualifies."
+            }
+          }
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
-          "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI; additionally external_deploy components require external_deploy_evidence. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; documentation components additionally require documentation_evidence; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
               "required_evidence": [
@@ -2749,6 +2775,9 @@
               "required_evidence": [
                 "deploy_evidence"
               ],
+              "additional_component_policy_evidence": [
+                "external_deploy_evidence when any component required_transition_type resolves to external_deploy"
+              ],
               "clears_tokens": [
                 "CAI",
                 "CCI"
@@ -2757,6 +2786,9 @@
             "closed": {
               "required_evidence": [
                 "live_validation_evidence"
+              ],
+              "additional_component_policy_evidence": [
+                "documentation_evidence when any component required_transition_type resolves to documentation"
               ],
               "releases_checkout": true
             }
@@ -2770,7 +2802,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2831,7 +2863,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2873,14 +2905,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -2909,7 +2941,7 @@
       }
     },
     "component_registry.component": {
-      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-J40 (PLN-060 Pile B): added a 6th field, deploy_targets, to the same capability-declaration set -- consumed by tools/assert_deploy_target_coverage.py to fail closed on blast-radius-scoped deploys when a component's declared targets are narrower than a merge's actual diff. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). DOC-157A790F9E8B / ENC-TSK-L77 hardens component identity with the injection pair component_address + component_repo_dir and classifies the row with component_address_class + component_class. required_transition_type is the v3 component policy enum code|external_deploy|documentation; checkout_service maps legacy component values at read time while task.transition_type keeps the existing lifecycle arc enum. ENC-TSK-E68 (ENC-PLN-031): capability-declaration fields are consumed by the continuous deploy capability auditor and pre-merge guard. ENC-TSK-J40 added deploy_targets for blast-radius-scoped deploy checks.",
       "fields": {
         "component_id": {
           "type": "string",
@@ -2939,37 +2971,76 @@
           ],
           "definition": "Classification category of the component."
         },
+        "component_address": {
+          "type": "string",
+          "required": true,
+          "unique": true,
+          "definition": "Universally addressable runtime/resource identity for the component. Accepted classes are governed by component_address_class. The create/propose surfaces reject duplicate addresses across the registry, including archived rows, preserving DOC-157A790F9E8B I1 address injection.",
+          "example": "arn:aws:lambda:us-west-2:123456789012:function:enceladus-checkout-service-gamma"
+        },
+        "component_repo_dir": {
+          "type": "string",
+          "required": true,
+          "unique_and_non_overlapping": true,
+          "definition": "Repository-relative source authority path for the component, or meta:{component_id} for meta components. The create/propose/update surfaces reject equal paths and prefix-overlaps against non-archived components, preserving DOC-157A790F9E8B I2 source injection and I3 source non-overlap.",
+          "example": "backend/lambda/checkout_service"
+        },
+        "component_address_class": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "aws_arn",
+            "https_url",
+            "cloudflare_resource",
+            "neo4j_auradb",
+            "external_manifest",
+            "meta"
+          ],
+          "definition": "Address verification/dispatch class. aws_arn must start with arn:aws:, https_url with https://, neo4j_auradb with neo4j+s://, and meta must use component_address=meta:{component_id}. component_address_class=aws_arn must not combine with required_transition_type=external_deploy."
+        },
+        "component_class": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "physical",
+            "external",
+            "meta"
+          ],
+          "definition": "Ontology class. physical is repo-produced runtime substrate, external is third-party/admin-managed substrate with governed repo configuration, and meta is governance-only. component_class=meta must be paired with component_address_class=meta and sentinel address/repo_dir values."
+        },
         "transition_type": {
           "type": "string",
           "enum": [
-            "github_pr_deploy",
-            "lambda_deploy",
-            "web_deploy",
-            "code_only",
-            "no_code"
+            "code",
+            "external_deploy",
+            "documentation"
           ],
-          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement \u2014 see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
+          "definition": "Documentation field describing the component's native artifact class. New writes use the v3 enum. Legacy stored values github_pr_deploy, lambda_deploy, web_deploy, code_only, data_only, and no_code are mapped at read time for compatibility."
         },
         "required_transition_type": {
           "type": "string",
           "required": true,
           "enum": [
-            "github_pr_deploy",
-            "lambda_deploy",
-            "web_deploy",
-            "code_only",
-            "no_code"
+            "code",
+            "external_deploy",
+            "documentation"
           ],
-          "strictness_rank": {
-            "github_pr_deploy": 0,
-            "lambda_deploy": 1,
-            "web_deploy": 1,
-            "code_only": 2,
-            "no_code": 3
+          "legacy_read_time_mapping": {
+            "github_pr_deploy": "code",
+            "lambda_deploy": "code",
+            "web_deploy": "code",
+            "code_only": "code",
+            "data_only": "code",
+            "no_code": "documentation for meta/doc-authored rows, otherwise code"
           },
-          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field \u2014 not the legacy transition_type \u2014 and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
-          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent \u2014 same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
-          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) \u2014 raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
+          "definition": "The component policy/artifact class required for tasks that declare this component. code requires a code-producing task arc; external_deploy requires a deploy-success stage plus external_deploy_evidence; documentation requires documentation_evidence at close. Checkout service reads this field, normalizes legacy populated rows at read time, and raises COMPONENT_MISCONFIGURED if the field is missing or invalid.",
+          "usage_guidance": "REQUIRED at create/propose time. New writes must use code, external_deploy, or documentation. PATCH may update but may not unset it. component_address_class=aws_arn rejects external_deploy. Default mapping: aws_arn->code; https_url->code for project-owned runtimes or external_deploy for third-party systems; cloudflare_resource/neo4j_auradb/external_manifest->external_deploy; meta->documentation.",
+          "enforcement_surface": "coordination_api validates create/propose/update. checkout_service._get_required_transition_type normalizes v3/legacy component values and compares them to task.transition_type lifecycle arcs; _handle_advance enforces external_deploy_evidence and documentation_evidence when matching component policies are present."
+        },
+        "required_transition_type_rationale": {
+          "type": "string",
+          "required": false,
+          "definition": "Optional rationale when required_transition_type departs from the component_address_class default mapping. Consumed by drift audit D4 in DOC-157A790F9E8B."
         },
         "description": {
           "type": "string",
@@ -3012,9 +3083,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -3047,11 +3118,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -3068,18 +3139,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -3190,7 +3261,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -3244,17 +3315,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -3272,7 +3343,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -3285,38 +3356,35 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
-      "description": "Five-surface defense-in-depth contract for required_transition_type on component_registry.component (ENC-TSK-F50 / ENC-ISS-270). Mirrors the governance.ogtm pattern (ENC-FTR-066): every component record must carry required_transition_type, and every write path into the component registry validates its presence and type. Governance-intent source: DOC-240A67973B13 (AC-1 per-component review document).",
+      "description": "V3 component-policy enforcement contract for required_transition_type on component_registry.component (ENC-TSK-L77 / DOC-157A790F9E8B). Every component record must carry one of code|external_deploy|documentation. Checkout service maps populated legacy values at read time, compares the component policy to the existing task.transition_type lifecycle arc, and enforces the new evidence sub-schemas at advance gates.",
       "fields": {
         "governing_task": {
           "type": "string",
-          "definition": "ENC-TSK-F50 (five-surface remediation of ENC-ISS-270)."
+          "definition": "ENC-TSK-L77 (component ontological hardening H-SCHEMA)."
         },
         "chosen_behavior_mode": {
           "type": "string",
           "enum": [
-            "A_strict",
-            "B_permissive_autofill"
+            "v3_strict_new_writes_legacy_read_mapping"
           ],
-          "value": "A_strict",
-          "definition": "ENC-TSK-F50 AC-6 permits either Option A (strict 400 on absent) or Option B (auto-fill from transition_type with WARNING). Enceladus selected Option A: POST /components that omits required_transition_type is rejected with HTTP 400 and a self-correcting envelope pointing to DOC-240A67973B13. Chosen because Option A matches the checkout_service fail-loud posture introduced by AC-3 and prevents silently-defaulted data from ever landing in the registry."
+          "value": "v3_strict_new_writes_legacy_read_mapping",
+          "definition": "New component writes must use code|external_deploy|documentation. Existing rows populated with github_pr_deploy, lambda_deploy, web_deploy, code_only, data_only, or no_code are normalized at read time so in-flight tasks do not regress during forward-only migration."
         },
         "strictness_rank": {
           "type": "object",
-          "definition": "Canonical rank table for required_transition_type enforcement. Task.transition_type with rank <= required_transition_type rank is permitted; higher rank (less strict) is rejected by checkout_service.",
+          "definition": "Component policy to task lifecycle compatibility. Task.transition_type remains the lifecycle arc enum; component required_transition_type is the artifact class policy.",
           "values": {
-            "github_pr_deploy": 0,
-            "lambda_deploy": 1,
-            "web_deploy": 1,
-            "code_only": 2,
-            "no_code": 3
+            "code": "task.transition_type rank must be <= code_only (github_pr_deploy, lambda_deploy, web_deploy, or code_only)",
+            "external_deploy": "task.transition_type rank must be <= web_deploy/lambda_deploy and deploy-success additionally requires external_deploy_evidence",
+            "documentation": "any task.transition_type rank may satisfy checkout strictness; close additionally requires documentation_evidence"
           }
         },
         "surfaces": {
@@ -3325,58 +3393,56 @@
           "items": [
             {
               "surface": "data_layer_review_and_backfill",
-              "file": "docstore://DOC-240A67973B13 (AC-1 review) + handoff (AC-2 superseding DOC-C1605D20665D)",
-              "responsibility": "Deliberate per-component governance-intent decision for required_transition_type, executed against prod DynamoDB enceladus-component-registry by io-dev-admin via the AC-2 handoff. Post-run scan with attribute_not_exists(required_transition_type) must return Count=0.",
-              "evidence_shape": "DOC-240A67973B13 referenced as backfill_rationale_ref on every updated row; backfilled_at + backfilled_by audit attributes stamped; post-scan Count=0."
+              "file": "docstore://DOC-157A790F9E8B H-BACKFILL",
+              "responsibility": "Backfill existing component rows with component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type after H-SCHEMA ships. Historical closed tasks remain forward-only unless explicitly governed by H-BACKFILL.",
+              "evidence_shape": "Post-scan shows no active component missing v3 identity fields or required_transition_type."
             },
             {
               "surface": "checkout_service_fail_loud",
               "file": "backend/lambda/checkout_service/lambda_function.py",
-              "responsibility": "_get_required_transition_type reads required_transition_type (not transition_type) and raises ComponentMisconfiguredError on missing/invalid. _handle_checkout and _handle_advance translate the exception into HTTP 500 with code=COMPONENT_MISCONFIGURED, surfaced via the standard api.error_envelope contract (ENC-TSK-D56 self-correcting envelope shape).",
-              "evidence_shape": "error_envelope.code=COMPONENT_MISCONFIGURED; error_envelope.details={component_id, reason in [missing, invalid_value], remediation_url=https://jreese.net/components/{id}, remediation_guidance, rule_citation='ENC-TSK-F50 / ENC-ISS-270 / DOC-240A67973B13'}."
+              "responsibility": "_get_required_transition_type reads required_transition_type, normalizes legacy populated values, raises ComponentMisconfiguredError on missing/invalid, and compares v3 component policy to task.transition_type lifecycle arcs. _handle_advance enforces P6 external_deploy evidence and P7 documentation evidence.",
+              "evidence_shape": "COMPONENT_MISCONFIGURED envelope for missing/invalid rows; 422 INVALID_INPUT for missing/invalid external_deploy_evidence or documentation_evidence."
             },
             {
               "surface": "coordination_api_create_update_validation",
               "file": "backend/lambda/coordination_api/lambda_function.py",
-              "responsibility": "_handle_components_create rejects POST /components that omits required_transition_type (HTTP 400, field=required_transition_type). _handle_components_update rejects PATCH /components/{id} that attempts to unset required_transition_type to null/empty/absent (HTTP 400, field=required_transition_type). Both validate the enum value and require Cognito/assistant auth parallel to the transition_type guard. _handle_components_propose stamps required_transition_type=requested_minimum_transition_type at proposal time; _handle_components_approve accepts an optional required_transition_type override.",
-              "evidence_shape": "400 envelope with field=required_transition_type + allowed_values + example_fix; or 201/200 with the created/updated item carrying the field."
+              "responsibility": "_handle_components_create and _handle_components_propose require component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type. They reject duplicate component_address, overlapping component_repo_dir, invalid class combinations, and aws_arn+external_deploy. PATCH may update but not unset governed identity/policy fields.",
+              "evidence_shape": "400/409/422 envelope naming the invalid field; 201/200 response carries the v3 fields."
             },
             {
               "surface": "seed_script_plus_ci_guard",
               "file": "tools/seed-component-registry.py + tools/verify_component_required_transition_type.py + .github/workflows/component-registry-guard.yml",
-              "responsibility": "seed-component-registry.py carries required_transition_type on every KNOWN_COMPONENTS entry (matched to the governance-intent decisions in DOC-240A67973B13). verify_component_required_transition_type.py audits the seed manifest and optionally probes the live registry via the coordination API (VERIFY_COMPONENT_REGISTRY_LIVE=1). component-registry-guard.yml runs the scanner on every PR that touches the component registry surface and fails CI on missing/invalid entries.",
-              "evidence_shape": "CI workflow run showing 'PASS: every seed manifest entry declares required_transition_type.' + optional 'PASS: every live registry row has required_transition_type.' lines."
+              "responsibility": "H-BACKFILL updates seed-component-registry.py and verify_component_required_transition_type.py so every KNOWN_COMPONENTS entry carries the four v3 identity fields and required_transition_type in code|external_deploy|documentation. component-registry-guard.yml fails CI on missing/invalid entries.",
+              "evidence_shape": "CI workflow run showing every seed manifest entry declares component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type."
             },
             {
               "surface": "governance_dictionary_field_spec",
               "file": "backend/lambda/coordination_api/governance_data_dictionary.json",
-              "responsibility": "component_registry.component.required_transition_type documented as REQUIRED enum with strictness_rank, usage_guidance, and enforcement_surface pointers. This entity (checkout_service.required_transition_type_enforcement) captures the five-surface contract. Dictionary_version bumped on every change touching this surface.",
-              "evidence_shape": "component_registry.component.required_transition_type.required=true; checkout_service.required_transition_type_enforcement entity present; version bumped."
+              "responsibility": "component_registry.component documents the four v3 identity fields, required_transition_type v3 enum, legacy read mapping, external_deploy_evidence, and documentation_evidence. Dictionary_version bumped on every change touching this surface.",
+              "evidence_shape": "version bumped; v3 fields required=true; evidence sub-schemas present."
             }
           ]
         },
         "rationale_anchor": {
           "type": "string",
-          "definition": "DOC-240A67973B13 (AC-1 review) is the governance-intent source of truth for every required_transition_type value. AC-2 backfill handoff (supersedes DOC-C1605D20665D) references this document as backfill_rationale_ref on every updated row."
+          "definition": "DOC-157A790F9E8B is the governance-intent source of truth for v3 component identity, required_transition_type policy, and P6/P7 evidence gates."
         },
         "invariant_statement": {
           "type": "string",
-          "definition": "Every component record in enceladus-component-registry carries a valid required_transition_type. checkout_service reads it for strictness enforcement; no silent default exists. This is the post-F50 replacement for the pre-F50 silent-default-to-github_pr_deploy behavior that caused ENC-ISS-270."
+          "definition": "Every active component record carries a unique component_address, non-overlapping component_repo_dir, valid component_address_class, valid component_class, and valid required_transition_type. Checkout service never silently defaults a missing component policy."
         }
       }
     },
     "checkout_service.component_enforcement": {
-      "description": "ENC-FTR-041: Component enforcement rules enforced by the checkout service in _handle_advance(). Documents the STRICTNESS_RANK ordering, no-components block, and checkout-service-assistant auto-remediation trigger.",
+      "description": "ENC-FTR-041 + ENC-TSK-L77: Component enforcement rules enforced by checkout_service. task.transition_type keeps the lifecycle arc matrix; component.required_transition_type is now the v3 artifact policy code|external_deploy|documentation.",
       "fields": {
-        "strictness_rank": {
+        "component_policy_to_task_arc_compatibility": {
           "type": "object",
-          "definition": "Rank ordering for transition types: github_pr_deploy=0 (strictest), lambda_deploy=1, web_deploy=1, code_only=2, no_code=3 (least strict). task.transition_type rank must be <= required_type rank.",
+          "definition": "Compatibility rules applied after legacy component required_transition_type values are normalized to v3.",
           "values": {
-            "github_pr_deploy": 0,
-            "lambda_deploy": 1,
-            "web_deploy": 1,
-            "code_only": 2,
-            "no_code": 3
+            "code": "allows task arcs github_pr_deploy, lambda_deploy, web_deploy, code_only; rejects no_code",
+            "external_deploy": "allows task arcs github_pr_deploy, lambda_deploy, web_deploy; rejects code_only and no_code; deploy-success requires external_deploy_evidence",
+            "documentation": "allows all task arcs; close requires documentation_evidence"
           }
         },
         "no_components_block": {
@@ -3385,7 +3451,7 @@
         },
         "assistant_trigger": {
           "type": "rule",
-          "definition": "If deploy-success evidence validation fails 3+ consecutive times on the same gate, _invoke_assistant() is called (non-blocking). The assistant infers the intended deploy method from the evidence shape and loosens affected components' transition_type if doing so would be less strict (higher rank). Never tightens."
+          "definition": "If deploy-success evidence validation fails 3+ consecutive times on the same gate, _invoke_assistant() is called (non-blocking). Under v3 it writes component transition fields using component policy values, not legacy task lifecycle arc values."
         },
         "lifecycle_status_gate": {
           "type": "rule",
@@ -3426,12 +3492,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3454,7 +3520,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3471,7 +3537,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "GET /api/v1/feed/corpus \u2014 JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+          "definition": "GET /api/v1/feed/corpus — JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
         },
         "cursor": {
           "type": "string",
@@ -3488,7 +3554,7 @@
       }
     },
     "feed_query.delta": {
-      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E \u00a79C/\u00a710.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
       "fields": {
         "since": {
           "type": "integer",
@@ -3505,7 +3571,7 @@
       }
     },
     "tracker.graphsearch": {
-      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges \u2014 never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges — never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
       "fields": {
         "search_type": {
           "type": "enum",
@@ -3786,7 +3852,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape \u2014 they do not abort the batch."
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
         }
       },
       "covered_lambdas": [
@@ -4128,7 +4194,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -4156,7 +4222,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -4169,7 +4235,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -4200,9 +4266,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -4310,7 +4376,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -4325,7 +4391,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -4689,7 +4755,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4719,7 +4785,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4736,12 +4802,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4774,23 +4840,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
+          "definition": "Plan → document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -4971,11 +5037,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -5008,7 +5074,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         },
         "orphan_purge_on_edge_removal": {
           "type": "string",
@@ -5063,7 +5129,7 @@
       }
     },
     "tracker.pathway_traversed": {
-      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection \u2014 graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation \u2014 tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability \u2014 graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
       "fields": {
         "edge_label": {
           "type": "string",
@@ -5071,11 +5137,11 @@
         },
         "relationship_type": {
           "type": "string",
-          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) \u2014 the lowercase tracker_mutation relationship_type keys."
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
         },
         "scoring_exclusion": {
           "type": "boolean",
-          "definition": "true \u2014 excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
         },
         "ogtm_compliance": {
           "type": "object",
@@ -5084,7 +5150,7 @@
       }
     },
     "graph_query_api.pathway_telemetry": {
-      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response \u2014 this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
       "fields": {
         "request_params": {
           "type": "object",
@@ -5105,7 +5171,7 @@
       }
     },
     "graph_query_api.drift_telemetry": {
-      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub \u2014 the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
       "fields": {
         "table": {
           "type": "string",
@@ -5126,7 +5192,7 @@
       }
     },
     "graph_query_api.stigmergic_trace": {
-      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation \u2014 exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
       "fields": {
         "table": {
           "type": "string",
@@ -5164,7 +5230,7 @@
       }
     },
     "graph_query_api.vector_read": {
-      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector \u2014 the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
       "fields": {
         "offset": {
           "type": "integer",
@@ -5194,7 +5260,7 @@
       }
     },
     "graph_query_api.adjacency": {
-      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes \u2014 OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
       "fields": {
         "project_id": {
           "type": "string",
@@ -5275,7 +5341,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -5294,12 +5360,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md \u00a713 Governance File Authority"
+          "reference": "agents.md §13 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -5311,7 +5377,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -5338,7 +5404,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -5351,7 +5417,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -5394,7 +5460,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -5481,7 +5547,7 @@
       "governing_plan": "ENC-PLN-014"
     },
     "monitoring.health_probe": {
-      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard \u2014 DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
+      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard — DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
       "fields": {
         "function_names": {
           "type": "array",
@@ -5560,7 +5626,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5609,7 +5675,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -5630,7 +5696,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5725,7 +5791,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -5762,7 +5828,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -5829,12 +5895,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match \u2014 fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match — fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -5844,28 +5910,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",
@@ -5947,7 +6013,7 @@
       }
     },
     "deploy.parity_validator": {
-      "description": "ENC-FTR-091 / ENC-TSK-F87 \u2014 v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
       "fields": {
         "function_name": {
           "type": "string",
@@ -5960,12 +6026,12 @@
         "detection_rules": {
           "type": "array",
           "item_type": "string",
-          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent \u2014 autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent \u2014 autonomous fix. ISS-279: enceladus-mcp-code-gamma missing \u2014 flag only. ISS-296: function_name_map gaps \u2014 flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas \u2014 flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api \u2014 flag only."
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
         },
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -5974,7 +6040,7 @@
       }
     },
     "auth.github_installation_token": {
-      "description": "Response contract for GET /api/v1/auth/github-token \u2014 vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
       "fields": {
         "token": {
           "type": "string",
@@ -5995,7 +6061,7 @@
         },
         "env_fallback": {
           "type": "string",
-          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
         },
         "default": {
           "type": "boolean",
@@ -6008,12 +6074,12 @@
             "env_fallback",
             "default"
           ],
-          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
         }
       }
     },
     "monitoring.continuous_drift_audit": {
-      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
       "fields": {
         "trigger": {
           "type": "string",
@@ -6034,12 +6100,12 @@
         },
         "alert_channel": {
           "type": "string",
-          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
         }
       }
     },
     "monitoring.mentions_drift_audit": {
-      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 \u2014 Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
       "governing_feature": "ENC-FTR-098",
       "governing_task": "ENC-TSK-G43",
       "fields": {
@@ -6065,7 +6131,7 @@
         },
         "iam_scope": {
           "type": "string",
-          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design \u2014 ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
         }
       }
     },
@@ -6108,7 +6174,7 @@
       }
     },
     "telemetry.eligible_fields": {
-      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only \u2014 it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
       "governing_feature": "ENC-FTR-086",
       "governing_task": "ENC-TSK-I83",
       "design_source": "DOC-E3F5E025B3D9",
@@ -6125,7 +6191,7 @@
           "type": "string",
           "required": true,
           "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
-          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint \u2014 this is a policy answer, not a degraded failure."
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
         },
         "record_type": {
           "type": "string",
@@ -6232,15 +6298,15 @@
           "enum": [
             "governance-version-current"
           ],
-          "usage_guidance": "Partition key. Always 'governance-version-current' \u2014 single-item canonical record."
+          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
         },
         "governance_revision": {
           "type": "string",
-          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md \u00a713."
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
         },
         "governance_hash": {
           "type": "string",
-          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per \u00a74.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
         },
         "generation": {
           "type": "integer",
@@ -6265,7 +6331,7 @@
       }
     },
     "recompute_governance.event_handler": {
-      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes \u00a74.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
       "fields": {
         "trigger": {
           "type": "object",
@@ -6285,7 +6351,7 @@
         },
         "recursion_invariant": {
           "type": "object",
-          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject \u2014 prevents ObjectCreated loops."
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
         },
         "env_vars": {
           "type": "object",
@@ -6294,7 +6360,7 @@
       }
     },
     "coordination_api.governance_hash_resolution": {
-      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed \u2014 it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 \u00a72.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
       "fields": {
         "primary_source": {
           "type": "object",
@@ -6306,7 +6372,7 @@
         },
         "removed_fallback": {
           "type": "object",
-          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents \u2014 stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
         },
         "env_vars": {
           "type": "object",
@@ -6315,7 +6381,7 @@
       }
     },
     "coordination_api.session_init_intent_classifier": {
-      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized \u2014 same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced \u2014 predictions are returned inline (AC-4). Scope guard (AC-5): inference-only \u2014 intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
       "fields": {
         "routes": {
           "type": "object",
@@ -6373,11 +6439,11 @@
         },
         "tier_3_canonical_ddb": {
           "type": "object",
-          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely \u2014 valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
         },
         "tier_4_s3_catalog": {
           "type": "object",
-          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort \u2014 no longer the primary docstore path."
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
         },
         "env_vars": {
           "type": "object",
@@ -6386,7 +6452,7 @@
       }
     },
     "governance_drift_check.handler": {
-      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the \u00a74.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
       "fields": {
         "drift_metric": {
           "type": "object",
@@ -6446,7 +6512,7 @@
       }
     },
     "unlearning.lambda": {
-      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only \u2014 io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection \u2014 no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
+      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only — io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection — no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
       "owner": "graph-sync",
       "source": "ENC-TSK-K03 / ENC-FTR-106",
       "telemetry_eligible": false,
@@ -6485,7 +6551,7 @@
       "telemetry_eligible": true
     },
     "monitoring.dedup_convergence_probe": {
-      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
       "fields": {
         "signals": {
           "type": "array",
@@ -6502,8 +6568,8 @@
         },
         "walk_back_model_health": {
           "type": "object",
-          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 \u00a710). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
-          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (\u00a713/\u00a74.3), so the live walk-back rate is 0 / shadow until then."
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
         },
         "config_env_vars": {
           "type": "array",
@@ -6548,7 +6614,7 @@
       }
     },
     "graph_query_api.publish_graph_health": {
-      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) \u2014 never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
+      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) — never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
       "fields": {
         "project_id": {
           "type": "string"
@@ -6868,7 +6934,7 @@
       }
     },
     "tracker.escalation": {
-      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations — Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
       "fields": {
         "escalation_id": {
           "type": "string",
@@ -6898,8 +6964,8 @@
             "required": true,
             "immutable": true
           },
-          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
-          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+          "definition": "Registry-resolved mutation handler key (§5.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT — the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
         },
         "payload": {
           "type": "object",
@@ -6944,13 +7010,13 @@
             "applied",
             "failed"
           ],
-          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
-          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+          "definition": "Escalation FSM state (§5.2). Enforced normally — escalations are not escalatable.",
+          "usage_guidance": "requested→{approved, denied, denied_with_guidance}; approved→applying; applying→{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
         },
         "events": {
           "type": "array",
           "item_type": "object",
-          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "definition": "Append-only event log (§11.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
           "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
         },
         "guidance_note": {
@@ -6975,7 +7041,7 @@
             "required": false
           },
           "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
-          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (§5.5)."
         },
         "result": {
           "type": "object",
@@ -7013,7 +7079,7 @@
       "dynamodb_key_schema": {
         "pk": "project_id",
         "sk_pattern": "escalation#{escalation_id}",
-        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "table": "existing tracker table (deliberate Channel B decision — no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
         "record_id_format": "{PREFIX}-ESC-{SEQ}",
         "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
       },
@@ -7021,8 +7087,8 @@
         "escalation_id": "IMMUTABLE (server-minted)",
         "target_record_id": "IMMUTABLE after create",
         "mutation_type": "IMMUTABLE after create",
-        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
-        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
+        "payload": "IMMUTABLE after create — the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (§5.2); enforced normally with no bypass",
         "events": "APPEND_ONLY (list_append only)",
         "approved_by": "Written only by the Cognito human approval route",
         "applied_at": "Written exactly once by applyEscalatedMutation"
@@ -7062,11 +7128,11 @@
       }
     },
     "mcp_server.escalation_actions": {
-      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action — override authorization exists only behind the Cognito human path (§6 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
       "fields": {
         "escalation.request": {
           "type": "execute_action",
-          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+          "definition": "Propose a human-gated mutation override. Envelope (§11.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
         },
         "escalation.get": {
           "type": "search_action",
@@ -7332,7 +7398,7 @@
       "description": "ENC-TSK-K20 (B67 AC-10 / AC-23): lightweight real-time event payload emitted by devops-appsync-feed-publisher to AppSync Events. Server-pre-rendered (summary is computed in the Lambda). Raw DynamoDB item images are NOT inlined; median payload <= 500 bytes (AC-23). Published to /feed/updates, /records/{recordId}, and /projects/{projectId}.",
       "fields": {
         "eventId": {
-          "definition": "UUID v7 (time-ordered, RFC 9562 \u00a75.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
+          "definition": "UUID v7 (time-ordered, RFC 9562 §5.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
           "type": "string"
         },
         "recordId": {
@@ -7445,7 +7511,7 @@
       }
     },
     "monitoring.v4_architecture_dashboard": {
-      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml \u2014 the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler \u03bb2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) \u2014 a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live \u2014 the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
+      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml — the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler λ2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) — a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live — the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
       "owner": "devops-monitoring",
       "source": "ENC-TSK-K46 / ENC-TSK-B66 (ENC-FTR-111 / ENC-TSK-H86)",
       "fields": {
@@ -7468,7 +7534,7 @@
       }
     },
     "user_preferences_api.lambda": {
-      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E \u00a715h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
+      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E §15h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
       "fields": {
         "USER_PREFERENCES_TABLE": {
           "definition": "DynamoDB table name for per-user preferences.",
@@ -7541,7 +7607,7 @@
       }
     },
     "opensearch_indexer.lambda": {
-      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser \u2014 TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
+      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E §15): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser — TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP, e.g. https://172.31.28.54:9200).",
@@ -7577,7 +7643,7 @@
       "telemetry_eligible": true
     },
     "graph_query_api.opensearch_keyword": {
-      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
+      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E §15d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "type": "string",
@@ -7608,12 +7674,19 @@
         },
         "facets_source": {
           "type": "enum",
-          "enum": ["opensearch", "feed_corpus"],
+          "enum": [
+            "opensearch",
+            "feed_corpus"
+          ],
           "definition": "Provenance of facets on hybrid responses."
         },
         "keyword_source": {
           "type": "enum",
-          "enum": ["opensearch", "neo4j_fallback", "unavailable"],
+          "enum": [
+            "opensearch",
+            "neo4j_fallback",
+            "unavailable"
+          ],
           "definition": "Provenance of the keyword RRF arm on hybrid responses."
         }
       },
@@ -7709,7 +7782,7 @@
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
     }
   },
-  "change_summary": "ENC-TSK-L89: FTR-122 retirement sweeps now atomically release task checkouts held by retired sessions, add an account-wide retired-session checkout-release backfill action, and expose the action through the MCP coordination surface.",
+  "change_summary": "ENC-TSK-L77: component registry v3 hardening (component_address/component_repo_dir/component_address_class/component_class), required_transition_type v3 enum {code,external_deploy,documentation} with legacy read-time mapping, and external_deploy_evidence + documentation_evidence advance gates. Integrated onto v4/main 2026-07-07.7 (ENC-SES-05V).",
   "change_log": [
     {
       "version": "2026-07-07.6",
@@ -7774,7 +7847,7 @@
     {
       "version": "2026-07-05.13",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.12",
@@ -7794,7 +7867,7 @@
     {
       "version": "2026-07-05.4",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus \u2014 cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
+      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus — cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
     },
     {
       "version": "2026-07-05.3",
@@ -7809,12 +7882,12 @@
     {
       "version": "2026-06-27.05",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop \u2014 governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 \u00a74.3 hash). New entity: governance_drift_check.handler. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-27.01",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution \u2014 agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
+      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution — agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
     },
     {
       "version": "2026-06-21.02",
@@ -7829,12 +7902,12 @@
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",
-      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
     },
     {
       "version": "2026-06-27.03",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, \u00a74.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, §4.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-28.06",
@@ -7874,7 +7947,7 @@
     {
       "version": "2026-07-02.01",
       "task": "ENC-TSK-J68",
-      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
+      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member — generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not — that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
     },
     {
       "version": "2026-07-02.02",
@@ -7929,32 +8002,32 @@
     {
       "version": "2026-07-02.20",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.22",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop \u2014 intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.26",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda \u2014 nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda — nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.27",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher \u2014 new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.28",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.29",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.30",
@@ -7984,12 +8057,17 @@
     {
       "version": "2026-07-05.8",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E \u00a715m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
+      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
     },
     {
       "version": "2026-07-05.14",
       "date": "2026-07-05",
       "summary": "ENC-TSK-L35 (B67 PWA2.0 session detail + worklog mirroring): coordination.agent_session gains updated_at (unconditional bump on every session-requiring call passing the SCI gate, including previously-untouched grandfathered/checkout-forwarded sessions) and history (best-effort mirror of every worklog entry the session appends to any governed record, via tracker_mutation._mirror_worklog_to_session). New GET /api/v1/coordination/agents/sessions/{id} single-session read route (coordination_api._handle_agent_session_get). Also wires the pre-existing agent-session-list/agent-type-list handlers (ENC-TSK-L34) to new API Gateway routes in 03-api.yaml. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-07.8",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L77: component registry v3 hardening adds component_address/component_repo_dir/component_address_class/component_class, migrates component required_transition_type to code|external_deploy|documentation with legacy read-time mapping, and documents external_deploy_evidence plus documentation_evidence advance gates."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -1233,6 +1233,8 @@ def _error(status_code: int, message: str, **extra: Any) -> Dict[str, Any]:
             code = "NOT_FOUND"
         elif status_code == 409:
             code = "CONFLICT"
+        elif status_code == 422:
+            code = "INVALID_INPUT"
         elif status_code == 429:
             code = "RATE_LIMITED"
         elif status_code >= 500:
@@ -8737,8 +8739,35 @@ _COMPONENT_CATEGORIES = frozenset({
     "lambda", "frontend", "infrastructure", "library", "workflow", "external"
 })
 _COMPONENT_TRANSITION_TYPES = frozenset({
-    "github_pr_deploy", "lambda_deploy", "web_deploy", "code_only", "no_code"
+    "code", "external_deploy", "documentation"
 })
+_LEGACY_COMPONENT_TRANSITION_TYPE_MAP = {
+    "github_pr_deploy": "code",
+    "lambda_deploy": "code",
+    "web_deploy": "code",
+    "code_only": "code",
+    "data_only": "code",
+    # no_code was split by authorship in DOC-157A790F9E8B. New writes must use
+    # v3 values; read-time compatibility defaults governance-only rows to docs.
+    "no_code": "documentation",
+}
+_COMPONENT_ADDRESS_CLASSES = frozenset({
+    "aws_arn",
+    "https_url",
+    "cloudflare_resource",
+    "neo4j_auradb",
+    "external_manifest",
+    "meta",
+})
+_COMPONENT_CLASSES = frozenset({"physical", "external", "meta"})
+_COMPONENT_ADDRESS_CLASS_DEFAULT_TRANSITION_TYPE = {
+    "aws_arn": "code",
+    "https_url": "code",
+    "cloudflare_resource": "external_deploy",
+    "neo4j_auradb": "external_deploy",
+    "external_manifest": "external_deploy",
+    "meta": "documentation",
+}
 _COMPONENT_STATUSES = frozenset({"active", "deprecated", "archived"})
 # ENC-TSK-E68 (ENC-PLN-031 Phase 3): capability-declaration fields accepted on
 # components_create / components_update / components_propose. All optional
@@ -8757,11 +8786,9 @@ _COMPONENT_CAPABILITY_FIELDS = (
     "deploy_targets",
 )
 _COMPONENT_STRICTNESS_RANK = {
-    "github_pr_deploy": 0,
-    "lambda_deploy": 1,
-    "web_deploy": 1,
-    "code_only": 2,
-    "no_code": 3,
+    "code": 0,
+    "external_deploy": 1,
+    "documentation": 2,
 }
 
 
@@ -8799,6 +8826,276 @@ def _component_validation_error(
     if example_fix:
         details["example_fix"] = example_fix
     return _error(status_code, message, **details)
+
+
+def _normalize_component_transition_type(value: Any) -> str:
+    """Return the v3 component transition type for legacy read compatibility."""
+    raw = str(value or "").strip().lower()
+    if raw in _COMPONENT_TRANSITION_TYPES:
+        return raw
+    return _LEGACY_COMPONENT_TRANSITION_TYPE_MAP.get(raw, "")
+
+
+def _component_record_with_v3_compat(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Expose legacy component rows through the v3 enum without mutating DDB."""
+    out = dict(record)
+    for field in (
+        "transition_type",
+        "required_transition_type",
+        "requested_minimum_transition_type",
+    ):
+        raw = str(out.get(field) or "").strip().lower()
+        mapped = _normalize_component_transition_type(raw)
+        if raw and mapped and raw != mapped:
+            out[f"legacy_{field}"] = raw
+            out[field] = mapped
+    return out
+
+
+def _component_repo_dir_overlaps(left: str, right: str) -> bool:
+    lval = left.rstrip("/")
+    rval = right.rstrip("/")
+    return lval == rval or lval.startswith(rval + "/") or rval.startswith(lval + "/")
+
+
+def _scan_component_registry_claims() -> list[Dict[str, Any]]:
+    ddb = _get_ddb()
+    items: list[Dict[str, Any]] = []
+    kwargs: Dict[str, Any] = {"TableName": COMPONENTS_TABLE}
+    while True:
+        resp = ddb.scan(**kwargs)
+        items.extend([_ddb_to_py(i) for i in resp.get("Items", [])])
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+    return items
+
+
+def _validate_component_registry_claims(
+    *,
+    component_id: str,
+    component_address: str = "",
+    component_repo_dir: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Enforce I1 address injection plus I2/I3 source injection/non-overlap."""
+    for existing in _scan_component_registry_claims():
+        existing_id = str(existing.get("component_id") or "").strip()
+        if existing_id == component_id:
+            continue
+
+        existing_address = str(existing.get("component_address") or "").strip()
+        if component_address and existing_address and existing_address == component_address:
+            return _component_validation_error(
+                409,
+                (
+                    "component_address must be unique across the component registry "
+                    f"(conflicts with {existing_id})."
+                ),
+                field="component_address",
+                component_id=component_id,
+                expected_type="unique string",
+                example_fix={"component_address": f"meta:{component_id}"},
+            )
+
+        lifecycle_status = str(existing.get("lifecycle_status") or existing.get("status") or "").strip().lower()
+        if lifecycle_status == "archived":
+            continue
+        existing_repo_dir = str(existing.get("component_repo_dir") or "").strip()
+        if component_repo_dir and existing_repo_dir and _component_repo_dir_overlaps(existing_repo_dir, component_repo_dir):
+            return _component_validation_error(
+                409,
+                (
+                    "component_repo_dir must be unique and non-overlapping under "
+                    f"the repo prefix order (conflicts with {existing_id}: {existing_repo_dir})."
+                ),
+                field="component_repo_dir",
+                component_id=component_id,
+                expected_type="repo-relative non-overlapping path",
+                example_fix={"component_repo_dir": f"infrastructure/external/{component_id.removeprefix('comp-')}.yaml"},
+            )
+    return None
+
+
+def _validate_component_hardening_fields(
+    body: Dict[str, Any],
+    component_id: str,
+    *,
+    require_all: bool,
+) -> Tuple[Optional[Dict[str, Any]], Dict[str, str]]:
+    """Validate DOC-157A790F9E8B v3 hardening fields for create/propose/update."""
+    parsed: Dict[str, str] = {}
+    required_fields = (
+        "component_address",
+        "component_repo_dir",
+        "component_address_class",
+        "component_class",
+    )
+    for field in required_fields:
+        if require_all and not str(body.get(field) or "").strip():
+            return (
+                _component_validation_error(
+                    400,
+                    f"{field} is required by the v3 component registry schema.",
+                    field=field,
+                    component_id=component_id,
+                    expected_type="string" if field in {"component_address", "component_repo_dir"} else "enum",
+                    allowed_values=(
+                        sorted(_COMPONENT_ADDRESS_CLASSES)
+                        if field == "component_address_class"
+                        else sorted(_COMPONENT_CLASSES)
+                        if field == "component_class"
+                        else None
+                    ),
+                ),
+                parsed,
+            )
+        if field in body and (body.get(field) is None or not str(body.get(field) or "").strip()):
+            return (
+                _component_validation_error(
+                    400,
+                    f"{field} cannot be unset to null/empty.",
+                    field=field,
+                    component_id=component_id,
+                    expected_type="string" if field in {"component_address", "component_repo_dir"} else "enum",
+                ),
+                parsed,
+            )
+        if field in body and body.get(field) is not None:
+            parsed[field] = str(body.get(field) or "").strip()
+
+    address_class = parsed.get("component_address_class", "")
+    if address_class:
+        address_class = address_class.lower()
+        if address_class not in _COMPONENT_ADDRESS_CLASSES:
+            return (
+                _component_validation_error(
+                    400,
+                    f"Invalid component_address_class '{address_class}'. Allowed: {sorted(_COMPONENT_ADDRESS_CLASSES)}",
+                    field="component_address_class",
+                    component_id=component_id,
+                    expected_type="enum",
+                    allowed_values=sorted(_COMPONENT_ADDRESS_CLASSES),
+                ),
+                parsed,
+            )
+        parsed["component_address_class"] = address_class
+
+    component_class = parsed.get("component_class", "")
+    if component_class:
+        component_class = component_class.lower()
+        if component_class not in _COMPONENT_CLASSES:
+            return (
+                _component_validation_error(
+                    400,
+                    f"Invalid component_class '{component_class}'. Allowed: {sorted(_COMPONENT_CLASSES)}",
+                    field="component_class",
+                    component_id=component_id,
+                    expected_type="enum",
+                    allowed_values=sorted(_COMPONENT_CLASSES),
+                ),
+                parsed,
+            )
+        parsed["component_class"] = component_class
+
+    address = parsed.get("component_address", "")
+    repo_dir = parsed.get("component_repo_dir", "")
+    if repo_dir:
+        if repo_dir.startswith("/") or any(part == ".." for part in repo_dir.split("/")):
+            return (
+                _component_validation_error(
+                    400,
+                    "component_repo_dir must be a repository-relative path without '..' segments.",
+                    field="component_repo_dir",
+                    component_id=component_id,
+                    expected_type="repo-relative path",
+                ),
+                parsed,
+            )
+        parsed["component_repo_dir"] = repo_dir.rstrip("/") if not repo_dir.startswith("meta:") else repo_dir
+
+    if address_class and address:
+        if address_class == "aws_arn" and not address.startswith("arn:aws:"):
+            return (
+                _component_validation_error(422, "component_address_class=aws_arn requires component_address to start with arn:aws:", field="component_address", component_id=component_id),
+                parsed,
+            )
+        if address_class == "https_url" and not address.startswith("https://"):
+            return (
+                _component_validation_error(422, "component_address_class=https_url requires an https:// component_address.", field="component_address", component_id=component_id),
+                parsed,
+            )
+        if address_class == "neo4j_auradb" and not address.startswith("neo4j+s://"):
+            return (
+                _component_validation_error(422, "component_address_class=neo4j_auradb requires a neo4j+s:// component_address.", field="component_address", component_id=component_id),
+                parsed,
+            )
+        if address_class == "meta" and address != f"meta:{component_id}":
+            return (
+                _component_validation_error(422, "component_address_class=meta requires component_address=meta:{component_id}.", field="component_address", component_id=component_id, example_fix={"component_address": f"meta:{component_id}"}),
+                parsed,
+            )
+
+    if component_class or address_class:
+        if (component_class == "meta") != (address_class == "meta"):
+            return (
+                _component_validation_error(
+                    422,
+                    "component_class=meta and component_address_class=meta must be used together.",
+                    field="component_class",
+                    component_id=component_id,
+                    expected_type="compatible enum pair",
+                ),
+                parsed,
+            )
+        if component_class == "external" and address_class == "aws_arn":
+            return (
+                _component_validation_error(
+                    422,
+                    "component_class=external cannot use component_address_class=aws_arn.",
+                    field="component_address_class",
+                    component_id=component_id,
+                    expected_type="compatible enum pair",
+                ),
+                parsed,
+            )
+
+    if component_class == "meta" and repo_dir and repo_dir != f"meta:{component_id}":
+        return (
+            _component_validation_error(
+                422,
+                "component_class=meta requires component_repo_dir=meta:{component_id}.",
+                field="component_repo_dir",
+                component_id=component_id,
+                example_fix={"component_repo_dir": f"meta:{component_id}"},
+            ),
+            parsed,
+        )
+
+    required_type = str(body.get("required_transition_type") or body.get("requested_minimum_transition_type") or "").strip().lower()
+    if address_class == "aws_arn" and required_type == "external_deploy":
+        return (
+            _component_validation_error(
+                422,
+                "component_address_class=aws_arn must not combine with required_transition_type=external_deploy; AWS-owned resources transition via code.",
+                field="required_transition_type",
+                component_id=component_id,
+                expected_type="compatible enum pair",
+                allowed_values=sorted(_COMPONENT_TRANSITION_TYPES - {"external_deploy"}),
+            ),
+            parsed,
+        )
+
+    if address or repo_dir:
+        conflict = _validate_component_registry_claims(
+            component_id=component_id,
+            component_address=address,
+            component_repo_dir=parsed.get("component_repo_dir", repo_dir),
+        )
+        if conflict:
+            return conflict, parsed
+
+    return None, parsed
 
 # Checkout-assistant key — allows updating transition_type without Cognito session
 CHECKOUT_ASSISTANT_KEY = os.environ.get("CHECKOUT_ASSISTANT_KEY", "")
@@ -8965,6 +9262,7 @@ def _handle_components_list(event: Dict[str, Any]) -> Dict[str, Any]:
                     break
                 kwargs["ExclusiveStartKey"] = last
 
+        items = [_component_record_with_v3_compat(item) for item in items]
         return _response(200, {"success": True, "components": items, "count": len(items)})
     except Exception as exc:
         logger.exception("components_list failed")
@@ -8987,7 +9285,7 @@ def _handle_components_get(component_id: str) -> Dict[str, Any]:
         ls = _ddb_to_py(item).get("lifecycle_status", "")
         if ls in _COMPONENT_LIFECYCLE_OPAQUE_STATUSES:
             return _error(404, f"Component '{component_id}' not found")
-        return _response(200, {"success": True, "component": _ddb_to_py(item)})
+        return _response(200, {"success": True, "component": _component_record_with_v3_compat(_ddb_to_py(item))})
     except Exception as exc:
         logger.exception("components_get failed")
         return _error(500, f"Failed to get component: {exc}")
@@ -8996,7 +9294,7 @@ def _handle_components_get(component_id: str) -> Dict[str, Any]:
 def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
     """POST /api/v1/coordination/components — create a new component.
 
-    transition_type defaults to github_pr_deploy for non-Cognito callers.
+    transition_type defaults to code for non-Cognito callers.
     """
     try:
         body = json.loads(event.get("body") or "{}")
@@ -9039,7 +9337,13 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
             allowed_values=sorted(_COMPONENT_CATEGORIES),
         )
 
-    # transition_type: Cognito/assistant can set any value; internal key defaults to github_pr_deploy
+    # Build component_id from provided slug or derive from name. The v3 identity
+    # fields use this for meta sentinels, so compute it before schema validation.
+    component_id = (body.get("component_id") or "").strip()
+    if not component_id:
+        component_id = _component_slug(component_name)
+
+    # transition_type: Cognito/assistant can set any v3 value; internal key defaults to code
     requested_type = (body.get("transition_type") or "").strip().lower()
     if requested_type and requested_type not in _COMPONENT_TRANSITION_TYPES:
         return _component_validation_error(
@@ -9056,19 +9360,20 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
             (
                 "Setting transition_type at create time requires Cognito authentication "
                 "(PWA session) or checkout-service-assistant key. "
-                "Internal API key callers receive the default 'github_pr_deploy'."
+                "Internal API key callers receive the default 'code'."
             ),
             field="transition_type",
             expected_type="enum",
             allowed_values=sorted(_COMPONENT_TRANSITION_TYPES),
             example_fix={
-                "transition_type": "github_pr_deploy",
+                "transition_type": "code",
                 "note": "Retry without transition_type, or use a Cognito session / checkout-service-assistant key to set a less strict component type.",
             },
         )
-    transition_type = requested_type or "github_pr_deploy"
+    transition_type = requested_type or "code"
 
-    # F50/AC-6 (Option A, strict — see ENC-TSK-F50 and DOC-240A67973B13):
+    # ENC-TSK-L77 / DOC-157A790F9E8B: required_transition_type is the v3
+    # component policy enum. New writes must use code|external_deploy|documentation.
     # required_transition_type is a first-class invariant field. Absent field
     # returns 400 with a descriptive error envelope. No auto-fill from
     # transition_type — the governance intent must be stated explicitly at
@@ -9082,21 +9387,20 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
             400,
             (
                 "required_transition_type is required and must be one of "
-                f"{sorted(_COMPONENT_TRANSITION_TYPES)} (ENC-TSK-F50 / ENC-ISS-270). "
+                f"{sorted(_COMPONENT_TRANSITION_TYPES)} (ENC-TSK-L77 / DOC-157A790F9E8B). "
                 "This field governs the minimum task strictness enforced by "
                 "checkout_service for tasks modifying this component. See "
-                "DOC-240A67973B13 for per-component selection rationale."
+                "DOC-157A790F9E8B for the v3 component policy rationale."
             ),
             field="required_transition_type",
             expected_type="enum",
             allowed_values=sorted(_COMPONENT_TRANSITION_TYPES),
             example_fix={
-                "required_transition_type": "github_pr_deploy",
+                "required_transition_type": "code",
                 "hint": (
-                    "For Lambda code use github_pr_deploy; for frontend/PWA use "
-                    "web_deploy; for CFN / governance docs / admin-managed "
-                    "externals use no_code. Match the existing transition_type "
-                    "unless you have a deliberate reason to diverge."
+                    "Use code for repo-produced components, external_deploy for "
+                    "third-party or admin-managed resources, and documentation "
+                    "for governed docstore/meta components."
                 ),
             },
         )
@@ -9113,11 +9417,6 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
         )
     required_transition_type = requested_required_type
 
-    # Build component_id from provided slug or derive from name
-    component_id = (body.get("component_id") or "").strip()
-    if not component_id:
-        component_id = _component_slug(component_name)
-
     status_val = (body.get("status") or "active").strip().lower()
     if status_val not in _COMPONENT_STATUSES:
         return _component_validation_error(
@@ -9127,6 +9426,14 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
             expected_type="enum",
             allowed_values=sorted(_COMPONENT_STATUSES),
         )
+
+    hardening_error, hardening_fields = _validate_component_hardening_fields(
+        body,
+        component_id,
+        require_all=True,
+    )
+    if hardening_error:
+        return hardening_error
 
     now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
@@ -9142,6 +9449,7 @@ def _handle_components_create(event: Dict[str, Any], claims: Dict[str, Any]) -> 
         "status": status_val,
         "created_at": now,
         "updated_at": now,
+        **hardening_fields,
     }
     if body.get("description"):
         item["description"] = str(body["description"]).strip()
@@ -9194,7 +9502,11 @@ def _handle_components_propose(event: Dict[str, Any], claims: Dict[str, Any]) ->
       project_id: str
       source_paths: list[str]
       description: str
-      requested_minimum_transition_type: str (must be in STRICTNESS_RANK)
+      requested_minimum_transition_type: str (v3 enum: code|external_deploy|documentation)
+      component_address: str
+      component_repo_dir: str
+      component_address_class: str
+      component_class: str
       proposing_agent_session_id: str (optional; falls back to auth claims sub / write_source provider)
     """
     if not ENABLE_COMPONENT_PROPOSAL:
@@ -9275,6 +9587,14 @@ def _handle_components_propose(event: Dict[str, Any], claims: Dict[str, Any]) ->
             field="proposing_agent_session_id", expected_type="string",
         )
 
+    hardening_error, hardening_fields = _validate_component_hardening_fields(
+        {**body, "required_transition_type": requested_type},
+        component_id,
+        require_all=True,
+    )
+    if hardening_error:
+        return hardening_error
+
     now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
     component_item: Dict[str, Any] = {
@@ -9296,6 +9616,7 @@ def _handle_components_propose(event: Dict[str, Any], claims: Dict[str, Any]) ->
         "created_at": now,
         "updated_at": now,
         "proposed_at": now,
+        **hardening_fields,
     }
 
     # ENC-TSK-E68 (ENC-PLN-031 Phase 3): capability declarations at proposal
@@ -12007,7 +12328,7 @@ def _handle_components_update(
                 allowed_values=sorted(_COMPONENT_TRANSITION_TYPES),
             )
 
-    # F50/AC-7 (ENC-TSK-F50 / ENC-ISS-270 / DOC-240A67973B13):
+    # ENC-TSK-L77 / DOC-157A790F9E8B:
     # required_transition_type can be updated to any valid enum value but
     # NEVER unset back to null/empty/absent. Once populated, the field
     # remains a first-class governance invariant that checkout_service reads
@@ -12063,11 +12384,40 @@ def _handle_components_update(
         # the clean enum, not whatever case/whitespace the caller sent.
         body["required_transition_type"] = new_required
 
+    hardening_patch_fields = {
+        "component_address",
+        "component_repo_dir",
+        "component_address_class",
+        "component_class",
+    }
+    if hardening_patch_fields & set(body.keys()):
+        if not (_is_cognito_session(claims) or _is_assistant_request(event)):
+            return _component_validation_error(
+                403,
+                (
+                    "Updating component identity fields requires Cognito "
+                    "authentication (PWA session) or checkout-service-assistant key."
+                ),
+                field="component_address",
+                component_id=component_id,
+                expected_type="governed identity field",
+            )
+        hardening_error, hardening_fields = _validate_component_hardening_fields(
+            body,
+            component_id,
+            require_all=False,
+        )
+        if hardening_error:
+            return hardening_error
+        body.update(hardening_fields)
+
     # Build update expression
     updatable_fields = {
         "component_name", "project_id", "category", "transition_type",
         # F50/AC-7: include required_transition_type so validated PATCHes persist.
         "required_transition_type",
+        "component_address", "component_repo_dir", "component_address_class",
+        "component_class", "required_transition_type_rationale",
         "description", "github_repo", "status", "assistant_reason",
     }
     # source_paths is a nested map — serialized via TypeSerializer, not as plain string
@@ -12168,7 +12518,7 @@ def _handle_components_update(
             ConditionExpression="attribute_exists(component_id)",
             ReturnValues="ALL_NEW",
         )
-        updated = _ddb_to_py(resp.get("Attributes", {}))
+        updated = _component_record_with_v3_compat(_ddb_to_py(resp.get("Attributes", {})))
         return _response(200, {"success": True, "component": updated})
     except ddb.exceptions.ConditionalCheckFailedException:
         return _error(404, f"Component '{component_id}' not found")

--- a/backend/lambda/coordination_api/test_component_error_context.py
+++ b/backend/lambda/coordination_api/test_component_error_context.py
@@ -36,10 +36,10 @@ class CoordinationComponentErrorContextTests(unittest.TestCase):
         self.assertEqual(response["statusCode"], 400)
         details = body["error_envelope"]["details"]
         self.assertEqual(details["field"], "transition_type")
-        self.assertIn("github_pr_deploy", details["allowed_values"])
+        self.assertIn("code", details["allowed_values"])
         rank_table = {entry["transition_type"]: entry["rank"] for entry in details["strictness_rank"]}
-        self.assertEqual(rank_table["github_pr_deploy"], 0)
-        self.assertEqual(rank_table["lambda_deploy"], 1)
+        self.assertEqual(rank_table["code"], 0)
+        self.assertEqual(rank_table["external_deploy"], 1)
 
 
 if __name__ == "__main__":

--- a/backend/lambda/coordination_api/test_components_approve_reject.py
+++ b/backend/lambda/coordination_api/test_components_approve_reject.py
@@ -142,11 +142,11 @@ class ComponentApproveTests(unittest.TestCase):
         }
         with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_approve(
-                "comp-x", _event({"transition_type": "code_only"}), COGNITO_CLAIMS
+                "comp-x", _event({"transition_type": "documentation"}), COGNITO_CLAIMS
             )
         self.assertEqual(resp["statusCode"], 200)
         kwargs = fake.update_item.call_args.kwargs
-        self.assertEqual(kwargs["ExpressionAttributeValues"][":tt"]["S"], "code_only")
+        self.assertEqual(kwargs["ExpressionAttributeValues"][":tt"]["S"], "documentation")
         self.assertIn("transition_type = :tt", kwargs["UpdateExpression"])
 
     # ENC-FTR-076 v2 / ENC-TSK-F40: approve accepts alarm_arn (optional,
@@ -203,19 +203,19 @@ class ComponentApproveTests(unittest.TestCase):
             "Attributes": {
                 "component_id": {"S": "comp-x"},
                 "lifecycle_status": {"S": "approved"},
-                "required_transition_type": {"S": "lambda_deploy"},
+                "required_transition_type": {"S": "external_deploy"},
             }
         }
         with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_approve(
                 "comp-x",
-                _event({"required_transition_type": "lambda_deploy"}),
+                _event({"required_transition_type": "external_deploy"}),
                 COGNITO_CLAIMS,
             )
         self.assertEqual(resp["statusCode"], 200)
         kwargs = fake.update_item.call_args.kwargs
         self.assertEqual(
-            kwargs["ExpressionAttributeValues"][":rtt"]["S"], "lambda_deploy"
+            kwargs["ExpressionAttributeValues"][":rtt"]["S"], "external_deploy"
         )
         self.assertIn("required_transition_type = :rtt", kwargs["UpdateExpression"])
 

--- a/backend/lambda/coordination_api/test_components_propose.py
+++ b/backend/lambda/coordination_api/test_components_propose.py
@@ -36,7 +36,11 @@ def _valid_body(**overrides):
         "project_id": "enceladus",
         "source_paths": ["backend/lambda/test_service/"],
         "description": "A test component proposal",
-        "requested_minimum_transition_type": "lambda_deploy",
+        "requested_minimum_transition_type": "external_deploy",
+        "component_address": "neo4j+s://test-proposal.databases.neo4j.io",
+        "component_repo_dir": "infrastructure/external/test-proposal.yaml",
+        "component_address_class": "neo4j_auradb",
+        "component_class": "external",
         "proposing_agent_session_id": "agent-session-abc123",
         "governance_hash": "hash-xyz",
     }
@@ -101,6 +105,7 @@ class ComponentProposeTests(unittest.TestCase):
     def test_duplicate_returns_409_on_transaction_cancelled(self):
         """AC1-9: TransactionCanceledException with ConditionalCheckFailed -> 409."""
         fake_ddb = mock.MagicMock()
+        fake_ddb.scan.return_value = {"Items": []}
 
         class _TCE(Exception):
             pass
@@ -119,6 +124,7 @@ class ComponentProposeTests(unittest.TestCase):
     def test_happy_path_201_and_transact_write(self):
         """AC1-8, AC1-9: happy path writes component + rel# pair via TransactWriteItems."""
         fake_ddb = mock.MagicMock()
+        fake_ddb.scan.return_value = {"Items": []}
 
         class _TCE(Exception):
             pass

--- a/backend/lambda/coordination_api/test_components_propose_sns.py
+++ b/backend/lambda/coordination_api/test_components_propose_sns.py
@@ -35,7 +35,11 @@ def _valid_body(**overrides):
         "project_id": "enceladus",
         "source_paths": ["backend/lambda/foo/"],
         "description": "SNS publish wiring test",
-        "requested_minimum_transition_type": "lambda_deploy",
+        "requested_minimum_transition_type": "external_deploy",
+        "component_address": "neo4j+s://test-sns.databases.neo4j.io",
+        "component_repo_dir": "infrastructure/external/test-sns.yaml",
+        "component_address_class": "neo4j_auradb",
+        "component_class": "external",
         "proposing_agent_session_id": "agent-session-sns-1",
     }
     body.update(overrides)
@@ -72,6 +76,7 @@ class ComponentProposeSnsTests(unittest.TestCase):
     def _ddb_ok(self):
         fake = mock.MagicMock()
         fake.exceptions.TransactionCanceledException = _TCE
+        fake.scan.return_value = {"Items": []}
         fake.transact_write_items.return_value = {}
         return fake
 
@@ -97,7 +102,7 @@ class ComponentProposeSnsTests(unittest.TestCase):
         self.assertEqual(payload["component_id"], "comp-test-sns")
         self.assertEqual(payload["project_id"], "enceladus")
         self.assertEqual(payload["proposing_agent_session_id"], "agent-session-sns-1")
-        self.assertEqual(payload["requested_minimum_transition_type"], "lambda_deploy")
+        self.assertEqual(payload["requested_minimum_transition_type"], "external_deploy")
         self.assertIn("jreese.net/components", payload["pwa_deep_link"])
 
     def test_no_topic_arn_skips_publish_silently(self):
@@ -124,6 +129,7 @@ class ComponentProposeSnsTests(unittest.TestCase):
     def test_publish_skipped_when_ddb_transaction_fails(self):
         fake_ddb = mock.MagicMock()
         fake_ddb.exceptions.TransactionCanceledException = _TCE
+        fake_ddb.scan.return_value = {"Items": []}
         fake_ddb.transact_write_items.side_effect = _TCE()
         fake_ddb.transact_write_items.side_effect.response = {
             "CancellationReasons": [{"Code": "ConditionalCheckFailed"}, {"Code": "None"}, {"Code": "None"}]

--- a/backend/lambda/coordination_api/test_components_required_transition_type.py
+++ b/backend/lambda/coordination_api/test_components_required_transition_type.py
@@ -60,6 +60,7 @@ def _happy_path_ddb(return_attrs: dict | None = None):
     fake.update_item.return_value = {
         "Attributes": return_attrs or {"component_id": {"S": "comp-x"}}
     }
+    fake.scan.return_value = {"Items": []}
     return fake
 
 
@@ -70,6 +71,10 @@ class CreateRequiredTransitionTypeTests(unittest.TestCase):
         "component_name": "Test Component",
         "project_id": "enceladus",
         "category": "lambda",
+        "component_address": "arn:aws:lambda:us-west-2:123456789012:function:test-component",
+        "component_repo_dir": "backend/lambda/test_component",
+        "component_address_class": "aws_arn",
+        "component_class": "physical",
     }
 
     def test_create_without_required_transition_type_returns_400(self):
@@ -82,11 +87,11 @@ class CreateRequiredTransitionTypeTests(unittest.TestCase):
         body = json.loads(resp["body"])
         details = body["error_envelope"]["details"]
         self.assertEqual(details["field"], "required_transition_type")
-        self.assertIn("github_pr_deploy", details["allowed_values"])
-        self.assertIn("no_code", details["allowed_values"])
+        self.assertIn("code", details["allowed_values"])
+        self.assertIn("documentation", details["allowed_values"])
         # Self-correcting envelope must surface the governance rule.
         self.assertIn("required_transition_type", body["error_envelope"]["message"])
-        self.assertIn("ENC-TSK-F50", body["error_envelope"]["message"])
+        self.assertIn("DOC-157A790F9E8B", body["error_envelope"]["message"])
 
     def test_create_with_invalid_required_transition_type_enum_returns_400(self):
         """AC-8(b): invalid enum value returns 400."""
@@ -106,7 +111,7 @@ class CreateRequiredTransitionTypeTests(unittest.TestCase):
     def test_create_with_valid_required_transition_type_persists_field(self):
         """Create happy path stamps both transition_type and required_transition_type."""
         body = dict(self._base_body)
-        body["required_transition_type"] = "github_pr_deploy"
+        body["required_transition_type"] = "code"
         fake = _happy_path_ddb()
         with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_create(
@@ -121,7 +126,7 @@ class CreateRequiredTransitionTypeTests(unittest.TestCase):
         # DynamoDB value is wrapped as {"S": "<value>"}; tolerant extraction.
         required_ddb = item_ddb.get("required_transition_type")
         self.assertIsNotNone(required_ddb, "required_transition_type not persisted")
-        self.assertEqual(required_ddb.get("S"), "github_pr_deploy")
+        self.assertEqual(required_ddb.get("S"), "code")
 
     def test_create_with_whitespace_only_required_transition_type_returns_400(self):
         """Whitespace-only value should be treated as absent."""
@@ -190,7 +195,7 @@ class PatchRequiredTransitionTypeTests(unittest.TestCase):
         """Direct agent writes with internal key are not permitted."""
         resp = coordination_lambda._handle_components_update(
             "comp-checkout-service",
-            _event({"required_transition_type": "no_code"}, method="PATCH"),
+            _event({"required_transition_type": "documentation"}, method="PATCH"),
             INTERNAL_CLAIMS,
         )
         self.assertEqual(resp["statusCode"], 403)
@@ -200,13 +205,13 @@ class PatchRequiredTransitionTypeTests(unittest.TestCase):
         fake = _happy_path_ddb(
             return_attrs={
                 "component_id": {"S": "comp-checkout-service"},
-                "required_transition_type": {"S": "no_code"},
+                "required_transition_type": {"S": "documentation"},
             }
         )
         with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake):
             resp = coordination_lambda._handle_components_update(
                 "comp-checkout-service",
-                _event({"required_transition_type": "no_code"}, method="PATCH"),
+                _event({"required_transition_type": "documentation"}, method="PATCH"),
                 COGNITO_CLAIMS,
             )
         self.assertEqual(resp["statusCode"], 200)

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -5404,6 +5404,18 @@ def _handle_update_field(
             me = transition_evidence["merge_evidence"]
             # ENC-ISS-097: merge_evidence may be a dict (checkout service) or a string (direct PATCH)
             extra_vals[":merge_ev"] = {"S": json.dumps(me, separators=(",", ":")) if isinstance(me, dict) else str(me).strip()}
+        if transition_evidence.get("external_deploy_evidence"):
+            extra_sets.append("external_deploy_evidence = :external_deploy_ev")
+            ede = transition_evidence["external_deploy_evidence"]
+            extra_vals[":external_deploy_ev"] = {
+                "S": json.dumps(ede, separators=(",", ":")) if isinstance(ede, dict) else str(ede).strip()
+            }
+        if transition_evidence.get("documentation_evidence"):
+            extra_sets.append("documentation_evidence = :documentation_ev")
+            docs = transition_evidence["documentation_evidence"]
+            extra_vals[":documentation_ev"] = {
+                "S": json.dumps(docs, separators=(",", ":")) if isinstance(docs, list) else str(docs).strip()
+            }
 
     update_expr = (
         "SET #fld = :val, updated_at = :now, last_update_note = :note, "


### PR DESCRIPTION
## ENC-TSK-L77 — Component registry v3 schema + required_transition_type v3 enum migration

Implements DOC-157A790F9E8B (Component Ontological Hardening v4). Unblocks ENC-TSK-L05 → ENC-TSK-B63 gate (blocked 3× on this missing prerequisite).

### Changes
- **Component registry schema**: adds `component_address`, `component_repo_dir`, `component_address_class` (aws_arn|https_url|cloudflare_resource|neo4j_auradb|external_manifest|meta), `component_class` (physical|external|meta).
- **coordination_api** `_COMPONENT_TRANSITION_TYPES`: migrated v1 → v3 enum `{code, external_deploy, documentation}` with legacy read-time mapping (github_pr_deploy/lambda_deploy/web_deploy/code_only/data_only → code; no_code → documentation) for backward compat on existing records.
- **checkout_service**: `external_deploy_evidence` (comp_external_id + retrieval_steps) and `documentation_evidence` advance-gates enforced.
- **governance_data_dictionary.json**: bumped 2026-07-07.7 → 2026-07-07.8 documenting all new fields, the v3 enum, and both evidence sub-schemas.

### Provenance / integration
Continues ENC-SES-05B's implementation (was left uncommitted on a 27-commit-stale base). Re-integrated onto current v4/main by ENC-SES-05V: all 3 lambda code files re-applied cleanly; govdict merged via disjoint entity overlay (L77's 4 entities vs 27 commits' 9 entities — zero overlap).

### Tests
- 73 v3 component/evidence-gate tests **pass**
- checkout_service full suite: 112 **pass**
- tracker_mutation full suite: 472 pass / 2 fail — both **pre-existing on v4/main** (test_counter_fields, test_if_match_l47), reproduce with L77 reverted, unrelated to this change.

CCI-4c3ff771e516484e98c0c9244f16aaab

🤖 Generated with [Claude Code](https://claude.com/claude-code)