### PR TITLE
ENC-TSK-M28: Band-B polish -- drawer dismiss + Feed filter params + tabs-bar containment

### DIFF
--- a/frontend/design-system-2/v2/components/Tabs/Tabs.jsx
+++ b/frontend/design-system-2/v2/components/Tabs/Tabs.jsx
@@ -1,7 +1,7 @@
 // Enceladus v2 · Tabs — Cloudscape Tabs, deep re-brand.
 const ev2TabsCss = `
-.ev2-tabs{font-family:var(--font-body,'Inter',sans-serif)}
-.ev2-tabs__bar{display:flex;gap:2px;border-bottom:1px solid var(--v2-divider,rgba(61,155,168,.12));overflow-x:auto}
+.ev2-tabs{font-family:var(--font-body,'Inter',sans-serif);max-width:100%}
+.ev2-tabs__bar{display:flex;gap:2px;border-bottom:1px solid var(--v2-divider,rgba(61,155,168,.12));overflow-x:auto;max-width:100%}
 .ev2-tab{appearance:none;border:none;background:none;padding:9px 16px;font-family:var(--font-heading,'Space Grotesk',sans-serif);font-weight:500;font-size:14px;color:var(--enc-dust,#6B8A94);cursor:pointer;position:relative;white-space:nowrap;transition:color var(--dur-fast,150ms) var(--ease-orbit,cubic-bezier(.4,0,.2,1))}
 .ev2-tab:hover:not(.ev2-tab--active):not(:disabled){color:var(--enc-teal-light,#7AC8D4)}
 .ev2-tab--active{color:var(--enc-seafoam,#C8DDD9)}

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -100,14 +100,21 @@ interface EntryCardRow {
   href: string
 }
 
-/** Filtered-view /feed searches for the counts strip. Both use /feed's
- * existing `status` property filter (a real, working reduction of the
- * corpus); priority and checkout_state aren't wired into Feed's
- * client-side property filter yet, so these land on the closest available
- * filtered view rather than an exact match — see the note under the strip. */
+/** Filtered-view /feed searches for the counts strip (ENC-FTR-130 Band-B).
+ * Tokens mirror the exact server-side semantics each count tile's own fetch
+ * uses (api/homeQueue.ts), so the destination list matches the number above
+ * it: "Open P0/P1" = status=open AND priority in (P0,P1); "Awaiting
+ * checkout" = status=open AND record_type=task AND checkout_state !=
+ * checked_out. */
 const OPEN_SEARCH: FeedRouteSearch = {
   ...FEED_SEARCH_DEFAULTS,
-  f: serializeFilterQuery({ tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }], operation: 'and' }),
+  f: serializeFilterQuery({
+    tokens: [
+      { propertyKey: 'status', operator: '=', value: 'open' },
+      { propertyKey: 'priority', operator: 'in', value: 'p0,p1' },
+    ],
+    operation: 'and',
+  }),
 }
 const OPEN_TASKS_SEARCH: FeedRouteSearch = {
   ...FEED_SEARCH_DEFAULTS,
@@ -115,6 +122,7 @@ const OPEN_TASKS_SEARCH: FeedRouteSearch = {
     tokens: [
       { propertyKey: 'status', operator: '=', value: 'open' },
       { propertyKey: 'record_type', operator: '=', value: 'task' },
+      { propertyKey: 'checkout_state', operator: '!=', value: 'checked_out' },
     ],
     operation: 'and',
   }),
@@ -345,9 +353,8 @@ export function HomeRoute() {
         </Link>
       </section>
       <p className="home-route__counts-note">
-        Counts are exact (server-computed). Their links open the closest available Feed filter —
-        priority and checkout-state filtering aren’t wired into Feed’s client-side search yet, so
-        each destination list is a superset of the exact count above it.
+        Counts are exact (server-computed). Their links open Feed pre-filtered to match — results
+        may lag briefly behind the count while the local feed snapshot finishes syncing.
       </p>
 
       <section className="home-route__recent" aria-label="Recent activity">

--- a/frontend/ui-v2/src/search/applyPropertyFilter.test.ts
+++ b/frontend/ui-v2/src/search/applyPropertyFilter.test.ts
@@ -19,26 +19,70 @@ const HITS: SearchResultHit[] = [
     status: 'open',
     tier: 'hybrid',
   },
+  {
+    recordId: 'ENC-TSK-M40',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Open P0 task',
+    status: 'open',
+    priority: 'P0',
+    checkoutState: 'checked_out',
+    tier: 'local',
+  },
+  {
+    recordId: 'ENC-TSK-M41',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Open P2 task',
+    status: 'open',
+    priority: 'P2',
+    checkoutState: 'available',
+    tier: 'local',
+  },
 ]
 
 describe('applyPropertyFilter', () => {
   it('returns all hits when no tokens', () => {
-    expect(applyPropertyFilter(HITS, { tokens: [] })).toHaveLength(2)
+    expect(applyPropertyFilter(HITS, { tokens: [] })).toHaveLength(HITS.length)
   })
 
   it('filters by status token pill', () => {
     const filtered = applyPropertyFilter(HITS, {
       tokens: [{ propertyKey: 'status', operator: '=', value: 'open' }],
     })
-    expect(filtered).toHaveLength(1)
-    expect(filtered[0]?.recordId).toBe('ENC-ISS-058')
+    expect(filtered.map((h) => h.recordId).sort()).toEqual(
+      ['ENC-ISS-058', 'ENC-TSK-M40', 'ENC-TSK-M41'].sort(),
+    )
   })
 
   it('filters by record_type token', () => {
     const filtered = applyPropertyFilter(HITS, {
       tokens: [{ propertyKey: 'record_type', operator: '=', value: 'task' }],
     })
+    expect(filtered).toHaveLength(3)
+    expect(filtered.every((h) => h.recordType === 'task')).toBe(true)
+  })
+
+  it('"in" operator matches any comma-separated value (Home "Open P0/P1" deep link)', () => {
+    const filtered = applyPropertyFilter(HITS, {
+      tokens: [
+        { propertyKey: 'status', operator: '=', value: 'open' },
+        { propertyKey: 'priority', operator: 'in', value: 'p0,p1' },
+      ],
+    })
     expect(filtered).toHaveLength(1)
-    expect(filtered[0]?.recordType).toBe('task')
+    expect(filtered[0]?.recordId).toBe('ENC-TSK-M40')
+  })
+
+  it('filters by checkout_state != (Home "Awaiting checkout" deep link)', () => {
+    const filtered = applyPropertyFilter(HITS, {
+      tokens: [
+        { propertyKey: 'record_type', operator: '=', value: 'task' },
+        { propertyKey: 'status', operator: '=', value: 'open' },
+        { propertyKey: 'checkout_state', operator: '!=', value: 'checked_out' },
+      ],
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.recordId).toBe('ENC-TSK-M41')
   })
 })

--- a/frontend/ui-v2/src/search/applyPropertyFilter.ts
+++ b/frontend/ui-v2/src/search/applyPropertyFilter.ts
@@ -29,6 +29,16 @@ function compareToken(actual: string, operator: string, expected: string): boole
       return a >= e
     case '<=':
       return a <= e
+    case 'in':
+      // ENC-FTR-130 Band-B: comma-separated OR-membership (e.g. priority
+      // "in" "p0,p1"), mirroring the backend's comma-list query convention
+      // (backend/lambda/feed_query/corpus.py) so Home's counts-strip links
+      // can express "P0 or P1" as a single filter token.
+      return expected
+        .split(',')
+        .map((v) => v.trim().toLowerCase())
+        .filter(Boolean)
+        .includes(a)
     default:
       return a.includes(e)
   }

--- a/frontend/ui-v2/src/search/attributeRegistry.test.ts
+++ b/frontend/ui-v2/src/search/attributeRegistry.test.ts
@@ -22,6 +22,15 @@ const CORPUS: LocalSearchRecord[] = [
     title: 'Sample issue',
     status: 'open',
   },
+  {
+    recordId: 'ENC-TSK-M40',
+    recordType: 'task',
+    projectId: 'enceladus',
+    title: 'Open P0 task',
+    status: 'open',
+    priority: 'P0',
+    checkoutState: 'checked_out',
+  },
 ]
 
 describe('attributeRegistry', () => {
@@ -45,5 +54,16 @@ describe('attributeRegistry', () => {
   it('resolves hit fields for filter matching', () => {
     expect(fieldValueForProperty(CORPUS[0], 'status')).toBe('in-progress')
     expect(fieldValueForProperty(CORPUS[0], 'record_id')).toBe('ENC-TSK-L19')
+  })
+
+  it('registers priority and checkout_state as filterable properties (ENC-FTR-130 Band-B)', () => {
+    const props = buildAttributeRegistry(CORPUS)
+    expect(props.some((p) => p.key === 'priority')).toBe(true)
+    expect(props.some((p) => p.key === 'checkout_state')).toBe(true)
+  })
+
+  it('resolves priority and checkout_state hit fields for filter matching', () => {
+    expect(fieldValueForProperty(CORPUS[2], 'priority')).toBe('P0')
+    expect(fieldValueForProperty(CORPUS[2], 'checkout_state')).toBe('checked_out')
   })
 })

--- a/frontend/ui-v2/src/search/attributeRegistry.ts
+++ b/frontend/ui-v2/src/search/attributeRegistry.ts
@@ -7,6 +7,13 @@ const GOVERNANCE_FILTER_PROPERTIES = [
   { key: 'project_id', operators: ['=', '!=', ':'] },
   { key: 'record_id', operators: ['=', '!=', ':'] },
   { key: 'title', operators: ['=', '!=', ':'] },
+  // ENC-FTR-130 Band-B: wired so Home's counts-strip deep links (status +
+  // priority + checkout_state) actually filter Feed instead of landing on
+  // an unfiltered/zero result set. 'in' matches a comma-separated value
+  // list (e.g. priority in "p0,p1"), mirroring the backend's own
+  // comma-list query convention (backend/lambda/feed_query/corpus.py).
+  { key: 'priority', operators: ['=', '!=', 'in'] },
+  { key: 'checkout_state', operators: ['=', '!=', 'in'] },
 ] as const
 
 export type FilteringProperty = {
@@ -26,6 +33,8 @@ export function buildAttributeRegistry(corpus: LocalSearchRecord[]): FilteringPr
     observe(keys, 'project_id', row.projectId)
     observe(keys, 'record_id', row.recordId)
     observe(keys, 'title', row.title)
+    if (row.priority) observe(keys, 'priority', row.priority)
+    if (row.checkoutState) observe(keys, 'checkout_state', row.checkoutState)
   }
 
   return [...keys.entries()].map(([key, operators]) => ({
@@ -56,6 +65,10 @@ export function fieldValueForProperty(
       return hit.recordId
     case 'title':
       return hit.title
+    case 'priority':
+      return hit.priority
+    case 'checkout_state':
+      return hit.checkoutState
     default:
       return undefined
   }

--- a/frontend/ui-v2/src/search/localKeywordSearch.ts
+++ b/frontend/ui-v2/src/search/localKeywordSearch.ts
@@ -4,27 +4,42 @@ import type { LocalSearchRecord, SearchResultHit } from '../types/search'
  * Tier-0 local keyword search — synchronous, bounded, intended to complete
  * within the <100ms autosuggest SLO (FTR-127). No network I/O.
  */
+function toHit(row: LocalSearchRecord): SearchResultHit {
+  return {
+    recordId: row.recordId,
+    recordType: row.recordType,
+    projectId: row.projectId,
+    title: row.title,
+    status: row.status,
+    priority: row.priority,
+    checkoutState: row.checkoutState,
+    tier: 'local',
+  }
+}
+
 export function searchLocalKeyword(
   corpus: LocalSearchRecord[],
   query: string,
   limit = 20,
 ): SearchResultHit[] {
   const q = query.trim().toLowerCase()
-  if (!q) return []
+  if (!q) {
+    // ENC-FTR-130 Band-B: a blank query means the caller is browsing/
+    // filtering rather than typing a search (e.g. Home's counts-strip deep
+    // links, which navigate straight to a property-filtered /feed?f=... URL
+    // with no `q`). Property-filter narrowing (applyPropertyFilter) only has
+    // something to narrow if the local tier returns the full corpus here --
+    // returning [] silently zeroed out every filter-only Feed deep link
+    // regardless of whether the filter itself was correct.
+    return corpus.map(toHit)
+  }
 
   const hits: SearchResultHit[] = []
   for (const row of corpus) {
     const idMatch = row.recordId.toLowerCase().includes(q)
     const titleMatch = row.title.toLowerCase().includes(q)
     if (!idMatch && !titleMatch) continue
-    hits.push({
-      recordId: row.recordId,
-      recordType: row.recordType,
-      projectId: row.projectId,
-      title: row.title,
-      status: row.status,
-      tier: 'local',
-    })
+    hits.push(toHit(row))
     if (hits.length >= limit) break
   }
   return hits

--- a/frontend/ui-v2/src/search/mergeSearchResults.test.ts
+++ b/frontend/ui-v2/src/search/mergeSearchResults.test.ts
@@ -26,6 +26,31 @@ describe('searchLocalKeyword', () => {
     expect(hits[0]?.recordId).toBe('ENC-ISS-058')
     expect(hits[0]?.tier).toBe('local')
   })
+
+  it('ENC-FTR-130 Band-B: returns the full corpus (not []) when the query is blank, so property-filter-only navigation (e.g. Home counts-strip deep links with no `q`) has something to filter', () => {
+    const hits = searchLocalKeyword(CORPUS, '')
+    expect(hits).toHaveLength(CORPUS.length)
+    expect(hits.map((h) => h.recordId).sort()).toEqual(CORPUS.map((r) => r.recordId).sort())
+  })
+
+  it('carries priority and checkoutState through to the hit shape', () => {
+    const withPriority: LocalSearchRecord[] = [
+      ...CORPUS,
+      {
+        recordId: 'ENC-TSK-M40',
+        recordType: 'task',
+        projectId: 'enceladus',
+        title: 'Open P0 task',
+        status: 'open',
+        priority: 'P0',
+        checkoutState: 'checked_out',
+      },
+    ]
+    const hits = searchLocalKeyword(withPriority, '')
+    const hit = hits.find((h) => h.recordId === 'ENC-TSK-M40')
+    expect(hit?.priority).toBe('P0')
+    expect(hit?.checkoutState).toBe('checked_out')
+  })
 })
 
 describe('mergeSearchResults', () => {

--- a/frontend/ui-v2/src/search/searchCorpus.ts
+++ b/frontend/ui-v2/src/search/searchCorpus.ts
@@ -23,12 +23,20 @@ export function buildSearchCorpus(
     if (!recordType) continue
     const projectId =
       resolveProjectFromRecordId(event.recordId, projects) ?? 'enceladus'
+    // ENC-FTR-130 Band-B: `record` (full body) is only present on per-record
+    // subscription events (ENC-TSK-L29) -- best-effort only. The warm cache
+    // path (sync/searchIndex.ts::tier1ToLocalSearchRecord) is the reliable
+    // source for priority/checkout_state; this just avoids a cold-start gap.
+    const fullRecord = event.record
     byId.set(event.recordId, {
       recordId: event.recordId,
       recordType,
       projectId,
       title: event.summary,
       status: event.action,
+      priority: typeof fullRecord?.priority === 'string' ? fullRecord.priority : undefined,
+      checkoutState:
+        typeof fullRecord?.checkout_state === 'string' ? fullRecord.checkout_state : undefined,
     })
   }
 

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -103,6 +103,20 @@ export function AppShell({ children }: { children: ReactNode }) {
     return () => desktop.removeEventListener('change', syncTools)
   }, [])
 
+  // Band-B polish (ENC-ISS-51x): Escape must dismiss the mobile nav drawer,
+  // matching the scrim tap-to-close affordance. Only listens while the
+  // drawer is open so it never intercepts Escape elsewhere in the app.
+  useEffect(() => {
+    if (!navigationOpen) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSidebarOpen(false)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [navigationOpen, setSidebarOpen])
+
   const followNav = (event: { detail: { href?: string; text?: React.ReactNode } }) => {
     const href = event.detail.href
     if (href === LOGOUT_HREF) {

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -42,10 +42,30 @@ function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '')
 }
 
+/** Extract the body of an `@media (...) { ... }` block (or any `{`-opened
+ * rule) by counting braces from the header match, rather than relying on a
+ * regex guess at what text follows the closing brace. Robust to whatever
+ * rules get added/reordered around the block (see ENC-ISS-51x: an earlier
+ * version of this test depended on `.ev2-shell__nav-scrim` being the very
+ * next selector after the media block, which broke the moment that rule's
+ * position was fixed as part of the Band-B drawer-dismiss repair). */
+function extractBlock(css: string, headerPattern: RegExp): string {
+  const match = css.match(headerPattern)
+  if (!match || match.index === undefined) return ''
+  const start = match.index + match[0].length
+  let depth = 1
+  let i = start
+  while (i < css.length && depth > 0) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}') depth--
+    i++
+  }
+  return css.slice(start, i - 1)
+}
+
 describe('mobile nav drawer (ENC-ISS-515 / defect A)', () => {
   const shellCss = stripCssComments(readSrc('shell/shell.css'))
-  const mobileBlockMatch = shellCss.match(/@media \(max-width: 48rem\) \{([\s\S]*?)\n\}\n\n\.ev2-shell__nav-scrim/)
-  const mobileBlock = mobileBlockMatch?.[1] ?? ''
+  const mobileBlock = extractBlock(shellCss, /@media \(max-width: 48rem\) \{/)
 
   it('has a mobile breakpoint block for the shell nav', () => {
     expect(mobileBlock.length).toBeGreaterThan(0)
@@ -71,6 +91,94 @@ describe('mobile nav drawer (ENC-ISS-515 / defect A)', () => {
     expect(appShell).toMatch(/ev2-shell--nav-open/)
     expect(appShell).toMatch(/ev2-shell__nav-scrim/)
     expect(appShell).toMatch(/toggleSidebar/)
+  })
+})
+
+/**
+ * Band-B polish (ENC-ISS-51x, io live-probe 2026-07-08 @ ~500px): the drawer
+ * opened (ENC-TSK-M26 above), but dismiss was dead. `.ev2-shell__nav-scrim`
+ * existed in the DOM with a real onClick handler, yet rendered at 0x0 --
+ * untappable -- because an unconditional `.ev2-shell__nav-scrim{display:
+ * none}` rule shipped *after* the mobile-scoped override in shell.css. Equal
+ * specificity + later source position means that rule always won the
+ * cascade, at any viewport. Escape wasn't wired at all. Fixed by moving the
+ * default-hidden rule before the media query, and adding a document-level
+ * Escape listener scoped to the open state.
+ */
+describe('drawer dismiss (ENC-ISS-51x / Band-B defect 1: scrim tap + Escape)', () => {
+  const shellCss = stripCssComments(readSrc('shell/shell.css'))
+  const mobileBlock = extractBlock(shellCss, /@media \(max-width: 48rem\) \{/)
+  const appShell = readSrc('shell/AppShell.tsx')
+
+  it('the mobile override gives the scrim real fixed-position geometry, not display:none', () => {
+    const scrimRuleMatch = mobileBlock.match(/\.ev2-shell__nav-scrim\s*\{([^}]*)\}/)
+    expect(scrimRuleMatch, 'expected a .ev2-shell__nav-scrim rule inside the mobile block').not.toBeNull()
+    const scrimRule = scrimRuleMatch?.[1] ?? ''
+    expect(scrimRule).toMatch(/display:\s*block/)
+    expect(scrimRule).toMatch(/position:\s*fixed/)
+    expect(scrimRule).toMatch(/inset:/)
+  })
+
+  it('the default-hidden scrim rule sits BEFORE the mobile media query, not after', () => {
+    // A same-specificity `.ev2-shell__nav-scrim` rule declared AFTER the
+    // mobile block would win the cascade at every viewport and re-zero the
+    // scrim (the exact regression this suite guards against). The only safe
+    // place for the unconditional `display: none` default is before it.
+    const mediaIdx = shellCss.indexOf('@media (max-width: 48rem)')
+    expect(mediaIdx).toBeGreaterThan(-1)
+    const before = shellCss.slice(0, mediaIdx)
+    const after = shellCss.slice(mediaIdx + '@media (max-width: 48rem) {'.length + mobileBlock.length)
+
+    expect(before).toMatch(/\.ev2-shell__nav-scrim\s*\{\s*display:\s*none;?\s*\}/)
+
+    // Strip out any subsequent @media blocks (nested selectors reusing the
+    // same class name inside a *different* scoped context are fine) before
+    // checking for a stray bare redeclaration.
+    let rest = after
+    let mediaMatch: RegExpMatchArray | null
+    while ((mediaMatch = rest.match(/@media[^{]*\{/))) {
+      const idx = mediaMatch.index ?? 0
+      const blockBody = extractBlock(rest, /@media[^{]*\{/)
+      rest = rest.slice(0, idx) + rest.slice(idx + mediaMatch[0].length + blockBody.length + 1)
+    }
+    expect(rest).not.toMatch(/\.ev2-shell__nav-scrim/)
+  })
+
+  it('the scrim button keeps a real click-to-close handler', () => {
+    const scrimBlockMatch = appShell.match(/className="ev2-shell__nav-scrim"[\s\S]{0,200}/)
+    expect(scrimBlockMatch).not.toBeNull()
+    expect(scrimBlockMatch?.[0] ?? '').toMatch(/onClick=\{[^}]*setSidebarOpen\(false\)[^}]*\}/)
+  })
+
+  it('Escape closes the drawer via a document-level keydown listener scoped to the open state', () => {
+    expect(appShell).toMatch(/addEventListener\(\s*['"]keydown['"]/)
+    const effectMatch = appShell.match(/useEffect\(\(\) => \{[\s\S]*?Escape[\s\S]*?\}, \[[^\]]*\]\)/)
+    expect(effectMatch, 'expected a useEffect wiring an Escape keydown handler').not.toBeNull()
+    const effectBody = effectMatch?.[0] ?? ''
+    expect(effectBody).toMatch(/navigationOpen/)
+    expect(effectBody).toMatch(/setSidebarOpen\(false\)/)
+    expect(effectBody).toMatch(/removeEventListener\(\s*['"]keydown['"]/)
+  })
+})
+
+/**
+ * Band-B polish (ENC-ISS-51x, defect 3): `.ev2-tabs__bar` (shared
+ * design-system-2 Tabs, used by Home's "Recent activity" section among
+ * other routes) already declared `overflow-x: auto`, but neither it nor its
+ * `.ev2-tabs` wrapper capped their own width -- the human probe measured the
+ * bar at 519px against a 452px viewport. Made explicit and contained with
+ * `max-width: 100%` on both, so the horizontal scroll stays local to the tab
+ * strip instead of bleeding the page.
+ */
+describe('tabs bar overflow containment (ENC-ISS-51x / Band-B defect 3)', () => {
+  const tabsSrc = readSrc('../../design-system-2/v2/components/Tabs/Tabs.jsx')
+
+  it('caps both the tabs wrapper and the scrollable bar to their container width', () => {
+    const wrapperRuleMatch = tabsSrc.match(/\.ev2-tabs\{([^}]*)\}/)
+    const barRuleMatch = tabsSrc.match(/\.ev2-tabs__bar\{([^}]*)\}/)
+    expect(wrapperRuleMatch?.[1] ?? '').toMatch(/max-width:\s*100%/)
+    expect(barRuleMatch?.[1] ?? '').toMatch(/max-width:\s*100%/)
+    expect(barRuleMatch?.[1] ?? '').toMatch(/overflow-x:\s*auto/)
   })
 })
 

--- a/frontend/ui-v2/src/shell/shell.css
+++ b/frontend/ui-v2/src/shell/shell.css
@@ -57,6 +57,19 @@
   color: var(--enc-teal-light);
 }
 
+/* Band-B fix (ENC-ISS-51x): this default MUST come before the mobile
+ * media query below. `.ev2-shell__nav-scrim` has equal specificity in both
+ * places, so whichever rule sits LATER in source order wins the cascade at
+ * any viewport -- including inside the media query's own matched range. The
+ * previous version declared this same `display: none` rule *after* the
+ * media block, which unconditionally beat the mobile `display: block`
+ * override at every width and left the scrim permanently 0x0 (rendered but
+ * never tappable, since a display:none box has no hit-testable box at all).
+ */
+.ev2-shell__nav-scrim {
+  display: none;
+}
+
 @media (max-width: 48rem) {
   .ev2-shell__bottom-nav {
     display: flex;
@@ -108,10 +121,6 @@
     border: none;
     padding: 0;
   }
-}
-
-.ev2-shell__nav-scrim {
-  display: none;
 }
 
 @media (min-width: 48.0625rem) {

--- a/frontend/ui-v2/src/sync/searchIndex.ts
+++ b/frontend/ui-v2/src/sync/searchIndex.ts
@@ -65,5 +65,11 @@ export function tier1ToLocalSearchRecord(record: Tier1Record): LocalSearchRecord
     projectId: record.projectId,
     title: record.title,
     status: record.status,
+    // ENC-FTR-130 Band-B: Tier1Record already carries priority (and a raw
+    // attrs bag with checkout_state) -- this mapping was dropping both on
+    // the floor before they ever reached the search/filter layer.
+    priority: record.priority,
+    checkoutState:
+      typeof record.attrs?.checkout_state === 'string' ? record.attrs.checkout_state : undefined,
   }
 }

--- a/frontend/ui-v2/src/types/search.ts
+++ b/frontend/ui-v2/src/types/search.ts
@@ -51,6 +51,10 @@ export interface SearchResultHit {
   projectId: string
   title: string
   status?: string
+  /** ENC-FTR-130 Band-B: task/issue priority (e.g. 'P0'), when known. */
+  priority?: string
+  /** ENC-FTR-130 Band-B: tracker checkout_state (e.g. 'checked_out'), when known. */
+  checkoutState?: string
   tier: SearchTier
   fusion?: HybridGraphsearchResponse['per_node_fusion'] extends Record<string, infer V>
     ? V
@@ -64,6 +68,10 @@ export interface LocalSearchRecord {
   projectId: string
   title: string
   status?: string
+  /** ENC-FTR-130 Band-B: task/issue priority (e.g. 'P0'), when known. */
+  priority?: string
+  /** ENC-FTR-130 Band-B: tracker checkout_state (e.g. 'checked_out'), when known. */
+  checkoutState?: string
 }
 
 export interface TieredSearchSnapshot {


### PR DESCRIPTION
## Summary
Fixes three mobile UX regressions found by a live human UAT probe on gamma (2026-07-08, ~500px width):

1. **Mobile nav drawer dismiss** (ENC-ISS-517): the scrim's mobile CSS override was shadowed by an unconditional `.ev2-shell__nav-scrim{display:none}` rule declared *after* it in `shell.css` -- equal specificity + later source position always won the cascade, leaving the scrim 0x0 (untappable) at every viewport despite already having a real click handler. Moved the default-hidden rule before the media query and added a document-level Escape keydown handler scoped to the open drawer state.
2. **Feed deep-link filters** (ENC-ISS-518): Home's counts-strip links to `/feed` always landed on 0 hits because `searchLocalKeyword()` short-circuited to `[]` whenever the `q` text query was blank -- property-filter-only navigation (no search text) had nothing to filter, independent of whether the filter itself was correct. Also wired `priority` and `checkout_state` all the way through (Tier1Record -> LocalSearchRecord -> attributeRegistry -> `applyPropertyFilter`'s new `in` operator), and updated Home's `OPEN_SEARCH`/`OPEN_TASKS_SEARCH` tokens to match the exact server-side semantics each count tile's own fetch uses.
3. **Tabs-bar overflow** (ENC-ISS-51x defect 3): `.ev2-tabs__bar` already declared `overflow-x:auto` but neither it nor its `.ev2-tabs` wrapper capped their own width, letting the intentional horizontal scroll strip bleed past the viewport. Added `max-width:100%` to both.

Tracker: ENC-TSK-M28, relates to ENC-ISS-517, ENC-ISS-518, ENC-FTR-130.

CCI-d450e7ea7e0c4b2e8b03f9c13b462d70

## Test plan
- [x] `npx vitest run` -- 206 tests pass (36 files) including new regression coverage
- [x] `npx tsc --noEmit` -- clean
- [x] `npx eslint` on touched files -- no new errors (3 pre-existing repo-wide errors unrelated to this diff)
- [ ] Live gamma verification post-deploy: scrim tap + Escape close drawer; Home counts-strip links return matching non-zero Feed results; tabs bar scrolls without page bleed at ~500px

🤖 Generated with [Claude Code](https://claude.com/claude-code)