### PR TITLE
ENC-TSK-L91: GDMP mutation-ramp durable safety (codify disarm + concurrency guard + auditable breakdown)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.8",
-  "updated_at": "2026-07-07T12:53:00Z",
-  "last_change_summary": "ENC-TSK-L77: component registry v3 hardening adds component_address/component_repo_dir/component_address_class/component_class, migrates component required_transition_type to code|external_deploy|documentation with legacy read-time mapping, and documents external_deploy_evidence plus documentation_evidence advance gates.",
+  "version": "2026-07-07.9",
+  "updated_at": "2026-07-07T13:35:00Z",
+  "last_change_summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7478,7 +7478,7 @@
       }
     },
     "corpus_entropy_gdmp_remediation.lambda": {
-      "description": "ENC-TSK-K42 / B66 Ph5 (ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda (enceladus-corpus-entropy-gdmp-remediation). EventBridge CorpusEntropyGdmpRemediationSchedule (gamma, cron 06:00 UTC, after K41's 05:00 detection scan) invokes lambda_handler per project. Reuses K41's corpus_entropy_core.detect_compliance_semantic_entropy unmodified (shared via .build_extras) to find raw documents with compliance_warnings, then classifies each warning against a fixed deterministic whitelist (gdmp_remediation_core.DETERMINISTIC_WARNING_CLASSIFIERS: fence_missing_language, metadata_field_missing) -- ambiguous/content-changing warnings (title format, empty document, heading hierarchy, list-marker consistency, table dividers, malformed alerts, COE section gaps) are left for agent/human review. For whitelisted findings, applies an additive pure-function text remediation (never deletes original content) and PATCHes the document via the governed document_api HTTP surface (documents.patch: content, then document_maturity_state=compliant once compliance_score clears COMPLIANCE_SCORE_THRESHOLD with zero remaining warnings) -- never direct DynamoDB/S3 document writes. Idempotency guard (is_already_compliant) skips any document already at compliant maturity or with zero compliance_warnings, so re-running Stage-1 on a compliant document is a no-op with no version churn. io-approval ramp (FTR-106 AC-4 / ENC-TSK-K03 pattern reuse, same S3 run-counter shape as UnlearningFunction): GDMP_DRY_RUN=1 (default) prevents all mutation; GDMP_MUTATION_ENABLED=0 (default) keeps report-only even when dry-run is off; GDMP_IO_APPROVAL_RUNS=3 gates the first three live (non-dry-run) invocations to candidate-report-only regardless of GDMP_MUTATION_ENABLED. CEE_GDMP_HARD_DISABLED kill switch (default \"1\") is checked first in the handler, mirroring CEE_HARD_DISABLED (K41). Every applied patch is logged with before/after compliance_score. Cost-preflight ISS-465: nightly-only cadence, well under $1/mo; CorpusEntropyGdmpRemediationCostHeadroomAlarm guards EventBridge invocation count (7-day window, threshold 10).",
+      "description": "ENC-TSK-K42 / B66 Ph5 (ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda (enceladus-corpus-entropy-gdmp-remediation). EventBridge CorpusEntropyGdmpRemediationSchedule (gamma, cron 06:00 UTC, after K41's 05:00 detection scan) invokes lambda_handler per project. Reuses K41's corpus_entropy_core.detect_compliance_semantic_entropy unmodified (shared via .build_extras) to find raw documents with compliance_warnings, then classifies each warning against a fixed deterministic whitelist (gdmp_remediation_core.DETERMINISTIC_WARNING_CLASSIFIERS: fence_missing_language, metadata_field_missing) -- ambiguous/content-changing warnings (title format, empty document, heading hierarchy, list-marker consistency, table dividers, malformed alerts, COE section gaps) are left for agent/human review. For whitelisted findings, applies an additive pure-function text remediation (never deletes original content) and PATCHes the document via the governed document_api HTTP surface (documents.patch: content, then document_maturity_state=compliant once compliance_score clears COMPLIANCE_SCORE_THRESHOLD with zero remaining warnings) -- never direct DynamoDB/S3 document writes. Idempotency guard (is_already_compliant) skips any document already at compliant maturity or with zero compliance_warnings, so re-running Stage-1 on a compliant document is a no-op with no version churn. io-approval ramp (FTR-106 AC-4 / ENC-TSK-K03 pattern reuse, same S3 run-counter shape as UnlearningFunction): GDMP_DRY_RUN=1 (default) prevents all mutation; GDMP_MUTATION_ENABLED=0 (default) keeps report-only even when dry-run is off; GDMP_IO_APPROVAL_RUNS=3 gates the first three live (non-dry-run) invocations to candidate-report-only regardless of GDMP_MUTATION_ENABLED. CEE_GDMP_HARD_DISABLED kill switch (default \"1\") is checked first in the handler, mirroring CEE_HARD_DISABLED (K41). Every applied patch is logged with before/after compliance_score. Cost-preflight ISS-465: nightly-only cadence, well under $1/mo; CorpusEntropyGdmpRemediationCostHeadroomAlarm guards EventBridge invocation count (7-day window, threshold 10). ENC-TSK-L91 (mutation-ramp durable safety): the remediation path now re-GETs each document fresh and RECOMPUTES the remediation plan from the fresh compliance_warnings immediately before PATCH (was reusing the run-start scan's stale findings against fresh content -> silent lost update), collapsing the race window from hours to ms and skipping concurrently-edited documents; and persists a per-run candidate breakdown (see GDMP_RUN_BREAKDOWN_SINK). CEE_GDMP_HARD_DISABLED now gates mutation only (see field). Durable document_api If-Match precondition tracked as ENC-ISS-503.",
       "owner": "enceladus-platform",
       "source": "ENC-TSK-K42 / ENC-TSK-B66",
       "telemetry_eligible": true,
@@ -7486,7 +7486,7 @@
         "CEE_GDMP_HARD_DISABLED": {
           "type": "feature_flag",
           "default": "1",
-          "definition": "Mandatory kill switch, installed ON before first scheduled run. When truthy (1/true/yes), handler skips all governed reads/writes for that invocation. Mirrors CEE_HARD_DISABLED (K41)."
+          "definition": "Mandatory kill switch, installed ON (default \"1\"), checked first in the handler. ENC-TSK-L91: gates MUTATION ONLY -- when truthy (1/true/yes) the deterministic candidate scan, candidate report, and per-run breakdown persistence still execute (so the disarmed soak produces the auditable candidate reports io reviews before any re-enable), but NO documents.patch is issued and the io-approval ramp counter is NOT advanced (a fresh GDMP_IO_APPROVAL_RUNS candidate-only buffer is preserved for after io re-enables). Codified =1 in 02-compute.yaml (IsGamma) so no deploy reverts the disarm. Distinct from the shared engine-wide CEE_HARD_DISABLED (K41) cost kill switch, which still fully short-circuits the entire run (no scan)."
         },
         "GDMP_DRY_RUN": {
           "type": "feature_flag",
@@ -7507,6 +7507,10 @@
           "type": "integer",
           "default": 70,
           "definition": "A remediated document only advances document_maturity_state to compliant once its post-PATCH compliance_score is at or above this value AND zero compliance_warnings remain. Matches CEE's (K41) COMPLIANCE_SCORE_THRESHOLD."
+        },
+        "GDMP_RUN_BREAKDOWN_SINK": {
+          "type": "s3_artifact",
+          "definition": "ENC-TSK-L91: every run persists a per-run candidate breakdown JSON (schema gdmp.run_breakdown.v1) to s3://${GDMP_STATE_BUCKET}/${GDMP_STATE_PREFIX}/breakdowns/ as run-<ts>-n<run_count>.json plus a stable latest.json. Partitions candidates into safe_deterministic vs needs_human with a per-doc list (record_id, action, deterministic_classes, ambiguous_warnings), making the GDMP_IO_APPROVAL_RUNS ramp auditable during the disarmed soak. Best-effort write; never raises into the run."
         }
       }
     },
@@ -7782,7 +7786,7 @@
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
     }
   },
-  "change_summary": "ENC-TSK-L77: component registry v3 hardening (component_address/component_repo_dir/component_address_class/component_class), required_transition_type v3 enum {code,external_deploy,documentation} with legacy read-time mapping, and external_deploy_evidence + documentation_evidence advance gates. Integrated onto v4/main 2026-07-07.7 (ENC-SES-05V).",
+  "change_summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH.",
   "change_log": [
     {
       "version": "2026-07-07.6",
@@ -8068,6 +8072,11 @@
       "version": "2026-07-07.8",
       "date": "2026-07-07",
       "summary": "ENC-TSK-L77: component registry v3 hardening adds component_address/component_repo_dir/component_address_class/component_class, migrates component required_transition_type to code|external_deploy|documentation with legacy read-time mapping, and documents external_deploy_evidence plus documentation_evidence advance gates."
+    },
+    {
+      "version": "2026-07-07.9",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH."
     }
   ]
 }

--- a/backend/lambda/corpus_entropy_gdmp_remediation/lambda_function.py
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/lambda_function.py
@@ -160,6 +160,93 @@ def _save_run_counter(run_count: int) -> None:
     )
 
 
+def _build_run_breakdown(
+    plans: List[Dict[str, Any]],
+    *,
+    now_iso: str,
+    run_count: int,
+    dry_run: bool,
+    mutation_allowed_flag: bool,
+    mutation_hard_disabled: bool,
+    applied: List[Dict[str, Any]],
+    skipped_idempotent: List[str],
+) -> Dict[str, Any]:
+    """ENC-TSK-L91: reviewable per-run audit record. Partitions the run's
+    candidates into safe-deterministic (auto-fixable whitelist) vs needs-human
+    (ambiguous warnings requiring agent/human review) and lists every candidate
+    doc, so io can audit the GDMP_IO_APPROVAL_RUNS ramp from persisted reports.
+    """
+    candidates: List[Dict[str, Any]] = []
+    safe_count = 0
+    needs_human_count = 0
+    for p in plans:
+        det = p.get("deterministic_findings") or []
+        amb = p.get("ambiguous_warnings") or []
+        is_safe = p.get("action") in ("remediate", "partial_remediate") and bool(det)
+        needs_human = bool(amb) or p.get("action") == "agent_review"
+        if is_safe:
+            safe_count += 1
+        if needs_human:
+            needs_human_count += 1
+        candidates.append({
+            "record_id": p.get("record_id"),
+            "action": p.get("action"),
+            "reason": p.get("reason"),
+            "safe_deterministic": is_safe,
+            "needs_human": needs_human,
+            "deterministic_classes": sorted({f.get("class") for f in det if f.get("class")}),
+            "deterministic_count": len(det),
+            "ambiguous_warnings": amb,
+            "ambiguous_count": len(amb),
+        })
+    return {
+        "schema": "gdmp.run_breakdown.v1",
+        "scanned_at": now_iso,
+        "project_id": PROJECT_ID,
+        "run_count": run_count,
+        "dry_run": dry_run,
+        "mutation_allowed": mutation_allowed_flag,
+        "mutation_hard_disabled": mutation_hard_disabled,
+        "totals": {
+            "candidates": len(plans),
+            "safe_deterministic": safe_count,
+            "needs_human": needs_human_count,
+            "remediated": len(applied),
+            "skipped_idempotent": len(skipped_idempotent),
+        },
+        "candidates": candidates,
+        "applied": applied,
+    }
+
+
+def _persist_run_breakdown(breakdown: Dict[str, Any]) -> Optional[str]:
+    """Write the per-run breakdown to S3 alongside the GDMP state prefix. Two
+    keys: a timestamped immutable record under breakdowns/ and a stable
+    latest.json for quick review. Best-effort -- never raises into the run.
+    """
+    if not GDMP_STATE_BUCKET:
+        logger.warning("[WARN] GDMP_STATE_BUCKET unset; run breakdown not persisted")
+        return None
+    prefix = GDMP_STATE_PREFIX.strip().strip("/")
+    safe_ts = str(breakdown.get("scanned_at") or "").replace(":", "").replace("-", "")
+    key = f"{prefix}/breakdowns/run-{safe_ts}-n{breakdown.get('run_count')}.json"
+    body = json.dumps(breakdown, indent=2, sort_keys=True).encode("utf-8")
+    try:
+        s3 = _get_s3()
+        s3.put_object(Bucket=GDMP_STATE_BUCKET, Key=key, Body=body, ContentType="application/json")
+        s3.put_object(
+            Bucket=GDMP_STATE_BUCKET,
+            Key=f"{prefix}/breakdowns/latest.json",
+            Body=body,
+            ContentType="application/json",
+        )
+        logger.info("[INFO] Persisted run breakdown to s3://%s/%s", GDMP_STATE_BUCKET, key)
+        return f"s3://{GDMP_STATE_BUCKET}/{key}"
+    except Exception as exc:  # noqa: BLE001 -- audit persistence must not break the run
+        logger.error("[ERROR] failed to persist run breakdown: %s", exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
@@ -167,19 +254,30 @@ def _save_run_counter(run_count: int) -> None:
 def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
     event = event or {}
 
-    if is_hard_disabled(os.environ) or _cee_is_hard_disabled(os.environ):
-        logger.info("[SKIP] CEE_GDMP_HARD_DISABLED (or CEE_HARD_DISABLED) is set; GDMP Stage-1 skipped")
+    # CEE_HARD_DISABLED is the shared corpus-entropy engine-wide cost kill switch
+    # (ISS-465): when set it skips the entire run, including the read-only scan.
+    # Left as a full short-circuit -- unchanged.
+    if _cee_is_hard_disabled(os.environ):
+        logger.info("[SKIP] CEE_HARD_DISABLED is set; GDMP Stage-1 skipped")
         return {
             "statusCode": 200,
             "body": json.dumps({"success": True, "skipped": True, "reason": "hard_disabled"}),
         }
 
+    # ENC-TSK-L91: CEE_GDMP_HARD_DISABLED gates MUTATION only, not the whole run.
+    # While disarmed (=1) the deterministic candidate scan + report + per-run
+    # breakdown persistence still execute so the soak produces the auditable
+    # candidate reports io reviews before any re-enable -- but no documents.patch
+    # is ever issued, and the io-approval ramp counter is NOT advanced (a fresh
+    # GDMP_IO_APPROVAL_RUNS candidate-only buffer is preserved for after re-enable).
+    gdmp_mutation_hard_disabled = is_hard_disabled(os.environ)
+
     now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     dry_run = is_dry_run(event)
     run_count = _load_run_counter()
     logger.info(
-        "[START] GDMP Stage-1 remediation: project=%s dry_run=%s run_count=%s",
-        PROJECT_ID, dry_run, run_count,
+        "[START] GDMP Stage-1 remediation: project=%s dry_run=%s run_count=%s mutation_hard_disabled=%s",
+        PROJECT_ID, dry_run, run_count, gdmp_mutation_hard_disabled,
     )
 
     try:
@@ -203,7 +301,10 @@ def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, A
             enriched_finding["compliance_warnings"] = doc_row.get("compliance_warnings") or []
             plans.append(plan_remediation(enriched_finding))
 
-        allow_mutate = mutation_allowed(run_count=run_count, dry_run=dry_run)
+        allow_mutate = (
+            mutation_allowed(run_count=run_count, dry_run=dry_run)
+            and not gdmp_mutation_hard_disabled
+        )
 
         applied: List[Dict[str, Any]] = []
         skipped_idempotent: List[str] = []
@@ -230,8 +331,28 @@ def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, A
                 if not content:
                     continue
 
+                # ENC-TSK-L91 optimistic-concurrency guard. The queued `plan` was
+                # computed from the run-start scan (_fetch_documents, up to
+                # GDMP_MAX_DOCS_PER_RUN docs earlier -- a minutes-to-hours stale
+                # read). Re-derive the remediation plan from THIS fresh GET's
+                # compliance_warnings so the deterministic fixes are consistent
+                # with the exact content we are about to PATCH. If a concurrent
+                # human/agent edit already resolved or changed the warnings, the
+                # fresh plan collapses to a no-op skip instead of clobbering that
+                # edit with stale findings (the silent lost-update this task fixes).
+                fresh_plan = plan_remediation({
+                    "record_id": document_id,
+                    "compliance_warnings": doc.get("compliance_warnings") or [],
+                })
+                fresh_findings = fresh_plan.get("deterministic_findings") or []
+                if fresh_plan.get("action") not in ("remediate", "partial_remediate") or not fresh_findings:
+                    # Fresh state no longer needs (or no longer supports) the
+                    # queued deterministic remediation -- skip rather than patch.
+                    skipped_idempotent.append(document_id)
+                    continue
+
                 before_score = doc.get("compliance_score")
-                remediated_content = remediate_content(content, plan["deterministic_findings"])
+                remediated_content = remediate_content(content, fresh_findings)
                 if remediated_content == content:
                     # No actual text change produced (e.g. fixer found nothing
                     # left to do) -- idempotent no-op, do not PATCH.
@@ -263,7 +384,7 @@ def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, A
                         maturity_patch_resp and maturity_patch_resp.get("success", True)
                     ),
                     "deterministic_classes_applied": sorted(
-                        {f["class"] for f in plan["deterministic_findings"]}
+                        {f["class"] for f in fresh_findings}
                     ),
                 })
                 logger.info(
@@ -276,7 +397,25 @@ def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, A
             PROJECT_ID, plans, run_count=run_count, dry_run=dry_run, mutation_enabled=allow_mutate,
         )
 
-        if not dry_run:
+        # ENC-TSK-L91: persist the per-run candidate breakdown EVERY run (incl.
+        # disarmed candidate-only soak runs) so the ramp is auditable from S3.
+        breakdown = _build_run_breakdown(
+            plans,
+            now_iso=now_iso,
+            run_count=run_count,
+            dry_run=dry_run,
+            mutation_allowed_flag=allow_mutate,
+            mutation_hard_disabled=gdmp_mutation_hard_disabled,
+            applied=applied,
+            skipped_idempotent=skipped_idempotent,
+        )
+        breakdown_ref = _persist_run_breakdown(breakdown)
+
+        # Advance the io-approval ramp only on ARMED live runs. Disarmed
+        # (CEE_GDMP_HARD_DISABLED=1) candidate-only runs during the soak do NOT
+        # consume the ramp, preserving a fresh GDMP_IO_APPROVAL_RUNS buffer for
+        # after io re-enables (ENC-TSK-L91).
+        if not dry_run and not gdmp_mutation_hard_disabled:
             _save_run_counter(run_count + 1)
 
         result = {
@@ -289,7 +428,10 @@ def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, A
             "candidate_count": len(plans),
             "remediated_count": len(applied),
             "skipped_idempotent_count": len(skipped_idempotent),
+            "mutation_hard_disabled": gdmp_mutation_hard_disabled,
             "applied": applied,
+            "breakdown_ref": breakdown_ref,
+            "breakdown_totals": breakdown["totals"],
             "report_preview": report_body[:2000],
         }
         logger.info(

--- a/backend/lambda/corpus_entropy_gdmp_remediation/test_lambda_function.py
+++ b/backend/lambda/corpus_entropy_gdmp_remediation/test_lambda_function.py
@@ -265,11 +265,66 @@ class _FakeS3:
         self._store[Key] = Body if isinstance(Body, bytes) else Body.encode("utf-8")
 
 
-def test_handler_respects_kill_switch(monkeypatch):
+def test_handler_gdmp_hard_disabled_reports_but_never_mutates(monkeypatch):
+    """ENC-TSK-L91: CEE_GDMP_HARD_DISABLED gates MUTATION only. Even with the
+    ramp cleared + dry_run off + mutation enabled (i.e. it WOULD mutate), the
+    disarm must block every _patch_document, must NOT advance the io-approval
+    ramp counter, yet must still run the candidate scan and persist the per-run
+    breakdown so the soak is auditable."""
     monkeypatch.setenv("CEE_GDMP_HARD_DISABLED", "1")
+    monkeypatch.delenv("CEE_HARD_DISABLED", raising=False)
+
+    import gdmp_remediation_core as gcore
+    monkeypatch.setattr(gcore, "GDMP_DRY_RUN", False)
+    monkeypatch.setattr(gcore, "GDMP_MUTATION_ENABLED", True)
+    monkeypatch.setattr(mod, "is_dry_run", lambda event=None: False)
+    monkeypatch.setattr(mod, "mutation_allowed", lambda **kw: gcore.mutation_allowed(
+        run_count=kw["run_count"], dry_run=False, mutation_enabled=True
+    ))
+    monkeypatch.setattr(mod, "_fetch_documents", lambda: [
+        {
+            "record_id": "DOC-RAW-DISARM",
+            "compliance_score": 40,
+            "document_maturity_state": "raw",
+            "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        },
+    ])
+
+    def _boom_patch(*args, **kwargs):
+        raise AssertionError("must not PATCH while CEE_GDMP_HARD_DISABLED=1")
+
+    def _boom_counter(*args, **kwargs):
+        raise AssertionError("must not advance io-approval ramp while disarmed")
+
+    monkeypatch.setattr(mod, "_patch_document", _boom_patch)
+    monkeypatch.setattr(mod, "_save_run_counter", _boom_counter)
+    monkeypatch.setattr(mod, "GDMP_STATE_BUCKET", "fake-bucket")
+    fake = _FakeS3(initial_counter=3)  # ramp already cleared -> would mutate if armed
+    monkeypatch.setattr(mod, "_get_s3", lambda: fake)
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["mutation_hard_disabled"] is True
+    assert body["mutation_allowed"] is False
+    assert body["remediated_count"] == 0
+    assert body["candidate_count"] == 1  # scan still ran
+    assert body["breakdown_ref"] is not None
+    assert body["breakdown_totals"]["candidates"] == 1
+    # breakdown persisted to S3 (timestamped record + stable latest.json)
+    assert any(k.endswith("breakdowns/latest.json") for k in fake._store)
+    assert any("/breakdowns/run-" in k for k in fake._store)
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+
+
+def test_handler_shared_cee_hard_disabled_short_circuits(monkeypatch):
+    """The shared engine-wide CEE_HARD_DISABLED cost kill switch (ISS-465) still
+    fully short-circuits the run: no document fetch, no scan, skipped=True."""
+    monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+    monkeypatch.setenv("CEE_HARD_DISABLED", "1")
 
     def _boom(*args, **kwargs):
-        raise AssertionError("must not fetch when kill switch is set")
+        raise AssertionError("must not fetch when CEE_HARD_DISABLED is set")
 
     monkeypatch.setattr(mod, "_fetch_documents", _boom)
     result = mod.lambda_handler({}, None)
@@ -277,7 +332,55 @@ def test_handler_respects_kill_switch(monkeypatch):
     assert result["statusCode"] == 200
     body = json.loads(result["body"])
     assert body["skipped"] is True
+    monkeypatch.delenv("CEE_HARD_DISABLED", raising=False)
+
+
+def test_concurrency_recompute_skips_when_fresh_doc_findings_differ(monkeypatch):
+    """ENC-TSK-L91 optimistic-concurrency guard: the queued plan (from the
+    run-start scan) had a deterministic auto-fixable warning, but the pre-PATCH
+    fresh GET shows the doc now carries only an AMBIGUOUS warning (a concurrent
+    human edit changed it). The handler must recompute from the fresh doc and
+    SKIP -- never apply the stale deterministic fix onto the changed content."""
     monkeypatch.delenv("CEE_GDMP_HARD_DISABLED", raising=False)
+    monkeypatch.delenv("CEE_HARD_DISABLED", raising=False)
+    import gdmp_remediation_core as gcore
+    monkeypatch.setattr(gcore, "GDMP_DRY_RUN", False)
+    monkeypatch.setattr(gcore, "GDMP_MUTATION_ENABLED", True)
+    monkeypatch.setattr(mod, "is_dry_run", lambda event=None: False)
+    monkeypatch.setattr(mod, "mutation_allowed", lambda **kw: gcore.mutation_allowed(
+        run_count=kw["run_count"], dry_run=False, mutation_enabled=True))
+    # Stale scan: deterministic (auto-fixable) fence warning -> plan=remediate.
+    monkeypatch.setattr(mod, "_fetch_documents", lambda: [
+        {
+            "record_id": "DOC-RACE",
+            "compliance_score": 40,
+            "document_maturity_state": "raw",
+            "compliance_warnings": ["Code fence at line 2 should include a language identifier."],
+        },
+    ])
+    # Fresh pre-PATCH GET: still raw + still non-compliant (so the idempotency
+    # guard does NOT short-circuit), but the warning is now ambiguous-only, so a
+    # fresh plan yields NO deterministic findings.
+    monkeypatch.setattr(mod, "_fetch_document_with_content", lambda doc_id: {
+        "record_id": doc_id,
+        "document_maturity_state": "raw",
+        "compliance_score": 45,
+        "compliance_warnings": ["Document appears to be empty or contains only whitespace."],
+        "content": "# Doc\n\nedited by a human mid-run\n",
+    })
+
+    def _boom_patch(*args, **kwargs):
+        raise AssertionError("must not apply stale deterministic fix to fresh content")
+
+    monkeypatch.setattr(mod, "_patch_document", _boom_patch)
+    monkeypatch.setattr(mod, "GDMP_STATE_BUCKET", "fake-bucket")
+    monkeypatch.setattr(mod, "_get_s3", lambda: _FakeS3(initial_counter=3))
+
+    result = mod.lambda_handler({}, None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["remediated_count"] == 0
+    assert body["skipped_idempotent_count"] == 1
 
 
 def test_handler_dry_run_default_never_patches(monkeypatch):

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2501,8 +2501,11 @@ Resources:
   # raw documents to compliant maturity_state with no agent involvement.
   # DATA-SAFETY: GDMP_DRY_RUN=0, GDMP_MUTATION_ENABLED=1, GDMP_IO_APPROVAL_RUNS=3
   # (FTR-106 AC-4 io-approval-ramp pattern, same shape as UnlearningFunction).
-  # Stage-1 mutation-ramp ARMED 2026-07-07 per io directive #2 (ENC-TSK-L90);
-  # code-enforced ramp still holds the next 3 live nightly runs candidate-only.
+  # Stage-1 mutation-ramp ARMED 2026-07-07 per io directive #2 (ENC-TSK-L90),
+  # then DISARMED same day (ENC-TSK-L91): CEE_GDMP_HARD_DISABLED="1" pulls the
+  # ~2026-07-11 4th-run mutation fuse after a silent-data-loss race + unauditable
+  # ramp were confirmed. GDMP performs NO live documents.patch until io reviews
+  # 3 nights of persisted candidate reports and gives an explicit go.
   # CEE_GDMP_HARD_DISABLED is the mandatory kill switch (ISS-465 cost-preflight
   # precedent), checked first thing in the handler. Gamma-only (Condition:
   # IsGamma): v3-prod is frozen (DOC-499FA089EC30).
@@ -2554,13 +2557,16 @@ Resources:
           GDMP_DRY_RUN: "0"
           GDMP_MUTATION_ENABLED: "1"
           GDMP_IO_APPROVAL_RUNS: "3"
-          # ISS-465-style kill switch -- installed disabled by default; io
-          # clears to "0" to enable. Mirrors CEE_HARD_DISABLED (K41) /
+          # ISS-465-style kill switch -- checked FIRST in the handler, halts all
+          # mutation regardless of ramp state. Mirrors CEE_HARD_DISABLED (K41) /
           # UNLEARNING_MUTATION_ENABLED (K03) sibling convention.
-          # Cleared 2026-07-02 per io; remains "0" through the 2026-07-07
-          # mutation-ramp flip -- the io-approval ramp (not this kill switch)
-          # now governs when live mutation begins (ENC-TSK-K42 / ENC-TSK-L90).
-          CEE_GDMP_HARD_DISABLED: "0"
+          # DISARMED 2026-07-07 (ENC-TSK-L91): set "1" to pull the ~2026-07-11
+          # 4th-run mutation fuse after a silent-data-loss race + unauditable
+          # ramp were confirmed on the L90 flip (architect-ruled load-bearing).
+          # Codifies the live out-of-band disarm so no deploy reverts it.
+          # Re-enable is io's explicit call post-soak -- do NOT flip back to "0"
+          # without io go after 3 nights of persisted candidate reports.
+          CEE_GDMP_HARD_DISABLED: "1"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
           APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
           APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]


### PR DESCRIPTION
## ENC-TSK-L91 — GDMP mutation-ramp durable safety

Architect-ruled load-bearing fix (ENC-SES-05E) before the ~2026-07-11 4th-run GDMP mutation. Follows the live out-of-band disarm already applied to gamma.

### Changes
- **(a) Codify disarm** — `02-compute.yaml` `CorpusEntropyGdmpRemediationFunction`: `CEE_GDMP_HARD_DISABLED "0" → "1"` so no deploy reverts the live disarm. `Condition: IsGamma` unaltered → **v3-prod untouched**. All other `GDMP_*` env intact.
- **(b) Optimistic-concurrency guard** — the remediation path re-GETs each doc fresh **and recomputes the remediation plan from the fresh `compliance_warnings`** immediately before PATCH (previously it applied the run-start scan's *stale* deterministic findings to fresh content → silent lost update). Concurrently-edited docs are now skipped, not clobbered. No document_api API change.
- **(c) Auditable breakdown** — `_persist_run_breakdown` writes a safe-deterministic-vs-needs-human partition + per-doc candidate list to `s3://…/{GDMP_STATE_PREFIX}/breakdowns/` (timestamped + `latest.json`) **every run**.

### Semantics change (io-approved)
`CEE_GDMP_HARD_DISABLED` now gates **mutation only**: the deterministic candidate scan + report + breakdown persistence still run while disarmed (so io reviews real reports during the soak), **no `documents.patch` is ever issued**, and the io-approval ramp counter is **not** advanced while disarmed (preserves a fresh `GDMP_IO_APPROVAL_RUNS` buffer after re-enable). The shared engine-wide `CEE_HARD_DISABLED` cost-kill keeps its full short-circuit.

**Does NOT re-enable** — that stays io's explicit call post-soak. Follow-up **ENC-ISS-503** filed for the gold-standard document_api If-Match precondition.

### Tests
39 GDMP tests pass, incl. 3 new: `test_handler_gdmp_hard_disabled_reports_but_never_mutates`, `test_handler_shared_cee_hard_disabled_short_circuits`, `test_concurrency_recompute_skips_when_fresh_doc_findings_differ`.

CCI-d612d13f37a7477494eb7d7ac6bc2aa7

🤖 Generated with [Claude Code](https://claude.com/claude-code)