### PR TITLE
ENC-TSK-M18: route code-splitting + list virtualization (UX-A4 perf budget)

### DIFF
--- a/frontend/ui-v2/package-lock.json
+++ b/frontend/ui-v2/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
+        "@tanstack/react-virtual": "^3.14.5",
         "cytoscape": "^3.34.0",
         "lucide-react": "^1.23.0",
         "react": "^19.2.7",
@@ -3433,6 +3434,23 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/router-core": {
       "version": "1.171.14",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.14.tgz",
@@ -3456,6 +3474,16 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
       "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/ui-v2/package.json
+++ b/frontend/ui-v2/package.json
@@ -6,17 +6,19 @@
   "description": "Enceladus PWA 2.0 governance cockpit scaffold (ENC-TSK-K21)",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run assert:bundle-budget",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && npm run lint:adherence",
     "lint:adherence": "node scripts/run-adherence-lint.mjs",
+    "assert:bundle-budget": "node scripts/assert-bundle-budget.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
+    "@tanstack/react-virtual": "^3.14.5",
     "cytoscape": "^3.34.0",
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",

--- a/frontend/ui-v2/scripts/assert-bundle-budget.mjs
+++ b/frontend/ui-v2/scripts/assert-bundle-budget.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Bundle-size budget gate (ENC-TSK-M18 / UX-A4, AC-2).
+ *
+ * Reads `dist/index.html` after `vite build` and computes the gzip size of
+ * every JS asset referenced by an initial (non-module-preload, non-dynamic)
+ * `<script>` tag — i.e. exactly what the browser downloads to paint the
+ * default mobile route ("/"). Route chunks (Feed/Projects/.../record
+ * primitives) are NOT in this set because router.tsx lazy-loads them via
+ * `lazyRouteComponent()` / `React.lazy()` — they only ship after
+ * `dist/index.html`'s own script tags resolve.
+ *
+ * Budget: 200 KB gzip (AC-2: "Initial mobile route JS ≤200KB gz, route
+ * code-split"). Fails the build (exit 1) if the initial JS payload exceeds
+ * budget, so a future PR that un-splits a route or grows the shell gets
+ * caught in CI rather than discovered by profiling a live device.
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const distDir = path.join(pkgRoot, 'dist')
+const indexHtmlPath = path.join(distDir, 'index.html')
+
+const BUDGET_BYTES = 200 * 1024 // 200 KB gz (AC-2)
+
+if (!existsSync(indexHtmlPath)) {
+  console.error(
+    `[assert-bundle-budget] ${indexHtmlPath} not found. Run "npm run build" first.`,
+  )
+  process.exit(1)
+}
+
+const html = readFileSync(indexHtmlPath, 'utf8')
+
+// Match `<script ... src="/assets/foo.js">` tags only (module-preload <link>
+// tags and the manifest/CSS links are not part of the initial JS payload).
+const scriptSrcRe = /<script[^>]*\ssrc="([^"]+\.js)"[^>]*>/g
+const initialScripts = [...html.matchAll(scriptSrcRe)].map((m) => m[1])
+
+if (initialScripts.length === 0) {
+  console.error('[assert-bundle-budget] No <script src="..."> tags found in dist/index.html.')
+  process.exit(1)
+}
+
+let totalRawBytes = 0
+let totalGzBytes = 0
+const rows = []
+
+for (const src of initialScripts) {
+  const assetPath = path.join(distDir, src.replace(/^\//, ''))
+  if (!existsSync(assetPath)) {
+    console.error(`[assert-bundle-budget] Referenced asset missing on disk: ${assetPath}`)
+    process.exit(1)
+  }
+  const raw = readFileSync(assetPath)
+  const gz = gzipSync(raw, { level: 9 })
+  totalRawBytes += raw.byteLength
+  totalGzBytes += gz.byteLength
+  rows.push({ src, rawKB: raw.byteLength / 1024, gzKB: gz.byteLength / 1024 })
+}
+
+const fmt = (kb) => `${kb.toFixed(2)} KB`
+
+console.log('[assert-bundle-budget] Initial route JS (referenced by dist/index.html):')
+for (const row of rows) {
+  console.log(`  ${row.src}  raw=${fmt(row.rawKB)}  gz=${fmt(row.gzKB)}`)
+}
+console.log(
+  `[assert-bundle-budget] TOTAL  raw=${fmt(totalRawBytes / 1024)}  gz=${fmt(totalGzBytes / 1024)}  budget=${fmt(BUDGET_BYTES / 1024)}`,
+)
+
+if (totalGzBytes > BUDGET_BYTES) {
+  console.error(
+    `[assert-bundle-budget] FAIL — initial route JS is ${fmt(totalGzBytes / 1024)} gz, over the ${fmt(BUDGET_BYTES / 1024)} gz budget (AC-2). Route-split the new weight with lazyRouteComponent()/React.lazy() or trim the dependency.`,
+  )
+  process.exit(1)
+}
+
+console.log('[assert-bundle-budget] PASS — within AC-2 budget.')

--- a/frontend/ui-v2/src/components/VirtualList.test.tsx
+++ b/frontend/ui-v2/src/components/VirtualList.test.tsx
@@ -1,0 +1,76 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { VirtualList } from './VirtualList'
+import { VIRTUALIZE_ROW_THRESHOLD } from './virtualListThreshold'
+
+/**
+ * No @testing-library/react in this package (see SessionPrimitive.test.tsx)
+ * — createRoot + act smoke tests only. jsdom has no real layout engine
+ * (clientHeight/scrollTop are always 0), so this deliberately does NOT
+ * assert exact visible-row counts from @tanstack/react-virtual's windowing
+ * math — it asserts the two behaviors ENC-TSK-M18 AC-3 actually cares
+ * about: (1) small lists render every row untouched, (2) large lists engage
+ * the windowed scroll container instead of mounting every row's DOM node.
+ */
+
+type Row = { id: string; label: string }
+
+function makeRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({ id: `row-${i}`, label: `Row ${i}` }))
+}
+
+describe('VirtualList', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('renders every row directly when at/under the threshold (no scroll container)', () => {
+    const rows = makeRows(VIRTUALIZE_ROW_THRESHOLD)
+    act(() => {
+      root.render(
+        <VirtualList
+          items={rows}
+          getKey={(r) => r.id}
+          renderItem={(r) => <span data-testid="row">{r.label}</span>}
+        />,
+      )
+    })
+
+    expect(container.querySelectorAll('[data-testid="row"]').length).toBe(
+      VIRTUALIZE_ROW_THRESHOLD,
+    )
+    expect(container.querySelector('[data-testid="virtual-list-scroll"]')).toBeNull()
+  })
+
+  it('engages the windowed scroll container above the threshold (AC-3: >30 rows)', () => {
+    const rows = makeRows(200)
+    act(() => {
+      root.render(
+        <VirtualList
+          items={rows}
+          getKey={(r) => r.id}
+          renderItem={(r) => <span data-testid="row">{r.label}</span>}
+        />,
+      )
+    })
+
+    const scrollEl = container.querySelector('[data-testid="virtual-list-scroll"]')
+    expect(scrollEl).not.toBeNull()
+
+    // The whole point of AC-3: the DOM must not hold all 200 rows at once.
+    const renderedRows = container.querySelectorAll('[data-testid="row"]').length
+    expect(renderedRows).toBeLessThan(rows.length)
+  })
+})

--- a/frontend/ui-v2/src/components/VirtualList.tsx
+++ b/frontend/ui-v2/src/components/VirtualList.tsx
@@ -1,0 +1,120 @@
+import { useRef, type ReactNode } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { shouldVirtualize } from './virtualListThreshold'
+
+export interface VirtualListProps<T> {
+  items: readonly T[]
+  /** Stable key for a row — required so windowed re-renders don't remount. */
+  getKey: (item: T, index: number) => string
+  renderItem: (item: T, index: number) => ReactNode
+  /** Estimated row height in px (AC-3 windowing math); tune per call site. */
+  estimateSize?: number
+  /** Rows rendered above/below the visible window, to smooth fast scrolls. */
+  overscan?: number
+  /** Scroll container max-height in px. */
+  maxHeight?: number
+  className?: string
+}
+
+/**
+ * Generic windowed list (ENC-TSK-M18 / UX-A4 AC-3: "Lists >30 rows
+ * virtualized"). Lists at or under the threshold render every row directly
+ * — no scroll container, no virtualizer bookkeeping — which keeps the
+ * common case (most Feed/Coordination/Projects views today) exactly as
+ * cheap as a plain `.map()`. Once a list crosses the threshold, rows are
+ * windowed via @tanstack/react-virtual so the DOM only ever holds the
+ * visible slice + overscan, regardless of how many records the list logically
+ * holds (Coordination's session/lesson/escalation tabs are documented as
+ * "<=200 row" datasets rendered with a bare `.map()` before this task).
+ */
+export function VirtualList<T>({
+  items,
+  getKey,
+  renderItem,
+  estimateSize = 88,
+  overscan = 6,
+  maxHeight = 640,
+  className,
+}: VirtualListProps<T>) {
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  if (!shouldVirtualize(items.length)) {
+    return (
+      <>
+        {items.map((item, index) => (
+          <div key={getKey(item, index)}>{renderItem(item, index)}</div>
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <VirtualizedWindow
+      items={items}
+      getKey={getKey}
+      renderItem={renderItem}
+      estimateSize={estimateSize}
+      overscan={overscan}
+      maxHeight={maxHeight}
+      className={className}
+      parentRef={parentRef}
+    />
+  )
+}
+
+/** Split out so the `useVirtualizer` hook is only ever called on the
+ * above-threshold path — hooks can't be called conditionally in
+ * `VirtualList` itself. */
+function VirtualizedWindow<T>({
+  items,
+  getKey,
+  renderItem,
+  estimateSize,
+  overscan,
+  maxHeight,
+  className,
+  parentRef,
+}: Required<Omit<VirtualListProps<T>, 'className'>> & {
+  className?: string
+  parentRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+  })
+
+  const virtualItems = virtualizer.getVirtualItems()
+
+  return (
+    <div
+      ref={parentRef}
+      className={className}
+      data-testid="virtual-list-scroll"
+      style={{ height: maxHeight, overflow: 'auto', position: 'relative' }}
+    >
+      <div style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
+        {virtualItems.map((virtualRow) => {
+          const item = items[virtualRow.index]
+          return (
+            <div
+              key={getKey(item, virtualRow.index)}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {renderItem(item, virtualRow.index)}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/ui-v2/src/components/virtualListThreshold.test.ts
+++ b/frontend/ui-v2/src/components/virtualListThreshold.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { shouldVirtualize, VIRTUALIZE_ROW_THRESHOLD } from './virtualListThreshold'
+
+describe('shouldVirtualize', () => {
+  it('does not virtualize at or below the threshold', () => {
+    expect(shouldVirtualize(0)).toBe(false)
+    expect(shouldVirtualize(1)).toBe(false)
+    expect(shouldVirtualize(VIRTUALIZE_ROW_THRESHOLD)).toBe(false)
+  })
+
+  it('virtualizes once a list exceeds the threshold (AC-3: >30 rows)', () => {
+    expect(shouldVirtualize(VIRTUALIZE_ROW_THRESHOLD + 1)).toBe(true)
+    expect(shouldVirtualize(200)).toBe(true)
+  })
+
+  it('threshold is exactly 30 per UX-A4 AC-3', () => {
+    expect(VIRTUALIZE_ROW_THRESHOLD).toBe(30)
+  })
+})

--- a/frontend/ui-v2/src/components/virtualListThreshold.ts
+++ b/frontend/ui-v2/src/components/virtualListThreshold.ts
@@ -1,0 +1,15 @@
+/**
+ * ENC-TSK-M18 (perf budget, AC-3): shared "when do we virtualize" rule.
+ *
+ * Kept as a standalone pure function (no React, no @tanstack/react-virtual
+ * import) so it stays trivially unit-testable and can be reused by any list
+ * surface (Feed, Coordination, Projects, Home) to decide whether to pay the
+ * windowing cost at all — small lists render every row directly, which is
+ * both simpler and avoids virtualizer measurement overhead for the common
+ * case where a list never gets long enough to matter.
+ */
+export const VIRTUALIZE_ROW_THRESHOLD = 30
+
+export function shouldVirtualize(itemCount: number): boolean {
+  return itemCount > VIRTUALIZE_ROW_THRESHOLD
+}

--- a/frontend/ui-v2/src/primitives/registry.tsx
+++ b/frontend/ui-v2/src/primitives/registry.tsx
@@ -3,16 +3,18 @@
  * record. The registry is the extension seam: a new primitive is added by
  * dropping a renderer and one entry here. Types are threaded through
  * RecordShapeMap so each renderer receives exactly its own record shape.
+ *
+ * ENC-TSK-M18 (perf budget): renderers are lazy-loaded via `React.lazy` —
+ * `PlanPrimitive` alone pulls in `PlanGraphExplorer` -> `cytoscape` (a large
+ * dependency), and none of the six primitives are needed on the routes that
+ * dominate the initial paint (Home/Feed/Coordination/Projects). Every
+ * `createRecordRoute` caller already wraps its component in a route-level
+ * `<Suspense fallback={<SkeletonCard />}>` (see routes/recordRoute.tsx), so
+ * this is a drop-in swap — no new Suspense boundary needed.
  */
 
-import type { ComponentType } from 'react'
+import { lazy, type ComponentType } from 'react'
 import type { RecordShapeMap, RecordType } from '../types/records'
-import { TaskPrimitive } from './TaskPrimitive'
-import { IssuePrimitive } from './IssuePrimitive'
-import { FeaturePrimitive } from './FeaturePrimitive'
-import { PlanPrimitive } from './PlanPrimitive'
-import { LessonPrimitive } from './LessonPrimitive'
-import { DocumentPrimitive } from './DocumentPrimitive'
 
 export type PrimitiveRenderer<K extends RecordType> = ComponentType<{
   record: RecordShapeMap[K]
@@ -21,15 +23,19 @@ export type PrimitiveRenderer<K extends RecordType> = ComponentType<{
 type Registry = { [K in RecordType]: PrimitiveRenderer<K> }
 
 export const PrimitiveRegistry: Registry = {
-  task: TaskPrimitive,
-  issue: IssuePrimitive,
-  feature: FeaturePrimitive,
-  plan: PlanPrimitive,
-  lesson: LessonPrimitive,
-  document: DocumentPrimitive,
+  task: lazy(() => import('./TaskPrimitive').then((m) => ({ default: m.TaskPrimitive }))),
+  issue: lazy(() => import('./IssuePrimitive').then((m) => ({ default: m.IssuePrimitive }))),
+  feature: lazy(() =>
+    import('./FeaturePrimitive').then((m) => ({ default: m.FeaturePrimitive })),
+  ),
+  plan: lazy(() => import('./PlanPrimitive').then((m) => ({ default: m.PlanPrimitive }))),
+  lesson: lazy(() => import('./LessonPrimitive').then((m) => ({ default: m.LessonPrimitive }))),
+  document: lazy(() =>
+    import('./DocumentPrimitive').then((m) => ({ default: m.DocumentPrimitive })),
+  ),
 }
 
-/** Type-safe accessor: `getPrimitive('task')` is `PrimitiveRenderer<'task'>`. */
+/** Type-safe accessor: `getPrimitive('task')` is `PrimitiveRenderer<K>`. */
 export function getPrimitive<K extends RecordType>(type: K): PrimitiveRenderer<K> {
   return PrimitiveRegistry[type]
 }

--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -16,6 +16,7 @@ import { useSearch } from '@tanstack/react-router'
 import { Cards, PropertyFilter, Tabs } from '../design-system'
 import { StatusChip } from '../components/StatusChip'
 import { RecordCard } from '../components/RecordCard'
+import { VirtualList } from '../components/VirtualList'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import {
@@ -88,17 +89,26 @@ export function CoordinationRoute() {
       label: 'Sessions',
       count: sessions.length,
       content: (
+        // ENC-TSK-M18 (AC-3): sessions is documented as a "<=200 row"
+        // dataset (see AC-16 note below) rendered with a bare .map() before
+        // this task -- VirtualList windows it past the 30-row threshold so
+        // an active-multi-agent day doesn't mount 100+ RecordCard DOM nodes
+        // at once.
         <div className="ev2-rc-grid ev2-rc-grid--2col">
-          {sessions.map((row) => (
-            <RecordCard
-              key={row.session_id}
-              recordId={row.session_id}
-              kindLabel={row.agent_type_id}
-              description={row.runtime ? `Runtime: ${row.runtime}` : undefined}
-              status={row.status}
-              variant="standard"
-            />
-          ))}
+          <VirtualList
+            items={sessions}
+            getKey={(row) => row.session_id}
+            estimateSize={96}
+            renderItem={(row) => (
+              <RecordCard
+                recordId={row.session_id}
+                kindLabel={row.agent_type_id}
+                description={row.runtime ? `Runtime: ${row.runtime}` : undefined}
+                status={row.status}
+                variant="standard"
+              />
+            )}
+          />
         </div>
       ),
     },

--- a/frontend/ui-v2/src/routes/router.tsx
+++ b/frontend/ui-v2/src/routes/router.tsx
@@ -2,18 +2,12 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  lazyRouteComponent,
   Outlet,
 } from '@tanstack/react-router'
 import { AppShell } from '../shell/AppShell'
-import { FeedRoute } from './FeedRoute'
 import { HomeRoute } from './HomeRoute'
 import { PlaceholderRoute } from './PlaceholderRoute'
-import { ProjectsRoute } from './ProjectsRoute'
-import { DocsRoute } from './DocsRoute'
-import { GovernanceRoute } from './GovernanceRoute'
-import { ChangelogRoute } from './ChangelogRoute'
-import { CoordinationRoute } from './CoordinationRoute'
-import { SkillLibraryRoute } from './SkillLibraryRoute'
 import { createSessionDetailRoute } from './SessionDetailRoute'
 import { createAgentDetailRoute } from './AgentDetailRoute'
 import { parseFeedSearch } from '../search/feedSearchParams'
@@ -79,32 +73,38 @@ const documentRoute = createDocumentRecordRoute({
   queryOptionsFor: documentQueryOptions,
 })
 
+// ENC-TSK-M18 (perf budget, AC-2): every non-Home top-level route is
+// code-split via lazyRouteComponent so the initial "/" bundle (mobile
+// default route) doesn't pay for Feed/Projects/Docs/Governance/Changelog/
+// Coordination/SkillLibrary JS it doesn't need. `parseFeedSearch` stays a
+// static import — it's a tiny pure function needed to validate the URL
+// before the Feed chunk loads, not the Feed UI itself.
 const feedRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/feed',
   validateSearch: parseFeedSearch,
-  component: FeedRoute,
+  component: lazyRouteComponent(() => import('./FeedRoute'), 'FeedRoute'),
 })
 
 const projectsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/projects',
-  component: ProjectsRoute,
+  component: lazyRouteComponent(() => import('./ProjectsRoute'), 'ProjectsRoute'),
 })
 const docsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/docs',
-  component: DocsRoute,
+  component: lazyRouteComponent(() => import('./DocsRoute'), 'DocsRoute'),
 })
 const governanceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/governance',
-  component: GovernanceRoute,
+  component: lazyRouteComponent(() => import('./GovernanceRoute'), 'GovernanceRoute'),
 })
 const changelogRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/changelog',
-  component: ChangelogRoute,
+  component: lazyRouteComponent(() => import('./ChangelogRoute'), 'ChangelogRoute'),
 })
 const coordinationRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -115,12 +115,12 @@ const coordinationRoute = createRoute({
   validateSearch: (raw: Record<string, unknown>) => ({
     tab: typeof raw.tab === 'string' ? raw.tab : '',
   }),
-  component: CoordinationRoute,
+  component: lazyRouteComponent(() => import('./CoordinationRoute'), 'CoordinationRoute'),
 })
 const skillLibraryRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/skills',
-  component: SkillLibraryRoute,
+  component: lazyRouteComponent(() => import('./SkillLibraryRoute'), 'SkillLibraryRoute'),
 })
 const sessionRoute = createSessionDetailRoute(() => rootRoute)
 const agentDetailRoute = createAgentDetailRoute({ getParentRoute: () => rootRoute })


### PR DESCRIPTION
## Summary
- Initial mobile route JS was a single monolithic 317.94 KB gz bundle (no code-splitting at all). `router.tsx` now lazy-loads every non-Home top-level route via `lazyRouteComponent()`, and `primitives/registry.tsx` lazy-loads all six record primitives via `React.lazy()` (the six `createRecordRoute` routes already wrap their component in a Suspense boundary, so this is a drop-in swap). This removes `PlanPrimitive -> PlanGraphExplorer -> cytoscape` (144 KB gz) from the initial payload.
- Added `scripts/assert-bundle-budget.mjs`, wired into `npm run build`, which parses `dist/index.html`'s initial `<script>` tags, gzips them, and fails the build if the total exceeds the 200KB AC-2 budget.
- Added a generic `VirtualList` component (`src/components/VirtualList.tsx`, threshold in `virtualListThreshold.ts`) on `@tanstack/react-virtual` — lists at/under 30 rows render directly, lists above the threshold are windowed. Wired into `CoordinationRoute`'s sessions tab (documented in-file as a "<=200 row" dataset, previously rendered with a bare `.map()`).

**Measured (before -> after, `npm run build` in `frontend/ui-v2`):**
- Initial route JS: 317.94 KB gz (single bundle) -> 147-151 KB gz (index chunk only; build-tool gzip vs. the assertion script's gzip level differ slightly) — under the 200KB AC-2 budget with ~25% headroom.
- `PlanPrimitive` (cytoscape) now its own lazy chunk: 144.23 KB gz, loaded only on `/plan/$id` visits.
- `CoordinationRoute` chunk: 10.80 KB gz (was 7.58 KB gz pre-virtualization; `@tanstack/react-virtual` only loads in this lazy chunk, confirmed via `assert-bundle-budget` — the initial index chunk size is unchanged at 147.28 KB gz after adding it).

## Not done in this PR (scoped out, noted for follow-up)
- Feed/Projects/agents/lessons/escalations/CRQ lists use the shared `design-system-2` `Cards` component rather than a bare `.map()` — retrofitting virtualization there means changing a component shared outside `ui-v2`'s ownership boundary, which is a higher-blast-radius change under concurrent multi-lane development. Left as a follow-up.
- AC-4 (tap feedback <100ms / route transition <200ms on a throttled mid-tier device) needs a real device/Lighthouse-throttled profiling pass with an authenticated session — not provable from an agent session that must not hold Cognito tokens. The route code-splitting in this PR is expected to help route-transition latency (smaller initial payload for the target route) but this claim is unverified against the literal device-throttled numbers in the AC.
- AC-1 (local-first paint generalized to Home/Feed/Coordination/Projects) is largely already satisfied by the existing react-query persisted cache (`sync/queryPersist.ts` + `CacheEngineProvider`) which hydrates from IndexedDB non-blockingly on every route — this PR does not change that layer, just confirmed its shape while investigating.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 205/205 tests pass (added 5 new: `virtualListThreshold.test.ts` x3, `VirtualList.test.tsx` x2)
- [x] `npm run build` — bundle-budget gate passes (147.28 KB gz vs 200 KB budget)
- [x] Dev server rendered cleanly at 375x812 mobile viewport, no console errors (verified via Sign-in gate since no Cognito session was injected)
- [ ] Human UAT: authenticated session + real-device/throttled profiling for AC-4's literal ms thresholds

CCI-248b766b4ee74b7c83cc1e9a6cb7d01c

🤖 Generated with [Claude Code](https://claude.com/claude-code)