### PR TITLE
ENC-TSK-L06: wire ID_SERVICE_FUNCTION env var onto TrackerMutationFunction

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -408,6 +408,10 @@ Resources:
           # is ON. The flag itself lives in AppConfig (independently toggleable); it defaults OFF
           # so this var is inert until the flag is flipped — a zero-behavior-change deploy.
           LIFECYCLE_SERVICE_FUNCTION: !Sub "enceladus-lifecycle-service${EnvironmentSuffix}"
+          # ENC-TSK-L06 / B63 Ph2 AC-6: the ID Service to invoke when
+          # enable_id_service_extraction is ON. Inert until the (default-OFF) flag is
+          # flipped -- matches the LIFECYCLE_SERVICE_FUNCTION pattern above.
+          ID_SERVICE_FUNCTION: !Sub "enceladus-id-service${EnvironmentSuffix}"
           # ENC-TSK-H47: the lesson-scoring SNS topic tracker_mutation publishes to when
           # enable_scoring_service_extraction is ON. Inert until the (default-OFF) flag is flipped.
           LESSON_SCORING_TOPIC_ARN: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:enceladus-lesson-scoring${EnvironmentSuffix}"


### PR DESCRIPTION
## Summary
- The `invoke-id-service` IAM grant (InvokeIdService) was already correctly templated on `TrackerMutationRole`, but `ID_SERVICE_FUNCTION` -- the env var `_invoke_id_service()` reads to find the function name -- was never added to `TrackerMutationFunction`'s Environment block.
- Without it, flipping `enable_id_service_extraction=true` would fail-closed on every create (`ID_SERVICE_FUNCTION not configured; failing closed`).
- Matches the existing `LIFECYCLE_SERVICE_FUNCTION` pattern exactly.

CCI-23bb2c14d35b4e16af7230fd95e8c041

## Test plan
- [x] No lambda code change -- CFN env var addition only
- [ ] CI green
- [ ] Post-merge: confirm live env var, flip AppConfig flag, live create+verify smoke test