### PR TITLE
ENC-TSK-M08: relocate escalation approver allowlist off public jreese-net bucket (ENC-ISS-505 SEV-1)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.9",
-  "updated_at": "2026-07-07T13:35:00Z",
-  "last_change_summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH.",
+  "version": "2026-07-07.10",
+  "updated_at": "2026-07-07T14:25:00Z",
+  "last_change_summary": "ENC-TSK-M08 / ENC-ISS-505 (SEV-1): relocated the escalation approver allowlist (ESCALATION_APPROVER_ALLOWLIST_BUCKET) off jreese-net -- that bucket is served publicly on the open web via CloudFront (multiple distributions), making the allowlist document publicly readable with no auth. Moved to enceladus-356364570033-us-west-2-an, a private bucket with full S3 Public Access Block and no CloudFront origin. Same key (security/escalation-approvers.md), same read-only IAM grant shape.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7165,7 +7165,7 @@
         },
         "ESCALATION_APPROVER_ALLOWLIST_BUCKET": {
           "type": "string",
-          "definition": "ENC-TSK-L92 / ENC-ISS-501. Env var (default 'jreese-net'). S3 bucket holding the escalation-approver allowlist document."
+          "definition": "ENC-TSK-L92 / ENC-ISS-501 / ENC-ISS-505. Env var (default 'enceladus-356364570033-us-west-2-an'). S3 bucket holding the escalation-approver allowlist document. ENC-ISS-505 (SEV-1): originally 'jreese-net', which is served publicly on the open web via CloudFront (multiple distributions) -- the allowlist was readable by anyone at https://jreese.net/security/escalation-approvers.md with no auth. Relocated to this bucket, which has no CloudFront origin and full S3 Public Access Block enabled."
         },
         "ESCALATION_APPROVER_ALLOWLIST_KEY": {
           "type": "string",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -9127,7 +9127,9 @@ def _is_assistant_request(event: Dict[str, Any]) -> bool:
 # governance-bypass escalations. This adds a positive allowlist on top: the
 # decider's claims.email must appear in a human-Console-only S3 document that
 # no Lambda role (including this one) has write access to -- only s3:GetObject.
-ESCALATION_APPROVER_ALLOWLIST_BUCKET = os.environ.get("ESCALATION_APPROVER_ALLOWLIST_BUCKET", "jreese-net")
+ESCALATION_APPROVER_ALLOWLIST_BUCKET = os.environ.get(
+    "ESCALATION_APPROVER_ALLOWLIST_BUCKET", "enceladus-356364570033-us-west-2-an"
+)
 ESCALATION_APPROVER_ALLOWLIST_KEY = os.environ.get(
     "ESCALATION_APPROVER_ALLOWLIST_KEY", "security/escalation-approvers.md"
 )

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -347,10 +347,14 @@ Resources:
           TRAINING_HARD_DISABLED: "1"
           INTENT_TRAINING_BUCKET: !Ref S3Bucket
           INTENT_TRAINING_PREFIX: !Sub "${S3EnvPrefix}intent-training"
-          # ENC-TSK-L92 / ENC-ISS-501: escalation approve/deny decider allowlist.
-          # This role is granted s3:GetObject only on this exact key -- no Lambda
-          # role, including this one, has write access. Edits are Console-only.
-          ESCALATION_APPROVER_ALLOWLIST_BUCKET: !Ref S3Bucket
+          # ENC-TSK-L92 / ENC-ISS-501 / ENC-ISS-505: escalation approve/deny decider
+          # allowlist. This role is granted s3:GetObject only on this exact key --
+          # no Lambda role, including this one, has write access. Edits are
+          # Console-only. ENC-ISS-505: relocated off !Ref S3Bucket (jreese-net) --
+          # that bucket is served publicly on the open web via CloudFront, which
+          # made this allowlist (approver identities + this control's own
+          # design) publicly readable. This bucket has no CloudFront origin.
+          ESCALATION_APPROVER_ALLOWLIST_BUCKET: enceladus-356364570033-us-west-2-an
           ESCALATION_APPROVER_ALLOWLIST_KEY: security/escalation-approvers.md
       Tags:
         - Key: Project
@@ -3785,7 +3789,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - s3:GetObject
-                Resource: !Sub "arn:aws:s3:::${S3Bucket}/security/escalation-approvers.md"
+                Resource: "arn:aws:s3:::enceladus-356364570033-us-west-2-an/security/escalation-approvers.md"
               - Sid: SSMDispatch
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
- ENC-ISS-505 (SEV-1): the ENC-TSK-L92 escalation approver allowlist at `s3://jreese-net/security/escalation-approvers.md` is served publicly on the open web at `https://jreese.net/security/escalation-approvers.md` (200, full content, no auth) because `jreese-net` is fronted by CloudFront with a broad, path-unrestricted `s3:GetObject` grant.
- Relocates the allowlist to `s3://enceladus-356364570033-us-west-2-an/security/escalation-approvers.md` -- private bucket, no CloudFront origin, full S3 Public Access Block enabled.
- Updates `coordination_api`'s default env var, the CFN env var, and the IAM read-only grant resource ARN.

CCI-f4eaec3319e4482684c27c5a5a48495d

## Test plan
- [x] `test_escalation_decision_j70.py` 20/20 pass unchanged
- [ ] CI green
- [ ] Post-merge: confirm gamma's live IAM role has GetObject on the new location, confirm approve/deny still works