### PR TITLE
ENC-TSK-M56 follow-up: IAM patch workflow for CFN deploy role appsync:* grant

### DIFF
--- a/.github/workflows/cloudformation-appsync-events-stack-deploy.yml
+++ b/.github/workflows/cloudformation-appsync-events-stack-deploy.yml
@@ -1,0 +1,242 @@
+name: CloudFormation AppSync Events Stack Deploy
+
+# ENC-TSK-M56 — AppSync Events real-time layer (06-appsync-events.yaml) had NO
+# CI/CD deploy lane at all (the template's own Metadata.EscalatedResidualSteps
+# documented it as privileged-terminal/manual-only). That gap is why its API
+# key silently hit AppSync's 7-day default expiration with nobody re-running
+# a deploy to renew it — gamma's entire realtime transport returned 401
+# UnauthorizedException on every connection_init as a result.
+#
+# DEPLOY TARGET: gamma (v4) ONLY. v3-prod is FROZEN (DOC-499FA089EC30). This
+# workflow therefore triggers exclusively on v4/** branches and resolves
+# ENVIRONMENT_SUFFIX to "-gamma"; it must never run against main / production.
+#
+# Plan/apply split (ENC-TSK-J62/J63 pattern, mirrors cloudformation-agent-auth-
+# stack-deploy.yml): the stack is gamma-only by construction (guard-gamma-only
+# refuses anything else), so apply runs in the v4-gamma environment — no
+# reviewer pause, but structurally identical to its gated siblings.
+#
+# Every run (push, manual dispatch, or the monthly schedule below) recomputes
+# ApiKeyExpiresEpoch as "now + 364 days" and re-passes it, so a normal deploy
+# doubles as a rolling key renewal — this is deliberate, not incidental: it
+# is what prevents ENC-TSK-M56 from recurring.
+
+on:
+  push:
+    branches:
+      - 'v4/**'
+    paths:
+      - "infrastructure/cloudformation/06-appsync-events.yaml"
+      - ".github/workflows/cloudformation-appsync-events-stack-deploy.yml"
+  schedule:
+    # Monthly renewal — comfortably inside AppSync's 365-day max, well short
+    # of ever approaching another expiration-driven outage.
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 06-appsync-events template"
+        type: string
+        required: false
+        default: "enceladus-appsync-events"
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual appsync-events stack deploy (gamma)"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-appsync-events-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/06-appsync-events.yaml
+  # schedule events have no github.ref branch context — pin the renewal cron
+  # to v4/main explicitly so ENVIRONMENT_SUFFIX still resolves to "-gamma".
+  ENVIRONMENT_SUFFIX: ${{ (startsWith(github.ref, 'refs/heads/v4/') || github.event_name == 'schedule') && '-gamma' || '' }}
+  DEFAULT_STACK_NAME: enceladus-appsync-events
+
+jobs:
+  guard-gamma-only:
+    name: Guard — gamma only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse non-gamma targets
+        run: |
+          set -euo pipefail
+          if [ "${ENVIRONMENT_SUFFIX}" != "-gamma" ]; then
+            echo "::error::AppSync Events stack is gamma-only (v3-prod is FROZEN, DOC-499FA089EC30)."
+            exit 1
+          fi
+          echo "Gamma target confirmed (ENVIRONMENT_SUFFIX=${ENVIRONMENT_SUFFIX})."
+
+  plan:
+    name: Plan AppSync Events stack change-set
+    needs: guard-gamma-only
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        run: |
+          set -euo pipefail
+          stack_name="${{ github.event.inputs.stack_name || env.DEFAULT_STACK_NAME }}${ENVIRONMENT_SUFFIX}"
+          echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
+          # 364 days: one day inside AppSync's 365-day hard max, hour-rounded
+          # by AppSync itself regardless of the exact second we compute here.
+          expires_epoch=$(date -u -d '+364 days' +%s)
+          echo "expires_epoch=${expires_epoch}" >> "${GITHUB_OUTPUT}"
+          echo "Computed ApiKeyExpiresEpoch=${expires_epoch} ($(date -u -d "@${expires_epoch}"))"
+
+      - name: Clean up ROLLBACK_COMPLETE stack if present (gamma self-heal)
+        run: |
+          set -euo pipefail
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${stack_name}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          if [ "${status}" = "ROLLBACK_COMPLETE" ]; then
+            echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy (gamma self-heal)"
+            aws cloudformation delete-stack \
+              --region "${AWS_REGION}" \
+              --stack-name "${stack_name}"
+            aws cloudformation wait stack-delete-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${stack_name}"
+            echo "Stack deleted successfully"
+          fi
+
+      - name: Create AppSync Events stack change-set (no execute)
+        id: changeset
+        run: |
+          set -euo pipefail
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 06-appsync-events/ \
+            --parameter-overrides \
+              EnvironmentSuffix="${ENVIRONMENT_SUFFIX}" \
+              ApiKeyExpiresEpoch="${{ steps.params.outputs.expires_epoch }}" 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## AppSync Events stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## AppSync Events stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply AppSync Events stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Gamma-only lane; environment kept for structural parity with the gated
+    # CFN siblings (ENC-FTR-120).
+    environment: v4-gamma
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          echo "=== Stack events (last 20) ==="
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"
+
+      - name: Report deployed stack state
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
+            --output table

--- a/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
@@ -132,3 +132,4 @@ jobs:
             --role-name "enceladus-cloudformation-deploy-github-role" \
             --query "AttachedPolicies[?PolicyName=='enceladus-cfn-deploy-appsync-events-ops']" \
             --output table
+# CCI-d88c82ba53034b27bae8ed7b00be78c1

--- a/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
@@ -1,0 +1,134 @@
+name: IAM CFN Deploy Role — AppSync Events Patch
+
+# ENC-TSK-M56: the CFN deploy role (enceladus-cloudformation-deploy-github-role)
+# has NEVER had any appsync:* permissions -- 06-appsync-events.yaml's initial
+# provisioning (2026-07-02) was done out-of-band via privileged-terminal
+# credentials per the template's own Metadata.EscalatedResidualSteps, not via
+# this OIDC role. The first attempt to deploy this stack through
+# cloudformation-appsync-events-stack-deploy.yml failed:
+#   "User: .../enceladus-cloudformation-deploy-github-role/GitHubActions is
+#    not authorized to perform: appsync:GetApi ... UPDATE_ROLLBACK_COMPLETE"
+#
+# Per prior-session precedent (this role's INLINE policy aggregate is already
+# at/near the 10,240-byte cap), this grant is a customer-managed policy
+# (create + attach), not another put-role-policy inline addition.
+#
+# Scoped to the specific FeedEventsApi ApiId (yri2ycadyfhjtm5cdmu3pxm4iq) and
+# its Api/ApiKey/ChannelNamespace sub-resources -- covers the full resource
+# surface 06-appsync-events.yaml manages, not just the single action that
+# failed, so the next property touched on this stack doesn't repeat this gap.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant appsync:* on the FeedEventsApi (gamma) to the CFN deploy role — 06-appsync-events.yaml had zero appsync permissions (ENC-TSK-M56)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Attach AppSync Events managed policy to CFN deploy role
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Create (or reuse) the AppSync Events managed policy
+        id: policy
+        run: |
+          set -euo pipefail
+          cat > /tmp/appsync-events-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AppSyncEventsApiManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetApi",
+                  "appsync:CreateApi",
+                  "appsync:UpdateApi",
+                  "appsync:DeleteApi",
+                  "appsync:TagResource",
+                  "appsync:UntagResource",
+                  "appsync:ListTagsForResource"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq"
+              },
+              {
+                "Sid": "AppSyncEventsApiKeyManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetApiKey",
+                  "appsync:ListApiKeys",
+                  "appsync:CreateApiKey",
+                  "appsync:UpdateApiKey",
+                  "appsync:DeleteApiKey"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq/apikeys/*"
+              },
+              {
+                "Sid": "AppSyncEventsChannelNamespaceManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetChannelNamespace",
+                  "appsync:ListChannelNamespaces",
+                  "appsync:CreateChannelNamespace",
+                  "appsync:UpdateChannelNamespace",
+                  "appsync:DeleteChannelNamespace"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq/channelNamespace/*"
+              }
+            ]
+          }
+          JSON
+
+          policy_arn="arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-appsync-events-ops"
+          if aws iam get-policy --policy-arn "${policy_arn}" >/dev/null 2>&1; then
+            echo "Policy already exists; creating a new default version instead of re-creating."
+            version_count=$(aws iam list-policy-versions --policy-arn "${policy_arn}" --query 'length(Versions)' --output text)
+            if [ "${version_count}" -ge 5 ]; then
+              oldest_non_default=$(aws iam list-policy-versions --policy-arn "${policy_arn}" \
+                --query 'Versions[?IsDefaultVersion==`false`]|sort_by(@,&CreateDate)[0].VersionId' --output text)
+              aws iam delete-policy-version --policy-arn "${policy_arn}" --version-id "${oldest_non_default}"
+            fi
+            aws iam create-policy-version \
+              --policy-arn "${policy_arn}" \
+              --policy-document "file:///tmp/appsync-events-policy.json" \
+              --set-as-default
+          else
+            aws iam create-policy \
+              --policy-name "enceladus-cfn-deploy-appsync-events-ops" \
+              --policy-document "file:///tmp/appsync-events-policy.json" \
+              --description "ENC-TSK-M56: appsync:* for the CFN deploy role, scoped to the gamma FeedEventsApi (06-appsync-events.yaml)"
+          fi
+          echo "policy_arn=${policy_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attach managed policy to the CFN deploy role
+        run: |
+          set -euo pipefail
+          aws iam attach-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-arn "${{ steps.policy.outputs.policy_arn }}"
+
+      - name: Verify attachment
+        run: |
+          aws iam list-attached-role-policies \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --query "AttachedPolicies[?PolicyName=='enceladus-cfn-deploy-appsync-events-ops']" \
+            --output table

--- a/infrastructure/cloudformation/06-appsync-events.yaml
+++ b/infrastructure/cloudformation/06-appsync-events.yaml
@@ -40,6 +40,19 @@ Parameters:
     Type: String
     Default: arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10
     Description: Shared enceladus_shared layer ARN (mirrors 02-compute.yaml pin).
+  ApiKeyExpiresEpoch:
+    Type: Number
+    Description: >
+      Unix epoch seconds (rounded to the nearest hour by AppSync) for
+      FeedEventsApiKey's expiration. MUST be supplied at deploy time by the
+      deploying workflow (computed as "now + up to 365 days", AppSync's hard
+      per-key maximum) — an AWS::AppSync::ApiKey with no Expires property
+      silently defaults to a 7-DAY expiration, which is what caused
+      ENC-TSK-M56 (gamma realtime layer returning 401 UnauthorizedException
+      on every connection_init, ~9 days after the key was first provisioned
+      with no explicit Expires). The deploy workflow recomputes and re-passes
+      this on every run so each deploy also re-extends the key, giving this
+      value a rolling-renewal side effect rather than a fixed cliff.
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, "production"]
@@ -82,6 +95,12 @@ Resources:
     Properties:
       ApiId: !GetAtt FeedEventsApi.ApiId
       Description: !Sub "enceladus feed events API key${EnvironmentSuffix}"
+      # ENC-TSK-M56: explicit Expires — without it AppSync defaults to 7 days,
+      # which silently expired the key that gates the entire realtime layer.
+      # UpdateApiKey (what this maps to) is an in-place update, not a
+      # replacement, so the ApiKeyId — and every deployed client's copy of it
+      # — stays stable across renewals.
+      Expires: !Ref ApiKeyExpiresEpoch
 
   # ---------------------------------------------------------------------------
   # Channel namespaces — wildcard subscription support per namespace.

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -142,6 +142,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-appsync-events-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-M56: environment: v3-prod -- patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml); grants appsync:* scoped to the specific gamma FeedEventsApi ApiId via a customer-managed policy (create-or-new-version + attach), not inline put-role-policy, since this role's inline policy aggregate is already at/near the 10,240-byte cap."
+    },
     "iam-cfn-deploy-role-cloudwatch-dashboard-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -50,6 +50,13 @@
       ],
       "notes": "v4/main-only file; gamma-only by construction (guard-gamma-only job refuses non-gamma, v3-prod FROZEN per DOC-499FA089EC30); ENC-TSK-J63 plan/apply split with apply environment: v4-gamma"
     },
+    "cloudformation-appsync-events-stack-deploy.yml": {
+      "class": "already-gated",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-M56: new workflow, gamma-only by construction (guard-gamma-only job refuses non-gamma, v3-prod FROZEN per DOC-499FA089EC30); plan/apply split mirroring cloudformation-agent-auth-stack-deploy.yml, apply environment: v4-gamma. Adds a monthly schedule trigger for API-key rolling renewal (schedule events have no branch ref, pinned gamma via github.event_name == 'schedule' in ENVIRONMENT_SUFFIX)."
+    },
     "cloudformation-opensearch-node-stack-deploy.yml": {
       "class": "already-gated",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
Follow-up to #982 (already merged). The first real deploy through the new `cloudformation-appsync-events-stack-deploy.yml` lane failed:

```
User: .../enceladus-cloudformation-deploy-github-role/GitHubActions is not authorized
to perform: appsync:GetApi ... UPDATE_ROLLBACK_COMPLETE
```

The deploy role has never had any `appsync:*` grants — `06-appsync-events.yaml`'s initial provisioning was done out-of-band via privileged-terminal credentials, never through this OIDC role.

Adds `iam-cfn-deploy-role-appsync-events-patch.yml` (`workflow_dispatch`, `environment: v3-prod` per the shared-role precedent — same pattern as `iam-cfn-deploy-role-gamma-patch.yml` et al.) granting `appsync:*` scoped to the specific gamma `FeedEventsApi` ApiId, via a customer-managed policy (create-or-new-version + attach) rather than another inline `put-role-policy`, since this role's inline aggregate is reportedly already at/near the 10,240-byte cap.

Classified in `tools/prod_gate_baseline.json` (`prod-mutating`, `patch-role` job gated `v3-prod`).

**Known follow-up gap**: this new `workflow_dispatch` workflow won't be dispatchable until it also exists on `main` (GitHub only discovers `workflow_dispatch` workflows from the default branch) — same gap ENC-TSK-L06/L83 hit. A forward-port PR to `main` will be opened separately per that precedent (io-approval required, CCI-exempt).

Same task (ENC-TSK-M56, still in-flight at deploy-init) as #982 — reusing that task's issued CCI rather than minting a second one for what is the same fix effort's second commit.

## Test plan
- [x] `tools/prod_gate_coverage_guard.py` passes locally with the new classification entry
- [ ] Forward-port to `main` (io-gated)
- [ ] Dispatch + io-approve the `v3-prod` gate on the `patch-role` job
- [ ] Re-run `cloudformation-appsync-events-stack-deploy.yml` and confirm apply succeeds

CCI-d88c82ba53034b27bae8ed7b00be78c1

🤖 Generated with Claude Code