### PR TITLE
ENC-TSK-M35/M36: Feed rebuild (dense rows + master-detail pane) + data-truth fixes

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-08.03",
-  "updated_at": "2026-07-08T05:10:00Z",
-  "last_change_summary": "ENC-TSK-M27 (ENC-FTR-130): io-queue completeness. Two new read-only, Cognito-gated GET routes on coordination_api close the two M19 Home \"Data gap\" placeholder rows -- GET /api/v1/coordination/queue/paused-approvals (GitHub Actions runs blocked on the v3-prod Environment's required-reviewer gate; reuses the existing ENC-FTR-021 GitHub App installation-token path via new _get_github_installation_token/_github_queue_api_get helpers, no new secret minted) and GET /api/v1/coordination/queue/stale-locks (Scan of the projects table for checkout_state=checked_out task records past STALE_CHECKOUT_THRESHOLD_MINUTES, mirroring backend/lambda/stale_checkout_monitor's detection core so the PWA agrees with the scheduled monitor's signal). Both handlers add no mutation path. New least-privilege GitHubAppSecretRead IAM statement (secretsmanager:GetSecretValue/DescribeSecret scoped to devops/github-app/*) on CoordinationApiRole (infrastructure/cloudformation/02-compute.yaml, covers gamma + prod via EnvironmentSuffix); no new DynamoDB IAM needed (TrackerTableAccess/ProjectsTableRead already grant Scan). New gamma-only APIGW routes RouteQueuePausedApprovals + RouteQueueStaleLocks (infrastructure/cloudformation/03-api.yaml, Condition: IsGamma, same posture as the Escalations feed). frontend/ui-v2 Home route now fetches both live and replaces routes/homeQueue.ts::GAP_QUEUE_ROWS with pausedApprovalRows/staleLockRows mapping functions.",
+  "version": "2026-07-08.04",
+  "updated_at": "2026-07-08T08:55:00Z",
+  "last_change_summary": "ENC-TSK-M36 (feed data-truth): backend/lambda/feed_query/lambda_function.py -- confirmed live against gamma that GET /api/v1/feed/tasks.json and GET /api/v1/feed/corpus both took ~20s on a cache miss because _query_all_records / _query_corpus_tracker_records queried every active project's project-type-index SEQUENTIALLY (one paginated DynamoDB Query per project, no concurrency). Factored the per-project fetch out to _query_project_tracker_records and fan it out concurrently via _fan_out_by_project (ThreadPoolExecutor, bounded _MAX_PROJECT_FANOUT_WORKERS=8); both callers now run the same per-project queries in parallel instead of serially. Separately, the per-type snapshot caps (MAX_ISSUES/FEATURES/LESSONS/PLANS_FULL_REFRESH=10, ENC-TSK-C34) used to apply to the merged cross-project pool -- since project-type-index is shared by every governed project in this table, a global cap meant one recently-active project's issue/feature/lesson/plan records could crowd another project's entirely out of the tasks.json snapshot, even though /feed/corpus (uncapped) proves the data was never actually missing from DynamoDB. _query_all_records now applies these caps PER PROJECT before merging so every active project keeps a fair slice regardless of what other tenants are doing; worst-case payload grows to N-active-projects x 140 minimal-projection rows, comfortably inside the 6 MB Lambda response limit. Read-only: no schema change, no new endpoint, no write path touched. Companion frontend fix (ui-v2, no backend dependency): CacheEngineProvider's one-shot corpus-seed call now retries (2 attempts, 1s/3s backoff) instead of permanently stranding isWarm=false on a single transient failure, and Home's \"Awaiting checkout\" tile now scopes its Feed destination link to the same project_id its count was computed against (routes/HomeRoute.tsx::openTasksSearchFor), fixing a count/filter project-scope mismatch.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7841,6 +7841,11 @@
   },
   "change_summary": "ENC-TSK-L93: documents-list metadata-only projection via include_content=false (skill catalog fields + runtime_hint).",
   "change_log": [
+    {
+      "version": "2026-07-08.04",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M36 (feed data-truth): feed_query per-project fan-out parallelized (ThreadPoolExecutor, was sequential -- confirmed ~20s cold-cache latency live on gamma) and per-type snapshot caps (issues/features/lessons/plans) moved from a global cross-project pool to per-project, so one active project's records can no longer crowd another's out of the tasks.json snapshot. Read-only, no schema/endpoint change. See last_change_summary for full detail."
+    },
     {
       "version": "2026-07-08.03",
       "date": "2026-07-08",

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -29,6 +29,7 @@ Environment variables:
 
 from __future__ import annotations
 
+import concurrent.futures
 import datetime as dt
 import json
 import logging
@@ -399,10 +400,18 @@ MAX_HISTORY_ENTRIES = 10
 # Lambda 6 MB sync response limit. With history entries populated per-record
 # (ENC-TSK-C01), the pre-cap response exceeded that limit and produced the
 # opaque {"message":"Internal Server Error"} that broke PWA plan + lesson
-# rendering. These caps hold the total to at most 140 records: 100 tasks +
-# 10 each of issues/features/lessons/plans. The frontend already caps the
-# visible feed list at 100 items (FeedPage.tsx useInfiniteList(items, 20, 100))
-# so these backend caps align with the existing UI contract.
+# rendering. The rows this cap applies to are the minimal 5-field snapshot
+# projection (_handle_snapshot._rows), not full record bodies, so headroom
+# under the 6 MB limit is large.
+#
+# ENC-TSK-M36: these caps are applied PER ACTIVE PROJECT (see
+# _query_all_records), not globally across every project sharing this table
+# -- a global cap meant one recently-active project could crowd out another
+# project's entire issue/feature/lesson/plan representation in the snapshot.
+# Worst case with N active projects is now N x (100 + 10*4) rows; at ~150
+# bytes/row that's comfortably inside the 6 MB limit even for a few dozen
+# projects, and the frontend already caps the visible feed list at 50 items
+# post-fetch (frontend/ui-v2/src/api/feeds.ts::fetchFeedSnapshot).
 MAX_TASKS_FULL_REFRESH = 100
 MAX_ISSUES_FULL_REFRESH = 10
 MAX_FEATURES_FULL_REFRESH = 10
@@ -1164,8 +1173,99 @@ _TRANSFORM = {
 }
 
 
-def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+# ENC-TSK-M36: bound how many active projects are fanned out to concurrently.
+# A plain constant rather than "len(projects)" unbounded, so an unexpectedly
+# large projects table can't spawn hundreds of simultaneous DynamoDB queries
+# from a single Lambda invocation.
+_MAX_PROJECT_FANOUT_WORKERS = 8
+
+
+def _query_project_tracker_records(
+    pid: str, cutoff: dt.datetime
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Query every tracker record for ONE project via project-type-index.
+
+    Factored out of what were two near-identical copies of this loop
+    (_query_all_records / _query_corpus_tracker_records, ENC-TSK-L23) so the
+    per-project fetch happens in exactly one place. Called concurrently, one
+    call per active project (ENC-TSK-M36) -- previously each caller ran this
+    same paginated query SEQUENTIALLY across every active project, which is
+    the confirmed root cause of the ~20s feed/tasks.json and feed/corpus
+    cold-cache latency (ENC-TSK-M36): N projects x paginated GSI query, one
+    at a time, no concurrency.
+    """
     ddb = _get_ddb()
+    tasks: List[Dict[str, Any]] = []
+    issues: List[Dict[str, Any]] = []
+    features: List[Dict[str, Any]] = []
+    lessons: List[Dict[str, Any]] = []
+    plans: List[Dict[str, Any]] = []
+
+    paginator = ddb.get_paginator("query")
+    try:
+        for page in paginator.paginate(
+            TableName=DYNAMODB_TABLE,
+            IndexName="project-type-index",
+            KeyConditionExpression="project_id = :pid",
+            ExpressionAttributeValues={":pid": {"S": pid}},
+        ):
+            for raw_item in page.get("Items", []):
+                record_type = _ddb_str(raw_item, "record_type")
+                if record_type not in _TRANSFORM:
+                    continue
+                # Per-record isolation: a single malformed record must not
+                # take down the entire feed response (ENC-TSK-C31).
+                try:
+                    if _is_stale_closed(raw_item, cutoff):
+                        continue
+                    transformed = _TRANSFORM[record_type](raw_item, pid)
+                except Exception as rec_exc:  # noqa: BLE001
+                    logger.error(
+                        "feed_query: skipping record_type=%s item_id=%s project=%s: %s",
+                        record_type,
+                        _ddb_str(raw_item, "item_id") or "?",
+                        pid,
+                        rec_exc,
+                    )
+                    continue
+                if record_type == "task":
+                    tasks.append(transformed)
+                elif record_type == "issue":
+                    issues.append(transformed)
+                elif record_type == "feature":
+                    features.append(transformed)
+                elif record_type == "lesson":
+                    lessons.append(transformed)
+                elif record_type == "plan":
+                    plans.append(transformed)
+    except (BotoCoreError, ClientError) as exc:
+        logger.error("DynamoDB query failed for project %s: %s", pid, exc)
+
+    return tasks, issues, features, lessons, plans
+
+
+def _fan_out_by_project(
+    projects: List[Dict[str, str]], cutoff: dt.datetime
+) -> List[Tuple[str, Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]]]:
+    """Run `_query_project_tracker_records` for every project concurrently.
+
+    Returns `[(project_id, (tasks, issues, features, lessons, plans)), ...]`
+    in the SAME project order as the input list (order is restored after the
+    executor map so both callers stay deterministic) -- a raised per-project
+    exception is already caught and logged inside `_query_project_tracker_records`
+    itself, so this never needs to handle executor-side failures specially.
+    """
+    if not projects:
+        return []
+    max_workers = min(_MAX_PROJECT_FANOUT_WORKERS, len(projects))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        results = list(
+            pool.map(lambda proj: _query_project_tracker_records(proj["project_id"], cutoff), projects)
+        )
+    return [(proj["project_id"], result) for proj, result in zip(projects, results)]
+
+
+def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
     projects = _get_active_projects()
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=CLOSED_ITEM_MAX_AGE_DAYS)
 
@@ -1175,58 +1275,23 @@ def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Li
     all_lessons: List[Dict[str, Any]] = []
     all_plans: List[Dict[str, Any]] = []
 
-    for proj in projects:
-        pid = proj["project_id"]
-        paginator = ddb.get_paginator("query")
-        try:
-            for page in paginator.paginate(
-                TableName=DYNAMODB_TABLE,
-                IndexName="project-type-index",
-                KeyConditionExpression="project_id = :pid",
-                ExpressionAttributeValues={":pid": {"S": pid}},
-            ):
-                for raw_item in page.get("Items", []):
-                    record_type = _ddb_str(raw_item, "record_type")
-                    if record_type not in _TRANSFORM:
-                        continue
-                    # Per-record isolation: a single malformed record must not
-                    # take down the entire feed response (ENC-TSK-C31).
-                    try:
-                        if _is_stale_closed(raw_item, cutoff):
-                            continue
-                        transformed = _TRANSFORM[record_type](raw_item, pid)
-                    except Exception as rec_exc:  # noqa: BLE001
-                        logger.error(
-                            "feed_query: skipping record_type=%s item_id=%s project=%s: %s",
-                            record_type,
-                            _ddb_str(raw_item, "item_id") or "?",
-                            pid,
-                            rec_exc,
-                        )
-                        continue
-                    if record_type == "task":
-                        all_tasks.append(transformed)
-                    elif record_type == "issue":
-                        all_issues.append(transformed)
-                    elif record_type == "feature":
-                        all_features.append(transformed)
-                    elif record_type == "lesson":
-                        all_lessons.append(transformed)
-                    elif record_type == "plan":
-                        all_plans.append(transformed)
-        except (BotoCoreError, ClientError) as exc:
-            logger.error("DynamoDB query failed for project %s: %s", pid, exc)
-            continue
-
-    # Per-type caps (ENC-TSK-C34): keep only the most-recently-updated
-    # N records of each type so the total sync response stays under the
-    # Lambda 6 MB limit. Apply the cap BEFORE the deterministic id sort
-    # so the truncation window is chosen by recency, not alphabetically.
-    all_tasks = _cap_by_updated_at(all_tasks, MAX_TASKS_FULL_REFRESH)
-    all_issues = _cap_by_updated_at(all_issues, MAX_ISSUES_FULL_REFRESH)
-    all_features = _cap_by_updated_at(all_features, MAX_FEATURES_FULL_REFRESH)
-    all_lessons = _cap_by_updated_at(all_lessons, MAX_LESSONS_FULL_REFRESH)
-    all_plans = _cap_by_updated_at(all_plans, MAX_PLANS_FULL_REFRESH)
+    # ENC-TSK-M36 (feed data-truth): the per-type caps below used to apply
+    # to the GLOBAL cross-project pool (all projects' lessons merged, THEN
+    # capped to 10 total). tasks.json/project-type-index is shared by every
+    # governed project in this table (enceladus, plus several others) -- a
+    # global cap meant any project's issue/feature/lesson/plan representation
+    # in the cold-start snapshot could be crowded out entirely by a more
+    # recently active sibling project, even though that project's own data
+    # was never actually missing from DynamoDB (confirmed via /feed/corpus,
+    # which has no caps and returns the full per-project set). Capping PER
+    # PROJECT before merging guarantees every active project keeps its own
+    # fair slice of the snapshot regardless of what other tenants are doing.
+    for _pid, (tasks, issues, features, lessons, plans) in _fan_out_by_project(projects, cutoff):
+        all_tasks.extend(_cap_by_updated_at(tasks, MAX_TASKS_FULL_REFRESH))
+        all_issues.extend(_cap_by_updated_at(issues, MAX_ISSUES_FULL_REFRESH))
+        all_features.extend(_cap_by_updated_at(features, MAX_FEATURES_FULL_REFRESH))
+        all_lessons.extend(_cap_by_updated_at(lessons, MAX_LESSONS_FULL_REFRESH))
+        all_plans.extend(_cap_by_updated_at(plans, MAX_PLANS_FULL_REFRESH))
 
     all_tasks.sort(key=lambda x: x.get("task_id", ""))
     all_issues.sort(key=lambda x: x.get("issue_id", ""))
@@ -1244,8 +1309,14 @@ def _query_corpus_tracker_records() -> Tuple[
     List[Dict[str, Any]],
     List[Dict[str, Any]],
 ]:
-    """Load the full tracker corpus without per-type refresh caps (ENC-TSK-L23)."""
-    ddb = _get_ddb()
+    """Load the full tracker corpus without per-type refresh caps (ENC-TSK-L23).
+
+    ENC-TSK-M36: shares `_query_project_tracker_records` / `_fan_out_by_project`
+    with `_query_all_records` -- this used to be its own near-identical copy of
+    the per-project query loop, run sequentially. Same concurrency fix applies
+    here since this is the function `seedCacheFromCorpus` (warm IndexedDB
+    cache) and the Home dashboard's count tiles ultimately depend on.
+    """
     projects = _get_active_projects()
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=CLOSED_ITEM_MAX_AGE_DAYS)
 
@@ -1255,46 +1326,12 @@ def _query_corpus_tracker_records() -> Tuple[
     all_lessons: List[Dict[str, Any]] = []
     all_plans: List[Dict[str, Any]] = []
 
-    for proj in projects:
-        pid = proj["project_id"]
-        paginator = ddb.get_paginator("query")
-        try:
-            for page in paginator.paginate(
-                TableName=DYNAMODB_TABLE,
-                IndexName="project-type-index",
-                KeyConditionExpression="project_id = :pid",
-                ExpressionAttributeValues={":pid": {"S": pid}},
-            ):
-                for raw_item in page.get("Items", []):
-                    record_type = _ddb_str(raw_item, "record_type")
-                    if record_type not in _TRANSFORM:
-                        continue
-                    try:
-                        if _is_stale_closed(raw_item, cutoff):
-                            continue
-                        transformed = _TRANSFORM[record_type](raw_item, pid)
-                    except Exception as rec_exc:  # noqa: BLE001
-                        logger.error(
-                            "feed_query corpus: skipping record_type=%s item_id=%s project=%s: %s",
-                            record_type,
-                            _ddb_str(raw_item, "item_id") or "?",
-                            pid,
-                            rec_exc,
-                        )
-                        continue
-                    if record_type == "task":
-                        all_tasks.append(transformed)
-                    elif record_type == "issue":
-                        all_issues.append(transformed)
-                    elif record_type == "feature":
-                        all_features.append(transformed)
-                    elif record_type == "lesson":
-                        all_lessons.append(transformed)
-                    elif record_type == "plan":
-                        all_plans.append(transformed)
-        except (BotoCoreError, ClientError) as exc:
-            logger.error("Corpus tracker query failed for project %s: %s", pid, exc)
-            continue
+    for _pid, (tasks, issues, features, lessons, plans) in _fan_out_by_project(projects, cutoff):
+        all_tasks.extend(tasks)
+        all_issues.extend(issues)
+        all_features.extend(features)
+        all_lessons.extend(lessons)
+        all_plans.extend(plans)
 
     return all_tasks, all_issues, all_features, all_lessons, all_plans
 

--- a/backend/lambda/feed_query/test_lambda_function.py
+++ b/backend/lambda/feed_query/test_lambda_function.py
@@ -364,6 +364,100 @@ def test_max_full_refresh_caps_configured():
 
 
 # ---------------------------------------------------------------------------
+# Per-project fan-out + per-project caps (ENC-TSK-M36 / feed data-truth)
+#
+# Confirmed live against gamma: /api/v1/feed/tasks.json and /api/v1/feed/corpus
+# both took ~20s on a cache miss because _query_all_records / (the former
+# _query_corpus_tracker_records copy) queried every active project's
+# project-type-index SEQUENTIALLY. Separately, the per-type caps used to
+# apply to the merged cross-project pool, so a project with many lessons
+# recently updated could crowd another project's lessons out of the snapshot
+# entirely even though that project's lessons were never actually missing
+# from DynamoDB. _fan_out_by_project fixes the latency (concurrent per-
+# project fetch); capping inside _query_all_records's per-project loop fixes
+# the fairness -- these tests lock in both behaviors without touching
+# DynamoDB (project fetch itself is monkeypatched).
+# ---------------------------------------------------------------------------
+
+
+def _fake_project_records(pid: str, lesson_count: int) -> tuple:
+    """Build a one-project (tasks, issues, features, lessons, plans) tuple
+    with `lesson_count` lessons, each with a distinct recent updated_at so
+    _cap_by_updated_at's ordering is deterministic."""
+    lessons = [
+        {
+            "lesson_id": f"{pid}-LSN-{i:03d}",
+            "project_id": pid,
+            "updated_at": f"2026-07-0{(i % 8) + 1}T00:00:00Z",
+        }
+        for i in range(lesson_count)
+    ]
+    return ([], [], [], lessons, [])
+
+
+def test_fan_out_by_project_queries_every_project_and_preserves_order(monkeypatch):
+    projects = [{"project_id": "enceladus"}, {"project_id": "cfg"}, {"project_id": "fly"}]
+    calls: list[str] = []
+
+    def fake_query(pid, _cutoff):
+        calls.append(pid)
+        return _fake_project_records(pid, lesson_count=1)
+
+    monkeypatch.setattr(feed_query, "_query_project_tracker_records", fake_query)
+    cutoff = feed_query.dt.datetime.now(feed_query.dt.timezone.utc)
+    results = feed_query._fan_out_by_project(projects, cutoff)
+
+    # Every project was queried exactly once...
+    assert sorted(calls) == ["cfg", "enceladus", "fly"]
+    # ...and results come back in the SAME order as the input project list,
+    # regardless of thread completion order.
+    assert [pid for pid, _ in results] == ["enceladus", "cfg", "fly"]
+
+
+def test_fan_out_by_project_empty_list_short_circuits(monkeypatch):
+    called = False
+
+    def fake_query(_pid, _cutoff):
+        nonlocal called
+        called = True
+        return ([], [], [], [], [])
+
+    monkeypatch.setattr(feed_query, "_query_project_tracker_records", fake_query)
+    cutoff = feed_query.dt.datetime.now(feed_query.dt.timezone.utc)
+    assert feed_query._fan_out_by_project([], cutoff) == []
+    assert called is False
+
+
+def test_query_all_records_caps_are_per_project_not_global(monkeypatch):
+    # A busier project ("enceladus") has 15 lessons (over the cap of 10); a
+    # quieter project ("cfg") has 2. Before ENC-TSK-M36, the cap applied to
+    # the MERGED 17-lesson pool, so with a global cap of 10 the two "cfg"
+    # lessons could be entirely dropped if enceladus's lessons all sorted
+    # more recent. Capping per project must keep BOTH projects represented.
+    monkeypatch.setattr(
+        feed_query,
+        "_get_active_projects",
+        lambda: [{"project_id": "enceladus"}, {"project_id": "cfg"}],
+    )
+
+    def fake_query(pid, _cutoff):
+        if pid == "enceladus":
+            return _fake_project_records(pid, lesson_count=15)
+        return _fake_project_records(pid, lesson_count=2)
+
+    monkeypatch.setattr(feed_query, "_query_project_tracker_records", fake_query)
+
+    _tasks, _issues, _features, all_lessons, _plans = feed_query._query_all_records()
+
+    lesson_ids = {l["lesson_id"] for l in all_lessons}
+    # enceladus capped down to 10 (its own cap, not zeroed out by cfg)...
+    assert sum(1 for lid in lesson_ids if lid.startswith("enceladus-")) == 10
+    # ...and cfg's 2 lessons survive too -- global capping would have let
+    # enceladus's 15 crowd them out entirely.
+    assert sum(1 for lid in lesson_ids if lid.startswith("cfg-")) == 2
+
+
+# ---------------------------------------------------------------------------
 # VALID_RECORD_TYPES whitelist (ENC-TSK-C40 / ENC-ISS-177)
 #
 # Before the fix, VALID_RECORD_TYPES = {"task", "issue", "feature"} silently

--- a/frontend/ui-v2/src/components/Badge.tsx
+++ b/frontend/ui-v2/src/components/Badge.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+import './badge.css'
+
+/** Enceladus-v4-Feed-Review.md §4.4 -- the only five sanctioned Badge hues. */
+export type BadgeColor = 'crimson' | 'amber' | 'dust' | 'teal' | 'lavender'
+
+const BADGE_COLOR_TOKEN: Record<BadgeColor, string> = {
+  crimson: 'var(--enc-crimson)',
+  amber: 'var(--v2-status-warning)',
+  dust: 'var(--enc-dust)',
+  teal: 'var(--enc-teal)',
+  lavender: 'var(--enc-lavender)',
+}
+
+/**
+ * Badge -- small bordered mono chip for priority / CCI / PR / deploy signals
+ * (Enceladus-v4-Feed-Review.md §4.4, §5.2, §5.3). Crimson badges glow on
+ * hover (P0 escalation), matching the DS `--glow-crimson` treatment used
+ * elsewhere (StatusChip, evidence tiles).
+ */
+export function Badge({ color, children }: { color: BadgeColor; children: ReactNode }) {
+  const token = BADGE_COLOR_TOKEN[color]
+  return (
+    <span
+      className={color === 'crimson' ? 'ev2-badge ev2-badge--crimson' : 'ev2-badge'}
+      style={{ color: token, borderColor: token }}
+    >
+      {children}
+    </span>
+  )
+}

--- a/frontend/ui-v2/src/components/RecordCard.feed.test.tsx
+++ b/frontend/ui-v2/src/components/RecordCard.feed.test.tsx
@@ -1,0 +1,101 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RecordCard } from './RecordCard'
+import { Badge } from './Badge'
+
+/**
+ * ENC-TSK-M35 -- smoke coverage for the dense "feed" RecordCard variant
+ * (Enceladus-v4-Feed-Review.md §3/§4). No @testing-library/react in this
+ * package (see SessionPrimitive.test.tsx) -- createRoot + act, matching the
+ * rest of ui-v2's component-level tests.
+ */
+describe('RecordCard variant="feed"', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('renders id, project, timestamp, single-line title, status and badges', () => {
+    act(() => {
+      root.render(
+        <RecordCard
+          recordId="ENC-TSK-M31"
+          recordType="task"
+          title="ISS-519 fix"
+          status="in-progress"
+          priority="P0"
+          variant="feed"
+          projectLabel="enceladus"
+          timestamp="46m ago"
+          accentColor="var(--enc-crimson)"
+          badges={
+            <>
+              <Badge color="crimson">P0</Badge>
+              <Badge color="amber">CHECKED OUT</Badge>
+            </>
+          }
+        />,
+      )
+    })
+    expect(container.textContent).toContain('ENC-TSK-M31')
+    expect(container.textContent).toContain('enceladus')
+    expect(container.textContent).toContain('46m ago')
+    expect(container.textContent).toContain('ISS-519 fix')
+    expect(container.textContent).toContain('in-progress')
+    expect(container.textContent).toContain('P0')
+    expect(container.textContent).toContain('CHECKED OUT')
+
+    const titleEl = container.querySelector('.ev2-rc__feed-title')
+    expect(titleEl).not.toBeNull()
+  })
+
+  it('applies the accent color as the left border', () => {
+    act(() => {
+      root.render(
+        <RecordCard
+          recordId="ENC-ISS-501"
+          title="P0 SEV-1"
+          status="open"
+          priority="P0"
+          variant="feed"
+          accentColor="rgb(200, 80, 96)"
+        />,
+      )
+    })
+    const card = container.querySelector('.ev2-rc--feed') as HTMLElement
+    expect(card).not.toBeNull()
+    expect(card.style.borderLeftColor).toBe('rgb(200, 80, 96)')
+  })
+
+  it('is clickable via onSelect when no href is supplied (wide master-detail mode, FTR-128 AC-18)', () => {
+    const onSelect = vi.fn()
+    act(() => {
+      root.render(
+        <RecordCard
+          recordId="ENC-TSK-M31"
+          title="ISS-519 fix"
+          status="open"
+          variant="feed"
+          onSelect={onSelect}
+        />,
+      )
+    })
+    const button = container.querySelector('button.ev2-rc--feed') as HTMLButtonElement
+    expect(button).not.toBeNull()
+    act(() => {
+      button.click()
+    })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/ui-v2/src/components/RecordCard.tsx
+++ b/frontend/ui-v2/src/components/RecordCard.tsx
@@ -25,11 +25,22 @@ export interface RecordCardProps {
   status?: string
   priority?: string
   href?: string
-  variant?: 'compact' | 'standard' | 'selectable'
+  variant?: 'compact' | 'standard' | 'selectable' | 'feed'
   selected?: boolean
   onSelect?: () => void
   /** Extra accessory rendered in the header (e.g. a tier badge). */
   trailing?: ReactNode
+  /**
+   * ENC-TSK-M35 -- dense feed-row extras (Enceladus-v4-Feed-Review.md §3/§4).
+   * Only consumed by `variant="feed"`.
+   */
+  projectLabel?: string
+  /** Pre-formatted relative time ("37m ago"), PAR-01. Omitted when unknown. */
+  timestamp?: string
+  /** 3px left-accent color, e.g. from `feedRowAccent()` (PAR-06, §4.5/§5.4). */
+  accentColor?: string
+  /** Priority/CCI/PR/deploy Badge strip rendered after the StatusChip (PAR-02/03/04/05). */
+  badges?: ReactNode
 }
 
 export function RecordCard({
@@ -45,29 +56,52 @@ export function RecordCard({
   selected = false,
   onSelect,
   trailing,
+  projectLabel,
+  timestamp,
+  accentColor,
+  badges,
 }: RecordCardProps) {
   const className = `ev2-rc ev2-rc--${variant}${selected ? ' ev2-rc--selected' : ''}`
+  const style = variant === 'feed' && accentColor ? { borderLeftColor: accentColor } : undefined
 
-  const body = (
-    <>
-      <div className="ev2-rc__header">
-        {kindLabel ? <span className="ev2-rc__kind">{kindLabel}</span> : null}
-        <RecordId id={recordId} />
-        {trailing}
-      </div>
-      {title ? <h4 className="ev2-rc__title">{title}</h4> : null}
-      {description ? <p className="ev2-rc__desc">{description}</p> : null}
-      {status ? (
-        <div className="ev2-rc__footer">
-          <StatusChip status={status} priority={priority} recordType={recordType} />
+  const body =
+    variant === 'feed' ? (
+      <>
+        <div className="ev2-rc__feed-top">
+          <span className="ev2-rc__feed-ids">
+            <RecordId id={recordId} />
+            {projectLabel ? <span className="ev2-rc__feed-project">{projectLabel}</span> : null}
+          </span>
+          {timestamp ? <span className="ev2-rc__feed-time">{timestamp}</span> : null}
         </div>
-      ) : null}
-    </>
-  )
+        {title ? <div className="ev2-rc__feed-title">{title}</div> : null}
+        {status || badges ? (
+          <div className="ev2-rc__feed-chips">
+            {status ? <StatusChip status={status} priority={priority} recordType={recordType} /> : null}
+            {badges}
+          </div>
+        ) : null}
+      </>
+    ) : (
+      <>
+        <div className="ev2-rc__header">
+          {kindLabel ? <span className="ev2-rc__kind">{kindLabel}</span> : null}
+          <RecordId id={recordId} />
+          {trailing}
+        </div>
+        {title ? <h4 className="ev2-rc__title">{title}</h4> : null}
+        {description ? <p className="ev2-rc__desc">{description}</p> : null}
+        {status ? (
+          <div className="ev2-rc__footer">
+            <StatusChip status={status} priority={priority} recordType={recordType} />
+          </div>
+        ) : null}
+      </>
+    )
 
   if (variant === 'selectable') {
     return (
-      <button type="button" className={className} aria-pressed={selected} onClick={onSelect}>
+      <button type="button" className={className} style={style} aria-pressed={selected} onClick={onSelect}>
         {body}
       </button>
     )
@@ -75,11 +109,33 @@ export function RecordCard({
 
   if (href) {
     return (
-      <Link to={href} className={className} onClick={onSelect}>
+      <Link to={href} className={className} style={style} onClick={onSelect}>
         {body}
       </Link>
     )
   }
 
-  return <article className={className}>{body}</article>
+  // ENC-TSK-M35: a "feed" row with no href (wide master-detail viewport,
+  // FTR-128 AC-18) still needs to be clickable to drive the reading pane —
+  // render as a button rather than an inert <article> whenever a caller
+  // supplies onSelect without a navigable href.
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        className={className}
+        style={style}
+        aria-pressed={variant === 'feed' ? selected : undefined}
+        onClick={onSelect}
+      >
+        {body}
+      </button>
+    )
+  }
+
+  return (
+    <article className={className} style={style}>
+      {body}
+    </article>
+  )
 }

--- a/frontend/ui-v2/src/components/badge.css
+++ b/frontend/ui-v2/src/components/badge.css
@@ -1,0 +1,19 @@
+/* ENC-TSK-M35 · Badge atom -- priority / CCI / PR / deploy chips. */
+
+.ev2-badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: var(--fw-medium);
+  line-height: 1.6;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  padding: 1px var(--space-2);
+  background: transparent;
+  transition: box-shadow var(--dur-base) var(--ease-orbit);
+}
+
+.ev2-badge--crimson:hover {
+  box-shadow: var(--glow-crimson);
+}

--- a/frontend/ui-v2/src/components/recordCard.css
+++ b/frontend/ui-v2/src/components/recordCard.css
@@ -102,6 +102,62 @@ button.ev2-rc:focus-visible {
   }
 }
 
+/* ENC-TSK-M35 · dense feed row (Enceladus-v4-Feed-Review.md §3/§4, PAR-01→08).
+ * ~72px tall: ids+time / single-line title / chip strip. 3px severity accent
+ * on the left, set inline per-row via `accentColor` (feedRowAccent()). */
+.ev2-rc--feed {
+  padding: 13px 16px;
+  margin: 0 0 var(--space-2);
+  border-left: 3px solid var(--enc-teal);
+}
+
+.ev2-rc__feed-top {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: 4px;
+}
+
+.ev2-rc__feed-ids {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.ev2-rc__feed-project {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--enc-dust);
+}
+
+.ev2-rc__feed-time {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--enc-dust);
+}
+
+.ev2-rc__feed-title {
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: var(--fw-medium);
+  line-height: var(--lh-snug);
+  color: var(--fg);
+  margin-bottom: var(--space-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ev2-rc__feed-chips {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
 .ev2-rc-grid {
   display: grid;
   /* minmax(0, 1fr) rather than a bare 1fr: a plain `1fr` track resolves to

--- a/frontend/ui-v2/src/format/relativeTime.test.ts
+++ b/frontend/ui-v2/src/format/relativeTime.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { formatRelativeTime } from './relativeTime'
+
+describe('formatRelativeTime', () => {
+  const now = Date.parse('2026-07-08T12:00:00Z')
+
+  it('returns null for missing input', () => {
+    expect(formatRelativeTime(undefined, now)).toBeNull()
+    expect(formatRelativeTime(null, now)).toBeNull()
+  })
+
+  it('returns null for unparseable input rather than fabricating a time', () => {
+    expect(formatRelativeTime('not-a-date', now)).toBeNull()
+  })
+
+  it('formats minutes', () => {
+    expect(formatRelativeTime('2026-07-08T11:37:00Z', now)).toBe('23m ago')
+  })
+
+  it('formats hours', () => {
+    expect(formatRelativeTime('2026-07-08T09:00:00Z', now)).toBe('3h ago')
+  })
+
+  it('formats days', () => {
+    expect(formatRelativeTime('2026-07-05T12:00:00Z', now)).toBe('3d ago')
+  })
+
+  it('formats sub-minute as "just now"', () => {
+    expect(formatRelativeTime('2026-07-08T11:59:50Z', now)).toBe('just now')
+  })
+})

--- a/frontend/ui-v2/src/format/relativeTime.ts
+++ b/frontend/ui-v2/src/format/relativeTime.ts
@@ -1,0 +1,28 @@
+/**
+ * ENC-TSK-M35 (PAR-01, Enceladus-v4-Feed-Review.md §3): the v3 feed stamped a
+ * relative timestamp ("37m ago") on every row -- v4 dropped it entirely. This
+ * restores it from real data (Tier1Record.updatedAt, already cached but
+ * previously dropped on the floor before reaching the search/filter layer --
+ * the same class of gap FTR-130 Band-B fixed for priority/checkout_state).
+ *
+ * Never fabricates a time: returns null when there is no real timestamp to
+ * report (e.g. cold-start realtime-events-only corpus), so callers can omit
+ * the meta slot entirely rather than render a fake "just now".
+ */
+export function formatRelativeTime(iso: string | null | undefined, now: number = Date.now()): string | null {
+  if (!iso) return null
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return null
+
+  const diffMs = now - then
+  if (diffMs < 0) return 'just now'
+
+  const MINUTE = 60_000
+  const HOUR = 60 * MINUTE
+  const DAY = 24 * HOUR
+
+  if (diffMs < MINUTE) return 'just now'
+  if (diffMs < HOUR) return `${Math.floor(diffMs / MINUTE)}m ago`
+  if (diffMs < DAY) return `${Math.floor(diffMs / HOUR)}h ago`
+  return `${Math.floor(diffMs / DAY)}d ago`
+}

--- a/frontend/ui-v2/src/routes/FeedReadingPane.tsx
+++ b/frontend/ui-v2/src/routes/FeedReadingPane.tsx
@@ -1,10 +1,26 @@
-import { Link } from '@tanstack/react-router'
+import { Suspense, type ComponentType } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Container, Header, Box } from '../design-system'
-import { SearchTierBadge } from '../components/SearchTierBadge'
-import { StatusChip } from '../components/StatusChip'
-import { documentHref, recordHrefForType } from './recordLink'
+import { SkeletonCard } from '../components/SkeletonCard'
+import { recordQueryOptions } from '../api/queryOptions'
+import { getPrimitive } from '../primitives/registry'
 import type { SearchResultHit } from '../types/search'
 
+/**
+ * FeedReadingPane -- the wide-viewport master-detail hub (FTR-128 AC-18,
+ * ENC-TSK-M35). Selecting a feed row loads the record's real data and
+ * renders it through the SAME `Primitive` (RecordDetailHub: Overview ·
+ * Neighbors · Worklog · Evidence tabs) used by the full-page record routes
+ * (routes/recordRoute.tsx) -- this is a merged in-place view, not a
+ * duplicate summary. No separate renderer is forked here.
+ *
+ * Description/body text renders through each Primitive's existing <Prose>
+ * component (plaintext today). Lane L1 is landing a shared MarkdownContent
+ * component for description rendering elsewhere in the primitive stack --
+ * because this pane reuses the primitives verbatim rather than re-rendering
+ * the description itself, it inherits that upgrade automatically on the next
+ * rebase with no changes needed here.
+ */
 export function FeedReadingPane({ hit }: { hit: SearchResultHit | null }) {
   if (!hit) {
     return (
@@ -14,32 +30,39 @@ export function FeedReadingPane({ hit }: { hit: SearchResultHit | null }) {
     )
   }
 
-  const href =
-    hit.recordType === 'document'
-      ? documentHref(hit.recordId)
-      : recordHrefForType(hit.projectId, hit.recordType, hit.recordId)
+  return <FeedReadingPaneRecord key={`${hit.recordType}:${hit.recordId}`} hit={hit} />
+}
 
-  const typeLabel = hit.recordType.replace(/^\w/, (c) => c.toUpperCase())
+function FeedReadingPaneRecord({ hit }: { hit: SearchResultHit }) {
+  const projectId = hit.projectId || 'enceladus'
+  const options =
+    hit.recordType === 'document'
+      ? recordQueryOptions.document(hit.recordId, projectId)
+      : recordQueryOptions[hit.recordType](projectId, hit.recordId)
+
+  const { data, isLoading, isError } = useQuery(options)
+
+  if (isLoading) {
+    return <SkeletonCard label={`Loading ${hit.recordType}`} />
+  }
+
+  if (isError || !data) {
+    return (
+      <Container header={<Header variant="h3">Reading pane</Header>}>
+        <Box variant="p">Couldn't load {hit.recordId} — try selecting it again.</Box>
+      </Container>
+    )
+  }
+
+  // Runtime dispatch across the six record-shape primitives: `hit.recordType`
+  // is a union at this point (not narrowed to a single literal K), so this
+  // boundary needs one cast -- the same pattern routes/recordRoute.tsx already
+  // uses (`route.useParams() as {...}`) for the equivalent dynamic-type seam.
+  const Primitive = getPrimitive(hit.recordType) as ComponentType<{ record: unknown }>
 
   return (
-    <Container
-      header={
-        <Header variant="h2" recordId={hit.recordId}>
-          {typeLabel} · {hit.title}
-        </Header>
-      }
-      footer={
-        <Link to={href} className="feed-route__detail-link">
-          Open full record →
-        </Link>
-      }
-    >
-      <div className="feed-reading-pane__meta">
-        {hit.status ? <StatusChip status={hit.status} /> : null}
-        <SearchTierBadge tier={hit.tier} />
-        <span className="feed-reading-pane__project">{hit.projectId}</span>
-      </div>
-      <Box variant="p">{hit.title}</Box>
-    </Container>
+    <Suspense fallback={<SkeletonCard label={`Loading ${hit.recordType}`} />}>
+      <Primitive record={data} />
+    </Suspense>
   )
 }

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -1,15 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
-import { Link, useNavigate, useSearch } from '@tanstack/react-router'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Autosuggest, ButtonDropdown, Cards, ColumnLayout } from '../design-system'
+import { Autosuggest, ButtonDropdown } from '../design-system'
 import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
-import { SearchTierBadge } from '../components/SearchTierBadge'
-import { StatusChip } from '../components/StatusChip'
+import { Badge } from '../components/Badge'
 import { RecordCard } from '../components/RecordCard'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { formatRelativeTime } from '../format/relativeTime'
 import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
 import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
+import {
+  feedRowAccent,
+  priorityBadgeColor,
+  sessionStateBadge,
+} from '../search/feedRowPresentation'
 import {
   parseFilterQuery,
   persistFeedReturnSearch,
@@ -247,45 +252,52 @@ export function FeedRoute() {
     })
   }
 
-  const cardDefinition = {
-    header: (hit: SearchResultHit) => (
-      <FeedCardTitle hit={hit} projects={projects} mobile={!isWide} feedSearch={feedSearch} />
-    ),
-    sections: [
-      {
-        id: 'status',
-        header: 'Status',
-        content: (hit: SearchResultHit) => (hit.status ? <StatusChip status={hit.status} /> : '—'),
-      },
-      {
-        id: 'tier',
-        header: 'Tier',
-        content: (hit: SearchResultHit) => <SearchTierBadge tier={hit.tier} />,
-      },
-      {
-        id: 'project',
-        header: 'Project',
-        content: (hit: SearchResultHit) => hit.projectId,
-      },
-    ],
+  // ENC-TSK-M35: one dense feed-row rendering for every viewport (Feed.dc.html
+  // §pixel-contract, Enceladus-v4-Feed-Review.md §3 PAR-08) — v4 previously
+  // forked mobile (RecordCard grid) from desktop (Cloudscape Cards), and the
+  // desktop fork showed only STATUS/TIER/PROJECT with no priority/CCI/accent.
+  // Narrow viewports link straight to the full record page; wide viewports
+  // select in place (no navigation) so the row list and reading pane stay in
+  // sync (FTR-128 AC-18).
+  const renderFeedRow = (hit: SearchResultHit) => {
+    const project =
+      hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
+    const href =
+      hit.recordType === 'document'
+        ? documentHref(hit.recordId)
+        : recordHrefForType(project, hit.recordType, hit.recordId)
+    const cci = sessionStateBadge(hit.checkoutState)
+
+    return (
+      <RecordCard
+        key={hit.recordId}
+        recordId={hit.recordId}
+        recordType={hit.recordType}
+        title={hit.title}
+        status={hit.status}
+        priority={hit.priority}
+        variant="feed"
+        projectLabel={project}
+        timestamp={formatRelativeTime(hit.updatedAt) ?? undefined}
+        accentColor={feedRowAccent(hit)}
+        badges={
+          <>
+            {hit.priority ? <Badge color={priorityBadgeColor(hit.priority)}>{hit.priority}</Badge> : null}
+            {cci ? <Badge color={cci.color}>{cci.label}</Badge> : null}
+          </>
+        }
+        {...(isWide
+          ? { selected: selectedHit?.recordId === hit.recordId, onSelect: () => selectHit(hit) }
+          : { href, onSelect: () => persistFeedReturnSearch(feedSearch) })}
+      />
+    )
   }
 
   const resultsBody =
     isWide && filteredHits.length > 0 ? (
-      <ColumnLayout columns={2} borders="vertical">
+      <div className="feed-route__split">
         <div className="feed-route__list-scroll" ref={listRef}>
-          <Cards
-            items={visibleHits}
-            trackBy="recordId"
-            columns={1}
-            selectionType="single"
-            selectedItems={selectedHit ? [selectedHit] : []}
-            onSelectionChange={(event) => {
-              const next = event.detail.selectedItems[0]
-              if (next) selectHit(next)
-            }}
-            cardDefinition={cardDefinition}
-          />
+          {visibleHits.map(renderFeedRow)}
           {visibleCount < filteredHits.length && (
             <p className="feed-route__scroll-hint">Scroll for more results…</p>
           )}
@@ -298,32 +310,9 @@ export function FeedRoute() {
           />
           <FeedReadingPane hit={selectedHit} />
         </div>
-      </ColumnLayout>
-    ) : (
-      <div className="ev2-rc-grid">
-        {visibleHits.map((hit) => {
-          const project =
-            hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
-          const href =
-            hit.recordType === 'document'
-              ? documentHref(hit.recordId)
-              : recordHrefForType(project, hit.recordType, hit.recordId)
-          return (
-            <RecordCard
-              key={hit.recordId}
-              recordId={hit.recordId}
-              recordType={hit.recordType}
-              kindLabel={hit.recordType}
-              title={hit.title}
-              status={hit.status}
-              href={href}
-              variant="compact"
-              trailing={<SearchTierBadge tier={hit.tier} />}
-              onSelect={() => persistFeedReturnSearch(feedSearch)}
-            />
-          )
-        })}
       </div>
+    ) : (
+      <div className="ev2-rc-grid">{visibleHits.map(renderFeedRow)}</div>
     )
 
   return (
@@ -440,37 +429,4 @@ export function FeedRoute() {
       {filteredHits.length > 0 ? resultsBody : null}
     </div>
   )
-}
-
-function FeedCardTitle({
-  hit,
-  projects,
-  mobile,
-  feedSearch,
-}: {
-  hit: SearchResultHit
-  projects: Array<{ project_id: string; prefix: string }>
-  mobile: boolean
-  feedSearch: FeedRouteSearch
-}) {
-  const project =
-    hit.projectId || resolveProjectFromRecordId(hit.recordId, projects) || 'enceladus'
-  const href =
-    hit.recordType === 'document'
-      ? documentHref(hit.recordId)
-      : recordHrefForType(project, hit.recordType, hit.recordId)
-
-  if (mobile) {
-    return (
-      <Link
-        to={href}
-        className="feed-route__card-link"
-        onClick={() => persistFeedReturnSearch(feedSearch)}
-      >
-        {hit.recordId}
-      </Link>
-    )
-  }
-
-  return <span className="feed-route__card-id">{hit.recordId}</span>
 }

--- a/frontend/ui-v2/src/routes/HomeRoute.test.ts
+++ b/frontend/ui-v2/src/routes/HomeRoute.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { openTasksSearchFor } from './HomeRoute'
+import { parseFilterQuery } from '../search/feedSearchParams'
+
+/**
+ * ENC-TSK-M36 (feed data-truth, AC-3) -- the "Awaiting checkout" Home tile
+ * counts a SINGLE project (api/homeQueue.ts::fetchAwaitingCheckoutCount), but
+ * its destination Feed link used to carry no project_id token at all, so the
+ * number shown on the tile and the number of rows Feed actually displayed
+ * could disagree the moment another project also had awaiting-checkout
+ * tasks. This locks in that the generated filter always scopes to the same
+ * project the count was computed for.
+ */
+describe('openTasksSearchFor', () => {
+  it('scopes the destination Feed filter to the given project', () => {
+    const search = openTasksSearchFor('enceladus')
+    const parsed = parseFilterQuery(search.f, search.op)
+    const propertyKeys = parsed.tokens.map((t) => t.propertyKey)
+    expect(propertyKeys).toContain('project_id')
+
+    const projectToken = parsed.tokens.find((t) => t.propertyKey === 'project_id')
+    expect(projectToken).toEqual({ propertyKey: 'project_id', operator: '=', value: 'enceladus' })
+  })
+
+  it('still carries the pre-existing status/record_type/checkout_state tokens', () => {
+    const search = openTasksSearchFor('some-other-project')
+    const parsed = parseFilterQuery(search.f, search.op)
+    const byKey = Object.fromEntries(parsed.tokens.map((t) => [t.propertyKey, t]))
+    expect(byKey.status).toEqual({ propertyKey: 'status', operator: '=', value: 'open' })
+    expect(byKey.record_type).toEqual({ propertyKey: 'record_type', operator: '=', value: 'task' })
+    expect(byKey.checkout_state).toEqual({
+      propertyKey: 'checkout_state',
+      operator: '!=',
+      value: 'checked_out',
+    })
+  })
+
+  it('changes with the project so two different projects never collide', () => {
+    const a = openTasksSearchFor('enceladus')
+    const b = openTasksSearchFor('harrisonfamily')
+    expect(a.f).not.toBe(b.f)
+  })
+})

--- a/frontend/ui-v2/src/routes/HomeRoute.tsx
+++ b/frontend/ui-v2/src/routes/HomeRoute.tsx
@@ -121,16 +121,26 @@ const OPEN_SEARCH: FeedRouteSearch = {
     operation: 'and',
   }),
 }
-const OPEN_TASKS_SEARCH: FeedRouteSearch = {
-  ...FEED_SEARCH_DEFAULTS,
-  f: serializeFilterQuery({
-    tokens: [
-      { propertyKey: 'status', operator: '=', value: 'open' },
-      { propertyKey: 'record_type', operator: '=', value: 'task' },
-      { propertyKey: 'checkout_state', operator: '!=', value: 'checked_out' },
-    ],
-    operation: 'and',
-  }),
+// ENC-TSK-M36 (feed data-truth, AC-3): `fetchAwaitingCheckoutCount` measures
+// a SINGLE project (api/homeQueue.ts — GET /api/v1/tracker/{projectId}...),
+// but this token set used to omit project_id entirely, so the tile's link
+// opened an UNSCOPED, cross-project Feed view — any other project's
+// awaiting-checkout tasks counted toward the number shown there even though
+// the tile itself never counted them. Scoping the destination filter to the
+// same project the count came from is what makes the two numbers agree.
+export function openTasksSearchFor(projectId: string): FeedRouteSearch {
+  return {
+    ...FEED_SEARCH_DEFAULTS,
+    f: serializeFilterQuery({
+      tokens: [
+        { propertyKey: 'status', operator: '=', value: 'open' },
+        { propertyKey: 'record_type', operator: '=', value: 'task' },
+        { propertyKey: 'checkout_state', operator: '!=', value: 'checked_out' },
+        { propertyKey: 'project_id', operator: '=', value: projectId },
+      ],
+      operation: 'and',
+    }),
+  }
 }
 
 function QueueCard({ row }: { row: QueueRow }) {
@@ -361,7 +371,7 @@ export function HomeRoute() {
           </span>
           <span className="home-route__count-label">Open P0/P1</span>
         </Link>
-        <Link to="/feed" search={OPEN_TASKS_SEARCH} className="home-route__count-tile">
+        <Link to="/feed" search={openTasksSearchFor(projectId)} className="home-route__count-tile">
           <span className="home-route__count-value">
             {awaitingCheckoutQuery.isLoading ? '…' : (awaitingCheckoutQuery.data ?? 0)}
           </span>

--- a/frontend/ui-v2/src/routes/feed.css
+++ b/frontend/ui-v2/src/routes/feed.css
@@ -146,22 +146,20 @@
   text-decoration: underline;
 }
 
-.feed-route__card-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.feed-route__card-link:hover {
-  color: var(--accent-hover);
-}
-
-.feed-route__card-id {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  color: var(--accent);
+/* ENC-TSK-M35: master-detail split (FTR-128 AC-18). Cloudscape's
+ * `ColumnLayout` only offers equal-width columns; Feed.dc.html's
+ * `.feed-pane`/`.record-pane` ratio is asymmetric (narrower dense list,
+ * wider reading pane), so this is a dedicated flex wrapper rather than a
+ * ColumnLayout instance. */
+.feed-route__split {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-5);
 }
 
 .feed-route__list-scroll {
+  flex: 1 1 380px;
+  max-width: 460px;
   max-height: calc(var(--space-16) * 28);
   overflow-y: auto;
   padding-right: var(--space-2);
@@ -171,6 +169,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  flex: 1.5 1 0;
   min-width: var(--space-0);
 }
 
@@ -180,31 +179,6 @@
   font-size: var(--text-xs);
   color: var(--fg-muted);
   text-align: center;
-}
-
-.feed-route__detail-link {
-  color: var(--accent-hover);
-  text-decoration: none;
-  font-family: var(--font-heading);
-  font-size: var(--text-sm);
-}
-
-.feed-route__detail-link:hover {
-  color: var(--enc-teal-light);
-}
-
-.feed-reading-pane__meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
-}
-
-.feed-reading-pane__project {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--fg-muted);
 }
 
 .feed-recent-nav {
@@ -225,10 +199,4 @@
 .feed-recent-nav .ev2-pag__btn:not([aria-label='Previous page']):not([aria-label='Next page']),
 .feed-recent-nav .ev2-pag__ellipsis {
   display: none;
-}
-
-@media (max-width: 48rem) {
-  .feed-route .ev2-cards__grid {
-    grid-template-columns: minmax(0, 1fr) !important;
-  }
 }

--- a/frontend/ui-v2/src/search/feedRowPresentation.test.ts
+++ b/frontend/ui-v2/src/search/feedRowPresentation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { feedRowAccent, priorityBadgeColor, sessionStateBadge } from './feedRowPresentation'
+
+describe('feedRowAccent', () => {
+  it('escalates P0 to the alert accent regardless of status', () => {
+    expect(feedRowAccent({ status: 'open', priority: 'P0' })).toBe('var(--enc-crimson)')
+  })
+  it('renders blocked as alert', () => {
+    expect(feedRowAccent({ status: 'blocked', priority: 'P2' })).toBe('var(--enc-crimson)')
+  })
+  it('renders in-progress as active (teal-light)', () => {
+    expect(feedRowAccent({ status: 'in-progress', priority: 'P1' })).toBe('var(--enc-teal-light)')
+  })
+  it('renders closed as slate', () => {
+    expect(feedRowAccent({ status: 'closed', priority: 'P2' })).toBe('var(--enc-slate)')
+  })
+  it('defaults open/neutral to teal', () => {
+    expect(feedRowAccent({ status: 'open', priority: 'P2' })).toBe('var(--enc-teal)')
+  })
+})
+
+describe('priorityBadgeColor', () => {
+  it('maps P0 -> crimson, P1 -> amber, else dust', () => {
+    expect(priorityBadgeColor('P0')).toBe('crimson')
+    expect(priorityBadgeColor('P1')).toBe('amber')
+    expect(priorityBadgeColor('P2')).toBe('dust')
+    expect(priorityBadgeColor('P3')).toBe('dust')
+  })
+})
+
+describe('sessionStateBadge', () => {
+  it('returns null when there is no checkout signal (never fabricates one)', () => {
+    expect(sessionStateBadge(undefined)).toBeNull()
+  })
+  it('maps checked_out -> amber CHECKED OUT', () => {
+    expect(sessionStateBadge('checked_out')).toEqual({ label: 'CHECKED OUT', color: 'amber' })
+  })
+  it('maps any other present state -> teal CHECKED IN', () => {
+    expect(sessionStateBadge('released')).toEqual({ label: 'CHECKED IN', color: 'teal' })
+  })
+})

--- a/frontend/ui-v2/src/search/feedRowPresentation.ts
+++ b/frontend/ui-v2/src/search/feedRowPresentation.ts
@@ -1,0 +1,56 @@
+/**
+ * ENC-TSK-M35 -- pure hit -> presentation mappings for the dense Feed row,
+ * bound exclusively to Enceladus-v4-Feed-Review.md §4/§5 tokens (never a raw
+ * hex, never an invented color). Kept side-effect-free and framework-free so
+ * the severity/badge logic is unit-testable without rendering React.
+ *
+ * The left-accent bar is SEVERITY-keyed (§4.5 / §5.4), not a fixed
+ * per-record-type hue: Feed.dc.html (the binding pixel contract) assigns
+ * `--enc-teal-light` to an active Plan, `--enc-slate` to a closed Issue AND a
+ * closed Task, and `--enc-crimson` to an open P0 Issue -- i.e. the same
+ * record type gets different accents depending on state. Per the dispatch
+ * directive the .dc.html wins over the AC's "record-type signature colors"
+ * prose.
+ */
+import type { BadgeColor } from '../components/Badge'
+import type { SearchResultHit } from '../types/search'
+
+const ACCENT = {
+  alert: 'var(--enc-crimson)',
+  active: 'var(--enc-teal-light)',
+  neutral: 'var(--enc-teal)',
+  closed: 'var(--enc-slate)',
+} as const
+
+const CLOSED_STATUSES = new Set(['closed', 'archived', 'retired', 'deprecated'])
+const ACTIVE_STATUSES = new Set(['in-progress', 'started', 'active'])
+const ALERT_STATUSES = new Set(['blocked'])
+
+/** 3px left-accent bar color (Enceladus-v4-Feed-Review.md §4.5 / §5.4, PAR-06). */
+export function feedRowAccent(hit: Pick<SearchResultHit, 'status' | 'priority'>): string {
+  const status = hit.status?.trim().toLowerCase() ?? ''
+  if (hit.priority?.trim().toLowerCase() === 'p0' || ALERT_STATUSES.has(status)) return ACCENT.alert
+  if (ACTIVE_STATUSES.has(status)) return ACCENT.active
+  if (CLOSED_STATUSES.has(status)) return ACCENT.closed
+  return ACCENT.neutral
+}
+
+/** Priority -> Badge color (§4.4 / §5.2, PAR-02). */
+export function priorityBadgeColor(priority: string): BadgeColor {
+  const p = priority.trim().toLowerCase()
+  if (p === 'p0') return 'crimson'
+  if (p === 'p1') return 'amber'
+  return 'dust'
+}
+
+/** Session/checkout state -> Badge (§4.4 / §5.3, PAR-03). Suppressed (null)
+ *  when the record carries no checkout_state signal at all -- never renders
+ *  a fabricated default. */
+export function sessionStateBadge(
+  checkoutState: string | undefined,
+): { label: string; color: BadgeColor } | null {
+  if (!checkoutState) return null
+  return checkoutState.trim().toLowerCase() === 'checked_out'
+    ? { label: 'CHECKED OUT', color: 'amber' }
+    : { label: 'CHECKED IN', color: 'teal' }
+}

--- a/frontend/ui-v2/src/search/localKeywordSearch.ts
+++ b/frontend/ui-v2/src/search/localKeywordSearch.ts
@@ -13,6 +13,7 @@ function toHit(row: LocalSearchRecord): SearchResultHit {
     status: row.status,
     priority: row.priority,
     checkoutState: row.checkoutState,
+    updatedAt: row.updatedAt,
     tier: 'local',
   }
 }

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -185,10 +185,15 @@ describe('tabs bar overflow containment (ENC-ISS-51x / Band-B defect 3)', () => 
 describe('card grid mobile collapse (ENC-ISS-516 / defect B)', () => {
   const gridOverridePattern = /@media \(max-width: 48rem\)[\s\S]*?\.ev2-cards__grid\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*!important/
 
+  // ENC-TSK-M35: Feed dropped Cloudscape `<Cards>` entirely (dense single
+  // column RecordCard variant="feed" rows now, per Feed.dc.html/
+  // Enceladus-v4-Feed-Review.md §3-4), so routes/feed.css no longer renders
+  // an `.ev2-cards__grid` element at all -- the defect-B regression this
+  // suite guards against is structurally impossible there now. Mobile-first
+  // single-column is covered instead by the `.ev2-rc-grid` assertion below.
   it.each([
     ['routes/home.css', '.home-route'],
     ['routes/projects.css', '.projects-route'],
-    ['routes/feed.css', '.feed-route'],
     ['routes/governance.css', '.governance-route'],
     ['routes/docs.css', '.docs-route'],
   ])('%s scopes a single-column mobile override to %s .ev2-cards__grid', (path, routeClass) => {

--- a/frontend/ui-v2/src/sync/CacheEngineProvider.test.ts
+++ b/frontend/ui-v2/src/sync/CacheEngineProvider.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { seedCacheFromCorpus } from './corpusSeed'
+import { seedCacheFromCorpusWithRetry } from './CacheEngineProvider'
+
+/**
+ * ENC-TSK-M36 (feed data-truth) -- seedCacheFromCorpusWithRetry. Before this,
+ * CacheEngineProvider called seedCacheFromCorpus() exactly once on mount; any
+ * single failure (the corpus endpoint is confirmed to take up to ~20s on a
+ * cold Lambda cache, live on gamma) permanently stranded `isWarm` at false
+ * for the whole session with no retry. These tests mock ./corpusSeed and use
+ * fake timers so the retry backoff (1s, 3s) doesn't actually slow the suite.
+ */
+vi.mock('./corpusSeed', () => ({
+  seedCacheFromCorpus: vi.fn(),
+}))
+
+describe('seedCacheFromCorpusWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(seedCacheFromCorpus).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns immediately on first-attempt success (no retry needed)', async () => {
+    vi.mocked(seedCacheFromCorpus).mockResolvedValue({ pages: 1, records: 10, durationMs: 5 })
+
+    const result = await seedCacheFromCorpusWithRetry()
+    expect(result).toEqual({ pages: 1, records: 10, durationMs: 5 })
+    expect(seedCacheFromCorpus).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after a transient failure and succeeds on the second attempt', async () => {
+    vi.mocked(seedCacheFromCorpus)
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ pages: 2, records: 40, durationMs: 20000 })
+
+    const promise = seedCacheFromCorpusWithRetry()
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result.records).toBe(40)
+    expect(seedCacheFromCorpus).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after exhausting all retries and throws the last error', async () => {
+    vi.mocked(seedCacheFromCorpus).mockRejectedValue(new Error('still failing'))
+
+    const promise = seedCacheFromCorpusWithRetry()
+    // Swallow the eventual rejection so it doesn't surface as an unhandled
+    // rejection while the fake-timer flush below is still in flight.
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+    await expect(promise).rejects.toThrow('still failing')
+    // Initial attempt + one retry per configured delay (2 delays -> 3 calls).
+    expect(seedCacheFromCorpus).toHaveBeenCalledTimes(3)
+  })
+})

--- a/frontend/ui-v2/src/sync/CacheEngineProvider.tsx
+++ b/frontend/ui-v2/src/sync/CacheEngineProvider.tsx
@@ -4,6 +4,40 @@ import { seedCacheFromCorpus } from './corpusSeed'
 import { attachQueryClientPersist, restorePersistedQueryClient } from './queryPersist'
 import { queryClient } from '../api/queryClient'
 
+// ENC-TSK-M36 (feed data-truth): confirmed live against gamma that the
+// authenticated /api/v1/feed/corpus this seed call depends on can take up
+// to ~20s on a cold cache (backend fix in feed_query/lambda_function.py
+// parallelizes the per-project fan-out that caused it), and a single
+// transient failure here (a slow response the browser aborts, or an auth
+// cookie not yet attached on the very first render) used to strand
+// `isWarm` at false for the rest of the session -- there was no retry.
+// Feed's search corpus falls back to a much thinner data set when
+// `!isWarm` (buildSearchCorpus over realtime events only), which is the
+// concrete mechanism behind "Home counts don't match Feed" and "gamma is
+// missing plan/lesson records" symptoms: it isn't that gamma lacks the
+// data (the same corpus endpoint serves Home's accurate counts), it's that
+// the one-shot warm-up silently gave up.
+const SEED_RETRY_DELAYS_MS = [1_000, 3_000]
+
+export async function seedCacheFromCorpusWithRetry(): Promise<{
+  pages: number
+  records: number
+  durationMs: number
+}> {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= SEED_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return await seedCacheFromCorpus()
+    } catch (error) {
+      lastError = error
+      const delay = SEED_RETRY_DELAYS_MS[attempt]
+      if (delay === undefined) break
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Corpus seed failed')
+}
+
 interface CacheEngineContextValue {
   isWarm: boolean
   warmDurationMs: number | null
@@ -35,10 +69,11 @@ export function CacheEngineProvider({ children }: { children: ReactNode }) {
       if (!cancelled) setIsWarm(engine.isWarm)
 
       try {
-        const result = await seedCacheFromCorpus()
+        const result = await seedCacheFromCorpusWithRetry()
         if (cancelled) return
         setIsWarm(true)
         setWarmDurationMs(result.durationMs)
+        setSeedError(null)
       } catch (error) {
         if (cancelled) return
         setSeedError(error instanceof Error ? error.message : 'Corpus seed failed')

--- a/frontend/ui-v2/src/sync/searchIndex.ts
+++ b/frontend/ui-v2/src/sync/searchIndex.ts
@@ -71,5 +71,8 @@ export function tier1ToLocalSearchRecord(record: Tier1Record): LocalSearchRecord
     priority: record.priority,
     checkoutState:
       typeof record.attrs?.checkout_state === 'string' ? record.attrs.checkout_state : undefined,
+    // ENC-TSK-M35 (PAR-01): Tier1Record already carries updatedAt -- restore
+    // it to the search/filter layer alongside priority/checkout_state.
+    updatedAt: record.updatedAt ?? undefined,
   }
 }

--- a/frontend/ui-v2/src/types/search.ts
+++ b/frontend/ui-v2/src/types/search.ts
@@ -55,6 +55,14 @@ export interface SearchResultHit {
   priority?: string
   /** ENC-FTR-130 Band-B: tracker checkout_state (e.g. 'checked_out'), when known. */
   checkoutState?: string
+  /**
+   * ENC-TSK-M35 (PAR-01): ISO timestamp of the record's last update, when
+   * known. Already cached on Tier1Record but was dropped before reaching the
+   * search/filter layer -- the same class of gap FTR-130 Band-B fixed for
+   * priority/checkout_state. Best-effort only (cold-start realtime-events
+   * corpus has no timestamp source); never fabricated when absent.
+   */
+  updatedAt?: string
   tier: SearchTier
   fusion?: HybridGraphsearchResponse['per_node_fusion'] extends Record<string, infer V>
     ? V
@@ -72,6 +80,8 @@ export interface LocalSearchRecord {
   priority?: string
   /** ENC-FTR-130 Band-B: tracker checkout_state (e.g. 'checked_out'), when known. */
   checkoutState?: string
+  /** ENC-TSK-M35 (PAR-01): ISO timestamp of the record's last update, when known. */
+  updatedAt?: string
 }
 
 export interface TieredSearchSnapshot {


### PR DESCRIPTION
## Summary

**ENC-TSK-M35 — Feed rebuild** (per `Feed.dc.html` pixel contract + `Enceladus-v4-Feed-Review.md` §3/§4):
- Replaces the mobile/desktop fork (RecordCard grid vs Cloudscape `<Cards>` showing only STATUS/TIER/PROJECT) with one dense `RecordCard variant="feed"` row used at every viewport — id+project+timestamp / single-line title / status + priority + session-state (Checked In/Out) chip strip, 3px severity-keyed left accent.
- Wide viewports (>=64rem) get a real master-detail split (FTR-128 AC-18): `FeedReadingPane` now fetches the selected record and renders it through the same `Primitive`/`RecordDetailHub` used by full record routes (Overview/Neighbors/Worklog/Evidence tabs), not a bare summary stub.
- Restores the relative-timestamp parity gap (PAR-01) from real cached data (`Tier1Record.updatedAt`), never fabricated.
- New `Badge` atom (priority/CCI chips, §4.4), `feedRowPresentation.ts` (pure severity/badge mappings, unit tested), `relativeTime.ts` (unit tested).

**ENC-TSK-M36 — Feed data truth** (confirmed live against gamma via authenticated curl, not just a 401 check):
- `/api/v1/feed/tasks.json` and `/api/v1/feed/corpus` both took **~20s** on a cache miss — `_query_all_records`/`_query_corpus_tracker_records` queried every active project's `project-type-index` **sequentially**. Parallelized via a shared `_fan_out_by_project` (bounded `ThreadPoolExecutor`).
- The per-type snapshot caps (issues/features/lessons/plans capped at 10) applied to the **merged cross-project pool**, not per project — since the table is shared by every governed project (confirmed: a live pull returned `CFG-`/`FLY-`/`MJR-`/`JAP-`/`MOD-` prefixed records alongside `ENC-`), one active project's records could crowd another's out of the snapshot entirely. This is the real "gamma seed gap": not empty tables, starved representation. Caps now apply **per project** before merging.
- `CacheEngineProvider`'s one-shot corpus-seed call had no retry — a single transient failure (plausible given the ~20s cold latency) permanently stranded `isWarm=false` for the session. Now retries twice with backoff.
- Home's "Awaiting checkout" tile measures one project but its Feed destination link carried no `project_id` filter, so the number and the destination view could disagree. Fixed via `openTasksSearchFor(projectId)`.

Backend change is read-only in effect: no schema/endpoint change, only concurrency + cap-application scope. `governance_data_dictionary.json` updated per the `backend/lambda/*/lambda_function.py` gate.

CCI-97d73dd1d18d4a2e95138e7c1a1b295f
CCI-068116ce50f248b592004d1262d880d9

## Test plan
- [x] `frontend/ui-v2`: `npm run typecheck`, `npm run test -- --run` (43 files / 235 tests pass), `npm run lint` (no new errors vs baseline), `npm run build` (bundle budget PASS)
- [x] `backend/lambda/feed_query`: `python3 -m pytest` (43 tests pass, incl. 3 new fan-out/per-project-cap tests)
- [x] `python3 tools/check_governance_dictionary_sync.py --base origin/v4/main --head HEAD` → OK
- [x] Root cause verified live against gamma with an authenticated Cognito session (curl against `/api/v1/feed/tasks.json` and `/api/v1/feed/corpus`, ~20s latency + cross-project record prefixes confirmed)
- [ ] Post-deploy: re-verify gamma latency dropped and Home tile counts agree with Feed filter results

🤖 Generated with [Claude Code](https://claude.com/claude-code)