### PR TITLE
ENC-TSK-M23: Record Details mobile hub (FND-03, cutover-blocking)

### DIFF
--- a/frontend/ui-v2/src/components/RecordDetailHub.tsx
+++ b/frontend/ui-v2/src/components/RecordDetailHub.tsx
@@ -1,0 +1,270 @@
+import { useState, type ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+import { RecordId } from './RecordId'
+import { StatusChip } from './StatusChip'
+import { Tabs } from '../design-system'
+import { recordHrefForType } from '../routes/recordLink'
+import type {
+  AcceptanceCriterion,
+  HistoryEntry,
+  RecordType,
+  TypedRelationshipEdge,
+} from '../types/records'
+import { TypedRelationshipSection } from './TypedRelationshipSection'
+import './recordDetailHub.css'
+
+export interface HubVital {
+  label: string
+  value: ReactNode
+}
+
+export interface HubAction {
+  label: string
+  href?: string
+  onClick?: () => void
+}
+
+/**
+ * RecordDetailHub -- the mobile-first Record Details organism (ENC-TSK-M23 /
+ * FND-03, cutover-blocking). Mobile base: a focused head (kind + ID + title
+ * + StatusChip + a key-value vitals grid) above the fold, a sticky bottom
+ * action bar in the thumb zone, and Overview/Neighbors/Worklog/Evidence
+ * behind a segmented `Tabs` control (design-system-2) so non-Overview
+ * content is only constructed once its tab is opened. Desktop (>= 64rem)
+ * projects the same segments into a two-column hub: head+actions become a
+ * sticky sidebar, tab content sits alongside it.
+ *
+ * Read-only surface by design (architect direction, DOC-6EFD5DB32CD8): the
+ * built-in action is Copy ID; callers may pass additional link-only actions
+ * (e.g. "Open PR") ONLY when the record's own data actually supports them.
+ * No governed-mutation trigger (Advance/Escalate) is wired from this page.
+ */
+export function RecordDetailHub({
+  recordId,
+  kindLabel,
+  title,
+  status,
+  priority,
+  recordType,
+  vitals = [],
+  overview,
+  neighbors,
+  worklog,
+  evidence,
+  actions = [],
+}: {
+  recordId: string
+  kindLabel: string
+  title: string
+  status?: string
+  priority?: string
+  recordType?: string
+  vitals?: HubVital[]
+  overview: ReactNode
+  neighbors?: ReactNode
+  worklog?: ReactNode
+  evidence?: ReactNode
+  actions?: HubAction[]
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const copyId = () => {
+    navigator.clipboard
+      ?.writeText(recordId)
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      })
+      .catch(() => {
+        // Clipboard API unavailable/denied -- the ID is always visible in
+        // the head for manual copy, so this is a silent no-op.
+      })
+  }
+
+  const tabs = [
+    { id: 'overview', label: 'Overview', content: overview },
+    ...(neighbors ? [{ id: 'neighbors', label: 'Neighbors', content: neighbors }] : []),
+    ...(worklog ? [{ id: 'worklog', label: 'Worklog', content: worklog }] : []),
+    ...(evidence ? [{ id: 'evidence', label: 'Evidence', content: evidence }] : []),
+  ]
+
+  return (
+    <div className="ev2-rdh">
+      <div className="ev2-rdh__main">
+        <header className="ev2-rdh__head">
+          <div className="ev2-rdh__kicker">
+            <span className="ev2-rdh__kind">{kindLabel}</span>
+            <RecordId id={recordId} />
+            {status ? (
+              <StatusChip status={status} priority={priority} recordType={recordType} />
+            ) : null}
+          </div>
+          <h1 className="ev2-rdh__title">{title}</h1>
+          {vitals.length ? (
+            <dl className="ev2-rdh__vitals">
+              {vitals.map((v) => (
+                <div className="ev2-rdh__vital" key={v.label}>
+                  <dt className="ev2-rdh__vital-label">{v.label}</dt>
+                  <dd className="ev2-rdh__vital-value">{v.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+          <div className="ev2-rdh__actionbar ev2-rdh__actionbar--inline">
+            <ActionButtons copied={copied} onCopy={copyId} actions={actions} />
+          </div>
+        </header>
+
+        <section className="ev2-rdh__body">
+          <Tabs tabs={tabs} />
+        </section>
+      </div>
+
+      <div
+        className="ev2-rdh__actionbar ev2-rdh__actionbar--sticky"
+        role="toolbar"
+        aria-label="Record actions"
+      >
+        <ActionButtons copied={copied} onCopy={copyId} actions={actions} />
+      </div>
+    </div>
+  )
+}
+
+function ActionButtons({
+  copied,
+  onCopy,
+  actions,
+}: {
+  copied: boolean
+  onCopy: () => void
+  actions: HubAction[]
+}) {
+  return (
+    <>
+      <button type="button" className="ev2-rdh__action ev2-rdh__action--copy" onClick={onCopy}>
+        {copied ? 'Copied' : 'Copy ID'}
+      </button>
+      {actions.map((a) =>
+        a.href ? (
+          <a key={a.label} className="ev2-rdh__action" href={a.href} target="_blank" rel="noreferrer">
+            {a.label}
+          </a>
+        ) : (
+          <button key={a.label} type="button" className="ev2-rdh__action" onClick={a.onClick}>
+            {a.label}
+          </button>
+        ),
+      )}
+    </>
+  )
+}
+
+function inferNeighborType(id: string): RecordType {
+  if (id.startsWith('DOC-')) return 'document'
+  if (id.includes('-PLN-')) return 'plan'
+  if (id.includes('-ISS-')) return 'issue'
+  if (id.includes('-FTR-')) return 'feature'
+  if (id.includes('-LSN-')) return 'lesson'
+  return 'task'
+}
+
+/** One labeled group of plain (untyped) related-record IDs, rendered as
+ *  navigable rows -- clicking a neighbor goes to THAT record's own details
+ *  page (graph navigable), never a modal or inline expansion. */
+export function NeighborGroup({
+  label,
+  ids,
+  projectId,
+  type,
+}: {
+  label: string
+  ids: string[] | undefined
+  projectId: string
+  type?: RecordType
+}) {
+  if (!ids?.length) return null
+  return (
+    <div className="ev2-rdh__neighbor-group">
+      <div className="ev2-rdh__neighbor-label">
+        {label} <span className="ev2-rdh__neighbor-count">{ids.length}</span>
+      </div>
+      <ul className="ev2-rdh__neighbor-list">
+        {ids.map((id) => {
+          const t = type ?? inferNeighborType(id)
+          return (
+            <li key={id}>
+              <Link
+                to={recordHrefForType(t === 'document' ? null : projectId, t, id)}
+                className="ev2-rdh__neighbor-link"
+              >
+                <RecordId id={id} />
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+/** Neighbors tab body: plain related-id groups plus the existing typed-edge
+ *  graph section (TypedRelationshipSection), when either is present. */
+export function NeighborsTab({
+  projectId,
+  groups,
+  typedEdges,
+}: {
+  projectId: string
+  groups: { label: string; ids: string[] | undefined; type?: RecordType }[]
+  typedEdges?: TypedRelationshipEdge[]
+}) {
+  return (
+    <div className="ev2-rdh__neighbors">
+      {groups.map((g) => (
+        <NeighborGroup key={g.label} label={g.label} ids={g.ids} projectId={projectId} type={g.type} />
+      ))}
+      {typedEdges?.length ? (
+        <TypedRelationshipSection projectId={projectId} edges={typedEdges} />
+      ) : null}
+    </div>
+  )
+}
+
+/** Worklog tab body: the record's history[], most recent first. */
+export function WorklogTab({ history }: { history: HistoryEntry[] | undefined }) {
+  if (!history?.length) return null
+  return (
+    <ul className="ev2-rdh__worklog-list">
+      {[...history].reverse().map((h, i) => (
+        <li className="ev2-rdh__worklog-item" key={`${h.timestamp}-${i}`}>
+          <div className="ev2-rdh__worklog-meta">
+            <span className="ev2-rdh__worklog-ts">{h.timestamp}</span>
+            <StatusChip status={h.status} />
+          </div>
+          <p className="ev2-rdh__worklog-desc">{h.description}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/** Evidence tab body: acceptance-criteria stamps (governed AC evidence). */
+export function EvidenceTab({ criteria }: { criteria: AcceptanceCriterion[] | undefined }) {
+  if (!criteria?.length) return null
+  return (
+    <ul className="ev2-rdh__evidence-list">
+      {criteria.map((c, i) => (
+        <li className="ev2-rdh__evidence-item" key={i}>
+          <span className={`ev2-rdh__evidence-badge${c.evidence_acceptance ? ' is-accepted' : ''}`}>
+            {c.evidence_acceptance ? 'Accepted' : 'Pending'}
+          </span>
+          <div className="ev2-rdh__evidence-body">
+            <p className="ev2-rdh__evidence-desc">{c.description}</p>
+            {c.evidence ? <p className="ev2-rdh__evidence-proof">{c.evidence}</p> : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/ui-v2/src/components/recordDetailHub.css
+++ b/frontend/ui-v2/src/components/recordDetailHub.css
@@ -1,0 +1,314 @@
+/* ENC-TSK-M23 -- Record Detail Hub, mobile-first record details organism.
+   Mobile base: single column, sticky bottom action bar in the thumb zone.
+   Desktop (>= 64rem): two-column hub; head becomes a sticky sidebar and the
+   action bar folds inline into it instead of pinning to the viewport. */
+
+.ev2-rdh {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding-bottom: calc(64px + var(--space-4));
+}
+
+.ev2-rdh__main {
+  display: block;
+  min-width: 0;
+}
+
+.ev2-rdh__head {
+  background: var(--bg-surface);
+  border: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-md);
+  box-sizing: border-box;
+  margin-bottom: var(--space-5);
+}
+
+.ev2-rdh__kicker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+
+.ev2-rdh__kind {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--accent);
+}
+
+.ev2-rdh__title {
+  font-family: var(--font-heading);
+  font-weight: var(--fw-medium);
+  font-size: var(--text-2xl);
+  line-height: var(--lh-snug);
+  color: var(--fg-display);
+  margin: 0 0 var(--space-5);
+}
+
+.ev2-rdh__vitals {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-3);
+  margin: 0 0 var(--space-5);
+}
+
+.ev2-rdh__vital {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ev2-rdh__vital-label {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.ev2-rdh__vital-value {
+  font-size: var(--text-sm);
+  color: var(--fg);
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.ev2-rdh__body {
+  background: var(--bg-surface);
+  border: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-2) var(--space-6) var(--space-6);
+  box-shadow: var(--shadow-md);
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.ev2-rdh__actionbar {
+  display: flex;
+  gap: var(--space-3);
+  box-sizing: border-box;
+}
+
+.ev2-rdh__actionbar--inline {
+  display: none;
+}
+
+.ev2-rdh__actionbar--sticky {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border-top: var(--border-subtle);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.28);
+  max-width: 100%;
+}
+
+.ev2-rdh__action {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  appearance: none;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  font-weight: var(--fw-medium);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--dur-base) var(--ease-orbit),
+    color var(--dur-base) var(--ease-orbit);
+}
+
+.ev2-rdh__action:hover {
+  background: var(--accent);
+  color: var(--bg-surface);
+}
+
+.ev2-rdh__action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ev2-rdh__action--copy {
+  border-style: dashed;
+}
+
+.ev2-rdh__neighbors {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.ev2-rdh__neighbor-label {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--fg-muted);
+  margin-bottom: var(--space-2);
+}
+
+.ev2-rdh__neighbor-count {
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+
+.ev2-rdh__neighbor-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ev2-rdh__neighbor-link {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  border: var(--border-subtle);
+  transition: border-color var(--dur-base) var(--ease-orbit);
+}
+
+.ev2-rdh__neighbor-link:hover {
+  border: var(--border-hover);
+}
+
+.ev2-rdh__worklog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.ev2-rdh__worklog-item {
+  border-top: var(--border-divider);
+  padding-top: var(--space-3);
+}
+
+.ev2-rdh__worklog-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-1);
+}
+
+.ev2-rdh__worklog-ts {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.ev2-rdh__worklog-desc {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--fg);
+}
+
+.ev2-rdh__evidence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.ev2-rdh__evidence-item {
+  display: flex;
+  gap: var(--space-3);
+  border-top: var(--border-divider);
+  padding-top: var(--space-3);
+}
+
+.ev2-rdh__evidence-badge {
+  flex: 0 0 auto;
+  height: fit-content;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--fg-muted);
+  color: var(--fg-muted);
+}
+
+.ev2-rdh__evidence-badge.is-accepted {
+  border-color: var(--status-open);
+  color: var(--status-open);
+}
+
+.ev2-rdh__evidence-desc {
+  margin: 0 0 var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--fg);
+}
+
+.ev2-rdh__evidence-proof {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+@media (min-width: 64rem) {
+  .ev2-rdh {
+    display: grid;
+    grid-template-columns: 22rem minmax(0, 1fr);
+    gap: var(--space-6);
+    align-items: start;
+    padding-bottom: 0;
+  }
+
+  .ev2-rdh__main {
+    display: contents;
+  }
+
+  .ev2-rdh__head {
+    position: sticky;
+    top: var(--space-6);
+    margin-bottom: 0;
+  }
+
+  .ev2-rdh__vitals {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ev2-rdh__actionbar--inline {
+    display: flex;
+    margin-top: var(--space-5);
+  }
+
+  .ev2-rdh__actionbar--sticky {
+    display: none;
+  }
+}

--- a/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
@@ -1,32 +1,43 @@
 import { FileText } from 'lucide-react'
 import type { Document } from '../types/records'
-import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { NeighborsTab, RecordDetailHub } from '../components/RecordDetailHub'
 
 export function DocumentPrimitive({ record }: { record: Document }) {
+  const vitals = [
+    { label: 'Project', value: record.project_id },
+    { label: 'Version', value: `v${record.version ?? '?'}` },
+    ...(record.document_subtype ? [{ label: 'Subtype', value: record.document_subtype }] : []),
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.document_id}
       kindLabel="Document"
       title={record.title}
       status={record.status}
-    >
-      <Prose>{record.description}</Prose>
-      <MetaRow label="File">
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <FileText size={14} strokeWidth={1.5} color="var(--accent)" />
-          <span style={{ fontFamily: 'var(--font-mono)' }}>{record.file_name}</span>
-        </span>
-      </MetaRow>
-      {record.document_subtype ? (
-        <MetaRow label="Subtype">{record.document_subtype}</MetaRow>
-      ) : null}
-      <MetaRow label="Version">
-        <Metric>v{record.version ?? '?'}</Metric>
-      </MetaRow>
-      <MetaRow label="Keywords">
-        {(record.keywords ?? []).length > 0 ? (record.keywords ?? []).join(', ') : 'None'}
-      </MetaRow>
-      <MetaRow label="Created by">{record.created_by}</MetaRow>
-    </PrimitiveCard>
+      vitals={vitals}
+      overview={
+        <>
+          <Prose>{record.description}</Prose>
+          <MetaRow label="File">
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <FileText size={14} strokeWidth={1.5} color="var(--accent)" />
+              <span style={{ fontFamily: 'var(--font-mono)' }}>{record.file_name}</span>
+            </span>
+          </MetaRow>
+          <MetaRow label="Version">
+            <Metric>v{record.version ?? '?'}</Metric>
+          </MetaRow>
+          <MetaRow label="Keywords">
+            {(record.keywords ?? []).length > 0 ? (record.keywords ?? []).join(', ') : 'None'}
+          </MetaRow>
+          <MetaRow label="Created by">{record.created_by}</MetaRow>
+        </>
+      }
+      neighbors={
+        <NeighborsTab projectId={record.project_id} groups={[{ label: 'Related items', ids: record.related_items }]} />
+      }
+    />
   )
 }

--- a/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
@@ -1,37 +1,48 @@
 import { Sparkles } from 'lucide-react'
 import type { Feature } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
-import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
 
 export function FeaturePrimitive({ record }: { record: Feature }) {
+  const vitals = [
+    { label: 'Project', value: record.project_id },
+    ...(record.transition_type ? [{ label: 'Transition type', value: record.transition_type }] : []),
+    ...(record.checked_out_by
+      ? [{ label: 'Checkout', value: `${record.checked_out_by} (${record.checkout_state ?? 'checked_out'})` }]
+      : []),
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.feature_id}
       kindLabel="Feature"
       title={record.title}
       status={record.status}
-    >
-      <Prose>{record.description}</Prose>
-      <MetaRow label="Owners">
-        {(record.owners ?? []).length > 0 ? (record.owners ?? []).join(', ') : 'Unowned'}
-      </MetaRow>
-      <MetaRow label="Success metrics">
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <Sparkles size={14} strokeWidth={1.5} color="var(--accent)" />
-          <Metric>{record.success_metrics?.length ?? 0}</Metric>
-        </span>
-      </MetaRow>
-      <MetaRow label="Related tasks">
-        <Metric>{record.related_task_ids?.length ?? 0}</Metric>
-      </MetaRow>
-      <ContextNodeBadges contextNode={record.context_node} />
-      {record.typed_relationships?.length ? (
-        <TypedRelationshipSection
+      vitals={vitals}
+      overview={
+        <>
+          <Prose>{record.description}</Prose>
+          <MetaRow label="Owners">
+            {(record.owners ?? []).length > 0 ? (record.owners ?? []).join(', ') : 'Unowned'}
+          </MetaRow>
+          <MetaRow label="Success metrics">
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <Sparkles size={14} strokeWidth={1.5} color="var(--accent)" />
+              <Metric>{record.success_metrics?.length ?? 0}</Metric>
+            </span>
+          </MetaRow>
+          <ContextNodeBadges contextNode={record.context_node} />
+        </>
+      }
+      neighbors={
+        <NeighborsTab
           projectId={record.project_id}
-          edges={record.typed_relationships}
+          groups={[{ label: 'Related tasks', ids: record.related_task_ids, type: 'task' }]}
+          typedEdges={record.typed_relationships}
         />
-      ) : null}
-    </PrimitiveCard>
+      }
+      worklog={<WorklogTab history={record.history} />}
+    />
   )
 }

--- a/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
@@ -1,40 +1,53 @@
 import { AlertTriangle } from 'lucide-react'
 import type { Issue } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
-import { MetaRow, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Prose } from '../components/PrimitiveCard'
+import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
 
 export function IssuePrimitive({ record }: { record: Issue }) {
+  const vitals = [
+    { label: 'Priority', value: record.priority },
+    { label: 'Severity', value: record.severity },
+    { label: 'Project', value: record.project_id },
+    ...(record.transition_type ? [{ label: 'Transition type', value: record.transition_type }] : []),
+    ...(record.checked_out_by
+      ? [{ label: 'Checkout', value: `${record.checked_out_by} (${record.checkout_state ?? 'checked_out'})` }]
+      : []),
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.issue_id}
       kindLabel="Issue"
       title={record.title}
       status={record.status}
       priority={record.priority}
-    >
-      <Prose>{record.description}</Prose>
-      <MetaRow label="Priority">{record.priority}</MetaRow>
-      <MetaRow label="Severity">
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <AlertTriangle
-            size={14}
-            strokeWidth={1.5}
-            color={record.severity === 'critical' ? 'var(--danger)' : 'var(--fg-muted)'}
-          />
-          {record.severity}
-        </span>
-      </MetaRow>
-      {record.hypothesis ? (
-        <MetaRow label="Hypothesis">{record.hypothesis}</MetaRow>
-      ) : null}
-      <ContextNodeBadges contextNode={record.context_node} />
-      {record.typed_relationships?.length ? (
-        <TypedRelationshipSection
+      vitals={vitals}
+      overview={
+        <>
+          <Prose>{record.description}</Prose>
+          <MetaRow label="Severity">
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <AlertTriangle
+                size={14}
+                strokeWidth={1.5}
+                color={record.severity === 'critical' ? 'var(--danger)' : 'var(--fg-muted)'}
+              />
+              {record.severity}
+            </span>
+          </MetaRow>
+          {record.hypothesis ? <MetaRow label="Hypothesis">{record.hypothesis}</MetaRow> : null}
+          <ContextNodeBadges contextNode={record.context_node} />
+        </>
+      }
+      neighbors={
+        <NeighborsTab
           projectId={record.project_id}
-          edges={record.typed_relationships}
+          groups={[{ label: 'Related tasks', ids: record.related_task_ids, type: 'task' }]}
+          typedEdges={record.typed_relationships}
         />
-      ) : null}
-    </PrimitiveCard>
+      }
+      worklog={<WorklogTab history={record.history} />}
+    />
   )
 }

--- a/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/LessonPrimitive.tsx
@@ -1,7 +1,8 @@
 import { Lightbulb } from 'lucide-react'
 import type { Lesson } from '../types/records'
-import { MetaRow, PrimitiveCard, Prose } from '../components/PrimitiveCard'
-import { BarChart, KeyValuePairs } from '../design-system'
+import { MetaRow, Prose } from '../components/PrimitiveCard'
+import { NeighborsTab, RecordDetailHub } from '../components/RecordDetailHub'
+import { BarChart } from '../design-system'
 
 const PILLAR_LABELS: { key: keyof Lesson['pillar_scores']; label: string }[] = [
   { key: 'efficiency', label: 'Efficiency' },
@@ -11,72 +12,70 @@ const PILLAR_LABELS: { key: keyof Lesson['pillar_scores']; label: string }[] = [
 ]
 
 export function LessonPrimitive({ record }: { record: Lesson }) {
+  const vitals = [
+    { label: 'Project', value: record.project_id },
+    { label: 'Category', value: record.category },
+    { label: 'Confidence', value: (record.confidence ?? 0).toFixed(2) },
+    { label: 'Pillar composite', value: (record.pillar_composite ?? 0).toFixed(3) },
+    { label: 'Resonance', value: (record.resonance_score ?? 0).toFixed(3) },
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.lesson_id}
       kindLabel="Lesson"
       title={record.title}
       status={record.status}
       recordType="lesson"
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-2)',
-          marginBottom: 'var(--space-3)',
-          color: 'var(--knowledge)',
-        }}
-      >
-        <Lightbulb size={16} strokeWidth={1.5} />
-        <span
-          style={{
-            fontFamily: 'var(--font-heading)',
-            fontSize: 'var(--text-xs)',
-            textTransform: 'uppercase',
-            letterSpacing: 'var(--tracking-label)',
-          }}
-        >
-          {record.category}
-        </span>
-      </div>
-      <Prose>{record.observation}</Prose>
-      <blockquote
-        style={{
-          borderLeft: '4px solid var(--knowledge)',
-          margin: 'var(--space-4) 0',
-          padding: 'var(--space-4) var(--space-5)',
-          fontStyle: 'italic',
-          background: 'rgba(138, 140, 181, 0.08)',
-          borderRadius: 'var(--radius-md)',
-          color: 'var(--fg)',
-        }}
-      >
-        {record.insight}
-      </blockquote>
-      <div style={{ marginBottom: 'var(--space-4)' }}>
-        <KeyValuePairs
-          columns={3}
-          items={[
-            { label: 'Confidence', value: (record.confidence ?? 0).toFixed(2), mono: true },
-            { label: 'Pillar Composite', value: (record.pillar_composite ?? 0).toFixed(3), mono: true },
-            { label: 'Resonance', value: (record.resonance_score ?? 0).toFixed(3), mono: true },
-          ]}
+      vitals={vitals}
+      overview={
+        <>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+              marginBottom: 'var(--space-3)',
+              color: 'var(--knowledge)',
+            }}
+          >
+            <Lightbulb size={16} strokeWidth={1.5} />
+          </div>
+          <Prose>{record.observation}</Prose>
+          <blockquote
+            style={{
+              borderLeft: '4px solid var(--knowledge)',
+              margin: 'var(--space-4) 0',
+              padding: 'var(--space-4) var(--space-5)',
+              fontStyle: 'italic',
+              background: 'rgba(138, 140, 181, 0.08)',
+              borderRadius: 'var(--radius-md)',
+              color: 'var(--fg)',
+            }}
+          >
+            {record.insight}
+          </blockquote>
+          <BarChart
+            title="Constitutional Pillar Scores"
+            subtitle="DOC-6EFD5DB32CD8 -- efficiency / human_protection / intention / alignment"
+            xDomain={PILLAR_LABELS.map((p) => p.label)}
+            series={[
+              {
+                title: 'Pillar Scores',
+                data: PILLAR_LABELS.map((p) => record.pillar_scores?.[p.key] ?? 0),
+              },
+            ]}
+            height={220}
+          />
+          <MetaRow label="Provenance">{record.provenance}</MetaRow>
+        </>
+      }
+      neighbors={
+        <NeighborsTab
+          projectId={record.project_id}
+          groups={[{ label: 'Evidence chain', ids: record.evidence_chain }]}
         />
-      </div>
-      <BarChart
-        title="Constitutional Pillar Scores"
-        subtitle="DOC-6EFD5DB32CD8 — efficiency / human_protection / intention / alignment"
-        xDomain={PILLAR_LABELS.map((p) => p.label)}
-        series={[
-          {
-            title: 'Pillar Scores',
-            data: PILLAR_LABELS.map((p) => record.pillar_scores?.[p.key] ?? 0),
-          },
-        ]}
-        height={220}
-      />
-      <MetaRow label="Provenance">{record.provenance}</MetaRow>
-    </PrimitiveCard>
+      }
+    />
   )
 }

--- a/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
@@ -2,41 +2,60 @@ import { Map as MapIcon } from 'lucide-react'
 import type { Plan } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
 import { PlanGraphExplorer } from '../components/PlanGraphExplorer'
-import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
-import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
 
 export function PlanPrimitive({ record }: { record: Plan }) {
+  const vitals = [
+    { label: 'Priority', value: record.priority },
+    { label: 'Project', value: record.project_id },
+    { label: 'Category', value: record.category ?? 'Uncategorized' },
+    ...(record.transition_type ? [{ label: 'Transition type', value: record.transition_type }] : []),
+    ...(record.checked_out_by
+      ? [{ label: 'Checkout', value: `${record.checked_out_by} (${record.checkout_state ?? 'checked_out'})` }]
+      : []),
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.plan_id}
       kindLabel="Plan"
       title={record.title}
       status={record.status}
-    >
-      <Prose>{record.description}</Prose>
-      <MetaRow label="Priority">{record.priority}</MetaRow>
-      <MetaRow label="Category">{record.category ?? 'Uncategorized'}</MetaRow>
-      <MetaRow label="Objectives">
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <MapIcon size={14} strokeWidth={1.5} color="var(--accent)" />
-          <Metric>{record.objectives_set?.length ?? 0}</Metric>
-        </span>
-      </MetaRow>
-      <MetaRow label="Attached docs">
-        <Metric>{record.attached_documents?.length ?? 0}</Metric>
-      </MetaRow>
-      <PlanGraphExplorer
-        projectId={record.project_id}
-        planId={record.plan_id}
-        objectiveIds={record.objectives_set ?? []}
-      />
-      <ContextNodeBadges contextNode={record.context_node} />
-      {record.typed_relationships?.length ? (
-        <TypedRelationshipSection
+      priority={record.priority}
+      vitals={vitals}
+      overview={
+        <>
+          <Prose>{record.description}</Prose>
+          <MetaRow label="Objectives">
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <MapIcon size={14} strokeWidth={1.5} color="var(--accent)" />
+              <Metric>{record.objectives_set?.length ?? 0}</Metric>
+            </span>
+          </MetaRow>
+          <MetaRow label="Attached docs">
+            <Metric>{record.attached_documents?.length ?? 0}</Metric>
+          </MetaRow>
+          <PlanGraphExplorer
+            projectId={record.project_id}
+            planId={record.plan_id}
+            objectiveIds={record.objectives_set ?? []}
+          />
+          <ContextNodeBadges contextNode={record.context_node} />
+        </>
+      }
+      neighbors={
+        <NeighborsTab
           projectId={record.project_id}
-          edges={record.typed_relationships}
+          groups={[
+            { label: 'Objectives', ids: record.objectives_set, type: 'task' },
+            { label: 'Attached documents', ids: record.attached_documents, type: 'document' },
+            { label: 'Related tasks', ids: record.related_task_ids, type: 'task' },
+          ]}
+          typedEdges={record.typed_relationships}
         />
-      ) : null}
-    </PrimitiveCard>
+      }
+      worklog={<WorklogTab history={record.history} />}
+    />
   )
 }

--- a/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
@@ -1,44 +1,56 @@
 import { ListChecks } from 'lucide-react'
 import type { Task } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { TypedRelationshipSection } from '../components/TypedRelationshipSection'
-import { MetaRow, Metric, PrimitiveCard, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { EvidenceTab, NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
 
 export function TaskPrimitive({ record }: { record: Task }) {
+  const vitals = [
+    { label: 'Priority', value: record.priority },
+    { label: 'Project', value: record.project_id },
+    ...(record.transition_type ? [{ label: 'Transition type', value: record.transition_type }] : []),
+    ...(record.checked_out_by
+      ? [{ label: 'Checkout', value: `${record.checked_out_by} (${record.checkout_state ?? 'checked_out'})` }]
+      : []),
+  ]
+
   return (
-    <PrimitiveCard
+    <RecordDetailHub
       recordId={record.task_id}
       kindLabel="Task"
       title={record.title}
       status={record.status}
       priority={record.priority}
-    >
-      <Prose>{record.description}</Prose>
-      <MetaRow label="Priority">{record.priority}</MetaRow>
-      <MetaRow label="Assigned">{record.assigned_to ?? 'Unassigned'}</MetaRow>
-      <MetaRow label="Checklist">
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <ListChecks size={14} strokeWidth={1.5} color="var(--accent)" />
-          <Metric>
-            {record.checklist_done ?? 0}/{record.checklist_total ?? 0}
-          </Metric>
-        </span>
-      </MetaRow>
-      <MetaRow label="Related">
-        <Metric>
-          {(record.related_task_ids?.length ?? 0) +
-            (record.related_issue_ids?.length ?? 0) +
-            (record.related_feature_ids?.length ?? 0)}
-        </Metric>{' '}
-        edges
-      </MetaRow>
-      <ContextNodeBadges contextNode={record.context_node} />
-      {record.typed_relationships?.length ? (
-        <TypedRelationshipSection
+      vitals={vitals}
+      overview={
+        <>
+          <Prose>{record.description}</Prose>
+          <MetaRow label="Assigned">{record.assigned_to ?? 'Unassigned'}</MetaRow>
+          <MetaRow label="Checklist">
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <ListChecks size={14} strokeWidth={1.5} color="var(--accent)" />
+              <Metric>
+                {record.checklist_done ?? 0}/{record.checklist_total ?? 0}
+              </Metric>
+            </span>
+          </MetaRow>
+          <ContextNodeBadges contextNode={record.context_node} />
+        </>
+      }
+      neighbors={
+        <NeighborsTab
           projectId={record.project_id}
-          edges={record.typed_relationships}
+          groups={[
+            { label: 'Related tasks', ids: record.related_task_ids, type: 'task' },
+            { label: 'Related issues', ids: record.related_issue_ids, type: 'issue' },
+            { label: 'Related features', ids: record.related_feature_ids, type: 'feature' },
+            { label: 'Subtasks', ids: record.subtask_ids, type: 'task' },
+          ]}
+          typedEdges={record.typed_relationships}
         />
-      ) : null}
-    </PrimitiveCard>
+      }
+      worklog={<WorklogTab history={record.history} />}
+      evidence={<EvidenceTab criteria={record.acceptance_criteria} />}
+    />
   )
 }

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -223,3 +223,49 @@ describe('card grid mobile collapse (ENC-ISS-516 / defect B)', () => {
     }
   })
 })
+
+/**
+ * ENC-TSK-M23 (FND-03, cutover-blocking) -- Record Details mobile hub.
+ * Same static-CSS-assertion approach as the suites above: jsdom has no real
+ * cascade, so this reads the shipped recordDetailHub.css and RecordDetailHub
+ * component source directly.
+ */
+describe('record detail hub sticky action bar (ENC-TSK-M23)', () => {
+  const hubCss = stripCssComments(readSrc('components/recordDetailHub.css'))
+  const hubSrc = readSrc('components/RecordDetailHub.tsx')
+
+  it('ships a mobile-base sticky bottom action bar pinned to the viewport', () => {
+    const stickyMatch = hubCss.match(/\.ev2-rdh__actionbar--sticky\s*\{([^}]*)\}/)
+    expect(stickyMatch, 'expected a .ev2-rdh__actionbar--sticky rule').not.toBeNull()
+    const stickyRule = stickyMatch?.[1] ?? ''
+    expect(stickyRule).toMatch(/position:\s*fixed/)
+    expect(stickyRule).toMatch(/bottom:\s*0/)
+  })
+
+  it('folds the action bar inline and hides the fixed bar at the desktop breakpoint', () => {
+    const desktopBlock = extractBlock(hubCss, /@media \(min-width: 64rem\) \{/)
+    expect(desktopBlock.length).toBeGreaterThan(0)
+    expect(desktopBlock).toMatch(/\.ev2-rdh__actionbar--inline\s*\{[^}]*display:\s*flex/)
+    expect(desktopBlock).toMatch(/\.ev2-rdh__actionbar--sticky\s*\{[^}]*display:\s*none/)
+  })
+
+  it('renders the sticky bar as a real toolbar with a Copy ID action', () => {
+    expect(hubSrc).toMatch(/ev2-rdh__actionbar--sticky/)
+    expect(hubSrc).toMatch(/role="toolbar"/)
+    expect(hubSrc).toMatch(/Copy ID/)
+  })
+
+  it('keeps the hub and its vitals grid capped to their container width (no horizontal scroll)', () => {
+    const rootMatch = hubCss.match(/\.ev2-rdh\s*\{([^}]*)\}/)
+    expect(rootMatch?.[1] ?? '').toMatch(/max-width:\s*100%/)
+    const vitalsMatch = hubCss.match(/\.ev2-rdh__vitals\s*\{([^}]*)\}/)
+    expect(vitalsMatch?.[1] ?? '').toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)/)
+    const bodyMatch = hubCss.match(/\.ev2-rdh__body\s*\{([^}]*)\}/)
+    expect(bodyMatch?.[1] ?? '').toMatch(/max-width:\s*100%/)
+  })
+
+  it('reserves bottom padding on mobile so the fixed bar never occludes content', () => {
+    const rootMatch = hubCss.match(/\.ev2-rdh\s*\{([^}]*)\}/)
+    expect(rootMatch?.[1] ?? '').toMatch(/padding-bottom:/)
+  })
+})

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -43,7 +43,25 @@ export interface RecordExtensions {
   subtask_ids?: string[]
 }
 
-export interface Task {
+/** AC evidence stamp (ENC-TSK-M23 / FND-03) -- the shape tracker.get returns
+ *  under `acceptance_criteria` for governed records. */
+export interface AcceptanceCriterion {
+  description: string
+  evidence: string
+  evidence_acceptance: boolean
+}
+
+/**
+ * Governed lifecycle metadata shared by every checked-out-able tracker
+ * record (ENC-TSK-M23 / FND-03).
+ */
+export interface GovernedLifecycleMeta {
+  transition_type?: string
+  checkout_state?: string
+  checked_out_by?: string | null
+}
+
+export interface Task extends GovernedLifecycleMeta {
   task_id: string
   project_id: string
   title: string
@@ -63,9 +81,10 @@ export interface Task {
   typed_relationships?: TypedRelationshipEdge[]
   context_node?: ContextNodeMeta
   subtask_ids?: string[]
+  acceptance_criteria?: AcceptanceCriterion[]
 }
 
-export interface Issue {
+export interface Issue extends GovernedLifecycleMeta {
   issue_id: string
   project_id: string
   title: string
@@ -82,7 +101,7 @@ export interface Issue {
   context_node?: ContextNodeMeta
 }
 
-export interface Feature {
+export interface Feature extends GovernedLifecycleMeta {
   feature_id: string
   project_id: string
   title: string
@@ -98,7 +117,7 @@ export interface Feature {
   context_node?: ContextNodeMeta
 }
 
-export interface Plan {
+export interface Plan extends GovernedLifecycleMeta {
   plan_id: string
   project_id: string
   title: string
@@ -158,11 +177,6 @@ export interface Document {
   document_subtype?: string
 }
 
-/**
- * Maps each record type to its concrete record interface. Used to keep the
- * query-options factories, the primitive registry, and the routes in lockstep
- * so `useSuspenseQuery` returns a fully-typed `T`, never `T | undefined`.
- */
 export interface RecordShapeMap {
   task: Task
   issue: Issue


### PR DESCRIPTION
## Summary
- Adds `RecordDetailHub`, a mobile-first Record Details organism replacing the desktop-only `PrimitiveCard` shell for all six governed record primitives (task/issue/feature/plan/lesson/document).
- Mobile base: focused head above the fold (record ID mono-teal, title, StatusChip, key-value vitals grid -- priority/project/transition_type/checkout state/scores where present), a sticky bottom action bar in the thumb zone (Copy ID always; extra link-only actions only when the record's own data supports them -- no governed-mutation triggers added to this page), and Overview/Neighbors/Worklog/Evidence behind design-system-2 `Tabs` (segmented control) so non-Overview content isn't constructed until its tab opens.
- Desktop (>= 64rem) progressively enhances into a two-column hub: head+actions become a sticky sidebar, tab content sits alongside it.
- Related-record rows (Neighbors tab) navigate to that record's own details page via the existing `recordHrefForType` routing -- graph navigable, consistent with the existing `TypedRelationshipSection`.
- Extends the trimmed `ui-v2` record types (`transition_type`, `checkout_state`, `checked_out_by`, `acceptance_criteria`) -- the backend already returns these fields on tracker.get; this stops discarding them client-side.
- Extends `mobileViewport.test.ts` with static-CSS-assertion coverage (matching the existing suite's jsdom-safe pattern) for the sticky action bar and no-horizontal-scroll containment.

## Scope notes / known limitations
- Evidence tab is wired for Task only (confirmed `acceptance_criteria` shape from a live `tracker.get`); Issue/Feature/Plan schemas for an evidence-like field were not independently verified in this pass, so no tab was added there rather than guessing the wrong shape.
- No record type in the current data model carries a PR URL field directly (GitHub PR metadata lives on `deployment_decision` records, not task/issue/feature), so no primitive currently populates an "Open PR" action -- this is honest to the data, not a gap in the component (which accepts an `actions` prop for exactly this once a PR-URL field is threaded onto a record type).
- "Advance/Escalate" buttons from the AC's literal action-bar list were deliberately NOT wired -- the dispatch's architect-approved design contract explicitly scopes this page to a read-only surface with no governed-mutation triggers beyond what already exists elsewhere in the PWA.

## Test plan
- [x] `RecordDetailHub`, its CSS, and all six primitives wired via the existing `createRecordRoute`/registry seam -- no route or registry changes needed.
- [x] Extended `frontend/ui-v2/src/shell/mobileViewport.test.ts` (sticky bar fixed+pinned at mobile, folds inline/hidden at 64rem, hub/vitals/body width-capped, mobile bottom padding reserved).
- [ ] CI: typecheck/lint/vitest (this environment's shared worktree pool was under heavy concurrent-lane contention during this session; local `npm test`/`tsc` could not be completed here -- relying on CI for the full run).
- [ ] Manual 375px dev-server render + live detail API curl (post-merge/gamma-deploy verification).

CCI-06fffd1732e54b38a88abdb9eeaede1f

🤖 Generated with [Claude Code](https://claude.com/claude-code)