### PR TITLE
ENC-TSK-L94: Skill Library PWA page (FTR-129)

### DIFF
--- a/frontend/ui-v2/src/api/skillLibrary.test.ts
+++ b/frontend/ui-v2/src/api/skillLibrary.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionExpiredError } from './client'
+import { fetchSkillLibrary, isTestSkillRecord, skillLibraryKeys } from './skillLibrary'
+
+const SKILL_DOCS = [
+  {
+    document_id: 'DOC-89D35679FE91',
+    title: 'enceladus-agent-webui-alpha',
+    description: 'Governed Web UI agent skill.',
+    version: '7',
+    updated_at: '2026-07-05T11:07:03Z',
+    runtime_hint: 'claude,agentskills',
+    document_subtype: 'skill',
+  },
+  {
+    document_id: 'DOC-82D57A4FE6DC',
+    title: 'E2E skill — FTR-078 phase-8 seed (cross-platform portable)',
+    description: '',
+    version: '0.1.0',
+    updated_at: '2026-04-19T01:49:27Z',
+    runtime_hint: 'claude,agentskills',
+    document_subtype: 'skill',
+  },
+]
+
+describe('fetchSkillLibrary', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('requests the body-excluded skill projection and unwraps documents', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ documents: SKILL_DOCS, count: 2, total_matches: 2 }), {
+        status: 200,
+      }),
+    )
+
+    const result = await fetchSkillLibrary('enceladus')
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!
+    expect(String(url)).toContain('/documents?')
+    expect(String(url)).toContain('project=enceladus')
+    expect(String(url)).toContain('document_subtype=skill')
+    expect(String(url)).toContain('include_content=false')
+    expect(init).toMatchObject({ credentials: 'include', cache: 'no-store' })
+
+    // AC-4: the ftr-078-e2e-skill test fixture is excluded by default.
+    expect(result).toHaveLength(1)
+    expect(result[0]!.document_id).toBe('DOC-89D35679FE91')
+  })
+
+  it('defaults to an empty array when documents is missing', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    const result = await fetchSkillLibrary('enceladus')
+    expect(result).toEqual([])
+  })
+
+  it('throws SessionExpiredError on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 401 }))
+    await expect(fetchSkillLibrary('enceladus')).rejects.toBeInstanceOf(SessionExpiredError)
+  })
+
+  it('throws on non-ok, non-401 responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }))
+    await expect(fetchSkillLibrary('enceladus')).rejects.toThrow('Failed to fetch skill library (500)')
+  })
+})
+
+describe('isTestSkillRecord', () => {
+  it('flags the known ftr-078-e2e-skill fixture', () => {
+    expect(isTestSkillRecord({ document_id: 'DOC-82D57A4FE6DC' })).toBe(true)
+  })
+
+  it('does not flag ordinary skill records', () => {
+    expect(isTestSkillRecord({ document_id: 'DOC-89D35679FE91' })).toBe(false)
+  })
+})
+
+describe('skillLibraryKeys.list', () => {
+  it('is a stable per-project query key', () => {
+    expect(skillLibraryKeys.list('enceladus')).toEqual(['skill-library', 'enceladus'])
+  })
+})

--- a/frontend/ui-v2/src/api/skillLibrary.ts
+++ b/frontend/ui-v2/src/api/skillLibrary.ts
@@ -1,0 +1,83 @@
+/**
+ * Skill Library reads — GET /api/v1/documents?project=&document_subtype=skill&
+ * include_content=false (document_api Lambda). ENC-TSK-L94 / FTR-129.
+ *
+ * Sources from the body-excluded metadata-only projection shipped by
+ * ENC-TSK-L93 (governance_hash-tracked, gamma): a `document_subtype=skill`
+ * list request with `include_content=false` returns only
+ * `{ document_id, title, description, version, updated_at, runtime_hint,
+ * document_subtype }` — no `full_description`/`claude_description`/`content`
+ * body fields, no `keywords`. That last point matters for the AC-4 filter
+ * below: `keywords` isn't available on this projection, so the test-fixture
+ * exclusion below matches on `document_id`, not on the seed's
+ * `keywords: ["enc-ftr-078", "e2e", "skill-seed"]`.
+ */
+
+import { queryOptions } from '@tanstack/react-query'
+import { API_BASE, SessionExpiredError } from './client'
+
+export interface SkillListItem {
+  document_id: string
+  title: string
+  description: string
+  version: string
+  updated_at: string
+  runtime_hint: string
+  document_subtype: string
+}
+
+/**
+ * ENC-TSK-L94 AC-4: `ftr-078-e2e-skill` (DOC-82D57A4FE6DC, agentskills_manifest
+ * name `ftr-078-e2e-skill`) is a smoke-test fixture seeded to verify the
+ * ENC-FTR-078 post-deploy `documents.put` validators — not a reusable skill
+ * for engineers to browse. Default, absent an explicit io decision: EXCLUDE
+ * it from the Skill Library page. Documented here (and in the task worklog)
+ * per the AC's "chosen default is documented" requirement — update this set
+ * if io decides to include it, or if more e2e fixtures get seeded.
+ */
+const EXCLUDED_SKILL_DOCUMENT_IDS = new Set<string>(['DOC-82D57A4FE6DC'])
+
+export function isTestSkillRecord(item: Pick<SkillListItem, 'document_id'>): boolean {
+  return EXCLUDED_SKILL_DOCUMENT_IDS.has(item.document_id)
+}
+
+export async function fetchSkillLibrary(
+  projectId: string,
+  init?: { signal?: AbortSignal },
+): Promise<SkillListItem[]> {
+  const qs = new URLSearchParams({
+    project: projectId,
+    document_subtype: 'skill',
+    include_content: 'false',
+  })
+  const res = await fetch(`${API_BASE}/documents?${qs.toString()}`, {
+    signal: init?.signal,
+    credentials: 'include',
+    cache: 'no-store',
+    headers: {
+      accept: 'application/json',
+      'x-requested-with': 'XMLHttpRequest',
+    },
+  })
+  if (res.status === 401) throw new SessionExpiredError()
+  if (!res.ok) throw new Error(`Failed to fetch skill library (${res.status})`)
+  const body = (await res.json()) as { documents?: SkillListItem[] }
+  return (body.documents ?? []).filter((item) => !isTestSkillRecord(item))
+}
+
+export const skillLibraryKeys = {
+  list: (projectId: string) => ['skill-library', projectId] as const,
+}
+
+/**
+ * No `staleTime` — every mount is treated as fresh (AC-2: "resolved on page
+ * mount; no client-side persistent catalog or cache of the skill list").
+ * TanStack Query's in-memory query cache is not persisted to disk/localStorage
+ * and refetches on mount by default (staleTime 0), matching the existing
+ * DocsRoute/ChangelogRoute/GovernanceRoute convention.
+ */
+export const skillLibraryQueryOptions = (projectId: string) =>
+  queryOptions({
+    queryKey: skillLibraryKeys.list(projectId),
+    queryFn: ({ signal }) => fetchSkillLibrary(projectId, { signal }),
+  })

--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.test.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { ReactElement } from 'react'
+import type { SkillListItem } from '../api/skillLibrary'
+import { buildSkillLibraryColumns, sortSkillLibraryRows } from './SkillLibraryRoute'
+
+const ITEMS: SkillListItem[] = [
+  {
+    document_id: 'DOC-B',
+    title: 'Bravo skill',
+    description: 'Second skill.',
+    version: '2',
+    updated_at: '2026-07-01T12:00:00Z',
+    runtime_hint: 'claude',
+    document_subtype: 'skill',
+  },
+  {
+    document_id: 'DOC-A',
+    title: 'Alpha skill',
+    description: 'First skill.',
+    version: '10',
+    updated_at: '2026-07-03T09:00:00Z',
+    runtime_hint: 'claude,agentskills',
+    document_subtype: 'skill',
+  },
+]
+
+describe('sortSkillLibraryRows', () => {
+  it('sorts ascending by title by default field', () => {
+    const sorted = sortSkillLibraryRows(ITEMS, { sortingField: 'title', isDescending: false })
+    expect(sorted.map((r) => r.document_id)).toEqual(['DOC-A', 'DOC-B'])
+  })
+
+  it('sorts descending when isDescending is true', () => {
+    const sorted = sortSkillLibraryRows(ITEMS, { sortingField: 'title', isDescending: true })
+    expect(sorted.map((r) => r.document_id)).toEqual(['DOC-B', 'DOC-A'])
+  })
+
+  it('sorts by updated_at', () => {
+    const sorted = sortSkillLibraryRows(ITEMS, { sortingField: 'updated_at', isDescending: false })
+    expect(sorted.map((r) => r.document_id)).toEqual(['DOC-B', 'DOC-A'])
+  })
+})
+
+describe('buildSkillLibraryColumns', () => {
+  const columns = buildSkillLibraryColumns()
+
+  it('renders title, description, version, runtime, and updated columns', () => {
+    expect(columns.map((c) => c.id)).toEqual([
+      'title',
+      'description',
+      'version',
+      'runtime_hint',
+      'updated_at',
+    ])
+  })
+
+  it('leftmost column renders a Link to the document detail route', () => {
+    const cellElement = columns[0]!.cell(ITEMS[0]!) as ReactElement<{
+      to: string
+      children: React.ReactNode
+    }>
+    expect(cellElement.props.to).toBe('/document/DOC-B')
+    expect(cellElement.props.children).toBe('Bravo skill')
+  })
+
+  it('falls back to document_id when title is empty', () => {
+    const noTitle = { ...ITEMS[0]!, title: '' }
+    const cellElement = columns[0]!.cell(noTitle) as ReactElement<{ children: React.ReactNode }>
+    expect(cellElement.props.children).toBe('DOC-B')
+  })
+
+  it('shows the description inline, falling back to an em dash when empty', () => {
+    expect(columns[1]!.cell(ITEMS[0]!)).toBe('Second skill.')
+    expect(columns[1]!.cell({ ...ITEMS[0]!, description: '' })).toBe('—')
+  })
+})

--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { Container, Header, Table } from '../design-system'
+import type { TableColumnDefinition } from '../../../design-system-2/v2/components/Table/Table'
+import { projectRegistryQueryOptions } from '../api/projectRegistry'
+import { skillLibraryQueryOptions, type SkillListItem } from '../api/skillLibrary'
+import { documentHref } from './recordLink'
+import './skillLibrary.css'
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value || '—'
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function buildSkillLibraryColumns(): TableColumnDefinition<SkillListItem>[] {
+  return [
+    {
+      id: 'title',
+      header: 'Skill',
+      sortingField: 'title',
+      cell: (item) => (
+        <Link to={documentHref(item.document_id)} className="ev2-skill-library__title-link">
+          {item.title || item.document_id}
+        </Link>
+      ),
+    },
+    {
+      id: 'description',
+      header: 'Description',
+      cell: (item) => (item.description?.trim() ? item.description : '—'),
+    },
+    {
+      id: 'version',
+      header: 'Version',
+      sortingField: 'version',
+      cell: (item) => <span className="ev2-table__mono">{item.version || '—'}</span>,
+    },
+    {
+      id: 'runtime_hint',
+      header: 'Runtime',
+      cell: (item) => item.runtime_hint || '—',
+    },
+    {
+      id: 'updated_at',
+      header: 'Updated',
+      sortingField: 'updated_at',
+      cell: (item) => formatUpdatedAt(item.updated_at),
+    },
+  ]
+}
+
+type SortState = { sortingField: string; isDescending: boolean }
+
+const DEFAULT_SORT: SortState = { sortingField: 'title', isDescending: false }
+
+export function sortSkillLibraryRows(rows: SkillListItem[], sort: SortState): SkillListItem[] {
+  const field = sort.sortingField as keyof SkillListItem
+  const sorted = [...rows].sort((a, b) => {
+    const av = String(a[field] ?? '')
+    const bv = String(b[field] ?? '')
+    return av < bv ? -1 : av > bv ? 1 : 0
+  })
+  return sort.isDescending ? sorted.reverse() : sorted
+}
+
+/**
+ * Skill Library page (ENC-TSK-L94 / FTR-129). Every document_subtype=skill
+ * record, eagerly loaded (no pagination, no lazy load — AC-1) from the
+ * body-excluded metadata projection (ENC-TSK-L93: GET /api/v1/documents
+ * ?document_subtype=skill&include_content=false) resolved fresh on mount
+ * (AC-2). Each row links to the existing document detail route (AC-3). The
+ * ftr-078-e2e-skill test fixture is excluded by default — see
+ * src/api/skillLibrary.ts for the AC-4 rationale.
+ */
+export function SkillLibraryRoute() {
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+  const projectId = projects[0]?.project_id ?? 'enceladus'
+
+  const {
+    data: items = [],
+    isPending,
+    isError,
+    error,
+    refetch,
+  } = useQuery(skillLibraryQueryOptions(projectId))
+
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT)
+  const sortedRows = sortSkillLibraryRows(items, sort)
+
+  return (
+    <div className="ev2-skill-library">
+      <Container
+        header={
+          <Header
+            variant="h1"
+            description="Every governed skill record — resolved fresh from the body-excluded metadata projection on each page load. No client-side catalog or cache of the list."
+          >
+            Skill Library
+          </Header>
+        }
+      >
+        {isError ? (
+          <div className="ev2-skill-library__error">
+            <p>Failed to load skill library{error instanceof Error ? `: ${error.message}` : ''}.</p>
+            <button type="button" onClick={() => refetch()}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <Table<SkillListItem>
+            columnDefinitions={buildSkillLibraryColumns()}
+            items={isPending ? [] : sortedRows}
+            trackBy="document_id"
+            sortingColumn={{ sortingField: sort.sortingField }}
+            sortingDescending={sort.isDescending}
+            onSortingChange={(event) =>
+              setSort({
+                sortingField: event.detail.sortingColumn.sortingField,
+                isDescending: event.detail.isDescending,
+              })
+            }
+            empty={isPending ? 'Loading skill library…' : 'No skills found.'}
+          />
+        )}
+      </Container>
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -13,6 +13,7 @@ import { DocsRoute } from './DocsRoute'
 import { GovernanceRoute } from './GovernanceRoute'
 import { ChangelogRoute } from './ChangelogRoute'
 import { CoordinationRoute } from './CoordinationRoute'
+import { SkillLibraryRoute } from './SkillLibraryRoute'
 import { createSessionDetailRoute } from './SessionDetailRoute'
 import { createAgentDetailRoute } from './AgentDetailRoute'
 import { parseFeedSearch } from '../search/feedSearchParams'
@@ -110,6 +111,11 @@ const coordinationRoute = createRoute({
   path: '/coordination',
   component: CoordinationRoute,
 })
+const skillLibraryRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/skills',
+  component: SkillLibraryRoute,
+})
 const sessionRoute = createSessionDetailRoute(() => rootRoute)
 const agentDetailRoute = createAgentDetailRoute({ getParentRoute: () => rootRoute })
 
@@ -138,6 +144,7 @@ const routeTree = rootRoute.addChildren([
   governanceRoute,
   changelogRoute,
   coordinationRoute,
+  skillLibraryRoute,
   sessionRoute,
   agentDetailRoute,
   ...placeholderRoutes,

--- a/frontend/ui-v2/src/routes/skillLibrary.css
+++ b/frontend/ui-v2/src/routes/skillLibrary.css
@@ -1,0 +1,26 @@
+.ev2-skill-library {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: calc(var(--space-16) * 56);
+}
+
+.ev2-skill-library__title-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+}
+
+.ev2-skill-library__title-link:hover {
+  color: var(--accent-hover);
+}
+
+.ev2-skill-library__error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--status-blocked);
+}

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -15,6 +15,7 @@ const SIDEBAR_ITEMS = [
   { type: 'link' as const, text: 'Projects', href: '/projects' },
   { type: 'link' as const, text: 'Feed', href: '/feed' },
   { type: 'link' as const, text: 'Docs', href: '/docs' },
+  { type: 'link' as const, text: 'Skill Library', href: '/skills' },
   { type: 'link' as const, text: 'Governance', href: '/governance' },
   { type: 'link' as const, text: 'Changelog', href: '/changelog' },
   { type: 'link' as const, text: 'Coordination', href: '/coordination' },


### PR DESCRIPTION
## Summary
- Adds a Skill Library page (`/skills`) to the ui-v2 PWA: a Table of every `document_subtype=skill` record, eagerly loaded (no pagination/lazy load) from the body-excluded live metadata projection shipped by ENC-TSK-L93 (`GET /api/v1/documents?project=&document_subtype=skill&include_content=false`), resolved fresh on page mount with no client-side catalog/cache.
- Each row links to the existing `/document/:id` detail route for the full skill body.
- New "Skill Library" sidebar nav entry (`src/shell/AppShell.tsx`).
- `ftr-078-e2e-skill` (DOC-82D57A4FE6DC) is excluded by default — documented in `src/api/skillLibrary.ts` (the projection omits `keywords`, so the filter matches by `document_id`).

## AC mapping
- AC-1 (table + nav, eager load): `src/routes/SkillLibraryRoute.tsx` + `src/shell/AppShell.tsx`
- AC-2 (live projection, no client cache): `src/api/skillLibrary.ts` (`fetchSkillLibrary`, no `staleTime`)
- AC-3 (links to document detail route): `documentHref()` used in the title column
- AC-4 (e2e test record handling + documented default): `EXCLUDED_SKILL_DOCUMENT_IDS` in `src/api/skillLibrary.ts`
- AC-5 (gamma verified, merged v4/main, no prod promotion): pending gamma deploy verification post-merge

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 172/172 passing (14 new: `skillLibrary.test.ts`, `SkillLibraryRoute.test.tsx`)
- [x] `npm run build` — clean production build
- [ ] Verify `/skills` live on gamma PWA post-merge

CCI-701bbe778a344cbe83056488c8901fe9

🤖 Generated with [Claude Code](https://claude.com/claude-code)