### PR TITLE
ENC-TSK-M49: parallelize shared-layer relationship-edge fetch

### DIFF
--- a/backend/lambda/feed_query/.build_extras
+++ b/backend/lambda/feed_query/.build_extras
@@ -2,3 +2,10 @@
 # the published enceladus-shared:10 Lambda layer. Vendor into the function zip
 # until the layer is bumped (see governance_data_dictionary enceladus_shared.record_extensions).
 backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+# ENC-TSK-M49: relationship_store's iter_project_relationship_items was
+# parallelized here but enceladus-shared:10 is frozen (deploy.sh is a
+# tombstone, no layer-publish mechanism exists in CI) -- vendor flat, same
+# reasoning as record_extensions.py above. record_extensions.py imports this
+# as a bare top-level module (try/except fallback to the layer's
+# package-qualified copy for non-vendored contexts, e.g. test_layer.py).
+backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py

--- a/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
@@ -137,7 +137,18 @@ def query_typed_relationships_for_projects(
     ddb_float: Callable[[Dict[str, Any], str], float],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Query all outgoing typed edges for the given projects."""
-    from enceladus_shared.relationship_store import iter_project_relationship_items
+    try:
+        # ENC-TSK-M49: feed_query/tracker_mutation vendor a flat top-level
+        # relationship_store.py (via .build_extras) to pick up the
+        # parallelized iter_project_relationship_items without waiting on a
+        # republish of the frozen enceladus-shared:10 Lambda layer -- see
+        # relationship_store.py's own docstring and ENC-TSK-M49's worklog.
+        # Falls back to the package-qualified import (resolved via the
+        # layer) for any environment that doesn't vendor the flat copy,
+        # e.g. shared_layer/test_layer.py's PYTHONPATH=python test context.
+        from relationship_store import iter_project_relationship_items
+    except ImportError:
+        from enceladus_shared.relationship_store import iter_project_relationship_items
 
     edges_by_source: Dict[str, List[Dict[str, Any]]] = {}
     for raw in iter_project_relationship_items(

--- a/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
@@ -6,6 +6,7 @@ fall back to the tracker table for keys not yet present in the new store.
 """
 from __future__ import annotations
 
+import concurrent.futures
 import os
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
@@ -194,6 +195,43 @@ def query_relationship_raw_items(
     return list(merged.values()), primary_cursor
 
 
+# ENC-TSK-M49: bounded to <=12 per the coord-lead architect decision (smaller
+# than ENC-TSK-M36/M48's 24 -- this fan-out runs on top of, not instead of,
+# feed_query's own already-concurrent OpenSearch-tier hydration, so a lower
+# cap keeps combined thread/connection pressure reasonable).
+_MAX_RELATIONSHIP_FANOUT_WORKERS = 12
+
+
+def _fetch_project_relationship_items(
+    ddb,
+    tracker_table: str,
+    rel_table: Optional[str],
+    pid: str,
+    rel_prefix: str,
+    ser_s: Callable[[str], PutItem],
+) -> List[Dict[str, Any]]:
+    """Fetch + merge one project's relationship rows across the table set."""
+    merged: Dict[str, Dict[str, Any]] = {}
+    tables = [rel_table, tracker_table] if rel_table else [tracker_table]
+    for table in tables:
+        if not table:
+            continue
+        paginator = ddb.get_paginator("query")
+        for page in paginator.paginate(
+            TableName=table,
+            KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
+            ExpressionAttributeValues={
+                ":pid": ser_s(pid),
+                ":rel_prefix": ser_s(rel_prefix),
+            },
+        ):
+            for raw in page.get("Items", []):
+                sk = raw.get("record_id", {}).get("S", "")
+                if sk.startswith("rel#") and sk not in merged:
+                    merged[sk] = raw
+    return list(merged.values())
+
+
 def iter_project_relationship_items(
     ddb,
     tracker_table: str,
@@ -202,27 +240,32 @@ def iter_project_relationship_items(
     ser_s: Callable[[str], PutItem],
     rel_prefix: str = "rel#",
 ) -> Iterable[Dict[str, Any]]:
-    """Yield all relationship raw items for projects (feed/extensions path)."""
+    """Yield all relationship raw items for projects (feed/extensions path).
+
+    ENC-TSK-M49: per-project fetches fan out concurrently (bounded
+    ThreadPoolExecutor, same pattern as ENC-TSK-M36/M48) instead of one
+    project at a time sequentially -- with ~20-25 active projects sharing
+    this table, the prior sequential loop was the dominant residual latency
+    in feed_query's OpenSearch-tier full refresh after ENC-TSK-M48. Items
+    are yielded in the SAME order as `project_ids` regardless of which
+    project's fetch completes first, preserving the exact output contract
+    every existing caller (feed_query, tracker_mutation) already depends on.
+    """
+    pids = [pid for pid in project_ids if pid]
+    if not pids:
+        return
+
     rel_table = relationships_table_name()
-    for pid in project_ids:
-        if not pid:
-            continue
-        merged: Dict[str, Dict[str, Any]] = {}
-        tables = [rel_table, tracker_table] if rel_table else [tracker_table]
-        for table in tables:
-            if not table:
-                continue
-            paginator = ddb.get_paginator("query")
-            for page in paginator.paginate(
-                TableName=table,
-                KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
-                ExpressionAttributeValues={
-                    ":pid": ser_s(pid),
-                    ":rel_prefix": ser_s(rel_prefix),
-                },
-            ):
-                for raw in page.get("Items", []):
-                    sk = raw.get("record_id", {}).get("S", "")
-                    if sk.startswith("rel#") and sk not in merged:
-                        merged[sk] = raw
-        yield from merged.values()
+    max_workers = min(_MAX_RELATIONSHIP_FANOUT_WORKERS, len(pids))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        per_project_items = list(
+            pool.map(
+                lambda pid: _fetch_project_relationship_items(
+                    ddb, tracker_table, rel_table, pid, rel_prefix, ser_s
+                ),
+                pids,
+            )
+        )
+
+    for items in per_project_items:
+        yield from items

--- a/backend/lambda/shared_layer/test_layer.py
+++ b/backend/lambda/shared_layer/test_layer.py
@@ -31,9 +31,12 @@ from enceladus_shared.record_extensions import (
     compute_structural_importance,
 )
 from enceladus_shared.relationship_store import (
+    _fetch_project_relationship_items,
     build_create_transact_puts,
+    iter_project_relationship_items,
     write_target_tables,
 )
+from enceladus_shared.record_extensions import query_typed_relationships_for_projects
 
 
 class AuthTests(unittest.TestCase):
@@ -263,6 +266,179 @@ class RelationshipStoreTests(unittest.TestCase):
             tables,
             {"enceladus-relationships-gamma", "devops-project-tracker-gamma"},
         )
+
+
+def _rel_item(project_id: str, sk: str) -> dict:
+    return {"project_id": {"S": project_id}, "record_id": {"S": sk}}
+
+
+class _FakeRelationshipPaginator:
+    def __init__(self, items_by_table_and_project):
+        self._items_by_table_and_project = items_by_table_and_project
+
+    def paginate(self, **kwargs):
+        table = kwargs["TableName"]
+        pid = kwargs["ExpressionAttributeValues"][":pid"]["S"]
+        items = self._items_by_table_and_project.get((table, pid), [])
+        yield {"Items": items}
+
+
+class _FakeRelationshipDdb:
+    """Records every query call so tests can assert per-project isolation."""
+
+    def __init__(self, items_by_table_and_project):
+        self._items_by_table_and_project = items_by_table_and_project
+        self.calls: list = []
+
+    def get_paginator(self, name):
+        assert name == "query"
+        return _FakeRelationshipPaginator(self._items_by_table_and_project)
+
+
+class IterProjectRelationshipItemsTests(unittest.TestCase):
+    """ENC-TSK-M49: parallel fan-out must match the prior sequential contract exactly."""
+
+    def _fixture_ddb(self):
+        # Two tables (relationships + tracker) x three projects, with one
+        # duplicate key across tables (rel_table must win, matching the
+        # pre-M49 first-seen-wins merge) and one project with no rows at all.
+        return _FakeRelationshipDdb(
+            {
+                ("enceladus-relationships-gamma", "enceladus"): [
+                    _rel_item("enceladus", "rel#A#relates-to#B"),
+                    _rel_item("enceladus", "rel#A#blocks#C"),
+                ],
+                ("devops-project-tracker-gamma", "enceladus"): [
+                    # Duplicate of the first row above -- rel_table copy must win.
+                    _rel_item("enceladus", "rel#A#relates-to#B"),
+                    _rel_item("enceladus", "rel#B#related-to#A"),
+                ],
+                ("enceladus-relationships-gamma", "cfg"): [
+                    _rel_item("cfg", "rel#X#relates-to#Y"),
+                ],
+                ("devops-project-tracker-gamma", "cfg"): [],
+                ("enceladus-relationships-gamma", "empty-proj"): [],
+                ("devops-project-tracker-gamma", "empty-proj"): [],
+            }
+        )
+
+    def test_parity_with_sequential_reference_implementation(self):
+        project_ids = ["enceladus", "cfg", "empty-proj"]
+        ser_s = lambda value: {"S": value}  # noqa: E731
+
+        with patch.dict(os.environ, {"RELATIONSHIPS_TABLE": "enceladus-relationships-gamma"}, clear=False):
+            parallel_result = list(
+                iter_project_relationship_items(
+                    self._fixture_ddb(), "devops-project-tracker-gamma", project_ids, ser_s=ser_s
+                )
+            )
+
+            # Reference: call the single-project fetch helper directly, in
+            # order, exactly as the pre-M49 sequential loop did.
+            sequential_result = []
+            rel_table = "enceladus-relationships-gamma"
+            for pid in project_ids:
+                sequential_result.extend(
+                    _fetch_project_relationship_items(
+                        self._fixture_ddb(), "devops-project-tracker-gamma", rel_table, pid, "rel#", ser_s
+                    )
+                )
+
+        self.assertEqual(parallel_result, sequential_result)
+        # rel_table's copy of the duplicate key must win (first-seen-wins,
+        # tables=[rel_table, tracker_table]).
+        enceladus_sks = {r["record_id"]["S"] for r in parallel_result if r["project_id"]["S"] == "enceladus"}
+        self.assertEqual(enceladus_sks, {"rel#A#relates-to#B", "rel#A#blocks#C", "rel#B#related-to#A"})
+
+    def test_preserves_original_project_ids_order(self):
+        ser_s = lambda value: {"S": value}  # noqa: E731
+        # Reversed vs. the fixture's natural table layout -- output order
+        # must follow THIS list, not fetch-completion order.
+        project_ids = ["empty-proj", "cfg", "enceladus"]
+
+        with patch.dict(os.environ, {"RELATIONSHIPS_TABLE": "enceladus-relationships-gamma"}, clear=False):
+            result = list(
+                iter_project_relationship_items(
+                    self._fixture_ddb(), "devops-project-tracker-gamma", project_ids, ser_s=ser_s
+                )
+            )
+
+        # cfg's single row must appear before any of enceladus's three rows.
+        cfg_index = next(i for i, r in enumerate(result) if r["project_id"]["S"] == "cfg")
+        enceladus_indices = [i for i, r in enumerate(result) if r["project_id"]["S"] == "enceladus"]
+        self.assertTrue(all(cfg_index < i for i in enceladus_indices))
+
+    def test_empty_project_ids_short_circuits_without_calling_ddb(self):
+        ddb = self._fixture_ddb()
+        result = list(iter_project_relationship_items(ddb, "devops-project-tracker-gamma", [], ser_s=lambda v: {"S": v}))
+        self.assertEqual(result, [])
+
+    def test_falsy_project_ids_are_skipped(self):
+        ser_s = lambda value: {"S": value}  # noqa: E731
+        with patch.dict(os.environ, {"RELATIONSHIPS_TABLE": "enceladus-relationships-gamma"}, clear=False):
+            result = list(
+                iter_project_relationship_items(
+                    self._fixture_ddb(), "devops-project-tracker-gamma", ["", None, "cfg"], ser_s=ser_s
+                )
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["project_id"]["S"], "cfg")
+
+
+class QueryTypedRelationshipsForProjectsTests(unittest.TestCase):
+    """ENC-TSK-M49: record_extensions' bare-import-with-fallback still resolves
+    iter_project_relationship_items correctly when only the real
+    enceladus_shared package (no flat vendored copy) is on sys.path -- the
+    exact shared_layer/test_layer.py situation."""
+
+    def test_builds_edges_by_source_via_package_qualified_fallback(self):
+        ddb = _FakeRelationshipDdb(
+            {
+                ("devops-project-tracker-gamma", "enceladus"): [
+                    _rel_item("enceladus", "rel#ENC-TSK-1#relates-to#ENC-TSK-2"),
+                ],
+            }
+        )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RELATIONSHIPS_TABLE", None)
+            edges = query_typed_relationships_for_projects(
+                ddb,
+                "devops-project-tracker-gamma",
+                ["enceladus"],
+                ddb_str=lambda item, key: item.get(key, {}).get("S", ""),
+                ddb_float=lambda item, key: 0.0,
+            )
+        self.assertIn("ENC-TSK-1", edges)
+        self.assertEqual(edges["ENC-TSK-1"][0]["relationship_type"], "relates-to")
+        self.assertEqual(edges["ENC-TSK-1"][0]["target_id"], "ENC-TSK-2")
+
+    def test_prefers_bare_vendored_module_when_present(self):
+        """Simulates the real deployed feed_query/tracker_mutation zip, where
+        .build_extras vendors relationship_store.py flat at the zip root
+        (a bare top-level module, not inside an enceladus_shared/ package)."""
+        import types
+
+        sentinel_calls = []
+
+        def fake_iter(ddb, table_name, project_ids, *, ser_s, rel_prefix="rel#"):
+            sentinel_calls.append(list(project_ids))
+            yield _rel_item("enceladus", "rel#ENC-TSK-9#relates-to#ENC-TSK-8")
+
+        fake_module = types.ModuleType("relationship_store")
+        fake_module.iter_project_relationship_items = fake_iter
+
+        with patch.dict(sys.modules, {"relationship_store": fake_module}):
+            edges = query_typed_relationships_for_projects(
+                _FakeRelationshipDdb({}),
+                "devops-project-tracker-gamma",
+                ["enceladus"],
+                ddb_str=lambda item, key: item.get(key, {}).get("S", ""),
+                ddb_float=lambda item, key: 0.0,
+            )
+
+        # The bare vendored module's fake was used, not the real package copy.
+        self.assertEqual(sentinel_calls, [["enceladus"]])
+        self.assertIn("ENC-TSK-9", edges)
 
 
 if __name__ == "__main__":

--- a/backend/lambda/tracker_mutation/.build_extras
+++ b/backend/lambda/tracker_mutation/.build_extras
@@ -2,3 +2,14 @@
 # the published enceladus-shared:10 Lambda layer. Vendor into the function zip
 # until the layer is bumped (see governance_data_dictionary enceladus_shared.record_extensions).
 backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+# ENC-TSK-M49: relationship_store's iter_project_relationship_items was
+# parallelized here but enceladus-shared:10 is frozen (deploy.sh is a
+# tombstone, no layer-publish mechanism exists in CI) -- vendor flat, same
+# reasoning as record_extensions.py above. record_extensions.py imports this
+# as a bare top-level module (try/except fallback to the layer's
+# package-qualified copy for non-vendored contexts, e.g. test_layer.py).
+# tracker_mutation's OWN direct enceladus_shared.appconfig_flags /
+# enceladus_shared.version_seq / enceladus_shared.relationship_store (write
+# helpers) imports are UNAFFECTED -- this only adds a new bare top-level
+# module name, it does not shadow the enceladus_shared package.
+backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py


### PR DESCRIPTION
## Summary
- Follow-up to ENC-TSK-M39/M47/M48 (#976/#977/#978, merged). Live gamma p95 was still ~3.6-4s after M48 — CloudWatch root-caused the residual to `enceladus_shared.relationship_store.iter_project_relationship_items`, called on every feed request to attach `typed_relationships`/`context_node` metadata, looping **sequentially** over ~20-25 active projects × up to 2 tables (40-50 sequential DynamoDB Query calls).

**AC-1 deploy-gate finding:** `backend/lambda/shared_layer/deploy.sh` is a 2-line tombstone ("see `_deploy.yml` matrix build"), but neither `_build.yml` nor `_deploy.yml` reference `shared_layer` at all — there is no automated or documented manual layer-publish mechanism in this repo, and the `enceladus-shared:10` Lambda Layer is effectively frozen. The team's already-established workaround (used for `record_extensions.py`, `embedding.py`, `dedup_convergence.py`, `search_index_core.py`, `mentions_extraction.py`, `corpus_entropy_core.py`) is `.build_extras`: flat-vendor a shared_layer file directly into a consuming Lambda's own zip via the **same** per-function Gen2 pipeline used for M39/M47/M48. **No layer publish needed or attempted** — this ships gamma-only via the identical, already-trusted deploy path, avoiding the risky out-of-band scenario entirely.

**AC-2 implementation:** parallelizes `iter_project_relationship_items` via a bounded `ThreadPoolExecutor` (`max_workers<=12`), preserving byte-identical output ordered by the original `project_ids` list regardless of fetch-completion order. `record_extensions.py`'s lazy import becomes try-bare-import-first (satisfied by the new flat-vendored `relationship_store.py`) with a fallback to the existing package-qualified import (satisfied by the layer) — preserving `shared_layer/test_layer.py`'s test context and every other `enceladus_shared.*` import in `tracker_mutation` (`appconfig_flags`, `version_seq`) untouched. Vendored into `feed_query/.build_extras` and `tracker_mutation/.build_extras`, the only two Lambdas reaching this function.

## Test plan
- [x] `backend/lambda/shared_layer`: `PYTHONPATH=python python3 -m pytest test_layer.py -q` — 29 passed (added parity, ordering, empty/falsy-input, and both import-branch tests)
- [x] `backend/lambda/feed_query`: 54 passed
- [x] `backend/lambda/graph_query_api`: 319 passed, 14 subtests
- [x] `backend/lambda/tracker_mutation`: 472 passed, 2 pre-existing unrelated failures confirmed via `git stash` (mock retry-timing in counter/if-match tests, present on `v4/main` before this change)
- [ ] Post-merge: verify gamma Gen2 deploy succeeds, fleet-smoke every `SharedLayerArn` consumer (AC-4), re-measure live p95 (AC-3, contingency: page-scoped attach if still >=500ms)

CCI-4793d89c162a49e680d165ccf24b87f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)