### PR TITLE
ENC-TSK-M53: remove manual memoization from PWA 2.0 realtime/search components (B67 AC-16)

### DIFF
--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearch } from '@tanstack/react-router'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Autosuggest, ButtonDropdown } from '../design-system'
 import { projectRegistryQueryOptions, resolveProjectFromRecordId } from '../api/projectRegistry'
 import { Badge } from '../components/Badge'
@@ -74,70 +74,61 @@ export function FeedRoute() {
   const [recentItems, setRecentItems] = useState<RecentlyViewedEntry[]>([])
   const listRef = useRef<HTMLDivElement>(null)
 
-  const filterQuery = useMemo(() => parseFilterQuery(f, op), [f, op])
+  const filterQuery = parseFilterQuery(f, op)
 
-  const patchFeedSearch = useCallback(
-    (patch: Partial<FeedRouteSearch>, replace = true) => {
-      navigate({
-        search: (prev) => {
-          const next = { ...prev, ...patch }
-          persistFeedReturnSearch(next)
-          return next
-        },
-        replace,
-      })
-    },
-    [navigate],
-  )
+  // AC-16: React Compiler owns memoization -- no manual useCallback.
+  const patchFeedSearch = (patch: Partial<FeedRouteSearch>, replace = true) => {
+    navigate({
+      search: (prev) => {
+        const next = { ...prev, ...patch }
+        persistFeedReturnSearch(next)
+        return next
+      },
+      replace,
+    })
+  }
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
   const { events, isHydrating } = useRealtimeFeed()
   const { isWarm } = useCacheEngineState()
-  const corpus = useMemo(() => {
+  const corpus = (() => {
     const fromEvents = buildSearchCorpus(events, projects)
     if (!isWarm) return fromEvents
     const byId = new Map(getCacheEngine().searchIndex.all().map((row) => [row.recordId, row]))
     for (const row of fromEvents) byId.set(row.recordId, row)
     return [...byId.values()]
-  }, [events, projects, isWarm])
+  })()
   // ENC-TSK-L32: feed search is reciprocally scoped to exclude document
   // records — the Docs page (DocsRoute) owns document-scoped search.
-  const feedCorpus = useMemo(() => excludeRecordType(corpus, 'document'), [corpus])
+  const feedCorpus = excludeRecordType(corpus, 'document')
   const projectId = projects[0]?.project_id ?? 'enceladus'
 
   const tiered = useTieredSearch({ projectId, query: q }, feedCorpus)
-  const filteredHits = useMemo(
-    () => excludeRecordType(sortSearchHits(applyPropertyFilter(tiered.hits, filterQuery), sort), 'document'),
-    [tiered.hits, filterQuery, sort],
-  )
+  const filteredHits = excludeRecordType(sortSearchHits(applyPropertyFilter(tiered.hits, filterQuery), sort), 'document')
   const visibleHits = filteredHits.slice(0, visibleCount)
 
   const hybridEnabled = Boolean(q.trim())
   const requestKey = `${q}|${f}|${op}|${sort}`
   useRequestFirstPageTelemetry(requestKey, hybridEnabled, tiered.hybridPending)
 
-  const searchSuggestions = useMemo(() => {
-    if (isWarm) {
-      return excludeRecordType(getCacheEngine().searchIndex.suggest(q, 12), 'document')
+  const searchSuggestions = isWarm
+    ? excludeRecordType(getCacheEngine().searchIndex.suggest(q, 12), 'document').map((row) => ({
+        value: row.recordId,
+        description: row.title,
+        tag: row.recordType,
+      }))
+    : feedCorpus
+        .filter((row) => {
+          const needle = q.trim().toLowerCase()
+          if (!needle) return true
+          return row.recordId.toLowerCase().includes(needle) || row.title.toLowerCase().includes(needle)
+        })
+        .slice(0, 12)
         .map((row) => ({
           value: row.recordId,
           description: row.title,
           tag: row.recordType,
         }))
-    }
-    return feedCorpus
-      .filter((row) => {
-        const needle = q.trim().toLowerCase()
-        if (!needle) return true
-        return row.recordId.toLowerCase().includes(needle) || row.title.toLowerCase().includes(needle)
-      })
-      .slice(0, 12)
-      .map((row) => ({
-        value: row.recordId,
-        description: row.title,
-        tag: row.recordType,
-      }))
-  }, [feedCorpus, q, isWarm])
 
   const suggestionsKey = searchSuggestions.map((row) => row.value).join(',')
   const { markKeystroke } = useKeystrokeSuggestionTelemetry(suggestionsKey)

--- a/frontend/ui-v2/src/search/useTieredSearch.ts
+++ b/frontend/ui-v2/src/search/useTieredSearch.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { hybridSearchQueryOptions } from '../api/searchQueryOptions'
 import { searchLocalKeyword } from './localKeywordSearch'
@@ -15,10 +14,7 @@ export function useTieredSearch(
   params: HybridSearchParams,
   corpus: LocalSearchRecord[],
 ): TieredSearchSnapshot {
-  const localHits = useMemo(
-    () => searchLocalKeyword(corpus, params.query ?? ''),
-    [corpus, params.query],
-  )
+  const localHits = searchLocalKeyword(corpus, params.query ?? '')
 
   const hybridEnabled =
     Boolean(params.projectId) &&
@@ -29,10 +25,7 @@ export function useTieredSearch(
     enabled: hybridEnabled,
   })
 
-  const merged = useMemo(
-    () => mergeSearchResults(localHits, hybridQuery.data, params.projectId),
-    [localHits, hybridQuery.data, params.projectId],
-  )
+  const merged = mergeSearchResults(localHits, hybridQuery.data, params.projectId)
 
   return {
     hits: merged.hits,

--- a/frontend/ui-v2/src/shell/FeedPane.tsx
+++ b/frontend/ui-v2/src/shell/FeedPane.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import { Button, Flashbar } from '../design-system'
 import { useUiStore } from '../store/uiStore'
 import { useFeedConnectionStore } from '../store/feedConnectionStore'
@@ -46,10 +46,7 @@ export function FeedPane({ onClose }: { onClose?: () => void }) {
   const bufferedCount = useFeedBufferStore((s) => s.bufferedEvents.length)
   const scrollRef = useRef<HTMLElement>(null)
 
-  const visibleEvents = useMemo(
-    () => filterFeedEvents(events, filters.recordTypes),
-    [events, filters.recordTypes],
-  )
+  const visibleEvents = filterFeedEvents(events, filters.recordTypes)
 
   const showNewActivities = () => {
     mergeBufferedEvents()


### PR DESCRIPTION
## Summary
- Removes 9 redundant manual `useMemo`/`useCallback` occurrences across `FeedRoute.tsx` (6), `useTieredSearch.ts` (2), `FeedPane.tsx` (1) — React Compiler v1.0 is already active (`vite.config.ts` babel-plugin-react-compiler) and owns memoization per B67 AC-16.
- `DocsRoute`/`CoordinationRoute`/`HomeRoute` already had zero occurrences (remediated in a prior session) — no changes needed there.
- No documented exceptions needed: verified `patchFeedSearch` (the one `useCallback`) is only ever invoked via inline closures, never placed directly in a dependency array, so removal is safe.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test -- --run` — 46 files / 273 tests pass
- [x] Post-edit grep confirms zero `useMemo`/`useCallback`/`React.memo` occurrences across all 6 target files
- [ ] Gamma deploy + live smoke on the 6 routes (post-merge)

CCI-50ed168534e14e748e0bb521d0f88601

🤖 Generated with Claude Code