### PR TITLE
ENC-TSK-M66: Implement tracker.creation_rules search action

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,40 +1,40 @@
 {
-  "version": "2026-07-11.5",
-  "updated_at": "2026-07-11T19:05:00Z",
-  "last_change_summary": "ENC-TSK-M65: Added entity.composition declarations to the governance data dictionary for the two composite tracker entities, tracker.plan and tracker.feature. tracker.plan.composition documents that plan objectives (task/issue/feature -- never lesson) attach exclusively via the objectives_set array field, governed by plan.add_objective/plan.remove_objective/plan.reorder_objectives/plan.replace_objectives, with 1:N (practically N:M) cardinality, and clarifies that tracker.task.parent (task-to-task only) is not the plan composition mechanism. tracker.feature.composition documents that features compose tasks via the bidirectional related_task_ids <-> related_feature_ids cross-reference pair (ENC-TSK-L07 mirrored PATCH), N:M cardinality. No behavioral/API change, dictionary-only addition.",
+  "version": "2026-07-11.6",
+  "updated_at": "2026-07-11T19:20:00Z",
+  "last_change_summary": "ENC-TSK-M66: Added mcp_server.tracker_creation_rules describing the new tracker.creation_rules search action (dictionary-derived pre-creation contract surface, no record_id).",
   "owners": [
     "enceladus-platform"
   ],
   "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
   "entities": {
     "tracker.dedup_auto_merge": {
-      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 \u00a7P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL \u2014 judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
       "fields": {
         "enable_dedup_auto_merge": {
           "type": "feature_flag",
-          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 \u00a74.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
           "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
         },
         "dedup_auto_merge_kill_switch": {
           "type": "feature_flag",
-          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} \u2014 auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 \u00a78).",
           "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
         },
         "precision_lcb_floor": {
           "type": "number",
           "default": 0.999,
-          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 \u00a74.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 \u2014 auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, \u00a74.4).",
           "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
         },
         "auto_walk_opt_out_latch": {
           "type": "behavior",
-          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
-          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge \u2014 un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source \u2014 PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required \u2014 the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
         },
         "audit_feed": {
           "type": "event",
           "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
-          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 \u00a710)."
         }
       }
     },
@@ -57,8 +57,8 @@
             "deployed",
             "superseded"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -110,8 +110,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -120,7 +120,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -146,14 +146,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -244,7 +244,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -254,12 +254,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -273,7 +273,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -289,7 +289,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -297,8 +297,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -346,7 +346,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -358,9 +358,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         },
         "auto_walk_opt_out": {
@@ -375,7 +375,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -433,7 +433,7 @@
             "closed",
             "superseded"
           ],
-          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
+          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
         },
         "priority": {
           "type": "enum",
@@ -505,7 +505,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -525,7 +525,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -770,7 +770,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
         }
       }
     },
@@ -806,7 +806,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -926,7 +926,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -951,7 +951,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -1059,7 +1059,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -1168,7 +1168,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -1197,7 +1197,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1305,7 +1305,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1437,7 +1437,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1463,7 +1463,7 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
           "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
@@ -1851,18 +1851,18 @@
           ],
           "default": "ci_triggered",
           "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
-          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field \u2014 including enceladus \u2014 are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier \u2014 never from evidence-field emptiness (DOC-078C57FC1BE6 \u00a77.2). seed value: enceladus = ci_triggered."
         }
       }
     },
     "lifecycle_service.arc_walker_walk": {
-      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 \u00a76.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (\u00a73.1/\u00a711): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) \u2014 distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the \u00a77.2 coding-complete trap).",
       "governing_feature": "ENC-FTR-111",
       "governing_task": "ENC-TSK-H85",
       "fields": {
         "feature_flag": {
           "type": "string",
-          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
+          "definition": "enable_arc_walker \u2014 independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 \u00a711).",
           "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
         },
         "phase1_legs": {
@@ -1872,19 +1872,19 @@
         },
         "idempotent_conditional_write": {
           "type": "object",
-          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly \u2014 no double-step, no lost update (DOC-078C57FC1BE6 \u00a78 idempotency / \u00a79 concurrent-advance mitigation)."
         },
         "safety_invariants": {
           "type": "object",
-          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity \u2014 a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning \u2014 if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
         },
         "write_source": {
           "type": "string",
-          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the \u00a713 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
         },
         "artifact_genesis": {
           "type": "string",
-          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 \u00a78/\u00a710): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
         }
       }
     },
@@ -2313,7 +2313,7 @@
       "fields": {
         "package_root": {
           "type": "string",
-          "definition": "tools/enceladus-mcp-server/mcp_server/ — sibling package imported by server.py."
+          "definition": "tools/enceladus-mcp-server/mcp_server/ \u2014 sibling package imported by server.py."
         },
         "handler_modules": {
           "type": "object",
@@ -2457,7 +2457,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2484,7 +2484,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2555,7 +2555,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2712,7 +2712,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2764,7 +2764,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI; additionally external_deploy components require external_deploy_evidence. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; documentation components additionally require documentation_evidence; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2826,7 +2826,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2887,7 +2887,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2929,14 +2929,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -3107,9 +3107,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -3142,11 +3142,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -3163,18 +3163,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -3285,7 +3285,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -3339,17 +3339,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -3367,7 +3367,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -3380,12 +3380,12 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
       "description": "V3 component-policy enforcement contract for required_transition_type on component_registry.component (ENC-TSK-L77 / DOC-157A790F9E8B). Every component record must carry one of code|external_deploy|documentation. Checkout service maps populated legacy values at read time, compares the component policy to the existing task.transition_type lifecycle arc, and enforces the new evidence sub-schemas at advance gates.",
@@ -3516,12 +3516,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3544,7 +3544,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3561,7 +3561,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "GET /api/v1/feed/corpus — JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+          "definition": "GET /api/v1/feed/corpus \u2014 JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
         },
         "cursor": {
           "type": "string",
@@ -3578,7 +3578,7 @@
       }
     },
     "feed_query.delta": {
-      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E \u00a79C/\u00a710.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
       "fields": {
         "since": {
           "type": "integer",
@@ -3595,7 +3595,7 @@
       }
     },
     "tracker.graphsearch": {
-      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges — never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges \u2014 never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
       "fields": {
         "search_type": {
           "type": "enum",
@@ -3876,7 +3876,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape \u2014 they do not abort the batch."
         }
       },
       "covered_lambdas": [
@@ -4218,7 +4218,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -4246,7 +4246,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -4259,7 +4259,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -4290,9 +4290,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -4400,7 +4400,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -4415,7 +4415,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -4646,17 +4646,17 @@
         },
         "item_id_provenance": {
           "type": "string",
-          "definition": "ENC-TSK-L06 / B63 Phase 2 AC-6: HMAC-SHA256 hex signature over `item_id||created_at||record_type`, stamped on every record allocated through the ID Service (enable_id_service_extraction flag ON). Signed with a shared secret held in Secrets Manager (enceladus/id-service/hmac-key{-gamma}, CFN-generated via GenerateSecretString — never hardcoded, never logged). Verified (warning-only, never blocking) by graph_sync before projecting a node into Neo4j. Absent on records created before this feature or while the flag was OFF (see tracker.id_boundary_enforcement backfill_and_quarantine for the AC-5 backfill status of pre-existing records).",
+          "definition": "ENC-TSK-L06 / B63 Phase 2 AC-6: HMAC-SHA256 hex signature over `item_id||created_at||record_type`, stamped on every record allocated through the ID Service (enable_id_service_extraction flag ON). Signed with a shared secret held in Secrets Manager (enceladus/id-service/hmac-key{-gamma}, CFN-generated via GenerateSecretString \u2014 never hardcoded, never logged). Verified (warning-only, never blocking) by graph_sync before projecting a node into Neo4j. Absent on records created before this feature or while the flag was OFF (see tracker.id_boundary_enforcement backfill_and_quarantine for the AC-5 backfill status of pre-existing records).",
           "usage_guidance": "Server-generated only, exactly like item_id/record_id. A tracker.create payload carrying a client-supplied item_id_provenance is rejected with the same ID_BOUNDARY_VIOLATION error as a client-supplied item_id/record_id."
         }
       }
     },
     "tracker.id_boundary_enforcement": {
-      "description": "ENC-TSK-L06 / B63 Phase 2 AC-6 (extends ENC-FTR-069's ENC-TSK-B99 ID Boundary Rule with a dedicated ID Service, idempotency contract, cryptographic provenance, and a trust-score feedback loop). The contract: (1) IAM isolation — record-ID counter items live in a dedicated enceladus-id-counters{-gamma} DynamoDB table that ONLY the ID Service Lambda's IAM role can access (tracker_mutation's role has no grant referencing that table's ARN at all — ordinary resource-scoped IAM, not a same-table dynamodb:LeadingKeys condition, which cannot constrain a sort-key prefix and would be a silent no-op on the shared tracker table's project_id-partitioned schema); (2) idempotency-key contract — a client-supplied idempotency_key on tracker.create returns the SAME record_id on retry (backed by enceladus-id-idempotency{-gamma}, TTL 24h); (3) cryptographic provenance — item_id_provenance HMAC-SHA256 signature stamped at allocation time and verified (warning-only) by graph_sync before projection; (4) edge-layer rejection — tracker_mutation's _handle_create_record rejects any create payload carrying top-level item_id, record_id, OR item_id_provenance with HTTP 400 error_envelope.code=ID_BOUNDARY_VIOLATION (ENC-ISS-132 origin, extended here); (5) trust-score feedback — every rejection fire-and-forget invokes the ID Service's record_violation action, incrementing a per-caller_identity counter (enceladus-id-violations{-gamma}) and flagging callers past VIOLATION_THRESHOLD (default 5); (6) backfill verification — tools/backfill_item_id_provenance.py stamps item_id_provenance on pre-existing records or reports them as a documented quarantine exemption (reusing the ENC-FTR-069 / ENC-TSK-D29 quarantine list: ENC-TSK-1291, ENC-TSK-1292).",
+      "description": "ENC-TSK-L06 / B63 Phase 2 AC-6 (extends ENC-FTR-069's ENC-TSK-B99 ID Boundary Rule with a dedicated ID Service, idempotency contract, cryptographic provenance, and a trust-score feedback loop). The contract: (1) IAM isolation \u2014 record-ID counter items live in a dedicated enceladus-id-counters{-gamma} DynamoDB table that ONLY the ID Service Lambda's IAM role can access (tracker_mutation's role has no grant referencing that table's ARN at all \u2014 ordinary resource-scoped IAM, not a same-table dynamodb:LeadingKeys condition, which cannot constrain a sort-key prefix and would be a silent no-op on the shared tracker table's project_id-partitioned schema); (2) idempotency-key contract \u2014 a client-supplied idempotency_key on tracker.create returns the SAME record_id on retry (backed by enceladus-id-idempotency{-gamma}, TTL 24h); (3) cryptographic provenance \u2014 item_id_provenance HMAC-SHA256 signature stamped at allocation time and verified (warning-only) by graph_sync before projection; (4) edge-layer rejection \u2014 tracker_mutation's _handle_create_record rejects any create payload carrying top-level item_id, record_id, OR item_id_provenance with HTTP 400 error_envelope.code=ID_BOUNDARY_VIOLATION (ENC-ISS-132 origin, extended here); (5) trust-score feedback \u2014 every rejection fire-and-forget invokes the ID Service's record_violation action, incrementing a per-caller_identity counter (enceladus-id-violations{-gamma}) and flagging callers past VIOLATION_THRESHOLD (default 5); (6) backfill verification \u2014 tools/backfill_item_id_provenance.py stamps item_id_provenance on pre-existing records or reports them as a documented quarantine exemption (reusing the ENC-FTR-069 / ENC-TSK-D29 quarantine list: ENC-TSK-1291, ENC-TSK-1292).",
       "fields": {
         "enable_id_service_extraction": {
           "type": "boolean",
-          "definition": "AppConfig flag (env_fallback ENABLE_ID_SERVICE, default false), read at request time via enceladus_shared.appconfig_flags.flag(). When ON, tracker_mutation delegates record-ID allocation to the standalone ID Service Lambda (enceladus-id-service{-gamma}) via a synchronous, FAIL-CLOSED RequestResponse invoke — mirroring the enable_lifecycle_service_extraction (ENC-TSK-H46) posture exactly: any invoke failure rejects the create (HTTP 503, code=ID_SERVICE_UNAVAILABLE), never silently falling back to the inline _next_record_id path (a silent fallback would defeat the IAM isolation property). When OFF (default), the inline counter-based allocation in tracker_mutation runs unchanged (zero-behavior-change rollback path) and continues reading/writing legacy counter#* rows in the shared tracker table."
+          "definition": "AppConfig flag (env_fallback ENABLE_ID_SERVICE, default false), read at request time via enceladus_shared.appconfig_flags.flag(). When ON, tracker_mutation delegates record-ID allocation to the standalone ID Service Lambda (enceladus-id-service{-gamma}) via a synchronous, FAIL-CLOSED RequestResponse invoke \u2014 mirroring the enable_lifecycle_service_extraction (ENC-TSK-H46) posture exactly: any invoke failure rejects the create (HTTP 503, code=ID_SERVICE_UNAVAILABLE), never silently falling back to the inline _next_record_id path (a silent fallback would defeat the IAM isolation property). When OFF (default), the inline counter-based allocation in tracker_mutation runs unchanged (zero-behavior-change rollback path) and continues reading/writing legacy counter#* rows in the shared tracker table."
         },
         "id_boundary_violation_error_code": {
           "type": "string",
@@ -4664,7 +4664,7 @@
         },
         "backfill_and_quarantine": {
           "type": "string",
-          "definition": "tools/backfill_item_id_provenance.py scans devops-project-tracker{-gamma}, computing + stamping item_id_provenance on any record with item_id + created_at + record_type but no existing signature. Records that cannot be signed (missing required fields) OR that match the ENC-FTR-069 quarantine list (ENC-TSK-1291, ENC-TSK-1292 — both already adjudicated as an intentional exemption, not re-litigated here) are reported as a documented quarantine exemption, never fabricated. Idempotent: re-running after a successful pass produces zero writes."
+          "definition": "tools/backfill_item_id_provenance.py scans devops-project-tracker{-gamma}, computing + stamping item_id_provenance on any record with item_id + created_at + record_type but no existing signature. Records that cannot be signed (missing required fields) OR that match the ENC-FTR-069 quarantine list (ENC-TSK-1291, ENC-TSK-1292 \u2014 both already adjudicated as an intentional exemption, not re-litigated here) are reported as a documented quarantine exemption, never fabricated. Idempotent: re-running after a successful pass produces zero writes."
         }
       }
     },
@@ -4779,7 +4779,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4809,7 +4809,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4826,12 +4826,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4864,23 +4864,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan → document. Attaches a document as reference material for the plan.",
+          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -5091,11 +5091,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -5128,7 +5128,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         },
         "orphan_purge_on_edge_removal": {
           "type": "string",
@@ -5183,7 +5183,7 @@
       }
     },
     "tracker.pathway_traversed": {
-      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection \u2014 graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation \u2014 tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability \u2014 graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
       "fields": {
         "edge_label": {
           "type": "string",
@@ -5191,11 +5191,11 @@
         },
         "relationship_type": {
           "type": "string",
-          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) \u2014 the lowercase tracker_mutation relationship_type keys."
         },
         "scoring_exclusion": {
           "type": "boolean",
-          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+          "definition": "true \u2014 excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
         },
         "ogtm_compliance": {
           "type": "object",
@@ -5204,7 +5204,7 @@
       }
     },
     "graph_query_api.pathway_telemetry": {
-      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response \u2014 this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
       "fields": {
         "request_params": {
           "type": "object",
@@ -5225,7 +5225,7 @@
       }
     },
     "graph_query_api.drift_telemetry": {
-      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub \u2014 the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
       "fields": {
         "table": {
           "type": "string",
@@ -5246,7 +5246,7 @@
       }
     },
     "graph_query_api.stigmergic_trace": {
-      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation \u2014 exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
       "fields": {
         "table": {
           "type": "string",
@@ -5284,7 +5284,7 @@
       }
     },
     "graph_query_api.vector_read": {
-      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector \u2014 the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
       "fields": {
         "offset": {
           "type": "integer",
@@ -5314,7 +5314,7 @@
       }
     },
     "graph_query_api.adjacency": {
-      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes \u2014 OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
       "fields": {
         "project_id": {
           "type": "string",
@@ -5395,7 +5395,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -5414,12 +5414,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md §13 Governance File Authority"
+          "reference": "agents.md \u00a713 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -5431,7 +5431,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -5458,7 +5458,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -5471,7 +5471,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -5529,7 +5529,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -5616,7 +5616,7 @@
       "governing_plan": "ENC-PLN-014"
     },
     "monitoring.health_probe": {
-      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard — DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
+      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard \u2014 DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
       "fields": {
         "function_names": {
           "type": "array",
@@ -5695,7 +5695,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5744,7 +5744,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -5765,7 +5765,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5860,7 +5860,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -5897,7 +5897,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -5964,12 +5964,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match — fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match \u2014 fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -5979,28 +5979,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",
@@ -6082,7 +6082,7 @@
       }
     },
     "deploy.parity_validator": {
-      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "description": "ENC-FTR-091 / ENC-TSK-F87 \u2014 v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
       "fields": {
         "function_name": {
           "type": "string",
@@ -6095,12 +6095,12 @@
         "detection_rules": {
           "type": "array",
           "item_type": "string",
-          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent \u2014 autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent \u2014 autonomous fix. ISS-279: enceladus-mcp-code-gamma missing \u2014 flag only. ISS-296: function_name_map gaps \u2014 flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas \u2014 flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api \u2014 flag only."
         },
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -6109,7 +6109,7 @@
       }
     },
     "auth.github_installation_token": {
-      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "description": "Response contract for GET /api/v1/auth/github-token \u2014 vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
       "fields": {
         "token": {
           "type": "string",
@@ -6130,7 +6130,7 @@
         },
         "env_fallback": {
           "type": "string",
-          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
         },
         "default": {
           "type": "boolean",
@@ -6143,12 +6143,12 @@
             "env_fallback",
             "default"
           ],
-          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
         }
       }
     },
     "monitoring.continuous_drift_audit": {
-      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
       "fields": {
         "trigger": {
           "type": "string",
@@ -6169,12 +6169,12 @@
         },
         "alert_channel": {
           "type": "string",
-          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
         }
       }
     },
     "monitoring.mentions_drift_audit": {
-      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 \u2014 Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
       "governing_feature": "ENC-FTR-098",
       "governing_task": "ENC-TSK-G43",
       "fields": {
@@ -6200,7 +6200,7 @@
         },
         "iam_scope": {
           "type": "string",
-          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design \u2014 ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
         }
       }
     },
@@ -6243,7 +6243,7 @@
       }
     },
     "telemetry.eligible_fields": {
-      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only \u2014 it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
       "governing_feature": "ENC-FTR-086",
       "governing_task": "ENC-TSK-I83",
       "design_source": "DOC-E3F5E025B3D9",
@@ -6260,7 +6260,7 @@
           "type": "string",
           "required": true,
           "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
-          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint \u2014 this is a policy answer, not a degraded failure."
         },
         "record_type": {
           "type": "string",
@@ -6367,15 +6367,15 @@
           "enum": [
             "governance-version-current"
           ],
-          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
+          "usage_guidance": "Partition key. Always 'governance-version-current' \u2014 single-item canonical record."
         },
         "governance_revision": {
           "type": "string",
-          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md \u00a713."
         },
         "governance_hash": {
           "type": "string",
-          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per \u00a74.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
         },
         "generation": {
           "type": "integer",
@@ -6400,7 +6400,7 @@
       }
     },
     "recompute_governance.event_handler": {
-      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes \u00a74.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
       "fields": {
         "trigger": {
           "type": "object",
@@ -6420,7 +6420,7 @@
         },
         "recursion_invariant": {
           "type": "object",
-          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject \u2014 prevents ObjectCreated loops."
         },
         "env_vars": {
           "type": "object",
@@ -6429,7 +6429,7 @@
       }
     },
     "coordination_api.governance_hash_resolution": {
-      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed \u2014 it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 \u00a72.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
       "fields": {
         "primary_source": {
           "type": "object",
@@ -6441,7 +6441,7 @@
         },
         "removed_fallback": {
           "type": "object",
-          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents \u2014 stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
         },
         "env_vars": {
           "type": "object",
@@ -6450,7 +6450,7 @@
       }
     },
     "coordination_api.session_init_intent_classifier": {
-      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized \u2014 same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced \u2014 predictions are returned inline (AC-4). Scope guard (AC-5): inference-only \u2014 intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
       "fields": {
         "routes": {
           "type": "object",
@@ -6508,11 +6508,11 @@
         },
         "tier_3_canonical_ddb": {
           "type": "object",
-          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely \u2014 valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
         },
         "tier_4_s3_catalog": {
           "type": "object",
-          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort \u2014 no longer the primary docstore path."
         },
         "env_vars": {
           "type": "object",
@@ -6521,7 +6521,7 @@
       }
     },
     "governance_drift_check.handler": {
-      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the \u00a74.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
       "fields": {
         "drift_metric": {
           "type": "object",
@@ -6581,7 +6581,7 @@
       }
     },
     "unlearning.lambda": {
-      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only — io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection — no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
+      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only \u2014 io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection \u2014 no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
       "owner": "graph-sync",
       "source": "ENC-TSK-K03 / ENC-FTR-106",
       "telemetry_eligible": false,
@@ -6620,7 +6620,7 @@
       "telemetry_eligible": true
     },
     "monitoring.dedup_convergence_probe": {
-      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
       "fields": {
         "signals": {
           "type": "array",
@@ -6637,8 +6637,8 @@
         },
         "walk_back_model_health": {
           "type": "object",
-          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
-          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 \u00a710). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (\u00a713/\u00a74.3), so the live walk-back rate is 0 / shadow until then."
         },
         "config_env_vars": {
           "type": "array",
@@ -6683,7 +6683,7 @@
       }
     },
     "graph_query_api.publish_graph_health": {
-      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) — never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
+      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) \u2014 never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
       "fields": {
         "project_id": {
           "type": "string"
@@ -7003,7 +7003,7 @@
       }
     },
     "tracker.escalation": {
-      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations — Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
       "fields": {
         "escalation_id": {
           "type": "string",
@@ -7033,8 +7033,8 @@
             "required": true,
             "immutable": true
           },
-          "definition": "Registry-resolved mutation handler key (§5.3 of DOC-5B888FCA43B8).",
-          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT — the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
         },
         "payload": {
           "type": "object",
@@ -7079,13 +7079,13 @@
             "applied",
             "failed"
           ],
-          "definition": "Escalation FSM state (§5.2). Enforced normally — escalations are not escalatable.",
-          "usage_guidance": "requested→{approved, denied, denied_with_guidance}; approved→applying; applying→{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
+          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
         },
         "events": {
           "type": "array",
           "item_type": "object",
-          "definition": "Append-only event log (§11.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
           "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
         },
         "guidance_note": {
@@ -7110,7 +7110,7 @@
             "required": false
           },
           "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
-          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (§5.5)."
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
         },
         "result": {
           "type": "object",
@@ -7148,7 +7148,7 @@
       "dynamodb_key_schema": {
         "pk": "project_id",
         "sk_pattern": "escalation#{escalation_id}",
-        "table": "existing tracker table (deliberate Channel B decision — no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
         "record_id_format": "{PREFIX}-ESC-{SEQ}",
         "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
       },
@@ -7156,8 +7156,8 @@
         "escalation_id": "IMMUTABLE (server-minted)",
         "target_record_id": "IMMUTABLE after create",
         "mutation_type": "IMMUTABLE after create",
-        "payload": "IMMUTABLE after create — the cached mutation is what io approves; the agent never resubmits after approval",
-        "status": "Escalation FSM transitions only (§5.2); enforced normally with no bypass",
+        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
         "events": "APPEND_ONLY (list_append only)",
         "approved_by": "Written only by the Cognito human approval route",
         "applied_at": "Written exactly once by applyEscalatedMutation"
@@ -7197,11 +7197,11 @@
       }
     },
     "mcp_server.escalation_actions": {
-      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action — override authorization exists only behind the Cognito human path (§6 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
       "fields": {
         "escalation.request": {
           "type": "execute_action",
-          "definition": "Propose a human-gated mutation override. Envelope (§11.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
         },
         "escalation.get": {
           "type": "search_action",
@@ -7475,7 +7475,7 @@
       "description": "ENC-TSK-K20 (B67 AC-10 / AC-23): lightweight real-time event payload emitted by devops-appsync-feed-publisher to AppSync Events. Server-pre-rendered (summary is computed in the Lambda). Raw DynamoDB item images are NOT inlined; median payload <= 500 bytes (AC-23). Published to /feed/updates, /records/{recordId}, and /projects/{projectId}.",
       "fields": {
         "eventId": {
-          "definition": "UUID v7 (time-ordered, RFC 9562 §5.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
+          "definition": "UUID v7 (time-ordered, RFC 9562 \u00a75.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
           "type": "string"
         },
         "recordId": {
@@ -7592,7 +7592,7 @@
       }
     },
     "monitoring.v4_architecture_dashboard": {
-      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml — the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler λ2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) — a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live — the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
+      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml \u2014 the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler \u03bb2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) \u2014 a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live \u2014 the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
       "owner": "devops-monitoring",
       "source": "ENC-TSK-K46 / ENC-TSK-B66 (ENC-FTR-111 / ENC-TSK-H86)",
       "fields": {
@@ -7615,7 +7615,7 @@
       }
     },
     "user_preferences_api.lambda": {
-      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E §15h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
+      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E \u00a715h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
       "fields": {
         "USER_PREFERENCES_TABLE": {
           "definition": "DynamoDB table name for per-user preferences.",
@@ -7688,7 +7688,7 @@
       }
     },
     "opensearch_indexer.lambda": {
-      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E §15): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser — TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
+      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser \u2014 TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP, e.g. https://172.31.28.54:9200).",
@@ -7724,7 +7724,7 @@
       "telemetry_eligible": true
     },
     "graph_query_api.opensearch_keyword": {
-      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E §15d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
+      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "type": "string",
@@ -7941,6 +7941,31 @@
       "owner": "search",
       "source": "ENC-TSK-M39",
       "telemetry_eligible": false
+    },
+    "mcp_server.tracker_creation_rules": {
+      "description": "ENC-TSK-M66: MCP search action tracker.creation_rules (tool tracker_creation_rules, route GET /api/v1/tracker/creation_rules on coordination_api). Type-keyed pre-creation contract surface -- given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract with NO record_id. Response is derived entirely from this governance dictionary at request time: required fields are the universal 'title' base field plus any entities['tracker.<type>'].fields entries whose constraints.min_items or constraints.min_length require a non-empty value; valid initial status is entities['tracker.<type>'].status.enum[0]; attachment contract reads entities['tracker.<type>.composition'] (what the type composes) and, when parent_type is supplied, entities['tracker.<parent_type>.composition'] (whether record_type is in that parent's child_record_types, per ENC-TSK-M65's plan/feature composition entries).",
+      "fields": {
+        "search_action": {
+          "type": "search_action",
+          "definition": "search(action='tracker.creation_rules', arguments={record_type, parent_type?})."
+        },
+        "arguments": {
+          "type": "object",
+          "definition": "record_type (required, e.g. task/feature/plan/issue); parent_type (optional, validates attachment as a child of that parent type)."
+        },
+        "response_shape": {
+          "type": "object",
+          "definition": "record_type, parent_type, valid_initial_status, status_enum, required_fields, required_field_detail (per-field derivation reason + constraints), attachment_contract (composes / as_child_of.valid / allowed_child_record_types / attachment_mechanism / cardinality)."
+        },
+        "derivation_source": {
+          "type": "rule",
+          "definition": "No hardcoded per-type contract table. Scans entities['tracker.<type>'].fields for constraints.min_items>=1 or constraints.min_length>=1; the sole non-dictionary-derived fact is the universal 'title' field, named explicitly in code (_CREATION_RULES_UNIVERSAL_REQUIRED_FIELDS) rather than folded into a silent per-type table."
+        },
+        "contract_parity": {
+          "type": "rule",
+          "definition": "required_fields/valid_initial_status match tracker_mutation lambda_function.py _handle_create_record and _DEFAULT_STATUS for task (title, acceptance_criteria; open), feature (title, user_story, acceptance_criteria; planned), and plan (title only; drafted) -- see test_creation_rules.py contract test."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-M69: appsync_feed_publisher's publish_to_appsync crashed on every invocation with TypeError: Object of type Decimal is not JSON serializable (DynamoDB Stream Number attributes deserialize to Decimal via boto3.dynamodb.types.TypeDeserializer). Added a single _json_default() hook applied to all three json.dumps call sites in the module (lightweight payload, /records/{recordId} full_body per ENC-TSK-L29, and the outer publish body) -- covers Decimal at any depth, not just the lightweight 7-field payload. Integral Decimal -> int (record IDs/counts/versions must not drift to float); non-integral -> float. No entity/field schema change, just a serialization-layer fix; bumping per the lambda_function.py touch guard.",
@@ -8008,7 +8033,7 @@
     {
       "version": "2026-07-07.1",
       "date": "2026-07-07",
-      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call — the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
+      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call \u2014 the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
     },
     {
       "version": "2026-07-05.23",
@@ -8018,7 +8043,7 @@
     {
       "version": "2026-07-05.22",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L44 (B67 Search2.0 hardening): opensearch_indexer.lambda gains OPENSEARCH_USERNAME field; OPENSEARCH_SECRET_NAME default switched from enceladus/opensearch/gamma-admin to enceladus/opensearch/gamma-indexer (write-only scoped credential). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L44 (B67 Search2.0 hardening): opensearch_indexer.lambda gains OPENSEARCH_USERNAME field; OPENSEARCH_SECRET_NAME default switched from enceladus/opensearch/gamma-admin to enceladus/opensearch/gamma-indexer (write-only scoped credential). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.20",
@@ -8028,27 +8053,27 @@
     {
       "version": "2026-07-05.19",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions — gamma detail pages were missing context_node because _deser_item only exposes item_id."
+      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions \u2014 gamma detail pages were missing context_node because _deser_item only exposes item_id."
     },
     {
       "version": "2026-07-05.18",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 hotfix: vendor record_extensions into feed_query/tracker_mutation Lambda zips via .build_extras — gamma was silently skipping extensions because enceladus-shared:10 lacks the new module."
+      "summary": "ENC-TSK-K26 hotfix: vendor record_extensions into feed_query/tracker_mutation Lambda zips via .build_extras \u2014 gamma was silently skipping extensions because enceladus-shared:10 lacks the new module."
     },
     {
       "version": "2026-07-05.17",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.15",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.13",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.12",
@@ -8068,7 +8093,7 @@
     {
       "version": "2026-07-05.4",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus — cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
+      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus \u2014 cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
     },
     {
       "version": "2026-07-05.3",
@@ -8083,12 +8108,12 @@
     {
       "version": "2026-06-27.05",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop \u2014 governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 \u00a74.3 hash). New entity: governance_drift_check.handler. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-27.01",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution — agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
+      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution \u2014 agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
     },
     {
       "version": "2026-06-21.02",
@@ -8103,12 +8128,12 @@
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",
-      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
     },
     {
       "version": "2026-06-27.03",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, §4.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, \u00a74.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-28.06",
@@ -8148,7 +8173,7 @@
     {
       "version": "2026-07-02.01",
       "task": "ENC-TSK-J68",
-      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member — generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not — that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
+      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
     },
     {
       "version": "2026-07-02.02",
@@ -8203,32 +8228,32 @@
     {
       "version": "2026-07-02.20",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.22",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop \u2014 intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.26",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda — nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda \u2014 nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.27",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher \u2014 new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.28",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.29",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.30",
@@ -8258,7 +8283,7 @@
     {
       "version": "2026-07-05.8",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
+      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E \u00a715m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
     },
     {
       "version": "2026-07-05.14",
@@ -8309,6 +8334,11 @@
       "version": "2026-07-11.5",
       "date": "2026-07-11",
       "summary": "ENC-TSK-M65: Added entity.composition declarations to the governance data dictionary for the two composite tracker entities, tracker.plan and tracker.feature. tracker.plan.composition documents that plan objectives (task/issue/feature -- never lesson) attach exclusively via the objectives_set array field, governed by plan.add_objective/plan.remove_objective/plan.reorder_objectives/plan.replace_objectives, with 1:N (practically N:M) cardinality, and clarifies that tracker.task.parent (task-to-task only) is not the plan composition mechanism. tracker.feature.composition documents that features compose tasks via the bidirectional related_task_ids <-> related_feature_ids cross-reference pair (ENC-TSK-L07 mirrored PATCH), N:M cardinality. No behavioral/API change, dictionary-only addition."
+    },
+    {
+      "version": "2026-07-11.6",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M66: Registered the tracker.creation_rules search action (tool tracker_creation_rules; coordination_api route GET /api/v1/tracker/creation_rules; MCP server thin passthrough in tools/enceladus-mcp-server/server.py). Given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract derived from entities['tracker.<type>'] and entities['tracker.<type>.composition'] (the ENC-TSK-M65 composition sections for plan/feature) -- no record_id, no hardcoded contract table."
     }
   ]
 }

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -8,33 +8,33 @@
   "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
   "entities": {
     "tracker.dedup_auto_merge": {
-      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 \u00a7P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL \u2014 judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
       "fields": {
         "enable_dedup_auto_merge": {
           "type": "feature_flag",
-          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 \u00a74.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
           "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
         },
         "dedup_auto_merge_kill_switch": {
           "type": "feature_flag",
-          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} \u2014 auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 \u00a78).",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
           "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
         },
         "precision_lcb_floor": {
           "type": "number",
           "default": 0.999,
-          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 \u00a74.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 \u2014 auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, \u00a74.4).",
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
           "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
         },
         "auto_walk_opt_out_latch": {
           "type": "behavior",
-          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge \u2014 un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source \u2014 PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
-          "usage_guidance": "No manual action required \u2014 the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
         },
         "audit_feed": {
           "type": "event",
           "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
-          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 \u00a710)."
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
         }
       }
     },
@@ -57,8 +57,8 @@
             "deployed",
             "superseded"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -110,8 +110,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -120,7 +120,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -146,14 +146,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -244,7 +244,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -254,12 +254,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -273,7 +273,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -289,7 +289,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -297,8 +297,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -346,7 +346,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -358,9 +358,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         },
         "auto_walk_opt_out": {
@@ -375,7 +375,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -433,7 +433,7 @@
             "closed",
             "superseded"
           ],
-          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) \u2014 never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 \u00a77. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge \u2014 flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
+          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
         },
         "priority": {
           "type": "enum",
@@ -505,7 +505,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -525,7 +525,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients \u2014 tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 \u00a77.",
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
           "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
         },
         "superseded_at": {
@@ -770,7 +770,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
         }
       }
     },
@@ -806,7 +806,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -926,7 +926,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -951,7 +951,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -1059,7 +1059,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -1168,7 +1168,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -1197,7 +1197,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1305,7 +1305,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1437,7 +1437,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1463,7 +1463,7 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
           "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
@@ -1851,18 +1851,18 @@
           ],
           "default": "ci_triggered",
           "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
-          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field \u2014 including enceladus \u2014 are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier \u2014 never from evidence-field emptiness (DOC-078C57FC1BE6 \u00a77.2). seed value: enceladus = ci_triggered."
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
         }
       }
     },
     "lifecycle_service.arc_walker_walk": {
-      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 \u00a76.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (\u00a73.1/\u00a711): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) \u2014 distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the \u00a77.2 coding-complete trap).",
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
       "governing_feature": "ENC-FTR-111",
       "governing_task": "ENC-TSK-H85",
       "fields": {
         "feature_flag": {
           "type": "string",
-          "definition": "enable_arc_walker \u2014 independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 \u00a711).",
+          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
           "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
         },
         "phase1_legs": {
@@ -1872,19 +1872,19 @@
         },
         "idempotent_conditional_write": {
           "type": "object",
-          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly \u2014 no double-step, no lost update (DOC-078C57FC1BE6 \u00a78 idempotency / \u00a79 concurrent-advance mitigation)."
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
         },
         "safety_invariants": {
           "type": "object",
-          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity \u2014 a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning \u2014 if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
         },
         "write_source": {
           "type": "string",
-          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the \u00a713 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
         },
         "artifact_genesis": {
           "type": "string",
-          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 \u00a78/\u00a710): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
         }
       }
     },
@@ -2313,7 +2313,7 @@
       "fields": {
         "package_root": {
           "type": "string",
-          "definition": "tools/enceladus-mcp-server/mcp_server/ \u2014 sibling package imported by server.py."
+          "definition": "tools/enceladus-mcp-server/mcp_server/ — sibling package imported by server.py."
         },
         "handler_modules": {
           "type": "object",
@@ -2457,7 +2457,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2484,7 +2484,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2555,7 +2555,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2712,7 +2712,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2764,7 +2764,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI; additionally external_deploy components require external_deploy_evidence. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; documentation components additionally require documentation_evidence; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2826,7 +2826,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2887,7 +2887,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2929,14 +2929,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -3107,9 +3107,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -3142,11 +3142,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -3163,18 +3163,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -3285,7 +3285,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -3339,17 +3339,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -3367,7 +3367,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -3380,12 +3380,12 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
       "description": "V3 component-policy enforcement contract for required_transition_type on component_registry.component (ENC-TSK-L77 / DOC-157A790F9E8B). Every component record must carry one of code|external_deploy|documentation. Checkout service maps populated legacy values at read time, compares the component policy to the existing task.transition_type lifecycle arc, and enforces the new evidence sub-schemas at advance gates.",
@@ -3516,12 +3516,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3544,7 +3544,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3561,7 +3561,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "GET /api/v1/feed/corpus \u2014 JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+          "definition": "GET /api/v1/feed/corpus — JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
         },
         "cursor": {
           "type": "string",
@@ -3578,7 +3578,7 @@
       }
     },
     "feed_query.delta": {
-      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E \u00a79C/\u00a710.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
       "fields": {
         "since": {
           "type": "integer",
@@ -3595,7 +3595,7 @@
       }
     },
     "tracker.graphsearch": {
-      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges \u2014 never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges — never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
       "fields": {
         "search_type": {
           "type": "enum",
@@ -3876,7 +3876,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape \u2014 they do not abort the batch."
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
         }
       },
       "covered_lambdas": [
@@ -4218,7 +4218,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -4246,7 +4246,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -4259,7 +4259,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -4290,9 +4290,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -4400,7 +4400,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -4415,7 +4415,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -4646,17 +4646,17 @@
         },
         "item_id_provenance": {
           "type": "string",
-          "definition": "ENC-TSK-L06 / B63 Phase 2 AC-6: HMAC-SHA256 hex signature over `item_id||created_at||record_type`, stamped on every record allocated through the ID Service (enable_id_service_extraction flag ON). Signed with a shared secret held in Secrets Manager (enceladus/id-service/hmac-key{-gamma}, CFN-generated via GenerateSecretString \u2014 never hardcoded, never logged). Verified (warning-only, never blocking) by graph_sync before projecting a node into Neo4j. Absent on records created before this feature or while the flag was OFF (see tracker.id_boundary_enforcement backfill_and_quarantine for the AC-5 backfill status of pre-existing records).",
+          "definition": "ENC-TSK-L06 / B63 Phase 2 AC-6: HMAC-SHA256 hex signature over `item_id||created_at||record_type`, stamped on every record allocated through the ID Service (enable_id_service_extraction flag ON). Signed with a shared secret held in Secrets Manager (enceladus/id-service/hmac-key{-gamma}, CFN-generated via GenerateSecretString — never hardcoded, never logged). Verified (warning-only, never blocking) by graph_sync before projecting a node into Neo4j. Absent on records created before this feature or while the flag was OFF (see tracker.id_boundary_enforcement backfill_and_quarantine for the AC-5 backfill status of pre-existing records).",
           "usage_guidance": "Server-generated only, exactly like item_id/record_id. A tracker.create payload carrying a client-supplied item_id_provenance is rejected with the same ID_BOUNDARY_VIOLATION error as a client-supplied item_id/record_id."
         }
       }
     },
     "tracker.id_boundary_enforcement": {
-      "description": "ENC-TSK-L06 / B63 Phase 2 AC-6 (extends ENC-FTR-069's ENC-TSK-B99 ID Boundary Rule with a dedicated ID Service, idempotency contract, cryptographic provenance, and a trust-score feedback loop). The contract: (1) IAM isolation \u2014 record-ID counter items live in a dedicated enceladus-id-counters{-gamma} DynamoDB table that ONLY the ID Service Lambda's IAM role can access (tracker_mutation's role has no grant referencing that table's ARN at all \u2014 ordinary resource-scoped IAM, not a same-table dynamodb:LeadingKeys condition, which cannot constrain a sort-key prefix and would be a silent no-op on the shared tracker table's project_id-partitioned schema); (2) idempotency-key contract \u2014 a client-supplied idempotency_key on tracker.create returns the SAME record_id on retry (backed by enceladus-id-idempotency{-gamma}, TTL 24h); (3) cryptographic provenance \u2014 item_id_provenance HMAC-SHA256 signature stamped at allocation time and verified (warning-only) by graph_sync before projection; (4) edge-layer rejection \u2014 tracker_mutation's _handle_create_record rejects any create payload carrying top-level item_id, record_id, OR item_id_provenance with HTTP 400 error_envelope.code=ID_BOUNDARY_VIOLATION (ENC-ISS-132 origin, extended here); (5) trust-score feedback \u2014 every rejection fire-and-forget invokes the ID Service's record_violation action, incrementing a per-caller_identity counter (enceladus-id-violations{-gamma}) and flagging callers past VIOLATION_THRESHOLD (default 5); (6) backfill verification \u2014 tools/backfill_item_id_provenance.py stamps item_id_provenance on pre-existing records or reports them as a documented quarantine exemption (reusing the ENC-FTR-069 / ENC-TSK-D29 quarantine list: ENC-TSK-1291, ENC-TSK-1292).",
+      "description": "ENC-TSK-L06 / B63 Phase 2 AC-6 (extends ENC-FTR-069's ENC-TSK-B99 ID Boundary Rule with a dedicated ID Service, idempotency contract, cryptographic provenance, and a trust-score feedback loop). The contract: (1) IAM isolation — record-ID counter items live in a dedicated enceladus-id-counters{-gamma} DynamoDB table that ONLY the ID Service Lambda's IAM role can access (tracker_mutation's role has no grant referencing that table's ARN at all — ordinary resource-scoped IAM, not a same-table dynamodb:LeadingKeys condition, which cannot constrain a sort-key prefix and would be a silent no-op on the shared tracker table's project_id-partitioned schema); (2) idempotency-key contract — a client-supplied idempotency_key on tracker.create returns the SAME record_id on retry (backed by enceladus-id-idempotency{-gamma}, TTL 24h); (3) cryptographic provenance — item_id_provenance HMAC-SHA256 signature stamped at allocation time and verified (warning-only) by graph_sync before projection; (4) edge-layer rejection — tracker_mutation's _handle_create_record rejects any create payload carrying top-level item_id, record_id, OR item_id_provenance with HTTP 400 error_envelope.code=ID_BOUNDARY_VIOLATION (ENC-ISS-132 origin, extended here); (5) trust-score feedback — every rejection fire-and-forget invokes the ID Service's record_violation action, incrementing a per-caller_identity counter (enceladus-id-violations{-gamma}) and flagging callers past VIOLATION_THRESHOLD (default 5); (6) backfill verification — tools/backfill_item_id_provenance.py stamps item_id_provenance on pre-existing records or reports them as a documented quarantine exemption (reusing the ENC-FTR-069 / ENC-TSK-D29 quarantine list: ENC-TSK-1291, ENC-TSK-1292).",
       "fields": {
         "enable_id_service_extraction": {
           "type": "boolean",
-          "definition": "AppConfig flag (env_fallback ENABLE_ID_SERVICE, default false), read at request time via enceladus_shared.appconfig_flags.flag(). When ON, tracker_mutation delegates record-ID allocation to the standalone ID Service Lambda (enceladus-id-service{-gamma}) via a synchronous, FAIL-CLOSED RequestResponse invoke \u2014 mirroring the enable_lifecycle_service_extraction (ENC-TSK-H46) posture exactly: any invoke failure rejects the create (HTTP 503, code=ID_SERVICE_UNAVAILABLE), never silently falling back to the inline _next_record_id path (a silent fallback would defeat the IAM isolation property). When OFF (default), the inline counter-based allocation in tracker_mutation runs unchanged (zero-behavior-change rollback path) and continues reading/writing legacy counter#* rows in the shared tracker table."
+          "definition": "AppConfig flag (env_fallback ENABLE_ID_SERVICE, default false), read at request time via enceladus_shared.appconfig_flags.flag(). When ON, tracker_mutation delegates record-ID allocation to the standalone ID Service Lambda (enceladus-id-service{-gamma}) via a synchronous, FAIL-CLOSED RequestResponse invoke — mirroring the enable_lifecycle_service_extraction (ENC-TSK-H46) posture exactly: any invoke failure rejects the create (HTTP 503, code=ID_SERVICE_UNAVAILABLE), never silently falling back to the inline _next_record_id path (a silent fallback would defeat the IAM isolation property). When OFF (default), the inline counter-based allocation in tracker_mutation runs unchanged (zero-behavior-change rollback path) and continues reading/writing legacy counter#* rows in the shared tracker table."
         },
         "id_boundary_violation_error_code": {
           "type": "string",
@@ -4664,7 +4664,7 @@
         },
         "backfill_and_quarantine": {
           "type": "string",
-          "definition": "tools/backfill_item_id_provenance.py scans devops-project-tracker{-gamma}, computing + stamping item_id_provenance on any record with item_id + created_at + record_type but no existing signature. Records that cannot be signed (missing required fields) OR that match the ENC-FTR-069 quarantine list (ENC-TSK-1291, ENC-TSK-1292 \u2014 both already adjudicated as an intentional exemption, not re-litigated here) are reported as a documented quarantine exemption, never fabricated. Idempotent: re-running after a successful pass produces zero writes."
+          "definition": "tools/backfill_item_id_provenance.py scans devops-project-tracker{-gamma}, computing + stamping item_id_provenance on any record with item_id + created_at + record_type but no existing signature. Records that cannot be signed (missing required fields) OR that match the ENC-FTR-069 quarantine list (ENC-TSK-1291, ENC-TSK-1292 — both already adjudicated as an intentional exemption, not re-litigated here) are reported as a documented quarantine exemption, never fabricated. Idempotent: re-running after a successful pass produces zero writes."
         }
       }
     },
@@ -4779,7 +4779,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4809,7 +4809,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4826,12 +4826,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4864,23 +4864,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
+          "definition": "Plan → document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -5091,11 +5091,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -5128,7 +5128,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         },
         "orphan_purge_on_edge_removal": {
           "type": "string",
@@ -5183,7 +5183,7 @@
       }
     },
     "tracker.pathway_traversed": {
-      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection \u2014 graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation \u2014 tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability \u2014 graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
       "fields": {
         "edge_label": {
           "type": "string",
@@ -5191,11 +5191,11 @@
         },
         "relationship_type": {
           "type": "string",
-          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) \u2014 the lowercase tracker_mutation relationship_type keys."
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
         },
         "scoring_exclusion": {
           "type": "boolean",
-          "definition": "true \u2014 excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
         },
         "ogtm_compliance": {
           "type": "object",
@@ -5204,7 +5204,7 @@
       }
     },
     "graph_query_api.pathway_telemetry": {
-      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response \u2014 this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
       "fields": {
         "request_params": {
           "type": "object",
@@ -5225,7 +5225,7 @@
       }
     },
     "graph_query_api.drift_telemetry": {
-      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub \u2014 the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
       "fields": {
         "table": {
           "type": "string",
@@ -5246,7 +5246,7 @@
       }
     },
     "graph_query_api.stigmergic_trace": {
-      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation \u2014 exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
       "fields": {
         "table": {
           "type": "string",
@@ -5284,7 +5284,7 @@
       }
     },
     "graph_query_api.vector_read": {
-      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector \u2014 the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
       "fields": {
         "offset": {
           "type": "integer",
@@ -5314,7 +5314,7 @@
       }
     },
     "graph_query_api.adjacency": {
-      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes \u2014 OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
       "fields": {
         "project_id": {
           "type": "string",
@@ -5395,7 +5395,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -5414,12 +5414,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md \u00a713 Governance File Authority"
+          "reference": "agents.md §13 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -5431,7 +5431,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -5458,7 +5458,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -5471,7 +5471,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -5529,7 +5529,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -5616,7 +5616,7 @@
       "governing_plan": "ENC-PLN-014"
     },
     "monitoring.health_probe": {
-      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard \u2014 DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
+      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard — DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
       "fields": {
         "function_names": {
           "type": "array",
@@ -5695,7 +5695,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5744,7 +5744,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -5765,7 +5765,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5860,7 +5860,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -5897,7 +5897,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -5964,12 +5964,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match \u2014 fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match — fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -5979,28 +5979,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",
@@ -6082,7 +6082,7 @@
       }
     },
     "deploy.parity_validator": {
-      "description": "ENC-FTR-091 / ENC-TSK-F87 \u2014 v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
       "fields": {
         "function_name": {
           "type": "string",
@@ -6095,12 +6095,12 @@
         "detection_rules": {
           "type": "array",
           "item_type": "string",
-          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent \u2014 autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent \u2014 autonomous fix. ISS-279: enceladus-mcp-code-gamma missing \u2014 flag only. ISS-296: function_name_map gaps \u2014 flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas \u2014 flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api \u2014 flag only."
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
         },
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -6109,7 +6109,7 @@
       }
     },
     "auth.github_installation_token": {
-      "description": "Response contract for GET /api/v1/auth/github-token \u2014 vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
       "fields": {
         "token": {
           "type": "string",
@@ -6130,7 +6130,7 @@
         },
         "env_fallback": {
           "type": "string",
-          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
         },
         "default": {
           "type": "boolean",
@@ -6143,12 +6143,12 @@
             "env_fallback",
             "default"
           ],
-          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
         }
       }
     },
     "monitoring.continuous_drift_audit": {
-      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
       "fields": {
         "trigger": {
           "type": "string",
@@ -6169,12 +6169,12 @@
         },
         "alert_channel": {
           "type": "string",
-          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
         }
       }
     },
     "monitoring.mentions_drift_audit": {
-      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 \u2014 Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
       "governing_feature": "ENC-FTR-098",
       "governing_task": "ENC-TSK-G43",
       "fields": {
@@ -6200,7 +6200,7 @@
         },
         "iam_scope": {
           "type": "string",
-          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design \u2014 ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
         }
       }
     },
@@ -6243,7 +6243,7 @@
       }
     },
     "telemetry.eligible_fields": {
-      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only \u2014 it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
       "governing_feature": "ENC-FTR-086",
       "governing_task": "ENC-TSK-I83",
       "design_source": "DOC-E3F5E025B3D9",
@@ -6260,7 +6260,7 @@
           "type": "string",
           "required": true,
           "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
-          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint \u2014 this is a policy answer, not a degraded failure."
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
         },
         "record_type": {
           "type": "string",
@@ -6367,15 +6367,15 @@
           "enum": [
             "governance-version-current"
           ],
-          "usage_guidance": "Partition key. Always 'governance-version-current' \u2014 single-item canonical record."
+          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
         },
         "governance_revision": {
           "type": "string",
-          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md \u00a713."
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
         },
         "governance_hash": {
           "type": "string",
-          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per \u00a74.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
         },
         "generation": {
           "type": "integer",
@@ -6400,7 +6400,7 @@
       }
     },
     "recompute_governance.event_handler": {
-      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes \u00a74.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
       "fields": {
         "trigger": {
           "type": "object",
@@ -6420,7 +6420,7 @@
         },
         "recursion_invariant": {
           "type": "object",
-          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject \u2014 prevents ObjectCreated loops."
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
         },
         "env_vars": {
           "type": "object",
@@ -6429,7 +6429,7 @@
       }
     },
     "coordination_api.governance_hash_resolution": {
-      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed \u2014 it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 \u00a72.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
       "fields": {
         "primary_source": {
           "type": "object",
@@ -6441,7 +6441,7 @@
         },
         "removed_fallback": {
           "type": "object",
-          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents \u2014 stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
         },
         "env_vars": {
           "type": "object",
@@ -6450,7 +6450,7 @@
       }
     },
     "coordination_api.session_init_intent_classifier": {
-      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized \u2014 same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced \u2014 predictions are returned inline (AC-4). Scope guard (AC-5): inference-only \u2014 intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
       "fields": {
         "routes": {
           "type": "object",
@@ -6508,11 +6508,11 @@
         },
         "tier_3_canonical_ddb": {
           "type": "object",
-          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely \u2014 valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
         },
         "tier_4_s3_catalog": {
           "type": "object",
-          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort \u2014 no longer the primary docstore path."
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
         },
         "env_vars": {
           "type": "object",
@@ -6521,7 +6521,7 @@
       }
     },
     "governance_drift_check.handler": {
-      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the \u00a74.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
       "fields": {
         "drift_metric": {
           "type": "object",
@@ -6581,7 +6581,7 @@
       }
     },
     "unlearning.lambda": {
-      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only \u2014 io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection \u2014 no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
+      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only — io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection — no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
       "owner": "graph-sync",
       "source": "ENC-TSK-K03 / ENC-FTR-106",
       "telemetry_eligible": false,
@@ -6620,7 +6620,7 @@
       "telemetry_eligible": true
     },
     "monitoring.dedup_convergence_probe": {
-      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 \u00a710). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
       "fields": {
         "signals": {
           "type": "array",
@@ -6637,8 +6637,8 @@
         },
         "walk_back_model_health": {
           "type": "object",
-          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 \u00a710). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
-          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (\u00a713/\u00a74.3), so the live walk-back rate is 0 / shadow until then."
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
         },
         "config_env_vars": {
           "type": "array",
@@ -6683,7 +6683,7 @@
       }
     },
     "graph_query_api.publish_graph_health": {
-      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) \u2014 never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
+      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) — never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
       "fields": {
         "project_id": {
           "type": "string"
@@ -7003,7 +7003,7 @@
       }
     },
     "tracker.escalation": {
-      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations — Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
       "fields": {
         "escalation_id": {
           "type": "string",
@@ -7033,8 +7033,8 @@
             "required": true,
             "immutable": true
           },
-          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
-          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+          "definition": "Registry-resolved mutation handler key (§5.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT — the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
         },
         "payload": {
           "type": "object",
@@ -7079,13 +7079,13 @@
             "applied",
             "failed"
           ],
-          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
-          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+          "definition": "Escalation FSM state (§5.2). Enforced normally — escalations are not escalatable.",
+          "usage_guidance": "requested→{approved, denied, denied_with_guidance}; approved→applying; applying→{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
         },
         "events": {
           "type": "array",
           "item_type": "object",
-          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "definition": "Append-only event log (§11.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
           "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
         },
         "guidance_note": {
@@ -7110,7 +7110,7 @@
             "required": false
           },
           "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
-          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (§5.5)."
         },
         "result": {
           "type": "object",
@@ -7148,7 +7148,7 @@
       "dynamodb_key_schema": {
         "pk": "project_id",
         "sk_pattern": "escalation#{escalation_id}",
-        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "table": "existing tracker table (deliberate Channel B decision — no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
         "record_id_format": "{PREFIX}-ESC-{SEQ}",
         "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
       },
@@ -7156,8 +7156,8 @@
         "escalation_id": "IMMUTABLE (server-minted)",
         "target_record_id": "IMMUTABLE after create",
         "mutation_type": "IMMUTABLE after create",
-        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
-        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
+        "payload": "IMMUTABLE after create — the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (§5.2); enforced normally with no bypass",
         "events": "APPEND_ONLY (list_append only)",
         "approved_by": "Written only by the Cognito human approval route",
         "applied_at": "Written exactly once by applyEscalatedMutation"
@@ -7197,11 +7197,11 @@
       }
     },
     "mcp_server.escalation_actions": {
-      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action — override authorization exists only behind the Cognito human path (§6 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
       "fields": {
         "escalation.request": {
           "type": "execute_action",
-          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+          "definition": "Propose a human-gated mutation override. Envelope (§11.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
         },
         "escalation.get": {
           "type": "search_action",
@@ -7475,7 +7475,7 @@
       "description": "ENC-TSK-K20 (B67 AC-10 / AC-23): lightweight real-time event payload emitted by devops-appsync-feed-publisher to AppSync Events. Server-pre-rendered (summary is computed in the Lambda). Raw DynamoDB item images are NOT inlined; median payload <= 500 bytes (AC-23). Published to /feed/updates, /records/{recordId}, and /projects/{projectId}.",
       "fields": {
         "eventId": {
-          "definition": "UUID v7 (time-ordered, RFC 9562 \u00a75.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
+          "definition": "UUID v7 (time-ordered, RFC 9562 §5.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
           "type": "string"
         },
         "recordId": {
@@ -7592,7 +7592,7 @@
       }
     },
     "monitoring.v4_architecture_dashboard": {
-      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml \u2014 the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler \u03bb2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) \u2014 a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live \u2014 the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
+      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml — the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler λ2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) — a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live — the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
       "owner": "devops-monitoring",
       "source": "ENC-TSK-K46 / ENC-TSK-B66 (ENC-FTR-111 / ENC-TSK-H86)",
       "fields": {
@@ -7615,7 +7615,7 @@
       }
     },
     "user_preferences_api.lambda": {
-      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E \u00a715h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
+      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E §15h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
       "fields": {
         "USER_PREFERENCES_TABLE": {
           "definition": "DynamoDB table name for per-user preferences.",
@@ -7688,7 +7688,7 @@
       }
     },
     "opensearch_indexer.lambda": {
-      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser \u2014 TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
+      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E §15): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser — TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP, e.g. https://172.31.28.54:9200).",
@@ -7724,7 +7724,7 @@
       "telemetry_eligible": true
     },
     "graph_query_api.opensearch_keyword": {
-      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E \u00a715d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
+      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E §15d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
       "fields": {
         "OPENSEARCH_ENDPOINT": {
           "type": "string",
@@ -8033,7 +8033,7 @@
     {
       "version": "2026-07-07.1",
       "date": "2026-07-07",
-      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call \u2014 the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
+      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call — the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
     },
     {
       "version": "2026-07-05.23",
@@ -8043,7 +8043,7 @@
     {
       "version": "2026-07-05.22",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L44 (B67 Search2.0 hardening): opensearch_indexer.lambda gains OPENSEARCH_USERNAME field; OPENSEARCH_SECRET_NAME default switched from enceladus/opensearch/gamma-admin to enceladus/opensearch/gamma-indexer (write-only scoped credential). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L44 (B67 Search2.0 hardening): opensearch_indexer.lambda gains OPENSEARCH_USERNAME field; OPENSEARCH_SECRET_NAME default switched from enceladus/opensearch/gamma-admin to enceladus/opensearch/gamma-indexer (write-only scoped credential). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.20",
@@ -8053,27 +8053,27 @@
     {
       "version": "2026-07-05.19",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions \u2014 gamma detail pages were missing context_node because _deser_item only exposes item_id."
+      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions — gamma detail pages were missing context_node because _deser_item only exposes item_id."
     },
     {
       "version": "2026-07-05.18",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 hotfix: vendor record_extensions into feed_query/tracker_mutation Lambda zips via .build_extras \u2014 gamma was silently skipping extensions because enceladus-shared:10 lacks the new module."
+      "summary": "ENC-TSK-K26 hotfix: vendor record_extensions into feed_query/tracker_mutation Lambda zips via .build_extras — gamma was silently skipping extensions because enceladus-shared:10 lacks the new module."
     },
     {
       "version": "2026-07-05.17",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.15",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.13",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-05.12",
@@ -8093,7 +8093,7 @@
     {
       "version": "2026-07-05.4",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus \u2014 cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
+      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus — cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
     },
     {
       "version": "2026-07-05.3",
@@ -8108,12 +8108,12 @@
     {
       "version": "2026-06-27.05",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop \u2014 governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 \u00a74.3 hash). New entity: governance_drift_check.handler. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-27.01",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution \u2014 agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
+      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution — agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
     },
     {
       "version": "2026-06-21.02",
@@ -8128,12 +8128,12 @@
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",
-      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
     },
     {
       "version": "2026-06-27.03",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, \u00a74.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, §4.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-28.06",
@@ -8173,7 +8173,7 @@
     {
       "version": "2026-07-02.01",
       "task": "ENC-TSK-J68",
-      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member \u2014 generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not \u2014 that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
+      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member — generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not — that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
     },
     {
       "version": "2026-07-02.02",
@@ -8228,32 +8228,32 @@
     {
       "version": "2026-07-02.20",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.22",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop \u2014 intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.26",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda \u2014 nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda — nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.27",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher \u2014 new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.28",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.29",
       "date": "2026-07-02",
-      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only \u2014 governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-07-02.30",
@@ -8283,7 +8283,7 @@
     {
       "version": "2026-07-05.8",
       "date": "2026-07-05",
-      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E \u00a715m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
+      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
     },
     {
       "version": "2026-07-05.14",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -588,6 +588,7 @@ _ENCELADUS_ALLOWED_RAW_TOOLS = {
     "tracker_list",
     "tracker_pending_updates",
     "tracker_validation_rules",
+    "tracker_creation_rules",
     "tracker_set",
     "tracker_log",
     "tracker_create",
@@ -14881,6 +14882,129 @@ def _handle_governance_dictionary(event: Dict[str, Any]) -> Dict[str, Any]:
     return _response(200, result)
 
 
+# ENC-TSK-M66: universal record fields predate the governed per-type field
+# dictionary and are enforced by tracker_mutation for every record type
+# regardless of entity.fields declarations (record has no title -> 400 in
+# _handle_create_record). This is the one contract fact NOT derivable from
+# an entities["tracker.<type>"].fields scan, so it is named explicitly here
+# rather than silently baked into a per-type table.
+_CREATION_RULES_UNIVERSAL_REQUIRED_FIELDS = ("title",)
+
+
+def _handle_tracker_creation_rules(event: Dict[str, Any]) -> Dict[str, Any]:
+    """GET /api/v1/tracker/creation_rules — type-keyed pre-creation contract surface (ENC-TSK-M66).
+
+    Derives the required-fields, valid-initial-status, and attachment contract
+    for a tracker record_type entirely from governance_data_dictionary.json
+    (entities["tracker.<type>"] and entities["tracker.<type>.composition"]),
+    with no record_id / no hardcoded per-type contract table. Required fields
+    beyond the universal 'title' are discovered by scanning each type's field
+    definitions for constraints that make the field non-optional at create
+    time (constraints.min_items >= 1 or constraints.min_length >= 1), which
+    matches the acceptance_criteria / user_story / evidence gates enforced in
+    tracker_mutation's _handle_create_record.
+    """
+    qs = event.get("queryStringParameters") or {}
+    record_type = str(qs.get("record_type") or "").strip().lower()
+    parent_type = str(qs.get("parent_type") or "").strip().lower() or None
+
+    if not record_type:
+        return _error(400, "Query parameter 'record_type' is required.", code="VALIDATION_ERROR")
+
+    dictionary, source_meta = _load_governance_dictionary()
+    entities = dictionary.get("entities")
+    if not isinstance(entities, dict):
+        return _error(500, "Governance dictionary payload missing 'entities' object.", code="INTERNAL_ERROR")
+
+    entity_key = f"tracker.{record_type}"
+    entity_def = entities.get(entity_key)
+    if not isinstance(entity_def, dict):
+        valid_types = sorted(
+            k.split(".", 1)[1]
+            for k in entities
+            if k.startswith("tracker.") and "." not in k.split(".", 1)[1]
+            and isinstance(entities[k], dict) and "fields" in entities[k]
+        )
+        return _error(
+            404,
+            f"Unknown tracker record_type '{record_type}'.",
+            code="NOT_FOUND",
+            valid_record_types=valid_types,
+        )
+
+    fields = entity_def.get("fields") if isinstance(entity_def.get("fields"), dict) else {}
+
+    status_def = fields.get("status") if isinstance(fields.get("status"), dict) else {}
+    status_enum = status_def.get("enum") if isinstance(status_def.get("enum"), list) else []
+    valid_initial_status = status_enum[0] if status_enum else None
+
+    required_fields = list(_CREATION_RULES_UNIVERSAL_REQUIRED_FIELDS)
+    required_field_detail: Dict[str, Any] = {
+        f: {"reason": "universal base record field (enforced for all record types)"}
+        for f in required_fields
+    }
+    for field_name, field_def in fields.items():
+        if not isinstance(field_def, dict):
+            continue
+        constraints = field_def.get("constraints")
+        if not isinstance(constraints, dict):
+            continue
+        min_items = constraints.get("min_items")
+        min_length = constraints.get("min_length")
+        if (isinstance(min_items, (int, float)) and min_items >= 1) or (
+            isinstance(min_length, (int, float)) and min_length >= 1
+        ):
+            required_fields.append(field_name)
+            required_field_detail[field_name] = {
+                "reason": f"governance dictionary {entity_key}.fields.{field_name}.constraints requires a non-empty value",
+                "constraints": constraints,
+            }
+
+    # Attachment contract: what THIS type composes (its own <type>.composition
+    # entry, e.g. plan/feature), and — when parent_type is supplied — how this
+    # type attaches under that parent (parent's <type>.composition entry).
+    attachment_contract: Dict[str, Any] = {}
+    own_composition = entities.get(f"{entity_key}.composition")
+    if isinstance(own_composition, dict):
+        attachment_contract["composes"] = own_composition.get("fields", own_composition)
+
+    if parent_type:
+        parent_key = f"tracker.{parent_type}.composition"
+        parent_composition = entities.get(parent_key)
+        if not isinstance(parent_composition, dict):
+            attachment_contract["as_child_of"] = {
+                "parent_type": parent_type,
+                "valid": False,
+                "reason": f"No composition contract found for parent_type '{parent_type}' ({parent_key} not in governance dictionary).",
+            }
+        else:
+            parent_fields = parent_composition.get("fields", {}) if isinstance(parent_composition.get("fields"), dict) else {}
+            child_types_def = parent_fields.get("child_record_types", {}) if isinstance(parent_fields.get("child_record_types"), dict) else {}
+            allowed_children = child_types_def.get("enum") if isinstance(child_types_def.get("enum"), list) else []
+            attachment_contract["as_child_of"] = {
+                "parent_type": parent_type,
+                "valid": record_type in allowed_children,
+                "allowed_child_record_types": allowed_children,
+                "attachment_mechanism": parent_fields.get("attachment_mechanism"),
+                "cardinality": parent_fields.get("cardinality"),
+            }
+
+    return _response(
+        200,
+        {
+            "source": source_meta,
+            "dictionary_version": dictionary.get("version"),
+            "record_type": record_type,
+            "parent_type": parent_type,
+            "valid_initial_status": valid_initial_status,
+            "status_enum": status_enum,
+            "required_fields": required_fields,
+            "required_field_detail": required_field_detail,
+            "attachment_contract": attachment_contract,
+        },
+    )
+
+
 def _trigger_governance_doc_sync_push(file_name: str, content_hash: str) -> None:
     """Fire-and-forget Lambda invocation to push-sync a governance file to the document store.
 
@@ -16893,6 +17017,11 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     # GET /api/v1/governance/dictionary
     if method == "GET" and path == "/api/v1/governance/dictionary":
         return _handle_governance_dictionary(event)
+
+    # GET /api/v1/tracker/creation_rules (ENC-TSK-M66: type-keyed pre-creation
+    # contract surface, dictionary-derived, no record_id required)
+    if method == "GET" and path == "/api/v1/tracker/creation_rules":
+        return _handle_tracker_creation_rules(event)
 
     # GET/PUT /api/v1/governance/{file_name...}  (ENC-FTR-040: GET added for MCP server)
     match_gov_file = re.fullmatch(r"/api/v1/governance/(.+)", path)

--- a/backend/lambda/coordination_api/test_creation_rules.py
+++ b/backend/lambda/coordination_api/test_creation_rules.py
@@ -1,0 +1,106 @@
+"""ENC-TSK-M66: contract tests for tracker.creation_rules (_handle_tracker_creation_rules).
+
+Verifies the dictionary-derived creation_rules response for plan/feature/task
+matches the actual required-field / initial-status behavior enforced by
+backend/lambda/tracker_mutation/lambda_function.py's _handle_create_record and
+_DEFAULT_STATUS (task: title + acceptance_criteria, status 'open'; feature:
+title + user_story + acceptance_criteria, status 'planned'; plan: title only,
+status 'drafted'), and that the M65 entity.composition sections drive the
+attachment_contract for parent_type lookups.
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).with_name("lambda_function.py")
+SPEC = importlib.util.spec_from_file_location("coordination_lambda_creation_rules", MODULE_PATH)
+coordination_lambda = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = coordination_lambda
+SPEC.loader.exec_module(coordination_lambda)
+
+
+def _call(record_type, parent_type=None):
+    qs = {"record_type": record_type}
+    if parent_type:
+        qs["parent_type"] = parent_type
+    event = {"queryStringParameters": qs}
+    resp = coordination_lambda._handle_tracker_creation_rules(event)
+    body = json.loads(resp["body"])
+    return resp["statusCode"], body
+
+
+class TrackerCreationRulesContractTests(unittest.TestCase):
+    def test_task_matches_actual_create_validation(self):
+        status, body = _call("task")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["valid_initial_status"], "open")
+        self.assertIn("title", body["required_fields"])
+        self.assertIn("acceptance_criteria", body["required_fields"])
+        self.assertNotIn("user_story", body["required_fields"])
+
+    def test_feature_matches_actual_create_validation(self):
+        status, body = _call("feature")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["valid_initial_status"], "planned")
+        for field in ("title", "user_story", "acceptance_criteria"):
+            self.assertIn(field, body["required_fields"])
+
+    def test_plan_matches_actual_create_validation(self):
+        status, body = _call("plan")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["valid_initial_status"], "drafted")
+        self.assertEqual(body["required_fields"], ["title"])
+
+    def test_no_record_id_required(self):
+        # AC-1: creation_rules never requires a record_id argument.
+        status, body = _call("task")
+        self.assertEqual(status, 200)
+        self.assertNotIn("record_id", body)
+
+    def test_response_is_dictionary_derived_not_hardcoded(self):
+        # AC-2: mutating the bundled dictionary's constraints changes the
+        # response, proving derivation rather than a hardcoded table.
+        dict_path = pathlib.Path(__file__).with_name("governance_data_dictionary.json")
+        original = dict_path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(original)
+            data["entities"]["tracker.plan"]["fields"]["category"] = {
+                "type": "string",
+                "constraints": {"min_length": 1},
+            }
+            dict_path.write_text(json.dumps(data), encoding="utf-8")
+            status, body = _call("plan")
+            self.assertEqual(status, 200)
+            self.assertIn("category", body["required_fields"])
+        finally:
+            dict_path.write_text(original, encoding="utf-8")
+
+    def test_attachment_contract_uses_m65_composition_sections(self):
+        status, body = _call("task", parent_type="plan")
+        self.assertEqual(status, 200)
+        as_child = body["attachment_contract"]["as_child_of"]
+        self.assertTrue(as_child["valid"])
+        self.assertIn("task", as_child["allowed_child_record_types"])
+        self.assertIn("objectives_set", as_child["attachment_mechanism"]["definition"])
+
+    def test_attachment_contract_rejects_invalid_parent(self):
+        status, body = _call("plan", parent_type="task")
+        self.assertEqual(status, 200)
+        as_child = body["attachment_contract"]["as_child_of"]
+        self.assertFalse(as_child["valid"])
+
+    def test_unknown_record_type_404(self):
+        status, body = _call("not_a_type")
+        self.assertEqual(status, 404)
+        self.assertIn("plan", body.get("valid_record_types", []))
+
+    def test_missing_record_type_400(self):
+        resp = coordination_lambda._handle_tracker_creation_rules({"queryStringParameters": {}})
+        self.assertEqual(resp["statusCode"], 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/enceladus-mcp-server/mcp_server/actions.py
+++ b/tools/enceladus-mcp-server/mcp_server/actions.py
@@ -27,6 +27,7 @@ def build_action_registries(flags: ActionFeatureFlags) -> Tuple[
         "tracker.list": {"tool": "tracker_list"},
         "tracker.pending_updates": {"tool": "tracker_pending_updates"},
         "tracker.validation_rules": {"tool": "tracker_validation_rules"},
+        "tracker.creation_rules": {"tool": "tracker_creation_rules"},
         "documents.search": {"tool": "documents_search"},
         "documents.get": {"tool": "documents_get"},
         "documents.list": {"tool": "documents_list"},

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3599,6 +3599,33 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="tracker_creation_rules",
+            description=(
+                "ENC-TSK-M66: Type-keyed pre-creation contract surface. Returns required "
+                "fields, the valid initial status, and the attachment contract for a tracker "
+                "record_type — no record_id required, derived entirely from the governance "
+                "data dictionary (including entity.composition sections)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "record_type": {
+                        "type": "string",
+                        "description": "Tracker record type, e.g. task, feature, plan, issue.",
+                    },
+                    "parent_type": {
+                        "type": "string",
+                        "description": (
+                            "Optional parent record type to also validate/describe the "
+                            "attachment contract for record_type as a child of parent_type "
+                            "(e.g. record_type=task, parent_type=plan)."
+                        ),
+                    },
+                },
+                "required": ["record_type"],
+            },
+        ),
+        Tool(
             name="tracker_list",
             description="Returns tracker records for a project, filterable by type and status. Paginated (default 25).",
             inputSchema={
@@ -5921,6 +5948,23 @@ async def _tracker_validation_rules(args: dict) -> list[TextContent]:
             result["dictionary"] = dict_resp
 
     return _result_text(result)
+
+
+async def _tracker_creation_rules(args: dict) -> list[TextContent]:
+    """ENC-TSK-M66: type-keyed pre-creation contract surface. No record_id —
+    thin passthrough to coordination_api's dictionary-derived
+    GET /api/v1/tracker/creation_rules (all derivation logic lives there so
+    the PR-deployed Lambda path, not this out-of-band server, owns the
+    contract facts)."""
+    record_type = args["record_type"]
+    parent_type = args.get("parent_type")
+
+    query: Dict[str, Any] = {"record_type": record_type}
+    if parent_type:
+        query["parent_type"] = parent_type
+
+    resp = _coordination_api_request("GET", "/tracker/creation_rules", query=query)
+    return _result_text(resp)
 
 
 async def _tracker_list(args: dict) -> list[TextContent]:
@@ -9772,6 +9816,7 @@ _TOOL_HANDLERS = {
     "projects_get": _projects_get,
     "tracker_get": _tracker_get,
     "tracker_validation_rules": _tracker_validation_rules,
+    "tracker_creation_rules": _tracker_creation_rules,
     "tracker_list": _tracker_list,
     "tracker_pending_updates": _tracker_pending_updates,
     "tracker_set": _tracker_set,


### PR DESCRIPTION
## Summary
- New MCP search action `tracker.creation_rules` (tool `tracker_creation_rules`): type-keyed pre-creation contract surface, no `record_id` required. Given `record_type` (+ optional `parent_type`), returns required fields, valid initial status, and attachment contract.
- New coordination_api route `GET /api/v1/tracker/creation_rules`, implemented entirely by scanning the bundled governance dictionary (`entities['tracker.<type>']` field constraints, `status.enum[0]`, and `entities['tracker.<type>.composition']` — the ENC-TSK-M65 composition sections for plan/feature). No hardcoded per-type contract table; the sole non-dictionary fact (`title` is always required) is named explicitly in code.
- `tools/enceladus-mcp-server`: thin passthrough tool + search-action registration. This file deploys out-of-band via a privileged manual path — see HANDOFF note below.
- `governance_data_dictionary.json`: version `2026-07-11.5` -> `2026-07-11.6`, new `mcp_server.tracker_creation_rules` entity documenting the action; passes `check_governance_dictionary_sync.py` against `origin/v4/main`.
- `test_creation_rules.py`: 9 contract tests proving plan/feature/task responses match `tracker_mutation`'s real `_handle_create_record` / `_DEFAULT_STATUS` behavior, and that the response is dictionary-derived (mutating the bundled dictionary changes the result).

## HANDOFF
`tools/enceladus-mcp-server/server.py`'s new `tracker_creation_rules` tool ships in this PR and will merge to `v4/main`, but that server deploys out-of-band via a privileged manual `update-function-code` path, not via this PR's `_deploy.yml` gamma job. After merge, someone with that access needs to sync `server.py` separately for the live MCP `search` surface to expose `tracker.creation_rules`. The `coordination_api` Lambda route (`GET /api/v1/tracker/creation_rules`) is fully covered by the normal PR-to-gamma deploy arc and needs no manual step.

## Test plan
- [x] `python3 -m pytest test_creation_rules.py` (9 passed)
- [x] `python3 tools/check_governance_dictionary_sync.py --base origin/v4/main --head HEAD` (OK)
- [ ] Governance Dictionary Guard CI passes
- [ ] Post-merge: verify `search(action="tracker.creation_rules", arguments={record_type:"plan"})` on gamma coordination_api route returns a dictionary-derived response

CCI-42dfb5fa4de849a28811e9d2b58e40f2

🤖 Generated with [Claude Code](https://claude.com/claude-code)