### PR TITLE
ENC-TSK-M03: Gen2 arm64 config for github-integration + checkout-auto

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -500,6 +500,32 @@ jobs:
                   log(f'::error::stage-to-{staging_bucket} failed for {fn}: {detail}', err=True)
                   return {'fn': fn, 'mapped_name': mapped_name, 'status': 'error', 'error': 'stage copy'}
 
+              # ENC-TSK-M03 / ENC-TSK-L96: Gen2-only Lambdas (github_integration,
+              # checkout_service -auto twin, etc.) may exist OOB without CFN Architectures.
+              # Align runtime+arch to the manifest BEFORE publishing arm64 artifacts.
+              if arch == 'arm64':
+                  target_runtime = f'python{py}'
+                  cfg_r = run_with_retry(
+                      ['aws', 'lambda', 'update-function-configuration',
+                       '--region', region, '--function-name', mapped_name,
+                       '--architectures', 'arm64', '--runtime', target_runtime],
+                      what=f'update-function-configuration {mapped_name}',
+                      skip_on=('ResourceNotFoundException', 'Function not found'),
+                  )
+                  if cfg_r is None:
+                      log(f'  [skip] {mapped_name}: not provisioned in this environment yet')
+                      return {'fn': fn, 'mapped_name': mapped_name, 'status': 'skip'}
+                  if cfg_r.returncode != 0:
+                      log(f'::error::update-function-configuration failed for {mapped_name}: '
+                          f'{(cfg_r.stderr or "").strip()}', err=True)
+                      return {'fn': fn, 'mapped_name': mapped_name, 'status': 'error',
+                              'error': 'update-function-configuration'}
+                  subprocess.run(
+                      ['aws', 'lambda', 'wait', 'function-updated-v2',
+                       '--region', region, '--function-name', mapped_name],
+                      check=False,
+                  )
+
               r = run_with_retry(
                   ['aws', 'lambda', 'update-function-code',
                    '--region', region, '--function-name', mapped_name,

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -5,6 +5,8 @@
 env_name: v4-gamma
 architecture: arm64
 runtime: python3.12
+# Gen2 _deploy.yml (ENC-TSK-M03) calls update-function-configuration to arm64/py3.12
+# before publishing artifacts — covers OOB Lambdas not yet in CFN.
 
 stack_name: enceladus-v4-gamma
 deploy_role_arn: arn:aws:iam::356364570033:role/GitHubActions-V4Gamma-DeployRole

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -4839,6 +4839,8 @@ Resources:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-code${EnvironmentSuffix}"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-streamable${EnvironmentSuffix}"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-coordination-api${EnvironmentSuffix}"
+                  # ENC-TSK-M03: github-integration Lambda is Gen2-managed (no CFN Function
+                  # resource yet); arm64/py3.12 enforced in _deploy.yml update-function-configuration.
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-github-integration${EnvironmentSuffix}"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-mcp-code-gamma"
               - Sid: DeployTableAccess
@@ -6982,6 +6984,8 @@ Resources:
   # clean Import/no-op change-set (rate(5 minutes), ENABLED, target the -auto Lambda).
   # NOTE: the events->lambda AWS::Lambda::Permission is NOT importable and stays
   # out-of-band (ENC-ISS-394 precedent); only the rule is adopted here.
+  # ENC-TSK-M03: enceladus-checkout-service-auto-gamma exists on gamma (Gen2 map);
+  # arm64/py3.12 enforced via _deploy.yml; prod-only rule below targets unsuffixed name.
   # After import, J14 drops the audit's documented-exception for enceladus-checkout-auto.
   CheckoutAutoScheduleRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
## Summary

- Gen2 `_deploy.yml`: on gamma (`arch=arm64`), call `update-function-configuration` (arm64 + manifest runtime) **before** `update-function-code` so OOB Lambdas migrate off x86_64.
- Documents scope in `envs/v4-gamma.yaml` and `02-compute.yaml` comments (github-integration + checkout-service-auto).

Closes L96 leakage for `devops-github-integration-gamma` and `enceladus-checkout-service-auto-gamma`.

CCI-5b524cc4bec74b80ae2994f47ede6cca

## Test plan

- [ ] v4/main Gen2 deploy succeeds
- [ ] Live `devops-github-integration-gamma` + `enceladus-checkout-service-auto-gamma` report `Architectures=[arm64]`

Made with [Cursor](https://cursor.com)