### PR TITLE
ENC-TSK-M66: fix creation_rules route path (coordination prefix)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-11.6",
-  "updated_at": "2026-07-11T19:20:00Z",
-  "last_change_summary": "ENC-TSK-M66: Added mcp_server.tracker_creation_rules describing the new tracker.creation_rules search action (dictionary-derived pre-creation contract surface, no record_id).",
+  "version": "2026-07-11.7",
+  "updated_at": "2026-07-11T19:25:00Z",
+  "last_change_summary": "ENC-TSK-M66 follow-up: corrected the documented tracker.creation_rules route to GET /api/v1/coordination/tracker/creation_rules (public /api/v1/tracker/* is CloudFront-routed to the tracker query API, not coordination_api).",
   "owners": [
     "enceladus-platform"
   ],
@@ -7943,7 +7943,7 @@
       "telemetry_eligible": false
     },
     "mcp_server.tracker_creation_rules": {
-      "description": "ENC-TSK-M66: MCP search action tracker.creation_rules (tool tracker_creation_rules, route GET /api/v1/tracker/creation_rules on coordination_api). Type-keyed pre-creation contract surface -- given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract with NO record_id. Response is derived entirely from this governance dictionary at request time: required fields are the universal 'title' base field plus any entities['tracker.<type>'].fields entries whose constraints.min_items or constraints.min_length require a non-empty value; valid initial status is entities['tracker.<type>'].status.enum[0]; attachment contract reads entities['tracker.<type>.composition'] (what the type composes) and, when parent_type is supplied, entities['tracker.<parent_type>.composition'] (whether record_type is in that parent's child_record_types, per ENC-TSK-M65's plan/feature composition entries).",
+      "description": "ENC-TSK-M66: MCP search action tracker.creation_rules (tool tracker_creation_rules, route GET /api/v1/coordination/tracker/creation_rules on coordination_api (the /api/v1/tracker/* public prefix is CloudFront-routed to the tracker query API, so the reachable route lives under the coordination prefix)). Type-keyed pre-creation contract surface -- given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract with NO record_id. Response is derived entirely from this governance dictionary at request time: required fields are the universal 'title' base field plus any entities['tracker.<type>'].fields entries whose constraints.min_items or constraints.min_length require a non-empty value; valid initial status is entities['tracker.<type>'].status.enum[0]; attachment contract reads entities['tracker.<type>.composition'] (what the type composes) and, when parent_type is supplied, entities['tracker.<parent_type>.composition'] (whether record_type is in that parent's child_record_types, per ENC-TSK-M65's plan/feature composition entries).",
       "fields": {
         "search_action": {
           "type": "search_action",
@@ -8339,6 +8339,11 @@
       "version": "2026-07-11.6",
       "date": "2026-07-11",
       "summary": "ENC-TSK-M66: Registered the tracker.creation_rules search action (tool tracker_creation_rules; coordination_api route GET /api/v1/tracker/creation_rules; MCP server thin passthrough in tools/enceladus-mcp-server/server.py). Given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract derived from entities['tracker.<type>'] and entities['tracker.<type>.composition'] (the ENC-TSK-M65 composition sections for plan/feature) -- no record_id, no hardcoded contract table."
+    },
+    {
+      "version": "2026-07-11.7",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M66 route fix: the creation_rules route registered in PR #995 at /api/v1/tracker/creation_rules was unreachable through CloudFront (that prefix routes to the tracker query API). Route moved under the coordination prefix: GET /api/v1/coordination/tracker/creation_rules, matching the MCP server's _coordination_api_request URL construction; bare /api/v1/tracker form retained for direct API Gateway callers. Dictionary entity description updated to match."
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -17018,9 +17018,17 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     if method == "GET" and path == "/api/v1/governance/dictionary":
         return _handle_governance_dictionary(event)
 
-    # GET /api/v1/tracker/creation_rules (ENC-TSK-M66: type-keyed pre-creation
-    # contract surface, dictionary-derived, no record_id required)
-    if method == "GET" and path == "/api/v1/tracker/creation_rules":
+    # GET /api/v1/coordination/tracker/creation_rules (ENC-TSK-M66: type-keyed
+    # pre-creation contract surface, dictionary-derived, no record_id required).
+    # NOTE: the public /api/v1/tracker/* prefix is CloudFront-routed to the
+    # tracker query API, NOT this Lambda -- the reachable path is under the
+    # /api/v1/coordination prefix (COORDINATION_API_BASE + /tracker/creation_rules,
+    # matching how the MCP server's _coordination_api_request builds URLs).
+    # The bare /api/v1/tracker/... form is kept for direct API Gateway callers.
+    if method == "GET" and path in (
+        "/api/v1/coordination/tracker/creation_rules",
+        "/api/v1/tracker/creation_rules",
+    ):
         return _handle_tracker_creation_rules(event)
 
     # GET/PUT /api/v1/governance/{file_name...}  (ENC-FTR-040: GET added for MCP server)


### PR DESCRIPTION
## Summary
Follow-up to #995. Live gamma verification showed the new creation_rules route was unreachable: the public `/api/v1/tracker/*` prefix is CloudFront-routed to the tracker query API, not coordination_api (the request returned the tracker list handler's empty-records response). The MCP passthrough builds `{COORDINATION_API_BASE}/tracker/creation_rules`, which arrives at the Lambda as `/api/v1/coordination/tracker/creation_rules`.

- Register the route under the coordination prefix: `GET /api/v1/coordination/tracker/creation_rules` (bare `/api/v1/tracker` form retained for direct API Gateway callers).
- Correct the documented route in the `mcp_server.tracker_creation_rules` dictionary entity; version `2026-07-11.6` -> `2026-07-11.7`.

## Test plan
- [x] `python3 -m pytest test_creation_rules.py` (9 passed — handler logic unchanged)
- [ ] Governance Dictionary Guard CI passes
- [ ] Post-merge gamma verification: `GET /api/v1/coordination/tracker/creation_rules?record_type=plan` returns the dictionary-derived contract

CCI-eb549a41a46d4a099b8d905f903042e2

🤖 Generated with [Claude Code](https://claude.com/claude-code)