### PR TITLE
ENC-TSK-L93: documents-list metadata-only projection (include_content=false)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-07.13",
-  "updated_at": "2026-07-07T15:18:41Z",
-  "last_change_summary": "ENC-TSK-L05 (B63 Ph2 H-BACKFILL AC2-6, DOC-157A790F9E8B): populated the v3 component-registry identity fields (component_address, component_repo_dir, component_address_class, component_class) and migrated required_transition_type to the v3 enum on all active enceladus components in tools/seed-component-registry.py; decomposed comp-enceladus-pwa into comp-enceladus-pwa-frontend/-pwa-cdn/-api-gateway (T2, no file split -- 03-api.yaml already API-Gateway-only, CDN already in 07-ui-cdn.yaml); registered comp-enceladus-neo4j + infrastructure/external/neo4j-auradb.yaml (T3); nine per-CFN-file umbrellas + narrowed comp-cloudformation-data/-app (T4a MECE); comp-enceladus-mcp-server single MCP umbrella (ENC-FTR-094 debt, T1); comp-umbrella-governance-documentation meta umbrella (AC-6). Schema was already v3 (ENC-TSK-L77); this records the registry-instance expansion. AC-5 task migration + live legacy-row rename/deprecation are io-Cognito follow-ups.",
+  "version": "2026-07-07.14",
+  "updated_at": "2026-07-07T17:05:00Z",
+  "last_change_summary": "ENC-TSK-L93: documents-list include_content=false metadata-only projection for skill catalog (runtime_hint derived field).",
   "owners": [
     "enceladus-platform"
   ],
@@ -5456,6 +5456,16 @@
           "definition": "Cross-references to governed records (ENC-TSK-*/ENC-ISS-*/ENC-FTR-*/ENC-LSN-*/ENC-PLN-*) this document relates to.",
           "usage_guidance": "documents.put / documents.patch(field include related_items). ENC-TSK-L07 (B65 AC-5/AC-7): bidirectional -- document_api atomically mirrors this document's ID onto each named tracker record's related_document_ids in the same request (contains-check conditional append; best-effort, non-blocking to the document write).",
           "inverse_of": "tracker.<task|issue|feature|lesson>.related_document_ids"
+        },
+        "list_include_content": {
+          "type": "query_parameter",
+          "definition": "GET /api/v1/documents?project= query param (ENC-TSK-L93). When include_content=false (or content=false alias), list responses omit body-heavy fields. document_subtype=skill rows collapse to document_id, title, description, version, updated_at, runtime_hint; other subtypes omit full_description, claude_description, content, agentskills_manifest, agentskills_spec_version, runtime_variants. Default true (omitted) preserves existing full-metadata list behavior.",
+          "usage_guidance": "Use include_content=false for PWA skill-library catalog views (ENC-TSK-L94). MCP documents.list forwards include_content to the HTTP query string."
+        },
+        "list_runtime_hint": {
+          "type": "string",
+          "definition": "ENC-TSK-L93 list projection field (skill subtype, include_content=false only). Comma-separated sorted keys from runtime_variants when present; otherwise the literal 'claude,agentskills' indicating dual-projection default.",
+          "usage_guidance": "Read-only derived field; not stored in DynamoDB."
         }
       }
     },
@@ -7786,8 +7796,13 @@
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
     }
   },
-  "change_summary": "ENC-TSK-L87: mentions_drift_audit false-positive fixes -- gamma comparison target, project_id threading, and cross-project neighbor visibility.",
+  "change_summary": "ENC-TSK-L93: documents-list metadata-only projection via include_content=false (skill catalog fields + runtime_hint).",
   "change_log": [
+    {
+      "version": "2026-07-07.14",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L93: document_api GET ?project= list now honors include_content=false (and content=false alias) for body-excluded metadata projection. Skill rows return document_id, title, description, version (from agentskills_manifest.version), updated_at, runtime_hint (runtime_variants keys or 'claude,agentskills' default). Non-skill rows omit full_description/claude_description/content/agentskills fields. Default include_content=true unchanged. MCP documents.list forwards include_content. New docstore.document.list_include_content + list_runtime_hint dictionary fields."
+    },
     {
       "version": "2026-07-07.13",
       "date": "2026-07-07",

--- a/backend/lambda/document_api/lambda_function.py
+++ b/backend/lambda/document_api/lambda_function.py
@@ -2165,6 +2165,67 @@ def _get_single(document_id: str, qs: Dict) -> Dict:
     return _response(200, payload)
 
 
+# ENC-TSK-L93: body fields stripped from list responses when include_content=false.
+_LIST_BODY_FIELDS = frozenset({
+    "full_description", "claude_description", "content",
+    "agentskills_manifest", "agentskills_spec_version", "runtime_variants",
+})
+
+
+def _parse_include_content(qs: Dict) -> bool:
+    """Parse list/get include_content; accepts content=false alias (ENC-TSK-L93)."""
+    if "include_content" in qs:
+        return str(qs.get("include_content", "true")).strip().lower() in ("true", "1", "yes")
+    if "content" in qs:
+        val = str(qs.get("content", "true")).strip().lower()
+        return val not in ("false", "0", "no")
+    return True
+
+
+def _parse_json_field(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return value
+    return value
+
+
+def _skill_list_version(doc: Dict[str, Any]) -> str:
+    manifest = _parse_json_field(doc.get("agentskills_manifest"))
+    if isinstance(manifest, dict):
+        ver = manifest.get("version")
+        if ver:
+            return str(ver)
+    ver = doc.get("version")
+    return str(ver) if ver else ""
+
+
+def _skill_runtime_hint(doc: Dict[str, Any]) -> str:
+    variants = _parse_json_field(doc.get("runtime_variants"))
+    if isinstance(variants, dict) and variants:
+        return ",".join(sorted(str(k) for k in variants.keys()))
+    return "claude,agentskills"
+
+
+def _project_list_document(doc: Dict[str, Any], include_content: bool) -> Dict[str, Any]:
+    """Apply list projection. Default (include_content=true) returns full metadata unchanged."""
+    if include_content:
+        return doc
+    subtype = str(doc.get("document_subtype") or "general").lower()
+    if subtype == "skill":
+        return {
+            "document_id": doc.get("document_id"),
+            "title": doc.get("title"),
+            "description": doc.get("description"),
+            "version": _skill_list_version(doc),
+            "updated_at": doc.get("updated_at"),
+            "runtime_hint": _skill_runtime_hint(doc),
+            "document_subtype": "skill",
+        }
+    return {k: v for k, v in doc.items() if k not in _LIST_BODY_FIELDS}
+
+
 def _list_by_project(qs: Dict) -> Dict:
     """List documents for a project using strongly consistent table scan.
 
@@ -2219,6 +2280,8 @@ def _list_by_project(qs: Dict) -> Dict:
         docs.sort(key=lambda d: d.get("created_at", "") or "")
     else:
         docs.sort(key=lambda d: d.get("updated_at", "") or "", reverse=True)
+    include_content = _parse_include_content(qs)
+    docs = [_project_list_document(d, include_content) for d in docs]
     sliced = docs[:PAGE_SIZE]
     return _response(
         200,

--- a/backend/lambda/document_api/test_lambda_function.py
+++ b/backend/lambda/document_api/test_lambda_function.py
@@ -418,6 +418,68 @@ class ListDocumentsTests(unittest.TestCase):
         # Should require either project= or document ID
         self.assertIn(resp["statusCode"], [400, 200])
 
+    @patch.object(document_api, "_authenticate",
+                  return_value=({"sub": "user1"}, None))
+    @patch.object(document_api, "_get_ddb")
+    def test_list_skill_metadata_projection(self, mock_ddb, _mock_auth):
+        """ENC-TSK-L93: include_content=false returns compact skill metadata."""
+        fake_ddb = MagicMock()
+        mock_ddb.return_value = fake_ddb
+        fake_ddb.scan.return_value = {
+            "Items": [
+                {
+                    "document_id": {"S": "DOC-SKILL-1"},
+                    "title": {"S": "Test Skill"},
+                    "description": {"S": "Short desc"},
+                    "project_id": {"S": "enceladus"},
+                    "document_subtype": {"S": "skill"},
+                    "updated_at": {"S": "2026-07-07T00:00:00Z"},
+                    "version": {"S": "1.0.0"},
+                    "full_description": {"S": "X" * 5000},
+                    "claude_description": {"S": "Y" * 500},
+                    "agentskills_manifest": {"S": json.dumps({"name": "test", "description": "d", "version": "2.1.0"})},
+                    "runtime_variants": {"S": json.dumps({"claude-code": {}, "cursor": {}})},
+                },
+            ],
+        }
+
+        # Default: full metadata preserved
+        event_full = _make_event(
+            method="GET",
+            path="/api/v1/documents",
+            query_params={"project": "enceladus", "document_subtype": "skill"},
+        )
+        resp_full = document_api.lambda_handler(event_full, None)
+        body_full = json.loads(resp_full["body"])
+        self.assertIn("full_description", body_full["documents"][0])
+
+        # Metadata-only projection
+        event_meta = _make_event(
+            method="GET",
+            path="/api/v1/documents",
+            query_params={"project": "enceladus", "document_subtype": "skill", "include_content": "false"},
+        )
+        resp_meta = document_api.lambda_handler(event_meta, None)
+        body_meta = json.loads(resp_meta["body"])
+        doc = body_meta["documents"][0]
+        self.assertEqual(set(doc.keys()), {
+            "document_id", "title", "description", "version",
+            "updated_at", "runtime_hint", "document_subtype",
+        })
+        self.assertEqual(doc["version"], "2.1.0")
+        self.assertEqual(doc["runtime_hint"], "claude-code,cursor")
+        self.assertNotIn("full_description", doc)
+
+        # content=false alias
+        event_alias = _make_event(
+            method="GET",
+            path="/api/v1/documents",
+            query_params={"project": "enceladus", "content": "false"},
+        )
+        resp_alias = document_api.lambda_handler(event_alias, None)
+        body_alias = json.loads(resp_alias["body"])
+        self.assertNotIn("full_description", body_alias["documents"][0])
+
 
 class S3HelperTests(unittest.TestCase):
     def test_s3_key_construction(self):

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3988,6 +3988,18 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Pagination cursor from previous response's next_cursor.",
                     },
+                    "document_subtype": {
+                        "type": "string",
+                        "description": "Filter by document_subtype (e.g. skill, handoff).",
+                    },
+                    "include_content": {
+                        "type": "boolean",
+                        "description": (
+                            "When false, list returns metadata-only projection "
+                            "(skill rows: id, title, description, version, updated_at, runtime_hint). "
+                            "Default true preserves full metadata."
+                        ),
+                    },
                 },
                 "required": ["project_id"],
             },
@@ -6348,9 +6360,9 @@ async def _documents_list(args: dict) -> list[TextContent]:
     # ENC-TSK-J46 / ENC-FTR-096 Ph2: thread through document_subtype /
     # handoff_status filters (the latter also covers the lesson-candidate
     # curation-state field) and the created_at sort used by candidate queues.
-    for passthrough_key in ("document_subtype", "handoff_status", "maturity_state", "sort"):
+    for passthrough_key in ("document_subtype", "handoff_status", "maturity_state", "sort", "include_content", "content"):
         value = args.get(passthrough_key)
-        if value:
+        if value is not None and value != "":
             query[passthrough_key] = value
     resp = _document_api_request("GET", query=query)
     if isinstance(resp, dict) and resp.get("error"):


### PR DESCRIPTION
## Summary
- **Finding (AC-0):** `GET /documents?project=` list path did not support body-excluded projection; only single-document `GET` had `include_content`. Skill lists returned full DynamoDB metadata including `full_description` (~34–76KB).
- **Fix (AC-1):** Additive `include_content=false` query param (plus `content=false` alias) on list. Skill rows project to `document_id`, `title`, `description`, `version`, `updated_at`, `runtime_hint`. Default `include_content=true` unchanged.
- **MCP:** `documents.list` forwards `include_content` + documents_list tool schema updated.
- **Dict:** governance bump `2026-07-07.14` — `docstore.document.list_include_content`, `list_runtime_hint`.
- **No CFN changes** (gamma document_api Lambda only via Gen2 deploy).

## Test plan
- [x] `pytest backend/lambda/document_api/test_lambda_function.py` — 36 passed
- [ ] Post-deploy gamma: `GET /documents?project=enceladus&document_subtype=skill` vs `&include_content=false` — metadata payload ~1KB vs full ~34KB+
- [ ] Default list unchanged (include_content omitted)

## Tracker
ENC-TSK-L93 | CCI-3ccadeaf06e94d55bd274c21ba866658 | target:gamma