### PR TITLE
ENC-TSK-M55: reduce feed edge-attach DynamoDB read volume (Design D)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-11.01",
-  "updated_at": "2026-07-11T01:25:00Z",
-  "last_change_summary": "ENC-TSK-M59 / ENC-ISS-526: document_api _get_content read-through fallback + lazy env-prefix provision. The env-prefixed computed S3 key (S3_PREFIX/{project_id}/{document_id}.md) remains authoritative; when it is absent and the record's stored s3_key/s3_bucket name a different location (gamma documents-gamma rows cloned from prod carry the unprefixed prod s3_key with no body under gamma/agent-documents/), the Lambda falls back to a read-only fetch of the stored location and lazily copies the body into the computed key so the env prefix self-provisions on first read. Fallback swallows AccessDenied (deploy-order-safe ahead of the IAM grant); no-op on prod where S3EnvPrefix is empty. New IAM statement S3DocumentsSourceReadFallback (02-compute.yaml) grants read-only s3:GetObject on the unprefixed agent-documents/* path. Applies to single GET include_content and the PATCH append read (which previously risked clobbering a prod-cloned body with only the appended text on gamma). New docstore.document.s3_key field entry documents the contract.",
+  "version": "2026-07-11.2",
+  "updated_at": "2026-07-11T01:40:00Z",
+  "last_change_summary": "ENC-TSK-M55: enceladus_shared.relationship_store gains read-volume reduction for the feed edge-attach path -- RELATIONSHIPS_TABLE_AUTHORITATIVE env flag (CFN, gamma=true) skips the legacy tracker-table fallback pass in iter_project_relationship_items; new build_page_sk_ranges emits sort-key BETWEEN bounds from the capped feed page's source IDs (FEED_EDGE_RANGE_MAX_CLUSTERS, default 1 range/project; FEED_EDGE_RANGE_BOUND_DISABLED kill switch); feed_query passes source_ids_by_project + logs edge_attach_stats (query_count/items_seen/scanned_count). Also revives the gamma attach path, dead since the layer/vendoring gap (relationship_store missing from enceladus-shared:10).",
   "owners": [
     "enceladus-platform"
   ],
@@ -4721,7 +4721,7 @@
       }
     },
     "enceladus_shared.relationship_store": {
-      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py) for B65 Ph4 typed-relationship table extraction (ENC-TSK-L13). When RELATIONSHIPS_TABLE is set, writes dual-put forward+inverse pairs to enceladus-relationships and devops-project-tracker; reads merge the relationships table first with legacy tracker fallback on SK conflicts.",
+      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py) for B65 Ph4 typed-relationship table extraction (ENC-TSK-L13). When RELATIONSHIPS_TABLE is set, writes dual-put forward+inverse pairs to enceladus-relationships and devops-project-tracker; reads merge the relationships table first with legacy tracker fallback on SK conflicts. ENC-TSK-M55: when RELATIONSHIPS_TABLE_AUTHORITATIVE is true (per-environment CFN flag; gamma live-verified 2026-07-11) the fallback pass is skipped on the feed/extensions read path, and per-project Queries may be range-bounded to the feed page's source-ID span.",
       "fields": {
         "write_target_tables": {
           "type": "function",
@@ -4733,7 +4733,19 @@
         },
         "iter_project_relationship_items": {
           "type": "function",
-          "definition": "Full-project rel# scan for feed/extensions; relationships table keys win over tracker duplicates."
+          "definition": "Feed/extensions rel# read; relationships table keys win over tracker duplicates. ENC-TSK-M55: optional sk_ranges_by_project applies BETWEEN bounds per project instead of the full-history begins_with scan; optional stats dict accumulates query_count/items_seen/scanned_count; skips the tracker fallback pass when relationships_authoritative()."
+        },
+        "relationships_authoritative": {
+          "type": "function",
+          "definition": "True when env RELATIONSHIPS_TABLE_AUTHORITATIVE is 1/true/yes -- the relationships table is a verified superset of tracker rel# rows and the legacy fallback pass is skipped (ENC-TSK-M55 component 1)."
+        },
+        "build_page_sk_ranges": {
+          "type": "function",
+          "definition": "Builds rel# sort-key BETWEEN bounds covering every edge of the given source IDs, grouped by record-type prefix and coalesced to FEED_EDGE_RANGE_MAX_CLUSTERS ranges (default 1) (ENC-TSK-M55 component 2)."
+        },
+        "range_bounding_disabled": {
+          "type": "function",
+          "definition": "True when env FEED_EDGE_RANGE_BOUND_DISABLED is 1/true/yes -- reverts the feed edge-attach path to full-history begins_with scans without a code rollback (ENC-TSK-M55 kill switch)."
         }
       }
     },
@@ -7889,7 +7901,7 @@
       "telemetry_eligible": false
     }
   },
-  "change_summary": "ENC-TSK-M48: parallelize feed_query's OpenSearch-tier BatchGetItem hydration (_hydrate_records_via_batch_get now fans batches out via ThreadPoolExecutor, matching ENC-TSK-M36 sizing) to bring live gamma p95 under the 500ms bar. Internal concurrency fix only -- no schema, field, or endpoint change; feed_query.opensearch_tier entity unchanged.",
+  "change_summary": "ENC-TSK-M55: enceladus_shared.relationship_store gains read-volume reduction for the feed edge-attach path -- RELATIONSHIPS_TABLE_AUTHORITATIVE env flag (CFN, gamma=true) skips the legacy tracker-table fallback pass in iter_project_relationship_items; new build_page_sk_ranges emits sort-key BETWEEN bounds from the capped feed page's source IDs (FEED_EDGE_RANGE_MAX_CLUSTERS, default 1 range/project; FEED_EDGE_RANGE_BOUND_DISABLED kill switch); feed_query passes source_ids_by_project + logs edge_attach_stats (query_count/items_seen/scanned_count). Also revives the gamma attach path, dead since the layer/vendoring gap (relationship_store missing from enceladus-shared:10).",
   "change_log": [
     {
       "version": "2026-07-08.05",
@@ -8235,6 +8247,11 @@
       "version": "2026-07-10.02",
       "date": "2026-07-10",
       "summary": "ENC-TSK-M48: parallelize feed_query's OpenSearch-tier BatchGetItem hydration (_hydrate_records_via_batch_get now fans batches out via ThreadPoolExecutor, matching ENC-TSK-M36 sizing) to bring live gamma p95 under the 500ms bar. Internal concurrency fix only -- no schema, field, or endpoint change; feed_query.opensearch_tier entity unchanged."
+    },
+    {
+      "version": "2026-07-11.2",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M55: enceladus_shared.relationship_store gains read-volume reduction for the feed edge-attach path -- RELATIONSHIPS_TABLE_AUTHORITATIVE env flag (CFN, gamma=true) skips the legacy tracker-table fallback pass in iter_project_relationship_items; new build_page_sk_ranges emits sort-key BETWEEN bounds from the capped feed page's source IDs (FEED_EDGE_RANGE_MAX_CLUSTERS, default 1 range/project; FEED_EDGE_RANGE_BOUND_DISABLED kill switch); feed_query passes source_ids_by_project + logs edge_attach_stats (query_count/items_seen/scanned_count). Also revives the gamma attach path, dead since the layer/vendoring gap (relationship_store missing from enceladus-shared:10)."
     }
   ]
 }

--- a/backend/lambda/feed_query/.build_extras
+++ b/backend/lambda/feed_query/.build_extras
@@ -2,3 +2,7 @@
 # the published enceladus-shared:10 Lambda layer. Vendor into the function zip
 # until the layer is bumped (see governance_data_dictionary enceladus_shared.record_extensions).
 backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+# ENC-TSK-M55: relationship_store gained range-bounded queries + authoritative-
+# table gating; the published layer (enceladus-shared:10) predates these, so the
+# flat copy vendored here must win (record_extensions imports it bare-first).
+backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -2150,12 +2150,39 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     query_typed_relationships_for_projects,
                 )
 
+                # ENC-TSK-M55: range-bound each project's edge Query to the
+                # sort-key span of the records actually in this capped page.
+                source_ids_by_project: Dict[str, List[str]] = {}
+                for coll, id_key in (
+                    (tasks, "task_id"),
+                    (issues, "issue_id"),
+                    (features, "feature_id"),
+                    (lessons, "lesson_id"),
+                    (plans, "plan_id"),
+                ):
+                    for r in coll:
+                        pid = r.get("project_id")
+                        rid = r.get(id_key)
+                        if pid and rid:
+                            source_ids_by_project.setdefault(pid, []).append(str(rid))
+
+                edge_attach_stats: Dict[str, int] = {}
                 edges_by_source = query_typed_relationships_for_projects(
                     _get_ddb(),
                     DYNAMODB_TABLE,
                     project_ids,
                     ddb_str=_ddb_str,
                     ddb_float=_ddb_float,
+                    source_ids_by_project=source_ids_by_project,
+                    stats=edge_attach_stats,
+                )
+                # ENC-TSK-M55 AC-3 evidence: DynamoDB read volume per full refresh.
+                logger.info(
+                    "edge_attach_stats projects=%d query_count=%d items_seen=%d scanned_count=%d",
+                    len(project_ids),
+                    edge_attach_stats.get("query_count", 0),
+                    edge_attach_stats.get("items_seen", 0),
+                    edge_attach_stats.get("scanned_count", 0),
                 )
                 attach_record_extensions(tasks, "task_id", "task", edges_by_source)
                 attach_record_extensions(issues, "issue_id", "issue", edges_by_source)

--- a/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
@@ -135,9 +135,39 @@ def query_typed_relationships_for_projects(
     *,
     ddb_str: Callable[[Dict[str, Any], str], str],
     ddb_float: Callable[[Dict[str, Any], str], float],
+    source_ids_by_project: Optional[Dict[str, List[str]]] = None,
+    stats: Optional[Dict[str, int]] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Query all outgoing typed edges for the given projects."""
-    from enceladus_shared.relationship_store import iter_project_relationship_items
+    """Query all outgoing typed edges for the given projects.
+
+    ENC-TSK-M55: source_ids_by_project, when provided, range-bounds each
+    project's Query to the sort-key span of the page's actual source records
+    (see relationship_store.build_page_sk_ranges). Callers that omit it keep
+    the full-history behavior unchanged.
+    """
+    # ENC-TSK-M55: bare import first — the vendored flat copy in the function
+    # zip must win over the stale published-layer package copy (.build_extras
+    # pattern, see PLN-006 catalog durable facts).
+    try:
+        from relationship_store import (  # type: ignore
+            build_page_sk_ranges,
+            iter_project_relationship_items,
+            range_bounding_disabled,
+        )
+    except ImportError:
+        from enceladus_shared.relationship_store import (
+            build_page_sk_ranges,
+            iter_project_relationship_items,
+            range_bounding_disabled,
+        )
+
+    sk_ranges_by_project: Optional[Dict[str, List[Any]]] = None
+    if source_ids_by_project and not range_bounding_disabled():
+        sk_ranges_by_project = {
+            pid: build_page_sk_ranges(ids)
+            for pid, ids in source_ids_by_project.items()
+            if ids
+        }
 
     edges_by_source: Dict[str, List[Dict[str, Any]]] = {}
     for raw in iter_project_relationship_items(
@@ -145,6 +175,8 @@ def query_typed_relationships_for_projects(
         table_name,
         project_ids,
         ser_s=lambda value: {"S": value},
+        sk_ranges_by_project=sk_ranges_by_project,
+        stats=stats,
     ):
         sk = ddb_str(raw, "record_id")
         if not sk or not sk.startswith("rel#"):
@@ -177,7 +209,10 @@ def query_edges_for_record(
     ddb_float: Callable[[Dict[str, Any], str], float],
 ) -> List[Dict[str, Any]]:
     """Query outgoing typed edges for a single source record."""
-    from enceladus_shared.relationship_store import query_relationship_raw_items
+    try:
+        from relationship_store import query_relationship_raw_items  # type: ignore
+    except ImportError:
+        from enceladus_shared.relationship_store import query_relationship_raw_items
 
     prefix = f"rel#{source_id}#"
     raw_items, _ = query_relationship_raw_items(

--- a/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
+++ b/backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py
@@ -22,6 +22,76 @@ def dual_write_enabled() -> bool:
     return relationships_table_name() is not None
 
 
+def relationships_authoritative() -> bool:
+    """ENC-TSK-M55 component 1: when true, the relationships table is a verified
+    superset of the tracker table's rel# rows and the legacy fallback pass in
+    iter_project_relationship_items is skipped. Set per environment via CFN
+    (gamma verified 2026-07-11; prod unverified, stays false)."""
+    raw = os.environ.get("RELATIONSHIPS_TABLE_AUTHORITATIVE", "").strip().lower()
+    return raw in ("1", "true", "yes")
+
+
+def range_bounding_disabled() -> bool:
+    """ENC-TSK-M55 component 2 kill switch (rollback lever short of git revert)."""
+    raw = os.environ.get("FEED_EDGE_RANGE_BOUND_DISABLED", "").strip().lower()
+    return raw in ("1", "true", "yes")
+
+
+# Sorts after every ASCII suffix of a rel#{source_id}# key, so the upper bound
+# of a BETWEEN range includes all of that source's edges.
+_RANGE_UPPER_SENTINEL = "￿"
+
+
+def build_page_sk_ranges(
+    source_ids: Iterable[str],
+    *,
+    rel_prefix: str = "rel#",
+    max_ranges: Optional[int] = None,
+) -> List[Tuple[str, str]]:
+    """ENC-TSK-M55 component 2: sort-key BETWEEN bounds covering every edge of
+    the given source records.
+
+    Groups the page's source IDs by record-type prefix (the ID up to its last
+    hyphen), then coalesces adjacent groups down to max_ranges. Every source's
+    rel#{source_id}#... keys fall inside the returned bounds by construction;
+    recency-consistency of the ID scheme only affects how narrow the spans are.
+    max_ranges defaults to FEED_EDGE_RANGE_MAX_CLUSTERS (1): at current edge
+    volume (~385 rows total, 2026-07-11) sequential Query round-trips dominate
+    scanned bytes, so one range per project minimizes total calls.
+    """
+    ids = sorted({str(s) for s in source_ids if s})
+    if not ids:
+        return []
+    if max_ranges is None:
+        try:
+            max_ranges = int(os.environ.get("FEED_EDGE_RANGE_MAX_CLUSTERS", "1"))
+        except ValueError:
+            max_ranges = 1
+    max_ranges = max(1, max_ranges)
+
+    groups: List[List[str]] = []
+    current_key: Optional[str] = None
+    for rid in ids:
+        key = rid.rsplit("-", 1)[0] if "-" in rid else rid
+        if key != current_key:
+            groups.append([rid, rid])
+            current_key = key
+        else:
+            groups[-1][1] = rid
+
+    if len(groups) > max_ranges:
+        chunk = -(-len(groups) // max_ranges)  # ceil division
+        groups = [
+            [groups[i][0], groups[min(i + chunk - 1, len(groups) - 1)][1]]
+            for i in range(0, len(groups), chunk)
+        ]
+
+    return [
+        (f"{rel_prefix}{lo}#", f"{rel_prefix}{hi}#{_RANGE_UPPER_SENTINEL}")
+        for lo, hi in groups
+    ]
+
+
 def write_target_tables(tracker_table: str) -> List[str]:
     rel_table = relationships_table_name()
     if rel_table and rel_table != tracker_table:
@@ -201,28 +271,64 @@ def iter_project_relationship_items(
     *,
     ser_s: Callable[[str], PutItem],
     rel_prefix: str = "rel#",
+    sk_ranges_by_project: Optional[Dict[str, List[Tuple[str, str]]]] = None,
+    stats: Optional[Dict[str, int]] = None,
 ) -> Iterable[Dict[str, Any]]:
-    """Yield all relationship raw items for projects (feed/extensions path)."""
+    """Yield all relationship raw items for projects (feed/extensions path).
+
+    ENC-TSK-M55: when sk_ranges_by_project supplies BETWEEN bounds for a
+    project (from build_page_sk_ranges), each range replaces the full-history
+    begins_with scan; projects without ranges keep the legacy scan. When the
+    relationships table is authoritative (verified per environment), the
+    tracker-table fallback pass is skipped entirely. `stats`, if given, is
+    incremented in place: query_count / items_seen / scanned_count.
+    """
     rel_table = relationships_table_name()
+    skip_legacy_pass = rel_table is not None and relationships_authoritative()
     for pid in project_ids:
         if not pid:
             continue
         merged: Dict[str, Dict[str, Any]] = {}
-        tables = [rel_table, tracker_table] if rel_table else [tracker_table]
+        if skip_legacy_pass:
+            tables = [rel_table]
+        else:
+            tables = [rel_table, tracker_table] if rel_table else [tracker_table]
+        ranges = (sk_ranges_by_project or {}).get(pid) or None
         for table in tables:
             if not table:
                 continue
+            if ranges:
+                key_variants = [
+                    (
+                        "project_id = :pid AND record_id BETWEEN :lo AND :hi",
+                        {":pid": ser_s(pid), ":lo": ser_s(lo), ":hi": ser_s(hi)},
+                    )
+                    for lo, hi in ranges
+                ]
+            else:
+                key_variants = [
+                    (
+                        "project_id = :pid AND begins_with(record_id, :rel_prefix)",
+                        {":pid": ser_s(pid), ":rel_prefix": ser_s(rel_prefix)},
+                    )
+                ]
             paginator = ddb.get_paginator("query")
-            for page in paginator.paginate(
-                TableName=table,
-                KeyConditionExpression="project_id = :pid AND begins_with(record_id, :rel_prefix)",
-                ExpressionAttributeValues={
-                    ":pid": ser_s(pid),
-                    ":rel_prefix": ser_s(rel_prefix),
-                },
-            ):
-                for raw in page.get("Items", []):
-                    sk = raw.get("record_id", {}).get("S", "")
-                    if sk.startswith("rel#") and sk not in merged:
-                        merged[sk] = raw
+            for key_condition, attr_values in key_variants:
+                for page in paginator.paginate(
+                    TableName=table,
+                    KeyConditionExpression=key_condition,
+                    ExpressionAttributeValues=attr_values,
+                ):
+                    if stats is not None:
+                        stats["query_count"] = stats.get("query_count", 0) + 1
+                        stats["items_seen"] = stats.get("items_seen", 0) + len(
+                            page.get("Items", [])
+                        )
+                        stats["scanned_count"] = stats.get("scanned_count", 0) + int(
+                            page.get("ScannedCount", 0) or 0
+                        )
+                    for raw in page.get("Items", []):
+                        sk = raw.get("record_id", {}).get("S", "")
+                        if sk.startswith("rel#") and sk not in merged:
+                            merged[sk] = raw
         yield from merged.values()

--- a/backend/lambda/shared_layer/test_layer.py
+++ b/backend/lambda/shared_layer/test_layer.py
@@ -265,5 +265,239 @@ class RelationshipStoreTests(unittest.TestCase):
         )
 
 
+class _FakePaginator:
+    """Emulates ddb.get_paginator('query') over in-memory raw items keyed by
+    (table, project_id). Supports the two KeyConditionExpressions used by
+    iter_project_relationship_items: begins_with prefix and BETWEEN bounds."""
+
+    def __init__(self, data, call_log):
+        self._data = data
+        self._call_log = call_log
+
+    def paginate(self, **kwargs):
+        self._call_log.append(kwargs)
+        table = kwargs["TableName"]
+        values = kwargs["ExpressionAttributeValues"]
+        pid = values[":pid"]["S"]
+        items = self._data.get((table, pid), [])
+        cond = kwargs["KeyConditionExpression"]
+        if "BETWEEN" in cond:
+            lo, hi = values[":lo"]["S"], values[":hi"]["S"]
+            matched = [i for i in items if lo <= i["record_id"]["S"] <= hi]
+        else:
+            prefix = values[":rel_prefix"]["S"]
+            matched = [i for i in items if i["record_id"]["S"].startswith(prefix)]
+        yield {"Items": matched, "ScannedCount": len(matched)}
+
+
+class _FakeDDB:
+    def __init__(self, data):
+        self.data = data
+        self.call_log = []
+
+    def get_paginator(self, op):
+        assert op == "query"
+        return _FakePaginator(self.data, self.call_log)
+
+
+def _rel_item(source_id, rel_type, target_id, weight="1"):
+    return {
+        "project_id": {"S": "enceladus"},
+        "record_id": {"S": f"rel#{source_id}#{rel_type}#{target_id}"},
+        "weight": {"N": weight},
+        "confidence": {"N": "0.9"},
+        "created_at": {"S": "2026-07-11T00:00:00Z"},
+    }
+
+
+class RangeBoundedRelationshipQueryTests(unittest.TestCase):
+    """ENC-TSK-M55: fallback elimination + range-bounded per-project queries."""
+
+    REL_TABLE = "enceladus-relationships-gamma"
+    TRK_TABLE = "devops-project-tracker-gamma"
+
+    def _env(self, authoritative=False, extra=None):
+        env = {"RELATIONSHIPS_TABLE": self.REL_TABLE}
+        if authoritative:
+            env["RELATIONSHIPS_TABLE_AUTHORITATIVE"] = "true"
+        env.update(extra or {})
+        return patch.dict(os.environ, env, clear=False)
+
+    def _edges_data(self):
+        items = [
+            _rel_item("ENC-TSK-M10", "relates-to", "ENC-ISS-100"),
+            _rel_item("ENC-TSK-M55", "implements", "ENC-FTR-130"),
+            _rel_item("ENC-ISS-100", "blocks", "ENC-TSK-M10"),
+            _rel_item("ENC-TSK-A01", "relates-to", "ENC-TSK-M10"),
+        ]
+        return {
+            (self.REL_TABLE, "enceladus"): list(items),
+            (self.TRK_TABLE, "enceladus"): list(items),
+        }
+
+    def test_relationships_authoritative_flag_parsing(self):
+        from enceladus_shared.relationship_store import relationships_authoritative
+
+        with patch.dict(os.environ, {"RELATIONSHIPS_TABLE_AUTHORITATIVE": "false"}, clear=False):
+            self.assertFalse(relationships_authoritative())
+        with patch.dict(os.environ, {"RELATIONSHIPS_TABLE_AUTHORITATIVE": "true"}, clear=False):
+            self.assertTrue(relationships_authoritative())
+
+    def test_build_page_sk_ranges_single_range_default(self):
+        from enceladus_shared.relationship_store import build_page_sk_ranges
+
+        ranges = build_page_sk_ranges(["ENC-TSK-M55", "ENC-ISS-100", "ENC-TSK-A01"])
+        self.assertEqual(len(ranges), 1)
+        lo, hi = ranges[0]
+        self.assertEqual(lo, "rel#ENC-ISS-100#")
+        self.assertTrue(hi.startswith("rel#ENC-TSK-M55#"))
+        # Every page source's edge keys fall inside the bounds.
+        for sk in (
+            "rel#ENC-ISS-100#blocks#ENC-TSK-M10",
+            "rel#ENC-TSK-A01#relates-to#ENC-TSK-M10",
+            "rel#ENC-TSK-M55#implements#ENC-FTR-130",
+        ):
+            self.assertTrue(lo <= sk <= hi, sk)
+        # Out-of-range sources are excluded.
+        self.assertFalse(lo <= "rel#ENC-TSK-Z99#relates-to#X" <= hi)
+
+    def test_build_page_sk_ranges_per_prefix_clusters(self):
+        from enceladus_shared.relationship_store import build_page_sk_ranges
+
+        ranges = build_page_sk_ranges(
+            ["ENC-TSK-M55", "ENC-ISS-100", "ENC-TSK-A01", "ENC-FTR-130"],
+            max_ranges=3,
+        )
+        self.assertEqual(len(ranges), 3)
+        self.assertEqual(ranges[0][0], "rel#ENC-FTR-130#")
+        self.assertEqual(ranges[1][0], "rel#ENC-ISS-100#")
+        self.assertEqual(ranges[2][0], "rel#ENC-TSK-A01#")
+
+    def test_build_page_sk_ranges_empty(self):
+        from enceladus_shared.relationship_store import build_page_sk_ranges
+
+        self.assertEqual(build_page_sk_ranges([]), [])
+
+    def test_authoritative_skips_tracker_fallback_pass(self):
+        from enceladus_shared.relationship_store import iter_project_relationship_items
+
+        ddb = _FakeDDB(self._edges_data())
+        with self._env(authoritative=True):
+            items = list(
+                iter_project_relationship_items(
+                    ddb, self.TRK_TABLE, ["enceladus"], ser_s=lambda v: {"S": v}
+                )
+            )
+        self.assertEqual(len(items), 4)
+        queried_tables = {c["TableName"] for c in ddb.call_log}
+        self.assertEqual(queried_tables, {self.REL_TABLE})
+        self.assertEqual(len(ddb.call_log), 1)
+
+    def test_non_authoritative_keeps_dual_pass(self):
+        from enceladus_shared.relationship_store import iter_project_relationship_items
+
+        ddb = _FakeDDB(self._edges_data())
+        with self._env(authoritative=False):
+            items = list(
+                iter_project_relationship_items(
+                    ddb, self.TRK_TABLE, ["enceladus"], ser_s=lambda v: {"S": v}
+                )
+            )
+        self.assertEqual(len(items), 4)  # merged dedup, rel table wins
+        queried_tables = {c["TableName"] for c in ddb.call_log}
+        self.assertEqual(queried_tables, {self.REL_TABLE, self.TRK_TABLE})
+
+    def test_range_bounded_query_shape_and_stats(self):
+        from enceladus_shared.relationship_store import (
+            build_page_sk_ranges,
+            iter_project_relationship_items,
+        )
+
+        ddb = _FakeDDB(self._edges_data())
+        ranges = {"enceladus": build_page_sk_ranges(["ENC-TSK-M10", "ENC-TSK-M55"])}
+        stats = {}
+        with self._env(authoritative=True):
+            items = list(
+                iter_project_relationship_items(
+                    ddb,
+                    self.TRK_TABLE,
+                    ["enceladus"],
+                    ser_s=lambda v: {"S": v},
+                    sk_ranges_by_project=ranges,
+                    stats=stats,
+                )
+            )
+        # Both in-span sources' edges are returned; out-of-span sources are not.
+        sks = {i["record_id"]["S"] for i in items}
+        self.assertIn("rel#ENC-TSK-M10#relates-to#ENC-ISS-100", sks)
+        self.assertIn("rel#ENC-TSK-M55#implements#ENC-FTR-130", sks)
+        self.assertNotIn("rel#ENC-ISS-100#blocks#ENC-TSK-M10", sks)
+        self.assertNotIn("rel#ENC-TSK-A01#relates-to#ENC-TSK-M10", sks)
+        self.assertIn("BETWEEN", ddb.call_log[0]["KeyConditionExpression"])
+        self.assertEqual(stats["query_count"], 1)
+        self.assertEqual(stats["items_seen"], 2)
+        self.assertEqual(stats["scanned_count"], 2)
+
+    def test_typed_relationships_parity_with_page_scoping(self):
+        """Output contract: typed_relationships byte-identical for in-page
+        records whether or not page scoping is applied (AC-2)."""
+        from enceladus_shared.record_extensions import (
+            query_typed_relationships_for_projects,
+        )
+
+        def ddb_str(raw, key):
+            val = raw.get(key, {})
+            return val.get("S", "") if isinstance(val, dict) else ""
+
+        def ddb_float(raw, key):
+            try:
+                return float(raw.get(key, {}).get("N", "0"))
+            except (TypeError, ValueError):
+                return 0.0
+
+        page_ids = ["ENC-TSK-M10", "ENC-TSK-M55", "ENC-ISS-100", "ENC-TSK-A01"]
+        with self._env(authoritative=True):
+            baseline = query_typed_relationships_for_projects(
+                _FakeDDB(self._edges_data()),
+                self.TRK_TABLE,
+                ["enceladus"],
+                ddb_str=ddb_str,
+                ddb_float=ddb_float,
+            )
+            scoped = query_typed_relationships_for_projects(
+                _FakeDDB(self._edges_data()),
+                self.TRK_TABLE,
+                ["enceladus"],
+                ddb_str=ddb_str,
+                ddb_float=ddb_float,
+                source_ids_by_project={"enceladus": page_ids},
+            )
+        for rid in page_ids:
+            self.assertEqual(baseline.get(rid), scoped.get(rid), rid)
+
+    def test_kill_switch_disables_range_bounding(self):
+        from enceladus_shared.record_extensions import (
+            query_typed_relationships_for_projects,
+        )
+
+        def ddb_str(raw, key):
+            val = raw.get(key, {})
+            return val.get("S", "") if isinstance(val, dict) else ""
+
+        ddb = _FakeDDB(self._edges_data())
+        with self._env(
+            authoritative=True, extra={"FEED_EDGE_RANGE_BOUND_DISABLED": "true"}
+        ):
+            query_typed_relationships_for_projects(
+                ddb,
+                self.TRK_TABLE,
+                ["enceladus"],
+                ddb_str=ddb_str,
+                ddb_float=lambda raw, key: 0.0,
+                source_ids_by_project={"enceladus": ["ENC-TSK-M10"]},
+            )
+        self.assertIn("begins_with", ddb.call_log[0]["KeyConditionExpression"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/lambda/tracker_mutation/.build_extras
+++ b/backend/lambda/tracker_mutation/.build_extras
@@ -2,3 +2,7 @@
 # the published enceladus-shared:10 Lambda layer. Vendor into the function zip
 # until the layer is bumped (see governance_data_dictionary enceladus_shared.record_extensions).
 backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py
+# ENC-TSK-M55: relationship_store gained range-bounded queries + authoritative-
+# table gating; the published layer (enceladus-shared:10) predates these, so the
+# flat copy vendored here must win (record_extensions imports it bare-first).
+backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -406,6 +406,9 @@ Resources:
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           RELATIONSHIPS_TABLE: !Sub "enceladus-relationships${EnvironmentSuffix}"
+          # ENC-TSK-M55: gamma live-verified 2026-07-11 (tracker rel# keys are a
+          # strict subset of the relationships table); prod unverified, stays false.
+          RELATIONSHIPS_TABLE_AUTHORITATIVE: !If [IsGamma, "true", "false"]
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: "45"
@@ -815,6 +818,9 @@ Resources:
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           DYNAMODB_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
           RELATIONSHIPS_TABLE: !Sub "enceladus-relationships${EnvironmentSuffix}"
+          # ENC-TSK-M55: gamma live-verified 2026-07-11 (tracker rel# keys are a
+          # strict subset of the relationships table); prod unverified, stays false.
+          RELATIONSHIPS_TABLE_AUTHORITATIVE: !If [IsGamma, "true", "false"]
           DYNAMODB_REGION: !Ref AWS::Region
           PROJECTS_TABLE: !Sub "projects${EnvironmentSuffix}"
           FEED_PUBLISHER_FUNCTION: !Sub "devops-feed-publisher${EnvironmentSuffix}"


### PR DESCRIPTION
## ENC-TSK-M55 — Design D: read-volume reduction for feed relationship-edge attach

Implements the AC-1-gated Design D (worklog, ENC-SES-081) after a live preflight (ENC-SES-085):

**Component 1 — fallback elimination**: `iter_project_relationship_items` skips the legacy tracker-table pass when `RELATIONSHIPS_TABLE_AUTHORITATIVE` is true. Live-verified on gamma 2026-07-11: tracker rel# keys (385) are a strict subset of `enceladus-relationships-gamma` (385, 0 missing). CFN sets the flag `!If [IsGamma, "true", "false"]` — prod behavior unchanged. Halves per-project Query round-trips.

**Component 2 — range-bounded queries**: feed_query passes the capped page's source IDs per project; `build_page_sk_ranges` converts them to sort-key `BETWEEN` bounds (SK = `rel#{source_id}#{rel_type}#{target_id}`, source_id verified to lead the key). Cluster knob `FEED_EDGE_RANGE_MAX_CLUSTERS` defaults to 1 range/project — at current edge volume (385 rows total) round-trips dominate scanned bytes, so per-prefix splitting stays available but off. `FEED_EDGE_RANGE_BOUND_DISABLED` is the kill switch.

**M49 lesson honored**: zero new thread pools; the win is strictly fewer DynamoDB calls + less data scanned, instrumented via the new `edge_attach_stats` log line (query_count/items_seen/scanned_count) for AC-3 before/after evidence.

**Contract (AC-2)**: `typed_relationships` byte-identical for in-page records (unit-tested parity); `context_node` shape unchanged. Disclosed nuance: `structural_importance`/`max_degree` are computed over the fetched subgraph — near-complete at the 1-range default; detailed in the task worklog preflight entry.

**Packaging**: `relationship_store.py` vendored into feed_query + tracker_mutation zips via `.build_extras` with bare-import-first in `record_extensions` (published layer enceladus-shared:10 predates these changes).

**Rollback (AC-5)**: env kill switch or straight `git revert` (M52 pattern). Gamma lane only.

Tests: shared_layer 32 passed (9 new), feed_query 54 passed, tracker_mutation 472 passed (2 pre-existing failures reproduced on clean tree).

Task: ENC-TSK-M55 (P1, github_pr_deploy)
Commit approval: CCI-d4a2337818eb4a4b8cd696c82bb53eef

🤖 Generated with [Claude Code](https://claude.com/claude-code)