### PR TITLE
ENC-TSK-M20: copy rewrite -- cut implementation prose + build tags (FND-02)

### DIFF
--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -207,12 +207,10 @@ export function CoordinationRoute() {
   return (
     <div className="coordination-route">
       <header className="coordination-route__header">
-        <p className="coordination-route__eyebrow">B67 PWA2.0 · Coordination</p>
+        <p className="coordination-route__eyebrow">COORDINATION · LIVE</p>
         <h1 className="coordination-route__title">Coordination monitor</h1>
         <p className="coordination-route__subtitle">
-          CRQ (coordination-request) documents and session / agent-type / lesson / escalation
-          records, split by record type. Served by comp-coordination-api's dedicated list
-          routes -- distinct from the tracker/documents/OpenSearch corpus.
+          Sessions, agent types, lessons, and escalations across active coordination requests.
         </p>
       </header>
 

--- a/frontend/ui-v2/src/routes/DocsRoute.tsx
+++ b/frontend/ui-v2/src/routes/DocsRoute.tsx
@@ -96,7 +96,7 @@ export function DocsRoute() {
   return (
     <div className="docs-route">
       <header className="docs-route__header">
-        <p className="docs-route__eyebrow">Search 2.0 · Documents</p>
+        <p className="docs-route__eyebrow">DOCUMENTS · LIVE</p>
         <h1 className="docs-route__title">Documents</h1>
         <p className="docs-route__subtitle">
           Search is scoped to document records only — tracker primitives (tasks, issues,

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -329,11 +329,11 @@ export function FeedRoute() {
   return (
     <div className="feed-route">
       <header className="feed-route__header">
-        <p className="feed-route__eyebrow">Search 2.0 · Feed</p>
+        <p className="feed-route__eyebrow">FEED · LIVE</p>
         <h1 className="feed-route__title">Results</h1>
         <p className="feed-route__subtitle">
-          Local tier paints instantly; hybrid merges async. Search state lives in the URL so back
-          navigation and breadcrumb return restore filters and scroll.
+          Search across every governed record type. Filters and scroll position are preserved on
+          your way back.
         </p>
       </header>
 

--- a/frontend/ui-v2/src/routes/GovernanceRoute.tsx
+++ b/frontend/ui-v2/src/routes/GovernanceRoute.tsx
@@ -61,11 +61,11 @@ export function GovernanceRoute() {
   return (
     <div className="governance-route">
       <header className="governance-route__header">
-        <p className="governance-route__eyebrow">Governance · Live docstore</p>
+        <p className="governance-route__eyebrow">GOVERNANCE · LIVE</p>
         <h1 className="governance-route__title">Governance documents</h1>
         <p className="governance-route__subtitle">
-          agents.md, lifecycle-primer, dictionary, and project reference files — fetched from the
-          governed docstore on each load (ENC-ISS-121 / B67 AC-20).
+          agents.md, lifecycle-primer, dictionary, and project reference files, fetched live on
+          each load.
         </p>
       </header>
 

--- a/frontend/ui-v2/src/routes/PlaceholderRoute.tsx
+++ b/frontend/ui-v2/src/routes/PlaceholderRoute.tsx
@@ -1,19 +1,15 @@
-import { useRouterState } from '@tanstack/react-router'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
-/** Scaffold page for cockpit nav targets filled in by L30–L34. */
+/** Scaffold page for cockpit nav targets not yet built out (ENC-ISS-513 /
+ * FND-02: no build-wave codenames or route plumbing in operator copy). */
 export function PlaceholderRoute({ title }: { title: string }) {
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
   useDocumentTitle(title)
 
   return (
     <div className="ev2-placeholder">
-      <p className="ev2-placeholder__eyebrow">Coming in catalog wave B</p>
+      <p className="ev2-placeholder__eyebrow">COMING SOON</p>
       <h1 className="ev2-placeholder__title">{title}</h1>
-      <p className="ev2-placeholder__body">
-        Route <code className="ev2-placeholder__path">{pathname}</code> is wired in the
-        design-system shell; page content lands in a follow-on task.
-      </p>
+      <p className="ev2-placeholder__body">This page isn't available yet.</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Removes internal build-wave codenames, tracker/AC tags, and architecture prose from operator-facing copy across the cockpit's page headers.

- **CoordinationRoute**: eyebrow `"B67 PWA2.0 · Coordination"` → `"COORDINATION · LIVE"`; subtitle no longer names `comp-coordination-api`, its routes, or the tracker/OpenSearch corpus split.
- **FeedRoute**: eyebrow `"Search 2.0 · Feed"` → `"FEED · LIVE"`; subtitle no longer explains the local/hybrid search-tier architecture or URL state mechanics.
- **DocsRoute**: eyebrow `"Search 2.0 · Documents"` → `"DOCUMENTS · LIVE"`. Subtitle kept as-is — it's useful cross-page navigation guidance, not architecture prose.
- **GovernanceRoute**: eyebrow standardized to `"GOVERNANCE · LIVE"`; subtitle no longer carries the `(ENC-ISS-121 / B67 AC-20)` tracker-ID tag.
- **PlaceholderRoute** (4 not-yet-built nav destinations — component registry, deployment manager, access tokens, terminal sessions): eyebrow `"Coming in catalog wave B"` → `"COMING SOON"`; body no longer describes the route being "wired in the design-system shell" awaiting a "follow-on task" — just says the page isn't available yet. Dropped the now-unused `useRouterState`/pathname plumbing that only fed that copy.

Record IDs, scores, and latencies are untouched — those stay as telemetry decoration per the task's AC. Grepped ui-v2 route/component sources for remaining `B67`/`PWA2.0`/`Lambda`/`comp-*`/route-name mentions — all other hits are code comments, not operator-visible copy.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 212/212 passing (none of these five files had test coverage on the changed strings)
- [x] `npx eslint .` — identical 20 pre-existing findings vs. base; no new lint errors introduced
- [ ] Human UAT: visual confirmation of the new eyebrow copy on gamma (Feed, Docs, Coordination, Governance, and the four placeholder nav destinations)

CCI-58de004f75bd46b181b7f4d601bdcdb2

🤖 Generated with [Claude Code](https://claude.com/claude-code)