### PR TITLE
ENC-TSK-M03: boto3 arm64 migration in Gen2 deploy

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -503,17 +503,17 @@ jobs:
               # ENC-TSK-M03 / ENC-TSK-L96: Gen2-only Lambdas (github_integration,
               # checkout_service -auto twin) may exist OOB without CFN Architectures.
               # Align runtime+arch to the manifest BEFORE publishing arm64 artifacts.
+              # ENC-TSK-M03 / ENC-TSK-L96: OOB x86 Gen2 targets (github_integration,
+              # checkout_service -auto) — bump runtime via config, then publish arm64
+              # artifacts with --architectures (supported on update-function-code even
+              # when the runner AWS CLI lacks Architectures on update-function-configuration).
+              target_runtime = f'python{py}'
               if arch == 'arm64' and fn in ('github_integration', 'checkout_service'):
-                  target_runtime = f'python{py}'
-                  cfg_input = json.dumps({
-                      'Architectures': ['arm64'],
-                      'Runtime': target_runtime,
-                  })
                   cfg_r = run_with_retry(
                       ['aws', 'lambda', 'update-function-configuration',
                        '--region', region, '--function-name', mapped_name,
-                       '--cli-input-json', cfg_input],
-                      what=f'update-function-configuration {mapped_name}',
+                       '--runtime', target_runtime],
+                      what=f'update-function-configuration runtime {mapped_name}',
                       skip_on=('ResourceNotFoundException', 'Function not found'),
                   )
                   if cfg_r is None:
@@ -530,11 +530,17 @@ jobs:
                       check=False,
                   )
 
+              code_cmd = [
+                  'aws', 'lambda', 'update-function-code',
+                  '--region', region, '--function-name', mapped_name,
+                  '--s3-bucket', staging_bucket, '--s3-key', s3_key,
+                  '--publish',
+              ]
+              if arch == 'arm64' and fn in ('github_integration', 'checkout_service'):
+                  code_cmd += ['--architectures', 'arm64']
+
               r = run_with_retry(
-                  ['aws', 'lambda', 'update-function-code',
-                   '--region', region, '--function-name', mapped_name,
-                   '--s3-bucket', staging_bucket, '--s3-key', s3_key,
-                   '--publish'],
+                  code_cmd,
                   what=f'update-function-code {mapped_name}',
                   skip_on=('ResourceNotFoundException', 'Function not found'),
               )


### PR DESCRIPTION
## Summary
Arm64 migration for OOB Gen2 Lambdas: runtime via update-function-configuration, architecture via `update-function-code --architectures arm64` (works on GHA AWS CLI).

CCI-1c91e2a4684b44638ab6134e705f28b8

## Test plan
- [ ] Gen2 deploy green
- [ ] github-integration-gamma + checkout-service-auto-gamma arm64