### PR TITLE
ENC-TSK-M43 / ENC-ISS-501: enable escalation_decision_authorizer in v3-prod Gen2 deploy map

### DIFF
--- a/envs/v3-prod.yaml
+++ b/envs/v3-prod.yaml
@@ -77,6 +77,7 @@ function_name_map:
   doc_prep: devops-doc-prep
   document_api: devops-document-api
   env_drift_auditor: devops-env-drift-auditor
+  escalation_decision_authorizer: escalation-decision-authorizer
   feed_publisher: devops-feed-publisher
   feed_query: devops-feed-query-api
   github_integration: devops-github-integration


### PR DESCRIPTION
## Summary
- `envs/v3-prod.yaml` `function_name_map` never included `escalation_decision_authorizer` since the Lambda was created by ENC-TSK-L95/PR#928 (ENC-ISS-501). The manifest's header comment documents the 3 functions deliberately excluded from the map (`auth_edge`, `deploy_capability_auditor`, `shared_layer`) — this one is not among them, confirming it's an oversight, not a design decision.
- Effect: the merged ENC-TSK-M12/PR#947 human-principal-rejection fix (ENC-ISS-501, P0 SEV-1) cannot reach the live `escalation-decision-authorizer` Lambda via the normal Gen2 `_deploy.yml` pipeline — every v3-prod run silently skips it (`[skip] escalation_decision_authorizer (not in function_name_map)`), so prod still runs the pre-fix code.
- Fix is the map entry only (alphabetical slot between `env_drift_auditor` and `feed_publisher`). No CFN/CodeDeploy changes needed: `03-api.yaml`'s `AuthorizerUri` invokes the unqualified function ARN (no `:$LATEST`/alias qualifier), so `update-function-code --publish` takes effect immediately regardless of the live-alias/CodeDeploy bookkeeping the pipeline also performs for canary-fronted functions.
- Does not touch any governance-dict-gated file (`backend/lambda/*/lambda_function.py`, `tracker_ops.py`, `handlers.py`, `tools/enceladus-mcp-server/server.py`, `coordination_api/config.py`), so no `governance_data_dictionary.json` update is required in this PR.

CCI-11da668ca72c43e2a11e78c1c7aa785a

## Test plan
- [x] `python3 tools/verify_lambda_workflow_coverage.py` — passes locally (25 production Lambdas mapped; unaffected by this change since `escalation_decision_authorizer` was already listed in `infrastructure/lambda_workflow_manifest.json`).
- [x] `python3 -c "import yaml; yaml.safe_load(open('envs/v3-prod.yaml'))"` — manifest still parses.
- [ ] After merge: v3-prod Gen2 promote run fires and pauses at the `v3-prod` Environment gate for io's approval (not performed by this PR/agent).
- [ ] After io approves: prod Lambda `escalation-decision-authorizer` LastModified advances past `2026-07-08T02:09:45Z` (PR #947 merge) and the machine-principal probe returns a structural rejection.

Related: ENC-ISS-501, ENC-TSK-M12, ENC-TSK-M43

🤖 Generated with [Claude Code](https://claude.com/claude-code)