### PR TITLE
ENC-ISS-509: gamma tracker detail read fallback to canonical table

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-08.01",
-  "updated_at": "2026-07-08T02:00:00Z",
-  "last_change_summary": "ENC-TSK-M12 / ENC-ISS-501: structural human-principal gate on escalation approve/deny (_is_human_cognito_principal: token_use=id + human app-client aud allowlist + machine email-domain rejection, fail-closed), layered in front of the ENC-TSK-L92 email allowlist.",
+  "version": "2026-07-08.02",
+  "updated_at": "2026-07-08T02:55:00Z",
+  "last_change_summary": "ENC-ISS-509 (carrier ENC-TSK-M24): tracker_mutation._handle_get_record gains _get_record_full_with_gamma_fallback -- on gamma, a miss against the local devops-project-tracker-gamma table (one-time-seeded, never continuously synced from the canonical table) falls through to a single read-only GetItem against the canonical devops-project-tracker table so the gamma PWA detail route can render recently-created records. GET-detail only; no change to writes, list, or search. New least-privilege TrackerTableCanonicalReadFallback IAM statement (dynamodb:GetItem only) on TrackerMutationRole, gated !If [IsGamma] (infrastructure/cloudformation/02-compute.yaml).",
   "owners": [
     "enceladus-platform"
   ],
@@ -8120,6 +8120,11 @@
       "version": "2026-07-07.9",
       "date": "2026-07-07",
       "summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH."
+    },
+    {
+      "version": "2026-07-08.02",
+      "date": "2026-07-08",
+      "summary": "ENC-ISS-509 (carrier ENC-TSK-M24): tracker_mutation._handle_get_record gains _get_record_full_with_gamma_fallback -- on gamma, a miss against the local devops-project-tracker-gamma table (one-time-seeded, never continuously synced from the canonical table) falls through to a single read-only GetItem against the canonical devops-project-tracker table so the gamma PWA detail route can render recently-created records. GET-detail only; no change to writes, list, or search. New least-privilege TrackerTableCanonicalReadFallback IAM statement (dynamodb:GetItem only) on TrackerMutationRole, gated !If [IsGamma] (infrastructure/cloudformation/02-compute.yaml)."
     }
   ]
 }

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -1874,6 +1874,41 @@ def _get_record_full(project_id: str, record_type: str, record_id: str) -> Optio
     return _deser_item(item)
 
 
+# ENC-ISS-509: gamma runs its own physically-separate tracker table
+# (devops-project-tracker-gamma per EnvironmentSuffix, infrastructure/cloudformation/
+# 02-compute.yaml TrackerMutationFunction). It is seeded once and not continuously
+# synced from the canonical governed table, so recently-created records (e.g. ones
+# minted via the prod MCP connector moments ago) 404 on gamma's PWA detail route even
+# though tracker.get resolves them fine against the canonical table. This is a
+# read-only, GET-detail-only fallback: on a gamma-table miss, do a single GetItem
+# against the canonical table so the detail page can render. Never used for writes
+# or list/search — those keep gamma's isolated data plane untouched.
+_CANONICAL_TRACKER_TABLE = "devops-project-tracker"
+
+
+def _get_record_full_with_gamma_fallback(project_id: str, record_type: str, record_id: str) -> Optional[Dict]:
+    """As _get_record_full, but on gamma a local miss falls back to a read-only
+    GetItem against the canonical (prod) tracker table. No-op on prod (DYNAMODB_TABLE
+    already equals _CANONICAL_TRACKER_TABLE there, so the fallback branch is skipped)."""
+    item = _get_record_full(project_id, record_type, record_id)
+    if item is not None:
+        return item
+    if DYNAMODB_TABLE == _CANONICAL_TRACKER_TABLE:
+        return None
+    try:
+        ddb = _get_ddb()
+        key = _build_key(project_id, record_type, record_id)
+        resp = ddb.get_item(TableName=_CANONICAL_TRACKER_TABLE, Key=key, ConsistentRead=True)
+        fallback_item = resp.get("Item")
+    except ClientError as exc:
+        logger.warning("[ISS-509] gamma canonical-table fallback read failed for %s: %s", record_id, exc)
+        return None
+    if fallback_item is None:
+        return None
+    logger.info("[ISS-509] gamma miss on %s; served from canonical table fallback", record_id)
+    return _deser_item(fallback_item)
+
+
 def _get_record_raw(project_id: str, record_type: str, record_id: str) -> Optional[Dict]:
     """GetItem with ConsistentRead. Returns raw DynamoDB item or None."""
     ddb = _get_ddb()
@@ -2751,7 +2786,7 @@ def _arc_walk_after_advance(project_id: str, record_id: str, item_data: Dict,
 def _handle_get_record(project_id: str, record_type: str, record_id: str) -> Dict:
     """GET /{project}/{type}/{id} — return full deserialized record."""
     try:
-        item = _get_record_full(project_id, record_type, record_id)
+        item = _get_record_full_with_gamma_fallback(project_id, record_type, record_id)
     except Exception as exc:
         logger.error("get_item failed: %s", exc)
         return _error(500, "Database read failed.")

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3993,6 +3993,22 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+              # ENC-ISS-509: gamma's tracker table is a physically separate, one-time-seeded
+              # DynamoDB table (devops-project-tracker-gamma) that is never continuously synced
+              # from the canonical governed table, so recently-created records 404 on gamma's
+              # PWA detail route. Read-only least-privilege GetItem fallback onto the canonical
+              # (un-suffixed) table lets tracker_mutation._get_record_full_with_gamma_fallback
+              # resolve a gamma-table miss for GET-detail only. Omitted entirely on prod (IsGamma
+              # false) since prod's own tracker-table statement above already covers that ARN.
+              - !If
+                - IsGamma
+                - Sid: TrackerTableCanonicalReadFallback
+                  Effect: Allow
+                  Action:
+                    - dynamodb:GetItem
+                  Resource:
+                    - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker"
+                - !Ref AWS::NoValue
               - Sid: RelationshipsTableAccess
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Summary
- Gamma's tracker_mutation Lambda reads a physically separate, one-time-seeded DynamoDB table (`devops-project-tracker-gamma`) that is never continuously synced from the canonical governed table (`devops-project-tracker`). Recently-created records (e.g. ENC-TSK-K27) 404 on the gamma PWA detail route even though the governed MCP `tracker.get` resolves them fine against the canonical table.
- `_handle_get_record`'s GET-detail path now falls back to a single read-only `GetItem` against the canonical table when the gamma-local lookup misses. GET-detail only -- writes, list, and search are untouched, preserving gamma's isolated data plane everywhere else.
- Adds a least-privilege `TrackerTableCanonicalReadFallback` IAM statement (`dynamodb:GetItem` only) on `TrackerMutationRole`, gated `!If [IsGamma]` -- omitted entirely on prod.
- `governance_data_dictionary.json` changelog entry for the PR gate on `backend/lambda/tracker_mutation/lambda_function.py`.

Root-caused and reproduced live via direct curl against gamma APIGW (`hi0dzmvqrc`): K27 (recent) 404s, F82 (old, seeded) 200s.

Closes ENC-ISS-509. Carrier: ENC-TSK-M24.

CCI-e0814b7ed0db4718988ee4356b58ca3b

## Test plan
- [x] `python3 -m py_compile backend/lambda/tracker_mutation/lambda_function.py`
- [x] CFN template YAML parse check on `infrastructure/cloudformation/02-compute.yaml`
- [x] `governance_data_dictionary.json` JSON validity check
- [ ] Post-merge: verify gamma PWA detail page renders for ENC-TSK-K27 live

🤖 Generated with [Claude Code](https://claude.com/claude-code)