### PR TITLE
ENC-TSK-M02: gamma arm64 agent-auth PreToken + M2M rotation

### DIFF
--- a/infrastructure/cloudformation/08-agent-auth.yaml
+++ b/infrastructure/cloudformation/08-agent-auth.yaml
@@ -103,11 +103,13 @@ Resources:
         ENC-FTR-074 Ph1 V3_0 pre-token generation trigger. On
         TokenGeneration_ClientCredentials, injects enc:agent_tier and enc:session_id custom claims
         into the M2M access token.
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt PreTokenLambdaRole.Arn
       Timeout: 5
       MemorySize: 128
+      Architectures:
+        - arm64
       Code:
         ZipFile: |
           """ENC-FTR-074 Ph1 — Cognito V3_0 pre-token generation trigger.
@@ -363,11 +365,13 @@ Resources:
       Description: >
         ENC-FTR-074 Ph1 Secrets Manager rotation Lambda for the enceladus-agent-m2m client secret
         (standard 4-step rotation; createSecret hydrates AWSPENDING from the live Cognito client).
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt SecretRotationLambdaRole.Arn
       Timeout: 30
       MemorySize: 128
+      Architectures:
+        - arm64
       Environment:
         Variables:
           USER_POOL_ID: !Ref AgentUserPool


### PR DESCRIPTION
## Summary

- Add explicit `Architectures: [arm64]` and bump runtime to `python3.12` on `PreTokenLambda` and `SecretRotationLambda` in `08-agent-auth.yaml`.
- Closes L96 leakage for live `enceladus-agent-pretoken-gamma` and `enceladus-agent-m2m-rotation-gamma` (gamma-only stack; matches AgentAuthorizer/Selftest pattern).

CCI-6822009602cc4216805c6071ca300c7c

## Test plan

- [ ] Agent-auth CFN stack deploy succeeds on v4-gamma
- [ ] `aws lambda get-function-configuration` shows `Architectures=[arm64]` for both functions