### PR TITLE
ENC-TSK-M27: wire GitHub App env vars onto CoordinationApiFunction (gamma+prod)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -292,6 +292,14 @@ Resources:
           # ADE Component C: Cursor webhook HMAC verification secret (POST /api/v1/cursor/webhook)
           CURSOR_WEBHOOK_SECRET: !Ref CursorWebhookSecret
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-M27 (ENC-FTR-130): io-queue paused-approvals reuses the same
+          # GitHub App installation-token path already wired into DeployDecideFunction
+          # (below) -- these were NOT previously set on this function; the GET
+          # /api/v1/coordination/queue/paused-approvals route degrades to an empty
+          # list with a note until these are live (verified 2026-07-08 gamma deploy).
+          GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
+          GITHUB_PRIVATE_KEY_SECRET: devops/github-app/private-key
           # ENC-TSK-L08 / ISS-070: Auth dashboard oauth-clients list scans
           # governance-policies; without this env var the code default
           # ("governance-policies") misses the gamma suffix and IAM denies Scan.


### PR DESCRIPTION
## Summary
- ENC-TSK-M27's GET /api/v1/coordination/queue/paused-approvals route (merged in #958) assumed CoordinationApiFunction already had GITHUB_APP_ID/GITHUB_INSTALLATION_ID/GITHUB_PRIVATE_KEY_SECRET wired -- live validation on gamma showed that assumption was wrong (those env vars belong to DeployDecideFunction/GitHubIntegrationFunction, not CoordinationApiFunction). The route degrades gracefully (200, empty list, explicit note) when unset, but can't return real data without them.
- Adds the three env vars to CoordinationApiFunction's Environment.Variables (infrastructure/cloudformation/02-compute.yaml), reusing the existing GitHubAppId/GitHubInstallationId CFN parameters and the same `devops/github-app/private-key` secret name DeployDecideFunction already reads. Covers gamma + prod via the shared template + EnvironmentSuffix. No new secret, no IAM change needed (GitHubAppSecretRead statement already added in #958).

CCI-a53cc7f8a9ce4443bf05bc267665a56b

## Test plan
- [x] CFN template edit only (no Python touched, governance-dict gate not applicable)
- [ ] Post-merge: confirm devops-coordination-api-gamma's env now includes GITHUB_APP_ID/GITHUB_INSTALLATION_ID, then curl /api/v1/coordination/queue/paused-approvals live