### PR TITLE
ENC-TSK-M34 + ENC-TSK-M38: Docs content/download + narrow-width overflow sweep

### DIFF
--- a/frontend/ui-v2/src/components/MarkdownContent.tsx
+++ b/frontend/ui-v2/src/components/MarkdownContent.tsx
@@ -1,0 +1,39 @@
+/**
+ * MarkdownContent — Content-tab renderer for full document bodies
+ * (ENC-TSK-M34, Docs.dc.html §"CONTENT · rendered markdown").
+ *
+ * TODO(ENC-TSK-M34 / concurrent lane L1): a shared, fully-interpreted
+ * Markdown renderer is being built on `agent/enc-tsk-m35-m36-feed` for the
+ * Feed reading pane. Per dispatch instruction this component is the
+ * *sanctioned interim* — safe plaintext (no HTML injection, whitespace
+ * preserved) behind this TODO — and must be replaced by an import of the
+ * shared component once that lane merges. Do NOT hand-roll a second
+ * Markdown-to-HTML parser here; if the shared component isn't available yet,
+ * keep this plaintext fallback.
+ */
+export function MarkdownContent({ content }: { content: string | undefined }) {
+  if (!content) {
+    return (
+      <p style={{ fontFamily: 'var(--font-body)', fontSize: 'var(--text-sm)', color: 'var(--fg-muted)' }}>
+        No content available.
+      </p>
+    )
+  }
+
+  return (
+    <pre
+      className="ev2-md-content"
+      style={{
+        margin: 0,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        fontFamily: 'var(--font-body)',
+        fontSize: 'var(--text-sm)',
+        lineHeight: 'var(--lh-relaxed)',
+        color: 'var(--fg)',
+      }}
+    >
+      {content}
+    </pre>
+  )
+}

--- a/frontend/ui-v2/src/components/RecordDetailHub.tsx
+++ b/frontend/ui-v2/src/components/RecordDetailHub.tsx
@@ -48,6 +48,7 @@ export function RecordDetailHub({
   recordType,
   vitals = [],
   overview,
+  content,
   neighbors,
   worklog,
   evidence,
@@ -61,6 +62,9 @@ export function RecordDetailHub({
   recordType?: string
   vitals?: HubVital[]
   overview: ReactNode
+  /** Optional "Content" tab (Docs.dc.html) — full document body, rendered
+   *  between Overview and Neighbors. ENC-TSK-M34. */
+  content?: ReactNode
   neighbors?: ReactNode
   worklog?: ReactNode
   evidence?: ReactNode
@@ -83,6 +87,7 @@ export function RecordDetailHub({
 
   const tabs = [
     { id: 'overview', label: 'Overview', content: overview },
+    ...(content !== undefined ? [{ id: 'content', label: 'Content', content }] : []),
     ...(neighbors ? [{ id: 'neighbors', label: 'Neighbors', content: neighbors }] : []),
     ...(worklog ? [{ id: 'worklog', label: 'Worklog', content: worklog }] : []),
     ...(evidence ? [{ id: 'evidence', label: 'Evidence', content: evidence }] : []),

--- a/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/DocumentPrimitive.tsx
@@ -1,7 +1,29 @@
 import { FileText } from 'lucide-react'
 import type { Document } from '../types/records'
+import { MarkdownContent } from '../components/MarkdownContent'
 import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
 import { NeighborsTab, RecordDetailHub } from '../components/RecordDetailHub'
+import { downloadTextFile } from '../utils/downloadTextFile'
+
+/** "8.6 KB" / "116.9 KB" style — matches Docs.dc.html row + metadata format. */
+function formatSize(bytes: number | undefined): string | null {
+  if (bytes == null || Number.isNaN(bytes)) return null
+  if (bytes < 1024) return `${bytes} B`
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+function formatTimestamp(iso: string | undefined): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
 
 export function DocumentPrimitive({ record }: { record: Document }) {
   const vitals = [
@@ -10,6 +32,11 @@ export function DocumentPrimitive({ record }: { record: Document }) {
     ...(record.document_subtype ? [{ label: 'Subtype', value: record.document_subtype }] : []),
   ]
 
+  const sizeLabel = formatSize(record.size_bytes)
+  const createdLabel = formatTimestamp(record.created_at)
+  const updatedLabel = formatTimestamp(record.updated_at)
+  const fileName = record.file_name || `${record.document_id}.md`
+
   return (
     <RecordDetailHub
       recordId={record.document_id}
@@ -17,15 +44,36 @@ export function DocumentPrimitive({ record }: { record: Document }) {
       title={record.title}
       status={record.status}
       vitals={vitals}
+      actions={[
+        {
+          label: 'Download .md',
+          onClick: () => downloadTextFile(fileName, record.content ?? '', 'text/markdown'),
+        },
+      ]}
       overview={
         <>
           <Prose>{record.description}</Prose>
           <MetaRow label="File">
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
               <FileText size={14} strokeWidth={1.5} color="var(--accent)" />
-              <span style={{ fontFamily: 'var(--font-mono)' }}>{record.file_name}</span>
+              <span style={{ fontFamily: 'var(--font-mono)' }}>{fileName}</span>
             </span>
           </MetaRow>
+          <MetaRow label="Type">
+            <span style={{ fontFamily: 'var(--font-mono)' }}>{record.content_type || 'text/markdown'}</span>
+          </MetaRow>
+          {sizeLabel ? (
+            <MetaRow label="Size">
+              <span style={{ fontFamily: 'var(--font-mono)' }}>{sizeLabel}</span>
+            </MetaRow>
+          ) : null}
+          {record.content_hash ? (
+            <MetaRow label="Hash">
+              <span style={{ fontFamily: 'var(--font-mono)', wordBreak: 'break-all', color: 'var(--fg-muted)' }}>
+                {record.content_hash}
+              </span>
+            </MetaRow>
+          ) : null}
           <MetaRow label="Version">
             <Metric>v{record.version ?? '?'}</Metric>
           </MetaRow>
@@ -33,8 +81,19 @@ export function DocumentPrimitive({ record }: { record: Document }) {
             {(record.keywords ?? []).length > 0 ? (record.keywords ?? []).join(', ') : 'None'}
           </MetaRow>
           <MetaRow label="Created by">{record.created_by}</MetaRow>
+          {createdLabel ? <MetaRow label="Created">{createdLabel}</MetaRow> : null}
+          {updatedLabel ? <MetaRow label="Updated">{updatedLabel}</MetaRow> : null}
+          {record.compliance_score != null ? (
+            <MetaRow label="Compliance">
+              <Metric>{record.compliance_score}</Metric>
+              {record.compliance_warnings?.length ? (
+                <span style={{ color: 'var(--fg-muted)' }}> · {record.compliance_warnings.length} warning(s)</span>
+              ) : null}
+            </MetaRow>
+          ) : null}
         </>
       }
+      content={<MarkdownContent content={record.content} />}
       neighbors={
         <NeighborsTab projectId={record.project_id} groups={[{ label: 'Related items', ids: record.related_items }]} />
       }

--- a/frontend/ui-v2/src/routes/coordination.css
+++ b/frontend/ui-v2/src/routes/coordination.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: var(--space-5);
   max-width: calc(var(--space-16) * 56);
+  /* ENC-TSK-M38 route sweep: same auto-minimum floor as feed/docs. */
+  min-width: var(--space-0);
 }
 
 .coordination-route__header {

--- a/frontend/ui-v2/src/routes/docs.css
+++ b/frontend/ui-v2/src/routes/docs.css
@@ -3,6 +3,10 @@
   flex-direction: column;
   gap: var(--space-5);
   max-width: calc(var(--space-16) * 56);
+  /* ENC-TSK-M38: see feed.css -- floors this flex item's auto-minimum so
+     no descendant can bubble a wider intrinsic min-content up through
+     .ev2-al__content and force horizontal scroll at narrow viewports. */
+  min-width: var(--space-0);
 }
 
 .docs-route__header {
@@ -42,10 +46,16 @@
   flex-wrap: wrap;
   align-items: flex-start;
   gap: var(--space-3);
+  /* ENC-TSK-M38: toolbar is itself a flex item of the column above it. */
+  min-width: var(--space-0);
 }
 
 .docs-route__search {
   flex: 1;
+  /* ENC-TSK-M38: see feed.css .feed-route__search -- explicit shrink
+     floor for the search box flex item, independent of the nested
+     Autosuggest/Input chain's own min-width:0. */
+  min-width: var(--space-0);
 }
 
 /* ENC-TSK-M26 fix: same unconditional 768px min-width bug as feed.css --

--- a/frontend/ui-v2/src/routes/feed.css
+++ b/frontend/ui-v2/src/routes/feed.css
@@ -3,6 +3,11 @@
   flex-direction: column;
   gap: var(--space-5);
   max-width: calc(var(--space-16) * 56);
+  /* ENC-TSK-M38: floor this flex item's cross-axis auto-minimum so a
+     long unbreakable descendant (a token, hash, or native form control)
+     can never bubble a wider intrinsic min-content up through
+     .ev2-al__content and force horizontal scroll at narrow viewports. */
+  min-width: var(--space-0);
 }
 
 .feed-route__header {
@@ -42,10 +47,22 @@
   flex-wrap: wrap;
   align-items: flex-start;
   gap: var(--space-3);
+  /* ENC-TSK-M38: same auto-minimum floor as .feed-route -- the toolbar is
+     itself a flex item of the column above it. */
+  min-width: var(--space-0);
 }
 
 .feed-route__search {
   flex: 1;
+  /* ENC-TSK-M38 (ENC-ISS-51x residual): flex:1 alone does not give this
+     item a shrink floor -- its automatic minimum size is its content's
+     min-content width unless min-width:0 overrides it. The nested
+     Autosuggest/Input chain sets min-width:0 on the innermost <input>,
+     but that alone is fragile across future content additions (icons,
+     inline suggestions); floor the outer flex item explicitly so the
+     "Search records or saved name…" box can always shrink to fit ≤606px
+     viewports instead of forcing this row (and the page) wider. */
+  min-width: var(--space-0);
 }
 
 /* ENC-TSK-M26 fix: this min-width (768px) was unconditional, so at mobile

--- a/frontend/ui-v2/src/routes/governance.css
+++ b/frontend/ui-v2/src/routes/governance.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: var(--space-5);
   max-width: calc(var(--space-16) * 56);
+  /* ENC-TSK-M38 route sweep: same auto-minimum floor as feed/docs. */
+  min-width: var(--space-0);
 }
 
 .governance-route__header {

--- a/frontend/ui-v2/src/routes/skillLibrary.css
+++ b/frontend/ui-v2/src/routes/skillLibrary.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: var(--space-5);
   max-width: calc(var(--space-16) * 56);
+  /* ENC-TSK-M38 route sweep: same auto-minimum floor as feed/docs. */
+  min-width: var(--space-0);
 }
 
 .ev2-skill-library__title-link {

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -211,10 +211,19 @@ describe('card grid mobile collapse (ENC-ISS-516 / defect B)', () => {
       ['routes/feed.css', '.feed-route__search'],
       ['routes/docs.css', '.docs-route__search'],
     ] as const) {
-      const css = readSrc(path)
+      // Comments stripped -- ENC-TSK-M38's own doc comments below mention
+      // "min-width:0" in prose, which would otherwise false-positive here.
+      const css = stripCssComments(readSrc(path))
       const baseRuleMatch = css.match(new RegExp(`(?<!@media[^{]*\\{[^}]*)${cls.replace('.', '\\.')}\\s*\\{([^}]*)\\}`))
       expect(baseRuleMatch, `expected a base (non-media) rule for ${cls} in ${path}`).not.toBeNull()
-      expect(baseRuleMatch?.[1] ?? '').not.toMatch(/min-width/)
+      // ENC-TSK-M38 added an explicit `min-width: 0` shrink floor to this same
+      // base rule (see the "search input + toolbar overflow floor" suite
+      // below) -- that's the fix, not a regression of the original bug. What
+      // must never come back is a NON-ZERO unconditional min-width forcing a
+      // wide box at every viewport.
+      const base = baseRuleMatch?.[1] ?? ''
+      const nonZeroMinWidth = /min-width:\s*(?!(?:0(?:px|rem|em)?|var\(--space-0\))\s*;)\S/
+      expect(base).not.toMatch(nonZeroMinWidth)
 
       const desktopGated = new RegExp(
         `@media \\(min-width: 48\\.0625rem\\) \\{[\\s\\S]*?${cls.replace('.', '\\.')}\\s*\\{[^}]*min-width`,
@@ -267,5 +276,63 @@ describe('record detail hub sticky action bar (ENC-TSK-M23)', () => {
   it('reserves bottom padding on mobile so the fixed bar never occludes content', () => {
     const rootMatch = hubCss.match(/\.ev2-rdh\s*\{([^}]*)\}/)
     expect(rootMatch?.[1] ?? '').toMatch(/padding-bottom:/)
+  })
+})
+
+/**
+ * ENC-TSK-M38 -- the "Search records or saved name…" input (FeedRoute) and
+ * its Docs-route twin sat inside a `flex: 1` toolbar item with no explicit
+ * `min-width`. `.ev2-al__content` (AppLayout.jsx) already floors its own
+ * cross-axis auto-minimum with `min-width: 0`, but that guarantee stops at
+ * the first descendant that doesn't repeat it -- a flex item's automatic
+ * minimum size defaults to its content's min-content width, not 0, unless
+ * the item (or a shrink-blocking ancestor) says so explicitly. The nested
+ * Autosuggest -> Input -> <input> chain sets `min-width: 0` only on the
+ * innermost field, which is fragile: any future sibling (an icon, an
+ * inline suggestion chip) breaks the guarantee again. This suite pins the
+ * floor at every level of the chain -- the route root, the toolbar, and the
+ * search box itself -- for both routes, plus a root-level sweep across the
+ * remaining flex-column route surfaces (ENC-TSK-M38 AC-2: route sweep).
+ */
+describe('search input + toolbar overflow floor (ENC-TSK-M38)', () => {
+  it.each([
+    ['routes/feed.css', '.feed-route', '.feed-route__toolbar', '.feed-route__search'],
+    ['routes/docs.css', '.docs-route', '.docs-route__toolbar', '.docs-route__search'],
+  ] as const)('%s floors the route root, toolbar, and search box to min-width: 0', (path, rootCls, toolbarCls, searchCls) => {
+    const css = stripCssComments(readSrc(path))
+    for (const cls of [rootCls, toolbarCls, searchCls]) {
+      const escaped = cls.replace('.', '\\.')
+      const ruleMatch = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+      expect(ruleMatch, `expected a base rule for ${cls} in ${path}`).not.toBeNull()
+      expect(ruleMatch?.[1] ?? '').toMatch(/min-width:\s*(var\(--space-0\)|0)/)
+    }
+  })
+
+  it('the search box base rule keeps its min-width:0 floor BEFORE the desktop min-width opt-in', () => {
+    // Regression guard: a later, higher-specificity or later-source-order
+    // rule re-introducing an unconditional min-width would silently undo
+    // the floor above at exactly the narrow widths this task targets.
+    for (const [path, cls] of [
+      ['routes/feed.css', '.feed-route__search'],
+      ['routes/docs.css', '.docs-route__search'],
+    ] as const) {
+      const css = stripCssComments(readSrc(path))
+      const floorIdx = css.search(new RegExp(`${cls.replace('.', '\\.')}\\s*\\{[^}]*min-width:\\s*(var\\(--space-0\\)|0)`))
+      const desktopGateIdx = css.indexOf('@media (min-width: 48.0625rem)')
+      expect(floorIdx).toBeGreaterThan(-1)
+      expect(desktopGateIdx).toBeGreaterThan(-1)
+      expect(floorIdx).toBeLessThan(desktopGateIdx)
+    }
+  })
+
+  it.each([
+    ['routes/coordination.css', '.coordination-route'],
+    ['routes/governance.css', '.governance-route'],
+    ['routes/skillLibrary.css', '.ev2-skill-library'],
+  ] as const)('route sweep: %s floors %s to min-width: 0', (path, rootCls) => {
+    const css = stripCssComments(readSrc(path))
+    const ruleMatch = css.match(new RegExp(`${rootCls.replace('.', '\\.')}\\s*\\{([^}]*)\\}`))
+    expect(ruleMatch, `expected a base rule for ${rootCls} in ${path}`).not.toBeNull()
+    expect(ruleMatch?.[1] ?? '').toMatch(/min-width:\s*(var\(--space-0\)|0)/)
   })
 })

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -175,6 +175,13 @@ export interface Document {
   updated_at: string
   version: number
   document_subtype?: string
+  /** Full raw markdown body. Present when fetched with include_content=true
+   *  (the default for a single-document GET) — ENC-TSK-M34. */
+  content?: string
+  content_hash?: string
+  size_bytes?: number
+  compliance_score?: number
+  compliance_warnings?: string[]
 }
 
 export interface RecordShapeMap {

--- a/frontend/ui-v2/src/utils/downloadTextFile.test.ts
+++ b/frontend/ui-v2/src/utils/downloadTextFile.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { downloadTextFile } from './downloadTextFile'
+
+describe('downloadTextFile (ENC-TSK-M34 AC-2)', () => {
+  it('builds a Blob, triggers a download anchor, and revokes the object URL', () => {
+    const createObjectURL = vi.fn(() => 'blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
+
+    const clickSpy = vi.fn()
+    const originalCreateElement = document.createElement.bind(document)
+    const appendSpy = vi.spyOn(document.body, 'appendChild')
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag)
+      if (tag === 'a') el.click = clickSpy
+      return el
+    })
+
+    downloadTextFile('DOC-B6B52E3BB9BB.md', '# hello world', 'text/markdown')
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    const [blobArg] = createObjectURL.mock.calls[0]
+    expect(blobArg).toBeInstanceOf(Blob)
+    expect(appendSpy).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/ui-v2/src/utils/downloadTextFile.ts
+++ b/frontend/ui-v2/src/utils/downloadTextFile.ts
@@ -1,0 +1,17 @@
+/**
+ * Client-side text-file download (ENC-TSK-M34 AC-2: ".md download" button).
+ * Builds a Blob from already-fetched text and triggers a browser download via
+ * a transient <a download> — no extra network round-trip, no auth/CORS
+ * concerns since the content is already in hand from the record fetch.
+ */
+export function downloadTextFile(fileName: string, text: string, mimeType = 'text/markdown'): void {
+  const blob = new Blob([text], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = fileName
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary

**ENC-TSK-M34** — Document detail pages render full content in interpreted form plus expanded metadata, with a `.md` download button.
- `RecordDetailHub` gains an optional `content` tab (Overview → Content → Neighbors, per `Docs.dc.html`).
- `DocumentPrimitive` wires a `MarkdownContent` renderer + expanded metadata (Type, Size, Hash, Created, Updated, Compliance) and a "Download .md" action (client-side Blob download, no extra round-trip since `content` is already in the single-document fetch).
- `MarkdownContent` renders safe pre-wrap plaintext behind an explicit TODO: lane L1 (`agent/enc-tsk-m35-m36-feed`) is building a shared Markdown renderer for the Feed reading pane; this is the sanctioned interim per dispatch, to avoid a second renderer.
- Validated against the live document named in the AC (`DOC-B6B52E3BB9BB`, 16978 bytes) via `documents.get` — content, size_bytes, content_hash, compliance_score all populate correctly.

CCI-7d45288012164f27a43cedcf97db7830

**ENC-TSK-M38** — Narrow-width (≤606px) horizontal-overflow sweep.
- The "Search records or saved name…" box (`FeedRoute`) and its Docs twin sit in a `flex: 1` toolbar item with no explicit shrink floor; `.ev2-al__content` already floors its own auto-minimum with `min-width: 0`, but that guarantee doesn't propagate through descendants automatically. Floors `min-width: 0` at every level (route root, toolbar, search box) for `feed.css` and `docs.css`, matching the existing `.feed-route__pane` pattern.
- Extends the same floor to the remaining flex-column route roots (`coordination.css`, `governance.css`, `skillLibrary.css`) per the route-sweep AC.
- Record-detail long-token overflow (the other sweep target) is already covered by `.ev2-rdh`/`.ev2-rdh__body`'s `max-width: 100%` (ENC-TSK-M23); token wrapping itself is lane L1's renderer concern.
- Extends `mobileViewport.test.ts`: floor assertions per route, a source-order regression guard, and the route-root sweep. Loosens the pre-existing M26 assertion to allow the new zero-floor while still rejecting a reintroduced non-zero unconditional min-width.

CCI-9e4f0dfda96a422b8d8799181c76a06e

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 219/219 passing (27 in `mobileViewport.test.ts`, incl. 5 new ENC-TSK-M38 tests + 1 loosened M26 assertion)
- [x] `npm run build` — succeeds, bundle-budget assertion passes (481.44 KB raw / 147.41 KB gz, budget 200 KB gz)
- [x] `documents.get(DOC-B6B52E3BB9BB)` — confirms live content/metadata shape used by the new Overview/Content tabs
- [ ] Post-merge: confirm on gamma (`enceladus-gamma.jreese.net`) — Docs → open a large doc → Content tab renders body, Overview shows expanded metadata, Download .md delivers the file; Feed/Docs search box has no horizontal scroll at ≤606px

🤖 Generated with [Claude Code](https://claude.com/claude-code)