### PR TITLE
ENC-TSK-L95: v3-prod backport of escalation approver allowlist (ENC-ISS-501, SEV-1)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,12 +1,25 @@
 {
-  "version": "2026-07-05.2",
-  "updated_at": "2026-07-05T00:00:00Z",
-  "last_change_summary": "ENC-TSK-J40: added component_registry.component.deploy_targets (stack names + function-name globs a component owns) to the ENC-TSK-E68 capability-declaration field set, consumed by tools/assert_deploy_target_coverage.py to fail closed when a component's declared targets are narrower than a merge's diff-inferred affected set.",
+  "version": "2026-07-07.1",
+  "updated_at": "2026-07-07T13:00:00Z",
+  "last_change_summary": "ENC-TSK-L95 / ENC-ISS-501 (SEV-1) v3-prod leg: escalation approve/deny now requires the decider's Cognito email to be on a Console-edit-only S3 allowlist (ESCALATION_APPROVER_ALLOWLIST_BUCKET/_KEY), closing a gap where _is_cognito_session (a fail-open blocklist) let a non-human identity self-approve governance-bypass escalations. NOTE: this repo's main-branch coordination_api/lambda_function.py source is stale relative to the live devops-coordination-api function (code deploys via the Gen2 artifact pipeline built from v4/main, independent of main's git tree) -- the live function already has the full escalation approve/deny feature; only the allowlist env vars + IAM read grant needed to land here since this Lambda's CFN definition (unlike its code) IS git-tracked. See coordination.escalations on v4/main's dictionary for the full feature description.",
   "owners": [
     "enceladus-platform"
   ],
   "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
   "entities": {
+    "coordination.escalation_approver_allowlist": {
+      "description": "ENC-TSK-L92/L95 / ENC-ISS-501 (SEV-1): positive allowlist gating the coordination_api escalation approve/deny routes, on top of the existing _is_cognito_session check (which was found to be a fail-open blocklist -- it excludes only auth_mode in {internal-key, managed-token}; any other or absent auth_mode passed as human). The decider's Cognito email claim must appear in a Console-edit-only S3 document; the allowlist check fails CLOSED on any fetch/parse error (denies everyone rather than falling back to allow-everyone).",
+      "fields": {
+        "ESCALATION_APPROVER_ALLOWLIST_BUCKET": {
+          "type": "string",
+          "definition": "Env var (default 'jreese-net'). S3 bucket holding the escalation-approver allowlist document."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_KEY": {
+          "type": "string",
+          "definition": "Env var (default 'security/escalation-approvers.md'). S3 key of the allowlist document, shared by BOTH gamma and prod coordination_api Lambdas (no env-suffix distinction). This Lambda's role is granted s3:GetObject ONLY on this exact key (EscalationApproverAllowlistRead statement, infrastructure/cloudformation/02-compute.yaml) -- no role in the account, including this Lambda's own, has PutObject/DeleteObject on it. The document is a markdown file with a fenced yaml block of `- email: \"...\"` list entries, parsed without a yaml dependency (60s in-memory cache). Edits require an AWS Console-authenticated human; there is deliberately no programmatic write path."
+        }
+      }
+    },
     "tracker.task": {
       "description": "Task tracker records created via MCP and tracker mutation APIs.",
       "fields": {

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -206,6 +206,11 @@ Resources:
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
           APPCONFIG_CONFIGURATION: feature-flags
+          # ENC-TSK-L92/L95 / ENC-ISS-501: escalation approve/deny decider allowlist.
+          # This role is granted s3:GetObject only on this exact key -- no Lambda
+          # role, including this one, has write access. Edits are Console-only.
+          ESCALATION_APPROVER_ALLOWLIST_BUCKET: !Ref S3Bucket
+          ESCALATION_APPROVER_ALLOWLIST_KEY: security/escalation-approvers.md
       Tags:
         - Key: Project
           Value: enceladus
@@ -1755,6 +1760,14 @@ Resources:
                   - s3:HeadBucket
                   - s3:GetBucketLocation
                 Resource: "arn:aws:s3:::jreese-net"
+              # ENC-TSK-L92/L95 / ENC-ISS-501: escalation approver allowlist -- READ ONLY.
+              # Deliberately no s3:PutObject/DeleteObject grant here or anywhere else
+              # in this role; the allowlist document is Console-edit-only by design.
+              - Sid: EscalationApproverAllowlistRead
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/security/escalation-approvers.md"
               - Sid: SSMDispatch
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
v3-prod leg of ENC-TSK-L92 (gamma, PR #921, already merged+deployed). Fixes ENC-ISS-501 (SEV-1) on real production — confirmed live that prod's actual API Gateway (`8nkzqkmxqc`) exposes the escalation approve/deny routes, so this is not gamma-only exposure.

**Important discovery**: `main`'s git tree for `backend/lambda/coordination_api/lambda_function.py` is stale relative to the live `devops-coordination-api` function — this Lambda's code deploys via the Gen2 artifact pipeline (built from `v4/main`), independent of `main`'s git history. The live function **already has** the full escalation approve/deny feature (confirmed by downloading and inspecting the live deployment package — `_handle_escalation_decision` exists). Since Channel B (code promote) sources from the already-correct gamma-built artifact, no code change is needed on `main`'s tree. Only the CFN-tracked pieces need to land here — those genuinely deploy from git.

## Changes
- `infrastructure/cloudformation/02-compute.yaml`: `ESCALATION_APPROVER_ALLOWLIST_BUCKET`/`_KEY` env vars + read-only `EscalationApproverAllowlistRead` IAM statement (`s3:GetObject`, scoped to exactly one key) on `CoordinationApiRole`/`Function`.
- `backend/lambda/coordination_api/governance_data_dictionary.json`: dictionary bump documenting the allowlist mechanism (new entity, since the broader escalation feature was never documented here either, matching the code drift).

## Critical sequencing (io: please read before approving either Environment gate)
The S3 allowlist object (`s3://jreese-net/security/escalation-approvers.md`) already exists live and is shared by both gamma and prod. Prod's role does **not** yet have the read grant this PR adds. If the already-in-flight code promote (Channel B, using the correct gamma-built artifact with the fail-closed allowlist check) reaches prod **before** this CFN PR's apply is live, prod will reject *all* escalation approve/deny calls with 403 until this catches up — a real (fail-safe, but disruptive) regression.

**Approve this PR's CFN apply Environment gate first. Confirm the IAM grant is live. Only then approve the code-promote Environment gate.**

## Test plan
- [x] `tools/pre-deploy-health-gate.sh --stack enceladus-compute --template infrastructure/cloudformation/02-compute.yaml` — PASSED (7/7 checks, no drift, 165/165 routes match live)
- [x] YAML + JSON validated
- [ ] Post-apply: `aws iam get-role-policy --role-name devops-coordination-api-lambda-role --policy-name devops-coordination-api-inline` shows `EscalationApproverAllowlistRead`
- [ ] Post-code-promote: no `AccessDenied` in CloudWatch logs for escalation decisions

CCI-03ed141da97e491ca4d18e09d25fcb7c

🤖 Generated with [Claude Code](https://claude.com/claude-code)