### PR TITLE
ENC-TSK-M57: fix PWA Refresh-App staleness — force SW update check + reload fallback (ISS-525)

### DIFF
--- a/frontend/ui-v2/src/offline/swUpdate.test.ts
+++ b/frontend/ui-v2/src/offline/swUpdate.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { refreshApp, setUpdateSW } from './swUpdate'
+
+/**
+ * ENC-TSK-M57 / ENC-ISS-525 regression coverage. The pre-fix refreshApp() only
+ * ever awaited vite-plugin-pwa's updateSW(true), which silently no-ops when no
+ * worker is waiting -- so an always-open tab's "App refresh" click did nothing
+ * and never picked up a freshly deployed build. refreshApp() must now force an
+ * update check and always guarantee forward progress (activate-and-reload, or a
+ * plain reload fallback).
+ */
+describe('refreshApp (ENC-ISS-525)', () => {
+  const reload = vi.fn()
+
+  beforeEach(() => {
+    reload.mockReset()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload },
+    })
+    // Reset the captured updateSW between tests.
+    setUpdateSW(undefined as unknown as (reloadPage?: boolean) => Promise<void>)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('forces an update check and activates a waiting worker via updateSW (no direct reload)', async () => {
+    const updateSW = vi.fn().mockResolvedValue(undefined)
+    setUpdateSW(updateSW)
+    const registration = {
+      update: vi.fn().mockResolvedValue(undefined),
+      waiting: {},
+    }
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistration: vi.fn().mockResolvedValue(registration),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    })
+
+    await refreshApp()
+
+    expect(registration.update).toHaveBeenCalledOnce()
+    expect(updateSW).toHaveBeenCalledWith(true)
+    // vite-plugin-pwa's updateSW owns the reload-on-controllerchange; we must
+    // NOT also force a plain reload in this path.
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real reload when no worker is waiting (the missing case)', async () => {
+    const registration = {
+      update: vi.fn().mockResolvedValue(undefined),
+      waiting: null,
+    }
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistration: vi.fn().mockResolvedValue(registration),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    })
+
+    await refreshApp()
+
+    expect(registration.update).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('reloads when service workers are unsupported', async () => {
+    vi.stubGlobal('navigator', {})
+
+    await refreshApp()
+
+    expect(reload).toHaveBeenCalledOnce()
+  })
+
+  it('reloads if the registration lookup throws', async () => {
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistration: vi.fn().mockRejectedValue(new Error('boom')),
+      },
+    })
+
+    await refreshApp()
+
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/ui-v2/src/offline/swUpdate.ts
+++ b/frontend/ui-v2/src/offline/swUpdate.ts
@@ -1,16 +1,24 @@
 /**
- * ENC-TSK-M37 -- the "Refresh App" control's force-activate path.
+ * ENC-TSK-M37 / ENC-TSK-M57 -- the "Refresh App" control's force-activate path.
  *
- * Before this task the only signal for a waiting service worker was the
- * dismiss-only "App update available" Flashbar (components/OfflineLayer.tsx,
- * driven by offlineStore.swUpdateReady): dismissing it just hid the banner
- * and left the waiting worker waiting forever, so probes kept running
- * against a stale precached shell indefinitely. `registerSW`'s return value
- * (vite-plugin-pwa's `updateSW`, semantics: skipWaiting + reload once the
- * new worker takes control) was never even captured in main.tsx.
+ * M37 introduced the "App refresh" menu item (AppShell.tsx, above Log out) so a
+ * waiting service worker could be force-activated instead of only ever showing
+ * the dismiss-only "App update available" Flashbar. It captured registerSW's
+ * return value (vite-plugin-pwa's `updateSW`, semantics: skipWaiting + reload
+ * once the new worker takes control) via setUpdateSW().
  *
- * This module holds that function so any UI surface -- today, the "App
- * refresh" menu item above Log out -- can force the swap.
+ * M57 (ENC-ISS-525): that alone was not enough. `updateSW(true)` only activates
+ * a worker that is ALREADY waiting -- but an always-loaded SPA may not have
+ * re-checked for a new service worker since the tab opened, so after a fresh
+ * gamma deploy there is often NO waiting worker yet and `updateSW(true)`
+ * silently no-ops (it does not even reload). Clicking "App refresh" then appears
+ * dead and the user is forced into a manual hard reload. `refreshApp()` now:
+ *   1. forces `registration.update()` so the browser notices a freshly deployed
+ *      worker,
+ *   2. activates it (skipWaiting) and reloads when one is waiting, and
+ *   3. always falls back to a real reload so the freshest shell loads even when
+ *      no new worker is found (the app shell is served NetworkFirst, so a reload
+ *      pulls the latest index.html + content-hashed bundles from the network).
  */
 
 type UpdateSWFn = (reloadPage?: boolean) => Promise<void>
@@ -22,13 +30,52 @@ export function setUpdateSW(fn: UpdateSWFn): void {
   updateSWRef = fn
 }
 
-/** Force-activates the waiting service worker (skipWaiting) and reloads once
- *  it takes control. Falls back to a plain reload if no SW registration
- *  exists yet (unsupported browser, or called before registerSW resolves). */
+/** skipWaiting the waiting worker and reload once it takes control. Used when
+ *  vite-plugin-pwa's `updateSW` was never captured. Reloads on a timeout too,
+ *  in case `controllerchange` never fires (some browsers/edge cases). */
+function activateWaitingWorker(registration: ServiceWorkerRegistration): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      navigator.serviceWorker.removeEventListener('controllerchange', finish)
+      window.location.reload()
+      resolve()
+    }
+    navigator.serviceWorker.addEventListener('controllerchange', finish)
+    registration.waiting?.postMessage({ type: 'SKIP_WAITING' })
+    setTimeout(finish, 3000)
+  })
+}
+
+/** Force-loads the newest deployed build. Forces an update check first (an
+ *  always-open SPA may not have re-checked since load), activates a waiting
+ *  worker when present, and otherwise falls back to a plain reload so the
+ *  NetworkFirst app shell still pulls the latest index.html + hashed bundles.
+ *  ENC-ISS-525. */
 export async function refreshApp(): Promise<void> {
-  if (updateSWRef) {
-    await updateSWRef(true)
-    return
+  try {
+    if ('serviceWorker' in navigator) {
+      const registration = await navigator.serviceWorker.getRegistration()
+      if (registration) {
+        // Force the browser to look for a newer worker before we conclude there
+        // is nothing to activate -- this is the check M37 was missing, and the
+        // reason a stale-but-open tab's "App refresh" click did nothing.
+        await registration.update()
+        if (registration.waiting) {
+          if (updateSWRef) {
+            // vite-plugin-pwa's updateSW: skipWaiting + reload-on-controllerchange.
+            await updateSWRef(true)
+            return
+          }
+          await activateWaitingWorker(registration)
+          return
+        }
+      }
+    }
+  } catch {
+    // Any service-worker error -> fall through to a plain reload below.
   }
   window.location.reload()
 }


### PR DESCRIPTION
## ENC-TSK-M57 — Fix PWA Refresh-App staleness (ENC-ISS-525)

CCI-5865cda4a47f4d25a2a1d8ce432a3098

### Problem
`refreshApp()` (`frontend/ui-v2/src/offline/swUpdate.ts`) only awaited vite-plugin-pwa's `updateSW(true)`, which activates only an *already-waiting* service worker and silently no-ops (no reload) when none is waiting. An always-open tab that had not re-checked for a new worker since load therefore did nothing on **App refresh** after a fresh gamma deploy — forcing a manual hard reload. This is the FTR-130 UAT re-sweep blocker reported in ENC-ISS-525.

### Fix
`refreshApp()` now:
1. forces `registration.update()` so the browser discovers a freshly deployed worker,
2. activates a waiting worker (`updateSW` / `skipWaiting` + reload-on-`controllerchange`),
3. **always** falls back to `window.location.reload()` (the NetworkFirst app shell pulls the latest `index.html` + content-hashed bundles).

Adds `swUpdate.test.ts` (activate-via-updateSW, no-waiting-worker fallback reload, SW-unsupported reload, registration-error reload). `tsc --noEmit` clean project-wide; 275 vitest tests pass.

### Scope note
M57 originally bundled ENC-ISS-526 (blank document Content tab / empty `.md`). Diagnosis showed ISS-526 is a **gamma backend/data** issue — gamma document bodies are absent from gamma's isolated S3 prefix (`S3EnvPrefix=gamma/`, table `documents-gamma`, IAM scoped accordingly), so even `GET /documents/{id}?include_content=true` returns no content on gamma — **not** a client-side bug. Split into **ENC-TSK-M59**. This PR covers ISS-525 only.

Deploy target: **gamma** (merges to `v4/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
