### PR TITLE
ENC-TSK-K23: five-step optimistic mutation layer (B67 AC-5/6/7)

### DIFF
--- a/frontend/ui-v2/src/components/OfflineLayer.tsx
+++ b/frontend/ui-v2/src/components/OfflineLayer.tsx
@@ -2,12 +2,19 @@ import { useEffect, useState } from 'react'
 import { Alert, Button, Flashbar, Modal } from '../design-system'
 import { useOfflineStore } from '../store/offlineStore'
 import { replayQueuedMutation } from '../api/mutations'
+import { mergeConflictFields } from '../api/mutations'
+import type { ConflictMergeState, MutationErrorState } from '../hooks/useRecordMutation'
 import {
-  mergeConflictFields,
-  type RevisionConflictError,
-} from '../api/mutations'
-import type { ConflictMergeState } from '../hooks/useRecordMutation'
-import { registerConflictMergeHandler } from '../hooks/useRecordMutation'
+  registerConflictMergeHandler,
+  registerMutationErrorHandler,
+} from '../hooks/useRecordMutation'
+
+const CLOSED_MUTATION_ERROR_STATE: MutationErrorState = {
+  open: false,
+  message: '',
+  vars: null,
+  retry: null,
+}
 
 export function OfflinePendingFlashbar() {
   const pendingCount = useOfflineStore((s) => s.pendingCount)
@@ -47,6 +54,55 @@ export function OfflinePendingFlashbar() {
   }
 
   if (items.length === 0) return null
+  return <Flashbar items={items} />
+}
+
+/**
+ * ENC-TSK-K23 (B67 AC-7): atomic-rollback surface for non-conflict mutation
+ * failures (network error, 5xx, mid-flight session expiry). The optimistic
+ * write already reverted synchronously in useRecordMutation's onError before
+ * this ever renders — this is purely the user-facing "it failed, want to
+ * retry?" notice, not part of the rollback itself.
+ */
+export function MutationErrorFlashbar() {
+  const [state, setState] = useState<MutationErrorState>(CLOSED_MUTATION_ERROR_STATE)
+
+  useEffect(() => {
+    registerMutationErrorHandler(setState)
+    return () => registerMutationErrorHandler(() => {})
+  }, [])
+
+  if (!state.open) return null
+
+  const dismiss = () => setState(CLOSED_MUTATION_ERROR_STATE)
+
+  const items = [
+    {
+      id: 'mutation-error',
+      type: 'error' as const,
+      header: 'Change failed to save',
+      dismissible: true,
+      onDismiss: dismiss,
+      content: (
+        <div className="flex items-center gap-3">
+          <span>{state.message}</span>
+          {state.retry ? (
+            <Button
+              variant="normal"
+              recordId={state.vars?.recordId}
+              onClick={() => {
+                state.retry?.()
+                dismiss()
+              }}
+            >
+              Retry
+            </Button>
+          ) : null}
+        </div>
+      ),
+    },
+  ]
+
   return <Flashbar items={items} />
 }
 

--- a/frontend/ui-v2/src/hooks/useRecordMutation.test.tsx
+++ b/frontend/ui-v2/src/hooks/useRecordMutation.test.tsx
@@ -1,0 +1,365 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import {
+  registerMutationErrorHandler,
+  useRecordMutation,
+  type MutationErrorState,
+} from './useRecordMutation'
+import { recordKeys } from '../api/queryOptions'
+import { feedCorpusKeys } from '../api/feedCorpusQueryOptions'
+import type { FeedCorpusPage } from '../sync/types'
+
+/**
+ * No @testing-library/react is installed in this package (every existing
+ * ui-v2 test is logic-level, not component-level) — this is a minimal
+ * createRoot + act harness using only what's already a dependency
+ * (react-dom/client), matching src/primitives/SessionPrimitive.test.tsx.
+ */
+
+vi.mock('../api/mutations', async () => {
+  const actual = await vi.importActual<typeof import('../api/mutations')>('../api/mutations')
+  return {
+    ...actual,
+    closeRecord: vi.fn(),
+    setField: vi.fn(),
+    submitNote: vi.fn(),
+  }
+})
+
+import { closeRecord, setField } from '../api/mutations'
+
+const PROJECT_ID = 'enceladus'
+const TASK_ID = 'ENC-TSK-K23'
+
+function makeTask(status: string) {
+  return { record_id: TASK_ID, status, title: 'Optimistic mutation layer', sync_version: 1 }
+}
+
+function makeFeedPage(status: string): FeedCorpusPage {
+  return {
+    success: true,
+    items: [
+      {
+        record_id: TASK_ID,
+        record_type: 'task',
+        project_id: PROJECT_ID,
+        title: 'Optimistic mutation layer',
+        source: 'tracker',
+        record_key: `task#${TASK_ID}`,
+        attrs: { status },
+      },
+    ],
+    next_cursor: null,
+    facets: {},
+    total_matches: 1,
+  }
+}
+
+describe('useRecordMutation — five-step onMutate (B67 AC-5)', () => {
+  let qc: QueryClient
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.clearAllMocks()
+    registerMutationErrorHandler(() => {})
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    qc.clear()
+  })
+
+  function TriggerComponent({ onReady }: { onReady: (mutate: ReturnType<typeof useRecordMutation>['mutate']) => void }) {
+    const mutation = useRecordMutation()
+    onReady(mutation.mutate)
+    return null
+  }
+
+  it('applies the optimistic write to cache before the network call resolves (zero perceptible loading state)', async () => {
+    qc.setQueryData(recordKeys.detail('task', PROJECT_ID, TASK_ID), makeTask('in-progress'))
+
+    let resolveFetch: (v: { success: true; record_id: string; updated_at: string }) => void = () => {}
+    vi.mocked(setField).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        }),
+    )
+
+    let mutate!: ReturnType<typeof useRecordMutation>['mutate']
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <TriggerComponent onReady={(m) => (mutate = m)} />
+        </QueryClientProvider>,
+      )
+    })
+
+    await act(async () => {
+      mutate({
+        projectId: PROJECT_ID,
+        recordType: 'task',
+        recordId: TASK_ID,
+        action: 'set_field',
+        field: 'status',
+        value: 'closed',
+      })
+      // onMutate's own steps (cancelQueries) are async, so the optimistic
+      // write lands a microtask after mutate() returns — flush that, but
+      // the mutationFn's fetch promise (resolveFetch) is still pending, so
+      // this is still strictly "before the network call resolves."
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Cache already reflects the new value before the network round trip
+    // completes — this is what "zero perceptible loading state" means.
+    const optimistic = qc.getQueryData<{ status: string }>(recordKeys.detail('task', PROJECT_ID, TASK_ID))
+    expect(optimistic?.status).toBe('closed')
+
+    await act(async () => {
+      resolveFetch({ success: true, record_id: TASK_ID, updated_at: '2026-07-07T15:30:00Z' })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Step 5 (onSettled) invalidated the query — it's no longer fresh.
+    expect(qc.getQueryState(recordKeys.detail('task', PROJECT_ID, TASK_ID))?.isInvalidated).toBe(true)
+  })
+
+  it('cancels outgoing refetches before snapshotting (step 1 precedes step 2)', async () => {
+    qc.setQueryData(recordKeys.detail('task', PROJECT_ID, TASK_ID), makeTask('open'))
+    const cancelSpy = vi.spyOn(qc, 'cancelQueries')
+    vi.mocked(setField).mockResolvedValue({ success: true, record_id: TASK_ID, updated_at: 'x' })
+
+    let mutate!: ReturnType<typeof useRecordMutation>['mutate']
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <TriggerComponent onReady={(m) => (mutate = m)} />
+        </QueryClientProvider>,
+      )
+    })
+
+    await act(async () => {
+      mutate({
+        projectId: PROJECT_ID,
+        recordType: 'task',
+        recordId: TASK_ID,
+        action: 'set_field',
+        field: 'status',
+        value: 'in-progress',
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: recordKeys.detail('task', PROJECT_ID, TASK_ID) })
+  })
+})
+
+describe('useRecordMutation — cross-page propagation (B67 AC-6)', () => {
+  let qc: QueryClient
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.clearAllMocks()
+    registerMutationErrorHandler(() => {})
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    qc.clear()
+  })
+
+  it('one setQueryData call updates every consumer of the same key in the same pass — no cascading extra renders', async () => {
+    qc.setQueryData(recordKeys.detail('task', PROJECT_ID, TASK_ID), makeTask('in-progress'))
+    qc.setQueryData(feedCorpusKeys.page({}), makeFeedPage('in-progress'))
+    vi.mocked(closeRecord).mockResolvedValue({ success: true, record_id: TASK_ID, updated_at: 'x' })
+
+    const detailRenders = { taskDetailView: 0, parentPlanView: 0 }
+
+    // Two independent consumers of the SAME query key — standing in for the
+    // task detail page and the parent plan page, which both read
+    // recordKeys.detail('task', ...) for this child task rather than the
+    // plan embedding its own copy.
+    function TaskDetailView() {
+      const { data } = useQuery<{ status: string }>({
+        queryKey: recordKeys.detail('task', PROJECT_ID, TASK_ID),
+        queryFn: () => Promise.reject(new Error('should not refetch in this test')),
+        enabled: false,
+      })
+      detailRenders.taskDetailView += 1
+      return <span data-testid="task-detail">{data?.status}</span>
+    }
+
+    function ParentPlanView() {
+      const { data } = useQuery<{ status: string }>({
+        queryKey: recordKeys.detail('task', PROJECT_ID, TASK_ID),
+        queryFn: () => Promise.reject(new Error('should not refetch in this test')),
+        enabled: false,
+      })
+      detailRenders.parentPlanView += 1
+      return <span data-testid="parent-plan">{data?.status}</span>
+    }
+
+    function FeedView() {
+      const { data } = useQuery<FeedCorpusPage>({
+        queryKey: feedCorpusKeys.page({}),
+        queryFn: () => Promise.reject(new Error('should not refetch in this test')),
+        enabled: false,
+      })
+      return <span data-testid="feed">{data?.items[0]?.attrs?.status as string}</span>
+    }
+
+    let mutate!: ReturnType<typeof useRecordMutation>['mutate']
+    function TriggerComponent() {
+      const mutation = useRecordMutation()
+      mutate = mutation.mutate
+      return null
+    }
+
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <TaskDetailView />
+          <ParentPlanView />
+          <FeedView />
+          <TriggerComponent />
+        </QueryClientProvider>,
+      )
+    })
+
+    expect(container.querySelector('[data-testid="task-detail"]')?.textContent).toBe('in-progress')
+    expect(container.querySelector('[data-testid="parent-plan"]')?.textContent).toBe('in-progress')
+    expect(container.querySelector('[data-testid="feed"]')?.textContent).toBe('in-progress')
+
+    const rendersBeforeMutate = { ...detailRenders }
+
+    await act(async () => {
+      mutate({ projectId: PROJECT_ID, recordType: 'task', recordId: TASK_ID, action: 'close' })
+      // Flush both the async onMutate steps AND notifyManager's own batched
+      // observer notifications (queued via a macrotask, not a microtask).
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Both consumers of the shared key reflect the transition in the same
+    // pass, and the independently-keyed feed cache also updated — three
+    // tabs, one optimistic write, verified via the DOM.
+    expect(container.querySelector('[data-testid="task-detail"]')?.textContent).toBe('closed')
+    expect(container.querySelector('[data-testid="parent-plan"]')?.textContent).toBe('closed')
+    expect(container.querySelector('[data-testid="feed"]')?.textContent).toBe('closed')
+
+    // No cascade: each consumer re-rendered exactly once for the one
+    // optimistic write, not once per other consumer's update.
+    expect(detailRenders.taskDetailView).toBe(rendersBeforeMutate.taskDetailView + 1)
+    expect(detailRenders.parentPlanView).toBe(rendersBeforeMutate.parentPlanView + 1)
+  })
+})
+
+describe('useRecordMutation — atomic rollback + retry (B67 AC-7)', () => {
+  let qc: QueryClient
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    qc.clear()
+  })
+
+  function TriggerComponent({ onReady }: { onReady: (mutate: ReturnType<typeof useRecordMutation>['mutate']) => void }) {
+    const mutation = useRecordMutation()
+    onReady(mutation.mutate)
+    return null
+  }
+
+  it('restores the exact pre-mutation snapshot on failure and surfaces a Flashbar Retry that resubmits', async () => {
+    const originalTask = makeTask('in-progress')
+    const originalFeed = makeFeedPage('in-progress')
+    qc.setQueryData(recordKeys.detail('task', PROJECT_ID, TASK_ID), originalTask)
+    qc.setQueryData(feedCorpusKeys.page({}), originalFeed)
+
+    vi.mocked(setField).mockRejectedValueOnce(new Error('network error'))
+
+    let capturedState: MutationErrorState | null = null
+    registerMutationErrorHandler((state) => {
+      capturedState = state
+    })
+
+    let mutate!: ReturnType<typeof useRecordMutation>['mutate']
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <TriggerComponent onReady={(m) => (mutate = m)} />
+        </QueryClientProvider>,
+      )
+    })
+
+    const vars = {
+      projectId: PROJECT_ID,
+      recordType: 'task' as const,
+      recordId: TASK_ID,
+      action: 'set_field' as const,
+      field: 'status',
+      value: 'closed',
+    }
+
+    await act(async () => {
+      mutate(vars)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Atomic rollback: BOTH caches touched by the optimistic write are back
+    // to their exact pre-mutation snapshot — not a partial revert.
+    expect(qc.getQueryData(recordKeys.detail('task', PROJECT_ID, TASK_ID))).toEqual(originalTask)
+    expect(qc.getQueryData(feedCorpusKeys.page({}))).toEqual(originalFeed)
+
+    // The Flashbar surface was notified with a Retry callback, not a raw
+    // exception — this is the UI contract OfflineLayer's MutationErrorFlashbar
+    // renders against.
+    expect(capturedState).not.toBeNull()
+    expect(capturedState!.open).toBe(true)
+    expect(capturedState!.message).toBeTruthy()
+    expect(typeof capturedState!.retry).toBe('function')
+
+    // Clicking Retry resubmits the exact same vars.
+    vi.mocked(setField).mockResolvedValueOnce({ success: true, record_id: TASK_ID, updated_at: 'x' })
+    await act(async () => {
+      capturedState!.retry!()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(vi.mocked(setField)).toHaveBeenCalledTimes(2)
+    expect(qc.getQueryData<{ status: string }>(recordKeys.detail('task', PROJECT_ID, TASK_ID))?.status).toBe('closed')
+  })
+})

--- a/frontend/ui-v2/src/hooks/useRecordMutation.ts
+++ b/frontend/ui-v2/src/hooks/useRecordMutation.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   closeRecord,
@@ -9,7 +10,10 @@ import {
   type RevisionConflictError,
   isRevisionConflictError,
 } from '../api/mutations'
+import { SessionExpiredError } from '../api/client'
 import { recordKeys } from '../api/queryOptions'
+import { feedCorpusKeys } from '../api/feedCorpusQueryOptions'
+import type { FeedCorpusPage } from '../sync/types'
 
 type RecordType = 'task' | 'issue' | 'feature' | 'plan'
 
@@ -37,12 +41,93 @@ export function registerConflictMergeHandler(handler: (state: ConflictMergeState
 }
 
 /**
- * Optimistic tracker mutations with If-Match revision headers (K25 / K23 pattern).
+ * ENC-TSK-K23 (B67 AC-7): non-conflict mutation failures (network error, 5xx,
+ * session expiry mid-flight) surface here as a design-system Flashbar with a
+ * Retry action — distinct from the 409 revision-conflict surface above,
+ * which needs a merge decision rather than a blind resubmit.
+ */
+export interface MutationErrorState {
+  open: boolean
+  message: string
+  vars: MutationVars | null
+  retry: (() => void) | null
+}
+
+let mutationErrorHandler: ((state: MutationErrorState) => void) | null = null
+
+export function registerMutationErrorHandler(handler: (state: MutationErrorState) => void): void {
+  mutationErrorHandler = handler
+}
+
+interface FeedSnapshotEntry {
+  key: readonly unknown[]
+  value: FeedCorpusPage | undefined
+}
+
+interface MutationSnapshot {
+  detailKey: readonly unknown[]
+  detailValue: unknown
+  feedEntries: FeedSnapshotEntry[]
+}
+
+/** Step 3 helper — the optimistic patch for a given action, applied to whatever
+ * shape the detail cache currently holds (Task | Issue | Feature | Plan all
+ * share `status`/arbitrary-field semantics at the tracker-record level). */
+function applyOptimisticPatch(current: unknown, vars: MutationVars): unknown {
+  if (!current || typeof current !== 'object') return current
+  const base = current as Record<string, unknown>
+  if (vars.action === 'close') {
+    return { ...base, status: 'closed' }
+  }
+  if (vars.action === 'set_field' && vars.field && vars.value !== undefined) {
+    return { ...base, [vars.field]: vars.value }
+  }
+  return current
+}
+
+function applyOptimisticFeedPatch(page: FeedCorpusPage, vars: MutationVars): FeedCorpusPage {
+  let changed = false
+  const items = page.items.map((item) => {
+    if (item.record_id !== vars.recordId || item.record_type !== vars.recordType) return item
+    changed = true
+    if (vars.action === 'close') {
+      return { ...item, attrs: { ...item.attrs, status: 'closed' } }
+    }
+    if (vars.action === 'set_field' && vars.field) {
+      return { ...item, attrs: { ...item.attrs, [vars.field]: vars.value } }
+    }
+    return item
+  })
+  return changed ? { ...page, items } : page
+}
+
+/**
+ * Optimistic tracker mutations (ENC-TSK-K23 / B67 AC-5/6/7), built on the
+ * If-Match revision contract (ENC-TSK-L47 / K25 AC-3).
+ *
+ * Five-step onMutate sequence per DOC-E470AC8CE9A8 §3.1:
+ *   1. cancel outgoing refetches for every cache this mutation touches
+ *   2. snapshot current values for atomic rollback
+ *   3. surgically write the optimistic value into cache
+ *   4. return the snapshot as onError's rollback context
+ *   5. onSettled invalidates regardless of outcome, reconciling with server truth
+ *
+ * Cross-page propagation (AC-6): the task detail page and the parent plan
+ * page both read the SAME `recordKeys.detail(...)` cache entry — a Plan
+ * record references child tasks by ID (`objectives_set`), it does not embed
+ * them — so one `setQueryData` call on that key is what makes both views
+ * reflect a transition in the same render pass, no second write needed. The
+ * feed corpus cache is a separate, list-shaped cache, so it gets its own
+ * predicate-matched `setQueriesData` patch (step 3) and its own snapshot
+ * entries (step 2 / rollback).
  */
 export function useRecordMutation() {
   const qc = useQueryClient()
+  const mutationRef = useRef<ReturnType<typeof useMutation<MutationResult, Error, MutationVars, MutationSnapshot>> | null>(
+    null,
+  )
 
-  return useMutation<MutationResult, Error, MutationVars>({
+  const mutation = useMutation<MutationResult, Error, MutationVars, MutationSnapshot>({
     mutationFn: async (vars) => {
       const revision = vars.syncVersion ?? undefined
       if (vars.action === 'close') {
@@ -60,33 +145,92 @@ export function useRecordMutation() {
         revision,
       )
     },
+
     onMutate: async (vars) => {
-      if (vars.action !== 'set_field' || vars.field !== 'status' || !vars.value) {
-        return { snapshot: undefined }
+      const detailKey = recordKeys.detail(vars.recordType, vars.projectId, vars.recordId)
+      const touchesDetail = vars.action === 'close' || vars.action === 'set_field'
+
+      // Step 1: cancel outgoing refetches so a stale in-flight response can't
+      // clobber the optimistic write below.
+      await qc.cancelQueries({ queryKey: detailKey })
+      if (touchesDetail) {
+        await qc.cancelQueries({ queryKey: feedCorpusKeys.all })
       }
-      const key = recordKeys.detail(vars.recordType, vars.projectId, vars.recordId)
-      await qc.cancelQueries({ queryKey: key })
-      const snapshot = qc.getQueryData(key)
-      return { snapshot }
+
+      // Step 2: snapshot every cache entry we're about to touch.
+      const detailValue = qc.getQueryData(detailKey)
+      const feedEntries: FeedSnapshotEntry[] = touchesDetail
+        ? qc
+            .getQueriesData<FeedCorpusPage>({ queryKey: feedCorpusKeys.all })
+            .map(([key, value]) => ({ key, value }))
+        : []
+
+      // Step 3: surgical optimistic write. `note` has no visible field to
+      // patch pre-emptively (worklog entries render from server history).
+      if (touchesDetail) {
+        if (detailValue !== undefined) {
+          qc.setQueryData(detailKey, applyOptimisticPatch(detailValue, vars))
+        }
+        qc.setQueriesData<FeedCorpusPage>({ queryKey: feedCorpusKeys.all }, (page) =>
+          page ? applyOptimisticFeedPatch(page, vars) : page,
+        )
+      }
+
+      // Step 4: return the full snapshot for atomic rollback in onError.
+      return { detailKey, detailValue, feedEntries }
     },
+
     onError: (error, vars, context) => {
       if (isRevisionConflictError(error)) {
         conflictHandler?.({ open: true, error, vars })
         return
       }
-      if (context?.snapshot !== undefined && vars) {
-        qc.setQueryData(
-          recordKeys.detail(vars.recordType, vars.projectId, vars.recordId),
-          context.snapshot,
-        )
+
+      // Step 4 (continued): atomic rollback — every cache entry touched in
+      // onMutate is restored in one pass, never a partial revert.
+      if (context) {
+        if (context.detailValue !== undefined) {
+          qc.setQueryData(context.detailKey, context.detailValue)
+        }
+        for (const entry of context.feedEntries) {
+          qc.setQueryData(entry.key, entry.value)
+        }
       }
+
+      mutationErrorHandler?.({
+        open: true,
+        message:
+          error instanceof SessionExpiredError
+            ? 'Session expired — sign in again to retry.'
+            : error.message || 'Change failed to save.',
+        vars,
+        retry: () => mutationRef.current?.mutate(vars),
+      })
     },
-    onSuccess: (_data, vars) => {
+
+    onSettled: (_data, _error, vars) => {
+      // Step 5: reconcile with server truth regardless of outcome. On
+      // success this picks up server-computed fields (history, updated_at)
+      // beyond what step 3 patched; on failure the just-restored snapshot
+      // may itself be stale, so this is not redundant with the rollback.
       void qc.invalidateQueries({
         queryKey: recordKeys.detail(vars.recordType, vars.projectId, vars.recordId),
       })
+      if (vars.action === 'close' || vars.action === 'set_field') {
+        void qc.invalidateQueries({ queryKey: feedCorpusKeys.all })
+      }
     },
   })
+
+  // Refs must not be written during render (React rules-of-hooks) — the
+  // retry closure in onError only ever runs from a user-triggered event
+  // (clicking Retry) well after mount, so committing this in an effect is
+  // still ready by the time it's needed.
+  useEffect(() => {
+    mutationRef.current = mutation
+  })
+
+  return mutation
 }
 
 export function extractRevisionFromRecord(record: unknown): number | undefined {

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -6,7 +6,7 @@ import { performLogout } from '../auth/logout'
 import { useUiStore } from '../store/uiStore'
 import { CommandPalette } from './CommandPalette'
 import { FeedPane } from './FeedPane'
-import { ConflictMergeModal, OfflinePendingFlashbar } from '../components/OfflineLayer'
+import { ConflictMergeModal, MutationErrorFlashbar, OfflinePendingFlashbar } from '../components/OfflineLayer'
 import './shell.css'
 
 const LOGOUT_HREF = '__logout__'
@@ -155,6 +155,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       />
       <CommandPalette />
       <OfflinePendingFlashbar />
+      <MutationErrorFlashbar />
       <ConflictMergeModal />
     </div>
   )


### PR DESCRIPTION
## Summary
- Implements the full DOC-E470AC8CE9A8 §3.1 five-step `onMutate` pattern in `useRecordMutation` (cancel → snapshot → surgical write → rollback context → `onSettled` invalidate). The prior implementation only snapshotted and never wrote the optimistic value -- there was no actual optimistic UI yet.
- **AC-5**: optimistic writes land on the detail cache before the network call resolves.
- **AC-6**: cross-page propagation falls out of the existing architecture -- task detail and parent plan pages read the *same* `recordKeys.detail(...)` cache entry (plans reference child tasks by ID, not embedded), so one `setQueryData` updates every consumer in one render pass, no cascade. Feed corpus cache gets its own predicate-matched patch.
- **AC-7**: atomic rollback restores every cache entry touched in `onMutate` in one pass, then surfaces a new `MutationErrorFlashbar` (design-system-2 Flashbar + Retry, mirroring the existing `ConflictMergeModal` singleton-handler pattern) -- per DOC-E470AC8CE9A8 §3.3/§10, Flashbar supersedes the task's own stale sonner-toast description.

CCI-991f45e5d2ed44c19095d14b5b5fbc8b

## Test plan
- [x] `useRecordMutation.test.tsx`: optimistic write lands before network resolves; `cancelQueries` precedes snapshot; two independent consumers of the same key update in one pass with no extra re-renders; simulated failure rolls back both caches exactly and Retry resubmits the identical mutation
- [x] Full suite: 147/147 pass, zero regressions
- [x] `tsc --noEmit` clean, `eslint` clean on all touched files
- [x] `npm run build` succeeds
- [ ] CI green