### PR TITLE
ENC-TSK-M15: fix mobile nav drawer, confirm shell ACs

### DIFF
--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -121,6 +121,14 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <div className={shellClass}>
+      {navigationOpen ? (
+        <button
+          type="button"
+          className="ev2-shell__nav-scrim"
+          aria-label="Close menu"
+          onClick={() => setSidebarOpen(false)}
+        />
+      ) : null}
       <AppLayout
         topNavigation={
           <TopNavigation

--- a/frontend/ui-v2/src/shell/shell.css
+++ b/frontend/ui-v2/src/shell/shell.css
@@ -62,17 +62,19 @@
     display: flex;
   }
 
-  .ev2-shell .ev2-al__nav:not(.ev2-shell__nav-drawer--open) {
-    display: none;
-  }
-
-  .ev2-shell .ev2-al__nav.ev2-shell__nav-drawer--open {
+  /* AppLayout already toggles `.ev2-al__nav--collapsed` off/on with the
+     `navigationOpen` prop (base rule: display:none when collapsed, any
+     viewport). On mobile the "Menu" toggle repurposes that same open state
+     as a full-screen drawer for the long-tail sidebar items, instead of the
+     desktop persistent-rail flex column. */
+  .ev2-shell .ev2-al__nav:not(.ev2-al__nav--collapsed) {
     position: fixed;
     inset: var(--space-0) var(--space-0) var(--space-0) var(--space-0);
     top: calc(var(--v2-control-height) + var(--space-6));
     z-index: 4;
     max-width: min(100%, calc(var(--space-16) * 14));
     box-shadow: var(--shadow-lg);
+    background: var(--enc-surface-alt);
   }
 
   .ev2-shell .ev2-al__tools {
@@ -82,6 +84,21 @@
   .ev2-shell .ev2-al__content {
     padding-bottom: calc(var(--space-12) + env(safe-area-inset-bottom, var(--space-0)));
   }
+
+  .ev2-shell__nav-scrim {
+    display: block;
+    position: fixed;
+    inset: var(--space-0);
+    top: calc(var(--v2-control-height) + var(--space-6));
+    z-index: 3;
+    background: rgba(10, 10, 15, 0.6);
+    border: none;
+    padding: 0;
+  }
+}
+
+.ev2-shell__nav-scrim {
+  display: none;
 }
 
 @media (min-width: 48.0625rem) {


### PR DESCRIPTION
## Summary
- Fixes a live bug in the mobile app-shell: `shell.css` gated the drawer-open styling on `.ev2-shell__nav-drawer--open`, a class nothing in the codebase ever applied (`AppLayout.jsx` only toggles `.ev2-al__nav--collapsed` off `navigationOpen`). Net effect: tapping "Menu" on mobile never produced a real drawer. Rewired the `max-width: 48rem` selectors to key off the class AppLayout actually sets, so the long-tail sidebar (Governance/Changelog/Coordination/etc, beyond the 4-item bottom tab bar) now renders as a fixed full-screen drawer on mobile.
- Added a tap-to-close scrim behind the open drawer (`AppShell.tsx`), wired to the existing `setSidebarOpen(false)` mobile-close logic (already fired on nav-item click).
- Audited the remaining ACs against the existing shell (no change needed): the core Enceladus logo mark (`TopNavigation`'s default concentric-circle SVG + wordmark) already renders on every route since `AppShell` wraps the router outlet unconditionally; `resolveActiveHref` already tracks the real route via `useRouterState` for both the bottom tab bar and side nav; the 4-item `MOBILE_NAV` bottom tab bar and desktop persistent-rail `SideNavigation` were already in place from ENC-TSK-L18/B67.

## Acceptance criteria
- [x] Bottom tab bar (3-4 destinations) + drawer for long tail on mobile; desktop projects drawer into persistent rail — bottom tab bar pre-existing (Home/Projects/Feed/Docs); drawer now actually opens (this PR's fix)
- [x] Core Enceladus logo identity visible in window content on EVERY viewport/page — pre-existing, verified live
- [x] Active nav item tracks the real route on every screen (FND-06) — pre-existing, verified via resolveActiveHref
- [x] No horizontal scroll at 360px anywhere in the shell — verified live, drawer fix keeps fixed-position full-screen overlay (no reflow of main content)

CCI-4395f2b465a04fed818395b79cdbfdfb

Task: ENC-TSK-M15