### PR TITLE
ENC-TSK-M19: mobile-first Home leads with io action queue (UX-B1)

### DIFF
--- a/frontend/ui-v2/src/api/homeQueue.ts
+++ b/frontend/ui-v2/src/api/homeQueue.ts
@@ -1,0 +1,74 @@
+/**
+ * Home "Requires io" queue + actionable-counts data (ENC-TSK-M19 / UX-B1 /
+ * FND-HOME). Consumes existing backend surfaces only -- no new endpoints:
+ *
+ *  - Escalations: reuses `fetchEscalations` (src/api/coordination.ts), the
+ *    same fetcher the Escalations tab on /coordination already calls.
+ *  - "Open P0/P1": GET /api/v1/feed/corpus (ENC-TSK-L23) already accepts
+ *    `status` + `priority` querystring filters server-side
+ *    (backend/lambda/feed_query/corpus.py::parse_corpus_query /
+ *    _matches_filters) and returns `total_matches` computed over the full
+ *    filtered set *before* the `limit` slice -- so a `limit:1` request is an
+ *    exact, cheap count. Mirrors the pattern already used by
+ *    api/feedCorpusQueryOptions.ts's `feedCorpusByTypeQueryOptions`.
+ *  - "Awaiting checkout": reuses the generic tracker list route
+ *    (GET /api/v1/tracker/{project}?type=...&status=...) that
+ *    api/coordination.ts's `fetchLessons` already calls with a different
+ *    `type`. Scoped to record_type=task (the dominant checkoutable type) and
+ *    one 200-row page -- a known, intentional undercount rather than N extra
+ *    per-type list requests for a single dashboard tile.
+ *
+ * Paused v3-prod GitHub Environment approvals and stale-lock/backfill flags
+ * have NO PWA-reachable data source today: GitHub Actions Environment
+ * protection state and worktree/session-lock bookkeeping (ENC-ISS-071) are
+ * not exposed by any Enceladus HTTP API. HomeRoute renders those two queue
+ * rows as static gap notices (see routes/homeQueue.ts::GAP_QUEUE_ROWS)
+ * instead of fabricating a fetch or a backend endpoint.
+ */
+
+import { API_BASE } from './client'
+import type { FeedCorpusPage } from '../sync/types'
+
+async function getJson<T>(url: string, init?: { signal?: AbortSignal }): Promise<T> {
+  const res = await fetch(url, {
+    signal: init?.signal,
+    credentials: 'include',
+    cache: 'no-store',
+    headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
+  })
+  if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
+  return (await res.json()) as T
+}
+
+/** Exact count of open P0/P1 tracker records across all projects. */
+export async function fetchOpenP0P1Count(init?: { signal?: AbortSignal }): Promise<number> {
+  const qs = new URLSearchParams({ status: 'open', priority: 'p0,p1', limit: '1' })
+  const page = await getJson<FeedCorpusPage>(`${API_BASE}/feed/corpus?${qs.toString()}`, init)
+  return page.total_matches ?? 0
+}
+
+interface AwaitingCheckoutRecord {
+  checkout_state?: string
+  [key: string]: unknown
+}
+
+interface TrackerListResponse {
+  success: boolean
+  records: AwaitingCheckoutRecord[]
+  count: number
+}
+
+/** Open tasks not currently checked out by any agent session (i.e. eligible
+ * to be picked up), capped at one 200-row page. See module docstring for the
+ * task-only-type / single-page scope note. */
+export async function fetchAwaitingCheckoutCount(
+  projectId: string,
+  init?: { signal?: AbortSignal },
+): Promise<number> {
+  const body = await getJson<TrackerListResponse>(
+    `${API_BASE}/tracker/${encodeURIComponent(projectId)}?type=task&status=open&page_size=200`,
+    init,
+  )
+  const records = body.records ?? []
+  return records.filter((r) => r.checkout_state !== 'checked_out').length
+}

--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -12,6 +12,7 @@
  */
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useSearch } from '@tanstack/react-router'
 import { Cards, PropertyFilter, Tabs } from '../design-system'
 import { StatusChip } from '../components/StatusChip'
 import { RecordCard } from '../components/RecordCard'
@@ -52,7 +53,10 @@ const agentTypesQueryOptions = {
 
 export function CoordinationRoute() {
   useDocumentTitle('Coordination')
-  const [activeTabId, setActiveTabId] = useState('sessions')
+  // ENC-TSK-M19: Home's "Requires io" queue deep-links here with
+  // ?tab=escalations; any other/missing value falls back to the default.
+  const { tab: initialTab } = useSearch({ from: '/coordination' })
+  const [activeTabId, setActiveTabId] = useState(initialTab || 'sessions')
   const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>(EMPTY_FILTER)
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -1,12 +1,18 @@
+import { useState } from 'react'
 import { useQueries, useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { BarChart, Box, Cards, Grid, Header, KeyValuePairs, PieChart } from '../design-system'
+import { BarChart, Box, Cards, Header, PieChart, Tabs } from '../design-system'
 import { feedCorpusByTypeQueryOptions, feedCorpusQueryOptions } from '../api/feedCorpusQueryOptions'
 import { recordQueryOptions } from '../api/queryOptions'
+import { fetchEscalations } from '../api/coordination'
+import { fetchAwaitingCheckoutCount, fetchOpenP0P1Count } from '../api/homeQueue'
+import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import { documentHref, recordHrefForType } from './recordLink'
 import { RecordId } from '../components/RecordId'
 import { RecordCard } from '../components/RecordCard'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { GAP_QUEUE_ROWS, pendingEscalationRows, type QueueRow } from './homeQueue'
+import { FEED_SEARCH_DEFAULTS, serializeFilterQuery, type FeedRouteSearch } from '../search/feedSearchParams'
 import {
   DASHBOARD_RECORD_TYPES,
   DASHBOARD_TYPE_LABEL,
@@ -25,14 +31,15 @@ import type {
   Task,
 } from '../types/records'
 import type { FeedCorpusItem } from '../sync/types'
+import './home.css'
 
 /**
- * B67 PWA 2.0 — Home dashboard (ENC-TSK-L30). Shared content model with the
- * desktop first-load home section per the AC: one entry Card per record/doc
- * type resolving to the most recent record of that type (ID + title +
- * truncated description), a recent-documents element, and dashboard-wide
- * charts. Sourced entirely from the already-live GET /api/v1/feed/corpus
- * endpoint (ENC-TSK-L23) — no new backend surface.
+ * Home dashboard (ENC-TSK-M19 / UX-B1, superseding the desktop-first
+ * ENC-TSK-L30 build). Mobile-first: 360px is the base viewport. Leads with
+ * the "Requires io" action queue (escalations + two documented data-gap
+ * rows) and a compact counts strip above the fold; most-recent-per-type +
+ * dashboard charts recede into a below-fold Tabs section. Desktop
+ * projection reference: Home-Redesign.dc.html (layout intent only).
  */
 
 type DetailRecord = Task | Issue | Feature | Plan | Lesson | Document
@@ -93,35 +100,95 @@ interface EntryCardRow {
   href: string
 }
 
+/** Filtered-view /feed searches for the counts strip. Both use /feed's
+ * existing `status` property filter (a real, working reduction of the
+ * corpus); priority and checkout_state aren't wired into Feed's
+ * client-side property filter yet, so these land on the closest available
+ * filtered view rather than an exact match — see the note under the strip. */
+const OPEN_SEARCH: FeedRouteSearch = {
+  ...FEED_SEARCH_DEFAULTS,
+  f: serializeFilterQuery({ tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }], operation: 'and' }),
+}
+const OPEN_TASKS_SEARCH: FeedRouteSearch = {
+  ...FEED_SEARCH_DEFAULTS,
+  f: serializeFilterQuery({
+    tokens: [
+      { propertyKey: 'status', operator: '=', value: 'open' },
+      { propertyKey: 'record_type', operator: '=', value: 'task' },
+    ],
+    operation: 'and',
+  }),
+}
+
+function QueueCard({ row }: { row: QueueRow }) {
+  if (row.gap) {
+    return (
+      <div className="home-route__gap-card">
+        <span className="home-route__gap-badge">Data gap</span>
+        <p className="home-route__gap-title">{row.title}</p>
+        <p className="home-route__gap-desc">{row.description}</p>
+      </div>
+    )
+  }
+  return (
+    <RecordCard
+      recordId={row.id}
+      kindLabel={row.kindLabel}
+      title={row.title}
+      description={row.description}
+      status={row.status}
+      href={row.href}
+      variant="standard"
+    />
+  )
+}
+
 export function HomeRoute() {
   useDocumentTitle('Home')
+  const [recentTabId, setRecentTabId] = useState('entry-cards')
+
+  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
+  const projectId = projects[0]?.project_id ?? 'enceladus'
+
+  // "Requires io" queue — escalations share the exact queryKey CoordinationRoute
+  // uses for its Escalations tab, so the two pages share one cache entry.
+  const escalationsQuery = useQuery({
+    queryKey: ['coordination', 'escalations', projectId] as const,
+    queryFn: ({ signal }) => fetchEscalations(projectId, { signal }),
+  })
+  const queueRows: QueueRow[] = [
+    ...pendingEscalationRows(escalationsQuery.data ?? []),
+    ...GAP_QUEUE_ROWS,
+  ]
+
+  // Actionable counts strip.
+  const openP0P1Query = useQuery({
+    queryKey: ['home', 'open-p0-p1'] as const,
+    queryFn: ({ signal }) => fetchOpenP0P1Count({ signal }),
+  })
+  const awaitingCheckoutQuery = useQuery({
+    queryKey: ['home', 'awaiting-checkout', projectId] as const,
+    queryFn: ({ signal }) => fetchAwaitingCheckoutCount(projectId, { signal }),
+  })
+
+  // Below-fold "recent activity" — dashboard-wide facets, most-recent-per-type
+  // entry cards, and recent documents. Unchanged data model from the prior
+  // ENC-TSK-L30 build (routes/homeDashboard.ts); only the placement moved.
   // Dashboard-wide facets (record_type / status counts) — a limit:1 request
   // is enough since the backend computes facets over the whole filtered set
   // before slicing to `limit` (backend/lambda/feed_query/corpus.py).
   const facetsQuery = useQuery(feedCorpusQueryOptions({ limit: 1 }))
-
-  // Recent documents element — top N documents by updated_at.
   const recentDocsQuery = useQuery(feedCorpusByTypeQueryOptions('document', { limit: 8 }))
-
-  // Most-recent-of-each-type identity rows (id/title/updated_at), one
-  // targeted query per type so correctness doesn't depend on all six types
-  // appearing within a single global recency window.
   const perTypeResults = useQueries({
     queries: DASHBOARD_RECORD_TYPES.map((type) => feedCorpusByTypeQueryOptions(type, { limit: 1 })),
   })
 
-  // AC-16 — React Compiler owns memoization; this is a plain derived value,
-  // not a hand-written useMemo.
   const mostRecentByType: Partial<Record<RecordType, FeedCorpusItem>> = {}
   DASHBOARD_RECORD_TYPES.forEach((type, i) => {
     const item = perTypeResults[i]?.data?.items?.[0]
     if (item) mostRecentByType[type] = item
   })
 
-  // Full-body detail fetch for each most-recent identity row, so the card can
-  // show a truncated *description* — the feed corpus deliberately omits
-  // description text (see corpus.py _handle_snapshot docstring: "stops
-  // leaking descriptions") to keep the sync payload small.
   const detailResults = useQueries({
     queries: DASHBOARD_RECORD_TYPES.map((type) => detailQueryFor(type, mostRecentByType[type])),
   })
@@ -153,7 +220,6 @@ export function HomeRoute() {
     DASHBOARD_RECORD_TYPES,
   )
   const statusPie = facetToPieData(facetsQuery.data?.facets?.status)
-  const totalRecords = facetsQuery.data?.total_matches ?? 0
 
   const recentDocDefinition = {
     header: (doc: FeedCorpusItem) => (
@@ -175,79 +241,125 @@ export function HomeRoute() {
     ],
   }
 
+  const recentTabs = [
+    {
+      id: 'entry-cards',
+      label: 'Most recent per type',
+      count: entryCards.length,
+      content: (
+        <div className="ev2-rc-grid ev2-rc-grid--2col">
+          {entryCards.map((row) => (
+            <RecordCard
+              key={row.type}
+              recordId={row.recordId || row.label}
+              recordType={row.type}
+              kindLabel={row.label}
+              title={row.title}
+              description={row.description}
+              status={row.status}
+              href={row.href || undefined}
+              variant="standard"
+            />
+          ))}
+        </div>
+      ),
+    },
+    {
+      id: 'recent-docs',
+      label: 'Recent documents',
+      count: recentDocuments.length,
+      content: (
+        <Cards
+          items={recentDocuments}
+          trackBy="record_id"
+          columns={1}
+          cardDefinition={recentDocDefinition}
+        />
+      ),
+    },
+    {
+      id: 'charts',
+      label: 'Dashboard charts',
+      content: (
+        <>
+          <div style={{ marginTop: 'var(--space-4)' }}>
+            <BarChart
+              title="Records by type"
+              subtitle="Dashboard-wide counts across every governed primitive"
+              xDomain={typeSeries.labels.map((label) => DASHBOARD_TYPE_LABEL[label as RecordType] ?? label)}
+              series={[{ title: 'Count', data: typeSeries.values }]}
+              height={220}
+            />
+          </div>
+          <div style={{ marginTop: 'var(--space-6)' }}>
+            <PieChart
+              title="Records by status"
+              subtitle="Across all tracker + document records"
+              data={statusPie}
+            />
+          </div>
+        </>
+      ),
+    },
+  ]
+
   return (
-    <div>
+    <div className="home-route">
       <Header
         variant="h1"
-        description="One card per record/document type -> the most recent of each, a recent-documents feed, and dashboard-wide counts across every governed primitive."
+        description="Requires io leads — escalations and other human-only unblocks come first; most-recent activity recedes below."
       >
         Home
       </Header>
 
-      <div style={{ margin: 'var(--space-6) 0' }}>
-        <KeyValuePairs
-          columns={3}
-          items={[
-            { label: 'Tracked records + documents', value: totalRecords, mono: true },
-            { label: 'Record types', value: DASHBOARD_RECORD_TYPES.length, mono: true },
-            { label: 'Recent documents shown', value: recentDocuments.length, mono: true },
-          ]}
-        />
-      </div>
-
-      <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
-        <div>
-          <Box variant="strong" margin="0 0 var(--space-2)">
-            Entry cards — most recent per type
-          </Box>
-          <div className="ev2-rc-grid ev2-rc-grid--2col">
-            {entryCards.map((row) => (
-              <RecordCard
-                key={row.type}
-                recordId={row.recordId || row.label}
-                recordType={row.type}
-                kindLabel={row.label}
-                title={row.title}
-                description={row.description}
-                status={row.status}
-                href={row.href || undefined}
-                variant="standard"
-              />
+      <section className="home-route__queue" aria-label="Requires io">
+        <div className="home-route__section-label home-route__section-label--alert">
+          Requires io
+          <span className="home-route__section-hint">
+            {queueRows.length} item{queueRows.length === 1 ? '' : 's'} only the principal can unblock
+          </span>
+        </div>
+        {escalationsQuery.isLoading ? (
+          <p className="home-route__empty">Loading escalations…</p>
+        ) : (
+          <div className="home-route__queue-list">
+            {queueRows.map((row) => (
+              <QueueCard key={row.id} row={row} />
             ))}
           </div>
-        </div>
+        )}
+      </section>
 
-        <div>
-          <Box variant="strong" margin="0 0 var(--space-2)">
-            Recent documents
-          </Box>
-          <Cards
-            items={recentDocuments}
-            trackBy="record_id"
-            columns={1}
-            cardDefinition={recentDocDefinition}
-          />
-        </div>
-      </Grid>
+      <section className="home-route__counts" aria-label="Actionable counts">
+        <Link to="/feed" search={OPEN_SEARCH} className="home-route__count-tile">
+          <span className="home-route__count-value">
+            {openP0P1Query.isLoading ? '…' : (openP0P1Query.data ?? 0)}
+          </span>
+          <span className="home-route__count-label">Open P0/P1</span>
+        </Link>
+        <Link to="/feed" search={OPEN_TASKS_SEARCH} className="home-route__count-tile">
+          <span className="home-route__count-value">
+            {awaitingCheckoutQuery.isLoading ? '…' : (awaitingCheckoutQuery.data ?? 0)}
+          </span>
+          <span className="home-route__count-label">Awaiting checkout</span>
+        </Link>
+      </section>
+      <p className="home-route__counts-note">
+        Counts are exact (server-computed). Their links open the closest available Feed filter —
+        priority and checkout-state filtering aren’t wired into Feed’s client-side search yet, so
+        each destination list is a superset of the exact count above it.
+      </p>
 
-      <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-        <div style={{ marginTop: 'var(--space-8)' }}>
-          <BarChart
-            title="Records by type"
-            subtitle="Dashboard-wide counts across every governed primitive"
-            xDomain={typeSeries.labels.map((label) => DASHBOARD_TYPE_LABEL[label as RecordType] ?? label)}
-            series={[{ title: 'Count', data: typeSeries.values }]}
-            height={220}
-          />
-        </div>
-        <div style={{ marginTop: 'var(--space-8)' }}>
-          <PieChart
-            title="Records by status"
-            subtitle="Across all tracker + document records"
-            data={statusPie}
-          />
-        </div>
-      </Grid>
+      <section className="home-route__recent" aria-label="Recent activity">
+        <Box variant="strong" margin="0 0 var(--space-2)">
+          Recent activity
+        </Box>
+        <Tabs
+          tabs={recentTabs}
+          activeTabId={recentTabId}
+          onChange={(event) => setRecentTabId(event.detail.activeTabId)}
+        />
+      </section>
     </div>
   )
 }

--- a/frontend/ui-v2/src/routes/home.css
+++ b/frontend/ui-v2/src/routes/home.css
@@ -1,0 +1,160 @@
+/* ENC-TSK-M19 -- Home dashboard, mobile-first (UX-B1 / FND-HOME).
+ * Base case is a 360px viewport: single column, no horizontal scroll,
+ * >=44px tap targets. Desktop projection reference: Home-Redesign.dc.html
+ * (layout INTENT only -- not copied desktop-first). Wider layouts opt in via
+ * `@media (min-width: 48.0625rem)`, matching the breakpoint already used by
+ * components/recordCard.css and shell/AppShell.tsx. */
+
+.home-route__section-label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
+  font-size: var(--text-base);
+  color: var(--fg-display);
+  border-left: 3px solid var(--accent);
+  padding-left: var(--space-3);
+  margin: 0 0 var(--space-3);
+}
+
+.home-route__section-label--alert {
+  border-left-color: var(--status-blocked);
+}
+
+.home-route__section-hint {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  font-weight: var(--fw-regular);
+}
+
+.home-route__queue {
+  margin-bottom: var(--space-6);
+}
+
+.home-route__queue-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Static gap notice -- visually distinct (dashed border, no hover/focus
+ * affordance) from a real actionable RecordCard so it never reads as a
+ * broken link. */
+.home-route__gap-card {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 44px;
+  background: transparent;
+  border: 1px dashed rgba(61, 155, 168, 0.35);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+}
+
+.home-route__gap-badge {
+  display: inline-block;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--fg-muted);
+  border: 1px solid var(--fg-muted);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.home-route__gap-title {
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-medium);
+  font-size: var(--text-base);
+  color: var(--fg-display);
+}
+
+.home-route__gap-desc {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: var(--lh-normal);
+  color: var(--fg-muted);
+}
+
+.home-route__empty {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+/* Counts strip -- two tiles at 360px, real min-height-44px Links. */
+.home-route__counts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-2);
+}
+
+.home-route__count-tile {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-height: 44px;
+  background: var(--bg-surface);
+  border: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color var(--dur-base) var(--ease-orbit);
+}
+
+.home-route__count-tile:hover,
+.home-route__count-tile:focus-visible {
+  border: var(--border-hover);
+}
+
+.home-route__count-tile:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.home-route__count-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: var(--fw-medium);
+  color: var(--fg-display);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.05;
+}
+
+.home-route__count-label {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+}
+
+@media (min-width: 48.0625rem) {
+  .home-route__counts {
+    grid-template-columns: repeat(2, minmax(0, 220px));
+  }
+}
+
+.home-route__counts-note {
+  margin: 0 0 var(--space-8);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  line-height: var(--lh-normal);
+  color: var(--fg-muted);
+}
+
+/* "Recent activity" tabs -- deliberately placed after the queue + counts
+ * strip so it recedes below the first (360px) viewport rather than
+ * competing with the io queue for the fold. */
+.home-route__recent {
+  margin-top: var(--space-6);
+}

--- a/frontend/ui-v2/src/routes/homeQueue.test.ts
+++ b/frontend/ui-v2/src/routes/homeQueue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { GAP_QUEUE_ROWS, pendingEscalationRows } from './homeQueue'
+import type { EscalationRecord } from '../api/coordination'
+
+function escalation(overrides: Partial<EscalationRecord>): EscalationRecord {
+  return {
+    item_id: 'ENC-ESC-001',
+    status: 'requested',
+    created_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('pendingEscalationRows', () => {
+  it('keeps only status=requested rows', () => {
+    const rows = pendingEscalationRows([
+      escalation({ item_id: 'ENC-ESC-001', status: 'requested' }),
+      escalation({ item_id: 'ENC-ESC-002', status: 'approved' }),
+      escalation({ item_id: 'ENC-ESC-003', status: 'denied' }),
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe('ENC-ESC-001')
+  })
+
+  it('links every row to the coordination escalations tab', () => {
+    const rows = pendingEscalationRows([escalation({})])
+    expect(rows[0]?.href).toBe('/coordination?tab=escalations')
+  })
+
+  it('titles by target record when present, falls back to the escalation id', () => {
+    const withTarget = pendingEscalationRows([
+      escalation({ item_id: 'ENC-ESC-001', target_record_id: 'ENC-TSK-K01' }),
+    ])
+    expect(withTarget[0]?.title).toBe('Unblock ENC-TSK-K01')
+
+    const withoutTarget = pendingEscalationRows([escalation({ item_id: 'ENC-ESC-002', target_record_id: undefined })])
+    expect(withoutTarget[0]?.title).toBe('Review ENC-ESC-002')
+  })
+
+  it('handles an empty list', () => {
+    expect(pendingEscalationRows([])).toEqual([])
+  })
+})
+
+describe('GAP_QUEUE_ROWS', () => {
+  it('are all marked gap:true and never carry an href', () => {
+    for (const row of GAP_QUEUE_ROWS) {
+      expect(row.gap).toBe(true)
+      expect(row.href).toBeUndefined()
+    }
+  })
+
+  it('covers paused prod runs and stale-lock/backfill flags', () => {
+    const ids = GAP_QUEUE_ROWS.map((row) => row.id)
+    expect(ids).toEqual(['gap-paused-prod', 'gap-stale-lock'])
+  })
+})

--- a/frontend/ui-v2/src/routes/homeQueue.ts
+++ b/frontend/ui-v2/src/routes/homeQueue.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure data-shaping helpers for the Home "Requires io" queue (ENC-TSK-M19 /
+ * UX-B1 / FND-HOME). Side-effect-free, framework-free -- same convention as
+ * routes/homeDashboard.ts.
+ */
+
+import type { EscalationRecord } from '../api/coordination'
+
+export interface QueueRow {
+  id: string
+  kindLabel: string
+  title: string
+  description?: string
+  status?: string
+  /** Present only for real, navigable rows. Gap rows omit this. */
+  href?: string
+  /** True for a static row that documents a known data-gap instead of a
+   * live record -- rendered non-interactively, never as a Link. */
+  gap?: boolean
+}
+
+/** Pending escalations (status=requested) are the only human-actionable
+ * escalation state -- terminal/resolved rows are noise on the "Requires io"
+ * queue (they remain visible on /coordination's Escalations tab). Each row
+ * links to that tab, the one surface for this record type per
+ * CoordinationRoute's own doc comment. */
+export function pendingEscalationRows(escalations: EscalationRecord[]): QueueRow[] {
+  return escalations
+    .filter((escalation) => (escalation.status ?? '').toLowerCase() === 'requested')
+    .map((escalation) => {
+      const id = escalation.item_id ?? escalation.record_id ?? '(unknown)'
+      const target = escalation.target_record_id
+      return {
+        id,
+        kindLabel: 'Escalation',
+        title: target ? `Unblock ${target}` : `Review ${id}`,
+        description: target ? `Target record: ${target}` : undefined,
+        status: escalation.status,
+        href: '/coordination?tab=escalations',
+      }
+    })
+}
+
+/** Static rows documenting queue slices with no PWA-reachable data source
+ * today (see api/homeQueue.ts module docstring). Kept as data, not inline
+ * JSX, so the "what's real vs. a gap" list is reviewable/testable on its
+ * own. */
+export const GAP_QUEUE_ROWS: QueueRow[] = [
+  {
+    id: 'gap-paused-prod',
+    kindLabel: 'Paused prod runs',
+    title: 'Paused v3-prod Environment approvals',
+    description:
+      'No PWA-reachable data source yet -- GitHub Actions Environment protection state isn’t exposed by any Enceladus HTTP API. Check the workflow run’s Environment approval gate directly in GitHub Actions.',
+    gap: true,
+  },
+  {
+    id: 'gap-stale-lock',
+    kindLabel: 'Stale locks',
+    title: 'Stale-lock / backfill flags',
+    description:
+      'No PWA-reachable data source yet -- worktree/session lock bookkeeping (ENC-ISS-071) and retirement-sweep backfills aren’t exposed by any Enceladus HTTP API today.',
+    gap: true,
+  },
+]

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -109,6 +109,12 @@ const changelogRoute = createRoute({
 const coordinationRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/coordination',
+  // ENC-TSK-M19: lets Home's "Requires io" queue deep-link an escalation row
+  // straight to the Escalations tab (?tab=escalations) instead of landing on
+  // the default Sessions tab.
+  validateSearch: (raw: Record<string, unknown>) => ({
+    tab: typeof raw.tab === 'string' ? raw.tab : '',
+  }),
   component: CoordinationRoute,
 })
 const skillLibraryRoute = createRoute({


### PR DESCRIPTION
## Summary
- Rebuilds Home (ui-v2) mobile-first: 360px is the base viewport. Leads above the fold with a "Requires io" action queue -- pending escalations (reusing the existing Escalations-tab fetcher `fetchEscalations`) plus two clearly-labeled data-gap rows (paused v3-prod Environment approvals, stale-lock/backfill flags) for which no PWA-reachable API exists today -- rendered as static, visually-distinct notices rather than fabricated links or a new backend.
- Adds a compact actionable-counts strip below the queue: "Open P0/P1" and "Awaiting checkout", both exact server-computed counts (`/feed/corpus` status+priority querystring facets already supported by `backend/lambda/feed_query/corpus.py`; the generic tracker-list route already used by `fetchLessons`). Each tile links to the closest available `/feed` filtered view; a caption notes that priority/checkout-state filtering isn't wired into Feed's client-side search yet, so the destination list is a superset of the exact count shown.
- Moves most-recent-per-type entry cards, recent documents, and dashboard charts (the prior ENC-TSK-L30 Home content, unchanged data model) into a below-fold `Tabs` section so they recede rather than compete with the queue for the first viewport.
- Adds `?tab=` deep-link support to `/coordination` so an escalation row lands directly on the Escalations tab.
- Consumes Band A: `StatusChip` (PR #948) and `RecordCard` (PR #950) render every queue/entry-card row; the responsive app-shell + mobile drawer (PR #951) hosts the route.
- Reference: `Home-Redesign.dc.html` (desktop projection) consulted for layout intent only -- not copied desktop-first.

## Test plan
- [x] `npm run typecheck` -- clean
- [x] `npm run test` -- 178/178 passing (incl. new `routes/homeQueue.test.ts`)
- [x] `npm run lint` -- no new errors (19 pre-existing errors on v4/main baseline, unchanged, none in touched files)
- [x] `npm run build` -- succeeds
- [x] Local dev preview at 375px viewport -- clean render, no console errors, no horizontal scroll (auth-gated locally; full interactive check happens live on gamma post-deploy)
- [ ] Live gamma verification post-deploy (queue above fold, counts strip, most-recent-per-type below fold, no horizontal scroll at ~375px)

CCI-4874330043df416a976cb709da89c54d