### PR TITLE
ENC-ISS-532: filter internal sentinel-project rows before channel construction

### DIFF
--- a/backend/lambda/appsync_feed_publisher/lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/lambda_function.py
@@ -282,6 +282,17 @@ def build_summary(actor_id: str, action: str, record_type: str, record_id: str, 
     return base
 
 
+# ENC-ISS-532: dunder-wrapped values ("__feed__" today) are this codebase's
+# convention for internal system sentinels (enceladus_shared.version_seq's
+# FEED_TOMBSTONE_PROJECT / VERSION_SEQ_COUNTER_PROJECT) -- checking the shape
+# rather than a fixed deny-list also catches any future similarly-named
+# sentinel without a code change here.
+def _is_real_project_id(project_id: str) -> bool:
+    if not project_id:
+        return False
+    return not (project_id.startswith("__") and project_id.endswith("__"))
+
+
 def build_event_payload(record: Dict[str, Any], batch_counter: int) -> Optional[Dict[str, Any]]:
     """Build the lightweight AppSync event payload for one stream record.
 
@@ -321,6 +332,22 @@ def build_event_payload(record: Dict[str, Any], batch_counter: int) -> Optional[
     record_type = _first_nonempty(primary.get("record_type"), "record")
     project_id = _first_nonempty(primary.get("project_id"), keys.get("project_id")) or DEFAULT_PROJECT_ID
     title = _first_nonempty(primary.get("title"), primary.get("name"))
+
+    # ENC-ISS-532: internal bookkeeping rows (enceladus_shared.version_seq's
+    # counter#version_seq / feed_tombstone rows) carry the sentinel
+    # project_id "__feed__" -- these are not project-scoped data and were
+    # never meant to appear on ANY human-facing channel. Filter them
+    # upstream, before any channel is constructed, rather than relying on
+    # ENC-TSK-M71's reject-and-skip backstop for a fully predictable shape.
+    if not _is_real_project_id(project_id):
+        logger.warning(
+            "appsync_feed_publisher: filtering non-project record_id=%s project_id=%r "
+            "-- internal/meta row, no channel constructed",
+            record_id,
+            project_id,
+        )
+        _emit_filtered_metric(record_id)
+        return None
 
     action = derive_action(event_name, new_image, old_image)
     actor_type, actor_id = infer_actor(primary)
@@ -532,6 +559,20 @@ def _emit_poison_metric(seq: str, http_status: int) -> None:
         logger.warning(
             "appsync_feed_publisher: failed to emit PoisonRecordSkipped metric for seq=%s",
             seq,
+            exc_info=True,
+        )
+
+
+def _emit_filtered_metric(record_id: str) -> None:
+    try:
+        _cloudwatch.put_metric_data(
+            Namespace=POISON_METRIC_NAMESPACE,
+            MetricData=[{"MetricName": "NonProjectRecordFiltered", "Value": 1, "Unit": "Count"}],
+        )
+    except Exception:  # noqa: BLE001 — metrics emission must never break the filter path
+        logger.warning(
+            "appsync_feed_publisher: failed to emit NonProjectRecordFiltered metric for record_id=%s",
+            record_id,
             exc_info=True,
         )
 

--- a/backend/lambda/appsync_feed_publisher/test_lambda_function.py
+++ b/backend/lambda/appsync_feed_publisher/test_lambda_function.py
@@ -669,3 +669,69 @@ def test_emit_poison_metric_failure_does_not_raise():
     fake_cloudwatch.put_metric_data.side_effect = RuntimeError("cloudwatch unavailable")
     with patch.object(mod, "_cloudwatch", fake_cloudwatch):
         mod._emit_poison_metric("seq-x", 400)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# ENC-ISS-532: internal sentinel-project rows (version_seq counter /
+# feed_tombstone, project_id="__feed__") must never construct a channel --
+# AppSync permanently rejects /projects/__feed__ (ENC-ISS-531/ENC-TSK-M71
+# poison-skips it, but filtering upstream avoids relying on that backstop
+# for a fully predictable, non-project record shape).
+# ---------------------------------------------------------------------------
+
+
+def test_is_real_project_id_rejects_dunder_sentinels_and_empty():
+    assert mod._is_real_project_id("__feed__") is False
+    assert mod._is_real_project_id("") is False
+    assert mod._is_real_project_id("enceladus") is True
+    assert mod._is_real_project_id("chosen-family") is True
+    # A leading/trailing single underscore is NOT the dunder-sentinel shape.
+    assert mod._is_real_project_id("_enceladus") is True
+
+
+def test_build_event_payload_returns_none_for_sentinel_project_id():
+    rec = _stream_record(
+        event_name="MODIFY",
+        new_image={
+            "project_id": "__feed__",
+            "record_id": "counter#version_seq",
+            "version_seq": 42,
+        },
+        keys={"project_id": "__feed__", "record_id": "counter#version_seq"},
+    )
+    assert mod.build_event_payload(rec, 0) is None
+
+
+def test_build_event_payload_unchanged_for_normal_record():
+    rec = _stream_record(
+        event_name="INSERT",
+        new_image={"record_id": "task#ENC-TSK-Z1", "item_id": "ENC-TSK-Z1", "project_id": "enceladus"},
+    )
+    payload = mod.build_event_payload(rec, 0)
+    assert payload is not None
+    assert payload["channels"] == ["/feed/updates", "/records/ENC-TSK-Z1", "/projects/enceladus"]
+
+
+def test_handler_filters_sentinel_project_row_without_publishing():
+    event = {
+        "Records": [
+            _stream_record(
+                event_name="MODIFY",
+                new_image={"project_id": "__feed__", "record_id": "counter#version_seq", "version_seq": 1},
+                keys={"project_id": "__feed__", "record_id": "counter#version_seq"},
+                seq="counter-seq",
+            ),
+        ]
+    }
+    fake_cloudwatch = MagicMock()
+    with patch.object(mod, "DRY_RUN", False), patch.object(
+        mod, "publish_to_appsync"
+    ) as mock_publish, patch.object(mod, "_cloudwatch", fake_cloudwatch):
+        result = mod.handler(event, None)
+
+    # Filtered upstream -- not a failure, not retried, and AppSync is never called.
+    assert result == {}
+    mock_publish.assert_not_called()
+    fake_cloudwatch.put_metric_data.assert_called_once()
+    call_kwargs = fake_cloudwatch.put_metric_data.call_args.kwargs
+    assert call_kwargs["MetricData"][0]["MetricName"] == "NonProjectRecordFiltered"

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-11.8",
-  "updated_at": "2026-07-11T19:45:00Z",
-  "last_change_summary": "ENC-ISS-531: appsync_feed_publisher now logs the AppSync response body on non-2xx publish errors, classifies permanent 4xx rejections (400/403/404, excluding 429) as poison records -- skipped with a PoisonRecordSkipped CloudWatch metric instead of retried forever -- and the DynamoDB Stream EventSourceMapping gained MaximumRetryAttempts=5, BisectBatchOnFunctionError, and an on-failure SQS DLQ destination as a generic backstop. No entity/field schema change, just serialization/retry-handling; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-11.9",
+  "updated_at": "2026-07-12T00:50:00Z",
+  "last_change_summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7968,7 +7968,7 @@
       }
     }
   },
-  "change_summary": "ENC-ISS-531: appsync_feed_publisher now logs the AppSync response body on non-2xx publish errors, classifies permanent 4xx rejections (400/403/404, excluding 429) as poison records -- skipped with a PoisonRecordSkipped CloudWatch metric instead of retried forever -- and the DynamoDB Stream EventSourceMapping gained MaximumRetryAttempts=5, BisectBatchOnFunctionError, and an on-failure SQS DLQ destination as a generic backstop. No entity/field schema change, just serialization/retry-handling; bumping per the lambda_function.py touch guard.",
+  "change_summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "change_log": [
     {
       "version": "2026-07-08.05",
@@ -8349,6 +8349,11 @@
       "version": "2026-07-11.8",
       "date": "2026-07-11",
       "summary": "ENC-ISS-531: appsync_feed_publisher now logs the AppSync response body on non-2xx publish errors, classifies permanent 4xx rejections (400/403/404, excluding 429) as poison records -- skipped with a PoisonRecordSkipped CloudWatch metric instead of retried forever -- and the DynamoDB Stream EventSourceMapping gained MaximumRetryAttempts=5, BisectBatchOnFunctionError, and an on-failure SQS DLQ destination as a generic backstop. No entity/field schema change, just serialization/retry-handling; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-11.9",
+      "date": "2026-07-12",
+      "summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Rows carrying the internal `__feed__` sentinel `project_id` (`enceladus_shared.version_seq`'s `counter#version_seq` / `feed_tombstone` bookkeeping rows) are not project-scoped data. AppSync permanently rejects `/projects/__feed__` (400) -- ENC-TSK-M71's poison-skip logic already classifies that as unrecoverable, but relying on reject-and-skip for a fully predictable, non-project record shape is unnecessary. This filters it upstream instead.

- New `_is_real_project_id()`: rejects empty and dunder-wrapped sentinels -- checks the *shape*, not a fixed deny-list, so any future similarly-named internal marker is caught without a code change.
- `build_event_payload` now checks `project_id` against this **before** constructing any channel list; sentinel rows return `None` (identical to the existing "no resolvable recordId" skip path) -- zero channels built, zero `publish_to_appsync` calls. Logs + emits a `NonProjectRecordFiltered` CloudWatch metric.
- 4 new unit tests. 41/41 passing.

Gamma-only; no prod-side changes.

CCI-1a69f98ce0cc4e2bb159eeb9cd2ff845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>