### PR TITLE
Fix ENC-ISS-519: harden deploy-record resolution against CFN race

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -316,6 +316,14 @@ jobs:
               'description': 'Gen2 deploy — ENC-FTR-090',
               'auto_merge': False,
               'required_contexts': [],
+              # ENC-ISS-519: durable discriminator so tools/compute_affected_targets.py's
+              # resolve_last_deployed_sha() can tell THIS Lambda code-deploy record apart
+              # from the GitHub-managed Deployment that cloudformation-api-stack-deploy.yml
+              # / cloudformation-compute-stack-deploy.yml auto-create for the same
+              # environment/sha via their `apply` job's `environment:` attribute. Keep this
+              # string in sync with LAMBDA_CODE_DEPLOY_TASK in
+              # tools/compute_affected_targets.py.
+              'task': 'lambda-artifacts',
           }))
           PY
           )
@@ -751,6 +759,31 @@ jobs:
 
           log(f'Deployed {deployed} Lambda functions  {arch}-py{py} @ {sha[:7]}')
           PY
+
+      # ENC-ISS-519 assertion: candidates 2+3 harden the *decision* of what to
+      # diff/deploy; this is the backstop that catches ANY other way a
+      # "0 Lambda updates but green run" false-positive could still slip
+      # through. Gamma-only (see the header comment): prod already carries
+      # its own CodeDeploy alarm-rollback + required-reviewer gate, and this
+      # step must never be the thing that risks that path. If it fails, this
+      # step's own non-zero exit fails the job, so the existing
+      # `if: success()` / `if: failure()` deployment-status steps below react
+      # correctly without any change to them.
+      - name: Assert post-deploy freshness (ENC-ISS-519)
+        if: contains(needs.resolve.outputs.environment, 'gamma')
+        env:
+          COMMIT_SHA: ${{ needs.resolve.outputs.commit_sha }}
+          FULL_SCOPE: ${{ needs.resolve.outputs.full_scope }}
+          AFFECTED_FUNCTIONS_JSON: ${{ needs.resolve.outputs.affected_functions_json }}
+          FUNCTION_NAME_MAP_JSON: ${{ needs.resolve.outputs.function_name_map_json }}
+        run: |
+          set -euo pipefail
+          python3 tools/assert_post_deploy_freshness.py \
+            --commit-sha "${COMMIT_SHA}" \
+            --full-scope "${FULL_SCOPE}" \
+            --affected-functions-json "${AFFECTED_FUNCTIONS_JSON}" \
+            --function-name-map-json "${FUNCTION_NAME_MAP_JSON}" \
+            --region "${{ env.AWS_REGION }}"
 
       - name: Set deployment status → success
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           set -euo pipefail
           python3 -m unittest tools.test_compute_affected_targets -v
 
+      - name: Test post-deploy freshness assertion (ENC-ISS-519)
+        run: |
+          set -euo pipefail
+          python3 -m unittest tools.test_assert_post_deploy_freshness -v
+
       # ENC-TSK-H22 (ENC-PLN-048 Obj 4.1): prove the env-parity gate catches a
       # template strip. Needs PyYAML (the gate's resolver parses CFN); no current
       # CI step imports yaml, so provision Python+PyYAML scoped to this step only.

--- a/tools/assert_post_deploy_freshness.py
+++ b/tools/assert_post_deploy_freshness.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""ENC-ISS-519 assertion: prove the deploy actually shipped.
+
+resolve_last_deployed_sha() / compute_affected_targets.py (candidates 2+3)
+harden the *decision* of what to diff and deploy. This tool is the backstop
+that catches ANY other way a "0 Lambda updates" false-green could happen
+(a future regression, a different discriminator bypass, a bad function_name_map
+entry, etc.): after _deploy.yml's "Deploy Lambda functions" step reports
+success, assert that every function this run claims to have touched actually
+has a CONFIGURATION LastModified timestamp at or after the merge commit's
+timestamp. If a claimed-deployed function's code is actually still stale,
+fail the run loudly instead of leaving a silent, undetected no-op behind a
+green check (the exact ENC-ISS-519 failure mode, reproduced live in run
+28919007760 / PR #958).
+
+Two pure, unit-testable pieces (no live AWS/git calls):
+  - resolve_target_functions(): affected_functions_json + function_name_map_json
+    -> the flat list of actual Lambda function names this run should have touched.
+  - is_fresh(): compare a function's LastModified string to the merge commit
+    timestamp string.
+
+main() wires those to `git show` (merge commit timestamp) and
+`aws lambda get-function-configuration` (LastModified) and fails loudly
+(exit 1, ::error::) on any stale or unreadable function.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve_target_functions(
+    full_scope: bool,
+    affected_functions: List[str],
+    function_name_map: Dict[str, str],
+    all_lambda_dirs: Optional[List[str]] = None,
+) -> List[str]:
+    """Flatten (dir -> mapped Lambda name(s), comma-separated per ENC-ISS-398)
+    into the list of real Lambda function names this deploy should have
+    touched. Dirs absent from the map are skipped -- _deploy.yml's own deploy
+    step silently skips them too (see 'not in function_name_map' logs), so
+    asserting freshness on them would be asserting something the deploy step
+    never claimed to do."""
+    dirs = list(all_lambda_dirs or []) if full_scope else list(affected_functions)
+    targets: List[str] = []
+    for d in dirs:
+        mapped = (function_name_map.get(d) or "").strip()
+        if not mapped:
+            continue
+        targets.extend(name.strip() for name in mapped.split(",") if name.strip())
+    return sorted(set(targets))
+
+
+def _parse_ts(value: str) -> datetime:
+    v = value.strip()
+    # AWS Lambda LastModified: "2026-07-08T06:10:00.000+0000" (no colon in tz offset).
+    if len(v) >= 5 and v[-5] in "+-" and v[-3] != ":":
+        v = f"{v[:-2]}:{v[-2:]}"
+    return datetime.fromisoformat(v)
+
+
+def is_fresh(last_modified: str, merge_commit_ts: str) -> bool:
+    """True iff the function's LastModified is at/after the merge commit's
+    timestamp -- proof this function's code was actually touched by (or
+    after) the commit being deployed, not left stale by a silent skip."""
+    lm = _parse_ts(last_modified)
+    merge = _parse_ts(merge_commit_ts)
+    if lm.tzinfo is None:
+        lm = lm.replace(tzinfo=timezone.utc)
+    if merge.tzinfo is None:
+        merge = merge.replace(tzinfo=timezone.utc)
+    return lm >= merge
+
+
+def _run(cmd: List[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=30)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def merge_commit_timestamp(sha: str) -> Optional[str]:
+    out = _run(["git", "show", "-s", "--format=%cI", sha])
+    if out is None:
+        return None
+    return out.strip()
+
+
+def function_last_modified(function_name: str, region: str) -> Optional[str]:
+    out = _run([
+        "aws", "lambda", "get-function-configuration",
+        "--function-name", function_name,
+        "--region", region,
+        "--query", "LastModified",
+        "--output", "text",
+    ])
+    if out is None:
+        return None
+    out = out.strip()
+    return out or None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--full-scope", required=True, choices=["true", "false"])
+    parser.add_argument("--affected-functions-json", default="[]")
+    parser.add_argument("--function-name-map-json", default="{}")
+    parser.add_argument("--region", default="us-west-2")
+    args = parser.parse_args()
+
+    merge_ts = merge_commit_timestamp(args.commit_sha)
+    if not merge_ts:
+        print(f"::error::could not resolve commit timestamp for {args.commit_sha} -- "
+              f"cannot verify post-deploy freshness", file=sys.stderr)
+        return 1
+
+    try:
+        affected = json.loads(args.affected_functions_json)
+        fn_map = json.loads(args.function_name_map_json)
+    except json.JSONDecodeError as exc:
+        print(f"::error::could not parse affected-functions/function-name-map JSON: {exc}", file=sys.stderr)
+        return 1
+
+    all_dirs = None
+    if args.full_scope == "true":
+        all_dirs = sorted(
+            p.parent.name for p in (REPO_ROOT / "backend" / "lambda").glob("*/lambda_function.py")
+        )
+
+    targets = resolve_target_functions(args.full_scope == "true", affected, fn_map, all_dirs)
+    if not targets:
+        print("No mapped target functions to verify (nothing claimed to deploy) -- skipping.")
+        return 0
+
+    print(f"Verifying {len(targets)} function(s) have LastModified >= {merge_ts} (commit {args.commit_sha[:7]})")
+    stale = []
+    unreadable = []
+    for name in targets:
+        lm = function_last_modified(name, args.region)
+        if lm is None:
+            unreadable.append(name)
+            print(f"::error::{name}: could not read LastModified via get-function-configuration", file=sys.stderr)
+            continue
+        if is_fresh(lm, merge_ts):
+            print(f"  OK {name}: LastModified={lm}")
+        else:
+            stale.append((name, lm))
+            print(f"::error::{name}: LastModified={lm} is BEFORE merge commit timestamp {merge_ts} "
+                  f"-- this function was NOT actually updated by this deploy (ENC-ISS-519 silent-skip class)", file=sys.stderr)
+
+    if stale or unreadable:
+        print(f"::error::Post-deploy freshness assertion FAILED: {len(stale)} stale, {len(unreadable)} unreadable "
+              f"out of {len(targets)} target function(s). This run must not be treated as a successful deploy.", file=sys.stderr)
+        return 1
+
+    print(f"Post-deploy freshness assertion passed for all {len(targets)} function(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/compute_affected_targets.py
+++ b/tools/compute_affected_targets.py
@@ -46,6 +46,22 @@ CROSS_CUTTING_PATTERNS = [
 
 LAMBDA_DIR_RE = re.compile(r"^backend/lambda/([^/]+)/")
 
+# ENC-ISS-519: discriminator for GitHub Deployment records that actually came
+# from THIS workflow's own Lambda code-deploy (see the "Create GitHub
+# Deployment" step in _deploy.yml). The CFN stack-deploy workflows
+# (cloudformation-api-stack-deploy.yml, cloudformation-compute-stack-deploy.yml)
+# declare `environment: v4-gamma` on their `apply` job, which makes GitHub
+# Actions itself auto-create a Deployment + success status for that same
+# environment/sha -- racing ahead of _deploy.yml's own deployment record for
+# the identical commit. Those GitHub-managed deployments default `task` to
+# "deploy" and carry no marker. Treating ANY success status on ANY deployment
+# for the environment as "already deployed" let the CFN race masquerade as a
+# real Lambda deploy: base_sha == head_sha, 0 Lambda updates, green run,
+# nothing shipped (reproduced live, run 28919007760 / PR #958). A deployment
+# record is only trustworthy evidence of a real Lambda deploy if it carries
+# this exact task.
+LAMBDA_CODE_DEPLOY_TASK = "lambda-artifacts"
+
 
 def _run(cmd: List[str]) -> Optional[str]:
     try:
@@ -74,6 +90,17 @@ def resolve_last_deployed_sha(environment: str, repo: str) -> Optional[str]:
     for dep in deployments:
         dep_id = dep.get("id")
         if dep_id is None:
+            continue
+        # ENC-ISS-519 (candidates 2+3): a deployment record is only usable as
+        # "last deployed sha" evidence if it is THIS workflow's own Lambda
+        # code-deploy. Any other deployment for the same environment/sha
+        # (e.g. a CFN stack-apply's auto-created Deployment) is skipped
+        # entirely -- it is never used to short-circuit base_sha == head_sha,
+        # and never returned as a base sha. This both discriminates the
+        # record (candidate 2) and hardens the same-sha short-circuit
+        # (candidate 3): fail-open by falling through to the next matching
+        # deployment, or to full_scope=True if none match.
+        if dep.get("task") != LAMBDA_CODE_DEPLOY_TASK:
             continue
         statuses_out = _run([
             "gh", "api", f"/repos/{repo}/deployments/{dep_id}/statuses?per_page=10",

--- a/tools/test_assert_post_deploy_freshness.py
+++ b/tools/test_assert_post_deploy_freshness.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""ENC-ISS-519: unit tests for the pure logic in assert_post_deploy_freshness.py
+(target-function resolution + LastModified-vs-merge-commit freshness check).
+No live git/AWS calls -- see tools/test_compute_affected_targets.py for the
+sibling resolver tests this assertion backstops.
+
+Run: python3 -m unittest tools.test_assert_post_deploy_freshness -v
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parent / "assert_post_deploy_freshness.py"
+spec = importlib.util.spec_from_file_location("assert_post_deploy_freshness", MODULE_PATH)
+apf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apf)
+
+
+class ResolveTargetFunctionsTest(unittest.TestCase):
+    def test_narrow_scope_maps_affected_dirs_only(self):
+        targets = apf.resolve_target_functions(
+            full_scope=False,
+            affected_functions=["tracker_mutation"],
+            function_name_map={"tracker_mutation": "devops-tracker-mutation-api-gamma"},
+        )
+        self.assertEqual(targets, ["devops-tracker-mutation-api-gamma"])
+
+    def test_dir_absent_from_map_is_skipped(self):
+        targets = apf.resolve_target_functions(
+            full_scope=False,
+            affected_functions=["tracker_mutation", "not_in_map"],
+            function_name_map={"tracker_mutation": "devops-tracker-mutation-api-gamma"},
+        )
+        self.assertEqual(targets, ["devops-tracker-mutation-api-gamma"])
+
+    def test_comma_list_expands_to_multiple_functions(self):
+        targets = apf.resolve_target_functions(
+            full_scope=False,
+            affected_functions=["checkout_service"],
+            function_name_map={"checkout_service": "enceladus-checkout-service-gamma, enceladus-checkout-service-auto-gamma"},
+        )
+        self.assertEqual(
+            targets,
+            ["enceladus-checkout-service-auto-gamma", "enceladus-checkout-service-gamma"],
+        )
+
+    def test_full_scope_uses_all_lambda_dirs(self):
+        targets = apf.resolve_target_functions(
+            full_scope=True,
+            affected_functions=[],
+            function_name_map={"a": "fn-a", "b": "fn-b"},
+            all_lambda_dirs=["a", "b", "c"],
+        )
+        self.assertEqual(targets, ["fn-a", "fn-b"])
+
+    def test_empty_map_yields_no_targets(self):
+        targets = apf.resolve_target_functions(
+            full_scope=False,
+            affected_functions=["tracker_mutation"],
+            function_name_map={},
+        )
+        self.assertEqual(targets, [])
+
+
+class IsFreshTest(unittest.TestCase):
+    def test_last_modified_after_merge_is_fresh(self):
+        self.assertTrue(apf.is_fresh(
+            "2026-07-08T06:15:00.000+0000",
+            "2026-07-08T06:00:00+00:00",
+        ))
+
+    def test_last_modified_before_merge_is_stale(self):
+        # The ENC-ISS-519 silent-skip case: function code predates the merge
+        # this run claims to have deployed.
+        self.assertFalse(apf.is_fresh(
+            "2026-07-07T12:00:00.000+0000",
+            "2026-07-08T06:00:00+00:00",
+        ))
+
+    def test_equal_timestamps_are_fresh(self):
+        self.assertTrue(apf.is_fresh(
+            "2026-07-08T06:00:00.000+0000",
+            "2026-07-08T06:00:00+00:00",
+        ))
+
+    def test_handles_naive_aws_style_offset_without_colon(self):
+        # AWS Lambda's LastModified format has no colon in the tz offset
+        # ("+0000"); Python's fromisoformat requires one. Must not raise.
+        result = apf.is_fresh("2026-07-08T06:00:00.000-0700", "2026-07-08T13:00:00+00:00")
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_compute_affected_targets.py
+++ b/tools/test_compute_affected_targets.py
@@ -6,6 +6,7 @@ subprocess seam in compute_affected_targets.py -- no live git/gh/AWS calls.
 Run: python3 tools/test_compute_affected_targets.py
 """
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -80,6 +81,82 @@ class ComputeAffectedTargetsTest(unittest.TestCase):
         ])):
             result = cat.compute("v4-gamma", "org/repo", "headsha", base_sha_override="basesha")
         self.assertFalse(result["full_scope"])
+        self.assertEqual(result["affected_functions"], [])
+
+
+class ResolveLastDeployedShaDiscriminatorTest(unittest.TestCase):
+    """ENC-ISS-519: a CFN stack-deploy workflow's `environment: v4-gamma` job
+    attribute makes GitHub Actions auto-create a Deployment + success status
+    for the same environment/sha as _deploy.yml's own Lambda code-deploy --
+    racing ahead of it. resolve_last_deployed_sha must never treat that
+    raced, non-code-deploy record as evidence a real Lambda deploy happened."""
+
+    @staticmethod
+    def _fake_run(deployments, statuses_by_id, diff_lines=None):
+        def _run(cmd):
+            if cmd[:2] == ["gh", "api"] and "deployments?environment=" in cmd[2]:
+                return json.dumps(deployments)
+            if cmd[:2] == ["gh", "api"] and "/statuses" in cmd[2]:
+                for dep_id, statuses in statuses_by_id.items():
+                    if f"/deployments/{dep_id}/statuses" in cmd[2]:
+                        return json.dumps(statuses)
+                return "[]"
+            if cmd[:2] == ["git", "diff"] and diff_lines is not None:
+                return "\n".join(diff_lines) + "\n"
+            return None
+        return _run
+
+    def test_skips_deployment_record_lacking_discriminator(self):
+        # id=2 (no task, i.e. a GitHub-managed CFN environment deployment) is
+        # newest and races ahead; id=1 carries the real code-deploy task.
+        deployments = [
+            {"id": 2, "sha": "racedsha"},
+            {"id": 1, "sha": "realsha", "task": cat.LAMBDA_CODE_DEPLOY_TASK},
+        ]
+        statuses = {2: [{"state": "success"}], 1: [{"state": "success"}]}
+        with patch.object(cat, "_run", self._fake_run(deployments, statuses)):
+            sha = cat.resolve_last_deployed_sha("v4-gamma", "org/repo")
+        self.assertEqual(sha, "realsha")
+
+    def test_no_discriminated_record_forces_full_scope(self):
+        # Only a raced, non-discriminated (CFN-auto-created) record exists --
+        # never treat it as "a real deploy happened here"; fail-open.
+        deployments = [{"id": 9, "sha": "cfnraced", "task": "deploy"}]
+        statuses = {9: [{"state": "success"}]}
+        with patch.object(cat, "_run", self._fake_run(deployments, statuses)):
+            result = cat.compute("v4-gamma", "org/repo", "headsha")
+        self.assertTrue(result["full_scope"], result["reason"])
+        self.assertIn("no prior successful deployment", result["reason"])
+
+    def test_base_sha_equals_head_short_circuit_only_from_real_code_deploy(self):
+        # id=3 races in at head_sha with no discriminator (the ENC-ISS-519
+        # bug case: base_sha == head_sha would wrongly short-circuit to
+        # "nothing to diff" if this record were trusted). The real prior
+        # code-deploy (id=2) sits at an older sha -- the resolver must skip
+        # the raced head_sha record and diff against the real prior deploy.
+        deployments = [
+            {"id": 3, "sha": "headsha", "task": "deploy"},
+            {"id": 2, "sha": "priorsha", "task": cat.LAMBDA_CODE_DEPLOY_TASK},
+        ]
+        statuses = {3: [{"state": "success"}], 2: [{"state": "success"}]}
+        diff_lines = ["backend/lambda/tracker_mutation/lambda_function.py"]
+        with patch.object(cat, "_run", self._fake_run(deployments, statuses, diff_lines)):
+            result = cat.compute("v4-gamma", "org/repo", "headsha")
+        self.assertFalse(result["full_scope"], result["reason"])
+        self.assertEqual(result["base_sha"], "priorsha")
+        self.assertEqual(result["affected_functions"], ["tracker_mutation"])
+
+    def test_legit_same_sha_redeploy_noop_still_short_circuits(self):
+        # A real code-deploy record (correct discriminator) already sits at
+        # head_sha -- this IS legitimate "nothing to diff, already deployed
+        # here" and must still short-circuit (candidate 3 must not become
+        # fail-closed-to-full-scope for the true no-op case).
+        deployments = [{"id": 1, "sha": "headsha", "task": cat.LAMBDA_CODE_DEPLOY_TASK}]
+        statuses = {1: [{"state": "success"}]}
+        with patch.object(cat, "_run", self._fake_run(deployments, statuses)):
+            result = cat.compute("v4-gamma", "org/repo", "headsha")
+        self.assertFalse(result["full_scope"], result["reason"])
+        self.assertEqual(result["base_sha"], "headsha")
         self.assertEqual(result["affected_functions"], [])
 
 


### PR DESCRIPTION
## Summary
- `resolve_last_deployed_sha()` in `tools/compute_affected_targets.py` treated ANY success-state GitHub Deployment for an environment as proof a real Lambda code-deploy happened there — including the auto-created Deployment that `cloudformation-api-stack-deploy.yml` / `cloudformation-compute-stack-deploy.yml` post via their `apply` job's `environment:` attribute for the SAME commit. When that record won the race against `_deploy.yml`'s own deployment, `base_sha == head_sha` short-circuited to "nothing to diff" and the run went green with 0 Lambda updates (reproduced live: PR #958, run 28919007760, `devops-coordination-api-gamma` stuck at v338).
- `_deploy.yml`'s "Create GitHub Deployment" step now tags its own record with `task=lambda-artifacts`.
- `resolve_last_deployed_sha()` only matches records carrying that task, skipping (never trusting) any other deployment for the environment — this both discriminates the record (candidate 2) and hardens the `base_sha == head_sha` short-circuit (candidate 3) to fail open: fall through to the next matching record, or to `full_scope=true`, instead of trusting a raced CFN record.
- New gamma-lane post-deploy step (`tools/assert_post_deploy_freshness.py`) asserts every claimed-deployed function's `LastModified` is at/after the merge commit timestamp, failing loudly on any future silent-skip regression of this class.
- Candidate 1 (a distinct CFN environment label) is deferred as a follow-up for the main-branch mirror at cutover: the CFN stack-deploy workflows are shared with the prod lane, and changing the `environment:` key risks the required-reviewer/OIDC gating there.

## Test plan
- [x] `python3 -m unittest tools.test_compute_affected_targets -v` — 11/11 pass, including 4 new tests reproducing the exact race (raced non-discriminated record at head_sha vs. real code-deploy record at an older sha; fail-open when no discriminated record exists; legit same-sha no-op still short-circuits)
- [x] `python3 -m unittest tools.test_assert_post_deploy_freshness -v` — 9/9 pass (target-function resolution + LastModified/merge-commit comparison, including AWS's colon-less tz offset format)
- [x] `python3 tools/prod_gate_coverage_guard.py` — passes unchanged (only added steps within the already-gated `deploy` job; no job-level `environment:` changes)
- [ ] Live: merge to v4/main and watch the triggered `Deploy Lambda Artifacts (Gen2)` run — resolver must compute a real diff (or full_scope) and the new freshness assertion must pass, even with the CFN workflows racing on the same commit

ENC-TSK-M31 / ENC-ISS-519
CCI-7d02007b13064ba287d2f12cde0825d8

🤖 Generated with [Claude Code](https://claude.com/claude-code)