### PR TITLE
ENC-TSK-M25: per-route document.title (browser tab-search/history/bookmarks)

### DIFF
--- a/frontend/ui-v2/index.html
+++ b/frontend/ui-v2/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0A0A0F" />
-    <title>Enceladus · Governance Cockpit</title>
+    <!-- Static fallback only — every route sets its own document.title via
+         useDocumentTitle (ENC-TSK-M25) before first paint is visible to the
+         user. No "Enceladus" branding token per AC-1: titles are a
+         browser-tab-search/history navigation aid, not an SEO surface. -->
+    <title>Cockpit</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/ui-v2/src/hooks/useDocumentTitle.ts
+++ b/frontend/ui-v2/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+/**
+ * Sets `document.title` for the current route (ENC-TSK-M25 / FTR-130 Band B).
+ *
+ * Titles are a UX navigation aid — browser tab-search, history, and
+ * bookmarks — not an SEO surface, so callers must NOT include any shared
+ * branding token ("Enceladus", etc.) in the string passed here.
+ *
+ * Two call sites cover the two ACs:
+ *   - List/landing routes call this once with a static short page name
+ *     ("Home", "Feed", "Coordination", …).
+ *   - Record/document detail routes call this from a component that only
+ *     renders after the record's data has resolved (e.g. inside the
+ *     `useSuspenseQuery` consumer, past the route's Suspense boundary), so
+ *     the title reflects loaded content immediately — never a stale
+ *     placeholder — and re-fires on every client-side navigation because the
+ *     effect dependency changes with the derived title string.
+ */
+export function useDocumentTitle(title: string): void {
+  useEffect(() => {
+    if (!title) return
+    document.title = title
+  }, [title])
+}

--- a/frontend/ui-v2/src/routes/AgentDetailRoute.tsx
+++ b/frontend/ui-v2/src/routes/AgentDetailRoute.tsx
@@ -9,6 +9,7 @@ import {
 import type { AgentSession, AgentSessionStatus } from '../api/agentSessions'
 import { KeyValuePairs, StatusIndicator, Table } from '../design-system'
 import { SkeletonCard } from '../components/SkeletonCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /**
  * Agent detail page (ENC-TSK-L36). Lists the live, currently-claimed,
@@ -49,6 +50,9 @@ export function createAgentDetailRoute(config: {
     )
     const { data: agentTypes } = useSuspenseQuery(agentTypesQueryOptions('active'))
     const agentType = agentTypes.find((t) => t.agent_type_id === agentTypeId)
+    // ENC-TSK-M25: agent types have no free-text "title" — surface is the
+    // closest content descriptor after the id itself.
+    useDocumentTitle(`${agentTypeId}: ${agentType?.surface ?? 'Agent'} sessions`)
 
     return (
       <div className="ev2-agent-detail">

--- a/frontend/ui-v2/src/routes/ChangelogRoute.tsx
+++ b/frontend/ui-v2/src/routes/ChangelogRoute.tsx
@@ -4,6 +4,7 @@ import { Link } from '@tanstack/react-router'
 import { changelogHistoryQueryOptions, type ChangelogEntry } from '../api/changelog'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import { Container, Header, Table } from '../design-system'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import type { TableColumnDefinition } from '../../../design-system-2/v2/components/Table/Table'
 
 /**
@@ -103,6 +104,7 @@ export function sortChangelogRows(rows: ChangelogRow[], sort: SortState): Change
  * the leftmost column linking to the owning project's page.
  */
 export function ChangelogRoute() {
+  useDocumentTitle('Changelog')
   const { data: projects = [], isPending: projectsPending } = useQuery(projectRegistryQueryOptions)
   const projectIds = projects.map((p) => p.project_id)
   const projectNameById = new Map(projects.map((p) => [p.project_id, p.name ?? p.prefix ?? p.project_id]))

--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -15,6 +15,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Cards, PropertyFilter, Tabs } from '../design-system'
 import { StatusChip } from '../components/StatusChip'
 import { RecordCard } from '../components/RecordCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import {
   fetchAgentSessions,
@@ -50,6 +51,7 @@ const agentTypesQueryOptions = {
 }
 
 export function CoordinationRoute() {
+  useDocumentTitle('Coordination')
   const [activeTabId, setActiveTabId] = useState('sessions')
   const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>(EMPTY_FILTER)
 

--- a/frontend/ui-v2/src/routes/DocsRoute.tsx
+++ b/frontend/ui-v2/src/routes/DocsRoute.tsx
@@ -14,6 +14,7 @@ import { useTieredSearch } from '../search/useTieredSearch'
 import { getCacheEngine } from '../sync/cacheEngine'
 import { useCacheEngineState } from '../sync/CacheEngineProvider'
 import { documentHref } from './recordLink'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import type { SearchResultHit } from '../types/search'
 import './docs.css'
 
@@ -34,6 +35,7 @@ const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
  * are plain per-render computations; the compiler owns memoization.
  */
 export function DocsRoute() {
+  useDocumentTitle('Docs')
   const [query, setQuery] = useState('')
   const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>({ tokens: [] })
   const [sort, setSort] = useState<FeedSort>('tier')

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -6,6 +6,7 @@ import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/
 import { SearchTierBadge } from '../components/SearchTierBadge'
 import { StatusChip } from '../components/StatusChip'
 import { RecordCard } from '../components/RecordCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
 import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
@@ -56,6 +57,7 @@ const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
 ]
 
 export function FeedRoute() {
+  useDocumentTitle('Feed')
   const feedSearch = useSearch({ from: '/feed' })
   const navigate = useNavigate({ from: '/feed' })
   const { q, f, op, sort, scroll } = feedSearch

--- a/frontend/ui-v2/src/routes/GovernanceRoute.tsx
+++ b/frontend/ui-v2/src/routes/GovernanceRoute.tsx
@@ -5,6 +5,7 @@ import { Cards } from '../design-system'
 import { fetchGovernanceDocs, governanceDocKeys } from '../api/documents'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import { documentHref } from './recordLink'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import type { Document } from '../types/records'
 import './governance.css'
 
@@ -14,6 +15,7 @@ import './governance.css'
  * read time (governance-file + project-reference keywords).
  */
 export function GovernanceRoute() {
+  useDocumentTitle('Governance')
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
   const [projectId, setProjectId] = useState('enceladus')
 

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -6,6 +6,7 @@ import { recordQueryOptions } from '../api/queryOptions'
 import { documentHref, recordHrefForType } from './recordLink'
 import { RecordId } from '../components/RecordId'
 import { RecordCard } from '../components/RecordCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import {
   DASHBOARD_RECORD_TYPES,
   DASHBOARD_TYPE_LABEL,
@@ -93,6 +94,7 @@ interface EntryCardRow {
 }
 
 export function HomeRoute() {
+  useDocumentTitle('Home')
   // Dashboard-wide facets (record_type / status counts) — a limit:1 request
   // is enough since the backend computes facets over the whole filtered set
   // before slicing to `limit` (backend/lambda/feed_query/corpus.py).

--- a/frontend/ui-v2/src/routes/PlaceholderRoute.tsx
+++ b/frontend/ui-v2/src/routes/PlaceholderRoute.tsx
@@ -1,8 +1,10 @@
 import { useRouterState } from '@tanstack/react-router'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /** Scaffold page for cockpit nav targets filled in by L30–L34. */
 export function PlaceholderRoute({ title }: { title: string }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
+  useDocumentTitle(title)
 
   return (
     <div className="ev2-placeholder">

--- a/frontend/ui-v2/src/routes/ProjectsRoute.tsx
+++ b/frontend/ui-v2/src/routes/ProjectsRoute.tsx
@@ -34,6 +34,7 @@ import {
 } from '../api/projects'
 import { SessionExpiredError } from '../api/client'
 import { StatusChip } from '../components/StatusChip'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 function formatUpdatedAt(value?: string): string {
   if (!value) return '—'
@@ -86,6 +87,7 @@ function validateAll(form: CreateProjectFormState): FormErrors {
 }
 
 export function ProjectsRoute() {
+  useDocumentTitle('Projects')
   const { data: projects = [], isPending, isError } = useQuery(projectRegistryQueryOptions)
   const queryClient = useQueryClient()
 

--- a/frontend/ui-v2/src/routes/SessionDetailRoute.tsx
+++ b/frontend/ui-v2/src/routes/SessionDetailRoute.tsx
@@ -5,6 +5,7 @@ import { queryClient } from '../api/queryClient'
 import { sessionQueryOptions } from '../api/sessions'
 import { RecordDetailBreadcrumbs } from '../components/RecordDetailBreadcrumbs'
 import { SkeletonCard } from '../components/SkeletonCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { SessionPrimitive } from '../primitives/SessionPrimitive'
 
 /**
@@ -42,6 +43,10 @@ import { SessionPrimitive } from '../primitives/SessionPrimitive'
 function SessionRecordComponent({ getParams }: { getParams: () => { id: string } }) {
   const { id } = getParams()
   const { data } = useSuspenseQuery(sessionQueryOptions(id))
+  // ENC-TSK-M25: sessions have no dedicated "title" field — agent_type_id is
+  // the record's content identity, matching what SessionPrimitive/PrimitiveCard
+  // already render as the card title.
+  useDocumentTitle(`${id}: ${data.agent_type_id || 'Session'}`)
   return (
     <>
       <RecordDetailBreadcrumbs recordId={id} />

--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
@@ -5,6 +5,7 @@ import { Container, Header, Table } from '../design-system'
 import type { TableColumnDefinition } from '../../../design-system-2/v2/components/Table/Table'
 import { skillLibraryQueryOptions, type SkillListItem } from '../api/skillLibrary'
 import { documentHref } from './recordLink'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import './skillLibrary.css'
 
 /**
@@ -90,6 +91,7 @@ export function sortSkillLibraryRows(rows: SkillListItem[], sort: SortState): Sk
  * src/api/skillLibrary.ts for the AC-4 rationale.
  */
 export function SkillLibraryRoute() {
+  useDocumentTitle('Skill Library')
   const {
     data: items = [],
     isPending,

--- a/frontend/ui-v2/src/routes/recordRoute.tsx
+++ b/frontend/ui-v2/src/routes/recordRoute.tsx
@@ -4,6 +4,7 @@ import { createRoute, type AnyRoute } from '@tanstack/react-router'
 import { queryClient } from '../api/queryClient'
 import { RecordDetailBreadcrumbs } from '../components/RecordDetailBreadcrumbs'
 import { SkeletonCard } from '../components/SkeletonCard'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getPrimitive } from '../primitives/registry'
 import { useRecordRealtimeSync } from '../realtime/useRecordRealtimeSync'
 import type { RecordShapeMap, RecordType } from '../types/records'
@@ -36,6 +37,11 @@ export function createRecordRoute<K extends TrackerRecordType>(config: {
     const { project, id } = route.useParams() as { project: string; id: string }
     const { data } = useSuspenseQuery(queryOptionsFor(project, id))
     useRecordRealtimeSync(type, project, id)
+    // ENC-TSK-M25: title derives from the resolved record (never the route
+    // param alone), so it updates again once the async fetch settles — this
+    // component only renders past the Suspense boundary below, i.e. after
+    // `data` is available.
+    useDocumentTitle(`${id}: ${data.title}`)
     const Primitive = getPrimitive(type)
     return (
       <>
@@ -77,6 +83,7 @@ export function createDocumentRecordRoute(config: {
   function RecordComponent() {
     const { id } = route.useParams() as { id: string }
     const { data } = useSuspenseQuery(queryOptionsFor(id))
+    useDocumentTitle(`${id}: ${data.title}`)
     const Primitive = getPrimitive('document')
     return (
       <>


### PR DESCRIPTION
## Summary
- All cockpit pages previously shared one static `<title>` ("Enceladus · Governance Cockpit"), defeating browser-native tab search, history search, and bookmarks. Titles are a UX navigation aid, not SEO, so no branding token belongs in them (io directive 2026-07-08).
- New `useDocumentTitle` hook (`frontend/ui-v2/src/hooks/useDocumentTitle.ts`): sets `document.title` in an effect keyed on the title string, so it updates on every SPA client-side navigation and again after async content resolves.
- Record/document detail routes (`recordRoute.tsx`, `SessionDetailRoute.tsx`, `AgentDetailRoute.tsx`) derive `"<RECORD-ID>: <content title>"` from the loaded record inside the component that renders past the route's Suspense boundary — title is never set from the route param alone, so it can't go stale relative to fetched content.
- Landing/list routes (Home, Feed, Projects, Docs, Governance, Changelog, Coordination, Skill Library, and the four placeholder nav routes) get a static short title matching the existing sidebar/mobile nav label.
- `index.html`'s static fallback title changed to `"Cockpit"` (no "Enceladus" token) for the brief pre-hydration window.

## Acceptance criteria
0. Detail routes -> `<RECORD-ID>: <content title>`; list/landing routes -> short page name — done, see recordRoute.tsx/SessionDetailRoute.tsx/AgentDetailRoute.tsx + the 9 static-title routes.
1. No "Enceladus" token in any title — done (index.html + all routes audited, `grep -rn document.title src/` shows only the hook).
2. Title updates on SPA nav and after async load — done, effect fires on every render of the post-Suspense component.
3. Browser-native tab-search/history findability — pending live gamma verification with 3+ open tabs (see task worklog).

## Test plan
- [x] `npm run typecheck` (tsc --noEmit) — clean
- [x] `npm run build` (vite build) — clean, PWA precache generated
- [x] `npx vitest run` — 172/172 tests passing across 34 files
- [ ] Live gamma tab-search verification (post-deploy)

CCI-fd2187c095cb432c90bea53652036655

🤖 Generated with governed dispatch ENC-SES-06J