### PR TITLE
ENC-TSK-M47: fix opensearch_request double-encoding bytes bodies

### DIFF
--- a/backend/lambda/graph_query_api/opensearch_keyword.py
+++ b/backend/lambda/graph_query_api/opensearch_keyword.py
@@ -95,7 +95,15 @@ def opensearch_request(method: str, path: str, body: Optional[Any] = None) -> Tu
         raise RuntimeError("OPENSEARCH_ENDPOINT is not configured")
     url = f"{OPENSEARCH_ENDPOINT}{path}"
     data = None
-    if body is not None:
+    if isinstance(body, bytes):
+        # ENC-TSK-M39: msearch's ndjson bodies are pre-built by the caller
+        # (a single json.dumps per header/query line, joined with newlines) --
+        # re-serializing here would double-encode and raise "Object of type
+        # bytes is not JSON serializable".
+        data = body
+    elif isinstance(body, str):
+        data = body.encode("utf-8")
+    elif body is not None:
         data = json.dumps(body).encode("utf-8")
     username, password = _get_credentials()
     req = urllib.request.Request(url, data=data, method=method)

--- a/backend/lambda/graph_query_api/test_opensearch_keyword.py
+++ b/backend/lambda/graph_query_api/test_opensearch_keyword.py
@@ -13,6 +13,56 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import opensearch_keyword as okw  # noqa: E402
 
 
+class TestOpensearchRequestBodyEncoding(unittest.TestCase):
+    """ENC-TSK-M39 regression: opensearch_request must not re-serialize a
+    pre-encoded body. A real (unmocked) exercise of opensearch_request itself
+    -- mocking opensearch_request away (as the rest of this file does) would
+    never have caught the double-encoding bug this guards against."""
+
+    class _FakeResp:
+        def __init__(self, body: bytes):
+            self._body = body
+            self.status = 200
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def test_bytes_body_passed_through_unmodified(self):
+        captured = {}
+
+        def fake_urlopen(req, context=None, timeout=None):
+            captured["data"] = req.data
+            return self._FakeResp(b"{}")
+
+        ndjson_body = b'{"index": "records_read"}\n{"size": 5}\n'
+        with mock.patch.object(okw, "OPENSEARCH_ENDPOINT", "https://os.example"), mock.patch.object(
+            okw, "_get_credentials", return_value=("user", "pass")
+        ), mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            okw.opensearch_request("POST", "/_msearch", ndjson_body)
+
+        self.assertEqual(captured["data"], ndjson_body)
+
+    def test_dict_body_still_json_encoded(self):
+        captured = {}
+
+        def fake_urlopen(req, context=None, timeout=None):
+            captured["data"] = req.data
+            return self._FakeResp(b"{}")
+
+        with mock.patch.object(okw, "OPENSEARCH_ENDPOINT", "https://os.example"), mock.patch.object(
+            okw, "_get_credentials", return_value=("user", "pass")
+        ), mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            okw.opensearch_request("POST", "/_search", {"size": 5})
+
+        self.assertEqual(json.loads(captured["data"]), {"size": 5})
+
+
 class TestRecordIdFromHit(unittest.TestCase):
     def test_parses_stable_doc_id(self):
         hit = {"_id": "enceladus#task#ENC-TSK-001", "_source": {}}


### PR DESCRIPTION
## Summary
- Follow-up to ENC-TSK-M39 (#976, merged). Live gamma verification showed `feed_source=ddb_fanout` on every `GET /api/v1/feed` request — the OpenSearch tier's circuit breaker was tripping on every call.
- Root cause: `opensearch_request(method, path, body)` unconditionally ran `json.dumps(body).encode('utf-8')`. `feed_selection_msearch` (new in M39) passes a pre-built ndjson **bytes** body for the `_msearch` call, so it got re-serialized and raised `TypeError: Object of type bytes is not JSON serializable`.
- Fix: `opensearch_request` now passes `bytes`/`str` bodies through unmodified and only `json.dumps()`s plain dict bodies — existing dict-body callers (`hybrid_keyword_ranks`) are unaffected.
- Added a regression test that exercises `opensearch_request` itself (not mocked) with a pre-encoded bytes body — the original M39 tests mocked `opensearch_request` away entirely and could not have caught this class of bug.

## Test plan
- [x] `backend/lambda/graph_query_api`: `python3 -m pytest -q` — 319 passed, 14 subtests
- [ ] Post-merge: verify gamma Gen2 deploy succeeds, then `feed_source=opensearch` and p95 <500ms on live `GET /api/v1/feed`

CCI-0323b0908b144b64ac863eb06c713892

🤖 Generated with [Claude Code](https://claude.com/claude-code)