### PR TITLE
ENC-TSK-M27: io-queue API completeness (paused approvals + stale locks)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-08.02",
-  "updated_at": "2026-07-08T02:55:00Z",
-  "last_change_summary": "ENC-ISS-509 (carrier ENC-TSK-M24): tracker_mutation._handle_get_record gains _get_record_full_with_gamma_fallback -- on gamma, a miss against the local devops-project-tracker-gamma table (one-time-seeded, never continuously synced from the canonical table) falls through to a single read-only GetItem against the canonical devops-project-tracker table so the gamma PWA detail route can render recently-created records. GET-detail only; no change to writes, list, or search. New least-privilege TrackerTableCanonicalReadFallback IAM statement (dynamodb:GetItem only) on TrackerMutationRole, gated !If [IsGamma] (infrastructure/cloudformation/02-compute.yaml).",
+  "version": "2026-07-08.03",
+  "updated_at": "2026-07-08T05:10:00Z",
+  "last_change_summary": "ENC-TSK-M27 (ENC-FTR-130): io-queue completeness. Two new read-only, Cognito-gated GET routes on coordination_api close the two M19 Home \"Data gap\" placeholder rows -- GET /api/v1/coordination/queue/paused-approvals (GitHub Actions runs blocked on the v3-prod Environment's required-reviewer gate; reuses the existing ENC-FTR-021 GitHub App installation-token path via new _get_github_installation_token/_github_queue_api_get helpers, no new secret minted) and GET /api/v1/coordination/queue/stale-locks (Scan of the projects table for checkout_state=checked_out task records past STALE_CHECKOUT_THRESHOLD_MINUTES, mirroring backend/lambda/stale_checkout_monitor's detection core so the PWA agrees with the scheduled monitor's signal). Both handlers add no mutation path. New least-privilege GitHubAppSecretRead IAM statement (secretsmanager:GetSecretValue/DescribeSecret scoped to devops/github-app/*) on CoordinationApiRole (infrastructure/cloudformation/02-compute.yaml, covers gamma + prod via EnvironmentSuffix); no new DynamoDB IAM needed (TrackerTableAccess/ProjectsTableRead already grant Scan). New gamma-only APIGW routes RouteQueuePausedApprovals + RouteQueueStaleLocks (infrastructure/cloudformation/03-api.yaml, Condition: IsGamma, same posture as the Escalations feed). frontend/ui-v2 Home route now fetches both live and replaces routes/homeQueue.ts::GAP_QUEUE_ROWS with pausedApprovalRows/staleLockRows mapping functions.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7802,10 +7802,50 @@
       },
       "owner": "devops-infrastructure",
       "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
+    },
+    "coordination.queue": {
+      "description": "ENC-TSK-M27 (ENC-FTR-130): the PWA Home \"Requires io\" queue's read surfaces for the two record classes that had no PWA-reachable data source before this task -- paused v3-prod Environment GitHub Actions approval runs, and stale checkout locks. Both routes are Cognito-session-gated (_is_cognito_session) exactly like coordination.escalations; neither adds a mutation path. Paused-approvals calls GitHub's REST API with an installation token minted via the existing ENC-FTR-021 GitHub App credential path (GITHUB_APP_ID/GITHUB_INSTALLATION_ID/GITHUB_PRIVATE_KEY_SECRET, already provisioned on this function's environment) -- no new GitHub credential. Stale-locks Scans the projects table with the same detection core as backend/lambda/stale_checkout_monitor/lambda_function.py.",
+      "fields": {
+        "GET /api/v1/coordination/queue/paused-approvals": {
+          "type": "route",
+          "definition": "Lists GitHub Actions workflow runs on GITHUB_QUEUE_REPO (default NX-2021-L/enceladus) with status=waiting, then calls pending_deployments per run and keeps only runs where an environment named 'v3-prod' (case-insensitive) is pending review (falls back to including a run if pending_deployments couldn't be read, rather than silently dropping a real approval need). Returns {id, run_url, requesting_workflow, environments, head_sha, created_at} per row. Returns an empty list with a note (not an error) when GITHUB_APP_ID/GITHUB_INSTALLATION_ID are unset. Cognito-only."
+        },
+        "GET /api/v1/coordination/queue/stale-locks": {
+          "type": "route",
+          "definition": "Scans PROJECTS_TABLE (default 'projects') for record_type=task AND checkout_state=checked_out, then filters to checked_out_at older than STALE_CHECKOUT_THRESHOLD_MINUTES (default 240, same env var and default as stale_checkout_monitor). Returns {record_id, holder_session, held_since, age_minutes} per row, newest-age-first, capped at a 500-item scan. Read-only; never mutates checkout_state. Cognito-only."
+        },
+        "GITHUB_APP_ID": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var (already provisioned on CoordinationApiFunction in infrastructure/cloudformation/02-compute.yaml). Reused unmodified by ENC-TSK-M27; no new value."
+        },
+        "GITHUB_INSTALLATION_ID": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var, reused unmodified by ENC-TSK-M27."
+        },
+        "GITHUB_PRIVATE_KEY_SECRET": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var naming the Secrets Manager secret holding the GitHub App private key (default 'devops/github-app/private-key'). ENC-TSK-M27 adds the GitHubAppSecretRead IAM statement (GetSecretValue/DescribeSecret scoped to devops/github-app/*) so coordination_api can read it; no new secret value, no write access."
+        },
+        "GITHUB_QUEUE_REPO": {
+          "type": "string",
+          "definition": "New ENC-TSK-M27 env var: owner/repo to query for paused Environment approval runs. Default 'NX-2021-L/enceladus'."
+        },
+        "STALE_CHECKOUT_THRESHOLD_MINUTES": {
+          "type": "string",
+          "definition": "Optional env var (default 240): age threshold in minutes for the stale-locks route. Shares its name and default with backend/lambda/stale_checkout_monitor/lambda_function.py's identical env var so the two surfaces agree on what counts as stale; set independently per-Lambda (not a shared CFN parameter)."
+        }
+      },
+      "pwa_surface": "Home route's \"Requires io\" queue (frontend/ui-v2/src/routes/HomeRoute.tsx): pausedApprovalRows/staleLockRows (routes/homeQueue.ts) render live rows in place of the ENC-TSK-M19 GAP_QUEUE_ROWS placeholders. Paused-approval rows link directly to the GitHub Actions run (approve/reject stays a GitHub action, not a new PWA mutation); stale-lock rows are informational only, no click-through action.",
+      "apigw_routes": "03-api.yaml (Condition: IsGamma, same v3-prod-promotion posture as escalations): RouteQueuePausedApprovals, RouteQueueStaleLocks -> CoordinationApiIntegration."
     }
   },
   "change_summary": "ENC-TSK-L93: documents-list metadata-only projection via include_content=false (skill catalog fields + runtime_hint).",
   "change_log": [
+    {
+      "version": "2026-07-08.03",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M27 (ENC-FTR-130): io-queue completeness. Two new read-only, Cognito-gated GET routes on coordination_api close the two M19 Home \"Data gap\" placeholder rows -- GET /api/v1/coordination/queue/paused-approvals (GitHub Actions runs blocked on the v3-prod Environment's required-reviewer gate; reuses the existing ENC-FTR-021 GitHub App installation-token path via new _get_github_installation_token/_github_queue_api_get helpers, no new secret minted) and GET /api/v1/coordination/queue/stale-locks (Scan of the projects table for checkout_state=checked_out task records past STALE_CHECKOUT_THRESHOLD_MINUTES, mirroring backend/lambda/stale_checkout_monitor's detection core so the PWA agrees with the scheduled monitor's signal). Both handlers add no mutation path. New least-privilege GitHubAppSecretRead IAM statement (secretsmanager:GetSecretValue/DescribeSecret scoped to devops/github-app/*) on CoordinationApiRole (infrastructure/cloudformation/02-compute.yaml, covers gamma + prod via EnvironmentSuffix); no new DynamoDB IAM needed (TrackerTableAccess/ProjectsTableRead already grant Scan). New gamma-only APIGW routes RouteQueuePausedApprovals + RouteQueueStaleLocks (infrastructure/cloudformation/03-api.yaml, Condition: IsGamma, same posture as the Escalations feed). frontend/ui-v2 Home route now fetches both live and replaces routes/homeQueue.ts::GAP_QUEUE_ROWS with pausedApprovalRows/staleLockRows mapping functions."
+    },
     {
       "version": "2026-07-08.01",
       "date": "2026-07-08",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -182,6 +182,19 @@ def _first_nonempty_env(*names: str) -> str:
 COORDINATION_TABLE = os.environ.get("COORDINATION_TABLE", "coordination-requests")
 TRACKER_TABLE = os.environ.get("TRACKER_TABLE", "devops-project-tracker")
 PROJECTS_TABLE = os.environ.get("PROJECTS_TABLE", "projects")
+# ENC-TSK-M27: io-queue read surfaces. GITHUB_* envs are the existing ENC-FTR-021
+# GitHub App credential path (already provisioned on this function -- see
+# infrastructure/cloudformation/02-compute.yaml CoordinationApiFunction -- and
+# mirrored from backend/lambda/deploy_decide/lambda_function.py). No new secret.
+GITHUB_APP_ID = os.environ.get("GITHUB_APP_ID", "")
+GITHUB_INSTALLATION_ID = os.environ.get("GITHUB_INSTALLATION_ID", "")
+GITHUB_PRIVATE_KEY_SECRET = os.environ.get("GITHUB_PRIVATE_KEY_SECRET", "devops/github-app/private-key")
+GITHUB_QUEUE_REPO = os.environ.get("GITHUB_QUEUE_REPO", "NX-2021-L/enceladus")
+# Same default/threshold convention as backend/lambda/stale_checkout_monitor/lambda_function.py
+# (DOC-476D273C6566) so the PWA queue and the scheduled monitor agree on "stale".
+STALE_CHECKOUT_THRESHOLD_MINUTES = int(
+    os.environ.get("STALE_CHECKOUT_THRESHOLD_MINUTES", "") or 240
+)
 COMPONENTS_TABLE = os.environ.get("COMPONENTS_TABLE", "component-registry")
 DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
 GOVERNANCE_POLICIES_TABLE = os.environ.get("GOVERNANCE_POLICIES_TABLE", "governance-policies")
@@ -987,6 +1000,76 @@ def _get_cognito():
             config=Config(retries={"max_attempts": 3, "mode": "standard"}),
         )
     return _cognito
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-M27: GitHub App installation-token path (io-queue paused-approvals
+# read). Same App/JWT/installation-token flow as
+# backend/lambda/deploy_decide/lambda_function.py -- reused here rather than
+# duplicated-and-diverged; no new GitHub credential is minted for this Lambda.
+# ---------------------------------------------------------------------------
+
+_github_installation_token_cache: Optional[str] = None
+_github_installation_token_fetched_at: float = 0.0
+_GITHUB_INSTALLATION_TOKEN_TTL = 8 * 60  # installation tokens live ~1h; refresh well inside that
+
+
+def _get_github_private_key() -> str:
+    resp = _get_secretsmanager().get_secret_value(SecretId=GITHUB_PRIVATE_KEY_SECRET)
+    return resp["SecretString"]
+
+
+def _generate_github_app_jwt() -> str:
+    if not _JWT_AVAILABLE:
+        raise ValueError("PyJWT not available in Lambda package (ENC-ISS-198)")
+    now = int(time.time())
+    payload = {"iat": now - 60, "exp": now + (9 * 60), "iss": str(GITHUB_APP_ID)}
+    return jwt.encode(payload, _get_github_private_key(), algorithm="RS256")
+
+
+def _get_github_installation_token() -> str:
+    global _github_installation_token_cache, _github_installation_token_fetched_at
+    now = time.time()
+    if (
+        _github_installation_token_cache
+        and (now - _github_installation_token_fetched_at) < _GITHUB_INSTALLATION_TOKEN_TTL
+    ):
+        return _github_installation_token_cache
+    app_jwt = _generate_github_app_jwt()
+    url = f"https://api.github.com/app/installations/{GITHUB_INSTALLATION_ID}/access_tokens"
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        headers={"Authorization": f"Bearer {app_jwt}", "Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read().decode())
+    _github_installation_token_cache = data["token"]
+    _github_installation_token_fetched_at = now
+    return _github_installation_token_cache
+
+
+def _github_queue_api_get(path: str) -> Tuple[int, Any]:
+    """Read-only GitHub REST GET with installation-token auth. Callers in this
+    module use this exclusively for GET paths (actions/runs, pending_deployments)
+    -- ENC-TSK-M27 AC3 adds no write-capable GitHub call."""
+    token = _get_github_installation_token()
+    url = f"https://api.github.com{path}"
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            return exc.code, json.loads(exc.read().decode())
+        except Exception:
+            return exc.code, {"error": str(exc)}
+    except Exception as exc:
+        return 0, {"error": str(exc)}
 
 
 # ---------------------------------------------------------------------------
@@ -10430,6 +10513,128 @@ def _render_escalation_diff(
     return diff
 
 
+def _handle_queue_paused_approvals(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/queue/paused-approvals -- ENC-TSK-M27 AC1.
+
+    Surfaces GitHub Actions workflow runs currently blocked on a required
+    reviewer for the v3-prod Environment (the promote-gamma-to-prod lane's
+    manual approval gate). Cognito-only, same as the escalations feed --
+    this is the human "Requires io" queue view, not an agent surface.
+    Read-only: two GitHub GET calls per request (list + pending_deployments
+    per candidate run), no mutation path.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, "The io-queue requires a Cognito session (PWA, human-only).")
+
+    if not (GITHUB_APP_ID and GITHUB_INSTALLATION_ID):
+        return _response(200, {
+            "success": True, "runs": [], "count": 0,
+            "note": "GitHub App credentials not configured in this environment",
+        })
+
+    status, runs_payload = _github_queue_api_get(
+        f"/repos/{GITHUB_QUEUE_REPO}/actions/runs?status=waiting&per_page=20"
+    )
+    if status != 200:
+        logger.error(
+            "queue/paused-approvals: GitHub runs list failed status=%s body=%s",
+            status, runs_payload,
+        )
+        return _error(502, "Failed to read paused GitHub Actions runs.")
+
+    paused: List[Dict[str, Any]] = []
+    for run in (runs_payload or {}).get("workflow_runs", [])[:20]:
+        run_id = run.get("id")
+        environments: List[str] = []
+        dep_status, deployments = _github_queue_api_get(
+            f"/repos/{GITHUB_QUEUE_REPO}/actions/runs/{run_id}/pending_deployments"
+        )
+        if dep_status == 200 and isinstance(deployments, list):
+            environments = [
+                str((dep.get("environment") or {}).get("name") or "")
+                for dep in deployments
+            ]
+        # Only surface runs actually paused on the v3-prod Environment gate;
+        # if pending_deployments couldn't be read, fall back to including the
+        # run rather than silently dropping a real approval need.
+        if environments and not any(env.lower() == "v3-prod" for env in environments):
+            continue
+        paused.append({
+            "id": run_id,
+            "run_url": run.get("html_url"),
+            "requesting_workflow": run.get("name") or run.get("path"),
+            "environments": environments,
+            "head_sha": run.get("head_sha"),
+            "created_at": run.get("created_at"),
+        })
+
+    return _response(200, {"success": True, "runs": paused, "count": len(paused)})
+
+
+def _handle_queue_stale_locks(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/queue/stale-locks -- ENC-TSK-M27 AC1.
+
+    Read-only Scan of the projects table for checked-out task records past
+    STALE_CHECKOUT_THRESHOLD_MINUTES, mirroring the detection core in
+    backend/lambda/stale_checkout_monitor/lambda_function.py (DOC-476D273C6566)
+    so the PWA queue agrees with the scheduled monitor's CloudWatch signal.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, "The io-queue requires a Cognito session (PWA, human-only).")
+
+    ddb = _get_ddb()
+    kwargs: Dict[str, Any] = {
+        "TableName": PROJECTS_TABLE,
+        "FilterExpression": "#rt = :task AND #cs = :checked_out",
+        "ExpressionAttributeNames": {"#rt": "record_type", "#cs": "checkout_state"},
+        "ExpressionAttributeValues": {
+            ":task": _serialize("task"),
+            ":checked_out": _serialize("checked_out"),
+        },
+    }
+    items: List[Dict[str, Any]] = []
+    try:
+        while True:
+            page = ddb.scan(**kwargs)
+            items.extend(_deserialize(raw) for raw in page.get("Items", []))
+            last_key = page.get("LastEvaluatedKey")
+            if not last_key or len(items) >= 500:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("queue/stale-locks scan failed: %s", exc)
+        return _error(500, "Failed to read stale-checkout locks.")
+
+    now = dt.datetime.now(dt.timezone.utc)
+    threshold = STALE_CHECKOUT_THRESHOLD_MINUTES
+    stale: List[Dict[str, Any]] = []
+    for item in items:
+        raw_ts = item.get("checked_out_at")
+        if not isinstance(raw_ts, str) or not raw_ts.strip():
+            continue
+        try:
+            ts = dt.datetime.fromisoformat(raw_ts.strip().replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.timezone.utc)
+        age_minutes = int((now - ts).total_seconds() // 60)
+        if age_minutes < threshold:
+            continue
+        stale.append({
+            "record_id": item.get("item_id") or item.get("record_id"),
+            "holder_session": item.get("checked_out_by"),
+            "held_since": raw_ts,
+            "age_minutes": age_minutes,
+        })
+
+    stale.sort(key=lambda r: r["age_minutes"], reverse=True)
+    return _response(200, {
+        "success": True, "locks": stale, "count": len(stale),
+        "threshold_minutes": threshold,
+    })
+
+
 def _handle_escalations_feed(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
     """GET /api/v1/coordination/escalations — io's approval queue (§5.7).
 
@@ -16735,6 +16940,13 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     # (DOC-5B888FCA43B8 §5.7). Cognito-gated inside the handlers; no agent path.
     if method == "GET" and path == "/api/v1/coordination/escalations":
         return _handle_escalations_feed(event, claims or {})
+
+    # ENC-TSK-M27 (ENC-FTR-130): io-queue completeness — paused v3-prod
+    # Environment approvals + stale-checkout locks. Read-only, Cognito-gated.
+    if method == "GET" and path == "/api/v1/coordination/queue/paused-approvals":
+        return _handle_queue_paused_approvals(event, claims or {})
+    if method == "GET" and path == "/api/v1/coordination/queue/stale-locks":
+        return _handle_queue_stale_locks(event, claims or {})
     match_escalation_decision = re.fullmatch(
         r"/api/v1/coordination/escalations/([a-z0-9_\-]+)/([A-Za-z0-9\-]+)/(approve|deny)", path
     )

--- a/frontend/ui-v2/src/api/homeQueue.ts
+++ b/frontend/ui-v2/src/api/homeQueue.ts
@@ -19,11 +19,13 @@
  *    per-type list requests for a single dashboard tile.
  *
  * Paused v3-prod GitHub Environment approvals and stale-lock/backfill flags
- * have NO PWA-reachable data source today: GitHub Actions Environment
- * protection state and worktree/session-lock bookkeeping (ENC-ISS-071) are
- * not exposed by any Enceladus HTTP API. HomeRoute renders those two queue
- * rows as static gap notices (see routes/homeQueue.ts::GAP_QUEUE_ROWS)
- * instead of fabricating a fetch or a backend endpoint.
+ * (ENC-TSK-M27 / ENC-FTR-130): now live, via the two read-only routes added
+ * to coordination_api --
+ *   GET /api/v1/coordination/queue/paused-approvals
+ *   GET /api/v1/coordination/queue/stale-locks
+ * Both are Cognito-session-gated, same as the escalations feed. See
+ * backend/lambda/coordination_api/lambda_function.py::
+ * _handle_queue_paused_approvals / _handle_queue_stale_locks.
  */
 
 import { API_BASE } from './client'
@@ -71,4 +73,61 @@ export async function fetchAwaitingCheckoutCount(
   )
   const records = body.records ?? []
   return records.filter((r) => r.checkout_state !== 'checked_out').length
+}
+
+/** ENC-TSK-M27 AC1: a GitHub Actions run paused on the v3-prod Environment's
+ * required-reviewer gate. */
+export interface PausedApprovalRun {
+  id: number | string
+  run_url?: string
+  requesting_workflow?: string
+  environments?: string[]
+  head_sha?: string
+  created_at?: string
+}
+
+interface PausedApprovalsResponse {
+  success: boolean
+  runs: PausedApprovalRun[]
+  count: number
+  note?: string
+}
+
+/** Paused v3-prod Environment approval runs, live from GitHub Actions via the
+ * coordination_api GitHub App installation-token path (ENC-FTR-021 reuse). */
+export async function fetchPausedApprovals(
+  init?: { signal?: AbortSignal },
+): Promise<PausedApprovalRun[]> {
+  const body = await getJson<PausedApprovalsResponse>(
+    `${API_BASE}/coordination/queue/paused-approvals`,
+    init,
+  )
+  return body.runs ?? []
+}
+
+/** ENC-TSK-M27 AC1: a checkout lock held past the stale-checkout threshold. */
+export interface StaleLockEntry {
+  record_id?: string
+  holder_session?: string
+  held_since?: string
+  age_minutes?: number
+}
+
+interface StaleLocksResponse {
+  success: boolean
+  locks: StaleLockEntry[]
+  count: number
+  threshold_minutes?: number
+}
+
+/** Stale checkout-lock entries, live from the same projects-table scan the
+ * scheduled stale_checkout_monitor Lambda already runs. */
+export async function fetchStaleLocks(
+  init?: { signal?: AbortSignal },
+): Promise<StaleLockEntry[]> {
+  const body = await getJson<StaleLocksResponse>(
+    `${API_BASE}/coordination/queue/stale-locks`,
+    init,
+  )
+  return body.locks ?? []
 }

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -5,13 +5,18 @@ import { BarChart, Box, Cards, Header, PieChart, Tabs } from '../design-system'
 import { feedCorpusByTypeQueryOptions, feedCorpusQueryOptions } from '../api/feedCorpusQueryOptions'
 import { recordQueryOptions } from '../api/queryOptions'
 import { fetchEscalations } from '../api/coordination'
-import { fetchAwaitingCheckoutCount, fetchOpenP0P1Count } from '../api/homeQueue'
+import {
+  fetchAwaitingCheckoutCount,
+  fetchOpenP0P1Count,
+  fetchPausedApprovals,
+  fetchStaleLocks,
+} from '../api/homeQueue'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import { documentHref, recordHrefForType } from './recordLink'
 import { RecordId } from '../components/RecordId'
 import { RecordCard } from '../components/RecordCard'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
-import { GAP_QUEUE_ROWS, pendingEscalationRows, type QueueRow } from './homeQueue'
+import { pausedApprovalRows, pendingEscalationRows, staleLockRows, type QueueRow } from './homeQueue'
 import { FEED_SEARCH_DEFAULTS, serializeFilterQuery, type FeedRouteSearch } from '../search/feedSearchParams'
 import {
   DASHBOARD_RECORD_TYPES,
@@ -164,9 +169,20 @@ export function HomeRoute() {
     queryKey: ['coordination', 'escalations', projectId] as const,
     queryFn: ({ signal }) => fetchEscalations(projectId, { signal }),
   })
+  // ENC-TSK-M27: paused v3-prod Environment approvals + stale-checkout locks,
+  // replacing the M19 "Data gap" placeholder rows with live fetches.
+  const pausedApprovalsQuery = useQuery({
+    queryKey: ['home', 'queue', 'paused-approvals'] as const,
+    queryFn: ({ signal }) => fetchPausedApprovals({ signal }),
+  })
+  const staleLocksQuery = useQuery({
+    queryKey: ['home', 'queue', 'stale-locks'] as const,
+    queryFn: ({ signal }) => fetchStaleLocks({ signal }),
+  })
   const queueRows: QueueRow[] = [
     ...pendingEscalationRows(escalationsQuery.data ?? []),
-    ...GAP_QUEUE_ROWS,
+    ...pausedApprovalRows(pausedApprovalsQuery.data ?? []),
+    ...staleLockRows(staleLocksQuery.data ?? []),
   ]
 
   // Actionable counts strip.

--- a/frontend/ui-v2/src/routes/homeQueue.test.ts
+++ b/frontend/ui-v2/src/routes/homeQueue.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { GAP_QUEUE_ROWS, pendingEscalationRows } from './homeQueue'
+import { pausedApprovalRows, pendingEscalationRows, staleLockRows } from './homeQueue'
 import type { EscalationRecord } from '../api/coordination'
+import type { PausedApprovalRun, StaleLockEntry } from '../api/homeQueue'
 
 function escalation(overrides: Partial<EscalationRecord>): EscalationRecord {
   return {
@@ -42,16 +43,34 @@ describe('pendingEscalationRows', () => {
   })
 })
 
-describe('GAP_QUEUE_ROWS', () => {
-  it('are all marked gap:true and never carry an href', () => {
-    for (const row of GAP_QUEUE_ROWS) {
-      expect(row.gap).toBe(true)
-      expect(row.href).toBeUndefined()
-    }
+describe('pausedApprovalRows', () => {
+  it('titles by requesting workflow when present, falls back to the run id', () => {
+    const withWorkflow = pausedApprovalRows([
+      { id: 42, requesting_workflow: 'promote-gamma-to-prod-request', run_url: 'https://github.com/x/y/actions/runs/42' } as PausedApprovalRun,
+    ])
+    expect(withWorkflow[0]?.title).toBe('promote-gamma-to-prod-request awaiting v3-prod approval')
+    expect(withWorkflow[0]?.href).toBe('https://github.com/x/y/actions/runs/42')
+
+    const withoutWorkflow = pausedApprovalRows([{ id: 7 } as PausedApprovalRun])
+    expect(withoutWorkflow[0]?.title).toBe('Run 7 awaiting v3-prod approval')
   })
 
-  it('covers paused prod runs and stale-lock/backfill flags', () => {
-    const ids = GAP_QUEUE_ROWS.map((row) => row.id)
-    expect(ids).toEqual(['gap-paused-prod', 'gap-stale-lock'])
+  it('handles an empty list', () => {
+    expect(pausedApprovalRows([])).toEqual([])
+  })
+})
+
+describe('staleLockRows', () => {
+  it('surfaces record id, holder session, and age', () => {
+    const rows = staleLockRows([
+      { record_id: 'ENC-TSK-K01', holder_session: 'ENC-SES-057', age_minutes: 312 } as StaleLockEntry,
+    ])
+    expect(rows[0]?.id).toBe('stale-lock-ENC-TSK-K01')
+    expect(rows[0]?.title).toBe('ENC-TSK-K01 checkout is stale')
+    expect(rows[0]?.description).toBe('Held by ENC-SES-057 — 312m')
+  })
+
+  it('handles an empty list', () => {
+    expect(staleLockRows([])).toEqual([])
   })
 })

--- a/frontend/ui-v2/src/routes/homeQueue.ts
+++ b/frontend/ui-v2/src/routes/homeQueue.ts
@@ -5,6 +5,7 @@
  */
 
 import type { EscalationRecord } from '../api/coordination'
+import type { PausedApprovalRun, StaleLockEntry } from '../api/homeQueue'
 
 export interface QueueRow {
   id: string
@@ -41,25 +42,36 @@ export function pendingEscalationRows(escalations: EscalationRecord[]): QueueRow
     })
 }
 
-/** Static rows documenting queue slices with no PWA-reachable data source
- * today (see api/homeQueue.ts module docstring). Kept as data, not inline
- * JSX, so the "what's real vs. a gap" list is reviewable/testable on its
- * own. */
-export const GAP_QUEUE_ROWS: QueueRow[] = [
-  {
-    id: 'gap-paused-prod',
-    kindLabel: 'Paused prod runs',
-    title: 'Paused v3-prod Environment approvals',
-    description:
-      'No PWA-reachable data source yet -- GitHub Actions Environment protection state isn’t exposed by any Enceladus HTTP API. Check the workflow run’s Environment approval gate directly in GitHub Actions.',
-    gap: true,
-  },
-  {
-    id: 'gap-stale-lock',
-    kindLabel: 'Stale locks',
-    title: 'Stale-lock / backfill flags',
-    description:
-      'No PWA-reachable data source yet -- worktree/session lock bookkeeping (ENC-ISS-071) and retirement-sweep backfills aren’t exposed by any Enceladus HTTP API today.',
-    gap: true,
-  },
-]
+/** ENC-TSK-M27: GitHub Actions runs paused on the v3-prod Environment's
+ * required-reviewer gate, one row per run. Links straight to the GitHub run
+ * so io can approve/reject there -- the PWA surfaces the queue, GitHub
+ * remains the (only) approval action surface. */
+export function pausedApprovalRows(runs: PausedApprovalRun[]): QueueRow[] {
+  return runs.map((run) => ({
+    id: `paused-approval-${run.id}`,
+    kindLabel: 'Paused prod run',
+    title: run.requesting_workflow
+      ? `${run.requesting_workflow} awaiting v3-prod approval`
+      : `Run ${run.id} awaiting v3-prod approval`,
+    description: run.head_sha ? `Commit ${run.head_sha.slice(0, 7)}` : undefined,
+    href: run.run_url,
+  }))
+}
+
+/** ENC-TSK-M27: checkout locks held past the stale-checkout threshold, one
+ * row per lock. Not directly actionable in the PWA (no new mutation path
+ * per AC3) -- surfaces the record + holder + age so io knows what to chase
+ * down via the tracker or a terminal session. */
+export function staleLockRows(locks: StaleLockEntry[]): QueueRow[] {
+  return locks.map((lock) => ({
+    id: `stale-lock-${lock.record_id}`,
+    kindLabel: 'Stale lock',
+    title: lock.record_id ? `${lock.record_id} checkout is stale` : 'Stale checkout lock',
+    description: [
+      lock.holder_session ? `Held by ${lock.holder_session}` : undefined,
+      typeof lock.age_minutes === 'number' ? `${lock.age_minutes}m` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' — '),
+  }))
+}

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -3881,6 +3881,16 @@ Resources:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
                 Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/coordination/*"
+              # ENC-TSK-M27 (ENC-FTR-130): io-queue paused-approvals read reuses the
+              # existing ENC-FTR-021 GitHub App installation-token path (same secret
+              # already read by DeployDecideRole below) -- least-privilege GET-only
+              # scope, no new secret minted, no write-capable GitHub call added.
+              - Sid: GitHubAppSecretRead
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:devops/github-app/*"
               - Sid: ComponentEventsTopicPublish
                 Effect: Allow
                 Action:

--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -2654,6 +2654,27 @@ Resources:
       RouteKey: "POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply"
       Target: !Sub integrations/${TrackerMutationIntegration}
 
+  # ENC-TSK-M27 (ENC-FTR-130): io-queue completeness — paused v3-prod Environment
+  # approvals + stale-checkout locks. Read-only, Cognito-gated inside the
+  # handlers (same posture as the Escalations feed above). Gamma-only for now,
+  # matching this task's scope; a v3-prod promotion of this surface would need
+  # its own io-gated follow-up, same as escalations' DOC-B716E8FB10B6 note.
+  RouteQueuePausedApprovals:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/queue/paused-approvals"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
+  RouteQueueStaleLocks:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: IsGamma
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "GET /api/v1/coordination/queue/stale-locks"
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
 Outputs:
   ApiEndpoint:
     Value: !GetAtt HttpApi.ApiEndpoint


### PR DESCRIPTION
## Summary
- Adds two read-only, Cognito-gated GET routes on coordination_api: `/api/v1/coordination/queue/paused-approvals` (GitHub Actions runs paused on the v3-prod Environment approval gate, via the existing ENC-FTR-021 GitHub App installation-token path) and `/api/v1/coordination/queue/stale-locks` (Scan of the projects table for stale `checkout_state=checked_out` task records, mirroring `stale_checkout_monitor`'s detection core).
- Wires the mobile Home "Requires io" queue to fetch both live, replacing the two ENC-TSK-M19 "Data gap" placeholder rows (`routes/homeQueue.ts::GAP_QUEUE_ROWS` removed in favor of `pausedApprovalRows`/`staleLockRows`).
- New least-privilege `GitHubAppSecretRead` IAM statement on `CoordinationApiRole` (secretsmanager Get/DescribeSecret scoped to `devops/github-app/*`, covers gamma + prod via `EnvironmentSuffix`); no new DynamoDB IAM needed (`TrackerTableAccess`/`ProjectsTableRead` already grant Scan).
- New gamma-only APIGW routes (`Condition: IsGamma`, same posture as Escalations) so the Lambda routes are actually reachable.
- `governance_data_dictionary.json` updated in the same PR (new `coordination.queue` entity + change log entry) per the governance-dict gate.

CCI-a53cc7f8a9ce4443bf05bc267665a56b

## Test plan
- [x] `python3 -m py_compile backend/lambda/coordination_api/lambda_function.py`
- [x] `python3 -c "import json; json.load(open(...governance_data_dictionary.json))"` — valid JSON
- [x] Updated `frontend/ui-v2/src/routes/homeQueue.test.ts` for the new row-mapping functions
- [ ] Post-merge: gamma deploy evidence + live curl of both new endpoints (tracked on ENC-TSK-M27)