### PR TITLE
ENC-TSK-L95: fix escalation-decision-authorizer IAM role name (v3-prod apply failure)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -256,7 +256,7 @@ Resources:
     Type: AWS::IAM::Role
     DeletionPolicy: Retain
     Properties:
-      RoleName: !Sub "escalation-decision-authorizer-role${EnvironmentSuffix}"
+      RoleName: !Sub "enceladus-escalation-decision-authorizer-role${EnvironmentSuffix}"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
## Summary
- PR #928's compute-stack apply failed on v3-prod and auto-rolled back cleanly: `EscalationDecisionAuthorizerRole` CREATE_FAILED with `iam:CreateRole` 403.
- `enceladus-cloudformation-deploy-github-role`'s `IAMRoleManagement` statement only permits role names matching `devops-*`, `enceladus-*`, `auth-refresh*`. The original name `escalation-decision-authorizer-role` matched none of them.
- Lambda function creation itself is unrestricted (`Resource: "*"`), so this is purely a role-name fix, not a scope or security change.

## Change
- Rename `EscalationDecisionAuthorizerRole`'s `RoleName` to `enceladus-escalation-decision-authorizer-role${EnvironmentSuffix}` — matches the `enceladus-*` allowed pattern.

CCI-03ed141da97e491ca4d18e09d25fcb7c

## Test plan
- [x] No functional/logic change — CFN resource rename only
- [ ] CI green
- [ ] Re-run compute-stack Environment-gated apply on v3-prod, io-approved