### PR TITLE
ENC-TSK-M17: StatusChip P0/blocked crimson+glow, lesson lavender

### DIFF
--- a/frontend/ui-v2/src/components/PrimitiveCard.tsx
+++ b/frontend/ui-v2/src/components/PrimitiveCard.tsx
@@ -12,12 +12,16 @@ export function PrimitiveCard({
   kindLabel,
   title,
   status,
+  priority,
+  recordType,
   children,
 }: {
   recordId: string
   kindLabel: string
   title: string
   status?: string
+  priority?: string
+  recordType?: string
   children: ReactNode
 }) {
   return (
@@ -53,7 +57,7 @@ export function PrimitiveCard({
           {kindLabel}
         </span>
         <RecordId id={recordId} />
-        {status ? <StatusChip status={status} /> : null}
+        {status ? <StatusChip status={status} priority={priority} recordType={recordType} /> : null}
       </header>
 
       <h3

--- a/frontend/ui-v2/src/components/StatusChip.tsx
+++ b/frontend/ui-v2/src/components/StatusChip.tsx
@@ -1,6 +1,11 @@
 /**
- * Status chip. Colors come exclusively from the design-system status tokens —
- * no hard-coded hex. Unknown statuses fall back to the muted/dust foreground.
+ * Status chip. Cloudscape StatusIndicator semantics (dot + label), re-branded
+ * onto Enceladus DS tokens exclusively — no hard-coded hex. Unknown statuses
+ * fall back to the muted/dust foreground.
+ *
+ * Governed escalation (FND-05):
+ *  - priority P0, or status "blocked"  -> crimson + glow
+ *  - lesson records (recordType="lesson") -> lavender, regardless of status
  */
 
 const STATUS_TOKEN: Record<string, string> = {
@@ -19,10 +24,34 @@ const STATUS_TOKEN: Record<string, string> = {
   deprecated: 'var(--status-closed)',
   active: 'var(--status-open)',
   archived: 'var(--status-closed)',
+  p0: 'var(--status-p0)',
+  lesson: 'var(--status-lesson)',
 }
 
-export function StatusChip({ status }: { status: string }) {
-  const color = STATUS_TOKEN[status.toLowerCase()] ?? 'var(--fg-muted)'
+const GLOW_TOKEN: Record<string, string> = {
+  p0: 'var(--glow-crimson)',
+  blocked: 'var(--glow-crimson)',
+  lesson: 'var(--glow-lavender)',
+}
+
+export function StatusChip({
+  status,
+  priority,
+  recordType,
+}: {
+  status: string
+  /** Optional governed priority (e.g. "P0"). P0 escalates to crimson+glow. */
+  priority?: string
+  /** Optional governed record kind. "lesson" escalates to lavender. */
+  recordType?: string
+}) {
+  const isP0 = priority?.toLowerCase() === 'p0'
+  const isLesson = recordType?.toLowerCase() === 'lesson'
+  const key = isLesson ? 'lesson' : isP0 ? 'p0' : status.toLowerCase()
+
+  const color = STATUS_TOKEN[key] ?? STATUS_TOKEN[status.toLowerCase()] ?? 'var(--fg-muted)'
+  const glow = GLOW_TOKEN[key]
+
   return (
     <span
       style={{
@@ -39,6 +68,7 @@ export function StatusChip({ status }: { status: string }) {
         borderRadius: 'var(--radius-sm)',
         padding: '2px var(--space-2)',
         background: 'transparent',
+        boxShadow: glow ?? 'none',
       }}
     >
       <span
@@ -48,7 +78,7 @@ export function StatusChip({ status }: { status: string }) {
           height: 6,
           borderRadius: '50%',
           background: color,
-          boxShadow: '0 0 6px currentColor',
+          boxShadow: glow ?? '0 0 6px currentColor',
         }}
       />
       {status}

--- a/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
@@ -11,6 +11,7 @@ export function IssuePrimitive({ record }: { record: Issue }) {
       kindLabel="Issue"
       title={record.title}
       status={record.status}
+      priority={record.priority}
     >
       <Prose>{record.description}</Prose>
       <MetaRow label="Priority">{record.priority}</MetaRow>

--- a/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
@@ -17,6 +17,7 @@ export function LessonPrimitive({ record }: { record: Lesson }) {
       kindLabel="Lesson"
       title={record.title}
       status={record.status}
+      recordType="lesson"
     >
       <div
         style={{

--- a/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
@@ -11,6 +11,7 @@ export function TaskPrimitive({ record }: { record: Task }) {
       kindLabel="Task"
       title={record.title}
       status={record.status}
+      priority={record.priority}
     >
       <Prose>{record.description}</Prose>
       <MetaRow label="Priority">{record.priority}</MetaRow>


### PR DESCRIPTION
## Summary
- StatusChip atom now escalates governed status enum to crimson+glow for P0/blocked (`--status-p0`/`--status-blocked` + `--glow-crimson`) and lavender for lesson records (`--status-lesson`), preserving Cloudscape StatusIndicator dot+label semantics.
- Added optional `priority`/`recordType` props (backward compatible — all existing StatusChip call sites unchanged).
- PrimitiveCard forwards priority/recordType; Task/Issue primitives pass priority, Lesson primitive passes recordType="lesson".

## Acceptance criteria
- [x] One StatusChip atom, Cloudscape StatusIndicator semantics; P0/blocked -> crimson+glow; lessons -> lavender (FND-05)
- [x] All surfaces consume it; zero bespoke chip treatments remain (already true — grep confirms only StatusChip renders governed status pills)

CCI-9893ce324ca74a13b2fef6a2163c33be

Task: ENC-TSK-M17