### PR TITLE
ENC-TSK-L94 follow-up: pin Skill Library page to enceladus project

### DIFF
--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
@@ -3,10 +3,19 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Container, Header, Table } from '../design-system'
 import type { TableColumnDefinition } from '../../../design-system-2/v2/components/Table/Table'
-import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import { skillLibraryQueryOptions, type SkillListItem } from '../api/skillLibrary'
 import { documentHref } from './recordLink'
 import './skillLibrary.css'
+
+/**
+ * The skill catalog is scoped to the `enceladus` project (ENC-TSK-L93/L94):
+ * the source projection endpoint, docstore skill records, and this task's
+ * ACs are all enceladus-specific. Deliberately NOT derived from
+ * `projects[0]` (project registry order is not guaranteed to put enceladus
+ * first — verified live during gamma validation, where it resolved to a
+ * different project and silently returned zero rows).
+ */
+const SKILL_LIBRARY_PROJECT_ID = 'enceladus'
 
 function formatUpdatedAt(value: string): string {
   const date = new Date(value)
@@ -81,16 +90,13 @@ export function sortSkillLibraryRows(rows: SkillListItem[], sort: SortState): Sk
  * src/api/skillLibrary.ts for the AC-4 rationale.
  */
 export function SkillLibraryRoute() {
-  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
-  const projectId = projects[0]?.project_id ?? 'enceladus'
-
   const {
     data: items = [],
     isPending,
     isError,
     error,
     refetch,
-  } = useQuery(skillLibraryQueryOptions(projectId))
+  } = useQuery(skillLibraryQueryOptions(SKILL_LIBRARY_PROJECT_ID))
 
   const [sort, setSort] = useState<SortState>(DEFAULT_SORT)
   const sortedRows = sortSkillLibraryRows(items, sort)


### PR DESCRIPTION
## Summary
- Follow-up to #943. Live gamma validation of the Skill Library page (`/skills`) found it silently rendering "No skills found." — `SkillLibraryRoute` derived its project scope from `projects[0]?.project_id`, and the project registry order does not guarantee `enceladus` sorts first (it resolved to a different project on the live registry).
- Pins the query to a fixed `SKILL_LIBRARY_PROJECT_ID = 'enceladus'` constant instead, matching the enceladus-specific scope of the source projection (ENC-TSK-L93) and this task's ACs.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/routes/SkillLibraryRoute.test.tsx src/api/skillLibrary.test.ts` — 14/14 passing
- [x] `npx eslint src/routes/SkillLibraryRoute.tsx` — clean
- [ ] Re-verify `/skills` live on gamma post-merge (populates from the enceladus projection)

Same task (ENC-TSK-L94) as #943; reusing that PR's commit-complete-id (still valid — checkout service task record clears it only at deploy-success, which this code_only task never reaches).

CCI-701bbe778a344cbe83056488c8901fe9

🤖 Generated with [Claude Code](https://claude.com/claude-code)