### PR TITLE
ENC-TSK-M16: RecordCard organism, mobile-compact base + variants

### DIFF
--- a/frontend/ui-v2/src/components/RecordCard.tsx
+++ b/frontend/ui-v2/src/components/RecordCard.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+import { RecordId } from './RecordId'
+import { StatusChip } from './StatusChip'
+import './recordCard.css'
+
+/**
+ * RecordCard organism (ENC-TSK-M16 / FND-01/FND-04/FND-08). Mobile-compact
+ * full-width is the base case (`variant="compact"`, the default); `standard`
+ * gets more breathing room at wider breakpoints (>= 48.0625rem, CSS-only —
+ * no JS layout branch); `selectable` renders as a real <button> so it can be
+ * a Cards-style selection target (min 44px touch target either way).
+ *
+ * One record ID per card. Empty fields (title/description/status) are
+ * suppressed rather than rendered as placeholders.
+ */
+export interface RecordCardProps {
+  recordId: string
+  /** Governed record kind, e.g. "task" — also escalates StatusChip (lesson -> lavender). */
+  recordType?: string
+  /** Human label shown above the record ID, e.g. "Task". */
+  kindLabel?: string
+  title?: string
+  description?: string
+  status?: string
+  priority?: string
+  href?: string
+  variant?: 'compact' | 'standard' | 'selectable'
+  selected?: boolean
+  onSelect?: () => void
+  /** Extra accessory rendered in the header (e.g. a tier badge). */
+  trailing?: ReactNode
+}
+
+export function RecordCard({
+  recordId,
+  recordType,
+  kindLabel,
+  title,
+  description,
+  status,
+  priority,
+  href,
+  variant = 'compact',
+  selected = false,
+  onSelect,
+  trailing,
+}: RecordCardProps) {
+  const className = `ev2-rc ev2-rc--${variant}${selected ? ' ev2-rc--selected' : ''}`
+
+  const body = (
+    <>
+      <div className="ev2-rc__header">
+        {kindLabel ? <span className="ev2-rc__kind">{kindLabel}</span> : null}
+        <RecordId id={recordId} />
+        {trailing}
+      </div>
+      {title ? <h4 className="ev2-rc__title">{title}</h4> : null}
+      {description ? <p className="ev2-rc__desc">{description}</p> : null}
+      {status ? (
+        <div className="ev2-rc__footer">
+          <StatusChip status={status} priority={priority} recordType={recordType} />
+        </div>
+      ) : null}
+    </>
+  )
+
+  if (variant === 'selectable') {
+    return (
+      <button type="button" className={className} aria-pressed={selected} onClick={onSelect}>
+        {body}
+      </button>
+    )
+  }
+
+  if (href) {
+    return (
+      <Link to={href} className={className} onClick={onSelect}>
+        {body}
+      </Link>
+    )
+  }
+
+  return <article className={className}>{body}</article>
+}

--- a/frontend/ui-v2/src/components/recordCard.css
+++ b/frontend/ui-v2/src/components/recordCard.css
@@ -1,0 +1,115 @@
+/* ENC-TSK-M16 · RecordCard organism — mobile-compact base, tokens only. */
+
+.ev2-rc {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+  background: var(--bg-surface);
+  border: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  margin: 0 0 var(--space-3);
+  text-align: left;
+  text-decoration: none;
+  color: inherit;
+  font: inherit;
+  transition:
+    border-color var(--dur-base) var(--ease-orbit),
+    box-shadow var(--dur-base) var(--ease-orbit);
+}
+
+a.ev2-rc,
+button.ev2-rc {
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+a.ev2-rc:hover,
+button.ev2-rc:hover {
+  border: var(--border-hover);
+}
+
+a.ev2-rc:focus-visible,
+button.ev2-rc:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ev2-rc--selected {
+  border: var(--border-hover);
+  box-shadow: var(--glow-teal);
+}
+
+.ev2-rc__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.ev2-rc__kind {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-bold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--accent);
+}
+
+.ev2-rc__title {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-medium);
+  font-size: var(--text-base);
+  line-height: var(--lh-snug);
+  color: var(--fg-display);
+}
+
+.ev2-rc__desc {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: var(--lh-normal);
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ev2-rc__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+/* "standard" variant — more breathing room once there's room to give it. */
+@media (min-width: 48.0625rem) {
+  .ev2-rc--standard {
+    padding: var(--space-5) var(--space-6);
+  }
+
+  .ev2-rc--standard .ev2-rc__title {
+    font-size: var(--text-lg);
+  }
+
+  .ev2-rc--standard .ev2-rc__header {
+    justify-content: space-between;
+  }
+}
+
+.ev2-rc-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-3);
+}
+
+@media (min-width: 48.0625rem) {
+  .ev2-rc-grid--2col {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Cards, PropertyFilter, Tabs } from '../design-system'
 import { StatusChip } from '../components/StatusChip'
+import { RecordCard } from '../components/RecordCard'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import {
   fetchAgentSessions,
@@ -81,20 +82,18 @@ export function CoordinationRoute() {
       label: 'Sessions',
       count: sessions.length,
       content: (
-        <Cards<AgentSession>
-          items={sessions}
-          trackBy="session_id"
-          columns={2}
-          cardDefinition={{
-            header: (row) => row.session_id,
-            sections: [
-              { id: 'agent_type', header: 'Agent type', content: (row) => row.agent_type_id },
-              { id: 'status', header: 'Status', content: (row) => <StatusChip status={row.status} /> },
-              { id: 'runtime', header: 'Runtime', content: (row) => row.runtime || '—' },
-              { id: 'claimed_at', header: 'Claimed at', content: (row) => row.claimed_at || '—' },
-            ],
-          }}
-        />
+        <div className="ev2-rc-grid ev2-rc-grid--2col">
+          {sessions.map((row) => (
+            <RecordCard
+              key={row.session_id}
+              recordId={row.session_id}
+              kindLabel={row.agent_type_id}
+              description={row.runtime ? `Runtime: ${row.runtime}` : undefined}
+              status={row.status}
+              variant="standard"
+            />
+          ))}
+        </div>
       ),
     },
     {

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -5,6 +5,7 @@ import { Autosuggest, ButtonDropdown, Cards, ColumnLayout } from '../design-syst
 import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
 import { SearchTierBadge } from '../components/SearchTierBadge'
 import { StatusChip } from '../components/StatusChip'
+import { RecordCard } from '../components/RecordCard'
 import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
 import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
@@ -297,7 +298,30 @@ export function FeedRoute() {
         </div>
       </ColumnLayout>
     ) : (
-      <Cards items={visibleHits} trackBy="recordId" columns={1} cardDefinition={cardDefinition} />
+      <div className="ev2-rc-grid">
+        {visibleHits.map((hit) => {
+          const project =
+            hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
+          const href =
+            hit.recordType === 'document'
+              ? documentHref(hit.recordId)
+              : recordHrefForType(project, hit.recordType, hit.recordId)
+          return (
+            <RecordCard
+              key={hit.recordId}
+              recordId={hit.recordId}
+              recordType={hit.recordType}
+              kindLabel={hit.recordType}
+              title={hit.title}
+              status={hit.status}
+              href={href}
+              variant="compact"
+              trailing={<SearchTierBadge tier={hit.tier} />}
+              onSelect={() => persistFeedReturnSearch(feedSearch)}
+            />
+          )
+        })}
+      </div>
     )
 
   return (

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -5,7 +5,7 @@ import { feedCorpusByTypeQueryOptions, feedCorpusQueryOptions } from '../api/fee
 import { recordQueryOptions } from '../api/queryOptions'
 import { documentHref, recordHrefForType } from './recordLink'
 import { RecordId } from '../components/RecordId'
-import { StatusChip } from '../components/StatusChip'
+import { RecordCard } from '../components/RecordCard'
 import {
   DASHBOARD_RECORD_TYPES,
   DASHBOARD_TYPE_LABEL,
@@ -153,49 +153,6 @@ export function HomeRoute() {
   const statusPie = facetToPieData(facetsQuery.data?.facets?.status)
   const totalRecords = facetsQuery.data?.total_matches ?? 0
 
-  const entryCardDefinition = {
-    header: (row: EntryCardRow) =>
-      row.recordId ? (
-        <Link to={row.href} style={{ textDecoration: 'none', color: 'var(--fg-display)' }}>
-          {row.label}
-        </Link>
-      ) : (
-        <span style={{ color: 'var(--fg-muted)' }}>{row.label}</span>
-      ),
-    sections: [
-      {
-        id: 'id',
-        header: 'Most recent',
-        content: (row: EntryCardRow) =>
-          row.recordId ? (
-            <span
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-2)',
-                flexWrap: 'wrap',
-              }}
-            >
-              <RecordId id={row.recordId} />
-              {row.status ? <StatusChip status={row.status} /> : null}
-            </span>
-          ) : (
-            '—'
-          ),
-      },
-      {
-        id: 'title',
-        header: 'Title',
-        content: (row: EntryCardRow) => row.title || '—',
-      },
-      {
-        id: 'description',
-        header: 'Description',
-        content: (row: EntryCardRow) => row.description || '—',
-      },
-    ],
-  }
-
   const recentDocDefinition = {
     header: (doc: FeedCorpusItem) => (
       <Link to={documentHref(doc.record_id)} style={{ textDecoration: 'none', color: 'var(--fg-display)' }}>
@@ -241,7 +198,21 @@ export function HomeRoute() {
           <Box variant="strong" margin="0 0 var(--space-2)">
             Entry cards — most recent per type
           </Box>
-          <Cards items={entryCards} trackBy="type" columns={2} cardDefinition={entryCardDefinition} />
+          <div className="ev2-rc-grid ev2-rc-grid--2col">
+            {entryCards.map((row) => (
+              <RecordCard
+                key={row.type}
+                recordId={row.recordId || row.label}
+                recordType={row.type}
+                kindLabel={row.label}
+                title={row.title}
+                description={row.description}
+                status={row.status}
+                href={row.href || undefined}
+                variant="standard"
+              />
+            ))}
+          </div>
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
- New RecordCard atom (`frontend/ui-v2/src/components/RecordCard.tsx` + `recordCard.css`): mobile full-width compact base is the default variant; `standard` variant gets more breathing room at >=48.0625rem (CSS-only, no JS layout branch); `selectable` variant renders as a real `<button>` for list-selection UIs. All variants keep a >=44px min-height touch target.
- One `RecordId` per card; `title`/`description`/`status` are only rendered when present (empty fields suppressed).
- Wired into Home (entry cards grid), Feed/Search (mobile results list — FeedRoute.tsx doubles as both Search and Feed per its own page header), and Coordination (sessions tab) as trivially-safe consumption points. Desktop/wide-viewport Cloudscape `Cards` usages elsewhere are left as-is — mass migration is Band B scope.

## Acceptance criteria
- [x] Single RecordCard organism, mobile compact full-width is the base case; standard/selectable variants at wider breakpoints
- [x] One record ID per card; empty fields suppressed (FND-01/FND-08)
- [x] Touch targets >=44px
- [x] Home, Search, Coordination, Feed all consume it (FND-04)

CCI-44b172587bb04d57b66639c1e801169f

Task: ENC-TSK-M16