### PR TITLE
ENC-TSK-M11: X-Ray active tracing on McpStreamingGatewayFunction (gamma)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1479,6 +1479,13 @@ Resources:
       Timeout: 900
       Architectures:
         - !If [IsGamma, arm64, x86_64]
+      # ENC-TSK-M11 / B66 AC-0 / ENC-TSK-K45 AC-0: active X-Ray tracing. This
+      # resource is stack-owned (CREATE_COMPLETE via enceladus-compute-gamma,
+      # not CFN-IMPORTed), so a normal change-set diffs and applies this
+      # property directly -- unlike the ENC-ISS-497 IMPORTed-resource gap that
+      # affects CheckoutServiceFunction (K44/K45/K66) and EnceladusMcpCodeGammaFunction.
+      TracingConfig:
+        Mode: Active
       Role: !GetAtt McpStreamingGatewayRole.Arn
       Layers:
         - !Ref SharedLayerArn


### PR DESCRIPTION
## Summary
- B66 AC-0 / ENC-TSK-K45 AC-0 remaining gap: 3 MCP-server gamma Lambdas were still `TracingConfig.Mode=PassThrough` (checked live 2026-07-07).
- Enables `TracingConfig: {Mode: Active}` on `McpStreamingGatewayFunction` (`enceladus-mcp-streaming-gateway-gamma`) in `infrastructure/cloudformation/02-compute.yaml`. This is the one of the three that is cleanly gamma-stack-owned (`Condition: IsGamma`, `CREATE_COMPLETE` — not CFN-IMPORTed), so a normal change-set diff applies the property directly.
- The other two MCP Lambdas (`enceladus-mcp-code-gamma`, `enceladus-mcp-streamable-gamma`) have separate structural CFN-ownership blockers (prod-stack-owned via `Condition: IsProduction`, and zero CFN resource at all respectively) tracked in a follow-up tracker issue — out of scope for a gamma-only dispatch.

CCI-77129b05a394436eb146d232ea0f6b30

## Test plan
- [ ] `Apply Data + Compute change-sets` workflow run green on v4/main merge (gamma)
- [ ] `aws lambda get-function-configuration --function-name enceladus-mcp-streaming-gateway-gamma` shows `TracingConfig.Mode=Active`
- [ ] Invoke a read path through the gamma MCP stack and confirm a connected X-Ray trace via `aws xray get-trace-summaries`