### PR TITLE
ENC-TSK-M33: Record-page v3 action parity (Copy ID, state-aware transitions, Note, GitHub link, chip row)

### DIFF
--- a/frontend/ui-v2/src/api/mutations.ts
+++ b/frontend/ui-v2/src/api/mutations.ts
@@ -150,6 +150,22 @@ export async function patchTrackerRecord(
   return sendMutationRequest(url, 'PATCH', body, headers)
 }
 
+/**
+ * Checkout release/acquire (ENC-TSK-M33 -- "Check In" primary action). Same
+ * transport conventions as sendMutationRequest, but hits the `/checkout`
+ * sub-resource with no body, matching the legacy PWA's `setCheckout`
+ * (frontend/ui/src/api/mutations.ts): POST acquires, DELETE releases.
+ */
+export async function setCheckout(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan',
+  recordId: string,
+  checkedOut: boolean,
+): Promise<MutationResult> {
+  const url = `${API_BASE}/tracker/${encodeURIComponent(projectId)}/${recordType}/${encodeURIComponent(recordId)}/checkout`
+  return sendMutationRequest(url, checkedOut ? 'POST' : 'DELETE', {}, {})
+}
+
 export async function replayQueuedMutation(entry: QueuedMutation): Promise<boolean> {
   try {
     await sendMutationRequest(entry.url, entry.method, entry.body, entry.headers)
@@ -180,6 +196,25 @@ export async function submitNote(
   return patchTrackerRecord(projectId, recordType, recordId, { action: 'note', note }, { ifMatchRevision })
 }
 
+/**
+ * Worklog append (ENC-TSK-M33 -- the "Note" primary-action button). Unlike
+ * `submitNote` ('note' action -- queued as a pending update for the next
+ * agent session to process, per the legacy PWA's queued-note flow), 'worklog'
+ * writes an immediate `history[]` entry the WORKLOG tab renders right away --
+ * matching the AC's "Note button appends a worklog entry" requirement and
+ * v3's identical "Submit + Close" note-then-status two-step (LifecycleActions
+ * .tsx `noteAction = closeImmediately ? 'worklog' : 'note'`).
+ */
+export async function submitWorklog(
+  projectId: string,
+  recordType: 'task' | 'issue' | 'feature' | 'plan',
+  recordId: string,
+  note: string,
+  ifMatchRevision?: number,
+): Promise<MutationResult> {
+  return patchTrackerRecord(projectId, recordType, recordId, { action: 'worklog', note }, { ifMatchRevision })
+}
+
 export async function setField(
   projectId: string,
   recordType: 'task' | 'issue' | 'feature' | 'plan' | 'lesson',
@@ -187,12 +222,16 @@ export async function setField(
   field: string,
   value: string,
   ifMatchRevision?: number,
+  /** ENC-ISS-092 user-initiated bypass ({user_initiated:true, user_note}) or
+   *  a backward revert ({revert_reason}) -- forwarded verbatim as
+   *  `transition_evidence` in the PATCH body. */
+  transitionEvidence?: Record<string, unknown>,
 ): Promise<MutationResult> {
   return patchTrackerRecord(
     projectId,
     recordType,
     recordId,
-    { field, value },
+    { field, value, ...(transitionEvidence ? { transition_evidence: transitionEvidence } : {}) },
     { ifMatchRevision },
   )
 }

--- a/frontend/ui-v2/src/components/ChipRow.tsx
+++ b/frontend/ui-v2/src/components/ChipRow.tsx
@@ -1,0 +1,122 @@
+/**
+ * ChipRow -- the additional record-detail chips beyond status (ENC-TSK-M33
+ * / DOC-B6B52E3BB9BB §7 chip-row parity): priority, severity, category, the
+ * ●Active green-dot session indicator, checkout Checked-Out(gold)/Checked-In,
+ * and component. Tokens bound per Enceladus-v4-LookFeel-Implementation-Spec
+ * §5.2/5.3 ("Never render a status/priority/CCI in a color outside this
+ * table") -- crimson=P0, amber(--v2-status-warning)=P1/CHECKED OUT,
+ * dust=P2/P3, lavender=category tag, teal=CHECKED IN / active dot.
+ */
+import type { ReactNode } from 'react'
+import './chipRow.css'
+
+function Chip({
+  label,
+  color,
+  title,
+  dot,
+}: {
+  label: ReactNode
+  color: string
+  title?: string
+  dot?: boolean
+}) {
+  return (
+    <span className="ev2-chip" style={{ color, borderColor: color }} title={title}>
+      {dot ? (
+        <span
+          aria-hidden
+          className="ev2-chip__dot"
+          style={{ background: color, boxShadow: `0 0 6px ${color}` }}
+        />
+      ) : null}
+      {label}
+    </span>
+  )
+}
+
+const PRIORITY_COLOR: Record<string, string> = {
+  P0: 'var(--enc-crimson, var(--danger, #C85060))',
+  P1: 'var(--v2-status-warning, #C9A15C)',
+  P2: 'var(--enc-dust, var(--fg-muted, #6B8A94))',
+  P3: 'var(--enc-dust, var(--fg-muted, #6B8A94))',
+}
+
+export function PriorityChip({ priority }: { priority?: string | null }) {
+  if (!priority) return null
+  const color = PRIORITY_COLOR[priority.toUpperCase()] ?? PRIORITY_COLOR.P2
+  return <Chip label={priority.toUpperCase()} color={color} />
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: 'var(--enc-crimson, var(--danger, #C85060))',
+  high: 'var(--enc-crimson, var(--danger, #C85060))',
+  medium: 'var(--v2-status-warning, #C9A15C)',
+  low: 'var(--enc-dust, var(--fg-muted, #6B8A94))',
+}
+
+export function SeverityChip({ severity }: { severity?: string | null }) {
+  if (!severity) return null
+  const color = SEVERITY_COLOR[severity.toLowerCase()] ?? SEVERITY_COLOR.low
+  return <Chip label={severity} color={color} />
+}
+
+export function CategoryChip({ category }: { category?: string | null }) {
+  if (!category) return null
+  return <Chip label={category} color="var(--enc-lavender, var(--accent-secondary, #8A8CB5))" />
+}
+
+export function ComponentChips({ components }: { components?: string[] }) {
+  if (!components?.length) return null
+  return (
+    <>
+      {components.map((c) => (
+        <Chip key={c} label={c} color="var(--enc-teal-light, var(--accent, #7AC8D4))" />
+      ))}
+    </>
+  )
+}
+
+/** The ●Active green-dot indicator -- an agent session is live on this
+ *  record right now (distinct from the gold Checked-Out chip, which merely
+ *  states the lock is held). */
+export function ActiveSessionChip({
+  active,
+  sessionId,
+}: {
+  active?: boolean
+  sessionId?: string | null
+}) {
+  if (!active) return null
+  return (
+    <Chip
+      label="Active"
+      color="var(--enc-teal, var(--accent, #3D9BA8))"
+      dot
+      title={sessionId ? `Active session: ${sessionId}` : 'Active agent session'}
+    />
+  )
+}
+
+export function CheckoutChip({
+  checkedOut,
+  checkedOutBy,
+  checkedInBy,
+}: {
+  checkedOut: boolean
+  checkedOutBy?: string | null
+  checkedInBy?: string | null
+}) {
+  const color = checkedOut
+    ? 'var(--v2-status-warning, #C9A15C)'
+    : 'var(--enc-teal, var(--accent, #3D9BA8))'
+  const label = checkedOut ? 'Checked Out' : 'Checked In'
+  const title = checkedOut
+    ? checkedOutBy
+      ? `Checked out by ${checkedOutBy}`
+      : undefined
+    : checkedInBy
+      ? `Checked in by ${checkedInBy}`
+      : undefined
+  return <Chip label={label} color={color} title={title} />
+}

--- a/frontend/ui-v2/src/components/PrimitiveCard.tsx
+++ b/frontend/ui-v2/src/components/PrimitiveCard.tsx
@@ -108,6 +108,27 @@ export function MetaRow({ label, children }: { label: string; children: ReactNod
   )
 }
 
+/** Labeled body-section heading (ENC-TSK-M33 / DOC-B6B52E3BB9BB §7 -- USER
+ *  STORY / DESCRIPTION / EVIDENCE are distinct labeled sections in v3, not
+ *  unlabeled prose). Dust, uppercase, mono-spaced label above the block. */
+export function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <h4
+      style={{
+        fontFamily: 'var(--font-heading)',
+        fontSize: 'var(--text-xs)',
+        fontWeight: 'var(--fw-bold)',
+        textTransform: 'uppercase',
+        letterSpacing: 'var(--tracking-label)',
+        color: 'var(--fg-muted)',
+        margin: '0 0 var(--space-2)',
+      }}
+    >
+      {children}
+    </h4>
+  )
+}
+
 /** Body prose -- record description/observation text, rendered through the
  *  shared MarkdownContent component (ENC-TSK-M32) rather than a raw <p>, so
  *  descriptions get real markdown, inline ENC-*\/DOC-* ID auto-linking, and

--- a/frontend/ui-v2/src/components/RecordDetailHub.tsx
+++ b/frontend/ui-v2/src/components/RecordDetailHub.tsx
@@ -2,21 +2,41 @@ import { useState, type ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import { RecordId } from './RecordId'
 import { StatusChip } from './StatusChip'
-import { Tabs } from '../design-system'
+import { Modal, Tabs } from '../design-system'
 import { recordHrefForType } from '../routes/recordLink'
 import type {
   AcceptanceCriterion,
   HistoryEntry,
+  IssueEvidence,
   RecordType,
   TypedRelationshipEdge,
 } from '../types/records'
 import { TypedRelationshipSection } from './TypedRelationshipSection'
 import { MarkdownContent } from './MarkdownContent'
+import { useRecordMutation } from '../hooks/useRecordMutation'
+import { computePrimaryActions, type TransitionAction } from '../utils/transitionArcs'
 import './recordDetailHub.css'
 
 export interface HubVital {
   label: string
   value: ReactNode
+}
+
+/**
+ * Drives the state-aware primary action + Note button (ENC-TSK-M33 AC-2/3).
+ * Every field here comes straight off the tracker record -- callers (the
+ * Task/Issue/Feature/Plan primitives) supply it alongside their own
+ * type-specific `vitals`/`overview`/tab content; RecordDetailHub owns the
+ * actual mutation wiring so it lives in exactly one place.
+ */
+export interface RecordMutationContext {
+  projectId: string
+  recordType: 'task' | 'issue' | 'feature' | 'plan'
+  recordId: string
+  status: string
+  transitionType?: string | null
+  checkedOut: boolean
+  syncVersion?: number
 }
 
 export interface HubAction {
@@ -35,10 +55,17 @@ export interface HubAction {
  * projects the same segments into a two-column hub: head+actions become a
  * sticky sidebar, tab content sits alongside it.
  *
- * Read-only surface by design (architect direction, DOC-6EFD5DB32CD8): the
- * built-in action is Copy ID; callers may pass additional link-only actions
- * (e.g. "Open PR") ONLY when the record's own data actually supports them.
- * No governed-mutation trigger (Advance/Escalate) is wired from this page.
+ * ENC-TSK-M33 (v3 action parity, HARD cutover gate) lifted the read-only
+ * restriction noted in the prior revision of this comment
+ * (DOC-6EFD5DB32CD8): Copy ID remains built in, and this component now also
+ * owns the state-aware primary transition button (Check In / advance /
+ * revert / Submit + Close) and the Note button, both executing through the
+ * SAME governed `useRecordMutation` write path the rest of the PWA uses
+ * (tracker PATCH -> ENC-ISS-092 user_initiated bypass for forward task
+ * writes, transition_evidence.revert_reason for backward writes on any
+ * type) -- never a new write surface. Callers still pass `actions` for
+ * simple link-only controls (GitHub link) and `chips` for the DOC-B6B52E3BB9BB
+ * §7 chip row.
  */
 export function RecordDetailHub({
   recordId,
@@ -47,6 +74,7 @@ export function RecordDetailHub({
   status,
   priority,
   recordType,
+  chips,
   vitals = [],
   overview,
   content,
@@ -54,6 +82,7 @@ export function RecordDetailHub({
   worklog,
   evidence,
   actions = [],
+  mutation,
 }: {
   recordId: string
   kindLabel: string
@@ -61,6 +90,9 @@ export function RecordDetailHub({
   status?: string
   priority?: string
   recordType?: string
+  /** Extra chips (severity/category/active-session/checkout/component)
+   *  rendered after the built-in StatusChip -- see components/ChipRow.tsx. */
+  chips?: ReactNode
   vitals?: HubVital[]
   overview: ReactNode
   /** Optional "Content" tab (Docs.dc.html) — full document body, rendered
@@ -70,8 +102,19 @@ export function RecordDetailHub({
   worklog?: ReactNode
   evidence?: ReactNode
   actions?: HubAction[]
+  /** ENC-TSK-M33 -- when present, renders the state-aware primary
+   *  transition button(s) + the Note button, wired to real governed writes. */
+  mutation?: RecordMutationContext
 }) {
   const [copied, setCopied] = useState(false)
+  const [noteOpen, setNoteOpen] = useState(false)
+  const [noteText, setNoteText] = useState('')
+  const [transition, setTransition] = useState<TransitionAction | null>(null)
+  const [transitionNote, setTransitionNote] = useState('')
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null)
+
+  const recordMutation = useRecordMutation()
 
   const copyId = () => {
     navigator.clipboard
@@ -86,6 +129,115 @@ export function RecordDetailHub({
       })
   }
 
+  const primaryActions = mutation
+    ? computePrimaryActions({
+        recordType: mutation.recordType,
+        status: mutation.status,
+        transitionType: mutation.transitionType,
+        checkedOut: mutation.checkedOut,
+      })
+    : []
+
+  function flashSuccess(message: string) {
+    setActionSuccess(message)
+    setTimeout(() => setActionSuccess(null), 3000)
+  }
+
+  function runCheckIn() {
+    if (!mutation) return
+    setActionError(null)
+    recordMutation.mutate(
+      {
+        projectId: mutation.projectId,
+        recordType: mutation.recordType,
+        recordId: mutation.recordId,
+        action: 'release',
+      },
+      {
+        onSuccess: () => flashSuccess('Checked in.'),
+        onError: (err) => setActionError(err.message || 'Check-in failed.'),
+      },
+    )
+  }
+
+  function openTransition(action: TransitionAction) {
+    setTransitionNote('')
+    setActionError(null)
+    setTransition(action)
+  }
+
+  function submitTransition(closeImmediately: boolean) {
+    if (!mutation || !transition?.targetStatus) return
+    if (!transitionNote.trim()) return
+    const targetStatus = closeImmediately ? 'closed' : transition.targetStatus
+    const transitionEvidence =
+      transition.kind === 'revert'
+        ? { revert_reason: transitionNote }
+        : { user_initiated: true, user_note: transitionNote }
+
+    // Two-step submit (mirrors the legacy PWA's LifecycleActions.tsx): first
+    // land the note as an immediate worklog entry, then apply the status
+    // write with the evidence stamped for audit.
+    recordMutation.mutate(
+      {
+        projectId: mutation.projectId,
+        recordType: mutation.recordType,
+        recordId: mutation.recordId,
+        action: 'worklog',
+        note: transitionNote,
+        syncVersion: mutation.syncVersion,
+      },
+      {
+        onSuccess: () => {
+          recordMutation.mutate(
+            {
+              projectId: mutation.projectId,
+              recordType: mutation.recordType,
+              recordId: mutation.recordId,
+              action: 'set_field',
+              field: 'status',
+              value: targetStatus,
+              transitionEvidence,
+              syncVersion: mutation.syncVersion,
+            },
+            {
+              onSuccess: () => {
+                setTransition(null)
+                setTransitionNote('')
+                flashSuccess(`Status changed to ${targetStatus}.`)
+              },
+              onError: (err) => setActionError(err.message || 'Status change failed.'),
+            },
+          )
+        },
+        onError: (err) => setActionError(err.message || 'Note submission failed.'),
+      },
+    )
+  }
+
+  function submitNoteOnly() {
+    if (!mutation || !noteText.trim()) return
+    setActionError(null)
+    recordMutation.mutate(
+      {
+        projectId: mutation.projectId,
+        recordType: mutation.recordType,
+        recordId: mutation.recordId,
+        action: 'worklog',
+        note: noteText,
+        syncVersion: mutation.syncVersion,
+      },
+      {
+        onSuccess: () => {
+          setNoteOpen(false)
+          setNoteText('')
+          flashSuccess('Note added to worklog.')
+        },
+        onError: (err) => setActionError(err.message || 'Note failed.'),
+      },
+    )
+  }
+
   const tabs = [
     { id: 'overview', label: 'Overview', content: overview },
     ...(content !== undefined ? [{ id: 'content', label: 'Content', content }] : []),
@@ -93,6 +245,25 @@ export function RecordDetailHub({
     ...(worklog ? [{ id: 'worklog', label: 'Worklog', content: worklog }] : []),
     ...(evidence ? [{ id: 'evidence', label: 'Evidence', content: evidence }] : []),
   ]
+
+  function renderActionButtons() {
+    return (
+      <ActionButtons
+        copied={copied}
+        onCopy={copyId}
+        actions={actions}
+        primaryActions={primaryActions}
+        mutating={recordMutation.isPending}
+        onCheckIn={runCheckIn}
+        onTransitionClick={openTransition}
+        onNoteClick={() => {
+          setNoteText('')
+          setActionError(null)
+          setNoteOpen(true)
+        }}
+      />
+    )
+  }
 
   return (
     <div className="ev2-rdh">
@@ -104,6 +275,7 @@ export function RecordDetailHub({
             {status ? (
               <StatusChip status={status} priority={priority} recordType={recordType} />
             ) : null}
+            {chips}
           </div>
           <h1 className="ev2-rdh__title">{title}</h1>
           {vitals.length ? (
@@ -116,8 +288,13 @@ export function RecordDetailHub({
               ))}
             </dl>
           ) : null}
+          {actionSuccess || actionError ? (
+            <p className={`ev2-rdh__action-feedback${actionError ? ' is-error' : ''}`}>
+              {actionError ?? actionSuccess}
+            </p>
+          ) : null}
           <div className="ev2-rdh__actionbar ev2-rdh__actionbar--inline">
-            <ActionButtons copied={copied} onCopy={copyId} actions={actions} />
+            {renderActionButtons()}
           </div>
         </header>
 
@@ -131,8 +308,118 @@ export function RecordDetailHub({
         role="toolbar"
         aria-label="Record actions"
       >
-        <ActionButtons copied={copied} onCopy={copyId} actions={actions} />
+        {renderActionButtons()}
       </div>
+
+      {/* Note bottom sheet (ENC-TSK-M33 AC-3) -- appends an immediate,
+          visible worklog entry through the governed write path. */}
+      <Modal
+        visible={noteOpen}
+        header="Add Note"
+        recordId={recordId}
+        onDismiss={() => {
+          setNoteOpen(false)
+          setNoteText('')
+        }}
+        footer={
+          <>
+            <button
+              type="button"
+              className="ev2-rdh__action ev2-rdh__modal-cancel"
+              onClick={() => {
+                setNoteOpen(false)
+                setNoteText('')
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="ev2-rdh__action ev2-rdh__modal-submit"
+              disabled={!noteText.trim() || recordMutation.isPending}
+              onClick={submitNoteOnly}
+            >
+              {recordMutation.isPending ? 'Saving…' : 'Submit'}
+            </button>
+          </>
+        }
+      >
+        <textarea
+          className="ev2-rdh__note-textarea"
+          rows={5}
+          maxLength={2000}
+          value={noteText}
+          onChange={(e) => setNoteText(e.target.value)}
+          placeholder="Describe what changed, what's needed, or any context…"
+          autoFocus
+        />
+        {actionError ? <p className="ev2-rdh__action-feedback is-error">{actionError}</p> : null}
+      </Modal>
+
+      {/* Transition bottom sheet (ENC-TSK-M33 AC-2) -- advance/revert require
+          a note (ENC-ISS-092 user_note / transition_evidence.revert_reason),
+          matching the legacy PWA's LifecycleActions modal. Tasks only get the
+          extra "Submit + Close" terminal shortcut. */}
+      <Modal
+        visible={transition !== null}
+        header={transition?.kind === 'revert' ? 'Revert status' : 'Advance status'}
+        recordId={recordId}
+        onDismiss={() => {
+          setTransition(null)
+          setTransitionNote('')
+        }}
+        footer={
+          <>
+            <button
+              type="button"
+              className="ev2-rdh__action ev2-rdh__modal-cancel"
+              onClick={() => {
+                setTransition(null)
+                setTransitionNote('')
+              }}
+            >
+              Cancel
+            </button>
+            {transition?.allowSubmitClose ? (
+              <button
+                type="button"
+                className="ev2-rdh__action ev2-rdh__modal-submit ev2-rdh__modal-submit--danger"
+                disabled={!transitionNote.trim() || recordMutation.isPending}
+                title="Skip all remaining stages and close this task immediately"
+                onClick={() => submitTransition(true)}
+              >
+                {recordMutation.isPending ? 'Saving…' : 'Submit + Close'}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="ev2-rdh__action ev2-rdh__modal-submit"
+              disabled={!transitionNote.trim() || recordMutation.isPending}
+              onClick={() => submitTransition(false)}
+            >
+              {recordMutation.isPending ? 'Saving…' : 'Submit'}
+            </button>
+          </>
+        }
+      >
+        <p className="ev2-rdh__modal-hint">
+          {transition?.kind === 'revert'
+            ? 'Add a note explaining why this is being reverted.'
+            : 'Add a note explaining why this is advancing.'}
+        </p>
+        <textarea
+          className="ev2-rdh__note-textarea"
+          rows={5}
+          maxLength={2000}
+          value={transitionNote}
+          onChange={(e) => setTransitionNote(e.target.value)}
+          placeholder={
+            transition?.kind === 'revert' ? 'Why is this being reverted?' : 'Why is this moving forward?'
+          }
+          autoFocus
+        />
+        {actionError ? <p className="ev2-rdh__action-feedback is-error">{actionError}</p> : null}
+      </Modal>
     </div>
   )
 }
@@ -141,15 +428,68 @@ function ActionButtons({
   copied,
   onCopy,
   actions,
+  primaryActions,
+  mutating,
+  onCheckIn,
+  onTransitionClick,
+  onNoteClick,
 }: {
   copied: boolean
   onCopy: () => void
   actions: HubAction[]
+  primaryActions: TransitionAction[]
+  mutating: boolean
+  onCheckIn: () => void
+  onTransitionClick: (action: TransitionAction) => void
+  onNoteClick: () => void
 }) {
   return (
     <>
       <button type="button" className="ev2-rdh__action ev2-rdh__action--copy" onClick={onCopy}>
         {copied ? 'Copied' : 'Copy ID'}
+      </button>
+      {primaryActions.map((pa) => {
+        if (pa.kind === 'check-in') {
+          return (
+            <button
+              key="check-in"
+              type="button"
+              className="ev2-rdh__action ev2-rdh__action--checkin"
+              disabled={mutating}
+              onClick={onCheckIn}
+            >
+              {pa.label}
+            </button>
+          )
+        }
+        if (pa.disabled) {
+          return (
+            <button
+              key={`${pa.kind}-disabled`}
+              type="button"
+              className="ev2-rdh__action"
+              disabled
+              title={pa.disabledReason}
+              aria-label={`${pa.label} -- ${pa.disabledReason ?? 'unavailable'}`}
+            >
+              {pa.label}
+            </button>
+          )
+        }
+        return (
+          <button
+            key={`${pa.kind}-${pa.targetStatus}`}
+            type="button"
+            className="ev2-rdh__action"
+            disabled={mutating}
+            onClick={() => onTransitionClick(pa)}
+          >
+            {pa.label}
+          </button>
+        )
+      })}
+      <button type="button" className="ev2-rdh__action ev2-rdh__action--note" onClick={onNoteClick}>
+        ✏ Note
       </button>
       {actions.map((a) =>
         a.href ? (
@@ -264,10 +604,13 @@ export function WorklogTab({
   )
 }
 
-/** Evidence tab body: acceptance-criteria stamps (governed AC evidence),
- *  rendered through MarkdownContent (ENC-TSK-M32) so evidence text -- which
- *  often embeds record IDs, hashes, or run URLs -- wraps instead of
- *  overflowing and links inline IDs like everywhere else. */
+/** Evidence tab body: ACCEPTANCE CRITERIA checklist (task/feature, DOC-
+ *  B6B52E3BB9BB §7) -- a ●/○ accept-state circle per AC (● = accepted, ○ =
+ *  evidence not yet accepted, matching the v3 direct visual capture verbatim
+ *  rather than a text "Accepted"/"Pending" badge), rendered through
+ *  MarkdownContent (ENC-TSK-M32) so evidence text -- which often embeds
+ *  record IDs, hashes, or run URLs -- wraps instead of overflowing and links
+ *  inline IDs like everywhere else. */
 export function EvidenceTab({
   criteria,
   projectId,
@@ -280,13 +623,50 @@ export function EvidenceTab({
     <ul className="ev2-rdh__evidence-list">
       {criteria.map((c, i) => (
         <li className="ev2-rdh__evidence-item" key={i}>
-          <span className={`ev2-rdh__evidence-badge${c.evidence_acceptance ? ' is-accepted' : ''}`}>
-            {c.evidence_acceptance ? 'Accepted' : 'Pending'}
+          <span
+            className={`ev2-rdh__evidence-badge${c.evidence_acceptance ? ' is-accepted' : ''}`}
+            role="img"
+            aria-label={c.evidence_acceptance ? 'Accepted' : 'Pending'}
+            title={c.evidence_acceptance ? 'Accepted' : 'Pending'}
+          >
+            {c.evidence_acceptance ? '●' : '○'}
           </span>
           <div className="ev2-rdh__evidence-body">
             <MarkdownContent text={c.description} projectId={projectId} className="ev2-rdh__evidence-desc" />
             {c.evidence ? (
               <MarkdownContent text={c.evidence} projectId={projectId} className="ev2-rdh__evidence-proof" />
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/** EVIDENCE tab body for issues (DOC-B6B52E3BB9BB §7): each entry is a
+ *  description plus its `steps_to_duplicate` repro list -- a different
+ *  shape than the AC evidence stamps above (no evidence_acceptance state),
+ *  so it gets its own renderer rather than overloading EvidenceTab. */
+export function IssueEvidenceTab({
+  entries,
+  projectId,
+}: {
+  entries: IssueEvidence[] | undefined
+  projectId?: string
+}) {
+  if (!entries?.length) return null
+  return (
+    <ul className="ev2-rdh__evidence-list">
+      {entries.map((e, i) => (
+        <li className="ev2-rdh__evidence-item" key={i}>
+          <div className="ev2-rdh__evidence-body">
+            <MarkdownContent text={e.description} projectId={projectId} className="ev2-rdh__evidence-desc" />
+            {e.steps_to_duplicate?.length ? (
+              <ol className="ev2-rdh__evidence-steps">
+                {e.steps_to_duplicate.map((step, j) => (
+                  <li key={j}>{step}</li>
+                ))}
+              </ol>
             ) : null}
           </div>
         </li>

--- a/frontend/ui-v2/src/components/chipRow.css
+++ b/frontend/ui-v2/src/components/chipRow.css
@@ -1,0 +1,26 @@
+/* ENC-TSK-M33 -- chip row parity (DOC-B6B52E3BB9BB §7). Deliberately mirrors
+   StatusChip's visual language (bordered pill + optional glow dot) so the
+   status chip and these sit flush in the same row. */
+
+.ev2-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  padding: 2px var(--space-2);
+  background: transparent;
+  white-space: nowrap;
+}
+
+.ev2-chip__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}

--- a/frontend/ui-v2/src/components/recordDetailHub.css
+++ b/frontend/ui-v2/src/components/recordDetailHub.css
@@ -154,6 +154,98 @@
   border-style: dashed;
 }
 
+/* ENC-TSK-M33 -- Check In uses the amber/warning token (matches the gold
+   CHECKED OUT chip -- releasing the lock is the meaningful action while
+   checked out, per DOC-B6B52E3BB9BB §7's direct v3 capture). */
+.ev2-rdh__action--checkin {
+  border-color: var(--v2-status-warning, #C9A15C);
+  color: var(--v2-status-warning, #C9A15C);
+}
+
+.ev2-rdh__action--checkin:hover {
+  background: var(--v2-status-warning, #C9A15C);
+  color: var(--bg-surface);
+}
+
+.ev2-rdh__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ev2-rdh__action:disabled:hover {
+  background: transparent;
+  color: var(--accent);
+}
+
+.ev2-rdh__action-feedback {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--enc-teal, var(--accent));
+}
+
+.ev2-rdh__action-feedback.is-error {
+  color: var(--enc-crimson, var(--danger));
+  white-space: pre-wrap;
+}
+
+.ev2-rdh__note-textarea {
+  width: 100%;
+  min-height: 7rem;
+  resize: vertical;
+  box-sizing: border-box;
+  background: var(--bg-void, var(--enc-void));
+  color: var(--fg);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+}
+
+.ev2-rdh__note-textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.ev2-rdh__modal-hint {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.ev2-rdh__modal-cancel {
+  flex: 0 0 auto;
+  min-width: 5rem;
+  border-color: var(--fg-muted);
+  color: var(--fg-muted);
+}
+
+.ev2-rdh__modal-submit {
+  flex: 0 0 auto;
+  min-width: 6rem;
+}
+
+.ev2-rdh__modal-submit--danger {
+  border-color: var(--enc-crimson, var(--danger));
+  color: var(--enc-crimson, var(--danger));
+}
+
+.ev2-rdh__modal-submit--danger:hover:not(:disabled) {
+  background: var(--enc-crimson, var(--danger));
+  color: var(--bg-surface);
+}
+
+.ev2-rdh__evidence-steps {
+  margin: var(--space-2) 0 0;
+  padding-left: 1.25rem;
+  font-size: var(--text-sm);
+  color: var(--fg);
+}
+
+.ev2-rdh__evidence-steps li {
+  margin-bottom: var(--space-1);
+}
+
 .ev2-rdh__neighbors {
   display: flex;
   flex-direction: column;
@@ -248,21 +340,17 @@
   padding-top: var(--space-3);
 }
 
+/* ENC-TSK-M33 -- a plain ●/○ accept-state circle glyph (DOC-B6B52E3BB9BB
+   §7: "checklist with ○ accept-state circles"), not a bordered text pill. */
 .ev2-rdh__evidence-badge {
   flex: 0 0 auto;
   height: fit-content;
-  font-family: var(--font-heading);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-label);
-  padding: 2px var(--space-2);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--fg-muted);
+  line-height: 1;
+  font-size: var(--text-lg, 1.1em);
   color: var(--fg-muted);
 }
 
 .ev2-rdh__evidence-badge.is-accepted {
-  border-color: var(--status-open);
   color: var(--status-open);
 }
 

--- a/frontend/ui-v2/src/hooks/useRecordMutation.ts
+++ b/frontend/ui-v2/src/hooks/useRecordMutation.ts
@@ -4,8 +4,10 @@ import {
   closeRecord,
   mergeConflictFields,
   readSyncVersion,
+  setCheckout,
   setField,
   submitNote,
+  submitWorklog,
   type MutationResult,
   type RevisionConflictError,
   isRevisionConflictError,
@@ -21,11 +23,14 @@ interface MutationVars {
   projectId: string
   recordType: RecordType
   recordId: string
-  action: 'close' | 'note' | 'set_field'
+  action: 'close' | 'note' | 'set_field' | 'worklog' | 'checkout' | 'release'
   note?: string
   field?: string
   value?: string
   syncVersion?: number
+  /** ENC-TSK-M33 -- forwarded to `setField` as `transition_evidence` for
+   *  state-aware advance (user_initiated) / revert (revert_reason) writes. */
+  transitionEvidence?: Record<string, unknown>
 }
 
 export interface ConflictMergeState {
@@ -136,6 +141,15 @@ export function useRecordMutation() {
       if (vars.action === 'note') {
         return submitNote(vars.projectId, vars.recordType, vars.recordId, vars.note ?? '', revision)
       }
+      if (vars.action === 'worklog') {
+        return submitWorklog(vars.projectId, vars.recordType, vars.recordId, vars.note ?? '', revision)
+      }
+      if (vars.action === 'checkout') {
+        return setCheckout(vars.projectId, vars.recordType, vars.recordId, true)
+      }
+      if (vars.action === 'release') {
+        return setCheckout(vars.projectId, vars.recordType, vars.recordId, false)
+      }
       return setField(
         vars.projectId,
         vars.recordType,
@@ -143,6 +157,7 @@ export function useRecordMutation() {
         vars.field!,
         vars.value!,
         revision,
+        vars.transitionEvidence,
       )
     },
 
@@ -216,7 +231,14 @@ export function useRecordMutation() {
       void qc.invalidateQueries({
         queryKey: recordKeys.detail(vars.recordType, vars.projectId, vars.recordId),
       })
-      if (vars.action === 'close' || vars.action === 'set_field') {
+      if (
+        vars.action === 'close' ||
+        vars.action === 'set_field' ||
+        vars.action === 'checkout' ||
+        vars.action === 'release'
+      ) {
+        // Checkout/release changes the feed card's session + checkout chips
+        // (ENC-TSK-M33 chip-row parity) even though it isn't a status write.
         void qc.invalidateQueries({ queryKey: feedCorpusKeys.all })
       }
     },

--- a/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/FeaturePrimitive.tsx
@@ -1,10 +1,13 @@
 import { Sparkles } from 'lucide-react'
 import type { Feature } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
-import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import { ActiveSessionChip, CategoryChip, CheckoutChip, ComponentChips } from '../components/ChipRow'
+import { MetaRow, Metric, Prose, SectionHeading } from '../components/PrimitiveCard'
+import { EvidenceTab, NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import { isCheckedOut } from '../utils/transitionArcs'
 
 export function FeaturePrimitive({ record }: { record: Feature }) {
+  const checkedOut = isCheckedOut(record)
   const vitals = [
     { label: 'Project', value: record.project_id },
     ...(record.transition_type ? [{ label: 'Transition type', value: record.transition_type }] : []),
@@ -20,8 +23,36 @@ export function FeaturePrimitive({ record }: { record: Feature }) {
       title={record.title}
       status={record.status}
       vitals={vitals}
+      chips={
+        <>
+          <CategoryChip category={record.category} />
+          <ComponentChips components={record.components} />
+          <ActiveSessionChip active={record.active_agent_session} sessionId={record.active_agent_session_id} />
+          <CheckoutChip
+            checkedOut={checkedOut}
+            checkedOutBy={record.checked_out_by}
+            checkedInBy={record.checked_in_by}
+          />
+        </>
+      }
+      mutation={{
+        projectId: record.project_id,
+        recordType: 'feature',
+        recordId: record.feature_id,
+        status: record.status,
+        checkedOut,
+        syncVersion: record.sync_version,
+      }}
+      actions={record.github_issue_url ? [{ label: 'GitHub ↗', href: record.github_issue_url }] : []}
       overview={
         <>
+          {record.user_story ? (
+            <>
+              <SectionHeading>User Story</SectionHeading>
+              <Prose projectId={record.project_id}>{record.user_story}</Prose>
+            </>
+          ) : null}
+          <SectionHeading>Description</SectionHeading>
           <Prose projectId={record.project_id}>{record.description}</Prose>
           <MetaRow label="Owners">
             {(record.owners ?? []).length > 0 ? (record.owners ?? []).join(', ') : 'Unowned'}
@@ -43,6 +74,7 @@ export function FeaturePrimitive({ record }: { record: Feature }) {
         />
       }
       worklog={<WorklogTab history={record.history} projectId={record.project_id} />}
+      evidence={<EvidenceTab criteria={record.acceptance_criteria} projectId={record.project_id} />}
     />
   )
 }

--- a/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/IssuePrimitive.tsx
@@ -1,10 +1,20 @@
 import { AlertTriangle } from 'lucide-react'
 import type { Issue } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { MetaRow, Prose } from '../components/PrimitiveCard'
-import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import {
+  ActiveSessionChip,
+  CategoryChip,
+  CheckoutChip,
+  ComponentChips,
+  PriorityChip,
+  SeverityChip,
+} from '../components/ChipRow'
+import { MetaRow, Prose, SectionHeading } from '../components/PrimitiveCard'
+import { IssueEvidenceTab, NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import { isCheckedOut } from '../utils/transitionArcs'
 
 export function IssuePrimitive({ record }: { record: Issue }) {
+  const checkedOut = isCheckedOut(record)
   const vitals = [
     { label: 'Priority', value: record.priority },
     { label: 'Severity', value: record.severity },
@@ -23,8 +33,32 @@ export function IssuePrimitive({ record }: { record: Issue }) {
       status={record.status}
       priority={record.priority}
       vitals={vitals}
+      chips={
+        <>
+          <PriorityChip priority={record.priority} />
+          <SeverityChip severity={record.severity} />
+          <CategoryChip category={record.category} />
+          <ComponentChips components={record.components} />
+          <ActiveSessionChip active={record.active_agent_session} sessionId={record.active_agent_session_id} />
+          <CheckoutChip
+            checkedOut={checkedOut}
+            checkedOutBy={record.checked_out_by}
+            checkedInBy={record.checked_in_by}
+          />
+        </>
+      }
+      mutation={{
+        projectId: record.project_id,
+        recordType: 'issue',
+        recordId: record.issue_id,
+        status: record.status,
+        checkedOut,
+        syncVersion: record.sync_version,
+      }}
+      actions={record.github_issue_url ? [{ label: 'GitHub ↗', href: record.github_issue_url }] : []}
       overview={
         <>
+          <SectionHeading>Description</SectionHeading>
           <Prose projectId={record.project_id}>{record.description}</Prose>
           <MetaRow label="Severity">
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
@@ -48,6 +82,7 @@ export function IssuePrimitive({ record }: { record: Issue }) {
         />
       }
       worklog={<WorklogTab history={record.history} projectId={record.project_id} />}
+      evidence={<IssueEvidenceTab entries={record.evidence} projectId={record.project_id} />}
     />
   )
 }

--- a/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/PlanPrimitive.tsx
@@ -1,11 +1,14 @@
 import { Map as MapIcon } from 'lucide-react'
 import type { Plan } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
+import { ActiveSessionChip, CategoryChip, CheckoutChip, ComponentChips, PriorityChip } from '../components/ChipRow'
 import { PlanGraphExplorer } from '../components/PlanGraphExplorer'
-import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { MetaRow, Metric, Prose, SectionHeading } from '../components/PrimitiveCard'
 import { NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import { isCheckedOut } from '../utils/transitionArcs'
 
 export function PlanPrimitive({ record }: { record: Plan }) {
+  const checkedOut = isCheckedOut(record)
   const vitals = [
     { label: 'Priority', value: record.priority },
     { label: 'Project', value: record.project_id },
@@ -24,8 +27,31 @@ export function PlanPrimitive({ record }: { record: Plan }) {
       status={record.status}
       priority={record.priority}
       vitals={vitals}
+      chips={
+        <>
+          <PriorityChip priority={record.priority} />
+          <CategoryChip category={record.category} />
+          <ComponentChips components={record.components} />
+          <ActiveSessionChip active={record.active_agent_session} sessionId={record.active_agent_session_id} />
+          <CheckoutChip
+            checkedOut={checkedOut}
+            checkedOutBy={record.checked_out_by}
+            checkedInBy={record.checked_in_by}
+          />
+        </>
+      }
+      mutation={{
+        projectId: record.project_id,
+        recordType: 'plan',
+        recordId: record.plan_id,
+        status: record.status,
+        checkedOut,
+        syncVersion: record.sync_version,
+      }}
+      actions={record.github_issue_url ? [{ label: 'GitHub ↗', href: record.github_issue_url }] : []}
       overview={
         <>
+          <SectionHeading>Description</SectionHeading>
           <Prose projectId={record.project_id}>{record.description}</Prose>
           <MetaRow label="Objectives">
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>

--- a/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
+++ b/frontend/ui-v2/src/primitives/TaskPrimitive.tsx
@@ -1,10 +1,13 @@
 import { ListChecks } from 'lucide-react'
 import type { Task } from '../types/records'
 import { ContextNodeBadges } from '../components/ContextNodeBadges'
-import { MetaRow, Metric, Prose } from '../components/PrimitiveCard'
+import { ActiveSessionChip, CheckoutChip, ComponentChips, PriorityChip } from '../components/ChipRow'
+import { MetaRow, Metric, Prose, SectionHeading } from '../components/PrimitiveCard'
 import { EvidenceTab, NeighborsTab, RecordDetailHub, WorklogTab } from '../components/RecordDetailHub'
+import { isCheckedOut } from '../utils/transitionArcs'
 
 export function TaskPrimitive({ record }: { record: Task }) {
+  const checkedOut = isCheckedOut(record)
   const vitals = [
     { label: 'Priority', value: record.priority },
     { label: 'Project', value: record.project_id },
@@ -22,8 +25,31 @@ export function TaskPrimitive({ record }: { record: Task }) {
       status={record.status}
       priority={record.priority}
       vitals={vitals}
+      chips={
+        <>
+          <PriorityChip priority={record.priority} />
+          <ComponentChips components={record.components} />
+          <ActiveSessionChip active={record.active_agent_session} sessionId={record.active_agent_session_id} />
+          <CheckoutChip
+            checkedOut={checkedOut}
+            checkedOutBy={record.checked_out_by}
+            checkedInBy={record.checked_in_by}
+          />
+        </>
+      }
+      mutation={{
+        projectId: record.project_id,
+        recordType: 'task',
+        recordId: record.task_id,
+        status: record.status,
+        transitionType: record.transition_type,
+        checkedOut,
+        syncVersion: record.sync_version,
+      }}
+      actions={record.github_issue_url ? [{ label: 'GitHub ↗', href: record.github_issue_url }] : []}
       overview={
         <>
+          <SectionHeading>Description</SectionHeading>
           <Prose projectId={record.project_id}>{record.description}</Prose>
           <MetaRow label="Assigned">{record.assigned_to ?? 'Unassigned'}</MetaRow>
           <MetaRow label="Checklist">

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -285,6 +285,60 @@ describe('record detail hub sticky action bar (ENC-TSK-M23)', () => {
 })
 
 /**
+ * ENC-TSK-M33 (v3 action parity, HARD cutover gate) -- the state-aware
+ * primary action bar built into RecordDetailHub. Same static-source-read
+ * approach as the M23 suite above (jsdom has no real cascade/layout, so this
+ * can't click-and-observe): asserts the wiring for Check In / advance /
+ * revert / Note actually exists and stays contained to the action bar's own
+ * width (no new horizontal-scroll source).
+ */
+describe('record detail hub state-aware action bar (ENC-TSK-M33)', () => {
+  const hubCss = stripCssComments(readSrc('components/recordDetailHub.css'))
+  const hubSrc = readSrc('components/RecordDetailHub.tsx')
+
+  it('computes the primary action(s) from the record transition arc + checkout state, not a static control', () => {
+    expect(hubSrc).toMatch(/computePrimaryActions/)
+    expect(hubSrc).toMatch(/useRecordMutation/)
+  })
+
+  it('renders a Check In control for checked-out records', () => {
+    expect(hubSrc).toMatch(/Check In/)
+    expect(hubSrc).toMatch(/ev2-rdh__action--checkin/)
+  })
+
+  it('renders the Note button, appending a worklog entry through the governed mutation hook', () => {
+    expect(hubSrc).toMatch(/✏ Note/)
+    expect(hubSrc).toMatch(/action:\s*'worklog'/)
+  })
+
+  it('disables (rather than fakes) a transition it cannot compute, with an explanatory reason', () => {
+    expect(hubSrc).toMatch(/disabledReason/)
+    expect(hubSrc).toMatch(/title=\{pa\.disabledReason\}/)
+  })
+
+  it('forward writes use the ENC-ISS-092 user_initiated evidence shape; backward writes use revert_reason', () => {
+    expect(hubSrc).toMatch(/user_initiated:\s*true/)
+    expect(hubSrc).toMatch(/revert_reason:\s*transitionNote/)
+  })
+
+  it('every new action button reuses the existing .ev2-rdh__action sizing/width rules (no bespoke width source)', () => {
+    // Check In / disabled / transition / Note buttons all render className
+    // "ev2-rdh__action ..." (never a bare custom class), so they inherit the
+    // same flex/min-width contract already covered by the M23 suite above
+    // instead of introducing a new overflow source.
+    const actionButtonClassUses = hubSrc.match(/className="ev2-rdh__action[^"]*"/g) ?? []
+    expect(actionButtonClassUses.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('the note/transition modal textarea is width-bound, not a fixed px width that could force scroll', () => {
+    const textareaMatch = hubCss.match(/\.ev2-rdh__note-textarea\s*\{([^}]*)\}/)
+    expect(textareaMatch, 'expected a .ev2-rdh__note-textarea rule').not.toBeNull()
+    expect(textareaMatch?.[1] ?? '').toMatch(/width:\s*100%/)
+    expect(textareaMatch?.[1] ?? '').toMatch(/box-sizing:\s*border-box/)
+  })
+})
+
+/**
  * ENC-TSK-M38 -- the "Search records or saved name…" input (FeedRoute) and
  * its Docs-route twin sat inside a `flex: 1` toolbar item with no explicit
  * `min-width`. `.ev2-al__content` (AppLayout.jsx) already floors its own

--- a/frontend/ui-v2/src/types/records.ts
+++ b/frontend/ui-v2/src/types/records.ts
@@ -53,12 +53,27 @@ export interface AcceptanceCriterion {
 
 /**
  * Governed lifecycle metadata shared by every checked-out-able tracker
- * record (ENC-TSK-M23 / FND-03).
+ * record (ENC-TSK-M23 / FND-03). Extended for ENC-TSK-M33 (v3 action
+ * parity): checkout/session fields drive the state-aware primary action
+ * (Check In vs advance/revert), `github_issue_url` drives the GitHub link
+ * button, and `components` feeds the chip row.
  */
 export interface GovernedLifecycleMeta {
   transition_type?: string
   checkout_state?: string
   checked_out_by?: string | null
+  checked_in_by?: string | null
+  checked_in_at?: string | null
+  /** True while an agent (or a borrowed Cognito user_initiated write) holds
+   *  this record's checkout lock -- the authoritative "checked out" signal. */
+  active_agent_session?: boolean
+  active_agent_session_id?: string | null
+  /** ENC-TSK-L47 If-Match revision counter -- required for safe concurrent writes. */
+  sync_version?: number
+  /** Populated once the record is linked to a GitHub PR/issue/commit. */
+  github_issue_url?: string | null
+  commit_sha?: string | null
+  components?: string[]
 }
 
 export interface Task extends GovernedLifecycleMeta {
@@ -82,6 +97,13 @@ export interface Task extends GovernedLifecycleMeta {
   context_node?: ContextNodeMeta
   subtask_ids?: string[]
   acceptance_criteria?: AcceptanceCriterion[]
+  commit_approval_id?: string | null
+  commit_complete_id?: string | null
+}
+
+export interface IssueEvidence {
+  description: string
+  steps_to_duplicate?: string[]
 }
 
 export interface Issue extends GovernedLifecycleMeta {
@@ -92,7 +114,9 @@ export interface Issue extends GovernedLifecycleMeta {
   status: 'open' | 'in-progress' | 'closed'
   priority: 'P0' | 'P1' | 'P2' | 'P3'
   severity: 'low' | 'medium' | 'high' | 'critical'
+  category?: string | null
   hypothesis: string | null
+  evidence?: IssueEvidence[]
   related_task_ids: string[]
   history: HistoryEntry[]
   updated_at: string | null
@@ -107,6 +131,9 @@ export interface Feature extends GovernedLifecycleMeta {
   title: string
   description: string
   status: 'planned' | 'in-progress' | 'completed' | 'production' | 'deprecated'
+  category?: string | null
+  user_story?: string | null
+  acceptance_criteria?: AcceptanceCriterion[]
   owners: string[]
   success_metrics: string[]
   related_task_ids: string[]

--- a/frontend/ui-v2/src/utils/transitionArcs.test.ts
+++ b/frontend/ui-v2/src/utils/transitionArcs.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { computePrimaryActions, isCheckedOut, arcFor } from './transitionArcs'
+
+/**
+ * ENC-TSK-M33 -- transition-computation logic tested against representative
+ * records pulled from live governed data (DOC-B6B52E3BB9BB §4): a task in
+ * 'pr' checked out by an agent session, an open issue, a planned feature,
+ * and a closed issue. No live write/click coverage here (agent sessions
+ * don't re-inject Cognito) -- this is the pure-logic contract the state-aware
+ * action bar renders from.
+ */
+
+describe('isCheckedOut', () => {
+  it('is true when active_agent_session is true', () => {
+    expect(isCheckedOut({ active_agent_session: true })).toBe(true)
+  })
+
+  it('falls back to checkout_state when active_agent_session is absent', () => {
+    expect(isCheckedOut({ checkout_state: 'checked_out' })).toBe(true)
+  })
+
+  it('is false for a checked-in record', () => {
+    expect(isCheckedOut({ active_agent_session: false, checkout_state: 'checked_in' })).toBe(false)
+  })
+})
+
+describe('computePrimaryActions -- representative records', () => {
+  it('task ENC-TSK-M31 shape: status=pr, checked_out by an agent session -> Check In only', () => {
+    const actions = computePrimaryActions({
+      recordType: 'task',
+      status: 'pr',
+      transitionType: 'github_pr_deploy',
+      checkedOut: true,
+    })
+    expect(actions).toEqual([{ kind: 'check-in', label: 'Check In' }])
+  })
+
+  it('open issue -> advance to in-progress, no revert (already at arc start)', () => {
+    const actions = computePrimaryActions({
+      recordType: 'issue',
+      status: 'open',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'advance', targetStatus: 'in-progress', label: 'In Progress →' })
+  })
+
+  it('planned feature -> advance to in-progress, no revert (already at arc start)', () => {
+    const actions = computePrimaryActions({
+      recordType: 'feature',
+      status: 'planned',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'advance', targetStatus: 'in-progress', label: 'In Progress →' })
+  })
+
+  it('closed issue -> revert to in-progress, no advance (terminal in its arc)', () => {
+    const actions = computePrimaryActions({
+      recordType: 'issue',
+      status: 'closed',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'revert', targetStatus: 'in-progress', label: '← In Progress' })
+  })
+
+  it('task not checked out, mid-arc (committed) -> both revert and advance, advance allows Submit + Close', () => {
+    const actions = computePrimaryActions({
+      recordType: 'task',
+      status: 'committed',
+      transitionType: 'github_pr_deploy',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(2)
+    expect(actions[0]).toMatchObject({ kind: 'revert', targetStatus: 'coding-complete' })
+    expect(actions[1]).toMatchObject({ kind: 'advance', targetStatus: 'pr', allowSubmitClose: true })
+  })
+
+  it('task at final arc status (closed) -> no actions at all (terminal, not checked out)', () => {
+    const actions = computePrimaryActions({
+      recordType: 'task',
+      status: 'closed',
+      transitionType: 'github_pr_deploy',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0].kind).toBe('revert')
+    expect(actions[0].targetStatus).toBe('deploy-success')
+  })
+
+  it('code_only task at merged-main -> advance target is closed (shorter arc), no deploy-init/success stage', () => {
+    const actions = computePrimaryActions({
+      recordType: 'task',
+      status: 'merged-main',
+      transitionType: 'code_only',
+      checkedOut: false,
+    })
+    const advance = actions.find((a) => a.kind === 'advance')
+    expect(advance?.targetStatus).toBe('closed')
+    // code_only tasks jump straight to closed here -- Submit + Close would be
+    // a no-op duplicate of the plain advance, so it's suppressed.
+    expect(advance?.allowSubmitClose).toBe(false)
+  })
+
+  it('no_code task arc is the shortest: open -> in-progress -> coding-complete -> closed', () => {
+    expect(arcFor('task', 'no_code')).toEqual(['open', 'in-progress', 'coding-complete', 'closed'])
+  })
+
+  it('unknown status not present in the computed arc -> disabled advance with an honest reason, not a faked transition', () => {
+    const actions = computePrimaryActions({
+      recordType: 'task',
+      status: 'some-unrecognized-status',
+      transitionType: 'github_pr_deploy',
+      checkedOut: false,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'advance', disabled: true })
+    expect(actions[0].disabledReason).toMatch(/isn't recognized/)
+  })
+
+  it('unknown task transition_type falls back to the strictest arc (github_pr_deploy) rather than allowing nothing', () => {
+    expect(arcFor('task', 'some_future_transition_type')).toEqual(arcFor('task', 'github_pr_deploy'))
+  })
+
+  it('plan arcs and feature arcs are exposed for completeness (no transition_type dependency)', () => {
+    expect(arcFor('plan')).toEqual(['drafted', 'started', 'complete', 'incomplete'])
+    expect(arcFor('feature')).toEqual(['planned', 'in-progress', 'completed', 'production', 'deprecated'])
+  })
+})

--- a/frontend/ui-v2/src/utils/transitionArcs.ts
+++ b/frontend/ui-v2/src/utils/transitionArcs.ts
@@ -1,0 +1,194 @@
+/**
+ * Governed lifecycle-transition computation (ENC-TSK-M33 / DOC-B6B52E3BB9BB
+ * §7). Pure functions, no React -- the state-aware primary action button
+ * needs to compute, for any record, the correct next control(s):
+ *
+ *  - checked out (active_agent_session) -> a single "Check In" control,
+ *    hiding the lifecycle stepper (matches the v3 direct visual capture:
+ *    button 1 shows exactly one of Check In / revert / advance, never a
+ *    lifecycle button while checkout is held).
+ *  - otherwise -> zero, one, or two adjacent-step buttons (revert to the
+ *    previous status, advance to the next), computed from the record's own
+ *    lifecycle arc.
+ *
+ * Task arcs are keyed by `transition_type` and mirror the backend's
+ * canonical matrix verbatim (backend/lambda/tracker_mutation/
+ * transition_type_matrix.py ALLOWED_TRANSITIONS_BY_TYPE, ENC-FTR-059 /
+ * DOC-B5B807D7C2CE), with the implicit 'open' starting state prefixed --
+ * NOT the legacy v3 frontend's hand-rolled TASK_STATUSES array
+ * (frontend/ui/src/lib/constants.ts), which is stale (`pushed` where the
+ * backend matrix and validation_rules both say `pr` -- see
+ * ENC-LSN feedback "validation_rules 'pushed' vs handler 'pr'"). Using the
+ * real backend matrix is what "compute the valid next transition from the
+ * record's transition_type arc" means; issue/feature/plan keep the simple
+ * linear arcs the legacy app already uses (those record types don't carry a
+ * transition_type).
+ *
+ * The one honest "cannot do this from the PWA" case this module detects is
+ * a record whose current status isn't a member of its own computed arc (bad
+ * data, or an arc this module doesn't yet know about) -- everything else a
+ * human can legally attempt via the existing ENC-ISS-092 user_initiated
+ * bypass (tasks) / revert_reason path (issue/feature/plan) is rendered live,
+ * matching v3 parity exactly rather than inventing a new restriction v3
+ * doesn't have.
+ */
+
+export type TrackerRecordType = 'task' | 'issue' | 'feature' | 'plan'
+
+/** Mirrors backend ALLOWED_TRANSITIONS_BY_TYPE (transition_type_matrix.py),
+ *  with 'open' prefixed as the implicit starting state. */
+export const TASK_ARC_BY_TRANSITION_TYPE: Record<string, string[]> = {
+  github_pr_deploy: [
+    'open', 'in-progress', 'coding-complete', 'committed', 'pr',
+    'merged-main', 'deploy-init', 'deploy-success', 'closed',
+  ],
+  lambda_deploy: [
+    'open', 'in-progress', 'coding-complete', 'committed', 'pr',
+    'merged-main', 'deploy-init', 'deploy-success', 'closed',
+  ],
+  web_deploy: [
+    'open', 'in-progress', 'coding-complete', 'committed', 'pr',
+    'merged-main', 'deploy-init', 'deploy-success', 'closed',
+  ],
+  code_only: [
+    'open', 'in-progress', 'coding-complete', 'committed', 'pr',
+    'merged-main', 'closed',
+  ],
+  no_code: [
+    'open', 'in-progress', 'coding-complete', 'closed',
+  ],
+}
+
+export const DEFAULT_TASK_TRANSITION_TYPE = 'github_pr_deploy'
+
+/** Issue/feature/plan don't carry a transition_type -- one fixed linear arc
+ *  each, matching the legacy PWA's LIFECYCLE_MAP (frontend/ui/src/components/
+ *  shared/LifecycleActions.tsx) verbatim for parity. */
+export const ISSUE_ARC = ['open', 'in-progress', 'closed']
+export const FEATURE_ARC = ['planned', 'in-progress', 'completed', 'production', 'deprecated']
+export const PLAN_ARC = ['drafted', 'started', 'complete', 'incomplete']
+
+export const STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  'in-progress': 'In Progress',
+  'coding-complete': 'Coding Complete',
+  committed: 'Committed',
+  pr: 'PR',
+  'merged-main': 'Merged to Main',
+  'deploy-init': 'Deploy Init',
+  'deploy-success': 'Deploy Success',
+  'coding-updates': 'Coding Updates',
+  closed: 'Closed',
+  planned: 'Planned',
+  completed: 'Completed',
+  production: 'Production',
+  deprecated: 'Deprecated',
+  drafted: 'Drafted',
+  started: 'Started',
+  complete: 'Complete',
+  incomplete: 'Incomplete',
+}
+
+export function labelForStatus(status: string): string {
+  return STATUS_LABELS[status] ?? status
+}
+
+/** Returns the record's lifecycle arc: the ordered list of statuses it
+ *  legitimately walks through. Unknown task transition_types fall back to
+ *  github_pr_deploy (the strictest arc) rather than silently allowing
+ *  nothing. */
+export function arcFor(recordType: TrackerRecordType, transitionType?: string | null): string[] {
+  if (recordType === 'task') {
+    return (
+      TASK_ARC_BY_TRANSITION_TYPE[transitionType ?? DEFAULT_TASK_TRANSITION_TYPE] ??
+      TASK_ARC_BY_TRANSITION_TYPE[DEFAULT_TASK_TRANSITION_TYPE]
+    )
+  }
+  if (recordType === 'issue') return ISSUE_ARC
+  if (recordType === 'feature') return FEATURE_ARC
+  return PLAN_ARC
+}
+
+export type TransitionActionKind = 'check-in' | 'advance' | 'revert'
+
+export interface TransitionAction {
+  kind: TransitionActionKind
+  label: string
+  /** Target status this action would set (absent for 'check-in', which is a
+   *  checkout-release call, not a status write). */
+  targetStatus?: string
+  disabled?: boolean
+  disabledReason?: string
+  /** True only for a task's forward step -- the primary action modal offers
+   *  a "Submit + Close" terminal shortcut alongside the normal advance
+   *  (matches v3's LifecycleActions "Submit + Close" for tasks only). */
+  allowSubmitClose?: boolean
+}
+
+/**
+ * Computes the primary action button(s) for a record's current lifecycle +
+ * checkout state (ENC-TSK-M33 AC-2). Checkout takes priority over the
+ * lifecycle stepper: a checked-out record renders exactly one "Check In"
+ * control (releases the checkout; does not touch status). Otherwise returns
+ * 0-2 buttons: a revert (if the record isn't at the arc's first status) and
+ * an advance (if it isn't at the arc's last status).
+ */
+export function computePrimaryActions(params: {
+  recordType: TrackerRecordType
+  status: string
+  transitionType?: string | null
+  checkedOut: boolean
+}): TransitionAction[] {
+  const { recordType, status, transitionType, checkedOut } = params
+
+  if (checkedOut) {
+    return [{ kind: 'check-in', label: 'Check In' }]
+  }
+
+  const arc = arcFor(recordType, transitionType)
+  const idx = arc.indexOf(status)
+
+  if (idx === -1) {
+    const arcLabel = recordType === 'task' ? (transitionType ?? DEFAULT_TASK_TRANSITION_TYPE) : recordType
+    return [
+      {
+        kind: 'advance',
+        label: 'Advance',
+        disabled: true,
+        disabledReason:
+          `Status "${status}" isn't recognized in this record's ${arcLabel} lifecycle arc -- ` +
+          'cannot safely compute the next transition from the PWA. Escalate to an agent session.',
+      },
+    ]
+  }
+
+  const actions: TransitionAction[] = []
+
+  if (idx > 0) {
+    const target = arc[idx - 1]
+    actions.push({ kind: 'revert', label: `← ${labelForStatus(target)}`, targetStatus: target })
+  }
+
+  if (idx < arc.length - 1) {
+    const target = arc[idx + 1]
+    actions.push({
+      kind: 'advance',
+      label: `${labelForStatus(target)} →`,
+      targetStatus: target,
+      allowSubmitClose: recordType === 'task' && target !== 'closed',
+    })
+  }
+
+  return actions
+}
+
+/** True when a record is considered "checked out" for primary-action
+ *  purposes -- active_agent_session is the authoritative live signal;
+ *  checkout_state is a secondary fallback for records the corpus/detail
+ *  fetch didn't populate active_agent_session on. */
+export function isCheckedOut(record: {
+  active_agent_session?: boolean
+  checkout_state?: string
+}): boolean {
+  return Boolean(record.active_agent_session) || record.checkout_state === 'checked_out'
+}


### PR DESCRIPTION
## Summary
- Builds v3 action parity INTO RecordDetailHub (used by both the standalone record routes and the M35 Feed reading pane) -- no fork.
- State-aware primary transition button(s) (Check In / advance / revert / Submit+Close) computed from the record's real `transition_type` arc (mirrors backend `transition_type_matrix.py` `ALLOWED_TRANSITIONS_BY_TYPE`, not the legacy PWA's stale hand-rolled array) + checkout state, executing through the SAME governed PATCH write path the PWA already uses (ENC-ISS-092 `user_initiated` bypass / `revert_reason`).
- Note button appends an immediate worklog entry (`action: 'worklog'`) through the same path.
- GitHub link action wired from `github_issue_url` when present.
- Body sections per type: USER STORY (feature, new), DESCRIPTION (all, now labeled), EVIDENCE + steps_to_duplicate (issue, new `IssueEvidenceTab`), ACCEPTANCE CRITERIA checklist with ●/○ circles (task -- existing; feature -- newly wired, was missing).
- Chip row parity (`ChipRow.tsx`): priority/severity/category/component/active-session/checkout chips bound to real DS tokens (LookFeel spec §5).

## Evidence
CCI-3c0cf346bd654dd0a686db10da2416e8

## Test plan
- [x] `vitest run` -- 266 tests pass (46 files), including 14 new `transitionArcs.test.ts` cases against representative records (task pr+checked-out, open issue, planned feature, closed issue) and 6 new `mobileViewport.test.ts` M33 assertions
- [x] `tsc --noEmit` -- zero new errors (byte-identical to baseline pre-existing error list)
- [x] `eslint` clean on all touched files
- [x] `vite build` + `assert:bundle-budget` -- pass (494KB raw / 151KB gz initial route JS, budget 200KB gz)
- [ ] Live UAT: state-aware action bar + Note + GitHub link exercised against a real Cognito session (see task worklog for checklist) -- not performed in this agent session (no Cognito re-injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)