### PR TITLE
ENC-TSK-M60: fix gamma Coordination Lessons/Escalations empty lists — pin to enceladus project (ISS-527)

### DIFF
--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -18,14 +18,12 @@ import { StatusChip } from '../components/StatusChip'
 import { RecordCard } from '../components/RecordCard'
 import { VirtualList } from '../components/VirtualList'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
-import { projectRegistryQueryOptions } from '../api/projectRegistry'
 import {
   fetchAgentSessions,
   fetchAgentTypes,
   fetchCoordinationRequests,
   fetchEscalations,
   fetchLessons,
-  type AgentSession,
   type AgentType,
   type CoordinationRequest,
   type EscalationRecord,
@@ -36,6 +34,15 @@ import { applyTokens } from './applyCoordinationFilter'
 import './coordination.css'
 
 const EMPTY_FILTER: PropertyFilterQuery = { tokens: [], operation: 'and' }
+
+// ENC-ISS-527 / ENC-TSK-M60: the coordination monitor is the enceladus
+// governance cockpit's own view, so it is pinned to the enceladus project.
+// Do NOT derive this from `projects[0]` -- the project-registry order is not
+// guaranteed to put enceladus first (on gamma it resolves to 'agentharmony'),
+// which silently made fetchLessons/fetchEscalations query the wrong project and
+// rendered the Lessons/Escalations sub-tabs empty. Same fix already applied in
+// GovernanceRoute.tsx and SkillLibraryRoute.tsx.
+const COORDINATION_PROJECT_ID = 'enceladus'
 
 const coordinationRequestsQueryOptions = {
   queryKey: ['coordination', 'monitor'] as const,
@@ -60,18 +67,15 @@ export function CoordinationRoute() {
   const [activeTabId, setActiveTabId] = useState(initialTab || 'sessions')
   const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>(EMPTY_FILTER)
 
-  const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
-  const projectId = projects[0]?.project_id ?? 'enceladus'
-
   const sessionsQuery = useQuery(agentSessionsQueryOptions)
   const agentTypesQuery = useQuery(agentTypesQueryOptions)
   const lessonsQuery = useQuery({
-    queryKey: ['coordination', 'lessons', projectId] as const,
-    queryFn: ({ signal }) => fetchLessons(projectId, { signal }),
+    queryKey: ['coordination', 'lessons', COORDINATION_PROJECT_ID] as const,
+    queryFn: ({ signal }) => fetchLessons(COORDINATION_PROJECT_ID, { signal }),
   })
   const escalationsQuery = useQuery({
-    queryKey: ['coordination', 'escalations', projectId] as const,
-    queryFn: ({ signal }) => fetchEscalations(projectId, { signal }),
+    queryKey: ['coordination', 'escalations', COORDINATION_PROJECT_ID] as const,
+    queryFn: ({ signal }) => fetchEscalations(COORDINATION_PROJECT_ID, { signal }),
   })
   const crqQuery = useQuery(coordinationRequestsQueryOptions)
 


### PR DESCRIPTION
## ENC-TSK-M60 — Fix gamma Coordination Lessons/Escalations empty lists (ENC-ISS-527)

CCI-a6cc26d4a75b4b7cbf767ef42705991a

### Root cause
`CoordinationRoute.tsx` derived its project from `projects[0]?.project_id ?? 'enceladus'`. The project-registry order is **not** guaranteed to put enceladus first — on gamma it resolves to **`agentharmony`**. So `fetchLessons` / `fetchEscalations` queried the wrong project and returned 0 rows, rendering the **Lessons** and **Escalations** sub-tabs empty even though enceladus has **67 lessons** and **3 escalations** (verified against the gamma API with a Cognito session).

### Fix
Pin the coordination monitor to a fixed `COORDINATION_PROJECT_ID = 'enceladus'`, matching [`GovernanceRoute.tsx`](../blob/v4/main/frontend/ui-v2/src/routes/GovernanceRoute.tsx) and [`SkillLibraryRoute.tsx`](../blob/v4/main/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx) — both of which already document this exact registry-order footgun ("silently returned zero rows" during gamma validation). Drops the now-unused `projectRegistry` query and a pre-existing unused `AgentSession` type import.

`tsc --noEmit` clean; eslint clean; 275 vitest pass.

### Notes
- The **CRQ docs** sub-tab is separately empty because `/coordination/monitor` returns **0 requests** on gamma (data absence, not a render bug) — documented on the issue.
- **Follow-up (out of scope):** `HomeRoute.tsx:179`, `FeedRoute.tsx:104`, `DocsRoute.tsx:59` carry the same `projects[0]` antipattern and are likely mis-scoped to `agentharmony` on gamma too.

Deploy target: **gamma** (merges to `v4/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
