### PR TITLE
[ENC-TSK-M44] Backport FTR-122 SCI onto main (ENC-ISS-441 reopened, P1)

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -35,6 +35,7 @@ Environment variables:
     GITHUB_PRIVATE_KEY_SECRET     Secrets Manager secret name for App private key (default: devops/github-app/enceladus-private-key)
     CHECKOUT_TOKENS_TABLE         DynamoDB table for token storage (default: enceladus-checkout-tokens)
     CHECKOUT_TOKENS_REGION        AWS region for token table (default: us-west-2)
+    AGENT_SESSIONS_TABLE          agent-sessions store for the SCI gate (default: agent-sessions)
     COGNITO_USER_POOL_ID          us-east-1_b2D0V3E1k
     COGNITO_CLIENT_ID             6q607dk3liirhtecgps7hifmlk
     CORS_ORIGIN                   default: https://jreese.net
@@ -155,6 +156,10 @@ CHECKOUT_ASSISTANT_KEY = os.environ.get("CHECKOUT_ASSISTANT_KEY", "")
 COORDINATION_API_BASE = os.environ.get(
     "COORDINATION_API_BASE", "https://jreese.net/api/v1/coordination"
 )
+# ENC-ISS-441 / ENC-TSK-J93: agent-sessions store (ENC-FTR-117 / ENC-TSK-I37)
+# read by the SCI enforcement gate for the grandfather-epoch check and the
+# last_activity_at heartbeat touch (J83 pattern).
+AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
 
 GITHUB_API_BASE = "https://api.github.com"
 
@@ -1024,6 +1029,218 @@ def _resolve_agent_session_id(raw_id: Any) -> Tuple[Optional[str], Optional[str]
 
 
 # ---------------------------------------------------------------------------
+# SCI enforcement gate (ENC-ISS-441 Phase 3 / ENC-TSK-J93)
+#
+# Agent-origin mutations — requests presenting a minted ENC-SES-NNN id as the
+# acting identity — must carry a valid Session Claim ID (`sci` in the request
+# body). SCI tokens are minted by coordination_api agent.claim (ENC-TSK-J92)
+# into CHECKOUT_TOKENS_TABLE alongside CAI/CCI tokens. Non-agent identities
+# (github, system:arc-walker, PWA/Cognito users, coordination_dispatch, ...)
+# are out of gate scope and pass through unchanged.
+# ---------------------------------------------------------------------------
+
+# ENC-ISS-441 Ph3 ship date; sessions created before this instant are
+# grandfathered and mutate without an SCI. Deliberately a module-level
+# constant, NOT an env var — out-of-band env vars get stripped by full-env
+# deploys (PLN-047 / ENC-LSN-053 Sev1 class).
+SCI_ENFORCEMENT_EPOCH = "2026-07-02T12:00:00Z"
+
+# J92 token shape: pk = "SCI-{uuid4_hex}"
+_SCI_TOKEN_RE = re.compile(r"^SCI-[0-9a-f]{32}$")
+# I37 minted session ids: ENC-SES-NNN (base-36, uppercase)
+_AGENT_SESSION_ID_RE = re.compile(r"^ENC-SES-[0-9A-Z]+$")
+
+_SCI_REMEDIATION = (
+    "Obtain a Session Claim ID via coordination agent.claim (register->claim "
+    "handshake, ENC-FTR-117 / ENC-ISS-441) and pass it as 'sci' on this request."
+)
+
+
+def _sci_error(failure_mode: str, message: str) -> dict:
+    """Build the 403 rejection envelope for an SCI gate failure (ENC-ISS-441)."""
+    logger.warning("[ERROR] SCI gate rejection (%s): %s", failure_mode, message)
+    return _error(
+        403,
+        f"{message} {_SCI_REMEDIATION}",
+        code="SCI_REQUIRED",
+        details={
+            "sci_failure_mode": failure_mode,
+            "remediation": _SCI_REMEDIATION,
+        },
+    )
+
+
+def _lookup_sci(sci_id: str) -> Optional[dict]:
+    """Look up the FULL SCI token item (J92 shape).
+
+    Dedicated helper: _lookup_token returns the partial CAI/CCI dict contract
+    consumed by the GitHub Actions gate — extending it would risk those
+    callers, so the SCI gate reads the item directly (ENC-TSK-J93).
+    """
+    try:
+        resp = _ddb.get_item(
+            TableName=CHECKOUT_TOKENS_TABLE,
+            Key={"pk": {"S": sci_id}},
+        )
+    except ClientError as exc:
+        logger.warning("SCI token lookup failed for %s: %s", sci_id, exc)
+        return None
+    item = resp.get("Item")
+    if not item:
+        return None
+    ttl_raw = item.get("ttl", {}).get("N")
+    try:
+        ttl_val = int(float(ttl_raw)) if ttl_raw is not None else 0
+    except (TypeError, ValueError):
+        ttl_val = 0
+    return {
+        "token_id": item.get("pk", {}).get("S", ""),
+        "token_type": item.get("token_type", {}).get("S", ""),
+        "session_id": item.get("session_id", {}).get("S", ""),
+        "agent_type_id": item.get("agent_type_id", {}).get("S", ""),
+        "issued_at": item.get("issued_at", {}).get("S", ""),
+        "revoked": bool(item.get("revoked", {}).get("BOOL", False)),
+        "ttl": ttl_val,
+    }
+
+
+def _get_agent_session(session_id: str) -> Optional[dict]:
+    """Fetch an agent-session record (ENC-FTR-117 store; key session_id)."""
+    try:
+        resp = _ddb.get_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+        )
+    except ClientError as exc:
+        logger.warning("Agent-session lookup failed for %s: %s", session_id, exc)
+        return None
+    item = resp.get("Item")
+    if not item:
+        return None
+    return {
+        "session_id": item.get("session_id", {}).get("S", ""),
+        "created_at": item.get("created_at", {}).get("S", ""),
+        "status": item.get("status", {}).get("S", ""),
+    }
+
+
+def _touch_session_activity(session_id: str) -> None:
+    """Refresh the session's last_activity_at heartbeat (J83 pattern).
+
+    Conditional on the session still being live (allocated/claimed); a retired
+    or vanished session is a silent no-op — the touch must NEVER fail the
+    mutation it rides on (ENC-ISS-441 / ENC-TSK-J93).
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        _ddb.update_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+            UpdateExpression="SET last_activity_at = :now",
+            ConditionExpression=(
+                "attribute_exists(session_id) AND (#st = :allocated OR #st = :claimed)"
+            ),
+            ExpressionAttributeNames={"#st": "status"},
+            ExpressionAttributeValues={
+                ":now": {"S": now},
+                ":allocated": {"S": "allocated"},
+                ":claimed": {"S": "claimed"},
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info(
+                "[INFO] last_activity_at touch skipped for %s (session not live)",
+                session_id,
+            )
+        else:
+            logger.warning(
+                "[ERROR] last_activity_at touch failed for %s (continuing): %s",
+                session_id, exc,
+            )
+    except Exception as exc:  # noqa: BLE001 — touch is best-effort by contract
+        logger.warning(
+            "[ERROR] last_activity_at touch failed for %s (continuing): %s",
+            session_id, exc,
+        )
+
+
+def _validate_sci_gate(session_id: str, sci: Any) -> Optional[dict]:
+    """SCI enforcement gate (ENC-ISS-441 Phase 3 / ENC-TSK-J93).
+
+    Callers invoke this only when ``session_id`` matches _AGENT_SESSION_ID_RE.
+    Returns None when the mutation may proceed (grandfathered session or valid
+    SCI, in which case last_activity_at is touched), else the 403 rejection
+    response naming the specific failure mode.
+    """
+    # Step 1: the session must exist — a fabricated ENC-SES id must not bypass
+    # the gate (fail closed).
+    session = _get_agent_session(session_id)
+    if session is None:
+        return _sci_error(
+            "unknown_session",
+            f"Agent session '{session_id}' is not a registered session; "
+            "mutation rejected (fail-closed).",
+        )
+
+    # Step 2: grandfather epoch gate — sessions created before the Phase 3
+    # ship instant pass without an SCI (skip token validation entirely).
+    # created_at uses the shared "%Y-%m-%dT%H:%M:%SZ" format, so lexicographic
+    # comparison is a correct chronological compare (see agent_id_alloc).
+    created_at = str(session.get("created_at") or "").strip()
+    if created_at and created_at < SCI_ENFORCEMENT_EPOCH:
+        return None
+
+    # Step 3: token validation.
+    sci_id = str(sci or "").strip()
+    if not sci_id:
+        return _sci_error(
+            "missing_sci",
+            f"Agent session '{session_id}' presented no Session Claim ID (sci); "
+            "agent-origin mutations require a valid SCI.",
+        )
+    if not _SCI_TOKEN_RE.match(sci_id):
+        return _sci_error(
+            "unknown_sci",
+            f"'{sci_id}' is not a valid Session Claim ID "
+            "(expected format SCI-{32 hex chars}).",
+        )
+    token = _lookup_sci(sci_id)
+    if token is None:
+        return _sci_error(
+            "unknown_sci",
+            f"Session Claim ID '{sci_id}' is not recognized.",
+        )
+    if token.get("token_type") != "SCI":
+        return _sci_error(
+            "wrong_token_type",
+            f"Token '{sci_id}' has token_type '{token.get('token_type')}'; "
+            "only SCI tokens authorize agent-origin mutations.",
+        )
+    if token.get("revoked"):
+        return _sci_error(
+            "revoked_sci",
+            f"Session Claim ID '{sci_id}' has been revoked.",
+        )
+    # DynamoDB native TTL deletion may lag, so also enforce expiry here.
+    if int(token.get("ttl") or 0) <= int(time.time()):
+        return _sci_error(
+            "expired_sci",
+            f"Session Claim ID '{sci_id}' has expired.",
+        )
+    if token.get("session_id") != session_id:
+        return _sci_error(
+            "session_mismatch",
+            f"Session Claim ID '{sci_id}' is bound to session "
+            f"'{token.get('session_id')}', not '{session_id}'.",
+        )
+
+    # Valid SCI — refresh the session heartbeat (never fails the mutation).
+    _touch_session_activity(session_id)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
 
@@ -1054,6 +1271,16 @@ def _handle_checkout(project_id: str, task_id: str, body: dict) -> dict:
             required_fields=["active_agent_session_id"],
             example_fix=_example_checkout_fix(task_id),
         )
+
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate. Agent-origin checkouts
+    # (provider is a minted ENC-SES id) must present a valid Session Claim ID
+    # BEFORE any state is written (checkout lock, status mutation, CAI token).
+    # Non-agent providers (github, coordination_dispatch, PWA users, ...) are
+    # out of gate scope and pass through unchanged.
+    if _AGENT_SESSION_ID_RE.match(provider):
+        sci_err = _validate_sci_gate(provider, body.get("sci"))
+        if sci_err:
+            return sci_err
 
     coordination_request_id = body.get("coordination_request_id", "")
 
@@ -2215,6 +2442,16 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
             },
         )
 
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate. `provider` is the acting
+    # agent-session identity on advance (must equal the checked-out session id
+    # downstream); when it is a minted ENC-SES id the request must carry a valid
+    # Session Claim ID BEFORE any gate evaluation or state mutation. PWA
+    # user_initiated / Cognito paths present non-ENC-SES identities and pass.
+    if _AGENT_SESSION_ID_RE.match(provider):
+        sci_err = _validate_sci_gate(provider, body.get("sci"))
+        if sci_err:
+            return sci_err
+
     # --- Fetch current task to validate checkout state and transition_type ---
     status, task = _get_task(project_id, task_id)
     if status != 200:
@@ -2883,6 +3120,15 @@ def _handle_log(project_id: str, task_id: str, body: dict) -> dict:
         return _error(400, "description is required")
     provider = body.get("provider")
     governance_hash = body.get("governance_hash")
+
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate — agent-origin worklog
+    # appends (provider is a minted ENC-SES id) must present a valid Session
+    # Claim ID before the append is forwarded to tracker_mutation.
+    provider_id = str(provider or "").strip()
+    if _AGENT_SESSION_ID_RE.match(provider_id):
+        sci_err = _validate_sci_gate(provider_id, body.get("sci"))
+        if sci_err:
+            return sci_err
 
     # Validate checkout state
     status, task = _get_task(project_id, task_id)

--- a/backend/lambda/checkout_service/test_component_lifecycle_gate.py
+++ b/backend/lambda/checkout_service/test_component_lifecycle_gate.py
@@ -54,8 +54,22 @@ def _make_task(components, transition_type="github_pr_deploy"):
 
 
 def _ddb_lifecycle_side_effect(component_lifecycle_map):
-    """Return a ddb.get_item side_effect answering with lifecycle + required_transition_type."""
+    """Return a ddb.get_item side_effect answering with lifecycle + required_transition_type.
+
+    Also answers AGENT_SESSIONS_TABLE lookups for the ENC-ISS-441 / ENC-TSK-J93 SCI gate
+    (backported by ENC-TSK-M44): "ENC-SES-001" resolves as a pre-Ph3 grandfathered
+    session (created_at before SCI_ENFORCEMENT_EPOCH), so these component-lifecycle
+    tests — unrelated to SCI — pass the gate without needing a minted SCI token.
+    """
     def _side(TableName, Key):
+        if "session_id" in Key:
+            return {
+                "Item": {
+                    "session_id": Key["session_id"],
+                    "created_at": {"S": "2026-06-01T00:00:00Z"},
+                    "status": {"S": "claimed"},
+                }
+            }
         cid = Key["component_id"]["S"]
         ls = component_lifecycle_map.get(cid)
         if ls is None:

--- a/backend/lambda/checkout_service/test_component_misconfig_failure.py
+++ b/backend/lambda/checkout_service/test_component_misconfig_failure.py
@@ -125,12 +125,25 @@ class CheckoutHandlerCOMPONENT_MISCONFIGUREDTests(unittest.TestCase):
                 "components": ["comp-checkout-service"],
             },
         )
+        def _get_item_side_effect(TableName, Key):
+            # ENC-ISS-441 / ENC-TSK-J93 SCI gate (backported by ENC-TSK-M44): answer the
+            # AGENT_SESSIONS_TABLE lookup as a pre-Ph3 grandfathered session so this
+            # COMPONENT_MISCONFIGURED regression test — unrelated to SCI — passes the
+            # gate without needing a minted SCI token.
+            if "session_id" in Key:
+                return {
+                    "Item": {
+                        "session_id": Key["session_id"],
+                        "created_at": {"S": "2026-06-01T00:00:00Z"},
+                        "status": {"S": "claimed"},
+                    }
+                }
+            return _registry_item(component_id="comp-checkout-service", required_value=None)
+
         with patch.object(
             checkout_service._ddb,
             "get_item",
-            return_value=_registry_item(
-                component_id="comp-checkout-service", required_value=None
-            ),
+            side_effect=_get_item_side_effect,
         ):
             response = checkout_service._handle_checkout(
                 "enceladus",

--- a/backend/lambda/checkout_service/test_component_opacity_gate.py
+++ b/backend/lambda/checkout_service/test_component_opacity_gate.py
@@ -36,8 +36,22 @@ def _make_task(components, transition_type="github_pr_deploy"):
 
 
 def _ddb_lifecycle_side_effect(component_lifecycle_map):
-    """Return a ddb.get_item side_effect that answers with lifecycle data."""
+    """Return a ddb.get_item side_effect that answers with lifecycle data.
+
+    Also answers AGENT_SESSIONS_TABLE lookups for the ENC-ISS-441 / ENC-TSK-J93 SCI gate
+    (backported by ENC-TSK-M44): "ENC-SES-001" resolves as a pre-Ph3 grandfathered
+    session (created_at before SCI_ENFORCEMENT_EPOCH), so these opacity-gate tests —
+    unrelated to SCI — pass the gate without needing a minted SCI token.
+    """
     def _side(TableName, Key):
+        if "session_id" in Key:
+            return {
+                "Item": {
+                    "session_id": Key["session_id"],
+                    "created_at": {"S": "2026-06-01T00:00:00Z"},
+                    "status": {"S": "claimed"},
+                }
+            }
         cid = Key["component_id"]["S"]
         ls = component_lifecycle_map.get(cid)
         if ls is None:

--- a/backend/lambda/checkout_service/test_sci_gate.py
+++ b/backend/lambda/checkout_service/test_sci_gate.py
@@ -1,0 +1,271 @@
+"""test_sci_gate.py — SCI enforcement gate in checkout_service (ENC-ISS-441 Ph3 / ENC-TSK-J93).
+
+Agent-origin mutations (provider = minted ENC-SES-NNN id) through the checkout
+service must present a valid Session Claim ID (`sci`, minted by coordination_api
+agent.claim, ENC-TSK-J92). Covers:
+
+  * All six rejection modes: missing_sci / unknown_sci / wrong_token_type /
+    revoked_sci / expired_sci / session_mismatch — each a 403 naming the mode.
+  * unknown_session fails closed (fabricated ENC-SES ids cannot bypass).
+  * Grandfathered pre-epoch sessions pass without an sci.
+  * Non-ENC-SES providers (github, system:arc-walker, PWA users) pass untouched.
+  * Valid SCI passes and touches agent-sessions.last_activity_at (J83 pattern).
+  * Retired-session touch is a silent no-op that never fails the mutation.
+  * The gate fires in _handle_checkout / _handle_advance / _handle_log BEFORE
+    any tracker state is read or written.
+
+Run: python3 -m pytest test_sci_gate.py -q
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import unittest
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+sys.path.insert(0, os.path.dirname(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_lambda_sci",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = checkout_lambda
+_SPEC.loader.exec_module(checkout_lambda)
+
+SESSION = "ENC-SES-0A1"
+OTHER_SESSION = "ENC-SES-0B2"
+PRE_EPOCH_SESSION = "ENC-SES-009"
+VALID_SCI = "SCI-" + "a" * 32
+POST_EPOCH_TS = "2026-07-02T13:00:00Z"   # after SCI_ENFORCEMENT_EPOCH
+PRE_EPOCH_TS = "2026-06-30T00:00:00Z"    # before SCI_ENFORCEMENT_EPOCH
+
+
+class SciGateBase(unittest.TestCase):
+    """Creates the moto-backed token + session tables and patches the module client.
+
+    moto is started in setUp (not via a class decorator) so the mock covers the
+    inherited fixture and every subclass test method uniformly.
+    """
+
+    def setUp(self):
+        self._moto = mock_aws()
+        self._moto.start()
+        self.addCleanup(self._moto.stop)
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        self.ddb.create_table(
+            TableName=checkout_lambda.CHECKOUT_TOKENS_TABLE,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        self.ddb.create_table(
+            TableName=checkout_lambda.AGENT_SESSIONS_TABLE,
+            AttributeDefinitions=[{"AttributeName": "session_id", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "session_id", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        patcher = mock.patch.object(checkout_lambda, "_ddb", self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # -- fixtures ------------------------------------------------------------
+    def put_session(self, session_id=SESSION, created_at=POST_EPOCH_TS, status="claimed"):
+        self.ddb.put_item(
+            TableName=checkout_lambda.AGENT_SESSIONS_TABLE,
+            Item={
+                "session_id": {"S": session_id},
+                "agent_type_id": {"S": "ENC-AGT-001"},
+                "created_at": {"S": created_at},
+                "status": {"S": status},
+            },
+        )
+
+    def put_sci(self, pk=VALID_SCI, session_id=SESSION, token_type="SCI",
+                revoked=False, ttl=None):
+        item = {
+            "pk": {"S": pk},
+            "token_type": {"S": token_type},
+            "session_id": {"S": session_id},
+            "agent_type_id": {"S": "ENC-AGT-001"},
+            "issued_at": {"S": POST_EPOCH_TS},
+            "revoked": {"BOOL": revoked},
+            "ttl": {"N": str(ttl if ttl is not None else int(time.time()) + 3600)},
+        }
+        self.ddb.put_item(TableName=checkout_lambda.CHECKOUT_TOKENS_TABLE, Item=item)
+
+    def get_session_item(self, session_id=SESSION):
+        resp = self.ddb.get_item(
+            TableName=checkout_lambda.AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+        )
+        return resp.get("Item") or {}
+
+    # -- assertions ----------------------------------------------------------
+    def assert_sci_403(self, resp, failure_mode):
+        self.assertIsNotNone(resp, "expected a 403 rejection, got pass-through")
+        self.assertEqual(resp["statusCode"], 403)
+        body = json.loads(resp["body"])
+        self.assertEqual(body.get("sci_failure_mode"), failure_mode)
+        self.assertIn("agent.claim", body.get("error", ""))
+        self.assertIn("ENC-ISS-441", body.get("error", ""))
+
+
+class ValidateSciGateRejectionTests(SciGateBase):
+    """The six rejection modes + fail-closed unknown session (ENC-TSK-J93)."""
+
+    def test_missing_sci_rejected(self):
+        self.put_session()
+        for empty in (None, "", "   "):
+            resp = checkout_lambda._validate_sci_gate(SESSION, empty)
+            self.assert_sci_403(resp, "missing_sci")
+
+    def test_malformed_sci_rejected_as_unknown(self):
+        self.put_session()
+        resp = checkout_lambda._validate_sci_gate(SESSION, "SCI-not-hex")
+        self.assert_sci_403(resp, "unknown_sci")
+
+    def test_unrecognized_sci_rejected(self):
+        self.put_session()
+        resp = checkout_lambda._validate_sci_gate(SESSION, "SCI-" + "f" * 32)
+        self.assert_sci_403(resp, "unknown_sci")
+
+    def test_wrong_token_type_rejected(self):
+        self.put_session()
+        self.put_sci(token_type="CAI")
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assert_sci_403(resp, "wrong_token_type")
+
+    def test_revoked_sci_rejected(self):
+        self.put_session()
+        self.put_sci(revoked=True)
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assert_sci_403(resp, "revoked_sci")
+
+    def test_expired_sci_rejected(self):
+        # DynamoDB native TTL may lag deletion — the gate must enforce expiry itself.
+        self.put_session()
+        self.put_sci(ttl=int(time.time()) - 10)
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assert_sci_403(resp, "expired_sci")
+
+    def test_session_mismatch_rejected(self):
+        self.put_session()
+        self.put_sci(session_id=OTHER_SESSION)
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assert_sci_403(resp, "session_mismatch")
+
+    def test_unknown_session_fails_closed(self):
+        # Fabricated ENC-SES id, even with a well-formed token, must not bypass.
+        self.put_sci(session_id="ENC-SES-ZZZ")
+        resp = checkout_lambda._validate_sci_gate("ENC-SES-ZZZ", VALID_SCI)
+        self.assert_sci_403(resp, "unknown_session")
+
+
+class ValidateSciGatePassTests(SciGateBase):
+    def test_grandfathered_pre_epoch_session_passes_without_sci(self):
+        self.put_session(session_id=PRE_EPOCH_SESSION, created_at=PRE_EPOCH_TS)
+        resp = checkout_lambda._validate_sci_gate(PRE_EPOCH_SESSION, None)
+        self.assertIsNone(resp)
+        # Token validation was skipped entirely — no heartbeat touch either.
+        self.assertNotIn("last_activity_at", self.get_session_item(PRE_EPOCH_SESSION))
+
+    def test_valid_sci_passes_and_touches_last_activity_at(self):
+        self.put_session()
+        self.put_sci()
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assertIsNone(resp)
+        item = self.get_session_item()
+        self.assertIn("last_activity_at", item)
+        self.assertRegex(item["last_activity_at"]["S"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_retired_session_touch_is_noop_and_does_not_fail(self):
+        # Conditional touch swallows ConditionalCheckFailedException — retired
+        # sessions just don't get touched; the mutation proceeds.
+        self.put_session(status="retired")
+        self.put_sci()
+        resp = checkout_lambda._validate_sci_gate(SESSION, VALID_SCI)
+        self.assertIsNone(resp)
+        self.assertNotIn("last_activity_at", self.get_session_item())
+
+
+class HandlerGateWiringTests(SciGateBase):
+    """The gate fires at the top of checkout/advance/log, before any tracker I/O."""
+
+    def test_checkout_handler_rejects_before_any_state_write(self):
+        self.put_session()
+        with mock.patch.object(checkout_lambda, "_get_task") as get_task, \
+                mock.patch.object(checkout_lambda, "_checkout_task") as co_task:
+            resp = checkout_lambda._handle_checkout(
+                "enceladus", "ENC-TSK-901", {"active_agent_session_id": SESSION},
+            )
+        self.assert_sci_403(resp, "missing_sci")
+        get_task.assert_not_called()
+        co_task.assert_not_called()
+
+    def test_advance_handler_rejects_before_task_fetch(self):
+        self.put_session()
+        with mock.patch.object(checkout_lambda, "_get_task") as get_task:
+            resp = checkout_lambda._handle_advance(
+                "enceladus", "ENC-TSK-901",
+                {"target_status": "coding-complete", "provider": SESSION},
+            )
+        self.assert_sci_403(resp, "missing_sci")
+        get_task.assert_not_called()
+
+    def test_log_handler_rejects_before_task_fetch(self):
+        self.put_session()
+        with mock.patch.object(checkout_lambda, "_get_task") as get_task:
+            resp = checkout_lambda._handle_log(
+                "enceladus", "ENC-TSK-901",
+                {"description": "[INFO] test entry", "provider": SESSION},
+            )
+        self.assert_sci_403(resp, "missing_sci")
+        get_task.assert_not_called()
+
+    def test_non_agent_providers_pass_untouched(self):
+        # Legacy / system / PWA identities are out of gate scope — the handler
+        # proceeds to normal task validation (here: a mocked 404 lookup),
+        # proving the gate did not 403 them and no session lookup occurred.
+        for provider in ("github", "system:arc-walker", "user", "coordination_dispatch"):
+            with mock.patch.object(
+                checkout_lambda, "_get_task", return_value=(404, {"error": "nope"}),
+            ):
+                resp = checkout_lambda._handle_advance(
+                    "enceladus", "ENC-TSK-901",
+                    {"target_status": "coding-complete", "provider": provider},
+                )
+            self.assertEqual(resp["statusCode"], 404, f"provider {provider} was gated")
+
+    def test_valid_sci_allows_checkout_and_touches_heartbeat(self):
+        self.put_session()
+        self.put_sci()
+        task = {
+            "record_id": "task#ENC-TSK-901", "status": "open",
+            "components": [], "transition_type": "github_pr_deploy",
+            "checkout_count": 1,
+        }
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_checkout_task",
+                                  return_value=(200, {"governance_hash": "gh"})), \
+                mock.patch.object(checkout_lambda, "_set_task_field",
+                                  return_value=(200, {})):
+            resp = checkout_lambda._handle_checkout(
+                "enceladus", "ENC-TSK-901",
+                {"active_agent_session_id": SESSION, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertIn("last_activity_at", self.get_session_item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import uuid
 from typing import Any, Dict, List, Mapping, Optional
 
 from botocore.exceptions import BotoCoreError, ClientError
@@ -46,6 +47,7 @@ from config import (
     AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS,
     AGENT_SESSIONS_TABLE,
     AGENT_TYPES_TABLE,
+    CHECKOUT_TOKENS_TABLE,
     logger,
 )
 from aws_clients import _get_ddb
@@ -70,6 +72,10 @@ __all__ = [
     "get_agent_type",
     "claim_session",
     "retire_session",
+    "SCI_PREFIX",
+    "SCI_TTL_SECONDS",
+    "mint_sci",
+    "revoke_sci_for_session",
     "sweep_idle_sessions",
     "list_sessions",
     "list_agent_types",
@@ -444,6 +450,138 @@ def retire_session(session_id: str) -> Dict[str, Any]:
     updated = _deserialize(resp.get("Attributes", {}))
     logger.info("[INFO] Retired session %s", session_id)
     return updated
+
+
+# ---------------------------------------------------------------------------
+# Session Claim ID (SCI) tokens — ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122)
+# ---------------------------------------------------------------------------
+# Backported to main by ENC-TSK-M44 (ENC-ISS-441 reopened by the 2026-07-08T22:25:44Z
+# main-ref v3-prod Lambda deploy that reverted this v4-first feature). See DOC-B716E8FB10B6
+# COE for the incident. SCI is the session-scoped credential a claimed agent session must
+# hold and present on every governed mutation (Ph3 enforcement gate lives in
+# checkout_service and tracker_mutation — see their _validate_sci_gate).
+
+SCI_PREFIX = "SCI"
+# 24h session lifetime per the ENC-ISS-441 spec — deliberately distinct from the checkout
+# service's 90-day CAI/CCI TTL. The checkout-tokens table's native TTL hard-deletes the
+# record at expiry, which is CORRECT here (a token is not append-only session state):
+# an absent token reads as invalid at the Ph3 enforcement gate, i.e. expiry fails closed.
+SCI_TTL_SECONDS = 86400
+
+
+def mint_sci(session: Mapping[str, Any]) -> Dict[str, Any]:
+    """Mint a Session Claim ID for a just-claimed session (ENC-ISS-441 / ENC-TSK-J92).
+
+    Server-only: issued exclusively by ``agent.claim`` on the allocated -> claimed flip.
+    Writes the token to the checkout-tokens table (pk = SCI-{uuid4_hex}, token_type=SCI —
+    the same key discipline as the checkout service's CAI/CCI records) and stamps
+    ``sci_token_id`` on the session item as a post-mint attribute (the same pattern as
+    ``last_activity_at``, so SESSION_NODE_PROPERTIES / the mint shape are unchanged).
+    The session stamp makes revocation a direct lookup — never a table scan.
+    """
+    session_id = str(session.get("session_id") or "").strip()
+    agent_type_id = str(session.get("agent_type_id") or "").strip()
+    if not session_id:
+        raise ValueError("session with session_id is required to mint an SCI")
+
+    ddb = _get_ddb()
+    now_dt = dt.datetime.now(dt.timezone.utc)
+    token_id = f"{SCI_PREFIX}-{uuid.uuid4().hex}"
+    issued_at = now_dt.strftime(_TS_FORMAT)
+    expires_epoch = int(now_dt.timestamp()) + SCI_TTL_SECONDS
+
+    ddb.put_item(
+        TableName=CHECKOUT_TOKENS_TABLE,
+        Item={
+            "pk": _serialize(token_id),
+            "token_type": _serialize("SCI"),
+            "session_id": _serialize(session_id),
+            "agent_type_id": _serialize(agent_type_id),
+            "issued_at": _serialize(issued_at),
+            "revoked": _serialize(False),
+            "ttl": {"N": str(expires_epoch)},
+        },
+        ConditionExpression="attribute_not_exists(pk)",
+    )
+    ddb.update_item(
+        TableName=AGENT_SESSIONS_TABLE,
+        Key={"session_id": _serialize(session_id)},
+        UpdateExpression="SET sci_token_id = :tok",
+        ConditionExpression="attribute_exists(session_id) AND #st = :claimed",
+        ExpressionAttributeNames={"#st": "status"},
+        ExpressionAttributeValues={
+            ":tok": _serialize(token_id),
+            ":claimed": _serialize("claimed"),
+        },
+    )
+    logger.info("[INFO] Minted SCI for session %s", session_id)
+    return {
+        "token_id": token_id,
+        "token_type": "SCI",
+        "session_id": session_id,
+        "agent_type_id": agent_type_id,
+        "issued_at": issued_at,
+        "ttl": expires_epoch,
+        "revoked": False,
+    }
+
+
+def revoke_sci_for_session(
+    session_id: str, *, reason: str = "explicit_retire"
+) -> Optional[Dict[str, Any]]:
+    """Revoke the SCI bound to a session, if any (ENC-ISS-441 / ENC-TSK-J92).
+
+    Idempotent by construction: a session with no ``sci_token_id`` returns None; a token
+    that is already revoked (or TTL-expired out of the table) is reported with
+    ``already_revoked`` and the first revocation's metadata is never overwritten.
+    Callers: ``agent.retire`` (reason=explicit_retire) and the ENC-TSK-J94 sweeps
+    (reason=unclaim_ttl_exceeded / idle_ttl_exceeded — not yet backported by M44; see
+    the M44 PR report for the follow-up).
+    """
+    if not session_id:
+        raise ValueError("session_id is required")
+    session = get_session(session_id)
+    if session is None:
+        raise ValueError(f"Session {session_id!r} not found")
+    token_id = str(session.get("sci_token_id") or "").strip()
+    if not token_id:
+        return None
+
+    ddb = _get_ddb()
+    try:
+        resp = ddb.update_item(
+            TableName=CHECKOUT_TOKENS_TABLE,
+            Key={"pk": _serialize(token_id)},
+            UpdateExpression=(
+                "SET revoked = :t, revoked_at = :now, revocation_reason = :reason"
+            ),
+            ConditionExpression="attribute_exists(pk) AND revoked = :f",
+            ExpressionAttributeValues={
+                ":t": _serialize(True),
+                ":f": _serialize(False),
+                ":now": _serialize(_now_z()),
+                ":reason": _serialize(reason),
+            },
+            ReturnValues="ALL_NEW",
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info(
+                "[INFO] SCI %s for session %s already revoked or expired", token_id, session_id
+            )
+            return {
+                "token_id": token_id,
+                "session_id": session_id,
+                "revoked": True,
+                "already_revoked": True,
+            }
+        raise
+
+    revoked = _deserialize(resp.get("Attributes", {}))
+    logger.info(
+        "[INFO] Revoked SCI %s for session %s (reason=%s)", token_id, session_id, reason
+    )
+    return revoked
 
 
 # ---------------------------------------------------------------------------

--- a/backend/lambda/coordination_api/config.py
+++ b/backend/lambda/coordination_api/config.py
@@ -47,6 +47,7 @@ __all__ = [
     "CALLBACK_EVENT_SOURCE",
     "CALLBACK_SQS_QUEUE_URL",
     "CALLBACK_TOKEN_TTL_SECONDS",
+    "CHECKOUT_TOKENS_TABLE",
     "CLAUDE_API_MAX_TOKENS_DEFAULT",
     "CLAUDE_API_MAX_TOKENS_MAX",
     "CLAUDE_API_MAX_TOKENS_MIN",
@@ -179,6 +180,11 @@ DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
 # names. The allocator (agent_id_alloc.py) is dormant until the agent.* surface (I38).
 AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
 AGENT_TYPES_TABLE = os.environ.get("AGENT_TYPES_TABLE", "agent-types")
+# ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122), backported to main by ENC-TSK-M44: Session Claim
+# ID (SCI) tokens live in the SAME DynamoDB table the checkout service uses for CAI/CCI
+# (pk = token id, token_type discriminator). Env-suffixed so gamma coordination_api writes
+# the -gamma twin.
+CHECKOUT_TOKENS_TABLE = os.environ.get("CHECKOUT_TOKENS_TABLE", "enceladus-checkout-tokens")
 # ENC-TSK-I71 / ENC-FTR-117 AC#8: scheduled idle-sweep backstop for abandoned agent
 # sessions. A session left in a live status (allocated/claimed) past the threshold is
 # reaped to 'retired' via an append-only status flip — NOT native DynamoDB TTL, which

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-08.1",
-  "updated_at": "2026-07-08T02:10:00Z",
-  "last_change_summary": "ENC-TSK-M12 / ENC-ISS-501: structural human-principal gate added to escalation-decision-authorizer (_is_human_cognito_principal: token_use=id + ESCALATION_HUMAN_CLIENT_IDS aud allowlist + ESCALATION_MACHINE_EMAIL_DOMAINS rejection, fail-closed) in front of the email allowlist.",
+  "version": "2026-07-08.2",
+  "updated_at": "2026-07-08T23:55:00Z",
+  "last_change_summary": "ENC-TSK-M44 (ENC-ISS-441 reopened, DOC-B716E8FB10B6 COE): backport FTR-122 Session Claim ID (SCI) from v4/main onto main. main-ref v3-prod Lambda deploys rebuild the whole per-env Lambda set and had silently reverted SCI (v4-first, never on main) at 2026-07-08T22:25:44Z, reopening ISS-441 fail-open. New entity coordination.session_claim_id (mint on agent.claim / revoke on agent.retire, ports ENC-TSK-J92). Adds the Ph3 enforcement gate (ports ENC-TSK-J93) to coordination.session_claim_id.fields: checkout_service._validate_sci_gate and tracker_mutation._validate_sci_gate/_sci_gate_for_request reject agent-origin (ENC-SES-*) mutations lacking a valid, unrevoked, unexpired SCI bound to the acting session (403 SCI_REQUIRED, fail-closed for unknown sessions/tokens); sessions created before SCI_ENFORCEMENT_EPOCH=2026-07-02T12:00:00Z are grandfathered. Also ports the enceladus-mcp-code 'sci' passthrough (ENC-TSK-K10) on tracker.set/tracker.log. ENC-TSK-J94 (retirement-sweep SCI revocation) and ENC-FTR-121 escalations were NOT backported by M44 (out of scope / tracked separately) -- see the M44 PR report.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5877,6 +5877,51 @@
           "isolation_note": "ENC-TSK-I40 AC-2 isolation deliverable. V4 drift-risk surface."
         }
       }
+    },
+    "coordination.session_claim_id": {
+      "description": "ENC-ISS-441 / ENC-TSK-J92+J93 (ENC-FTR-122), backported to main by ENC-TSK-M44: Session Claim ID (SCI) is a server-minted bearer token proving a session completed the ENC-FTR-117 register->claim handshake, and the enforcement gate that requires it on every agent-origin governed mutation. Minted EXCLUSIVELY by coordination agent.claim on the allocated->claimed flip (agent_id_alloc.mint_sci); format SCI-{uuid4_hex} (regex ^SCI-[0-9a-f]{32}$), stored in the checkout-tokens table (CHECKOUT_TOKENS_TABLE, env-suffixed; pk = token id, token_type=SCI discriminator -- coexists with CAI/CCI records) with a 24h native-TTL expiry (SCI_TTL_SECONDS=86400); TTL deletion fails CLOSED at the enforcement gate. The claimed session item is stamped with sci_token_id (post-mint attribute; SESSION_NODE_PROPERTIES mint shape unchanged) so revocation is a direct lookup, never a scan. Revoked (revoked=true, revoked_at, revocation_reason; first-revocation metadata immutable) by agent.retire (reason=explicit_retire); non-fatal on revocation failure. Enforcement (checkout_service._validate_sci_gate, tracker_mutation._validate_sci_gate / _sci_gate_for_request): a request whose acting identity (checkout_service's resolved provider; tracker_mutation's normalized write_source.provider) matches ^ENC-SES-[0-9A-Z]+$ must present a valid 'sci' -- unknown session (fail-closed), missing/unknown/wrong-token-type/revoked/expired sci, or session-id mismatch each return 403 SCI_REQUIRED with a distinct sci_failure_mode and remediation pointing to coordination agent.claim. Sessions with created_at before SCI_ENFORCEMENT_EPOCH=2026-07-02T12:00:00Z (module constant, not an env var -- avoids the PLN-047/ENC-LSN-053 out-of-band-env-var-stripping class) are grandfathered and skip token validation. tracker_mutation exempts ENC-FTR-037 X-Checkout-Service-Key requests (checkout_service already ran the identical gate at its own edge). A valid pass touches the session's last_activity_at heartbeat (best-effort, never fails the mutation). enceladus-mcp-code (ENC-TSK-K10) passes an optional 'sci' argument through verbatim on tracker.set / tracker.log (no MCP-layer validation; backend-only enforcement). NOT backported by M44: the ENC-TSK-J94 retirement-sweep SCI revocation (10-min unclaim TTL / 2h idle TTL reapers) -- SCI still mints and enforces without it, but a session abandoned pre-retire keeps a live, unrevoked SCI until its 24h TTL.",
+      "fields": {
+        "token_id": {
+          "type": "string",
+          "definition": "SCI-{uuid4_hex} (pk in the checkout-tokens table). Returned to the caller as 'sci' in the agent.claim response envelope alongside sci_issued_at and sci_ttl_seconds."
+        },
+        "token_type": {
+          "type": "string",
+          "definition": "Fixed 'SCI' discriminator -- coexists with CAI/CCI records in the same checkout-tokens table."
+        },
+        "session_id": {
+          "type": "string",
+          "definition": "Bound ENC-SES-NNN. The enforcement gate matches this against the presented acting-identity provider."
+        },
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Bound ENC-AGT-NNN lineage captured at claim time."
+        },
+        "issued_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC mint timestamp."
+        },
+        "ttl": {
+          "type": "integer",
+          "definition": "Unix epoch expiry = issued_at + 86400s. DynamoDB native TTL deletes the record at expiry; an absent token is invalid at the enforcement gate (fails closed)."
+        },
+        "revoked": {
+          "type": "boolean",
+          "definition": "False at mint. Set true (with revoked_at + revocation_reason) by agent.retire; idempotent -- first revocation metadata is never overwritten."
+        },
+        "sci_token_id": {
+          "type": "string",
+          "definition": "Post-mint attribute stamped onto the agent-sessions item (same pattern as last_activity_at); makes revocation a direct lookup, never a scan."
+        },
+        "SCI_ENFORCEMENT_EPOCH": {
+          "type": "string",
+          "definition": "Module-level constant (checkout_service and tracker_mutation), fixed at '2026-07-02T12:00:00Z' -- NOT an env var, to avoid the PLN-047/ENC-LSN-053 out-of-band-env-var-stripping Sev1 class. Sessions created before this instant are grandfathered through the gate without an SCI."
+        },
+        "sci_failure_mode": {
+          "type": "string",
+          "definition": "Detail key on the 403 SCI_REQUIRED error envelope: one of unknown_session, missing_sci, unknown_sci, wrong_token_type, revoked_sci, expired_sci, session_mismatch."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -5927,6 +5972,11 @@
       "version": "2026-06-28.02",
       "date": "2026-06-28",
       "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip \u2014 NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
+    },
+    {
+      "version": "2026-07-08.2",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M44 (ENC-ISS-441 reopened, DOC-B716E8FB10B6 COE): backport FTR-122 Session Claim ID (SCI) from v4/main onto main. main-ref v3-prod Lambda deploys rebuild the whole per-env Lambda set and had silently reverted SCI (v4-first, never on main) at 2026-07-08T22:25:44Z, reopening ISS-441 fail-open. New entity coordination.session_claim_id (mint on agent.claim / revoke on agent.retire, ports ENC-TSK-J92). Adds the Ph3 enforcement gate (ports ENC-TSK-J93) to coordination.session_claim_id.fields: checkout_service._validate_sci_gate and tracker_mutation._validate_sci_gate/_sci_gate_for_request reject agent-origin (ENC-SES-*) mutations lacking a valid, unrevoked, unexpired SCI bound to the acting session (403 SCI_REQUIRED, fail-closed for unknown sessions/tokens); sessions created before SCI_ENFORCEMENT_EPOCH=2026-07-02T12:00:00Z are grandfathered. Also ports the enceladus-mcp-code 'sci' passthrough (ENC-TSK-K10) on tracker.set/tracker.log. ENC-TSK-J94 (retirement-sweep SCI revocation) and ENC-FTR-121 escalations were NOT backported by M44 (out of scope / tracked separately) -- see the M44 PR report."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -13649,7 +13649,29 @@ def _handle_agent_session_claim(event: Dict[str, Any], claims: Dict[str, Any]) -
     except (BotoCoreError, ClientError) as exc:
         logger.exception("[ERROR] claim_session failed: %s", exc)
         return _error(500, "DynamoDB error during session claim")
-    return _response(200, {"session": item})
+    # ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122), backported to main by ENC-TSK-M44: a
+    # successful claim mints the session's SCI. A claim without an SCI would wedge the
+    # session at the Ph3 enforcement gate, so a mint failure is a hard error — the caller
+    # should retire this session and register anew.
+    try:
+        sci = _agent_alloc.mint_sci(item)
+    except (ValueError, BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] mint_sci failed after claim of %s: %s", session_id, exc)
+        return _error(
+            500,
+            "Session claimed but SCI mint failed — retire this session (agent.retire) "
+            "and register a new one",
+        )
+    item["sci_token_id"] = sci["token_id"]
+    return _response(
+        200,
+        {
+            "session": item,
+            "sci": sci["token_id"],
+            "sci_issued_at": sci["issued_at"],
+            "sci_ttl_seconds": _agent_alloc.SCI_TTL_SECONDS,
+        },
+    )
 
 
 def _handle_agent_session_list(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -13684,7 +13706,21 @@ def _handle_agent_session_retire(
     except (BotoCoreError, ClientError) as exc:
         logger.exception("[ERROR] retire_session failed: %s", exc)
         return _error(500, "DynamoDB error during session retire")
-    return _response(200, {"session": item})
+    # ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122), backported to main by ENC-TSK-M44:
+    # retirement revokes the session's SCI. The retire itself is already durable
+    # (append-only flip above); a revocation failure is surfaced but non-fatal.
+    payload: Dict[str, Any] = {"session": item}
+    try:
+        revoked = _agent_alloc.revoke_sci_for_session(session_id, reason="explicit_retire")
+    except (ValueError, BotoCoreError, ClientError) as exc:
+        logger.exception("[ERROR] SCI revocation failed on retire of %s: %s", session_id, exc)
+        payload["sci_revoked"] = False
+        payload["sci_revocation_error"] = "SCI revocation failed"
+    else:
+        payload["sci_revoked"] = bool(revoked)
+        if revoked:
+            payload["sci_token_id"] = revoked.get("token_id") or revoked.get("pk")
+    return _response(200, payload)
 
 
 def _handle_agent_session_idle_sweep(event: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/lambda/coordination_api/test_agent_id_alloc.py
+++ b/backend/lambda/coordination_api/test_agent_id_alloc.py
@@ -507,5 +507,114 @@ class IdleSweepTest(unittest.TestCase):
                 alloc.sweep_idle_sessions(idle_threshold_seconds=bad, now=self._future)
 
 
+@mock_aws
+class SciTokenTest(unittest.TestCase):
+    """ENC-ISS-441 / ENC-TSK-J92: Session Claim ID mint-on-claim + revoke-on-retire."""
+
+    def setUp(self):
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        for table, key in (
+            (config.AGENT_SESSIONS_TABLE, "session_id"),
+            (config.AGENT_TYPES_TABLE, "agent_type_id"),
+            (config.CHECKOUT_TOKENS_TABLE, "pk"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(alloc, "_get_ddb", return_value=self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _claimed_session(self):
+        minted = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="test")
+        return alloc.claim_session(minted["session_id"])
+
+    def _token_count(self):
+        return self.ddb.scan(TableName=config.CHECKOUT_TOKENS_TABLE)["Count"]
+
+    def _get_token(self, token_id):
+        resp = self.ddb.get_item(
+            TableName=config.CHECKOUT_TOKENS_TABLE, Key={"pk": {"S": token_id}}
+        )
+        return resp.get("Item")
+
+    # -- mint-on-claim --------------------------------------------------------
+    def test_mint_sci_shape_and_binding(self):
+        import time as _time
+
+        session = self._claimed_session()
+        sci = alloc.mint_sci(session)
+        self.assertRegex(sci["token_id"], r"^SCI-[0-9a-f]{32}$")
+        self.assertEqual(sci["token_type"], "SCI")
+        self.assertEqual(sci["session_id"], session["session_id"])
+        self.assertEqual(sci["agent_type_id"], "ENC-AGT-001")
+        self.assertFalse(sci["revoked"])
+        self.assertAlmostEqual(
+            sci["ttl"], int(_time.time()) + alloc.SCI_TTL_SECONDS, delta=60
+        )
+        item = self._get_token(sci["token_id"])
+        self.assertIsNotNone(item)
+        self.assertEqual(item["token_type"]["S"], "SCI")
+        self.assertEqual(item["session_id"]["S"], session["session_id"])
+        self.assertFalse(item["revoked"]["BOOL"])
+        # session stamped with the token id (post-mint attribute, mint shape untouched)
+        stamped = alloc.get_session(session["session_id"])
+        self.assertEqual(stamped["sci_token_id"], sci["token_id"])
+
+    def test_mint_sci_requires_session_id(self):
+        with self.assertRaises(ValueError):
+            alloc.mint_sci({})
+
+    def test_mint_sci_rejects_unclaimed_session(self):
+        from botocore.exceptions import ClientError as _CE
+
+        minted = alloc.mint_session_id(agent_type_id="ENC-AGT-001", runtime="test")
+        with self.assertRaises(_CE):
+            alloc.mint_sci(minted)  # session-stamp condition requires status=claimed
+
+    def test_failed_claim_mints_nothing(self):
+        session = self._claimed_session()
+        with self.assertRaises(ValueError):
+            alloc.claim_session(session["session_id"])  # double-claim rejected
+        self.assertEqual(self._token_count(), 0)  # no orphan tokens
+
+    # -- revoke-on-retire ------------------------------------------------------
+    def test_revoke_sci_for_session(self):
+        session = self._claimed_session()
+        sci = alloc.mint_sci(session)
+        revoked = alloc.revoke_sci_for_session(
+            session["session_id"], reason="explicit_retire"
+        )
+        self.assertTrue(revoked["revoked"])
+        self.assertEqual(revoked["revocation_reason"], "explicit_retire")
+        self.assertTrue(revoked["revoked_at"])
+        item = self._get_token(sci["token_id"])
+        self.assertTrue(item["revoked"]["BOOL"])
+
+    def test_revoke_is_idempotent_and_preserves_first_reason(self):
+        session = self._claimed_session()
+        alloc.mint_sci(session)
+        alloc.revoke_sci_for_session(session["session_id"], reason="explicit_retire")
+        second = alloc.revoke_sci_for_session(
+            session["session_id"], reason="idle_ttl_exceeded"
+        )
+        self.assertTrue(second["revoked"])
+        self.assertTrue(second.get("already_revoked"))
+        stamped = alloc.get_session(session["session_id"])
+        item = self._get_token(stamped["sci_token_id"])
+        self.assertEqual(item["revocation_reason"]["S"], "explicit_retire")
+
+    def test_revoke_without_token_returns_none(self):
+        session = self._claimed_session()
+        self.assertIsNone(alloc.revoke_sci_for_session(session["session_id"]))
+
+    def test_revoke_missing_session_raises(self):
+        with self.assertRaises(ValueError):
+            alloc.revoke_sci_for_session("ENC-SES-404")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -29,6 +29,8 @@ Environment variables:
   COGNITO_USER_POOL_ID    us-east-1_b2D0V3E1k
   COGNITO_CLIENT_ID       6q607dk3liirhtecgps7hifmlk
   COORDINATION_INTERNAL_API_KEY  (service auth key)
+  CHECKOUT_TOKENS_TABLE   default: enceladus-checkout-tokens (SCI gate, ENC-ISS-441)
+  AGENT_SESSIONS_TABLE    default: agent-sessions (SCI gate, ENC-ISS-441)
 """
 
 from __future__ import annotations
@@ -147,6 +149,12 @@ GITHUB_INTEGRATION_API_BASE = os.environ.get("GITHUB_INTEGRATION_API_BASE", "")
 CORS_ORIGIN = os.environ.get("CORS_ORIGIN", "https://jreese.net")
 # ENC-FTR-037: checkout service gate key — only checkout_service Lambda may change task status
 CHECKOUT_SERVICE_KEY = os.environ.get("CHECKOUT_SERVICE_KEY", "")
+# ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate stores. SCI tokens (minted
+# by coordination_api agent.claim, ENC-TSK-J92) live in the checkout-tokens
+# table; the grandfather-epoch check and last_activity_at touch read the
+# agent-sessions store (ENC-FTR-117 / ENC-TSK-I37).
+CHECKOUT_TOKENS_TABLE = os.environ.get("CHECKOUT_TOKENS_TABLE", "enceladus-checkout-tokens")
+AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
 MAX_NOTE_LENGTH = 2000
 # ENC-FTR-052: Governed Lesson Primitive — feature flag
 # ENC-TSK-H08 (F63): AppConfig is the source of truth (env_fallback preserves legacy/local behavior)
@@ -588,6 +596,226 @@ def _is_conditional_check_failed(exc: Exception) -> bool:
     if not isinstance(exc, ClientError):
         return False
     return exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException"
+
+
+# ---------------------------------------------------------------------------
+# SCI enforcement gate (ENC-ISS-441 Phase 3 / ENC-TSK-J93)
+#
+# Agent-origin mutations — requests presenting a minted ENC-SES-NNN id as
+# write_source.provider — must carry a valid Session Claim ID (`sci` in the
+# request body). SCI tokens are minted by coordination_api agent.claim
+# (ENC-TSK-J92) into CHECKOUT_TOKENS_TABLE. Non-agent identities (github,
+# system:arc-walker, Cognito subs/usernames, coordination_dispatch, ...) are
+# out of gate scope and pass through unchanged, as do requests bearing
+# X-Checkout-Service-Key: the checkout_service runs the same gate at its own
+# edge (ENC-FTR-037 chain) and does not forward `sci` downstream.
+# ---------------------------------------------------------------------------
+
+# ENC-ISS-441 Ph3 ship date; sessions created before this instant are
+# grandfathered and mutate without an SCI. Deliberately a module-level
+# constant, NOT an env var — out-of-band env vars get stripped by full-env
+# deploys (PLN-047 / ENC-LSN-053 Sev1 class).
+SCI_ENFORCEMENT_EPOCH = "2026-07-02T12:00:00Z"
+
+# J92 token shape: pk = "SCI-{uuid4_hex}"
+_SCI_TOKEN_RE = re.compile(r"^SCI-[0-9a-f]{32}$")
+# I37 minted session ids: ENC-SES-NNN (base-36, uppercase)
+_AGENT_SESSION_ID_RE = re.compile(r"^ENC-SES-[0-9A-Z]+$")
+
+_SCI_REMEDIATION = (
+    "Obtain a Session Claim ID via coordination agent.claim (register->claim "
+    "handshake, ENC-FTR-117 / ENC-ISS-441) and pass it as 'sci' on this request."
+)
+
+
+def _sci_error(failure_mode: str, message: str) -> Dict:
+    """Build the 403 rejection envelope for an SCI gate failure (ENC-ISS-441)."""
+    logger.warning("[ERROR] SCI gate rejection (%s): %s", failure_mode, message)
+    return _error(
+        403,
+        f"{message} {_SCI_REMEDIATION}",
+        code="SCI_REQUIRED",
+        sci_failure_mode=failure_mode,
+        remediation=_SCI_REMEDIATION,
+    )
+
+
+def _lookup_sci(sci_id: str) -> Optional[Dict]:
+    """Look up the full SCI token item (J92 shape) from the checkout-tokens table."""
+    try:
+        resp = _get_ddb().get_item(
+            TableName=CHECKOUT_TOKENS_TABLE,
+            Key={"pk": {"S": sci_id}},
+        )
+    except Exception as exc:
+        logger.warning("SCI token lookup failed for %s: %s", sci_id, exc)
+        return None
+    item = resp.get("Item")
+    if not item:
+        return None
+    ttl_raw = item.get("ttl", {}).get("N")
+    try:
+        ttl_val = int(float(ttl_raw)) if ttl_raw is not None else 0
+    except (TypeError, ValueError):
+        ttl_val = 0
+    return {
+        "token_id": item.get("pk", {}).get("S", ""),
+        "token_type": item.get("token_type", {}).get("S", ""),
+        "session_id": item.get("session_id", {}).get("S", ""),
+        "revoked": bool(item.get("revoked", {}).get("BOOL", False)),
+        "ttl": ttl_val,
+    }
+
+
+def _get_agent_session(session_id: str) -> Optional[Dict]:
+    """Fetch an agent-session record (ENC-FTR-117 store; key session_id)."""
+    try:
+        resp = _get_ddb().get_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+        )
+    except Exception as exc:
+        logger.warning("Agent-session lookup failed for %s: %s", session_id, exc)
+        return None
+    item = resp.get("Item")
+    if not item:
+        return None
+    return {
+        "session_id": item.get("session_id", {}).get("S", ""),
+        "created_at": item.get("created_at", {}).get("S", ""),
+        "status": item.get("status", {}).get("S", ""),
+    }
+
+
+def _touch_session_activity(session_id: str) -> None:
+    """Refresh the session's last_activity_at heartbeat (J83 pattern).
+
+    Conditional on the session still being live (allocated/claimed); a retired
+    or vanished session is a silent no-op — the touch must NEVER fail the
+    mutation it rides on (ENC-ISS-441 / ENC-TSK-J93).
+    """
+    try:
+        _get_ddb().update_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+            UpdateExpression="SET last_activity_at = :now",
+            ConditionExpression=(
+                "attribute_exists(session_id) AND (#st = :allocated OR #st = :claimed)"
+            ),
+            ExpressionAttributeNames={"#st": "status"},
+            ExpressionAttributeValues={
+                ":now": {"S": _now_z()},
+                ":allocated": {"S": "allocated"},
+                ":claimed": {"S": "claimed"},
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — touch is best-effort by contract
+        if _is_conditional_check_failed(exc):
+            logger.info(
+                "[INFO] last_activity_at touch skipped for %s (session not live)",
+                session_id,
+            )
+        else:
+            logger.warning(
+                "[ERROR] last_activity_at touch failed for %s (continuing): %s",
+                session_id, exc,
+            )
+
+
+def _validate_sci_gate(session_id: str, sci: Any) -> Optional[Dict]:
+    """SCI enforcement gate (ENC-ISS-441 Phase 3 / ENC-TSK-J93).
+
+    Callers invoke this only when ``session_id`` matches _AGENT_SESSION_ID_RE.
+    Returns None when the mutation may proceed (grandfathered session or valid
+    SCI, in which case last_activity_at is touched), else the 403 rejection
+    response naming the specific failure mode.
+    """
+    # Step 1: the session must exist — a fabricated ENC-SES id must not bypass
+    # the gate (fail closed).
+    session = _get_agent_session(session_id)
+    if session is None:
+        return _sci_error(
+            "unknown_session",
+            f"Agent session '{session_id}' is not a registered session; "
+            "mutation rejected (fail-closed).",
+        )
+
+    # Step 2: grandfather epoch gate — sessions created before the Phase 3
+    # ship instant pass without an SCI (skip token validation entirely).
+    # created_at uses the shared "%Y-%m-%dT%H:%M:%SZ" format, so lexicographic
+    # comparison is a correct chronological compare (see agent_id_alloc).
+    created_at = str(session.get("created_at") or "").strip()
+    if created_at and created_at < SCI_ENFORCEMENT_EPOCH:
+        return None
+
+    # Step 3: token validation.
+    sci_id = str(sci or "").strip()
+    if not sci_id:
+        return _sci_error(
+            "missing_sci",
+            f"Agent session '{session_id}' presented no Session Claim ID (sci); "
+            "agent-origin mutations require a valid SCI.",
+        )
+    if not _SCI_TOKEN_RE.match(sci_id):
+        return _sci_error(
+            "unknown_sci",
+            f"'{sci_id}' is not a valid Session Claim ID "
+            "(expected format SCI-{32 hex chars}).",
+        )
+    token = _lookup_sci(sci_id)
+    if token is None:
+        return _sci_error(
+            "unknown_sci",
+            f"Session Claim ID '{sci_id}' is not recognized.",
+        )
+    if token.get("token_type") != "SCI":
+        return _sci_error(
+            "wrong_token_type",
+            f"Token '{sci_id}' has token_type '{token.get('token_type')}'; "
+            "only SCI tokens authorize agent-origin mutations.",
+        )
+    if token.get("revoked"):
+        return _sci_error(
+            "revoked_sci",
+            f"Session Claim ID '{sci_id}' has been revoked.",
+        )
+    # DynamoDB native TTL deletion may lag, so also enforce expiry here.
+    if int(token.get("ttl") or 0) <= int(time.time()):
+        return _sci_error(
+            "expired_sci",
+            f"Session Claim ID '{sci_id}' has expired.",
+        )
+    if token.get("session_id") != session_id:
+        return _sci_error(
+            "session_mismatch",
+            f"Session Claim ID '{sci_id}' is bound to session "
+            f"'{token.get('session_id')}', not '{session_id}'.",
+        )
+
+    # Valid SCI — refresh the session heartbeat (never fails the mutation).
+    _touch_session_activity(session_id)
+    return None
+
+
+def _sci_gate_for_request(body: Dict, event: Optional[Dict]) -> Optional[Dict]:
+    """Run the SCI gate for a mutation request when it is agent-origin.
+
+    Agent-origin means write_source.provider is a minted ENC-SES id. Everything
+    else — internal-key writes under legacy providers (github, user, ...),
+    Cognito writes (provider defaults to claims.sub), EventBridge/system writes
+    (system:arc-walker) — is out of gate scope and passes through unchanged.
+    Requests bearing X-Checkout-Service-Key are exempt: checkout_service runs
+    the identical gate at its own edge and the ENC-FTR-037 chain does not
+    forward `sci` (same trust model / rollout semantics as the FTR-037 status
+    gate, including permissive mode while CHECKOUT_SERVICE_KEY is unset).
+    """
+    ws = _normalize_write_source(body)
+    session_id = str(ws.get("provider", "")).strip()
+    if not _AGENT_SESSION_ID_RE.match(session_id):
+        return None
+    if _is_checkout_service_request(event):
+        return None
+    return _validate_sci_gate(session_id, body.get("sci"))
 
 
 # ---------------------------------------------------------------------------
@@ -1580,8 +1808,21 @@ def _handle_pending_updates(query_params: Dict) -> Dict:
 # ---------------------------------------------------------------------------
 
 
-def _handle_create_record(project_id: str, record_type: str, body: Dict) -> Dict:
+def _handle_create_record(
+    project_id: str,
+    record_type: str,
+    body: Dict,
+    event: Optional[Dict] = None,
+) -> Dict:
     """POST /{project}/{type} — create a new tracker record."""
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate — agent-origin record
+    # creation (write_source.provider is a minted ENC-SES id) requires a valid
+    # Session Claim ID before any validation or minting occurs. Non-agent
+    # providers (github, system:arc-walker, Cognito subs, ...) pass unchanged.
+    _sci_err = _sci_gate_for_request(body, event)
+    if _sci_err:
+        return _sci_err
+
     title = body.get("title", "").strip()
     if not title:
         return _tracker_create_validation_error(
@@ -2870,6 +3111,15 @@ def _handle_update_field(
 
     _normalize_write_source(body)
 
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate. Agent-origin field
+    # updates (write_source.provider is a minted ENC-SES id) must present a
+    # valid Session Claim ID BEFORE any state mutation below (user-initiated
+    # advance, checkout/release branch, generic field write). Checkout-service
+    # requests are exempt — the identical gate already ran at that edge.
+    _sci_err = _sci_gate_for_request(body, event)
+    if _sci_err:
+        return _sci_err
+
     field = body.get("field", "").strip()
     value = body.get("value", "")
     if not field:
@@ -3923,12 +4173,26 @@ def _handle_pwa_action(project_id: str, record_type: str, record_id: str, body: 
         return _error(500, "Database write failed. Please try again.")
 
 
-def _handle_log(project_id: str, record_type: str, record_id: str, body: Dict) -> Dict:
+def _handle_log(
+    project_id: str,
+    record_type: str,
+    record_id: str,
+    body: Dict,
+    event: Optional[Dict] = None,
+) -> Dict:
     """POST /{project}/{type}/{id}/log — append worklog entry to history."""
     description = body.get("description", "").strip()
     if not description:
         return _error(400, "Field 'description' is required.")
     _normalize_write_source(body)
+
+    # ENC-ISS-441 / ENC-TSK-J93: SCI enforcement gate — agent-origin worklog
+    # appends (write_source.provider is a minted ENC-SES id) require a valid
+    # Session Claim ID. Checkout-service /log forwarding is exempt (gate runs
+    # at that edge); non-agent providers pass through unchanged.
+    _sci_err = _sci_gate_for_request(body, event)
+    if _sci_err:
+        return _sci_err
 
     ddb = _get_ddb()
     key = _build_key(project_id, record_type, record_id)
@@ -4114,18 +4378,32 @@ def _handle_lesson_extend(project_id: str, record_id: str, body: Dict) -> Dict:
     })
 
 
-def _handle_checkout(project_id: str, record_type: str, record_id: str, body: Dict) -> Dict:
+def _handle_checkout(
+    project_id: str,
+    record_type: str,
+    record_id: str,
+    body: Dict,
+    event: Optional[Dict] = None,
+) -> Dict:
     """POST /{project}/{type}/{id}/checkout — session checkout."""
     body["field"] = "active_agent_session"
     body["value"] = True
-    return _handle_update_field(project_id, record_type, record_id, body)
+    # ENC-TSK-J93: pass event through so the SCI gate can honor the
+    # X-Checkout-Service-Key exemption on the ENC-FTR-037 checkout chain.
+    return _handle_update_field(project_id, record_type, record_id, body, event=event)
 
 
-def _handle_release(project_id: str, record_type: str, record_id: str, body: Dict) -> Dict:
+def _handle_release(
+    project_id: str,
+    record_type: str,
+    record_id: str,
+    body: Dict,
+    event: Optional[Dict] = None,
+) -> Dict:
     """DELETE /{project}/{type}/{id}/checkout — session release."""
     body["field"] = "active_agent_session"
     body["value"] = False
-    return _handle_update_field(project_id, record_type, record_id, body)
+    return _handle_update_field(project_id, record_type, record_id, body, event=event)
 
 
 def _handle_acceptance_evidence(project_id: str, record_type: str, record_id: str, body: Dict) -> Dict:
@@ -4880,13 +5158,13 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         _normalize_write_source(body, claims)
 
         if sub == "log" and method == "POST":
-            return _handle_log(project_id, record_type, record_id, body)
+            return _handle_log(project_id, record_type, record_id, body, event=event)
         elif sub == "extend" and method == "POST" and record_type == "lesson":
             return _handle_lesson_extend(project_id, record_id, body)
         elif sub == "checkout" and method == "POST":
-            return _handle_checkout(project_id, record_type, record_id, body)
+            return _handle_checkout(project_id, record_type, record_id, body, event=event)
         elif sub == "checkout" and method == "DELETE":
-            return _handle_release(project_id, record_type, record_id, body)
+            return _handle_release(project_id, record_type, record_id, body, event=event)
         elif sub == "acceptance-evidence" and method == "POST":
             return _handle_acceptance_evidence(project_id, record_type, record_id, body)
         else:
@@ -4942,7 +5220,7 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
             except (ValueError, TypeError):
                 return _error(400, "Invalid JSON body.")
             _normalize_write_source(body, claims)
-            return _handle_create_record(project_id, record_type, body)
+            return _handle_create_record(project_id, record_type, body, event=event)
         else:
             return _error(405, f"Method {method} not allowed. Use POST to create.")
 

--- a/backend/lambda/tracker_mutation/test_sci_gate.py
+++ b/backend/lambda/tracker_mutation/test_sci_gate.py
@@ -1,0 +1,384 @@
+"""test_sci_gate.py — SCI enforcement gate in tracker_mutation (ENC-ISS-441 Ph3 / ENC-TSK-J93).
+
+Agent-origin mutations (write_source.provider = minted ENC-SES-NNN id) must
+present a valid Session Claim ID (`sci`, minted by coordination_api agent.claim,
+ENC-TSK-J92). Covers:
+
+  * All six rejection modes: missing_sci / unknown_sci / wrong_token_type /
+    revoked_sci / expired_sci / session_mismatch — each a 403 naming the mode.
+  * unknown_session fails closed (fabricated ENC-SES ids cannot bypass).
+  * Grandfathered pre-epoch sessions pass without an sci.
+  * Non-ENC-SES providers (github, system:arc-walker, Cognito subs) pass untouched.
+  * X-Checkout-Service-Key requests are exempt (the ENC-FTR-037 chain runs the
+    identical gate at the checkout_service edge and does not forward sci).
+  * Valid SCI passes real moto-backed mutations (tracker.set field update,
+    worklog append, record create) and touches agent-sessions.last_activity_at.
+  * Retired-session touch is a silent no-op that never fails the mutation.
+
+Run: python3 -m pytest test_sci_gate.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import unittest
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+sys.path.insert(0, os.path.dirname(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "tracker_mutation_sci",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+tm = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules[_spec.name] = tm
+_spec.loader.exec_module(tm)
+
+SESSION = "ENC-SES-0A1"
+OTHER_SESSION = "ENC-SES-0B2"
+PRE_EPOCH_SESSION = "ENC-SES-009"
+VALID_SCI = "SCI-" + "a" * 32
+POST_EPOCH_TS = "2026-07-02T13:00:00Z"   # after SCI_ENFORCEMENT_EPOCH
+PRE_EPOCH_TS = "2026-06-30T00:00:00Z"    # before SCI_ENFORCEMENT_EPOCH
+CS_KEY = "cs-test-key"
+
+
+def _body(provider=SESSION, sci=None, **extra):
+    body = {"write_source": {"provider": provider, "channel": "mcp_server"}}
+    if sci is not None:
+        body["sci"] = sci
+    body.update(extra)
+    return body
+
+
+class TrackerSciGateBase(unittest.TestCase):
+    """moto-backed tracker + token + session + projects tables.
+
+    moto is started in setUp (not via a class decorator) so the mock covers the
+    inherited fixture and every subclass test method uniformly.
+    CHECKOUT_SERVICE_KEY is patched non-empty so the FTR-037-style exemption is
+    header-gated instead of rollout-permissive.
+    """
+
+    def setUp(self):
+        self._moto = mock_aws()
+        self._moto.start()
+        self.addCleanup(self._moto.stop)
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        self.ddb.create_table(
+            TableName=tm.DYNAMODB_TABLE,
+            AttributeDefinitions=[
+                {"AttributeName": "project_id", "AttributeType": "S"},
+                {"AttributeName": "record_id", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "project_id", "KeyType": "HASH"},
+                {"AttributeName": "record_id", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        for table, key in (
+            (tm.CHECKOUT_TOKENS_TABLE, "pk"),
+            (tm.AGENT_SESSIONS_TABLE, "session_id"),
+            (tm.PROJECTS_TABLE, "project_id"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        for patcher in (
+            mock.patch.object(tm, "_ddb", self.ddb),
+            mock.patch.object(tm, "CHECKOUT_SERVICE_KEY", CS_KEY),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    # -- fixtures ------------------------------------------------------------
+    def put_session(self, session_id=SESSION, created_at=POST_EPOCH_TS, status="claimed"):
+        self.ddb.put_item(
+            TableName=tm.AGENT_SESSIONS_TABLE,
+            Item={
+                "session_id": {"S": session_id},
+                "agent_type_id": {"S": "ENC-AGT-001"},
+                "created_at": {"S": created_at},
+                "status": {"S": status},
+            },
+        )
+
+    def put_sci(self, pk=VALID_SCI, session_id=SESSION, token_type="SCI",
+                revoked=False, ttl=None):
+        self.ddb.put_item(
+            TableName=tm.CHECKOUT_TOKENS_TABLE,
+            Item={
+                "pk": {"S": pk},
+                "token_type": {"S": token_type},
+                "session_id": {"S": session_id},
+                "agent_type_id": {"S": "ENC-AGT-001"},
+                "issued_at": {"S": POST_EPOCH_TS},
+                "revoked": {"BOOL": revoked},
+                "ttl": {"N": str(ttl if ttl is not None else int(time.time()) + 3600)},
+            },
+        )
+
+    def put_task(self, item_id="ENC-TSK-901", **extra):
+        item = {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": f"task#{item_id}"},
+            "item_id": {"S": item_id},
+            "record_type": {"S": "task"},
+            "status": {"S": "open"},
+            "title": {"S": "SCI gate test task"},
+            "description": {"S": "original"},
+            "history": {"L": []},
+        }
+        item.update(extra)
+        self.ddb.put_item(TableName=tm.DYNAMODB_TABLE, Item=item)
+
+    def put_plan(self, item_id="ENC-PLN-001"):
+        self.ddb.put_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Item={
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": f"plan#{item_id}"},
+                "item_id": {"S": item_id},
+                "record_type": {"S": "plan"},
+                "status": {"S": "drafted"},
+                "title": {"S": "SCI gate test plan"},
+                "history": {"L": []},
+            },
+        )
+
+    def put_project(self, project_id="enceladus", prefix="ENC"):
+        self.ddb.put_item(
+            TableName=tm.PROJECTS_TABLE,
+            Item={"project_id": {"S": project_id}, "prefix": {"S": prefix}},
+        )
+
+    def get_record(self, record_id="task#ENC-TSK-901"):
+        resp = self.ddb.get_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Key={"project_id": {"S": "enceladus"}, "record_id": {"S": record_id}},
+        )
+        return resp.get("Item") or {}
+
+    def get_session_item(self, session_id=SESSION):
+        resp = self.ddb.get_item(
+            TableName=tm.AGENT_SESSIONS_TABLE,
+            Key={"session_id": {"S": session_id}},
+        )
+        return resp.get("Item") or {}
+
+    # -- assertions ----------------------------------------------------------
+    def assert_sci_403(self, resp, failure_mode):
+        self.assertIsNotNone(resp, "expected a 403 rejection, got pass-through")
+        self.assertEqual(resp["statusCode"], 403)
+        body = json.loads(resp["body"])
+        self.assertEqual(body.get("sci_failure_mode"), failure_mode)
+        self.assertIn("agent.claim", body.get("error", ""))
+        self.assertIn("ENC-ISS-441", body.get("error", ""))
+
+
+class ValidateSciGateRejectionTests(TrackerSciGateBase):
+    """The six rejection modes + fail-closed unknown session (ENC-TSK-J93)."""
+
+    def test_missing_sci_rejected(self):
+        self.put_session()
+        for empty in (None, "", "   "):
+            self.assert_sci_403(tm._validate_sci_gate(SESSION, empty), "missing_sci")
+
+    def test_malformed_sci_rejected_as_unknown(self):
+        self.put_session()
+        self.assert_sci_403(tm._validate_sci_gate(SESSION, "SCI-not-hex"), "unknown_sci")
+
+    def test_unrecognized_sci_rejected(self):
+        self.put_session()
+        self.assert_sci_403(
+            tm._validate_sci_gate(SESSION, "SCI-" + "f" * 32), "unknown_sci")
+
+    def test_wrong_token_type_rejected(self):
+        self.put_session()
+        self.put_sci(token_type="CCI")
+        self.assert_sci_403(tm._validate_sci_gate(SESSION, VALID_SCI), "wrong_token_type")
+
+    def test_revoked_sci_rejected(self):
+        self.put_session()
+        self.put_sci(revoked=True)
+        self.assert_sci_403(tm._validate_sci_gate(SESSION, VALID_SCI), "revoked_sci")
+
+    def test_expired_sci_rejected(self):
+        # DynamoDB native TTL may lag deletion — the gate must enforce expiry itself.
+        self.put_session()
+        self.put_sci(ttl=int(time.time()) - 10)
+        self.assert_sci_403(tm._validate_sci_gate(SESSION, VALID_SCI), "expired_sci")
+
+    def test_session_mismatch_rejected(self):
+        self.put_session()
+        self.put_sci(session_id=OTHER_SESSION)
+        self.assert_sci_403(tm._validate_sci_gate(SESSION, VALID_SCI), "session_mismatch")
+
+    def test_unknown_session_fails_closed(self):
+        # Fabricated ENC-SES id, even with a well-formed token, must not bypass.
+        self.put_sci(session_id="ENC-SES-ZZZ")
+        self.assert_sci_403(
+            tm._validate_sci_gate("ENC-SES-ZZZ", VALID_SCI), "unknown_session")
+
+
+class GateScopeTests(TrackerSciGateBase):
+    """_sci_gate_for_request scoping: identity match + checkout-service exemption."""
+
+    def test_non_agent_providers_pass_untouched(self):
+        # Legacy/system/Cognito identities are out of gate scope — no session
+        # lookup, no sci required, request proceeds unchanged.
+        for provider in (
+            "github", "system:arc-walker", "user", "coordination_dispatch",
+            "1234abcd-cognito-sub", "io", "",
+        ):
+            body = _body(provider=provider)
+            self.assertIsNone(tm._sci_gate_for_request(body, None),
+                              f"provider {provider!r} was gated")
+
+    def test_agent_origin_without_sci_rejected(self):
+        self.put_session()
+        self.assert_sci_403(tm._sci_gate_for_request(_body(), None), "missing_sci")
+
+    def test_checkout_service_key_request_is_exempt(self):
+        # checkout_service runs the identical gate at its own edge and the
+        # ENC-FTR-037 chain does not forward sci — the presented key exempts.
+        event = {"headers": {"x-checkout-service-key": CS_KEY}}
+        self.assertIsNone(tm._sci_gate_for_request(_body(), event))
+
+    def test_wrong_checkout_service_key_is_not_exempt(self):
+        self.put_session()
+        event = {"headers": {"x-checkout-service-key": "not-the-key"}}
+        self.assert_sci_403(tm._sci_gate_for_request(_body(), event), "missing_sci")
+
+
+class MutationPathTests(TrackerSciGateBase):
+    """Full moto-backed mutation paths through the gated handlers."""
+
+    def test_update_field_rejected_without_sci_and_record_unchanged(self):
+        self.put_session()
+        self.put_task()
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-901",
+            _body(field="description", value="mutated"),
+        )
+        self.assert_sci_403(resp, "missing_sci")
+        self.assertEqual(self.get_record()["description"]["S"], "original")
+
+    def test_update_field_with_valid_sci_succeeds_and_touches_heartbeat(self):
+        self.put_session()
+        self.put_sci()
+        self.put_task()
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-901",
+            _body(sci=VALID_SCI, field="description", value="mutated"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual(self.get_record()["description"]["S"], "mutated")
+        item = self.get_session_item()
+        self.assertIn("last_activity_at", item)
+        self.assertRegex(
+            item["last_activity_at"]["S"],
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
+        )
+
+    def test_update_field_grandfathered_session_passes_without_sci(self):
+        self.put_session(session_id=PRE_EPOCH_SESSION, created_at=PRE_EPOCH_TS)
+        self.put_task()
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-901",
+            _body(provider=PRE_EPOCH_SESSION, field="description", value="mutated"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual(self.get_record()["description"]["S"], "mutated")
+
+    def test_retired_session_touch_is_noop_and_mutation_still_succeeds(self):
+        self.put_session(status="retired")
+        self.put_sci()
+        self.put_task()
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-901",
+            _body(sci=VALID_SCI, field="description", value="mutated"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertNotIn("last_activity_at", self.get_session_item())
+
+    def test_unknown_session_fails_closed_on_update(self):
+        self.put_sci(session_id="ENC-SES-XX9")
+        self.put_task()
+        resp = tm._handle_update_field(
+            "enceladus", "task", "ENC-TSK-901",
+            _body(provider="ENC-SES-XX9", sci=VALID_SCI, field="description", value="x"),
+        )
+        self.assert_sci_403(resp, "unknown_session")
+
+    def test_log_append_gated_and_passes_with_valid_sci(self):
+        # Non-task records accept direct agent worklogs (no checkout needed) —
+        # the SCI gate still applies to the ENC-SES identity.
+        self.put_session()
+        self.put_plan()
+        resp = tm._handle_log(
+            "enceladus", "plan", "ENC-PLN-001",
+            _body(description="[INFO] direct agent worklog"),
+        )
+        self.assert_sci_403(resp, "missing_sci")
+
+        self.put_sci()
+        resp = tm._handle_log(
+            "enceladus", "plan", "ENC-PLN-001",
+            _body(sci=VALID_SCI, description="[INFO] direct agent worklog"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertIn("last_activity_at", self.get_session_item())
+
+    def test_create_record_gated_and_passes_with_valid_sci(self):
+        self.put_session()
+        self.put_project()
+        resp = tm._handle_create_record(
+            "enceladus", "task", _body(title="SCI gate create test"),
+        )
+        self.assert_sci_403(resp, "missing_sci")
+
+        self.put_sci()
+        resp = tm._handle_create_record(
+            "enceladus", "task",
+            _body(
+                sci=VALID_SCI,
+                title="SCI gate create test",
+                acceptance_criteria=["record is created via a valid SCI"],
+            ),
+        )
+        self.assertIn(resp["statusCode"], (200, 201))
+        self.assertIn("last_activity_at", self.get_session_item())
+
+    def test_checkout_chain_via_service_key_still_works_without_sci(self):
+        # checkout_service -> tracker_mutation POST .../checkout presents
+        # X-Checkout-Service-Key and an ENC-SES provider but no sci (the gate
+        # already ran at the checkout_service edge). Must not regress.
+        self.put_session()
+        self.put_task()
+        event = {"headers": {"x-checkout-service-key": CS_KEY}}
+        resp = tm._handle_checkout(
+            "enceladus", "task", "ENC-TSK-901", _body(), event=event,
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        record = self.get_record()
+        self.assertEqual(record["active_agent_session_id"]["S"], SESSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -5035,6 +5035,14 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Agent identity checking out the task (e.g., 'claude_agent_sdk').",
                     },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
+                    },
                     "governance_hash": {
                         "type": "string",
                         "description": "Current governance hash for write authorization.",
@@ -5101,6 +5109,14 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Provider advancing the task (must match checkout owner).",
                     },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
+                    },
                     "governance_hash": {
                         "type": "string",
                         "description": "Current governance hash for write authorization.",
@@ -5138,6 +5154,14 @@ async def list_tools() -> list[Tool]:
                     "provider": {
                         "type": "string",
                         "description": "Provider appending the worklog (must match checkout owner).",
+                    },
+                    "sci": {
+                        "type": "string",
+                        "description": (
+                            "Session Claim ID issued by coordination agent.claim (ENC-ISS-441). "
+                            "Required by the backend for agent sessions claimed after the SCI "
+                            "enforcement epoch; strip-and-forwarded, never validated here."
+                        ),
                     },
                     "governance_hash": {
                         "type": "string",
@@ -5831,6 +5855,11 @@ async def _tracker_set(args: dict) -> list[TextContent]:
         payload["coordination"] = args["coordination"]
     if args.get("transition_evidence"):
         payload["transition_evidence"] = args["transition_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _tracker_api_request("PATCH", f"/{project_id}/{record_type}/{rid}", payload=payload)
     return _result_text(resp)
@@ -5874,6 +5903,11 @@ async def _tracker_log(args: dict) -> list[TextContent]:
         payload["dispatch_id"] = args["dispatch_id"]
     if args.get("provider"):
         payload["provider"] = args["provider"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _tracker_api_request("POST", f"/{project_id}/{record_type}/{rid}/log", payload=payload)
     return _result_text(resp)
@@ -5888,6 +5922,8 @@ async def _tracker_log(args: dict) -> list[TextContent]:
 # into the downstream POST body; every other field declared in tracker_mutation's
 # governance schema forwards automatically, and tracker_mutation remains the single
 # source of truth for which fields are valid per record_type.
+# ENC-ISS-441: the optional Session Claim ID ("sci") also rides this passthrough —
+# it is forwarded verbatim when the caller supplies it and never validated here.
 _TRACKER_CREATE_BODY_DENYLIST = frozenset({
     "project_id",
     "record_type",
@@ -9180,7 +9216,13 @@ async def _agent_register(args: dict) -> list[TextContent]:
 
 
 async def _agent_claim(args: dict) -> list[TextContent]:
-    """Claim a pre-minted ENC-SES-NNN (allocated → claimed, agent.claim)."""
+    """Claim a pre-minted ENC-SES-NNN (allocated → claimed, agent.claim).
+
+    ENC-ISS-441: the backend claim envelope now includes top-level
+    "sci", "sci_issued_at", and "sci_ttl_seconds". The response body is
+    returned unchanged (raw passthrough), so those fields flow to the
+    caller automatically — do not reshape this response.
+    """
     payload: Dict[str, Any] = {"session_id": args["session_id"]}
     if args.get("expected_agent_type_id"):
         payload["expected_agent_type_id"] = args["expected_agent_type_id"]
@@ -9344,6 +9386,12 @@ async def _checkout_task(args: dict) -> list[TextContent]:
     }
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty so requests stay byte-identical for grandfathered
+    # sessions that don't pass it.
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/checkout", payload=payload)
     if isinstance(resp, dict) and resp.get("success"):
@@ -9409,6 +9457,11 @@ async def _advance_task_status(args: dict) -> list[TextContent]:
         payload["coordination_request_id"] = args["coordination_request_id"]
     if args.get("live_validation_evidence"):
         payload["live_validation_evidence"] = args["live_validation_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/advance", payload=payload)
     if (
@@ -9455,6 +9508,11 @@ async def _append_worklog(args: dict) -> list[TextContent]:
         payload["provider"] = args["provider"]
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/{record_type}/{rid}/log", payload=payload)
     return _result_text(resp)
@@ -9635,6 +9693,11 @@ async def _plan_checkout(args: dict) -> list[TextContent]:
     }
     if args.get("coordination_request_id"):
         payload["coordination_request_id"] = args["coordination_request_id"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/plan/{rid}/checkout", payload=payload)
     return _result_text(resp)
@@ -9669,6 +9732,11 @@ async def _plan_advance(args: dict) -> list[TextContent]:
     }
     if args.get("transition_evidence"):
         payload["transition_evidence"] = args["transition_evidence"]
+    # ENC-ISS-441: strip-and-forward the Session Claim ID; never validated here.
+    # Only set when non-empty (grandfathered sessions omit it).
+    sci = (args.get("sci") or "").strip()
+    if sci:
+        payload["sci"] = sci
 
     resp = _checkout_api_request("POST", f"/{project_id}/plan/{rid}/advance", payload=payload)
     return _result_text(resp)


### PR DESCRIPTION
## Summary

P1 prod-restoration. Restores ENC-ISS-441 (SCI mint + enforcement) which was
silently reverted from v3-prod at 2026-07-08T22:25:44Z by a main-ref Gen2
Lambda deploy (commit cb71380 / ENC-TSK-M43 / ISS-501). That deploy rebuilt
every prod Lambda from `main`, and FTR-122 SCI was built v4-first — it only
ever lived on `v4/main` (main<->v4/main sync disabled since ENC-TSK-H63) and
reached prod exclusively via surgical promotion, never a `main` commit. Any
`main`-ref deploy therefore reverts it. Root cause, timeline, and the
"v4-first features required on prod" registry are documented in
**DOC-B716E8FB10B6** (COE + registry, updated 2026-07-08), which is also the
authoritative Channel B (Lambda code / promote-path) restoration procedure
this PR follows.

Tracker: **ENC-TSK-M44** — "Backport FTR-122 SCI (ISS-441) onto main + io-gated v3-prod redeploy"

## Scope (surgical — see completeness note below)

Ported from `origin/v4/main` as targeted hunks against main's *current*
structure (not file replacement — main and v4/main have diverged
substantially elsewhere in these same files):

- **ENC-TSK-J92** — `mint_sci` / `revoke_sci_for_session` in
  `coordination_api/agent_id_alloc.py`; wired into `agent.claim` (mint on
  allocated->claimed) and `agent.retire` (revoke); `CHECKOUT_TOKENS_TABLE`
  config.
- **ENC-TSK-J93** — SCI enforcement gate (`_validate_sci_gate`) in
  `checkout_service` (checkout / advance / log) and `tracker_mutation`
  (`_sci_gate_for_request`, covering update_field / log / create_record).
  Agent-origin (`ENC-SES-*`) mutations require a valid, unrevoked, unexpired
  SCI bound to the acting session — 403 `SCI_REQUIRED` with a specific
  `sci_failure_mode` otherwise (`unknown_session`, `missing_sci`,
  `unknown_sci`, `wrong_token_type`, `revoked_sci`, `expired_sci`,
  `session_mismatch`). Sessions created before `SCI_ENFORCEMENT_EPOCH`
  (`2026-07-02T12:00:00Z`, module constant — not an env var, per the
  PLN-047/LSN-053 class) are grandfathered. `tracker_mutation` exempts
  `X-Checkout-Service-Key` requests (ENC-FTR-037 — checkout_service already
  ran the gate at its own edge).
- **ENC-TSK-K10** — `enceladus-mcp-code` `sci` passthrough on
  `tracker.set` / `tracker.log`.
- `governance_data_dictionary.json` — new `coordination.session_claim_id`
  entity (version bumped `2026-07-08.1` -> `2026-07-08.2`), per the
  Governance Dictionary Guard (this PR touches
  `coordination_api/lambda_function.py`, `checkout_service/lambda_function.py`,
  `tracker_mutation/lambda_function.py`).

Three pre-existing `checkout_service` test files
(`test_component_lifecycle_gate.py`, `test_component_opacity_gate.py`,
`test_component_misconfig_failure.py`) build
`active_agent_session_id="ENC-SES-001"` fixtures for unrelated
component-gate scenarios. Their DDB mocks are extended to also answer the
new `AGENT_SESSIONS_TABLE` lookup (as a pre-epoch grandfathered session) so
the new gate doesn't intercept tests that aren't exercising SCI.

## Completeness check (Step 0)

`git diff --stat origin/main origin/v4/main -- backend/lambda/` shows **252
files / 56,907 insertions** — the full v4-first feature generation (new
Lambdas: `id_service`, `lifecycle_service`, `rhythm_cycle`,
`memory_consolidation`, `scoring_service`, `corpus_entropy_engine`, etc.),
not just governance features. Per DOC-B716E8FB10B6's own registry and its
"surgical = smallest diff" invariant, this PR is scoped to only the entries
that registry marks **actually reverted-and-relied-upon on prod**:

- ✅ **FTR-122 SCI** — this PR.
- ⚠️ **FTR-121 escalations** (request/mint/applier) — also in the registry
  as reverted-and-required, and named in this task's dispatch scope. **Not
  included here.** The v4/main commits for it (J68/J69) are entangled with
  unrelated, much larger v4-first features (I07 supersession primitive,
  I08/I09 dedup-review) that also aren't on main — a clean surgical
  extraction wasn't practical in this pass without either dragging in
  ~2000 lines of unreviewed, untested-in-this-context code or a
  significantly larger budget. Recommend a dedicated follow-up task
  (DOC-B716E8FB10B6's registry already lists its backport as "pending,
  parallels ENC-TSK-M44").
- ✅ **FTR-119 watchdog** — confirmed out of scope: ships from the separate
  `enceladus-support` repo, status=planned, never lived on the enceladus
  v3-prod Lambda stack (per DOC-B716E8FB10B6's `not_in_registry`).
- Also not included: **ENC-TSK-J94** retirement-sweep SCI revocation
  (10-min unclaim / 2h idle TTL reapers). SCI still mints and enforces
  without it; a session abandoned without an explicit retire keeps a live,
  unrevoked SCI until its 24h native TTL. Low risk, small follow-up.

## Tests

- `checkout_service`: 114/114 (98 pre-existing + 16 new `test_sci_gate.py`)
- `tracker_mutation`: 255/255 (235 pre-existing + 20 new `test_sci_gate.py`)
- `coordination_api`: 408/408 (400 pre-existing + 8 new SCI tests in
  `test_agent_id_alloc.py`) + 3 pre-existing failures reproduced identically
  on a clean, unmodified `origin/main` baseline (real-AWS-call leakage
  across the full local suite run, unrelated to this change — not present
  when those files run in isolation).
- `enceladus-mcp-server`: SCI-relevant subset green; the dispatch-plan
  manifest-fixture failures are pre-existing (reproduced identically on
  clean `origin/main`, missing local `agent-manifest.json` fixture).

## PR Commit Gate — cannot be satisfied through the normal path

This is the P1 incident itself: SCI enforcement being down means
`checkout_task` / `advance` / mutation calls needed to mint a normal CAI ->
CCI cannot be exercised safely from this agent session (per this task's
dispatch: reads work, but execute/mutation/checkout is expected to fail and
was not attempted). **No CCI token is in this PR body — none was faked.**
Per DOC-B716E8FB10B6's standing invariants, this needs **io to admin-merge**
(bypass the PR Commit Gate) given governance/SCI is currently down — this is
exactly the scenario that gate can't self-resolve, since the fix for the
gate's dependency is the content of this PR.

## Deploy path (Channel B — NOT triggered by this PR)

Per DOC-B716E8FB10B6 Channel B: once merged to `main`, the fix reaches
v3-prod via `workflow_dispatch _deploy.yml ref=main target_environment=v3-prod`,
which **pauses on the v3-prod GitHub Environment required-reviewer gate**.
This PR does not trigger that dispatch — merge is io's action (admin-merge,
gate down), and per DOC-B716E8FB10B6's Consent Protocol and Step 3
("Auto-promote discipline... never approve any v3-prod Environment request
on the agent's own initiative"), the deploy dispatch and its approval are
both left to io as a deliberate, separate, post-merge action.

Cites: **ENC-TSK-M44**, **DOC-B716E8FB10B6**.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>