### PR TITLE
Forward-port iam-cfn-deploy-role-appsync-events-patch.yml to main (workflow_dispatch discovery)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
@@ -1,0 +1,135 @@
+name: IAM CFN Deploy Role — AppSync Events Patch
+
+# ENC-TSK-M56: the CFN deploy role (enceladus-cloudformation-deploy-github-role)
+# has NEVER had any appsync:* permissions -- 06-appsync-events.yaml's initial
+# provisioning (2026-07-02) was done out-of-band via privileged-terminal
+# credentials per the template's own Metadata.EscalatedResidualSteps, not via
+# this OIDC role. The first attempt to deploy this stack through
+# cloudformation-appsync-events-stack-deploy.yml failed:
+#   "User: .../enceladus-cloudformation-deploy-github-role/GitHubActions is
+#    not authorized to perform: appsync:GetApi ... UPDATE_ROLLBACK_COMPLETE"
+#
+# Per prior-session precedent (this role's INLINE policy aggregate is already
+# at/near the 10,240-byte cap), this grant is a customer-managed policy
+# (create + attach), not another put-role-policy inline addition.
+#
+# Scoped to the specific FeedEventsApi ApiId (yri2ycadyfhjtm5cdmu3pxm4iq) and
+# its Api/ApiKey/ChannelNamespace sub-resources -- covers the full resource
+# surface 06-appsync-events.yaml manages, not just the single action that
+# failed, so the next property touched on this stack doesn't repeat this gap.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant appsync:* on the FeedEventsApi (gamma) to the CFN deploy role — 06-appsync-events.yaml had zero appsync permissions (ENC-TSK-M56)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Attach AppSync Events managed policy to CFN deploy role
+    # ENC-TSK-J64 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Create (or reuse) the AppSync Events managed policy
+        id: policy
+        run: |
+          set -euo pipefail
+          cat > /tmp/appsync-events-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AppSyncEventsApiManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetApi",
+                  "appsync:CreateApi",
+                  "appsync:UpdateApi",
+                  "appsync:DeleteApi",
+                  "appsync:TagResource",
+                  "appsync:UntagResource",
+                  "appsync:ListTagsForResource"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq"
+              },
+              {
+                "Sid": "AppSyncEventsApiKeyManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetApiKey",
+                  "appsync:ListApiKeys",
+                  "appsync:CreateApiKey",
+                  "appsync:UpdateApiKey",
+                  "appsync:DeleteApiKey"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq/apikeys/*"
+              },
+              {
+                "Sid": "AppSyncEventsChannelNamespaceManage",
+                "Effect": "Allow",
+                "Action": [
+                  "appsync:GetChannelNamespace",
+                  "appsync:ListChannelNamespaces",
+                  "appsync:CreateChannelNamespace",
+                  "appsync:UpdateChannelNamespace",
+                  "appsync:DeleteChannelNamespace"
+                ],
+                "Resource": "arn:aws:appsync:us-west-2:356364570033:apis/yri2ycadyfhjtm5cdmu3pxm4iq/channelNamespace/*"
+              }
+            ]
+          }
+          JSON
+
+          policy_arn="arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-appsync-events-ops"
+          if aws iam get-policy --policy-arn "${policy_arn}" >/dev/null 2>&1; then
+            echo "Policy already exists; creating a new default version instead of re-creating."
+            version_count=$(aws iam list-policy-versions --policy-arn "${policy_arn}" --query 'length(Versions)' --output text)
+            if [ "${version_count}" -ge 5 ]; then
+              oldest_non_default=$(aws iam list-policy-versions --policy-arn "${policy_arn}" \
+                --query 'Versions[?IsDefaultVersion==`false`]|sort_by(@,&CreateDate)[0].VersionId' --output text)
+              aws iam delete-policy-version --policy-arn "${policy_arn}" --version-id "${oldest_non_default}"
+            fi
+            aws iam create-policy-version \
+              --policy-arn "${policy_arn}" \
+              --policy-document "file:///tmp/appsync-events-policy.json" \
+              --set-as-default
+          else
+            aws iam create-policy \
+              --policy-name "enceladus-cfn-deploy-appsync-events-ops" \
+              --policy-document "file:///tmp/appsync-events-policy.json" \
+              --description "ENC-TSK-M56: appsync:* for the CFN deploy role, scoped to the gamma FeedEventsApi (06-appsync-events.yaml)"
+          fi
+          echo "policy_arn=${policy_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attach managed policy to the CFN deploy role
+        run: |
+          set -euo pipefail
+          aws iam attach-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-arn "${{ steps.policy.outputs.policy_arn }}"
+
+      - name: Verify attachment
+        run: |
+          aws iam list-attached-role-policies \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --query "AttachedPolicies[?PolicyName=='enceladus-cfn-deploy-appsync-events-ops']" \
+            --output table
+# CCI-d88c82ba53034b27bae8ed7b00be78c1

--- a/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-appsync-events-patch.yml
@@ -133,3 +133,4 @@ jobs:
             --query "AttachedPolicies[?PolicyName=='enceladus-cfn-deploy-appsync-events-ops']" \
             --output table
 # CCI-d88c82ba53034b27bae8ed7b00be78c1
+

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -128,6 +128,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-appsync-events-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-M56: environment: v3-prod -- patches the SHARED CFN deploy role object (same pattern as iam-cfn-deploy-role-gamma-patch.yml); grants appsync:* scoped to the specific gamma FeedEventsApi ApiId via a customer-managed policy (create-or-new-version + attach), not inline put-role-policy, since this role's inline aggregate is already at/near the 10,240-byte cap. Forward-ported from v4/main (PR #983) for workflow_dispatch discoverability."
+    },
     "iam-cfn-deploy-role-nat-gateway-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary
Pure workflow_dispatch-discoverability forward-port, same pattern as ENC-TSK-L06/L83 (PR #915/#913).

`iam-cfn-deploy-role-appsync-events-patch.yml` was added to v4/main via PR #983 (ENC-TSK-M56) but GitHub only discovers `workflow_dispatch`-triggerable workflows from the **default branch**. Without this, the workflow exists but can never be manually run.

This PR adds the identical file content to `main`, plus the matching `tools/prod_gate_baseline.json` classification entry (main's copy of that file didn't have it yet, which the prod-gate coverage guard correctly caught). It changes no runtime behavior on `main` — the workflow only ever fires via `workflow_dispatch`, and its single job is gated `environment: v3-prod` (a live IAM mutation on the shared CFN deploy role, per the FTR-120 invariant).

**Why I'm not merging this myself**: this session's authorization is gamma-only deploy work (DOC-499FA089EC30); merging to `main` is outside that scope, same boundary ENC-TSK-L06 and ENC-TSK-L83 cited for their equivalent PRs.

**Context**: this unblocks ENC-TSK-M56 (gamma AppSync Events realtime returning 401 UnauthorizedException on every connection — the API key expired because its CFN template never set an explicit `Expires`, defaulting to AppSync's 7-day expiration). The CFN fix is already merged and deployed-lane-created on v4/main (PR #982); the deploy attempt failed because the CFN deploy role has zero `appsync:*` grants (PR #983 adds the patch workflow to grant them, gated on this PR + io approval of the `v3-prod` environment).

Same task (ENC-TSK-M56) as #982/#983 — reusing that task's issued CCI.

## Test plan
- [x] `tools/prod_gate_coverage_guard.py` passes locally against main's tree with the new classification entry
- [ ] io merges this PR
- [ ] Dispatch + io-approve the `v3-prod` gate on the `patch-role` job
- [ ] Re-run `cloudformation-appsync-events-stack-deploy.yml` and confirm apply succeeds

CCI-d88c82ba53034b27bae8ed7b00be78c1

🤖 Generated with Claude Code