### PR TITLE
ENC-TSK-M45: backport FTR-121 escalations onto main (M44 sibling)

### DIFF
--- a/backend/lambda/coordination_api/agent_id_alloc.py
+++ b/backend/lambda/coordination_api/agent_id_alloc.py
@@ -452,6 +452,42 @@ def retire_session(session_id: str) -> Dict[str, Any]:
     return updated
 
 
+def touch_session_activity(session_id: str) -> bool:
+    """Refresh a live session's ``last_activity_at`` heartbeat (ENC-TSK-J71).
+
+    DOC-5B888FCA43B8 §5.9 / ENC-ISS-441: a listening agent polling
+    ``escalation.watch`` performs only reads and would otherwise be idle-retired
+    mid-wait. Each watch poll calls this to advance the heartbeat the idle
+    sweep measures against (see ``_idle_reference``). Best-effort by contract:
+    a missing or already-retired session returns False rather than failing the
+    poll — the watch response reports ``session_touched`` so the caller can
+    notice its session died. The 10-minute unclaim TTL is unaffected (that
+    path reads ``created_at`` on allocated sessions only).
+    """
+    if not session_id:
+        return False
+
+    ddb = _get_ddb()
+    try:
+        ddb.update_item(
+            TableName=AGENT_SESSIONS_TABLE,
+            Key={"session_id": _serialize(session_id)},
+            UpdateExpression="SET last_activity_at = :now",
+            ConditionExpression="attribute_exists(session_id) AND (#st = :allocated OR #st = :claimed)",
+            ExpressionAttributeNames={"#st": "status"},
+            ExpressionAttributeValues={
+                ":now": _serialize(dt.datetime.now(dt.timezone.utc).strftime(_TS_FORMAT)),
+                ":allocated": _serialize("allocated"),
+                ":claimed": _serialize("claimed"),
+            },
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Session Claim ID (SCI) tokens — ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122)
 # ---------------------------------------------------------------------------
@@ -589,13 +625,20 @@ def revoke_sci_for_session(
 # ---------------------------------------------------------------------------
 
 def _idle_reference(item: Mapping[str, Any]) -> str:
-    """Return the timestamp marking a session's last lifecycle transition.
+    """Return the timestamp marking a session's most recent activity.
 
-    For a claimed session that is ``claimed_at``; for an allocated (never-claimed) session
-    it is ``created_at``. There is no separate heartbeat attribute, so the most recent
-    lifecycle event stands in as the clock against which idleness is measured.
+    ENC-TSK-J71 (DOC-5B888FCA43B8 §5.9): ``last_activity_at`` — the heartbeat
+    advanced by every ``escalation.watch`` poll — takes precedence when present,
+    so a listening agent waiting on io's approval is not idle-retired. Sessions
+    that never polled fall back to the last lifecycle transition: ``claimed_at``
+    for claimed sessions, else ``created_at``.
     """
-    return str(item.get("claimed_at") or item.get("created_at") or "")
+    return str(
+        item.get("last_activity_at")
+        or item.get("claimed_at")
+        or item.get("created_at")
+        or ""
+    )
 
 
 def sweep_idle_sessions(

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-08.2",
-  "updated_at": "2026-07-08T23:55:00Z",
-  "last_change_summary": "ENC-TSK-M44 (ENC-ISS-441 reopened, DOC-B716E8FB10B6 COE): backport FTR-122 Session Claim ID (SCI) from v4/main onto main. main-ref v3-prod Lambda deploys rebuild the whole per-env Lambda set and had silently reverted SCI (v4-first, never on main) at 2026-07-08T22:25:44Z, reopening ISS-441 fail-open. New entity coordination.session_claim_id (mint on agent.claim / revoke on agent.retire, ports ENC-TSK-J92). Adds the Ph3 enforcement gate (ports ENC-TSK-J93) to coordination.session_claim_id.fields: checkout_service._validate_sci_gate and tracker_mutation._validate_sci_gate/_sci_gate_for_request reject agent-origin (ENC-SES-*) mutations lacking a valid, unrevoked, unexpired SCI bound to the acting session (403 SCI_REQUIRED, fail-closed for unknown sessions/tokens); sessions created before SCI_ENFORCEMENT_EPOCH=2026-07-02T12:00:00Z are grandfathered. Also ports the enceladus-mcp-code 'sci' passthrough (ENC-TSK-K10) on tracker.set/tracker.log. ENC-TSK-J94 (retirement-sweep SCI revocation) and ENC-FTR-121 escalations were NOT backported by M44 (out of scope / tracked separately) -- see the M44 PR report.",
+  "version": "2026-07-09.1",
+  "updated_at": "2026-07-09T02:00:00Z",
+  "last_change_summary": "ENC-TSK-M45 (FTR-121 registry entry, DOC-B716E8FB10B6 COE, M44 sibling): backport the ENC-FTR-121 Escalations request/applier/watch/notify surface from v4/main onto main. The 2026-07-08T22:25:44Z main-ref v3-prod Lambda deploy had reverted the escalation.request/get/list surface (ENC-TSK-J68), the applyEscalatedMutation applier (ENC-TSK-J69), coordination_api's approve/deny/feed handlers (ENC-TSK-J70 backend portion only -- PWA/CFN already landed via ENC-TSK-J82/J80), the agent-side escalation.watch cursor poll (ENC-TSK-J71, with the ENC-TSK-J89 base-relative-path fix folded in), and the SNS [ESCALATION] notify hook (ENC-TSK-J72), leaving execute() unable to resolve action 'escalation.request'. Extraction was surgical by function/hunk, NOT by commit: v4/main's J68/J69/J71 commits are git-history-entangled with the unrelated ENC-TSK-I07 supersession primitive and ENC-TSK-I08/I09 dedup-review surfaces (neither present on main), and J70/J71's coordination_api hunks are similarly entangled with the unrelated ENC-TSK-J46/FTR-096 lesson-candidate curation surface (also not on main) -- those were excluded by isolating function-boundary content within each 3-way-merge conflict block rather than accepting the whole hunk. New entities: tracker.escalation (the escalation item type + FSM + mutation-handler registry + applier + waiver semantics, tracker_mutation), mcp_server.escalation_actions (escalation.request/get/list/watch code-mode actions), coordination.escalations (coordination_api's feed/approve/deny/watch routes -- the base ENC-TSK-J70 in-Lambda _is_cognito_session check only; the additional ENC-TSK-L92/M12 allowlist + human-principal gates remain exclusively in the standalone escalation_decision_authorizer Lambda per that entity's existing prod-vs-gamma split, unchanged by this task). CFN routes/env (ENC-TSK-J80) and the PWA Escalations page (ENC-TSK-J82) were already on main prior to this task and are unmodified here.",
   "owners": [
     "enceladus-platform"
   ],
@@ -5922,6 +5922,260 @@
           "definition": "Detail key on the 403 SCI_REQUIRED error envelope: one of unknown_session, missing_sci, unknown_sci, wrong_token_type, revoked_sci, expired_sci, session_mismatch."
         }
       }
+    },
+    "tracker.escalation": {
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "fields": {
+        "escalation_id": {
+          "type": "string",
+          "constraints": {
+            "format": "{PREFIX}-ESC-{SEQ}",
+            "immutable": true
+          },
+          "definition": "Server-minted escalation ID (e.g. ENC-ESC-001).",
+          "usage_guidance": "Minted by tracker_mutation's atomic-counter ID authority via the 'escalation' entry in _TRACKER_TYPE_SUFFIX. ID Boundary Rule holds without exception: no client predicts, computes, or scans for the next ID."
+        },
+        "target_record_id": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "The tracker record the requested mutation targets.",
+          "usage_guidance": "Must be an existing task (TSK), issue (ISS), or feature (FTR) record. Validated for existence at request time with a consistent read."
+        },
+        "mutation_type": {
+          "type": "enum",
+          "enum": [
+            "deploy_arc_change",
+            "direct_state_override"
+          ],
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+        },
+        "payload": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Mutation-type-specific payload, validated by the handler's validate_payload at request time.",
+          "usage_guidance": "Stored as a JSON document on the item; malformed payloads fail fast at request time and never reach io's queue."
+        },
+        "justification": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "definition": "Required free-text rationale from the requesting agent, shown to io on the PWA approval card."
+        },
+        "expected_version": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Optional target-record version or content hash captured at request time.",
+          "usage_guidance": "When supplied and the target has drifted by approval time, the PWA shows a drift warning; io may still approve (informed consent) or deny."
+        },
+        "requested_by": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Requesting agent identity: {session_id (ENC-SES-*, required), agent_type_id (ENC-AGT-*), sci_present (bool)}.",
+          "usage_guidance": "session_id is required (server-minted ENC-SES id; ENC-FTR-117). SCI-bearing sessions stamp sci_present=true once ENC-ISS-441 ships."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "requested",
+            "approved",
+            "denied",
+            "denied_with_guidance",
+            "applying",
+            "applied",
+            "failed"
+          ],
+          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
+          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+        },
+        "events": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
+        },
+        "guidance_note": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "io's free-text course-correction note on deny-with-guidance; travels back to the agent in the event stream."
+        },
+        "approved_by": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Cognito sub + email of the approving human. Null until approval.",
+          "usage_guidance": "Written only by the Cognito-gated approval route (Ph3/ENC-TSK-J70). Structurally unwritable by agent credentials."
+        },
+        "applied_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "required": false
+          },
+          "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
+        },
+        "result": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Applier outcome object (success detail or captured error on failed). Null until terminal."
+        },
+        "created_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "immutable": true
+          },
+          "definition": "Server-stamped at request time."
+        },
+        "updated_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "definition": "Server-stamped on every mutation."
+        },
+        "escalation_provenance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-J69: append-only list of escalation IDs applied to a TARGET record (stamped on the target, not the escalation, inside the applier's atomic write together with the [ESCALATION-APPLIED] worklog entry carrying requesting session, approving human, before/after states, and waived fields). Artifact-Genesis: every override leaves an artifact."
+        }
+      },
+      "dynamodb_key_schema": {
+        "pk": "project_id",
+        "sk_pattern": "escalation#{escalation_id}",
+        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "record_id_format": "{PREFIX}-ESC-{SEQ}",
+        "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
+      },
+      "mutation_rules": {
+        "escalation_id": "IMMUTABLE (server-minted)",
+        "target_record_id": "IMMUTABLE after create",
+        "mutation_type": "IMMUTABLE after create",
+        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
+        "events": "APPEND_ONLY (list_append only)",
+        "approved_by": "Written only by the Cognito human approval route",
+        "applied_at": "Written exactly once by applyEscalatedMutation"
+      },
+      "required_fields": [
+        "target_record_id",
+        "mutation_type",
+        "payload",
+        "justification",
+        "requested_by"
+      ],
+      "waiver_semantics": {
+        "escalation_waived_sentinel": {
+          "shape": {
+            "escalation_waived": true,
+            "escalation_id": "ENC-ESC-NNN",
+            "waived_at": "iso8601"
+          },
+          "definition": "Section 5.6: when direct_state_override lands a record in a state whose invariant fields are unsupplied, each such field is written with this sentinel rather than left null. Downstream consumers read 'known-absent by human decision', semantically distinct from 'never reached' or 'data loss'. LIVE as of ENC-TSK-J69: written by _apply_direct_state_override. Null-handling audit finding (2026-07-02): the deploy/closed evidence validators in tracker_mutation validate REQUEST transition_evidence, not stored record state, so sentinel-bearing records do not break them; the sentinel is a dict, making accidental string ops fail loudly and grep-ably rather than silently."
+        },
+        "escalated_closure": {
+          "type": "boolean",
+          "definition": "Set true on any record closed via direct_state_override so ENC-FTR-118 empirical-runtime metrics and close-quality reporting can filter override closures out of organic-completion datasets. LIVE as of ENC-TSK-J69 (written by _apply_direct_state_override; task closures also increment closed_count so DESIGNS-edge and subtask gates keep organic parity)."
+        }
+      },
+      "applier": {
+        "function": "applyEscalatedMutation (_handle_escalation_apply, tracker_mutation)",
+        "route": "POST /{projectId}/escalation/{escalationId}/apply (rides the registered {recordType}/{recordId}/{sub} route shape; tracker:write scope)",
+        "definition": "ENC-TSK-J69 (Ph2): the SINGLE privileged code path that may write transitions the normal FSM forbids (Tenet 2). Sequence per section 5.5: approved+applied_at-null guard (repeat/concurrent invocation no-ops); conditional approved->applying transition is the concurrency gate (ConditionExpression status=approved AND attribute_not_exists(applied_at)); fresh consistent target read; registry handler apply executes exactly ONE atomic UpdateItem on the target (provenance worklog + escalation_provenance append ride the same write, so a handler exception leaves the target untouched); applying->applied stamps applied_at + result; on failure applying->failed captures the error in result and a corrective request is a NEW escalation. Reachability: application requires status=approved, which only the Cognito-human approval route (Ph3/ENC-TSK-J70) can write - no MCP action, SCI token, or internal key maps to approve. Normal validators in _handle_update_field are untouched and carry no bypass flags. Emits record.escalation.applied to the enceladus.tracker audit event bus.",
+        "handler_applies": {
+          "deploy_arc_change": "rewrites transition_type (and checkout_transition_type when present, which recomputes arc-derived gate expectations) in place; checkout fields untouched so an active checkout survives.",
+          "direct_state_override": "writes target_status regardless of path legality; supplied field_values written verbatim; unsupplied required-for-state fields (from the transition-matrix gate contracts: committed->commit_sha, deploy-success->arc evidence key, closed->arc closed-evidence key, issue closed->evidence) get the escalation_waived sentinel; closures set escalated_closure=true and increment closed_count for tasks (organic-gate parity)."
+        }
+      },
+      "notifications": {
+        "definition": "ENC-TSK-J72 (Ph5, section 5.8): tracker_mutation publishes an SNS notification with subject prefix [ESCALATION] on requested (after the durable item write) and on the terminal applied/failed transitions (closure telemetry). Topic: ESCALATION_ALERTS_TOPIC_ARN env, defaulting via CFN to the existing devops-feed-alerts{EnvironmentSuffix} topic (reuse - zero new infrastructure). FAILURE-ISOLATED by contract: an SNS error or unset ARN is logged and swallowed; notification can never fail the escalation write or the applier. Payload: escalation_id, target_record_id, mutation_type, requesting session, justification/result excerpt. Cost: tens of emails/month inside the SNS email free tier - combined feature incremental cost under one dollar per month. RESIDUAL (Ph8): the topic has no email subscription yet; io must subscribe + confirm to actually receive mail. IAM: PublishEscalationAlerts Sid on TrackerMutationRole (gamma via the compute stack; prod via Ph7a backport)."
+      }
+    },
+    "mcp_server.escalation_actions": {
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "fields": {
+        "escalation.request": {
+          "type": "execute_action",
+          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+        },
+        "escalation.get": {
+          "type": "search_action",
+          "definition": "Return the full escalation item by escalation_id (project_id required)."
+        },
+        "escalation.list": {
+          "type": "search_action",
+          "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first. ENC-TSK-J69: the MCP server calls GET /{project}/escalation/list (pseudo-id alias riding the registered {recordType}/{recordId} API Gateway route) because explicit gamma-style route tables register no bare {recordType} collection path; 'list' can never collide with a server-minted ENC-ESC-* id."
+        },
+        "escalation.watch": {
+          "type": "coordination_action",
+          "definition": "ENC-TSK-J71: coordination(action=escalation.watch, arguments={session_id, since?, project_id?}) -> GET /api/v1/coordination/escalations/watch. Pass the returned next_cursor back as since. Registered behind ENABLE_ESCALATION_PRIMITIVE. ENC-TSK-J89 (2026-07-02.07): MCP handler fixed to call the coordination API with a base-relative path (/escalations/watch); the prior absolute path double-prefixed COORDINATION_API_BASE and 404d on gamma and prod."
+        }
+      }
+    },
+    "coordination.escalations": {
+      "description": "ENC-FTR-121 Ph3 (ENC-TSK-J70, DOC-5B888FCA43B8 sections 5.7 + 6): io's escalation approval surface on coordination_api - the SOLE origin of override authorization in the platform. Every route verifies a genuine Cognito session server-side per call (_is_cognito_session); internal-key and managed-token credentials are structurally rejected with 403. ENC-TSK-L92 / ENC-ISS-501 (SEV-1, 2026-07-07): _is_cognito_session alone was found to be a fail-open BLOCKLIST (it excludes only auth_mode in {internal-key, managed-token} -- any OTHER or absent auth_mode passed), which let a non-human Cognito-authenticated identity self-approve escalations within seconds of filing with no human review. The approve/deny routes now ALSO require the decider's Cognito email claim to appear in a positive allowlist (_is_allowlisted_escalation_decider) sourced from a Console-edit-only S3 document that no Lambda role -- including this one -- has write access to; the allowlist check fails CLOSED on any fetch/parse error. No MCP action maps to approve or deny. Approve stamps approved_by {sub, email}, walks requested->approved under a ConditionExpression race guard, and drives applyEscalatedMutation (ENC-TSK-J69) in tracker_mutation via direct Lambda invoke (TRACKER_MUTATION_LAMBDA_NAME + X-Coordination-Internal-Key); the approval is durable even if the applier invoke fails (fail-soft: the escalation stays approved and the idempotent apply route can be re-driven - the agent never resubmits the cached mutation). Deny walks requested->denied, or requested->denied_with_guidance when a guidance_note is supplied; the note is stored on the item AND rides the denial event so watch polling (Ph4) delivers it to the agent. ENC-TSK-M12 / ENC-ISS-501 (2026-07-08): the email allowlist authorizes WHICH identities may decide but not WHAT KIND of token may decide -- coordination_api's _verify_token deliberately accepts Cognito ACCESS tokens (token_use=access, client_id match) for the general API surface, and machine-operated Cognito users in the human pool (e.g. terminal-agent@enceladus.internal, mintable via coordination auth.cognito_session) carry genuine ID tokens, so an allowlisted-by-mistake machine identity would have reopened approve/deny. The decision routes now ALSO require _is_human_cognito_principal (fail-closed): token_use must be exactly 'id' (rejects access/client_credentials/M2M grants and the token-use-less internal-key/managed-token modes), the token's aud must be on the human app-client allowlist (ESCALATION_HUMAN_CLIENT_IDS, default COGNITO_CLIENT_ID), bare client_id-without-aud shapes are rejected, and the email claim must exist and not fall under a machine principal domain (ESCALATION_MACHINE_EMAIL_DOMAINS, default enceladus.internal). This gate runs BEFORE the allowlist check and rejects machine principals with 403 regardless of allowlist contents. Prod (main branch) enforces the identical claim checks in the standalone escalation_decision_authorizer (ENC-TSK-L95) in front of the routes.",
+      "fields": {
+        "GET /api/v1/coordination/escalations": {
+          "type": "route",
+          "definition": "io approval queue feed. Query params: project_id (default enceladus), status. Pending (requested) escalations carry a fresh section-5.7 render_diff computed from the LIVE target record at render time - never the cached request - including a drift object {expected_version, current_sync_version, current_updated_at, detected} when expected_version was supplied. Terminal escalations return in a separate array for the collapsed audit section. Cognito-only."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve": {
+          "type": "route",
+          "definition": "Non-delegable approve: requested->approved + approved_by + event, then drives the applier. Returns applied:true|false with apply_result or apply_error+retry. ENC-TSK-L92: gated by _is_cognito_session AND _is_allowlisted_escalation_decider (both must pass); an allowlist-miss returns 403 before any DynamoDB write. ENC-TSK-M12: additionally gated by _is_human_cognito_principal (token_use=id + human app-client aud + non-machine email domain, fail-closed) BEFORE the allowlist check; machine token shapes 403 with a distinct 'structurally rejected' error."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny": {
+          "type": "route",
+          "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied. ENC-TSK-L92: same dual gate as approve. ENC-TSK-M12: same triple gate as approve."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_BUCKET": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501 / ENC-ISS-505. Env var (default 'enceladus-356364570033-us-west-2-an'). S3 bucket holding the escalation-approver allowlist document. ENC-ISS-505 (SEV-1): originally 'jreese-net', which is served publicly on the open web via CloudFront (multiple distributions) -- the allowlist was readable by anyone at https://jreese.net/security/escalation-approvers.md with no auth. Relocated to this bucket, which has no CloudFront origin and full S3 Public Access Block enabled."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_KEY": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501. Env var (default 'security/escalation-approvers.md'). S3 key of the allowlist document. coordination_api's Lambda role is granted s3:GetObject ONLY on this exact key (EscalationApproverAllowlistRead statement, infrastructure/cloudformation/02-compute.yaml) -- no role in the account, including this Lambda's own, has PutObject/DeleteObject on it. The document is a markdown file with a fenced yaml block of `- email: \"...\"` list entries, parsed without a yaml dependency by _load_escalation_approver_allowlist (60s in-memory cache). Edits require an AWS Console-authenticated human; there is deliberately no programmatic write path."
+        },
+        "GET /api/v1/coordination/escalations/watch": {
+          "type": "route",
+          "definition": "ENC-TSK-J71 (Ph4, section 5.4 + 5.9): session-scoped cursor polling - the listening AGENT's side of the loop (read scope; agent credentials are the intended callers; approval stays Cognito-only). Query params: session_id (required, ENC-SES-*), since (opaque cursor), project_id (default enceladus). Returns every section-11.2 lifecycle event newer than the cursor across all escalations the session originated (guidance_note rides denied_with_guidance events), plus next_cursor and session_touched. CURSOR SEMANTICS: base64url(JSON {escalation_id: events_consumed}) counting against the append-only events array - event timestamps are second-granular and FSM edges (applying->applied) land inside one second, so a timestamp cursor would drop same-second events; the count cursor is lossless, exactly-once, and stable on empty polls. Malformed/absent cursors replay from the start (events are facts; replay is safe). Every poll refreshes the session's last_activity_at heartbeat. POLLING GUIDANCE (section 5.8): 15-30s interval, exponential backoff after two idle hours; transport is polling ONLY (no WebSocket/SSE by design)."
+        },
+        "ESCALATION_HUMAN_CLIENT_IDS": {
+          "type": "string",
+          "definition": "ENC-TSK-M12 / ENC-ISS-501. Optional env var: comma-separated Cognito app-client ids whose ID tokens may represent a human escalation decider. Defaults to COGNITO_CLIENT_ID (the interactive PWA client) when unset. Read per-call by _escalation_human_client_ids(); an empty resolved set fails CLOSED (every decision denied). Tokens minted by any other app client (e.g. the ENC-FTR-074 agent M2M client) are rejected 403 on the decision routes regardless of their other claims."
+        },
+        "ESCALATION_MACHINE_EMAIL_DOMAINS": {
+          "type": "string",
+          "definition": "ENC-TSK-M12 / ENC-ISS-501. Optional env var: comma-separated email domains marking machine-operated Cognito principals (default 'enceladus.internal'). An otherwise-valid human-shaped ID token whose email falls under one of these domains is rejected 403 on the decision routes even if that email appears on the approver allowlist -- the allowlist must never be the only barrier between a machine principal and an escalation approval (the ENC-ISS-501 attacker identity terminal-agent@enceladus.internal is exactly this class)."
+        }
+      },
+      "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
+      "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -5977,6 +6231,11 @@
       "version": "2026-07-08.2",
       "date": "2026-07-08",
       "summary": "ENC-TSK-M44 (ENC-ISS-441 reopened, DOC-B716E8FB10B6 COE): backport FTR-122 Session Claim ID (SCI) from v4/main onto main. main-ref v3-prod Lambda deploys rebuild the whole per-env Lambda set and had silently reverted SCI (v4-first, never on main) at 2026-07-08T22:25:44Z, reopening ISS-441 fail-open. New entity coordination.session_claim_id (mint on agent.claim / revoke on agent.retire, ports ENC-TSK-J92). Adds the Ph3 enforcement gate (ports ENC-TSK-J93) to coordination.session_claim_id.fields: checkout_service._validate_sci_gate and tracker_mutation._validate_sci_gate/_sci_gate_for_request reject agent-origin (ENC-SES-*) mutations lacking a valid, unrevoked, unexpired SCI bound to the acting session (403 SCI_REQUIRED, fail-closed for unknown sessions/tokens); sessions created before SCI_ENFORCEMENT_EPOCH=2026-07-02T12:00:00Z are grandfathered. Also ports the enceladus-mcp-code 'sci' passthrough (ENC-TSK-K10) on tracker.set/tracker.log. ENC-TSK-J94 (retirement-sweep SCI revocation) and ENC-FTR-121 escalations were NOT backported by M44 (out of scope / tracked separately) -- see the M44 PR report."
+    },
+    {
+      "version": "2026-07-09.1",
+      "date": "2026-07-09",
+      "summary": "ENC-TSK-M45 (FTR-121 registry entry, DOC-B716E8FB10B6 COE, M44 sibling): backport the ENC-FTR-121 Escalations request/applier/watch/notify surface from v4/main onto main. The 2026-07-08T22:25:44Z main-ref v3-prod Lambda deploy had reverted the escalation.request/get/list surface (ENC-TSK-J68), the applyEscalatedMutation applier (ENC-TSK-J69), coordination_api's approve/deny/feed handlers (ENC-TSK-J70 backend portion only -- PWA/CFN already landed via ENC-TSK-J82/J80), the agent-side escalation.watch cursor poll (ENC-TSK-J71, with the ENC-TSK-J89 base-relative-path fix folded in), and the SNS [ESCALATION] notify hook (ENC-TSK-J72), leaving execute() unable to resolve action 'escalation.request'. Extraction was surgical by function/hunk, NOT by commit: v4/main's J68/J69/J71 commits are git-history-entangled with the unrelated ENC-TSK-I07 supersession primitive and ENC-TSK-I08/I09 dedup-review surfaces (neither present on main), and J70/J71's coordination_api hunks are similarly entangled with the unrelated ENC-TSK-J46/FTR-096 lesson-candidate curation surface (also not on main) -- those were excluded by isolating function-boundary content within each 3-way-merge conflict block rather than accepting the whole hunk. New entities: tracker.escalation (the escalation item type + FSM + mutation-handler registry + applier + waiver semantics, tracker_mutation), mcp_server.escalation_actions (escalation.request/get/list/watch code-mode actions), coordination.escalations (coordination_api's feed/approve/deny/watch routes -- the base ENC-TSK-J70 in-Lambda _is_cognito_session check only; the additional ENC-TSK-L92/M12 allowlist + human-principal gates remain exclusively in the standalone escalation_decision_authorizer Lambda per that entity's existing prod-vs-gamma split, unchanged by this task). CFN routes/env (ENC-TSK-J80) and the PWA Escalations page (ENC-TSK-J82) were already on main prior to this task and are unmodified here."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -37,6 +37,7 @@ import ssl
 import time
 import uuid
 import urllib.error
+import base64
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -145,6 +146,13 @@ GOVERNANCE_PROJECT_ID = os.environ.get("GOVERNANCE_PROJECT_ID", "devops")
 GOVERNANCE_KEYWORD = os.environ.get("GOVERNANCE_KEYWORD", "governance-file")
 # ENC-TSK-729: push-on-write sync — Lambda name for async document store refresh
 DOCUMENT_API_LAMBDA_NAME = os.environ.get("DOCUMENT_API_LAMBDA_NAME", "devops-document-api")
+# ENC-FTR-121 Ph3 (ENC-TSK-J70): tracker_mutation Lambda hosting applyEscalatedMutation.
+# Default derives the environment suffix so a code deploy that races the CFN env
+# addition still targets the same environment's tracker mutation function.
+TRACKER_MUTATION_LAMBDA_NAME = os.environ.get(
+    "TRACKER_MUTATION_LAMBDA_NAME",
+    f"devops-tracker-mutation-api{os.environ.get('ENVIRONMENT_SUFFIX', '')}",
+)
 S3_BUCKET = os.environ.get("S3_BUCKET", "jreese-net")
 S3_GOVERNANCE_PREFIX = os.environ.get("S3_GOVERNANCE_PREFIX", "governance/live")
 S3_GOVERNANCE_HISTORY_PREFIX = os.environ.get("S3_GOVERNANCE_HISTORY_PREFIX", "governance/history")
@@ -8757,6 +8765,493 @@ def _handle_components_reject(
     )
 
 
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph3 / ENC-TSK-J70 — Escalations approval surface (DOC-5B888FCA43B8
+# §5.7 + §6). Approval is non-delegable by construction: every route here
+# verifies a genuine Cognito human session server-side; internal-key, SCI, and
+# managed-token credentials are structurally rejected (403). No MCP action maps
+# to approve/deny. Approve is the ONLY reachable entry to applyEscalatedMutation
+# (tracker_mutation) because status=approved is written nowhere else.
+# ---------------------------------------------------------------------------
+
+_ESCALATION_TARGET_SEGMENTS = {"TSK": "task", "ISS": "issue", "FTR": "feature"}
+
+
+def _invoke_tracker_mutation_api(
+    method: str, path: str, body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Invoke the tracker_mutation Lambda via the same internal Lambda-invoke
+    mechanism as _invoke_document_api. Used by the escalation approval flow to
+    drive applyEscalatedMutation (ENC-TSK-J69) after io approval.
+    """
+    fn_name = TRACKER_MUTATION_LAMBDA_NAME
+    if not fn_name:
+        raise RuntimeError("TRACKER_MUTATION_LAMBDA_NAME not configured")
+
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    internal_key = (COORDINATION_INTERNAL_API_KEY or "").strip()
+    if internal_key:
+        headers["X-Coordination-Internal-Key"] = internal_key
+
+    invoke_event = {
+        "version": "2.0",
+        "routeKey": f"{method.upper()} {path}",
+        "rawPath": path,
+        "requestContext": {"http": {"method": method.upper(), "path": path}},
+        "httpMethod": method.upper(),
+        "headers": headers,
+        "isBase64Encoded": False,
+        "body": json.dumps(body) if body is not None else None,
+    }
+
+    resp = _get_lambda_client().invoke(
+        FunctionName=fn_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(invoke_event).encode("utf-8"),
+    )
+    raw = resp.get("Payload")
+    payload_text = raw.read().decode("utf-8") if raw is not None else ""
+    envelope = json.loads(payload_text) if payload_text else {}
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"tracker mutation invoke error: {envelope}")
+
+    status_code = int(envelope.get("statusCode") or 0)
+    inner_raw = envelope.get("body")
+    inner: Dict[str, Any] = {}
+    if isinstance(inner_raw, str) and inner_raw:
+        try:
+            inner = json.loads(inner_raw)
+        except json.JSONDecodeError:
+            inner = {}
+    elif isinstance(inner_raw, dict):
+        inner = inner_raw
+    inner["_status_code"] = status_code
+    return inner
+
+
+def _escalation_payload_dict(escalation: Dict[str, Any]) -> Dict[str, Any]:
+    """The escalation payload is stored as a JSON string on the item."""
+    raw = escalation.get("payload")
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            return {}
+    return {}
+
+
+def _read_escalation_item(project_id: str, escalation_id: str) -> Optional[Dict[str, Any]]:
+    resp = _get_ddb().get_item(
+        TableName=TRACKER_TABLE,
+        Key={
+            "project_id": _serialize(project_id),
+            "record_id": _serialize(f"escalation#{escalation_id}"),
+        },
+        ConsistentRead=True,
+    )
+    raw = resp.get("Item")
+    return _deserialize(raw) if raw else None
+
+
+def _read_escalation_target(project_id: str, target_record_id: str) -> Optional[Dict[str, Any]]:
+    parts = str(target_record_id or "").split("-")
+    record_type = _ESCALATION_TARGET_SEGMENTS.get(parts[1].upper()) if len(parts) >= 3 else None
+    if not record_type:
+        return None
+    resp = _get_ddb().get_item(
+        TableName=TRACKER_TABLE,
+        Key={
+            "project_id": _serialize(project_id),
+            "record_id": _serialize(f"{record_type}#{target_record_id}"),
+        },
+        ConsistentRead=True,
+    )
+    raw = resp.get("Item")
+    return _deserialize(raw) if raw else None
+
+
+def _render_escalation_diff(
+    escalation: Dict[str, Any], target: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """§5.7 render_diff: fresh current-versus-requested delta computed at render
+    time from the LIVE target record — never from the cached request — with an
+    explicit drift flag when expected_version mismatches.
+    """
+    payload = _escalation_payload_dict(escalation)
+    mutation_type = str(escalation.get("mutation_type") or "")
+    diff: Dict[str, Any] = {
+        "mutation_type": mutation_type,
+        "target_record_id": escalation.get("target_record_id"),
+    }
+    if target is None:
+        diff["target_missing"] = True
+        return diff
+
+    if mutation_type == "deploy_arc_change":
+        diff["field"] = "transition_type"
+        diff["current"] = target.get("transition_type")
+        diff["requested"] = payload.get("new_deploy_arc_type")
+    elif mutation_type == "direct_state_override":
+        diff["field"] = "status"
+        diff["current"] = target.get("status")
+        diff["requested"] = payload.get("target_status")
+        field_values = payload.get("field_values")
+        if isinstance(field_values, dict) and field_values:
+            diff["field_values"] = {
+                field: {"current": target.get(field), "requested": requested}
+                for field, requested in field_values.items()
+            }
+
+    diff["target_snapshot"] = {
+        "title": target.get("title"),
+        "status": target.get("status"),
+        "transition_type": target.get("transition_type"),
+        "checkout_state": target.get("checkout_state"),
+        "sync_version": target.get("sync_version"),
+        "updated_at": target.get("updated_at"),
+    }
+    expected_version = str(escalation.get("expected_version") or "").strip()
+    if expected_version:
+        current_markers = {
+            str(target.get("sync_version") or ""),
+            str(target.get("updated_at") or ""),
+            f"sync_version:{target.get('sync_version')}",
+        }
+        diff["drift"] = {
+            "expected_version": expected_version,
+            "current_sync_version": str(target.get("sync_version") or ""),
+            "current_updated_at": str(target.get("updated_at") or ""),
+            "detected": expected_version not in current_markers,
+        }
+    return diff
+
+
+def _handle_escalations_feed(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/escalations — io's approval queue (§5.7).
+
+    Pending escalations carry a fresh diff + drift flag; terminal escalations
+    remain browsable for audit. Cognito-only: this is the human queue view.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, "The escalations queue requires a Cognito session (PWA, human-only).")
+
+    params = event.get("queryStringParameters") or {}
+    project_id = str(params.get("project_id") or "enceladus").strip()
+    status_filter = str(params.get("status") or "").strip()
+
+    ddb = _get_ddb()
+    query_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
+        "ExpressionAttributeValues": {
+            ":pid": _serialize(project_id),
+            ":prefix": _serialize("escalation#"),
+        },
+    }
+    if status_filter:
+        query_kwargs["FilterExpression"] = "#st = :status_filter"
+        query_kwargs["ExpressionAttributeNames"] = {"#st": "status"}
+        query_kwargs["ExpressionAttributeValues"][":status_filter"] = _serialize(status_filter)
+
+    escalations = []
+    try:
+        while True:
+            page = ddb.query(**query_kwargs)
+            escalations.extend(_deserialize(raw) for raw in page.get("Items", []))
+            last_key = page.get("LastEvaluatedKey")
+            if not last_key or len(escalations) >= 200:
+                break
+            query_kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalations feed query failed: %s", exc)
+        return _error(500, "Failed to read escalations.")
+
+    for escalation in escalations:
+        escalation["payload"] = _escalation_payload_dict(escalation)
+        if escalation.get("status") == "requested":
+            target = _read_escalation_target(
+                project_id, str(escalation.get("target_record_id") or ""))
+            escalation["diff"] = _render_escalation_diff(escalation, target)
+
+    escalations.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
+    pending = [e for e in escalations if e.get("status") == "requested"]
+    terminal = [e for e in escalations if e.get("status") != "requested"]
+    return _response(200, {
+        "success": True,
+        "project_id": project_id,
+        "pending": pending,
+        "terminal": terminal,
+        "count": len(escalations),
+    })
+
+
+def _record_escalation_decision(
+    project_id: str, escalation_id: str, new_status: str, actor: str,
+    approved_by: Optional[Dict[str, str]] = None, guidance_note: str = "",
+) -> bool:
+    """Conditionally walk requested→{approved|denied|denied_with_guidance},
+    appending the §11.2 event. Returns False when the race guard loses.
+    """
+    now = _now_z()
+    event_entry: Dict[str, Any] = {"event_type": new_status, "at": now, "actor": actor}
+    if guidance_note:
+        event_entry["guidance_note"] = guidance_note
+    update_parts = [
+        "#st = :new_status",
+        "updated_at = :now",
+        "#ev = list_append(if_not_exists(#ev, :empty), :event)",
+    ]
+    names = {"#st": "status", "#ev": "events"}
+    values: Dict[str, Any] = {
+        ":new_status": _serialize(new_status),
+        ":requested": _serialize("requested"),
+        ":now": _serialize(now),
+        ":empty": _serialize([]),
+        ":event": _serialize([event_entry]),
+    }
+    if approved_by is not None:
+        update_parts.append("approved_by = :approved_by")
+        values[":approved_by"] = _serialize(approved_by)
+    if guidance_note:
+        update_parts.append("guidance_note = :guidance_note")
+        values[":guidance_note"] = _serialize(guidance_note)
+    try:
+        _get_ddb().update_item(
+            TableName=TRACKER_TABLE,
+            Key={
+                "project_id": _serialize(project_id),
+                "record_id": _serialize(f"escalation#{escalation_id}"),
+            },
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ConditionExpression="attribute_exists(record_id) AND #st = :requested",
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except Exception as exc:
+        code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        if code == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _handle_escalation_decision(
+    project_id: str, escalation_id: str, decision: str,
+    event: Dict[str, Any], claims: Dict[str, Any],
+) -> Dict[str, Any]:
+    """POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve|deny.
+
+    Non-delegable (§6): Cognito human session only. Approve stamps approved_by
+    and drives applyEscalatedMutation; if the applier invoke fails, the
+    approval remains durable (status=approved) and the idempotent apply route
+    can be re-driven — the agent never resubmits the mutation.
+    """
+    if not _is_cognito_session(claims):
+        return _error(403, (
+            "Escalation approval/denial requires a Cognito session (human-only). "
+            "Agent, SCI, and internal-key credentials are structurally rejected."
+        ))
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except (ValueError, TypeError):
+        body = {}
+
+    escalation = _read_escalation_item(project_id, escalation_id)
+    if escalation is None:
+        return _error(404, f"Escalation not found: {escalation_id}")
+    current_status = str(escalation.get("status") or "")
+    if current_status != "requested":
+        return _error(409, (
+            f"Escalation {escalation_id} is '{current_status}'; only 'requested' "
+            "escalations can be decided."
+        ))
+
+    decider = _resolve_decider_identity(claims)
+    actor = str(claims.get("sub") or decider)
+
+    if decision == "approve":
+        approved_by = {
+            "sub": str(claims.get("sub") or ""),
+            "email": str(claims.get("email") or ""),
+        }
+        if not _record_escalation_decision(
+            project_id, escalation_id, "approved", actor, approved_by=approved_by,
+        ):
+            return _error(409, "Escalation was decided concurrently; refresh the queue.")
+
+        apply_result: Dict[str, Any] = {}
+        apply_error = ""
+        try:
+            apply_result = _invoke_tracker_mutation_api(
+                "POST",
+                f"/api/v1/tracker/{project_id}/escalation/{escalation_id}/apply",
+                body={"write_source": {"provider": f"io:{decider}", "channel": "coordination_api"}},
+            )
+            status_code = int(apply_result.get("_status_code") or 0)
+            if status_code >= 400:
+                apply_error = str(apply_result.get("error") or f"apply returned HTTP {status_code}")
+        except Exception as exc:
+            logger.error("escalation apply invoke failed: %s", exc)
+            apply_error = str(exc)
+
+        if apply_error:
+            return _response(200, {
+                "success": True,
+                "escalation_id": escalation_id,
+                "status": "approved",
+                "applied": False,
+                "approved_by": decider,
+                "apply_error": apply_error,
+                "retry": (
+                    f"POST /api/v1/tracker/{project_id}/escalation/{escalation_id}/apply "
+                    "(idempotent; applies only while status=approved and applied_at unset)"
+                ),
+            })
+        return _response(200, {
+            "success": True,
+            "escalation_id": escalation_id,
+            "status": str(apply_result.get("status") or "applied"),
+            "applied": str(apply_result.get("status") or "applied") == "applied",
+            "approved_by": decider,
+            "apply_result": apply_result.get("result"),
+        })
+
+    guidance_note = str(body.get("guidance_note") or "").strip()
+    new_status = "denied_with_guidance" if guidance_note else "denied"
+    if not _record_escalation_decision(
+        project_id, escalation_id, new_status, actor, guidance_note=guidance_note,
+    ):
+        return _error(409, "Escalation was decided concurrently; refresh the queue.")
+    return _response(200, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": new_status,
+        "denied_by": decider,
+        "guidance_note": guidance_note,
+    })
+
+
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph4 / ENC-TSK-J71 — escalation.watch cursor polling (§5.4, §5.9)
+# ---------------------------------------------------------------------------
+
+
+def _decode_watch_cursor(raw: str) -> Dict[str, int]:
+    """Decode the opaque watch cursor: base64url(JSON {escalation_id: events_consumed}).
+
+    Event timestamps are second-granular and FSM edges (applying→applied) land
+    inside one second, so a timestamp cursor would drop same-second events.
+    The cursor instead counts consumed events per escalation against the
+    append-only events array — lossless and stable on empty polls. Garbage or
+    absent cursors decode to {} (full replay; events are facts, replay is safe).
+    """
+    if not raw:
+        return {}
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(raw.encode("ascii")).decode("utf-8"))
+        if not isinstance(decoded, dict):
+            return {}
+        return {str(k): int(v) for k, v in decoded.items() if int(v) >= 0}
+    except Exception:  # noqa: BLE001 — any malformed cursor means full replay
+        return {}
+
+
+def _encode_watch_cursor(counts: Dict[str, int]) -> str:
+    return base64.urlsafe_b64encode(
+        json.dumps(counts, sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+
+
+def _handle_escalation_watch(event: Dict[str, Any], claims: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/coordination/escalations/watch — session-scoped event polling.
+
+    Returns escalation lifecycle events newer than the supplied cursor across
+    every escalation the calling session originated, and refreshes the
+    session's last_activity_at heartbeat (§5.9) so a listening agent survives
+    the idle sweep while waiting on io. Read-scoped: agent credentials are the
+    intended callers (this is the agent side of the loop; approval stays
+    Cognito-only). Recommended polling: 15-30s with exponential backoff after
+    two idle hours (§5.8).
+    """
+    params = event.get("queryStringParameters") or {}
+    session_id = str(params.get("session_id") or "").strip()
+    if not session_id:
+        return _error(400, "Query parameter 'session_id' is required (ENC-SES-*).")
+    project_id = str(params.get("project_id") or "enceladus").strip()
+    cursor_counts = _decode_watch_cursor(str(params.get("since") or "").strip())
+
+    ddb = _get_ddb()
+    query_kwargs: Dict[str, Any] = {
+        "TableName": TRACKER_TABLE,
+        "KeyConditionExpression": "project_id = :pid AND begins_with(record_id, :prefix)",
+        "FilterExpression": "requested_by.session_id = :sid",
+        "ExpressionAttributeValues": {
+            ":pid": _serialize(project_id),
+            ":prefix": _serialize("escalation#"),
+            ":sid": _serialize(session_id),
+        },
+    }
+    escalations = []
+    try:
+        while True:
+            page = ddb.query(**query_kwargs)
+            escalations.extend(_deserialize(raw) for raw in page.get("Items", []))
+            last_key = page.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            query_kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalation watch query failed: %s", exc)
+        return _error(500, "Failed to read escalations for watch.")
+
+    new_events = []
+    next_counts = dict(cursor_counts)
+    for escalation in escalations:
+        escalation_id = str(escalation.get("item_id") or "")
+        events = escalation.get("events") or []
+        consumed = cursor_counts.get(escalation_id, 0)
+        for entry in events[consumed:]:
+            if not isinstance(entry, dict):
+                continue
+            emitted = {
+                "escalation_id": escalation_id,
+                "escalation_status": escalation.get("status"),
+                "target_record_id": escalation.get("target_record_id"),
+                "event_type": entry.get("event_type"),
+                "at": entry.get("at"),
+                "actor": entry.get("actor"),
+            }
+            if entry.get("detail") is not None:
+                emitted["detail"] = entry.get("detail")
+            if entry.get("guidance_note"):
+                emitted["guidance_note"] = entry.get("guidance_note")
+            new_events.append(emitted)
+        next_counts[escalation_id] = len(events)
+
+    new_events.sort(key=lambda item: (str(item.get("at") or ""), str(item["escalation_id"])))
+    session_touched = False
+    try:
+        session_touched = _agent_alloc.touch_session_activity(session_id)
+    except Exception as exc:  # noqa: BLE001 — heartbeat failure must not fail the poll
+        logger.error("watch heartbeat touch failed for %s: %s", session_id, exc)
+
+    return _response(200, {
+        "success": True,
+        "session_id": session_id,
+        "project_id": project_id,
+        "events": new_events,
+        "count": len(new_events),
+        "next_cursor": _encode_watch_cursor(next_counts),
+        "session_touched": session_touched,
+    })
+
+
 def _handle_components_cloudwatch_event(
     component_id: str, event: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -13930,6 +14425,29 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if decision == "approve":
             return _handle_components_approve(comp_id, event, claims or {})
         return _handle_components_reject(comp_id, event, claims or {})
+
+    # ENC-FTR-121 Ph4 (ENC-TSK-J71): session-scoped escalation event polling —
+    # the AGENT side of the loop (approval stays Cognito-only).
+    if method == "GET" and path == "/api/v1/coordination/escalations/watch":
+        return _handle_escalation_watch(event, claims or {})
+
+
+    # ENC-FTR-121 Ph3 (ENC-TSK-J70): Escalations — io approval queue + decisions
+    # (DOC-5B888FCA43B8 §5.7). Cognito-gated inside the handlers; no agent path.
+    if method == "GET" and path == "/api/v1/coordination/escalations":
+        return _handle_escalations_feed(event, claims or {})
+    match_escalation_decision = re.fullmatch(
+        r"/api/v1/coordination/escalations/([a-z0-9_\-]+)/([A-Za-z0-9\-]+)/(approve|deny)", path
+    )
+    if method == "POST" and match_escalation_decision:
+        return _handle_escalation_decision(
+            match_escalation_decision.group(1),
+            match_escalation_decision.group(2),
+            match_escalation_decision.group(3),
+            event,
+            claims or {},
+        )
+
 
     # POST /api/v1/coordination/components/{componentId}/{action} where action is
     # one of the ENC-FTR-076 v2 / ENC-TSK-F40 state-machine actions.

--- a/backend/lambda/coordination_api/test_escalation_watch_j71.py
+++ b/backend/lambda/coordination_api/test_escalation_watch_j71.py
@@ -1,0 +1,228 @@
+"""ENC-TSK-J71 (ENC-FTR-121 Ph4): escalation.watch polling tests.
+
+Covers the count-based opaque cursor (first poll full replay, incremental
+polls return only unconsumed events, multi-escalation interleaving in a
+merged at-sorted stream, stability on empty polls, malformed-cursor safe
+replay), §11.2 event shape passthrough with guidance_note only on
+denied_with_guidance, session scoping (the DDB filter targets
+requested_by.session_id), the §5.9 last_activity_at heartbeat
+(touch_session_activity conditional write + _idle_reference precedence), and
+the agent-callable auth posture (no Cognito gate — internal-key claims work).
+"""
+import base64
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
+import importlib.util
+
+_SPEC = importlib.util.spec_from_file_location(
+    "coordination_lambda_j71",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+coordination_lambda = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = coordination_lambda
+_SPEC.loader.exec_module(coordination_lambda)
+
+import agent_id_alloc
+
+INTERNAL_CLAIMS = {"auth_mode": "internal-key"}
+
+
+def _event_entry(event_type, at, actor="ENC-SES-02F", guidance_note=None):
+    entry = {"event_type": event_type, "at": at, "actor": actor}
+    if guidance_note:
+        entry["guidance_note"] = guidance_note
+    return entry
+
+
+def _escalation(escalation_id, status, events, session_id="ENC-SES-02F"):
+    return {
+        "project_id": "enceladus",
+        "record_id": f"escalation#{escalation_id}",
+        "item_id": escalation_id,
+        "record_type": "escalation",
+        "status": status,
+        "mutation_type": "deploy_arc_change",
+        "target_record_id": "ENC-TSK-J10",
+        "requested_by": {"session_id": session_id},
+        "events": events,
+        "created_at": "2026-07-02T04:00:00Z",
+        "updated_at": "2026-07-02T04:10:00Z",
+    }
+
+
+def _serialized(item):
+    return {k: coordination_lambda._serialize(v) for k, v in item.items()}
+
+
+def _cursor(counts):
+    return base64.urlsafe_b64encode(json.dumps(counts).encode()).decode()
+
+
+def _watch(escalations, params, touched=True):
+    fake = mock.MagicMock()
+    fake.query.return_value = {"Items": [_serialized(e) for e in escalations]}
+    with mock.patch.object(coordination_lambda, "_get_ddb", return_value=fake), \
+         mock.patch.object(coordination_lambda._agent_alloc, "touch_session_activity",
+                           return_value=touched) as touch:
+        resp = coordination_lambda._handle_escalation_watch(
+            {"queryStringParameters": params}, INTERNAL_CLAIMS)
+    return resp, fake, touch
+
+
+class TestWatchCursor(unittest.TestCase):
+    def test_first_poll_replays_all_events_and_returns_full_cursor(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("approved", "2026-07-02T04:05:00Z", actor="cognito-sub"),
+        ]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "approved", events)],
+                            {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+        self.assertEqual(["requested", "approved"],
+                         [e["event_type"] for e in body["events"]])
+        decoded = json.loads(base64.urlsafe_b64decode(body["next_cursor"]))
+        self.assertEqual({"ENC-ESC-001": 2}, decoded)
+
+    def test_incremental_poll_returns_only_unconsumed_events(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("approved", "2026-07-02T04:05:00Z"),
+            _event_entry("applying", "2026-07-02T04:05:30Z"),
+            _event_entry("applied", "2026-07-02T04:05:30Z"),  # same second as applying
+        ]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "applied", events)],
+                            {"session_id": "ENC-SES-02F",
+                             "since": _cursor({"ENC-ESC-001": 2})})
+        body = json.loads(resp["body"])
+        # Both same-second events delivered — the count cursor cannot drop them.
+        self.assertEqual(["applying", "applied"],
+                         [e["event_type"] for e in body["events"]])
+
+    def test_empty_poll_returns_stable_cursor_and_no_events(self):
+        events = [_event_entry("requested", "2026-07-02T04:00:00Z")]
+        cursor = _cursor({"ENC-ESC-001": 1})
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "requested", events)],
+                            {"session_id": "ENC-SES-02F", "since": cursor})
+        body = json.loads(resp["body"])
+        self.assertEqual(0, body["count"])
+        self.assertEqual(json.loads(base64.urlsafe_b64decode(cursor)),
+                         json.loads(base64.urlsafe_b64decode(body["next_cursor"])))
+
+    def test_multi_escalation_events_merge_sorted_by_time(self):
+        first = _escalation("ENC-ESC-001", "applied", [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("applied", "2026-07-02T04:09:00Z"),
+        ])
+        second = _escalation("ENC-ESC-002", "denied_with_guidance", [
+            _event_entry("requested", "2026-07-02T04:03:00Z"),
+            _event_entry("denied_with_guidance", "2026-07-02T04:06:00Z",
+                         guidance_note="Use a successor task."),
+        ])
+        resp, _, _ = _watch([first, second], {"session_id": "ENC-SES-02F"})
+        body = json.loads(resp["body"])
+        self.assertEqual(
+            [("ENC-ESC-001", "requested"), ("ENC-ESC-002", "requested"),
+             ("ENC-ESC-002", "denied_with_guidance"), ("ENC-ESC-001", "applied")],
+            [(e["escalation_id"], e["event_type"]) for e in body["events"]])
+
+    def test_malformed_cursor_replays_from_start(self):
+        events = [_event_entry("requested", "2026-07-02T04:00:00Z")]
+        resp, _, _ = _watch([_escalation("ENC-ESC-001", "requested", events)],
+                            {"session_id": "ENC-SES-02F", "since": "!!!not-a-cursor!!!"})
+        body = json.loads(resp["body"])
+        self.assertEqual(1, body["count"])
+
+
+class TestWatchSemantics(unittest.TestCase):
+    def test_guidance_note_present_only_on_denied_with_guidance(self):
+        events = [
+            _event_entry("requested", "2026-07-02T04:00:00Z"),
+            _event_entry("denied_with_guidance", "2026-07-02T04:06:00Z",
+                         guidance_note="Fix the arc first."),
+        ]
+        resp, _, _ = _watch(
+            [_escalation("ENC-ESC-001", "denied_with_guidance", events)],
+            {"session_id": "ENC-SES-02F"})
+        body = json.loads(resp["body"])
+        requested, denied = body["events"]
+        self.assertNotIn("guidance_note", requested)
+        self.assertEqual("Fix the arc first.", denied["guidance_note"])
+
+    def test_query_filters_to_the_calling_session(self):
+        resp, fake, _ = _watch([], {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertEqual("requested_by.session_id = :sid", kwargs["FilterExpression"])
+        self.assertEqual({"S": "ENC-SES-02F"},
+                         kwargs["ExpressionAttributeValues"][":sid"])
+
+    def test_missing_session_id_400(self):
+        resp, fake, _ = _watch([], {})
+        self.assertEqual(400, resp["statusCode"])
+        fake.query.assert_not_called()
+
+    def test_internal_key_claims_are_allowed(self):
+        # The watch surface is the AGENT side of the loop — no Cognito gate.
+        resp, _, _ = _watch([], {"session_id": "ENC-SES-02F"})
+        self.assertEqual(200, resp["statusCode"])
+
+    def test_poll_touches_session_and_reports_result(self):
+        resp, _, touch = _watch([], {"session_id": "ENC-SES-02F"}, touched=True)
+        touch.assert_called_once_with("ENC-SES-02F")
+        self.assertTrue(json.loads(resp["body"])["session_touched"])
+
+    def test_retired_session_reports_untouched_but_poll_succeeds(self):
+        resp, _, _ = _watch([], {"session_id": "ENC-SES-0FF"}, touched=False)
+        body = json.loads(resp["body"])
+        self.assertEqual(200, resp["statusCode"])
+        self.assertFalse(body["session_touched"])
+
+
+class TestSessionActivity(unittest.TestCase):
+    def test_touch_writes_last_activity_at_conditionally(self):
+        fake = mock.MagicMock()
+        with mock.patch.object(agent_id_alloc, "_get_ddb", return_value=fake):
+            self.assertTrue(agent_id_alloc.touch_session_activity("ENC-SES-02F"))
+        kwargs = fake.update_item.call_args.kwargs
+        self.assertEqual("SET last_activity_at = :now", kwargs["UpdateExpression"])
+        self.assertIn("#st = :allocated OR #st = :claimed",
+                      kwargs["ConditionExpression"])
+
+    def test_touch_returns_false_for_dead_session(self):
+        from botocore.exceptions import ClientError
+        fake = mock.MagicMock()
+        fake.update_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem")
+        with mock.patch.object(agent_id_alloc, "_get_ddb", return_value=fake):
+            self.assertFalse(agent_id_alloc.touch_session_activity("ENC-SES-0FF"))
+
+    def test_touch_empty_session_id_is_noop_false(self):
+        self.assertFalse(agent_id_alloc.touch_session_activity(""))
+
+    def test_idle_reference_prefers_last_activity_at(self):
+        item = {"created_at": "2026-07-01T00:00:00Z",
+                "claimed_at": "2026-07-01T01:00:00Z",
+                "last_activity_at": "2026-07-02T05:00:00Z"}
+        self.assertEqual("2026-07-02T05:00:00Z", agent_id_alloc._idle_reference(item))
+
+    def test_idle_reference_falls_back_to_lifecycle_timestamps(self):
+        self.assertEqual(
+            "2026-07-01T01:00:00Z",
+            agent_id_alloc._idle_reference(
+                {"created_at": "2026-07-01T00:00:00Z",
+                 "claimed_at": "2026-07-01T01:00:00Z"}))
+        self.assertEqual(
+            "2026-07-01T00:00:00Z",
+            agent_id_alloc._idle_reference({"created_at": "2026-07-01T00:00:00Z"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -64,6 +64,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from transition_type_matrix import (
     MATRIX_VERSION,
+    CLOSED_EVIDENCE,
     DEPLOY_SUCCESS_EVIDENCE,
     IMMUTABLE_TRANSITION_TYPES,
     STRICTNESS_RANK,
@@ -164,8 +165,8 @@ ENABLE_LESSON_PRIMITIVE = _appconfig_flag("enable_lesson_primitive", env_fallbac
 _RECORD_TYPES = {"task", "issue", "feature", "lesson", "plan", "generation"}
 _CLOSED_STATUS = {"task": "closed", "issue": "closed", "feature": "completed", "lesson": "archived", "plan": "complete", "generation": "archived"}
 _DEFAULT_STATUS = {"task": "open", "issue": "open", "feature": "planned", "lesson": "draft", "plan": "drafted", "generation": "drafted"}
-_TRACKER_TYPE_SUFFIX = {"task": "TSK", "issue": "ISS", "feature": "FTR", "lesson": "LSN", "plan": "PLN", "generation": "GEN"}
-_ID_SEGMENT_TO_TYPE = {"TSK": "task", "ISS": "issue", "FTR": "feature", "LSN": "lesson", "PLN": "plan", "GEN": "generation"}
+_TRACKER_TYPE_SUFFIX = {"task": "TSK", "issue": "ISS", "feature": "FTR", "lesson": "LSN", "plan": "PLN", "generation": "GEN", "escalation": "ESC"}
+_ID_SEGMENT_TO_TYPE = {"TSK": "task", "ISS": "issue", "FTR": "feature", "LSN": "lesson", "PLN": "plan", "GEN": "generation", "ESC": "escalation"}
 
 # Category validation per record type
 _VALID_CATEGORIES = {
@@ -254,6 +255,323 @@ _REVERT_TRANSITIONS = {
         "started": {"incomplete"},
     },
 }
+
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 / ENC-TSK-J68 — Escalations: Human-Gated Mutation Override
+# Surface (DOC-5B888FCA43B8), Phase 1: entity + request/read surface.
+#
+# Escalation items live in the EXISTING tracker table (record_id =
+# "escalation#ENC-ESC-…"; no new table or GSI — Channel B purity). They are
+# deliberately NOT a member of _RECORD_TYPES: the generic record CRUD,
+# checkout, lifecycle, and tracker.set surfaces cannot touch them. The
+# escalation FSM below is enforced normally — escalations are not themselves
+# escalatable (§5.2). ENC-ESC IDs are minted by _next_record_id via the
+# "escalation" entry in _TRACKER_TYPE_SUFFIX (ID Boundary Rule holds).
+# ---------------------------------------------------------------------------
+ENABLE_ESCALATION_PRIMITIVE = _appconfig_flag(
+    "enable_escalation_primitive",
+    env_fallback="ENABLE_ESCALATION_PRIMITIVE",
+    default=True,
+)
+
+# §5.2 escalation status lifecycle. `failed` is terminal: a corrective
+# request is a NEW escalation (exactly-once semantics stay trivial).
+_ESCALATION_FSM = {
+    "requested": {"approved", "denied", "denied_with_guidance"},
+    "approved": {"applying"},
+    "applying": {"applied", "failed"},
+    "denied": set(),
+    "denied_with_guidance": set(),
+    "applied": set(),
+    "failed": set(),
+}
+_ESCALATION_STATUSES = set(_ESCALATION_FSM.keys())
+_ESCALATION_TARGET_TYPES = {"task", "issue", "feature"}
+
+
+def _statuses_for_record_type(record_type: str) -> set:
+    """Full dictionary-legal status universe for a record type.
+
+    Derived from the normal transition graph (keys ∪ targets) plus the
+    create-time default and the ENC-FTR-115 `superseded` alt-terminal.
+    Used by direct_state_override validation, which checks status LEGALITY
+    only — path legality is deliberately unchecked (§5.3): the path is
+    precisely what io's approval overrides.
+    """
+    graph = _VALID_TRANSITIONS.get(record_type, {})
+    statuses = set(graph.keys())
+    for targets in graph.values():
+        statuses |= set(targets)
+    default_status = _DEFAULT_STATUS.get(record_type)
+    if default_status:
+        statuses.add(default_status)
+    if record_type in ("task", "issue", "lesson"):
+        statuses.add("superseded")
+    return statuses
+
+
+def _validate_deploy_arc_change_payload(payload: Dict, target_record_type: str) -> str:
+    """§5.3 handler 1: request-time validation for deploy_arc_change."""
+    if target_record_type != "task":
+        return (
+            "deploy_arc_change targets must be task records; "
+            f"'{target_record_type}' records have no deploy arc."
+        )
+    new_arc = str(payload.get("new_deploy_arc_type") or "").strip()
+    if not new_arc:
+        return "Field 'payload.new_deploy_arc_type' is required for deploy_arc_change."
+    if new_arc not in VALID_TRANSITION_TYPES:
+        return (
+            f"Invalid new_deploy_arc_type '{new_arc}'. "
+            f"Allowed: {sorted(VALID_TRANSITION_TYPES)}"
+        )
+    return ""
+
+
+def _validate_direct_state_override_payload(payload: Dict, target_record_type: str) -> str:
+    """§5.3 handler 2: request-time validation for direct_state_override.
+
+    Confirms target_status is dictionary-legal for the record type. Path
+    legality is deliberately NOT checked here — that is what io approval
+    overrides.
+    """
+    target_status = str(payload.get("target_status") or "").strip()
+    if not target_status:
+        return "Field 'payload.target_status' is required for direct_state_override."
+    legal = _statuses_for_record_type(target_record_type)
+    if target_status not in legal:
+        return (
+            f"Invalid target_status '{target_status}' for record type "
+            f"'{target_record_type}'. Allowed: {sorted(legal)}"
+        )
+    field_values = payload.get("field_values")
+    if field_values is not None and not isinstance(field_values, dict):
+        return "Field 'payload.field_values' must be an object when supplied."
+    return ""
+
+
+def _escalation_waivable_fields(target: Dict, target_status: str) -> list:
+    """Required-for-state fields the waiver sentinel covers (§5.6).
+
+    Derived from the canonical transition matrix gate contracts: the fields a
+    record landing in target_status would normally have to prove. Fields the
+    escalation payload supplies (or the record already carries) are written
+    verbatim; the rest get the escalation_waived sentinel — never silent null.
+    """
+    record_type = str(target.get("record_type") or "")
+    arc = str(target.get("transition_type") or "github_pr_deploy")
+    fields = []
+    if record_type == "task":
+        if target_status == "committed":
+            fields.append("commit_sha")
+        elif target_status == "deploy-success":
+            gate = DEPLOY_SUCCESS_EVIDENCE.get(arc)
+            if gate:
+                fields.append(gate["evidence_key"])
+        elif target_status == "closed":
+            gate = CLOSED_EVIDENCE.get(arc)
+            if gate:
+                fields.append(gate["evidence_key"])
+    elif record_type == "issue" and target_status == "closed":
+        fields.append("evidence")
+    return fields
+
+
+def _escalation_waiver_sentinel(escalation_id: str, now: str) -> Dict:
+    """§5.6 sentinel in DynamoDB attribute shape: known-absent by human decision."""
+    return {"M": {
+        "escalation_waived": {"BOOL": True},
+        "escalation_id": {"S": escalation_id},
+        "waived_at": {"S": now},
+    }}
+
+
+def _escalation_provenance_note(escalation: Dict, before: Dict, after: Dict,
+                                waived: list) -> str:
+    """Structured worklog description for the target record (§5.5 step 6)."""
+    requested_by = escalation.get("requested_by") or {}
+    approved_by = escalation.get("approved_by") or {}
+    approver = approved_by.get("email") or approved_by.get("sub") or "io"
+    return (
+        f"[ESCALATION-APPLIED] {escalation.get('item_id')} "
+        f"({escalation.get('mutation_type')}) "
+        f"requested_by={requested_by.get('session_id', 'unknown')} "
+        f"approved_by={approver} "
+        f"before={json.dumps(before, default=str)} "
+        f"after={json.dumps(after, default=str)} "
+        f"waived={json.dumps(waived)}"
+    )
+
+
+def _apply_deploy_arc_change(project_id: str, escalation: Dict, target: Dict) -> Dict:
+    """§5.3 handler 1 apply: rewrite the task's deploy arc in place.
+
+    Single atomic UpdateItem. Checkout fields are deliberately untouched — an
+    active checkout survives. checkout_transition_type (the arc snapshot the
+    checkout service gates against) is rewritten alongside transition_type
+    when present, which is what recomputes the remaining-lifecycle
+    expectations. The ENC-FTR-060 sealing validator in _handle_update_field
+    is NOT modified — this dedicated entry point applies io's approved
+    override with escalation provenance as a write precondition.
+    """
+    new_arc = str((escalation.get("payload") or {}).get("new_deploy_arc_type") or "").strip()
+    if new_arc not in VALID_TRANSITION_TYPES:
+        raise ValueError(f"payload.new_deploy_arc_type '{new_arc}' is not a legal arc type")
+    target_sk = f"{target.get('record_type')}#{target.get('item_id')}"
+    escalation_id = str(escalation.get("item_id") or "")
+    now = _now_z()
+    before = {
+        "transition_type": target.get("transition_type"),
+        "checkout_transition_type": target.get("checkout_transition_type"),
+        "checkout_state": target.get("checkout_state"),
+    }
+    after = {
+        "transition_type": new_arc,
+        "checkout_transition_type": new_arc if target.get("checkout_transition_type") else target.get("checkout_transition_type"),
+        "checkout_state": target.get("checkout_state"),
+    }
+    note = _escalation_provenance_note(escalation, before, after, [])
+
+    update_parts = [
+        "#tt = :arc",
+        "updated_at = :now",
+        "last_update_note = :note",
+        "sync_version = if_not_exists(sync_version, :zero) + :one",
+        "history = list_append(if_not_exists(history, :empty), :hentry)",
+        "escalation_provenance = list_append(if_not_exists(escalation_provenance, :empty), :esc)",
+    ]
+    names = {"#tt": "transition_type"}
+    values = {
+        ":arc": _ser_s(new_arc),
+        ":now": _ser_s(now),
+        ":note": _ser_s(f"Deploy arc changed via escalation {escalation_id}"),
+        ":zero": {"N": "0"},
+        ":one": {"N": "1"},
+        ":empty": {"L": []},
+        ":hentry": {"L": [{"M": {
+            "timestamp": _ser_s(now),
+            "status": _ser_s("worklog"),
+            "description": _ser_s(note),
+        }}]},
+        ":esc": {"L": [_ser_s(escalation_id)]},
+    }
+    if target.get("checkout_transition_type"):
+        update_parts.append("checkout_transition_type = :arc")
+
+    _get_ddb().update_item(
+        TableName=DYNAMODB_TABLE,
+        Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+        UpdateExpression="SET " + ", ".join(update_parts),
+        ConditionExpression="attribute_exists(record_id)",
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+    return {"before": before, "after": after, "waived_fields": []}
+
+
+def _apply_direct_state_override(project_id: str, escalation: Dict, target: Dict) -> Dict:
+    """§5.3 handler 2 apply: land the record in target_status regardless of
+    path legality, with supplied field_values verbatim and §5.6 waiver
+    sentinels on every unsupplied required-for-state field. Closures set
+    escalated_closure=true (ENC-FTR-118 metric filter) and, for tasks,
+    increment closed_count for organic-gate parity. Single atomic UpdateItem —
+    a handler exception leaves the target untouched (no-partial-write).
+    """
+    payload = escalation.get("payload") or {}
+    target_status = str(payload.get("target_status") or "").strip()
+    field_values = payload.get("field_values") or {}
+    if not target_status:
+        raise ValueError("payload.target_status is required")
+    record_type = str(target.get("record_type") or "")
+    if target_status not in _statuses_for_record_type(record_type):
+        raise ValueError(
+            f"target_status '{target_status}' is not dictionary-legal for {record_type}")
+
+    target_sk = f"{record_type}#{target.get('item_id')}"
+    escalation_id = str(escalation.get("item_id") or "")
+    now = _now_z()
+    before = {"status": target.get("status")}
+    waivable = _escalation_waivable_fields(target, target_status)
+    waived = [
+        field for field in waivable
+        if field not in field_values and not target.get(field)
+    ]
+    is_closure = target_status == _CLOSED_STATUS.get(record_type, "closed")
+    after = {"status": target_status, "field_values": sorted(field_values.keys()),
+             "escalated_closure": is_closure}
+    note = _escalation_provenance_note(escalation, before, after, waived)
+
+    update_parts = [
+        "#st = :target_status",
+        "updated_at = :now",
+        "last_update_note = :note",
+        "sync_version = if_not_exists(sync_version, :zero) + :one",
+        "history = list_append(if_not_exists(history, :empty), :hentry)",
+        "escalation_provenance = list_append(if_not_exists(escalation_provenance, :empty), :esc)",
+    ]
+    names = {"#st": "status"}
+    values = {
+        ":target_status": _ser_s(target_status),
+        ":now": _ser_s(now),
+        ":note": _ser_s(f"Status override to '{target_status}' via escalation {escalation_id}"),
+        ":zero": {"N": "0"},
+        ":one": {"N": "1"},
+        ":empty": {"L": []},
+        ":hentry": {"L": [{"M": {
+            "timestamp": _ser_s(now),
+            "status": _ser_s("worklog"),
+            "description": _ser_s(note),
+        }}]},
+        ":esc": {"L": [_ser_s(escalation_id)]},
+    }
+    for index, (field, value) in enumerate(sorted(field_values.items())):
+        name_key = f"#fv{index}"
+        value_key = f":fv{index}"
+        update_parts.append(f"{name_key} = {value_key}")
+        names[name_key] = str(field)
+        values[value_key] = _ser_value(value)
+    for index, field in enumerate(waived):
+        name_key = f"#wv{index}"
+        value_key = f":wv{index}"
+        update_parts.append(f"{name_key} = {value_key}")
+        names[name_key] = field
+        values[value_key] = _escalation_waiver_sentinel(escalation_id, now)
+    update_expression = "SET " + ", ".join(update_parts)
+    if is_closure:
+        update_parts.append("escalated_closure = :esc_closure")
+        values[":esc_closure"] = {"BOOL": True}
+        update_expression = "SET " + ", ".join(update_parts)
+        if record_type == "task":
+            update_expression += " ADD closed_count :one_count"
+            values[":one_count"] = {"N": "1"}
+
+    _get_ddb().update_item(
+        TableName=DYNAMODB_TABLE,
+        Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+        UpdateExpression=update_expression,
+        ConditionExpression="attribute_exists(record_id)",
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+    return {"before": before, "after": after, "waived_fields": waived}
+
+
+# §5.3 mutation handler registry (v4-shaped). Each handler grows three
+# functions across the feature: validate_payload (request time, Ph1/ENC-TSK-J68),
+# render_diff (approval time, Ph3/ENC-TSK-J70), and apply (invoked ONLY by
+# applyEscalatedMutation after io approval, Ph2/ENC-TSK-J69). Adding a third
+# mutation type is a registry entry plus handler, not an architectural change.
+_ESCALATION_MUTATION_HANDLERS = {
+    "deploy_arc_change": {
+        "validate_payload": _validate_deploy_arc_change_payload,
+        "apply": _apply_deploy_arc_change,
+    },
+    "direct_state_override": {
+        "validate_payload": _validate_direct_state_override_payload,
+        "apply": _apply_direct_state_override,
+    },
+}
+
 
 # ENC-FTR-076 / ENC-TSK-E08: Component lifecycle transitions.
 # Components are registered in the component-registry table (separate from
@@ -417,6 +735,10 @@ def _validate_pillar_scores(raw_pillar_scores, record_type="lesson"):
 # EventBridge event config for reopen notifications
 EVENT_BUS = os.environ.get("EVENT_BUS", "default")
 EVENT_SOURCE = "enceladus.tracker"
+# ENC-FTR-121 Ph5 / ENC-TSK-J72: SNS topic for io's escalation email (§5.8).
+# Reuses the existing devops-feed-alerts topic (subject-prefixed [ESCALATION]);
+# empty/unset ARN disables publishing (logged skip — never fails the write).
+ESCALATION_ALERTS_TOPIC_ARN = os.environ.get("ESCALATION_ALERTS_TOPIC_ARN", "")
 EVENT_DETAIL_TYPE_REOPENED = "record.status.reopened"
 
 # Type segment mapping for SK construction
@@ -468,6 +790,48 @@ def _get_events():
     if _events_client is None:
         _events_client = boto3.client("events")
     return _events_client
+
+
+_sns_client = None
+
+
+def _get_sns():
+    global _sns_client
+    if _sns_client is None:
+        _sns_client = boto3.client("sns", region_name=DYNAMODB_REGION)
+    return _sns_client
+
+
+def _notify_escalation_event(kind: str, escalation_id: str, target_record_id: str,
+                             mutation_type: str, session_id: str, note: str = "") -> None:
+    """§5.8 io notification: best-effort SNS publish, failure-isolated by contract.
+
+    An SNS error (or an unset topic ARN) is logged and swallowed — notification
+    must never fail the escalation write. Subject is [ESCALATION]-prefixed for
+    inbox routing; expected volume is tens/month, inside the SNS email free
+    tier (sub-dollar budget).
+    """
+    if not ESCALATION_ALERTS_TOPIC_ARN:
+        logger.info("escalation notify skipped (%s %s): ESCALATION_ALERTS_TOPIC_ARN unset",
+                    kind, escalation_id)
+        return
+    try:
+        lines = [
+            f"Escalation {kind}: {escalation_id}",
+            f"Target: {target_record_id}",
+            f"Mutation: {mutation_type}",
+            f"Requested by: {session_id}",
+        ]
+        if note:
+            lines.append(f"Note: {note[:500]}")
+        lines.append("Review queue: PWA menu → Escalations")
+        _get_sns().publish(
+            TopicArn=ESCALATION_ALERTS_TOPIC_ARN,
+            Subject=f"[ESCALATION] {kind}: {escalation_id} ({mutation_type})"[:100],
+            Message="\n".join(lines),
+        )
+    except Exception as exc:  # noqa: BLE001 — §5.8 failure isolation
+        logger.error("escalation notify failed (%s %s): %s", kind, escalation_id, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -5064,11 +5428,523 @@ def _handle_list_relationships(project_id: str, query_params: Dict) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph1 / ENC-TSK-J68 — escalation request/read handlers
+# ---------------------------------------------------------------------------
+
+def _parse_escalation_target(target_record_id: str):
+    """Resolve (record_type, sort_key, error) for an escalation target ID.
+
+    Target IDs look like PREFIX-SEG-SEQ (e.g. ENC-TSK-J68); SEG resolves the
+    record type via _ID_SEGMENT_TO_TYPE and must be an escalatable type.
+    """
+    parts = str(target_record_id or "").strip().split("-")
+    if len(parts) < 3:
+        return None, None, (
+            "Field 'target_record_id' must look like PREFIX-SEG-SEQ "
+            "(e.g. ENC-TSK-123)."
+        )
+    segment = parts[1].upper()
+    record_type = _ID_SEGMENT_TO_TYPE.get(segment)
+    if record_type is None or record_type not in _ESCALATION_TARGET_TYPES:
+        return None, None, (
+            f"target_record_id type '{segment}' is not escalatable. "
+            "Allowed: task (TSK), issue (ISS), feature (FTR)."
+        )
+    return record_type, f"{record_type}#{target_record_id}", ""
+
+
+def _escalation_event(event_type: str, actor: str, detail: Optional[Dict] = None,
+                      guidance_note: str = "") -> Dict:
+    """Build one §11.2 event object in DynamoDB attribute shape (append-only)."""
+    event_attrs = {
+        "event_type": _ser_s(event_type),
+        "at": _ser_s(_now_z()),
+        "actor": _ser_s(actor or "system"),
+    }
+    if detail:
+        event_attrs["detail"] = _ser_s(json.dumps(detail, default=str))
+    if guidance_note:
+        event_attrs["guidance_note"] = _ser_s(guidance_note)
+    return {"M": event_attrs}
+
+
+def _escalation_public(item: Dict) -> Dict:
+    """Deserialize an escalation item for API responses (payload back to JSON)."""
+    record = _deser_item(item)
+    raw_payload = record.get("payload")
+    if isinstance(raw_payload, str):
+        try:
+            record["payload"] = json.loads(raw_payload)
+        except (ValueError, TypeError):
+            pass
+    for event in record.get("events") or []:
+        raw_detail = event.get("detail") if isinstance(event, dict) else None
+        if isinstance(raw_detail, str):
+            try:
+                event["detail"] = json.loads(raw_detail)
+            except (ValueError, TypeError):
+                pass
+    return record
+
+
+def _handle_escalation_request(project_id: str, body: Dict) -> Dict:
+    """POST /{project}/escalation — governed escalation.request (§5.4).
+
+    Validates the §11.1 envelope via the mutation-handler registry, mints an
+    ENC-ESC id server-side, writes the item with status=requested, and appends
+    the `requested` event. Malformed requests fail fast and write NOTHING —
+    they never reach io's queue.
+    """
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    target_record_id = str(body.get("target_record_id") or "").strip()
+    mutation_type = str(body.get("mutation_type") or "").strip()
+    payload = body.get("payload")
+    justification = str(body.get("justification") or "").strip()
+    expected_version = str(body.get("expected_version") or "").strip()
+
+    if not target_record_id:
+        return _error(400, "Field 'target_record_id' is required.")
+    handler = _ESCALATION_MUTATION_HANDLERS.get(mutation_type)
+    if handler is None:
+        return _error(
+            400,
+            f"Unknown mutation_type '{mutation_type}'. "
+            f"Allowed: {sorted(_ESCALATION_MUTATION_HANDLERS)}.",
+        )
+    if not isinstance(payload, dict) or not payload:
+        return _error(400, "Field 'payload' is required and must be a non-empty object.")
+    if not justification:
+        return _error(400, "Field 'justification' is required (free-text rationale for io).")
+
+    target_type, target_sk, target_err = _parse_escalation_target(target_record_id)
+    if target_err:
+        return _error(400, target_err)
+
+    requested_by_raw = body.get("requested_by")
+    requested_by = requested_by_raw if isinstance(requested_by_raw, dict) else {}
+    session_id = str(
+        requested_by.get("session_id")
+        or (body.get("write_source") or {}).get("provider")
+        or ""
+    ).strip()
+    if not session_id:
+        return _error(
+            400,
+            "Field 'requested_by.session_id' is required "
+            "(server-minted ENC-SES session id).",
+        )
+    agent_type_id = str(requested_by.get("agent_type_id") or "").strip()
+    sci_present = bool(requested_by.get("sci_present", False))
+
+    validation_error = handler["validate_payload"](payload, target_type)
+    if validation_error:
+        return _error(400, validation_error)
+
+    # Target must exist — read fresh, never trust the caller's snapshot.
+    ddb = _get_ddb()
+    try:
+        target_item = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation target read failed: %s", exc)
+        return _error(500, "Database read failed while validating target record.")
+    if not target_item:
+        return _error(404, f"Target record not found: {target_record_id}")
+
+    prefix = _get_project_prefix(project_id)
+    if not prefix:
+        return _error(404, f"Project '{project_id}' not found or has no prefix.")
+
+    escalation_id = _next_record_id(project_id, prefix, "escalation")
+    now = _now_z()
+    item = {
+        "project_id": _ser_s(project_id),
+        "record_id": _ser_s(f"escalation#{escalation_id}"),
+        "item_id": _ser_s(escalation_id),
+        "record_type": _ser_s("escalation"),
+        "target_record_id": _ser_s(target_record_id),
+        "target_record_type": _ser_s(target_type),
+        "mutation_type": _ser_s(mutation_type),
+        "payload": _ser_s(json.dumps(payload, default=str)),
+        "justification": _ser_s(justification),
+        "requested_by": {"M": {
+            "session_id": _ser_s(session_id),
+            "agent_type_id": _ser_s(agent_type_id),
+            "sci_present": {"BOOL": sci_present},
+        }},
+        "status": _ser_s("requested"),
+        "events": {"L": [_escalation_event(
+            "requested",
+            session_id,
+            detail={"mutation_type": mutation_type, "target_record_id": target_record_id},
+        )]},
+        "created_at": _ser_s(now),
+        "updated_at": _ser_s(now),
+        "write_source": _build_write_source(body),
+    }
+    if expected_version:
+        item["expected_version"] = _ser_s(expected_version)
+
+    try:
+        ddb.put_item(
+            TableName=DYNAMODB_TABLE,
+            Item=item,
+            ConditionExpression="attribute_not_exists(record_id)",
+        )
+    except Exception as exc:
+        logger.error("escalation put_item failed: %s", exc)
+        return _error(500, "Database write failed while creating escalation.")
+
+    # ENC-TSK-J72 (§5.8): push io's email AFTER the durable write; never fails it.
+    _notify_escalation_event(
+        "requested", escalation_id, target_record_id, mutation_type,
+        session_id, note=justification,
+    )
+
+    return _response(201, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": "requested",
+        "target_record_id": target_record_id,
+        "target_record_type": target_type,
+        "mutation_type": mutation_type,
+        "created_at": now,
+    })
+
+
+def _handle_escalation_get(project_id: str, escalation_id: str) -> Dict:
+    """GET /{project}/escalation/{id} — full escalation item (§5.4)."""
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+    ddb = _get_ddb()
+    try:
+        item = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation get_item failed: %s", exc)
+        return _error(500, "Database read failed.")
+    if not item:
+        return _error(404, f"Escalation not found: {escalation_id}")
+    return _response(200, {"success": True, "escalation": _escalation_public(item)})
+
+
+def _handle_escalation_list(project_id: str, query_params: Dict) -> Dict:
+    """GET /{project}/escalation — list with status/target/session filters (§5.4)."""
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    status_filter = str(query_params.get("status") or "").strip()
+    target_filter = str(query_params.get("target_record_id") or "").strip()
+    session_filter = str(query_params.get("session_id") or "").strip()
+    if status_filter and status_filter not in _ESCALATION_STATUSES:
+        return _error(
+            400,
+            f"Invalid status filter '{status_filter}'. "
+            f"Allowed: {sorted(_ESCALATION_STATUSES)}",
+        )
+    try:
+        page_size = max(1, min(int(query_params.get("page_size", "50")), 200))
+    except (TypeError, ValueError):
+        page_size = 50
+
+    ddb = _get_ddb()
+    key_values = {
+        ":pid": _ser_s(project_id),
+        ":esc_prefix": _ser_s("escalation#"),
+    }
+    filter_clauses = []
+    expression_names = {}
+    if status_filter:
+        filter_clauses.append("#st = :status_filter")
+        expression_names["#st"] = "status"
+        key_values[":status_filter"] = _ser_s(status_filter)
+    if target_filter:
+        filter_clauses.append("target_record_id = :target_filter")
+        key_values[":target_filter"] = _ser_s(target_filter)
+    if session_filter:
+        filter_clauses.append("requested_by.session_id = :session_filter")
+        key_values[":session_filter"] = _ser_s(session_filter)
+
+    kwargs = {
+        "TableName": DYNAMODB_TABLE,
+        "KeyConditionExpression": (
+            "project_id = :pid AND begins_with(record_id, :esc_prefix)"
+        ),
+        "ExpressionAttributeValues": key_values,
+    }
+    if filter_clauses:
+        kwargs["FilterExpression"] = " AND ".join(filter_clauses)
+    if expression_names:
+        kwargs["ExpressionAttributeNames"] = expression_names
+
+    escalations = []
+    try:
+        while True:
+            resp = ddb.query(**kwargs)
+            escalations.extend(
+                _escalation_public(raw) for raw in resp.get("Items", [])
+            )
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key or len(escalations) >= page_size:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+    except Exception as exc:
+        logger.error("escalation list query failed: %s", exc)
+        return _error(500, "Database query failed.")
+
+    escalations.sort(key=lambda esc: esc.get("created_at", ""), reverse=True)
+    escalations = escalations[:page_size]
+    return _response(200, {
+        "success": True,
+        "escalations": escalations,
+        "count": len(escalations),
+    })
+
+
+# ---------------------------------------------------------------------------
+# ENC-FTR-121 Ph2 / ENC-TSK-J69 — applyEscalatedMutation
+#
+# The SINGLE privileged code path that may write transitions the normal FSM
+# forbids (DOC-5B888FCA43B8 §5.5, Tenet 2). Reachable only through the
+# io-approval flow: the apply route no-ops unless the escalation is in
+# status=approved with applied_at unset, and status=approved is writable
+# ONLY by the Cognito-human approval route (Ph3/ENC-TSK-J70) — no MCP
+# action, SCI token, or internal key can approve. Validators in
+# _handle_update_field remain untouched and carry no bypass flags.
+# ---------------------------------------------------------------------------
+
+EVENT_DETAIL_TYPE_ESCALATION_APPLIED = "record.escalation.applied"
+
+
+def _escalation_fsm_transition(project_id: str, escalation_id: str,
+                               from_status: str, to_status: str, actor: str,
+                               detail: Optional[Dict] = None,
+                               extra_names: Optional[Dict] = None,
+                               extra_values: Optional[Dict] = None,
+                               extra_sets: Optional[list] = None,
+                               require_not_applied: bool = False) -> bool:
+    """Conditionally walk the escalation FSM one edge, appending the §11.2 event.
+
+    Returns False (without raising) when the ConditionExpression loses — the
+    concurrent-applier no-op path of the §5.5 idempotency contract.
+    """
+    if to_status not in _ESCALATION_FSM.get(from_status, set()):
+        raise ValueError(f"escalation FSM forbids {from_status}→{to_status}")
+    now = _now_z()
+    update_parts = [
+        "#st = :to_status",
+        "updated_at = :now",
+        "#ev = list_append(if_not_exists(#ev, :empty), :event)",
+    ] + (extra_sets or [])
+    names = {"#st": "status", "#ev": "events"}
+    names.update(extra_names or {})
+    values = {
+        ":to_status": _ser_s(to_status),
+        ":from_status": _ser_s(from_status),
+        ":now": _ser_s(now),
+        ":empty": {"L": []},
+        ":event": {"L": [_escalation_event(to_status, actor, detail=detail)]},
+    }
+    values.update(extra_values or {})
+    condition = "#st = :from_status"
+    if require_not_applied:
+        condition += " AND attribute_not_exists(applied_at)"
+    try:
+        _get_ddb().update_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ConditionExpression=condition,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _emit_escalation_applied_event(project_id: str, escalation: Dict,
+                                   result_detail: Dict) -> None:
+    """Best-effort audit-feed emission after a successful application."""
+    detail = {
+        "project_id": project_id,
+        "event": "escalation_applied",
+        "escalation_id": escalation.get("item_id"),
+        "target_record_id": escalation.get("target_record_id"),
+        "mutation_type": escalation.get("mutation_type"),
+        "requested_by": (escalation.get("requested_by") or {}).get("session_id"),
+        "approved_by": (escalation.get("approved_by") or {}).get("email")
+        or (escalation.get("approved_by") or {}).get("sub"),
+        "waived_fields": result_detail.get("waived_fields", []),
+        "applied_at": _now_z(),
+    }
+    try:
+        _get_events().put_events(Entries=[{
+            "Source": EVENT_SOURCE,
+            "DetailType": EVENT_DETAIL_TYPE_ESCALATION_APPLIED,
+            "Detail": json.dumps(detail, default=str),
+            "EventBusName": EVENT_BUS,
+        }])
+    except Exception as exc:
+        logger.error("escalation applied audit event emit failed: %s", exc)
+
+
+def _handle_escalation_apply(project_id: str, escalation_id: str, body: Dict) -> Dict:
+    """POST /{project}/escalation/{id}/apply — applyEscalatedMutation (§5.5).
+
+    Sequence: (1) approved + applied_at-null guard; (2) conditional
+    approved→applying transition (the concurrency gate — a losing racer
+    no-ops); (3) fresh target read; (4) expected_version drift was surfaced
+    at approval time, proceed on io's informed approval; (5) registry handler
+    apply — one atomic UpdateItem on the target; (6) provenance is stamped
+    inside that same write; (7) applying→applied with applied_at + result.
+    On handler exception: applying→failed with the error in result and no
+    partial target write.
+    """
+    if not ENABLE_ESCALATION_PRIMITIVE:
+        return _error(503, "Escalation primitive is disabled (enable_escalation_primitive).")
+
+    actor = str((body.get("write_source") or {}).get("provider") or "system")
+    ddb = _get_ddb()
+    try:
+        raw = ddb.get_item(
+            TableName=DYNAMODB_TABLE,
+            Key={
+                "project_id": _ser_s(project_id),
+                "record_id": _ser_s(f"escalation#{escalation_id}"),
+            },
+            ConsistentRead=True,
+        ).get("Item")
+    except Exception as exc:
+        logger.error("escalation apply read failed: %s", exc)
+        return _error(500, "Database read failed.")
+    if not raw:
+        return _error(404, f"Escalation not found: {escalation_id}")
+
+    escalation = _escalation_public(raw)
+    status = escalation.get("status")
+    if escalation.get("applied_at") or status == "applied":
+        return _response(200, {
+            "success": True, "no_op": True, "escalation_id": escalation_id,
+            "status": "applied",
+            "reason": "applied_at already set — exactly-once guard (§5.5 step 1)",
+        })
+    if status != "approved":
+        return _error(409, (
+            f"Escalation {escalation_id} is '{status}', not 'approved'. "
+            "Only the Cognito-human approval flow can authorize application."
+        ))
+
+    handler = _ESCALATION_MUTATION_HANDLERS.get(str(escalation.get("mutation_type")))
+    if handler is None or "apply" not in handler:
+        return _error(500, f"No apply handler for mutation_type '{escalation.get('mutation_type')}'.")
+
+    # Concurrency gate: exactly one applier wins approved→applying.
+    if not _escalation_fsm_transition(
+        project_id, escalation_id, "approved", "applying", actor,
+        detail={"target_record_id": escalation.get("target_record_id")},
+        require_not_applied=True,
+    ):
+        return _response(200, {
+            "success": True, "no_op": True, "escalation_id": escalation_id,
+            "reason": "concurrent applier holds the applying transition",
+        })
+
+    now = _now_z()
+    target_type, target_sk, target_err = _parse_escalation_target(
+        str(escalation.get("target_record_id") or ""))
+    result_detail = None
+    failure = ""
+    if target_err:
+        failure = target_err
+    else:
+        try:
+            target_raw = ddb.get_item(
+                TableName=DYNAMODB_TABLE,
+                Key={"project_id": _ser_s(project_id), "record_id": _ser_s(target_sk)},
+                ConsistentRead=True,
+            ).get("Item")
+            if not target_raw:
+                failure = f"Target record not found: {escalation.get('target_record_id')}"
+            else:
+                result_detail = handler["apply"](project_id, escalation, _deser_item(target_raw))
+        except Exception as exc:
+            logger.error("escalation apply handler failed: %s", exc)
+            failure = f"{type(exc).__name__}: {exc}"
+
+    if failure:
+        _escalation_fsm_transition(
+            project_id, escalation_id, "applying", "failed", "system",
+            detail={"error": failure},
+            extra_sets=["#res = :result"],
+            extra_names={"#res": "result"},
+            extra_values={":result": _ser_value({"success": False, "error": failure})},
+        )
+        # ENC-TSK-J72 (§5.8 optional terminal notification): closure telemetry
+        # for io without opening the PWA; same failure-isolation contract.
+        _notify_escalation_event(
+            "failed", escalation_id,
+            str(escalation.get("target_record_id") or ""),
+            str(escalation.get("mutation_type") or ""),
+            str((escalation.get("requested_by") or {}).get("session_id") or ""),
+            note=failure,
+        )
+        return _error(409, f"Escalation application failed (no partial write): {failure}")
+
+    _escalation_fsm_transition(
+        project_id, escalation_id, "applying", "applied", "system",
+        detail=result_detail,
+        extra_sets=["applied_at = :applied_at", "#res = :result"],
+        extra_names={"#res": "result"},
+        extra_values={
+            ":applied_at": _ser_s(now),
+            ":result": _ser_value({"success": True, **(result_detail or {})}),
+        },
+    )
+    _emit_escalation_applied_event(project_id, escalation, result_detail or {})
+    # ENC-TSK-J72 (§5.8 optional terminal notification): applied closure telemetry.
+    _notify_escalation_event(
+        "applied", escalation_id,
+        str(escalation.get("target_record_id") or ""),
+        str(escalation.get("mutation_type") or ""),
+        str((escalation.get("requested_by") or {}).get("session_id") or ""),
+        note=json.dumps(result_detail or {}, default=str)[:300],
+    )
+    return _response(200, {
+        "success": True,
+        "escalation_id": escalation_id,
+        "status": "applied",
+        "applied_at": now,
+        "result": result_detail,
+    })
+
+
+# ---------------------------------------------------------------------------
 # Path parsing & routing
 # ---------------------------------------------------------------------------
 
 # Route patterns — order matters (most specific first)
 _RE_PENDING_UPDATES = re.compile(r"^(?:/api/v1/tracker)?/pending-updates$")
+_RE_ESCALATION = re.compile(
+    r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/escalation"
+    r"(?:/(?P<id>[A-Za-z0-9_-]+)(?:/(?P<sub>apply))?)?$"
+)
 _RE_RELATIONSHIP = re.compile(
     r"^(?:/api/v1/tracker)?/(?P<project>[a-zA-Z0-9_-]+)/relationship$"
 )
@@ -5104,6 +5980,48 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         if auth_err:
             return auth_err
         return _handle_pending_updates(query_params)
+
+    # --- Route: escalations (ENC-FTR-121 Ph1+Ph2 / ENC-TSK-J68, ENC-TSK-J69) ---
+    m_escalation = _RE_ESCALATION.match(path)
+    if m_escalation:
+        project_id = m_escalation.group("project")
+        escalation_id = m_escalation.group("id")
+        escalation_sub = m_escalation.group("sub")
+        claims, auth_err = _authenticate(
+            event,
+            ["tracker:read"] if method == "GET" else ["tracker:write"],
+        )
+        if auth_err:
+            return auth_err
+        project_err = _validate_project_exists(project_id)
+        if project_err:
+            return _error(404, project_err)
+        if method == "POST" and escalation_sub == "apply":
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except (ValueError, TypeError):
+                return _error(400, "Invalid JSON body.")
+            _normalize_write_source(body, claims)
+            return _handle_escalation_apply(project_id, escalation_id, body)
+        elif method == "POST" and not escalation_id:
+            try:
+                body = json.loads(event.get("body") or "{}")
+            except (ValueError, TypeError):
+                return _error(400, "Invalid JSON body.")
+            _normalize_write_source(body, claims)
+            return _handle_escalation_request(project_id, body)
+        elif method == "GET" and escalation_id == "list":
+            # Pseudo-id alias: gamma APIGW registers {recordType}/{recordId}
+            # but not the bare {recordType} collection path, so the list
+            # surface rides GET /{project}/escalation/list (ENC-TSK-J69;
+            # found during ENC-TSK-J68 gamma validation). "list" can never
+            # collide with a server-minted ENC-ESC-* id.
+            return _handle_escalation_list(project_id, query_params)
+        elif method == "GET" and escalation_id:
+            return _handle_escalation_get(project_id, escalation_id)
+        elif method == "GET":
+            return _handle_escalation_list(project_id, query_params)
+        return _error(405, f"Method {method} not allowed on /escalation.")
 
     # --- Route: typed relationship edges (ENC-FTR-049) ---
     m_rel = _RE_RELATIONSHIP.match(path)

--- a/backend/lambda/tracker_mutation/test_escalation_applier_j69.py
+++ b/backend/lambda/tracker_mutation/test_escalation_applier_j69.py
@@ -1,0 +1,472 @@
+"""ENC-TSK-J69 (ENC-FTR-121 Ph2): applyEscalatedMutation applier tests.
+
+The applier is the single privileged code path allowed to write transitions
+the normal FSM forbids (DOC-5B888FCA43B8 Tenet 2) — the last line of defense,
+so it carries the feature's heaviest test weight: exactly-once semantics via
+the applied_at guard and the conditional approved→applying gate, the full
+approved→applying→applied|failed FSM walk with §11.2 events, checkout
+survival under deploy_arc_change, path-illegal direct_state_override
+(coding-complete→closed AND closed→pr), §5.6 escalation_waived sentinels,
+escalated_closure, provenance stamping, no-partial-write failure handling,
+and negative assertions that the normal validators acquired no bypass.
+"""
+import json
+import unittest
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+
+def _ccfe():
+    return ClientError(
+        {"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem")
+
+
+def _escalation_item(status="approved", mutation_type="deploy_arc_change",
+                     payload=None, target="ENC-TSK-J10", applied_at=None):
+    if payload is None:
+        payload = {"new_deploy_arc_type": "code_only"}
+    item = {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": "escalation#ENC-ESC-001"},
+        "item_id": {"S": "ENC-ESC-001"},
+        "record_type": {"S": "escalation"},
+        "status": {"S": status},
+        "mutation_type": {"S": mutation_type},
+        "target_record_id": {"S": target},
+        "payload": {"S": json.dumps(payload)},
+        "justification": {"S": "test"},
+        "requested_by": {"M": {
+            "session_id": {"S": "ENC-SES-02F"},
+            "agent_type_id": {"S": "ENC-AGT-006"},
+            "sci_present": {"BOOL": False},
+        }},
+        "approved_by": {"M": {"email": {"S": "io@jreese.net"}, "sub": {"S": "abc-123"}}},
+        "events": {"L": []},
+        "created_at": {"S": "2026-07-02T04:00:00Z"},
+        "updated_at": {"S": "2026-07-02T04:00:00Z"},
+    }
+    if applied_at:
+        item["applied_at"] = {"S": applied_at}
+    return item
+
+
+def _target_task(status="in-progress", transition_type="github_pr_deploy",
+                 checked_out=True, record_id="ENC-TSK-J10"):
+    item = {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": f"task#{record_id}"},
+        "item_id": {"S": record_id},
+        "record_type": {"S": "task"},
+        "status": {"S": status},
+        "title": {"S": "target"},
+        "transition_type": {"S": transition_type},
+    }
+    if checked_out:
+        item["checkout_state"] = {"S": "checked_out"}
+        item["checked_out_by"] = {"S": "ENC-SES-02C"}
+        item["checked_out_at"] = {"S": "2026-07-02T03:00:00Z"}
+        item["active_agent_session_id"] = {"S": "ENC-SES-02C"}
+        item["checkout_transition_type"] = {"S": transition_type}
+    return item
+
+
+class _FakeDdb:
+    """Routes get_item by record_id; records every update_item call."""
+
+    def __init__(self, escalation=None, target=None,
+                 fail_first_update=False, fail_target_update=False):
+        self.escalation = escalation
+        self.target = target
+        self.updates = []
+        self._fail_first_update = fail_first_update
+        self._fail_target_update = fail_target_update
+        self.exceptions = mock.MagicMock()
+
+    def get_item(self, TableName=None, Key=None, **kwargs):
+        record_id = (Key or {}).get("record_id", {}).get("S", "")
+        if record_id.startswith("escalation#") and self.escalation is not None:
+            return {"Item": self.escalation}
+        if record_id.startswith(("task#", "issue#", "feature#")) and self.target is not None:
+            return {"Item": self.target}
+        return {}
+
+    def update_item(self, **kwargs):
+        record_id = kwargs.get("Key", {}).get("record_id", {}).get("S", "")
+        if self._fail_first_update and not self.updates:
+            self.updates.append(kwargs)
+            raise _ccfe()
+        if self._fail_target_update and not record_id.startswith("escalation#"):
+            self.updates.append(kwargs)
+            raise RuntimeError("forced target write failure")
+        self.updates.append(kwargs)
+        return {}
+
+    def escalation_updates(self):
+        return [u for u in self.updates
+                if u["Key"]["record_id"]["S"].startswith("escalation#")]
+
+    def target_updates(self):
+        return [u for u in self.updates
+                if not u["Key"]["record_id"]["S"].startswith("escalation#")]
+
+
+class _ApplierBase(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._patches = [
+            mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True),
+            mock.patch.object(lf, "_get_events", return_value=mock.MagicMock()),
+        ]
+        for patch in self._patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in self._patches:
+            patch.stop()
+
+    def _apply(self, ddb, body=None):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb):
+            return self.lf._handle_escalation_apply(
+                "enceladus", "ENC-ESC-001",
+                body or {"write_source": {"provider": "ENC-SES-02F"}})
+
+
+class TestApplierGuards(_ApplierBase):
+    def test_already_applied_no_ops_without_any_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(
+            status="applied", applied_at="2026-07-02T04:05:00Z"))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertTrue(body["no_op"])
+        self.assertEqual([], ddb.updates)
+
+    def test_applied_at_set_but_status_stale_still_no_ops(self):
+        ddb = _FakeDdb(escalation=_escalation_item(
+            status="applying", applied_at="2026-07-02T04:05:00Z"))
+        resp = self._apply(ddb)
+        self.assertTrue(json.loads(resp["body"])["no_op"])
+        self.assertEqual([], ddb.updates)
+
+    def test_requested_status_refused_409(self):
+        ddb = _FakeDdb(escalation=_escalation_item(status="requested"))
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        self.assertIn("not 'approved'", json.loads(resp["body"])["error"])
+        self.assertEqual([], ddb.updates)
+
+    def test_denied_status_refused_409(self):
+        ddb = _FakeDdb(escalation=_escalation_item(status="denied"))
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+    def test_missing_escalation_404(self):
+        ddb = _FakeDdb(escalation=None)
+        resp = self._apply(ddb)
+        self.assertEqual(404, resp["statusCode"])
+
+    def test_concurrent_applier_losing_race_no_ops(self):
+        ddb = _FakeDdb(escalation=_escalation_item(),
+                       target=_target_task(), fail_first_update=True)
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertTrue(body["no_op"])
+        self.assertIn("concurrent", body["reason"])
+        # Only the losing conditional write was attempted — target untouched.
+        self.assertEqual([], ddb.target_updates())
+
+    def test_double_sequential_apply_is_exactly_once(self):
+        first = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp1 = self._apply(first)
+        self.assertEqual(200, resp1["statusCode"])
+        self.assertEqual(1, len(first.target_updates()))
+        # Second invocation sees the applied state; must be a pure no-op.
+        second = _FakeDdb(escalation=_escalation_item(
+            status="applied", applied_at="2026-07-02T04:06:00Z"))
+        resp2 = self._apply(second)
+        self.assertTrue(json.loads(resp2["body"])["no_op"])
+        self.assertEqual([], second.updates)
+
+    def test_flag_off_503(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        with mock.patch.object(self.lf, "ENABLE_ESCALATION_PRIMITIVE", False):
+            resp = self._apply(ddb)
+        self.assertEqual(503, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+
+class TestApplierFsmWalk(_ApplierBase):
+    def test_success_walks_applying_then_applied_with_events(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual("applied", body["status"])
+        self.assertTrue(body["applied_at"])
+        esc_updates = ddb.escalation_updates()
+        self.assertEqual(2, len(esc_updates))
+        applying, applied = esc_updates
+        self.assertEqual({"S": "applying"},
+                         applying["ExpressionAttributeValues"][":to_status"])
+        self.assertIn("attribute_not_exists(applied_at)",
+                      applying["ConditionExpression"])
+        applying_event = applying["ExpressionAttributeValues"][":event"]["L"][0]["M"]
+        self.assertEqual("applying", applying_event["event_type"]["S"])
+        self.assertEqual({"S": "applied"},
+                         applied["ExpressionAttributeValues"][":to_status"])
+        self.assertIn("applied_at = :applied_at",
+                      applied["UpdateExpression"])
+        self.assertEqual("result",
+                         applied["ExpressionAttributeNames"]["#res"])
+        applied_event = applied["ExpressionAttributeValues"][":event"]["L"][0]["M"]
+        self.assertEqual("applied", applied_event["event_type"]["S"])
+
+    def test_missing_target_fails_escalation_with_error_result(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=None)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        esc_updates = ddb.escalation_updates()
+        self.assertEqual(2, len(esc_updates))
+        failed = esc_updates[1]
+        self.assertEqual({"S": "failed"},
+                         failed["ExpressionAttributeValues"][":to_status"])
+        result = failed["ExpressionAttributeValues"][":result"]
+        self.assertIn("not found", json.dumps(result))
+        self.assertEqual([], ddb.target_updates())
+
+    def test_handler_exception_fails_escalation_no_partial_target_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task(),
+                       fail_target_update=True)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        failed = ddb.escalation_updates()[1]
+        self.assertEqual({"S": "failed"},
+                         failed["ExpressionAttributeValues"][":to_status"])
+        result_json = json.dumps(failed["ExpressionAttributeValues"][":result"])
+        self.assertIn("forced target write failure", result_json)
+        # The single atomic target UpdateItem raised — nothing partial landed.
+        self.assertEqual(1, len(ddb.target_updates()))
+
+    def test_unknown_mutation_type_500_before_any_transition(self):
+        ddb = _FakeDdb(escalation=_escalation_item(mutation_type="mystery"))
+        resp = self._apply(ddb)
+        self.assertEqual(500, resp["statusCode"])
+        self.assertEqual([], ddb.updates)
+
+    def test_applied_emits_audit_event(self):
+        events_client = mock.MagicMock()
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        with mock.patch.object(self.lf, "_get_events", return_value=events_client):
+            resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        entry = events_client.put_events.call_args.kwargs["Entries"][0]
+        self.assertEqual("record.escalation.applied", entry["DetailType"])
+        detail = json.loads(entry["Detail"])
+        self.assertEqual("ENC-ESC-001", detail["escalation_id"])
+        self.assertEqual("io@jreese.net", detail["approved_by"])
+
+    def test_escalation_fsm_helper_refuses_illegal_edges(self):
+        with self.assertRaises(ValueError):
+            self.lf._escalation_fsm_transition(
+                "enceladus", "ENC-ESC-001", "requested", "applied", "system")
+
+
+class TestDeployArcChangeApply(_ApplierBase):
+    def test_arc_rewrite_preserves_active_checkout(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task(checked_out=True))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertEqual("transition_type",
+                         target_update["ExpressionAttributeNames"]["#tt"])
+        self.assertEqual({"S": "code_only"},
+                         target_update["ExpressionAttributeValues"][":arc"])
+        # checkout_transition_type recomputed alongside the arc...
+        self.assertIn("checkout_transition_type = :arc", expression)
+        # ...while checkout ownership fields are untouched (checkout survives).
+        for forbidden in ("checked_out_by", "checkout_state", "checked_out_at",
+                          "active_agent_session_id"):
+            self.assertNotIn(forbidden, expression)
+
+    def test_arc_rewrite_without_checkout_snapshot_skips_mirror(self):
+        ddb = _FakeDdb(escalation=_escalation_item(),
+                       target=_target_task(checked_out=False))
+        self._apply(ddb)
+        expression = ddb.target_updates()[0]["UpdateExpression"]
+        self.assertNotIn("checkout_transition_type", expression)
+
+    def test_provenance_rides_the_same_atomic_write(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        self._apply(ddb)
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertIn("escalation_provenance = list_append", expression)
+        self.assertIn("history = list_append", expression)
+        history_entry = target_update["ExpressionAttributeValues"][":hentry"]["L"][0]["M"]
+        note = history_entry["description"]["S"]
+        self.assertIn("[ESCALATION-APPLIED] ENC-ESC-001", note)
+        self.assertIn("requested_by=ENC-SES-02F", note)
+        self.assertIn("approved_by=io@jreese.net", note)
+        self.assertIn("before=", note)
+        self.assertIn("after=", note)
+        provenance = target_update["ExpressionAttributeValues"][":esc"]["L"]
+        self.assertEqual([{"S": "ENC-ESC-001"}], provenance)
+
+
+def _override_escalation(target_status, field_values=None, target="ENC-TSK-J10"):
+    payload = {"target_status": target_status}
+    if field_values is not None:
+        payload["field_values"] = field_values
+    return _escalation_item(mutation_type="direct_state_override",
+                            payload=payload, target=target)
+
+
+class TestDirectStateOverrideApply(_ApplierBase):
+    def test_coding_complete_to_closed_waives_and_flags_closure(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("closed"),
+            target=_target_task(status="coding-complete", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        result = json.loads(resp["body"])["result"]
+        self.assertEqual(["live_validation_evidence"], result["waived_fields"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        values = target_update["ExpressionAttributeValues"]
+        names = target_update["ExpressionAttributeNames"]
+        self.assertEqual({"S": "closed"}, values[":target_status"])
+        self.assertEqual("live_validation_evidence", names["#wv0"])
+        sentinel = values[":wv0"]["M"]
+        self.assertTrue(sentinel["escalation_waived"]["BOOL"])
+        self.assertEqual("ENC-ESC-001", sentinel["escalation_id"]["S"])
+        self.assertIn("waived_at", sentinel)
+        self.assertIn("escalated_closure = :esc_closure", expression)
+        self.assertTrue(values[":esc_closure"]["BOOL"])
+        self.assertIn("ADD closed_count :one_count", expression)
+
+    def test_closed_to_pr_path_illegal_transition_lands(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("pr"),
+            target=_target_task(status="closed", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        values = target_update["ExpressionAttributeValues"]
+        self.assertEqual({"S": "pr"}, values[":target_status"])
+        expression = target_update["UpdateExpression"]
+        self.assertNotIn("escalated_closure", expression)
+        self.assertNotIn("closed_count", expression)
+        self.assertNotIn("#wv0", expression)
+
+    def test_supplied_field_values_written_verbatim_not_waived(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation(
+                "closed", {"live_validation_evidence": "gamma smoke 200 OK"}),
+            target=_target_task(status="deploy-success", checked_out=False))
+        resp = self._apply(ddb)
+        result = json.loads(resp["body"])["result"]
+        self.assertEqual([], result["waived_fields"])
+        target_update = ddb.target_updates()[0]
+        names = target_update["ExpressionAttributeNames"]
+        values = target_update["ExpressionAttributeValues"]
+        self.assertEqual("live_validation_evidence", names["#fv0"])
+        self.assertEqual({"S": "gamma smoke 200 OK"}, values[":fv0"])
+
+    def test_deploy_success_waives_arc_specific_evidence_key(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation("deploy-success"),
+            target=_target_task(status="pr", transition_type="web_deploy",
+                                checked_out=False))
+        self._apply(ddb)
+        names = ddb.target_updates()[0]["ExpressionAttributeNames"]
+        self.assertEqual("web_deploy_evidence", names["#wv0"])
+
+    def test_issue_closure_waives_evidence_without_closed_count(self):
+        issue = {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": "issue#ENC-ISS-441"},
+            "item_id": {"S": "ENC-ISS-441"},
+            "record_type": {"S": "issue"},
+            "status": {"S": "open"},
+        }
+        ddb = _FakeDdb(
+            escalation=_override_escalation("closed", target="ENC-ISS-441"),
+            target=issue)
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        target_update = ddb.target_updates()[0]
+        expression = target_update["UpdateExpression"]
+        self.assertEqual("evidence",
+                         target_update["ExpressionAttributeNames"]["#wv0"])
+        self.assertIn("escalated_closure", expression)
+        self.assertNotIn("closed_count", expression)
+
+    def test_works_on_closed_record_with_no_checkout(self):
+        ddb = _FakeDdb(
+            escalation=_override_escalation(
+                "deploy-success", {"deploy_evidence": {"id": 1, "conclusion": "success"}}),
+            target=_target_task(status="closed", checked_out=False))
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        self.assertEqual(1, len(ddb.target_updates()))
+
+
+class TestValidatorsUntouched(unittest.TestCase):
+    """AC-7: the normal FSM acquired no bypass — the applier is a separate path."""
+
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_normal_task_fsm_still_forbids_the_overridden_paths(self):
+        graph = self.lf._VALID_TRANSITIONS["task"]
+        self.assertNotIn("closed", graph)  # closed is terminal — no forward edges
+        self.assertNotIn("closed", graph["coding-complete"])  # no direct jump
+
+    def test_update_field_signature_carries_no_bypass_parameter(self):
+        import inspect
+        params = set(inspect.signature(self.lf._handle_update_field).parameters)
+        self.assertFalse(
+            {"escalation", "bypass", "override", "skip_validation"} & params,
+            "validator entry point must not grow bypass parameters")
+
+    def test_revert_transitions_unchanged(self):
+        self.assertEqual({"in-progress": {"open"}},
+                         self.lf._REVERT_TRANSITIONS["issue"])
+
+    def test_escalation_fsm_is_not_wired_into_normal_transitions(self):
+        for record_type_graph in self.lf._VALID_TRANSITIONS.values():
+            for status in record_type_graph:
+                self.assertNotIn(status, self.lf._ESCALATION_FSM.keys() - set())
+
+
+class TestApplyRouteRegex(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_apply_sub_path_matches(self):
+        match = self.lf._RE_ESCALATION.match(
+            "/api/v1/tracker/enceladus/escalation/ENC-ESC-001/apply")
+        self.assertIsNotNone(match)
+        self.assertEqual("ENC-ESC-001", match.group("id"))
+        self.assertEqual("apply", match.group("sub"))
+
+    def test_list_pseudo_id_matches_as_id(self):
+        match = self.lf._RE_ESCALATION.match("/enceladus/escalation/list")
+        self.assertIsNotNone(match)
+        self.assertEqual("list", match.group("id"))
+        self.assertIsNone(match.group("sub"))
+
+    def test_arbitrary_sub_does_not_match(self):
+        self.assertIsNone(self.lf._RE_ESCALATION.match(
+            "/enceladus/escalation/ENC-ESC-001/delete"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/tracker_mutation/test_escalation_j68.py
+++ b/backend/lambda/tracker_mutation/test_escalation_j68.py
@@ -1,0 +1,401 @@
+"""ENC-TSK-J68 (ENC-FTR-121 Ph1): Escalations entity + request/read surface tests.
+
+Covers, in the established tracker_mutation house style (no DDB round-trip):
+the mutation-handler registry validate_payload contracts (deploy_arc_change
+arc-type legality + task-only targets; direct_state_override status legality
+with path legality DELIBERATELY unchecked — that is what io approval
+overrides), the request handler's fail-fast envelope validation (malformed
+requests write NOTHING), server-side ENC-ESC minting through the existing
+atomic-counter ID authority, the `requested` event append shape (§11.2),
+get/list read paths with status/target/session filters, and the route regex.
+
+The applier (applyEscalatedMutation), waiver sentinels, and escalated_closure
+land in Ph2 (ENC-TSK-J69) with their own test weight.
+"""
+import json
+import unittest
+from unittest import mock
+
+
+def _fake_ddb(target_item=None, counter_next=7):
+    """MagicMock DDB serving the target read, the mint counter, and put capture.
+
+    get_item routes on the record_id key: counter#escalation returns a live
+    counter (so _next_record_id skips the seed scan); anything else returns
+    target_item (or nothing).
+    """
+    fake = mock.MagicMock()
+
+    def _get_item(TableName=None, Key=None, **kwargs):
+        record_id = (Key or {}).get("record_id", {}).get("S", "")
+        if record_id.startswith("counter#"):
+            return {"Item": {"next_num": {"N": str(counter_next - 1)}}}
+        if target_item is not None:
+            return {"Item": target_item}
+        return {}
+
+    fake.get_item.side_effect = _get_item
+    fake.update_item.return_value = {"Attributes": {"next_num": {"N": str(counter_next)}}}
+    return fake
+
+
+def _request_body(**overrides):
+    body = {
+        "target_record_id": "ENC-TSK-J10",
+        "mutation_type": "deploy_arc_change",
+        "payload": {"new_deploy_arc_type": "code_only"},
+        "justification": "Arc misclassified at create; task ships no deployable artifact.",
+        "requested_by": {"session_id": "ENC-SES-02F", "agent_type_id": "ENC-AGT-006"},
+    }
+    body.update(overrides)
+    return body
+
+
+_TARGET_TASK_ITEM = {
+    "project_id": {"S": "enceladus"},
+    "record_id": {"S": "task#ENC-TSK-J10"},
+    "item_id": {"S": "ENC-TSK-J10"},
+    "record_type": {"S": "task"},
+    "status": {"S": "open"},
+    "title": {"S": "target"},
+}
+
+
+class TestStatusUniverse(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_task_universe_includes_full_arc_and_superseded(self):
+        statuses = self.lf._statuses_for_record_type("task")
+        for expected in ("open", "in-progress", "coding-complete", "committed",
+                         "pr", "merged-main", "deploy-init", "deploy-success",
+                         "closed", "coding-updates", "superseded"):
+            self.assertIn(expected, statuses)
+
+    def test_issue_universe(self):
+        statuses = self.lf._statuses_for_record_type("issue")
+        self.assertEqual({"open", "in-progress", "closed", "superseded"}, statuses)
+
+    def test_feature_universe_has_no_superseded(self):
+        statuses = self.lf._statuses_for_record_type("feature")
+        self.assertIn("production", statuses)
+        self.assertNotIn("superseded", statuses)
+
+
+class TestDeployArcChangeValidation(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.validate = lf._ESCALATION_MUTATION_HANDLERS["deploy_arc_change"]["validate_payload"]
+
+    def test_legal_arc_on_task_passes(self):
+        self.assertEqual("", self.validate({"new_deploy_arc_type": "code_only"}, "task"))
+
+    def test_non_task_target_rejected(self):
+        err = self.validate({"new_deploy_arc_type": "code_only"}, "issue")
+        self.assertIn("task records", err)
+
+    def test_missing_arc_rejected(self):
+        self.assertIn("new_deploy_arc_type", self.validate({}, "task"))
+
+    def test_illegal_arc_rejected(self):
+        err = self.validate({"new_deploy_arc_type": "carrier_pigeon"}, "task")
+        self.assertIn("carrier_pigeon", err)
+        self.assertIn("github_pr_deploy", err)
+
+
+class TestDirectStateOverrideValidation(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.validate = lf._ESCALATION_MUTATION_HANDLERS["direct_state_override"]["validate_payload"]
+
+    def test_path_illegal_but_dictionary_legal_status_passes(self):
+        # closed -> pr is path-illegal in the normal FSM; the validator must
+        # accept it (status legality only) — path is what io approval overrides.
+        self.assertEqual("", self.validate({"target_status": "pr"}, "task"))
+
+    def test_terminal_closure_status_passes(self):
+        self.assertEqual("", self.validate({"target_status": "closed"}, "task"))
+
+    def test_superseded_passes_for_task(self):
+        self.assertEqual("", self.validate({"target_status": "superseded"}, "task"))
+
+    def test_status_from_wrong_type_universe_rejected(self):
+        err = self.validate({"target_status": "deploy-success"}, "issue")
+        self.assertIn("deploy-success", err)
+
+    def test_missing_target_status_rejected(self):
+        self.assertIn("target_status", self.validate({}, "task"))
+
+    def test_non_dict_field_values_rejected(self):
+        err = self.validate({"target_status": "closed", "field_values": "oops"}, "task")
+        self.assertIn("field_values", err)
+
+    def test_dict_field_values_passes(self):
+        payload = {"target_status": "closed", "field_values": {"live_validation_evidence": "gamma smoke ok"}}
+        self.assertEqual("", self.validate(payload, "task"))
+
+
+class TestTargetParse(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_task_issue_feature_targets_resolve(self):
+        for record_id, expected_type in (("ENC-TSK-J10", "task"), ("ENC-ISS-441", "issue"), ("ENC-FTR-121", "feature")):
+            record_type, sort_key, err = self.lf._parse_escalation_target(record_id)
+            self.assertEqual("", err)
+            self.assertEqual(expected_type, record_type)
+            self.assertEqual(f"{expected_type}#{record_id}", sort_key)
+
+    def test_lesson_target_rejected(self):
+        _, _, err = self.lf._parse_escalation_target("ENC-LSN-039")
+        self.assertIn("not escalatable", err)
+
+    def test_malformed_id_rejected(self):
+        _, _, err = self.lf._parse_escalation_target("garbage")
+        self.assertIn("PREFIX-SEG-SEQ", err)
+
+
+class TestEscalationRequest(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _run(self, body, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb), \
+             mock.patch.object(self.lf, "_get_project_prefix", return_value="ENC"):
+            return self.lf._handle_escalation_request("enceladus", body)
+
+    def test_happy_path_mints_and_writes_requested_item(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM, counter_next=7)
+        resp = self._run(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        payload = json.loads(resp["body"])
+        self.assertTrue(payload["success"])
+        self.assertEqual("requested", payload["status"])
+        self.assertRegex(payload["escalation_id"], r"^ENC-ESC-[A-Z0-9]{3}$")
+
+        self.assertEqual(1, ddb.put_item.call_count)
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual(f"escalation#{payload['escalation_id']}", item["record_id"]["S"])
+        self.assertEqual("escalation", item["record_type"]["S"])
+        self.assertEqual("requested", item["status"]["S"])
+        self.assertEqual("ENC-SES-02F", item["requested_by"]["M"]["session_id"]["S"])
+        self.assertFalse(item["requested_by"]["M"]["sci_present"]["BOOL"])
+        events = item["events"]["L"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("requested", events[0]["M"]["event_type"]["S"])
+        self.assertEqual("ENC-SES-02F", events[0]["M"]["actor"]["S"])
+        stored_payload = json.loads(item["payload"]["S"])
+        self.assertEqual("code_only", stored_payload["new_deploy_arc_type"])
+
+    def test_expected_version_persisted_when_supplied(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._run(_request_body(expected_version="sync_version:4"), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual("sync_version:4", item["expected_version"]["S"])
+
+    def test_session_falls_back_to_write_source_provider(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        body = _request_body(requested_by=None,
+                             write_source={"provider": "ENC-SES-02F", "channel": "mcp_server"})
+        resp = self._run(body, ddb)
+        self.assertEqual(201, resp["statusCode"])
+        item = ddb.put_item.call_args.kwargs["Item"]
+        self.assertEqual("ENC-SES-02F", item["requested_by"]["M"]["session_id"]["S"])
+
+    def _assert_rejected_without_write(self, body, status, fragment, target_item=_TARGET_TASK_ITEM):
+        ddb = _fake_ddb(target_item=target_item)
+        resp = self._run(body, ddb)
+        self.assertEqual(status, resp["statusCode"])
+        self.assertIn(fragment, json.loads(resp["body"])["error"])
+        ddb.put_item.assert_not_called()
+
+    def test_unknown_mutation_type_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(mutation_type="delete_everything"), 400, "delete_everything")
+
+    def test_missing_justification_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(justification=""), 400, "justification")
+
+    def test_missing_payload_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(payload=None), 400, "payload")
+
+    def test_missing_target_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(target_record_id=""), 400, "target_record_id")
+
+    def test_missing_session_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(requested_by={}), 400, "session_id")
+
+    def test_invalid_payload_for_handler_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(payload={"new_deploy_arc_type": "bogus"}), 400, "bogus")
+
+    def test_nonexistent_target_rejected_without_write(self):
+        self._assert_rejected_without_write(
+            _request_body(), 404, "not found", target_item=None)
+
+    def test_arc_change_on_issue_target_rejected_without_write(self):
+        body = _request_body(target_record_id="ENC-ISS-441")
+        self._assert_rejected_without_write(body, 400, "task records")
+
+    def test_flag_off_returns_503(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        with mock.patch.object(self.lf, "ENABLE_ESCALATION_PRIMITIVE", False):
+            resp = self._run(_request_body(), ddb)
+        self.assertEqual(503, resp["statusCode"])
+        ddb.put_item.assert_not_called()
+
+
+class TestEscalationGet(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def test_found_returns_deserialized_escalation_with_parsed_payload(self):
+        item = {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": "escalation#ENC-ESC-001"},
+            "item_id": {"S": "ENC-ESC-001"},
+            "record_type": {"S": "escalation"},
+            "status": {"S": "requested"},
+            "payload": {"S": json.dumps({"target_status": "closed"})},
+            "events": {"L": [{"M": {
+                "event_type": {"S": "requested"},
+                "at": {"S": "2026-07-02T04:00:00Z"},
+                "actor": {"S": "ENC-SES-02F"},
+                "detail": {"S": json.dumps({"mutation_type": "direct_state_override"})},
+            }}]},
+        }
+        fake = mock.MagicMock()
+        fake.get_item.return_value = {"Item": item}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_get("enceladus", "ENC-ESC-001")
+        self.assertEqual(200, resp["statusCode"])
+        escalation = json.loads(resp["body"])["escalation"]
+        self.assertEqual({"target_status": "closed"}, escalation["payload"])
+        self.assertEqual("direct_state_override", escalation["events"][0]["detail"]["mutation_type"])
+        key = fake.get_item.call_args.kwargs["Key"]
+        self.assertEqual("escalation#ENC-ESC-001", key["record_id"]["S"])
+
+    def test_missing_returns_404(self):
+        fake = mock.MagicMock()
+        fake.get_item.return_value = {}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_get("enceladus", "ENC-ESC-999")
+        self.assertEqual(404, resp["statusCode"])
+
+
+class TestEscalationList(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._flag = mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True)
+        self._flag.start()
+
+    def tearDown(self):
+        self._flag.stop()
+
+    def _item(self, esc_id, created_at):
+        return {
+            "project_id": {"S": "enceladus"},
+            "record_id": {"S": f"escalation#{esc_id}"},
+            "item_id": {"S": esc_id},
+            "record_type": {"S": "escalation"},
+            "status": {"S": "requested"},
+            "payload": {"S": "{}"},
+            "created_at": {"S": created_at},
+        }
+
+    def _run(self, query_params, items):
+        fake = mock.MagicMock()
+        fake.query.return_value = {"Items": items}
+        with mock.patch.object(self.lf, "_get_ddb", return_value=fake):
+            resp = self.lf._handle_escalation_list("enceladus", query_params)
+        return resp, fake
+
+    def test_unfiltered_list_sorts_newest_first(self):
+        items = [self._item("ENC-ESC-001", "2026-07-02T01:00:00Z"),
+                 self._item("ENC-ESC-002", "2026-07-02T03:00:00Z")]
+        resp, fake = self._run({}, items)
+        self.assertEqual(200, resp["statusCode"])
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+        self.assertEqual("ENC-ESC-002", body["escalations"][0]["item_id"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("begins_with(record_id, :esc_prefix)", kwargs["KeyConditionExpression"])
+        self.assertNotIn("FilterExpression", kwargs)
+
+    def test_status_filter_lands_in_filter_expression(self):
+        resp, fake = self._run({"status": "requested"}, [])
+        self.assertEqual(200, resp["statusCode"])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("#st = :status_filter", kwargs["FilterExpression"])
+        self.assertEqual({"#st": "status"}, kwargs["ExpressionAttributeNames"])
+        self.assertEqual({"S": "requested"}, kwargs["ExpressionAttributeValues"][":status_filter"])
+
+    def test_target_and_session_filters_compose(self):
+        resp, fake = self._run(
+            {"target_record_id": "ENC-TSK-J10", "session_id": "ENC-SES-02F"}, [])
+        kwargs = fake.query.call_args.kwargs
+        self.assertIn("target_record_id = :target_filter", kwargs["FilterExpression"])
+        self.assertIn("requested_by.session_id = :session_filter", kwargs["FilterExpression"])
+        self.assertIn(" AND ", kwargs["FilterExpression"])
+
+    def test_invalid_status_filter_rejected(self):
+        resp, fake = self._run({"status": "pending"}, [])
+        self.assertEqual(400, resp["statusCode"])
+        fake.query.assert_not_called()
+
+    def test_page_size_clamped(self):
+        items = [self._item(f"ENC-ESC-{i:03d}", f"2026-07-02T0{i}:00:00Z") for i in range(1, 4)]
+        resp, _ = self._run({"page_size": "2"}, items)
+        body = json.loads(resp["body"])
+        self.assertEqual(2, body["count"])
+
+
+class TestEscalationRoute(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_regex_matches_collection_and_item_paths(self):
+        for path, expected_id in (
+            ("/api/v1/tracker/enceladus/escalation", None),
+            ("/enceladus/escalation", None),
+            ("/api/v1/tracker/enceladus/escalation/ENC-ESC-001", "ENC-ESC-001"),
+        ):
+            match = self.lf._RE_ESCALATION.match(path)
+            self.assertIsNotNone(match, path)
+            self.assertEqual("enceladus", match.group("project"))
+            self.assertEqual(expected_id, match.group("id"))
+
+    def test_regex_does_not_swallow_other_routes(self):
+        self.assertIsNone(self.lf._RE_ESCALATION.match("/enceladus/task"))
+        self.assertIsNone(self.lf._RE_ESCALATION.match("/enceladus/task/ENC-TSK-J10"))
+
+    def test_escalation_never_joined_generic_record_types(self):
+        # Guard: escalations must stay OUT of the generic CRUD surface.
+        self.assertNotIn("escalation", self.lf._RECORD_TYPES)
+        self.assertEqual("ESC", self.lf._TRACKER_TYPE_SUFFIX["escalation"])
+        self.assertEqual("escalation", self.lf._ID_SEGMENT_TO_TYPE["ESC"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/tracker_mutation/test_escalation_notify_j72.py
+++ b/backend/lambda/tracker_mutation/test_escalation_notify_j72.py
@@ -1,0 +1,116 @@
+"""ENC-TSK-J72 (ENC-FTR-121 Ph5): escalation SNS notification tests.
+
+Covers: exactly one [ESCALATION]-prefixed publish on a successful
+escalation.request (after the durable write, carrying escalation_id, target,
+mutation type, requesting session, and the justification excerpt); §5.8
+failure isolation (a raising SNS client never fails the request or applier);
+no publish on request-validation failures (nothing reached io's queue);
+terminal applied/failed notifications; and the unset-ARN skip path.
+"""
+import json
+import unittest
+from unittest import mock
+
+from test_escalation_j68 import _fake_ddb, _request_body, _TARGET_TASK_ITEM
+from test_escalation_applier_j69 import _FakeDdb, _escalation_item, _target_task
+
+
+class _NotifyBase(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+        self._patches = [
+            mock.patch.object(lf, "ENABLE_ESCALATION_PRIMITIVE", True),
+            mock.patch.object(lf, "ESCALATION_ALERTS_TOPIC_ARN",
+                              "arn:aws:sns:us-west-2:1:devops-feed-alerts-test"),
+            mock.patch.object(lf, "_get_events", return_value=mock.MagicMock()),
+        ]
+        for patch in self._patches:
+            patch.start()
+        self.sns = mock.MagicMock()
+        self._sns_patch = mock.patch.object(self.lf, "_get_sns", return_value=self.sns)
+        self._sns_patch.start()
+
+    def tearDown(self):
+        self._sns_patch.stop()
+        for patch in self._patches:
+            patch.stop()
+
+
+class TestRequestNotification(_NotifyBase):
+    def _request(self, body, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb), \
+             mock.patch.object(self.lf, "_get_project_prefix", return_value="ENC"):
+            return self.lf._handle_escalation_request("enceladus", body)
+
+    def test_successful_request_publishes_exactly_one_escalation_email(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM, counter_next=7)
+        resp = self._request(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        self.assertEqual(1, self.sns.publish.call_count)
+        kwargs = self.sns.publish.call_args.kwargs
+        self.assertTrue(kwargs["Subject"].startswith("[ESCALATION] requested:"))
+        self.assertIn("deploy_arc_change", kwargs["Subject"])
+        message = kwargs["Message"]
+        escalation_id = json.loads(resp["body"])["escalation_id"]
+        self.assertIn(escalation_id, message)
+        self.assertIn("ENC-TSK-J10", message)
+        self.assertIn("ENC-SES-02F", message)
+        self.assertIn("Arc misclassified at create", message)
+        self.assertEqual(kwargs["TopicArn"],
+                         "arn:aws:sns:us-west-2:1:devops-feed-alerts-test")
+
+    def test_publish_happens_after_write_and_failure_never_fails_request(self):
+        self.sns.publish.side_effect = RuntimeError("SNS down")
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._request(_request_body(), ddb)
+        # The escalation write succeeded and the response is still 201.
+        self.assertEqual(201, resp["statusCode"])
+        self.assertEqual(1, ddb.put_item.call_count)
+
+    def test_validation_failure_publishes_nothing(self):
+        ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+        resp = self._request(_request_body(justification=""), ddb)
+        self.assertEqual(400, resp["statusCode"])
+        self.sns.publish.assert_not_called()
+
+    def test_unset_topic_arn_skips_publish_without_error(self):
+        with mock.patch.object(self.lf, "ESCALATION_ALERTS_TOPIC_ARN", ""):
+            ddb = _fake_ddb(target_item=_TARGET_TASK_ITEM)
+            resp = self._request(_request_body(), ddb)
+        self.assertEqual(201, resp["statusCode"])
+        self.sns.publish.assert_not_called()
+
+
+class TestTerminalNotifications(_NotifyBase):
+    def _apply(self, ddb):
+        with mock.patch.object(self.lf, "_get_ddb", return_value=ddb):
+            return self.lf._handle_escalation_apply(
+                "enceladus", "ENC-ESC-001",
+                {"write_source": {"provider": "io:test"}})
+
+    def test_applied_sends_terminal_notification(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        subjects = [call.kwargs["Subject"] for call in self.sns.publish.call_args_list]
+        self.assertTrue(any(s.startswith("[ESCALATION] applied: ENC-ESC-001") for s in subjects))
+
+    def test_failed_sends_terminal_notification_with_error_note(self):
+        ddb = _FakeDdb(escalation=_escalation_item(), target=None)
+        resp = self._apply(ddb)
+        self.assertEqual(409, resp["statusCode"])
+        kwargs = self.sns.publish.call_args.kwargs
+        self.assertTrue(kwargs["Subject"].startswith("[ESCALATION] failed: ENC-ESC-001"))
+        self.assertIn("not found", kwargs["Message"])
+
+    def test_terminal_publish_failure_does_not_break_applier(self):
+        self.sns.publish.side_effect = RuntimeError("SNS down")
+        ddb = _FakeDdb(escalation=_escalation_item(), target=_target_task())
+        resp = self._apply(ddb)
+        self.assertEqual(200, resp["statusCode"])
+        self.assertEqual("applied", json.loads(resp["body"])["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -231,6 +231,10 @@ ENABLE_LESSON_PRIMITIVE = _appconfig_flag("enable_lesson_primitive", env_fallbac
 ENABLE_HANDOFF_PRIMITIVE = _appconfig_flag("enable_handoff_primitive", env_fallback="ENABLE_HANDOFF_PRIMITIVE")
 # ENC-FTR-076 / ENC-TSK-E08
 ENABLE_COMPONENT_PROPOSAL = _appconfig_flag("enable_component_proposal", env_fallback="ENABLE_COMPONENT_PROPOSAL")
+# ENC-FTR-121 / ENC-TSK-J68: Escalations — human-gated mutation override surface
+# (DOC-5B888FCA43B8). Default ON: the request/read surface is inert unless
+# called and carries no privileged write path (the applier is io-approval-gated).
+ENABLE_ESCALATION_PRIMITIVE = _appconfig_flag("enable_escalation_primitive", env_fallback="ENABLE_ESCALATION_PRIMITIVE", default=True)
 
 TRACKER_API_INTERNAL_API_KEY = os.environ.get(
     "ENCELADUS_TRACKER_API_INTERNAL_API_KEY",
@@ -5954,6 +5958,88 @@ async def _tracker_create(args: dict) -> list[TextContent]:
     resp = _tracker_api_request("POST", f"/{project_id}/{record_type}", payload=payload)
     return _result_text(resp)
 
+
+# --- ENC-FTR-121 / ENC-TSK-J68: Escalations request/read surface ------------
+# escalation.request proposes a lifecycle-forbidden mutation for io approval.
+# The backend validates the envelope via its mutation-handler registry and
+# mints the ENC-ESC id server-side (ID Boundary Rule). approve/deny have NO
+# MCP surface by design — they exist only behind the Cognito human path (§6).
+
+
+async def _escalation_request(args: dict) -> list[TextContent]:
+    governance_error = _require_governance_hash(args)
+    if governance_error:
+        return _result_text({"error": governance_error})
+
+    project_id = args["project_id"]
+    payload: Dict[str, Any] = {
+        "target_record_id": args.get("target_record_id", ""),
+        "mutation_type": args.get("mutation_type", ""),
+        "payload": args.get("payload"),
+        "justification": args.get("justification", ""),
+        "governance_hash": args.get("governance_hash", ""),
+    }
+    for optional_key in ("expected_version", "requested_by", "provider",
+                         "coordination_request_id", "dispatch_id"):
+        if args.get(optional_key) is not None:
+            payload[optional_key] = args[optional_key]
+
+    resp = _tracker_api_request("POST", f"/{project_id}/escalation", payload=payload)
+    return _result_text(resp)
+
+
+async def _escalation_get(args: dict) -> list[TextContent]:
+    project_id = args.get("project_id", "")
+    escalation_id = str(args.get("escalation_id", "")).strip()
+    if not escalation_id:
+        return _result_text({"error": "Field 'escalation_id' is required."})
+    if not project_id:
+        return _result_text({"error": "Field 'project_id' is required."})
+    resp = _tracker_api_request("GET", f"/{project_id}/escalation/{escalation_id}")
+    return _result_text(resp)
+
+
+async def _escalation_list(args: dict) -> list[TextContent]:
+    project_id = args.get("project_id", "")
+    if not project_id:
+        return _result_text({"error": "Field 'project_id' is required."})
+    query = {
+        "status": args.get("status"),
+        "target_record_id": args.get("target_record_id"),
+        "session_id": args.get("session_id"),
+        "page_size": args.get("page_size"),
+    }
+    # ENC-TSK-J69: the "list" pseudo-id rides the API Gateway route
+    # GET /{projectId}/{recordType}/{recordId} — the bare collection path has
+    # no registered route on the explicit (gamma-style) route tables.
+    resp = _tracker_api_request("GET", f"/{project_id}/escalation/list", query=query)
+    return _result_text(resp)
+
+
+async def _escalation_watch(args: dict) -> list[TextContent]:
+    """ENC-TSK-J71 (Ph4): cursor-based escalation event polling.
+
+    Streams §11.2 lifecycle events for every escalation the calling session
+    originated and refreshes the session's last_activity_at heartbeat so a
+    listening agent survives the idle sweep (§5.9). Pass the returned
+    next_cursor back as `since`. Recommended cadence: 15-30s, exponential
+    backoff after two idle hours (§5.8).
+    """
+    session_id = str(args.get("session_id") or "").strip()
+    if not session_id:
+        return _result_text({"error": "Field 'session_id' is required (ENC-SES-*)."})
+    query = {
+        "session_id": session_id,
+        "since": args.get("since"),
+        "project_id": args.get("project_id"),
+    }
+    # ENC-TSK-J89: path is RELATIVE to COORDINATION_API_BASE (which already ends
+    # in /api/v1/coordination) — the absolute form double-prefixed and 404'd.
+    resp = _coordination_api_request(
+        "GET", "/escalations/watch", query=query)
+    return _result_text(resp)
+
+
 # --- Acceptance Criteria Evidence Handshake (§7.1.1) ---
 
 
@@ -7506,6 +7592,25 @@ if ENABLE_TYPED_RELATIONSHIPS:
     }
     _SEARCH_ACTIONS["tracker.list_relationships"] = {
         "tool": "tracker_list_relationships",
+    }
+
+# ENC-FTR-121 / ENC-TSK-J68: Escalations — governed request/read surface.
+# escalation.request proposes a lifecycle-forbidden mutation for io approval;
+# approve/deny deliberately have NO MCP action (Cognito human path only, §6).
+if ENABLE_ESCALATION_PRIMITIVE:
+    _EXECUTE_ACTIONS["escalation.request"] = {
+        "tool": "escalation_request", "requires_governance_hash": True,
+    }
+    _SEARCH_ACTIONS["escalation.get"] = {
+        "tool": "escalation_get",
+    }
+    _SEARCH_ACTIONS["escalation.list"] = {
+        "tool": "escalation_list",
+    }
+    # ENC-TSK-J71 (Ph4): session-scoped cursor polling — the listening agent's
+    # side of the loop (§5.4 coordination surface, §5.9 activity rule).
+    _COORDINATION_ACTIONS["escalation.watch"] = {
+        "tool": "escalation_watch",
     }
 
 # ENC-FTR-052: Conditionally register lesson actions behind feature flag
@@ -10275,6 +10380,12 @@ _TOOL_HANDLERS = {
     "github_create_issue": _github_create_issue,
     "github_projects_sync": _github_projects_sync,
     "github_projects_list": _github_projects_list,
+    # ENC-FTR-121 / ENC-TSK-J68: Escalations request/read surface
+    "escalation_request": _escalation_request,
+    "escalation_get": _escalation_get,
+    "escalation_list": _escalation_list,
+    # ENC-FTR-121 / ENC-TSK-J71: session-scoped event polling
+    "escalation_watch": _escalation_watch,
     # ENC-FTR-047: Graph search
     "tracker_graphsearch": _tracker_graphsearch,
     # ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read

--- a/tools/enceladus-mcp-server/test_escalation_watch_path_j89.py
+++ b/tools/enceladus-mcp-server/test_escalation_watch_path_j89.py
@@ -1,0 +1,68 @@
+"""ENC-TSK-J89: escalation.watch must call the coordination API with a path
+RELATIVE to COORDINATION_API_BASE.
+
+The base already ends in /api/v1/coordination; the original handler passed the
+absolute route and double-prefixed the URL, 404ing on both gamma and prod while
+every unit test mocked the helper. These tests pin the composed URL itself so a
+prefix regression can never be mock-blind again.
+"""
+import asyncio
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import uuid
+from unittest.mock import patch
+
+MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _load_server(**env):
+    module_name = f"enceladus_server_watch_path_{uuid.uuid4().hex}"
+    with patch.dict(os.environ, env, clear=False):
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+def test_watch_path_is_base_relative_and_never_double_prefixed():
+    server = _load_server(
+        ENCELADUS_COORDINATION_API_BASE="https://example.test/api/v1/coordination")
+    captured = {}
+
+    def fake_request(method, path="", payload=None, query=None):
+        base = server.COORDINATION_API_BASE.rstrip("/")
+        route = path if path.startswith("/") else (f"/{path}" if path else "")
+        captured["url"] = f"{base}{route}"
+        captured["path"] = path
+        return {"success": True, "events": [], "next_cursor": "e30"}
+
+    with patch.object(server, "_coordination_api_request", side_effect=fake_request):
+        result = _run(server._escalation_watch(
+            {"session_id": "ENC-SES-02F", "project_id": "enceladus"}))
+
+    assert captured["path"] == "/escalations/watch"
+    assert captured["url"] == (
+        "https://example.test/api/v1/coordination/escalations/watch")
+    assert "/api/v1/coordination/api/v1/coordination" not in captured["url"]
+    payload = json.loads(result[0].text)
+    assert payload["success"] is True
+
+
+def test_watch_requires_session_id():
+    server = _load_server()
+    result = _run(server._escalation_watch({"project_id": "enceladus"}))
+    payload = json.loads(result[0].text)
+    assert "session_id" in payload.get("error", "")


### PR DESCRIPTION
## Summary

The 2026-07-08T22:25:44Z main-ref Gen2 deploy (cb71380) reverted the FTR-121 escalation
surface from v3-prod alongside FTR-122 SCI (ENC-TSK-M44 / PR #974 restored SCI only).
`execute()` no longer resolves action `escalation.request` on prod. This PR is the M44
sibling: it restores FTR-121 by landing the escalation code on `main` so a routine
`main`-ref v3-prod deploy no longer reverts it (DOC-B716E8FB10B6 COE / registry).

## What's grafted

Extraction was **surgical by function/hunk, not by commit** — v4/main's J68/J69/J70/J71/J72
commits are git-history-entangled with unrelated large features not present on `main`
(ENC-TSK-I07 supersession primitive, ENC-TSK-I08/I09 dedup-review, ENC-TSK-J46/FTR-096
lesson-candidate curation). Cherry-picking whole commits drags all of that in; instead each
3-way-merge conflict was resolved by keeping only the escalation-bounded content and
discarding the rest.

- `tracker_mutation/lambda_function.py`: escalation entity + FSM + mutation-handler registry
  + request/get/list handlers (J68), `applyEscalatedMutation` applier (J69), SNS
  `[ESCALATION]` notify hook (J72).
- `coordination_api/lambda_function.py`: io approval queue feed + approve/deny decision
  handlers (J70 **backend portion only** — PWA already on main via ENC-TSK-J82, CFN already
  on main via ENC-TSK-J80), agent-side `escalation.watch` cursor poll (J71).
- `coordination_api/agent_id_alloc.py`: `touch_session_activity` heartbeat (J71).
- `tools/enceladus-mcp-server/server.py`: `escalation.request`/`get`/`list` (J68) and
  `escalation.watch` (J71) code-mode actions, with the ENC-TSK-J89 base-relative-path fix
  folded in directly.
- `governance_data_dictionary.json` → 2026-07-09.1: new `tracker.escalation`,
  `mcp_server.escalation_actions`, `coordination.escalations` entities.
- Ported the J68/J69/J71/J72 + J89 unit tests, fixed to main's `_agent_alloc` import alias
  (cosmetic naming drift between branches — v4/main uses `_agent_id_alloc`).

**Not touched**: coordination_api's ENC-TSK-L92/M12 allowlist + human-principal checks
remain exclusively in the standalone `escalation_decision_authorizer` Lambda per that
entity's existing prod-vs-gamma architectural split (already documented in the dictionary;
the gamma counterpart enforces the same checks in-Lambda). CFN routes/env (J80) and the PWA
Escalations page (J82) were already on `main` and are unmodified here.

## Test plan

- [x] `backend/lambda/tracker_mutation`: 331/331 passed (includes 76 ported escalation tests)
- [x] `backend/lambda/coordination_api`: 424/427 passed; the 3 failures
      (`test_component_opacity` x2, `test_decomposition_uses_tracker_helpers_with_metadata`)
      are pre-existing test-order-dependent flakes, reproduced identically on clean `main` HEAD
- [x] `tools/enceladus-mcp-server`: targeted `escalation.watch` path test (J89 regression) 2/2 passed
- [x] `python3 -m py_compile` clean on all four modified Python files
- [x] Diff-scanned for I07/I08/I09/J46/lesson-candidate/dedup content leakage — none found
- [ ] Live verification against prod (post-deploy, io-gated per DOC-B716E8FB10B6)

CCI-12da72bfb9f8415baff4d930c5b21594

🤖 Generated with [Claude Code](https://claude.com/claude-code)