### PR TITLE
ENC-TSK-M69: fix Decimal JSON serialization crash in appsync_feed_publisher

### DIFF
--- a/backend/lambda/appsync_feed_publisher/lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/lambda_function.py
@@ -67,6 +67,7 @@ import os
 import time
 import urllib.error
 import urllib.request
+from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
@@ -376,6 +377,23 @@ def build_full_record_body(record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _json_default(obj: Any) -> Any:
+    """json.dumps default= hook, applied to EVERY dumps call in this module.
+
+    DynamoDB Stream Number (N) attributes deserialize to Decimal
+    (boto3.dynamodb.types.TypeDeserializer) — json.dumps has no native
+    Decimal support. Covers both the lightweight payload and the
+    /records/{recordId} full_body payload (ENC-TSK-L29), since full_body is
+    a full deserialized NewImage and Decimal can appear at any depth.
+
+    Integral Decimals become int, not float — record IDs, counts, and
+    versions must round-trip exactly, not drift into float representation.
+    """
+    if isinstance(obj, Decimal):
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+
 def _endpoint_url() -> str:
     """Normalize APPSYNC_EVENTS_HTTP_ENDPOINT to a full /event POST URL."""
     ep = APPSYNC_EVENTS_HTTP_ENDPOINT
@@ -427,9 +445,9 @@ def publish_to_appsync(payload: Dict[str, Any], full_body: Optional[Dict[str, An
         raise RuntimeError("APPSYNC_EVENTS_HTTP_ENDPOINT is not configured")
 
     host = url.split("://", 1)[-1].split("/", 1)[0]
-    event_json = json.dumps(payload, separators=(",", ":"))
+    event_json = json.dumps(payload, separators=(",", ":"), default=_json_default)
     detail_event_json = (
-        json.dumps({**payload, "record": full_body}, separators=(",", ":"))
+        json.dumps({**payload, "record": full_body}, separators=(",", ":"), default=_json_default)
         if full_body is not None
         else event_json
     )
@@ -440,7 +458,7 @@ def publish_to_appsync(payload: Dict[str, Any], full_body: Optional[Dict[str, An
             "channel": channel,
             "events": [detail_event_json if is_record_channel else event_json],
         }
-        body = json.dumps(body_obj, separators=(",", ":")).encode("utf-8")
+        body = json.dumps(body_obj, separators=(",", ":"), default=_json_default).encode("utf-8")
 
         headers = {"Content-Type": "application/json", "host": host}
         if APPSYNC_EVENTS_API_KEY:

--- a/backend/lambda/appsync_feed_publisher/test_lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/test_lambda_function.py
@@ -39,7 +39,19 @@ def _stream_record(
     approx_secs: float | None = 1_700_000_000.0,
 ) -> dict:
     def _typed(image: dict | None) -> dict:
-        return {k: {"S": str(v)} for k, v in (image or {}).items()}
+        out = {}
+        for k, v in (image or {}).items():
+            if isinstance(v, bool):
+                out[k] = {"BOOL": v}
+            elif isinstance(v, (int, float)):
+                out[k] = {"N": str(v)}
+            elif isinstance(v, dict):
+                out[k] = {"M": _typed(v)}
+            elif isinstance(v, list):
+                out[k] = {"L": [_typed({"_": x})["_"] for x in v]}
+            else:
+                out[k] = {"S": str(v)}
+        return out
 
     ddb: dict = {"SequenceNumber": seq}
     if approx_secs is not None:
@@ -455,3 +467,97 @@ def test_publish_to_appsync_without_full_body_is_unchanged():
 
     for body in sent_bodies.values():
         assert "record" not in body
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-M69: Decimal-safe JSON serialization
+#
+# DynamoDB Stream Number (N) attributes deserialize to Decimal
+# (boto3.dynamodb.types.TypeDeserializer); json.dumps has no native Decimal
+# support. Covers both the lightweight payload and the /records/{recordId}
+# full_body payload (ENC-TSK-L29) since full_body can carry Decimal at any
+# depth (top-level and nested inside M/L attributes).
+# ---------------------------------------------------------------------------
+
+
+def test_json_default_converts_integral_decimal_to_int():
+    from decimal import Decimal
+
+    assert mod._json_default(Decimal("3")) == 3
+    assert isinstance(mod._json_default(Decimal("3")), int)
+
+
+def test_json_default_converts_non_integral_decimal_to_float():
+    from decimal import Decimal
+
+    assert mod._json_default(Decimal("4.5")) == 4.5
+    assert isinstance(mod._json_default(Decimal("4.5")), float)
+
+
+def test_json_default_reraises_typeerror_for_unsupported_types():
+    class _Unserializable:
+        pass
+
+    try:
+        mod._json_default(_Unserializable())
+        assert False, "expected TypeError"
+    except TypeError:
+        pass
+
+
+def test_build_full_record_body_deserializes_number_attribute_as_decimal():
+    from decimal import Decimal
+
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={
+            "record_id": "task#ENC-TSK-M69T",
+            "item_id": "ENC-TSK-M69T",
+            "sync_version": 3,
+        },
+    )
+    full_body = mod.build_full_record_body(rec)
+    assert isinstance(full_body["sync_version"], Decimal)
+
+
+def test_publish_to_appsync_serializes_decimal_in_full_body_top_level_and_nested():
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={
+            "record_id": "task#ENC-TSK-M69T",
+            "item_id": "ENC-TSK-M69T",
+            "record_type": "task",
+            "project_id": "enceladus",
+            "sync_version": 7,
+            "checkout_count": 2.5,
+            "ontology": {"earned_points": 45, "max_points": 70},
+        },
+    )
+    payload = mod.build_event_payload(rec, 0)
+    full_body = mod.build_full_record_body(rec)
+    assert payload is not None and full_body is not None
+
+    sent_bodies = {}
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ARG001
+        body = json.loads(req.data.decode("utf-8"))
+        sent_bodies[body["channel"]] = json.loads(body["events"][0])
+        return _FakeResponse(200)
+
+    with patch.object(mod.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        mod.publish_to_appsync(payload, full_body)  # must not raise
+
+    record = sent_bodies["/records/ENC-TSK-M69T"]["record"]
+    # Integral Decimal -> int (record ids/counts/versions must not drift to float)
+    assert record["sync_version"] == 7
+    assert isinstance(record["sync_version"], int)
+    # Non-integral Decimal -> float
+    assert record["checkout_count"] == 2.5
+    assert isinstance(record["checkout_count"], float)
+    # Nested Decimal (inside an M-typed sub-map) also serializes cleanly
+    assert record["ontology"]["earned_points"] == 45
+    assert isinstance(record["ontology"]["earned_points"], int)
+
+    # AC-23: lightweight channels are unaffected and still exclude "record"
+    assert "record" not in sent_bodies["/feed/updates"]
+    assert "record" not in sent_bodies["/projects/enceladus"]

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-11.3",
-  "updated_at": "2026-07-11T01:50:00Z",
-  "last_change_summary": "ENC-TSK-M55 REVERT (AC-5 rollback discipline): PR #986 reverted. Live gamma p95 regressed 4.63s -> 5.99s (mean 4.14s -> 5.77s, 22-request probes) because the change also revived the feed edge-attach path, dead since the enceladus-shared:10 layer/vendoring gap -- reviving it re-adds 14 sequential DDB Queries + O(records x edges) context_node compute per full refresh on the 256MB Lambda. relationship_store reverts to pre-M55 shape (RELATIONSHIPS_TABLE_AUTHORITATIVE / build_page_sk_ranges / range_bounding_disabled removed from code; the gamma CFN env var is removed in the same commit). The edge-attach restoration question (functionality vs latency) is handed to io -- see ENC-TSK-M55 worklog HANDOFF.",
+  "version": "2026-07-11.4",
+  "updated_at": "2026-07-11T18:30:00Z",
+  "last_change_summary": "ENC-TSK-M69: appsync_feed_publisher's publish_to_appsync crashed on every invocation with TypeError: Object of type Decimal is not JSON serializable (DynamoDB Stream Number attributes deserialize to Decimal via boto3.dynamodb.types.TypeDeserializer). Added a single _json_default() hook applied to all three json.dumps call sites in the module (lightweight payload, /records/{recordId} full_body per ENC-TSK-L29, and the outer publish body) -- covers Decimal at any depth, not just the lightweight 7-field payload. Integral Decimal -> int (record IDs/counts/versions must not drift to float); non-integral -> float. No entity/field schema change, just a serialization-layer fix; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7889,7 +7889,7 @@
       "telemetry_eligible": false
     }
   },
-  "change_summary": "ENC-TSK-M55 REVERT (AC-5 rollback discipline): PR #986 reverted. Live gamma p95 regressed 4.63s -> 5.99s (mean 4.14s -> 5.77s, 22-request probes) because the change also revived the feed edge-attach path, dead since the enceladus-shared:10 layer/vendoring gap -- reviving it re-adds 14 sequential DDB Queries + O(records x edges) context_node compute per full refresh on the 256MB Lambda. relationship_store reverts to pre-M55 shape (RELATIONSHIPS_TABLE_AUTHORITATIVE / build_page_sk_ranges / range_bounding_disabled removed from code; the gamma CFN env var is removed in the same commit). The edge-attach restoration question (functionality vs latency) is handed to io -- see ENC-TSK-M55 worklog HANDOFF.",
+  "change_summary": "ENC-TSK-M69: appsync_feed_publisher's publish_to_appsync crashed on every invocation with TypeError: Object of type Decimal is not JSON serializable (DynamoDB Stream Number attributes deserialize to Decimal via boto3.dynamodb.types.TypeDeserializer). Added a single _json_default() hook applied to all three json.dumps call sites in the module (lightweight payload, /records/{recordId} full_body per ENC-TSK-L29, and the outer publish body) -- covers Decimal at any depth, not just the lightweight 7-field payload. Integral Decimal -> int (record IDs/counts/versions must not drift to float); non-integral -> float. No entity/field schema change, just a serialization-layer fix; bumping per the lambda_function.py touch guard.",
   "change_log": [
     {
       "version": "2026-07-08.05",
@@ -8245,6 +8245,11 @@
       "version": "2026-07-11.3",
       "date": "2026-07-11",
       "summary": "ENC-TSK-M55 REVERT (AC-5 rollback discipline): PR #986 reverted. Live gamma p95 regressed 4.63s -> 5.99s (mean 4.14s -> 5.77s, 22-request probes) because the change also revived the feed edge-attach path, dead since the enceladus-shared:10 layer/vendoring gap -- reviving it re-adds 14 sequential DDB Queries + O(records x edges) context_node compute per full refresh on the 256MB Lambda. relationship_store reverts to pre-M55 shape (RELATIONSHIPS_TABLE_AUTHORITATIVE / build_page_sk_ranges / range_bounding_disabled removed from code; the gamma CFN env var is removed in the same commit). The edge-attach restoration question (functionality vs latency) is handed to io -- see ENC-TSK-M55 worklog HANDOFF."
+    },
+    {
+      "version": "2026-07-11.4",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M69: appsync_feed_publisher's publish_to_appsync crashed on every invocation with TypeError: Object of type Decimal is not JSON serializable (DynamoDB Stream Number attributes deserialize to Decimal via boto3.dynamodb.types.TypeDeserializer). Added a single _json_default() hook applied to all three json.dumps call sites in the module (lightweight payload, /records/{recordId} full_body per ENC-TSK-L29, and the outer publish body) -- covers Decimal at any depth, not just the lightweight 7-field payload. Integral Decimal -> int (record IDs/counts/versions must not drift to float); non-integral -> float. No entity/field schema change, just a serialization-layer fix; bumping per the lambda_function.py touch guard."
     }
   ]
 }


### PR DESCRIPTION
## Summary

`publish_to_appsync` crashed on **every** invocation with `TypeError: Object of type Decimal is not JSON serializable` — DynamoDB Stream Number attributes deserialize to `Decimal` (`boto3.dynamodb.types.TypeDeserializer`), which `json.dumps` can't handle natively. This silently blocked ENC-TSK-M56's AC-3 (a live `/feed/updates` data frame) even after the AppSync Events transport/auth fix went live on gamma.

- Adds a single `_json_default()` hook applied to **all three** `json.dumps` call sites in the module — the lightweight payload, the `/records/{recordId}` `full_body` payload (ENC-TSK-L29), and the outer publish body. `full_body` is a full deserialized `NewImage`, so Decimal can appear at any depth (top-level or nested inside M/L-typed sub-attributes), not just the lightweight 7-field payload.
- Integral `Decimal` values convert to `int` (record IDs, counts, versions must not drift into float representation); non-integral values convert to `float`. Genuinely unsupported types still raise `TypeError` — this doesn't silently swallow other serialization bugs.
- 5 new unit tests: the encoder helper directly (both branches + TypeError passthrough), a deserialized `NewImage` producing `Decimal`, and `publish_to_appsync` succeeding with `Decimal` at both top level and nested inside an `M`-typed sub-map — verifying int/float fidelity and that the lightweight channels stay untouched (AC-23 budget). 32/32 tests pass.

CCI-2bc8ac58e27348d2a2becede9cb6434a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>