### PR TITLE
ENC-ISS-504: remove Gen2 arm64 special-case regression

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -500,24 +500,11 @@ jobs:
                   log(f'::error::stage-to-{staging_bucket} failed for {fn}: {detail}', err=True)
                   return {'fn': fn, 'mapped_name': mapped_name, 'status': 'error', 'error': 'stage copy'}
 
-              # ENC-TSK-M03 / ENC-TSK-L96: Gen2-only Lambdas (github_integration,
-              # checkout_service -auto twin) may exist OOB without CFN Architectures.
-              # Align runtime+arch to the manifest BEFORE publishing arm64 artifacts.
-              # ENC-TSK-M03 / ENC-TSK-L96: OOB x86 Gen2 targets (github_integration,
-              # checkout_service -auto) — publish arm64 artifacts with
-              # update-function-code --architectures (deploy role has UpdateFunctionCode
-              # but not UpdateFunctionConfiguration).
-              code_cmd = [
-                  'aws', 'lambda', 'update-function-code',
-                  '--region', region, '--function-name', mapped_name,
-                  '--s3-bucket', staging_bucket, '--s3-key', s3_key,
-                  '--publish',
-              ]
-              if arch == 'arm64' and fn in ('github_integration', 'checkout_service'):
-                  code_cmd += ['--architectures', 'arm64']
-
               r = run_with_retry(
-                  code_cmd,
+                  ['aws', 'lambda', 'update-function-code',
+                   '--region', region, '--function-name', mapped_name,
+                   '--s3-bucket', staging_bucket, '--s3-key', s3_key,
+                   '--publish'],
                   what=f'update-function-code {mapped_name}',
                   skip_on=('ResourceNotFoundException', 'Function not found'),
               )


### PR DESCRIPTION
## Summary
Remove the M03 `github_integration` / `checkout_service` `--architectures arm64` branch from Gen2 `_deploy.yml`. Both functions are already arm64; the special-case caused ParamValidation failures on the shared Deploy→v4-gamma job.

Fixes ENC-ISS-504.

CCI-3cced87816964fa3a0137698af0809c4

## Test plan
- [ ] Deploy→v4-gamma succeeds for checkout_service + github_integration
- [ ] Both functions remain arm64 live

Made with [Cursor](https://cursor.com)