### PR TITLE
ENC-TSK-M66: wire creation_rules route into API Gateway (03-api)

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -265,6 +265,18 @@ Resources:
       RouteKey: POST /api/v1/coordination/components
       Target: !Sub integrations/${CoordinationApiIntegration}
 
+  # ENC-TSK-M66: tracker.creation_rules -- type-keyed pre-creation contract
+  # surface (dictionary-derived; no record_id). Handler lives in
+  # coordination_api lambda_function.py (_handle_tracker_creation_rules);
+  # the MCP server passthrough calls COORDINATION_API_BASE
+  # + /tracker/creation_rules, which needs this explicit HTTP API route.
+  RouteTrackerCreationRules:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /api/v1/coordination/tracker/creation_rules
+      Target: !Sub integrations/${CoordinationApiIntegration}
+
   # ENC-TSK-L34 (B67 PWA2.0 Coordination monitor page): these two GET routes were
   # implemented server-side by ENC-TSK-I38/J43 (_handle_agent_session_list /
   # _handle_agent_type_list in coordination_api/lambda_function.py, backed by


### PR DESCRIPTION
## Summary
Third and final wiring step for `tracker.creation_rules` (follow-up to #995 handler + #996 Lambda route path fix). The HTTP API declares explicit routes for the coordination prefix — no greedy proxy — so `GET /api/v1/coordination/tracker/creation_rules` was still returning API Gateway's 404 even after the Lambda knew the path. Adds `RouteTrackerCreationRules` targeting `CoordinationApiIntegration`.

CFN-only change: `cloudformation-api-stack-deploy.yml` deploys 03-api to the gamma stack on v4/main push (no reviewer gate for v4/**). No dictionary bump needed — 03-api.yaml is not in deploy.governance_guard trigger_patterns.

## Test plan
- [ ] cloudformation-api-stack-deploy gamma apply succeeds
- [ ] `GET https://mcp-gamma.jreese.net/api/v1/coordination/tracker/creation_rules?record_type=plan` returns the dictionary-derived contract (dictionary_version 2026-07-11.7)

CCI-eb549a41a46d4a099b8d905f903042e2

🤖 Generated with [Claude Code](https://claude.com/claude-code)