### PR TITLE
ENC-TSK-M73 (B67 AC-13): realtime feed events sole-sourced from TanStack cache

### DIFF
--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.test.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.test.tsx
@@ -2,7 +2,8 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { RealtimeFeedProvider, useRealtimeFeed } from './RealtimeFeedProvider'
+import { RealtimeFeedProvider, useRealtimeFeed, useRealtimeFeedEvents } from './RealtimeFeedProvider'
+import { REALTIME_FEED_QUERY_KEY } from './feedEventReducer'
 import { useFeedBufferStore } from '../store/feedBufferStore'
 import type { RealtimeClientEvent } from './appsyncRealtimeClient'
 import type { FeedRealtimeEvent } from '../types/feedEvents'
@@ -92,7 +93,9 @@ describe('RealtimeFeedProvider — buffered live events (ENC-TSK-K24)', () => {
   })
 
   function Consumer() {
-    const { events } = useRealtimeFeed()
+    // ENC-TSK-M73 (B67 AC-13): the visible list is read from the
+    // REALTIME_FEED_QUERY_KEY cache via the shared hook — no ctx.events copy.
+    const events = useRealtimeFeedEvents()
     return (
       <ul data-testid="visible-events">
         {events.map((e) => (
@@ -130,9 +133,10 @@ describe('RealtimeFeedProvider — buffered live events (ENC-TSK-K24)', () => {
     let ctx!: ReturnType<typeof useRealtimeFeed>
     function CaptureConsumer() {
       ctx = useRealtimeFeed()
+      const events = useRealtimeFeedEvents()
       return (
         <ul data-testid="visible-events">
-          {ctx.events.map((e) => (
+          {events.map((e) => (
             <li key={e.eventId}>{e.eventId}</li>
           ))}
         </ul>
@@ -199,7 +203,8 @@ describe('RealtimeFeedProvider — buffered live events (ENC-TSK-K24)', () => {
       ctx.mergeBufferedEvents()
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
-    expect(ctx.events.map((e) => e.eventId)).toEqual(['replay-1'])
+    const afterFirst = qc.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? []
+    expect(afterFirst.map((e) => e.eventId)).toEqual(['replay-1'])
 
     // Same eventId redelivered post-reconnect (replay-from-cursor overlap).
     await act(async () => {
@@ -211,7 +216,8 @@ describe('RealtimeFeedProvider — buffered live events (ENC-TSK-K24)', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(ctx.events.filter((e) => e.eventId === 'replay-1')).toHaveLength(1)
+    const afterReplay = qc.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? []
+    expect(afterReplay.filter((e) => e.eventId === 'replay-1')).toHaveLength(1)
   })
 
   it('a burst of rapid live events does not corrupt or drop buffered state (AC-15 low-priority scheduling proxy)', async () => {
@@ -240,5 +246,45 @@ describe('RealtimeFeedProvider — buffered live events (ENC-TSK-K24)', () => {
     // the scenario the buffer exists to absorb without ever forcing an
     // uncontrolled render storm on the rendered list.
     expect(container.querySelector('[data-testid="visible-events"]')?.textContent).toBe('')
+  })
+
+  it('the consumer view is the REALTIME_FEED_QUERY_KEY cache itself — no divergent component-local copy (AC-13)', async () => {
+    let ctx!: ReturnType<typeof useRealtimeFeed>
+    let hookEvents: FeedRealtimeEvent[] = []
+    function CaptureConsumer() {
+      ctx = useRealtimeFeed()
+      hookEvents = useRealtimeFeedEvents()
+      return null
+    }
+
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <RealtimeFeedProvider>
+            <CaptureConsumer />
+          </RealtimeFeedProvider>
+        </QueryClientProvider>,
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      pushEvent(makeEvent({ eventId: 'a', cursor: 1 }))
+      pushEvent(makeEvent({ eventId: 'b', cursor: 2 }))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await act(async () => {
+      ctx.mergeBufferedEvents()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const cache = qc.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? []
+    expect(cache.map((e) => e.eventId).sort()).toEqual(['a', 'b'])
+    // Same contents AND same array reference: the consumer holds no copy that
+    // could drift from the cache — the cache is the sole source of truth.
+    expect(hookEvents).toEqual(cache)
+    expect(hookEvents).toBe(cache)
   })
 })

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -4,7 +4,6 @@ import {
   useContext,
   useEffect,
   useRef,
-  useState,
   type ReactNode,
 } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -26,16 +25,15 @@ import type { FeedRealtimeEvent } from '../types/feedEvents'
 import { getCacheEngine, tier1FromFeedEvent } from '../sync/cacheEngine'
 
 interface RealtimeFeedContextValue {
-  events: FeedRealtimeEvent[]
   isHydrating: boolean
   isSnapshotError: boolean
   refetchSnapshot: () => void
   manualReconnect: () => void
   /**
    * ENC-TSK-K24 (B67 AC-11): merges every buffered "new activity" into the
-   * visible list in one call — the only way a live-pushed event reaches
-   * `events`. Returns the number merged so the caller (FeedPane's banner)
-   * can decide whether to scroll to top.
+   * visible list in one call — the only way a live-pushed event reaches the
+   * REALTIME_FEED_QUERY_KEY cache (ENC-TSK-M73). Returns the number merged so
+   * the caller (FeedPane's banner) can decide whether to scroll to top.
    */
   mergeBufferedEvents: () => number
   /**
@@ -54,10 +52,31 @@ export function useRealtimeFeed(): RealtimeFeedContextValue {
   return ctx
 }
 
+/**
+ * ENC-TSK-M73 (B67 AC-13): the visible feed-event list lives SOLELY in the
+ * TanStack Query cache at REALTIME_FEED_QUERY_KEY — there is no parallel
+ * component useState copy. This hook subscribes consumers (FeedPane,
+ * FeedRoute, DocsRoute) to that single cache entry so they re-render when the
+ * provider mutates it via setQueryData (snapshot seed + banner-merge drain).
+ * The queryFn only ever returns the current cached value — every write comes
+ * exclusively from setQueryData inside the provider — and staleTime:Infinity
+ * means it is never refetched or clobbered.
+ */
+export function useRealtimeFeedEvents(): FeedRealtimeEvent[] {
+  const queryClient = useQueryClient()
+  const { data } = useQuery<FeedRealtimeEvent[]>({
+    queryKey: REALTIME_FEED_QUERY_KEY,
+    queryFn: () => queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? [],
+    initialData: () => queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? [],
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+  return data
+}
+
 export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient()
   const clientRef = useRef<AppSyncRealtimeClient | null>(null)
-  const [events, setEvents] = useState<FeedRealtimeEvent[]>([])
 
   const setPhase = useFeedConnectionStore((s) => s.setPhase)
   const setReconnectAttempt = useFeedConnectionStore((s) => s.setReconnectAttempt)
@@ -77,7 +96,6 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
     const seeded = snapshotToFeedState(snapshotQuery.data)
     const merged = mergeFeedEvents(seeded, queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? [])
     queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)
-    setEvents(merged)
   }, [snapshotQuery.data, queryClient])
 
   useEffect(() => {
@@ -178,7 +196,6 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
   ])
 
   const value: RealtimeFeedContextValue = {
-    events,
     isHydrating: snapshotQuery.isPending,
     isSnapshotError: snapshotQuery.isError,
     refetchSnapshot: () => {
@@ -192,12 +209,14 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
     mergeBufferedEvents: () => {
       const drained = useFeedBufferStore.getState().drainBuffer()
       if (drained.length === 0) return 0
+      // ENC-TSK-M73 (B67 AC-13): merge into the REALTIME_FEED_QUERY_KEY cache
+      // — the sole source of truth — instead of a parallel useState copy. The
+      // startTransition wrapping (B67 AC-15) and buffer-drain semantics
+      // (AC-11) are preserved exactly; only the write target changed.
       startTransition(() => {
-        setEvents((prev) => {
-          const merged = mergeFeedEvents(prev, drained)
-          queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)
-          return merged
-        })
+        const prev = queryClient.getQueryData<FeedRealtimeEvent[]>(REALTIME_FEED_QUERY_KEY) ?? []
+        const merged = mergeFeedEvents(prev, drained)
+        queryClient.setQueryData(REALTIME_FEED_QUERY_KEY, merged)
       })
       return drained.length
     },

--- a/frontend/ui-v2/src/routes/DocsRoute.tsx
+++ b/frontend/ui-v2/src/routes/DocsRoute.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Autosuggest, Cards } from '../design-system'
 import { projectRegistryQueryOptions } from '../api/projectRegistry'
-import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
+import { useRealtimeFeedEvents } from '../realtime/RealtimeFeedProvider'
 import { applyPropertyFilter, type PropertyFilterQuery } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
 import { onlyRecordType } from '../search/recordTypeScope'
@@ -41,7 +41,7 @@ export function DocsRoute() {
   const [sort, setSort] = useState<FeedSort>('tier')
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
-  const { events } = useRealtimeFeed()
+  const events = useRealtimeFeedEvents()
   const { isWarm } = useCacheEngineState()
 
   const fromEvents = buildSearchCorpus(events, projects)

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -7,7 +7,7 @@ import { Badge } from '../components/Badge'
 import { RecordCard } from '../components/RecordCard'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { formatRelativeTime } from '../format/relativeTime'
-import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
+import { useRealtimeFeed, useRealtimeFeedEvents } from '../realtime/RealtimeFeedProvider'
 import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
 import {
@@ -32,7 +32,6 @@ import {
   getRecentlyViewed,
   hitFromRecent,
   trackRecentlyViewed,
-  type RecentlyViewedEntry,
 } from '../search/recentlyViewed'
 import { buildSearchCorpus } from '../search/searchCorpus'
 import { excludeRecordType } from '../search/recordTypeScope'
@@ -45,6 +44,7 @@ import {
   useRequestFirstPageTelemetry,
 } from '../search/useSearchTelemetry'
 import { useFeedConnectionStore } from '../store/feedConnectionStore'
+import { useUiStore } from '../store/uiStore'
 import { documentHref, recordHrefForType } from '../routes/recordLink'
 import type { SearchResultHit } from '../types/search'
 import { FeedReadingPane } from './FeedReadingPane'
@@ -71,7 +71,8 @@ export function FeedRoute() {
   const [isWide, setIsWide] = useState(false)
   const [selectedHit, setSelectedHit] = useState<SearchResultHit | null>(null)
   const [visibleCount, setVisibleCount] = useState(LIST_CHUNK)
-  const [recentItems, setRecentItems] = useState<RecentlyViewedEntry[]>([])
+  const recentItems = useUiStore((s) => s.recentItems)
+  const setRecentItems = useUiStore((s) => s.setRecentItems)
   const listRef = useRef<HTMLDivElement>(null)
 
   const filterQuery = parseFilterQuery(f, op)
@@ -89,7 +90,8 @@ export function FeedRoute() {
   }
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
-  const { events, isHydrating } = useRealtimeFeed()
+  const { isHydrating } = useRealtimeFeed()
+  const events = useRealtimeFeedEvents()
   const { isWarm } = useCacheEngineState()
   const corpus = (() => {
     const fromEvents = buildSearchCorpus(events, projects)
@@ -180,7 +182,7 @@ export function FeedRoute() {
     setSelectedHit(first)
     trackRecentlyViewed(first)
     setRecentItems(getRecentlyViewed(first.recordType))
-  }, [isWide, filteredHits, selectedHit])
+  }, [isWide, filteredHits, selectedHit, setRecentItems])
 
   useEffect(() => {
     if (isWide) return

--- a/frontend/ui-v2/src/shell/FeedPane.test.tsx
+++ b/frontend/ui-v2/src/shell/FeedPane.test.tsx
@@ -14,7 +14,6 @@ const mergeBufferedEvents = vi.fn(() => 0)
 
 vi.mock('../realtime/RealtimeFeedProvider', () => ({
   useRealtimeFeed: () => ({
-    events: [] as FeedRealtimeEvent[],
     isHydrating: false,
     isSnapshotError: false,
     refetchSnapshot: () => {},
@@ -22,6 +21,9 @@ vi.mock('../realtime/RealtimeFeedProvider', () => ({
     mergeBufferedEvents,
     watchRecord: () => () => {},
   }),
+  // ENC-TSK-M73 (B67 AC-13): the visible list now comes from the
+  // REALTIME_FEED_QUERY_KEY cache via this hook, not from the context.
+  useRealtimeFeedEvents: () => [] as FeedRealtimeEvent[],
 }))
 
 describe('FeedPane — new-activities banner (ENC-TSK-K24 / B67 AC-11)', () => {

--- a/frontend/ui-v2/src/shell/FeedPane.tsx
+++ b/frontend/ui-v2/src/shell/FeedPane.tsx
@@ -3,7 +3,7 @@ import { Button, Flashbar } from '../design-system'
 import { useUiStore } from '../store/uiStore'
 import { useFeedConnectionStore } from '../store/feedConnectionStore'
 import { useFeedBufferStore } from '../store/feedBufferStore'
-import { useRealtimeFeed } from '../realtime/RealtimeFeedProvider'
+import { useRealtimeFeed, useRealtimeFeedEvents } from '../realtime/RealtimeFeedProvider'
 import { filterFeedEvents } from '../realtime/feedEventReducer'
 import type { RecordType } from '../types/records'
 
@@ -41,8 +41,9 @@ export function FeedPane({ onClose }: { onClose?: () => void }) {
   const p99LatencyMs = useFeedConnectionStore((s) => s.p99LatencyMs)
   const errorMessage = useFeedConnectionStore((s) => s.errorMessage)
 
-  const { events, isHydrating, isSnapshotError, refetchSnapshot, manualReconnect, mergeBufferedEvents } =
+  const { isHydrating, isSnapshotError, refetchSnapshot, manualReconnect, mergeBufferedEvents } =
     useRealtimeFeed()
+  const events = useRealtimeFeedEvents()
   const bufferedCount = useFeedBufferStore((s) => s.bufferedEvents.length)
   const scrollRef = useRef<HTMLElement>(null)
 

--- a/frontend/ui-v2/src/store/uiStore.ts
+++ b/frontend/ui-v2/src/store/uiStore.ts
@@ -8,6 +8,7 @@
 
 import { create } from 'zustand'
 import type { RecordType } from '../types/records'
+import type { RecentlyViewedEntry } from '../search/recentlyViewed'
 
 export interface ActiveFilters {
   /** Record types the feed pane is scoped to. Empty = show all. */
@@ -32,6 +33,15 @@ interface UiState {
   // Selected record (drives feed highlight / deep-link affordances)
   selectedRecordId: string | null
   selectRecord: (recordId: string | null) => void
+
+  // Recently-viewed record-reference nav state (ENC-TSK-M73 / B67 AC-13).
+  // This is UI navigation state, not server-state: the durable copy lives in
+  // localStorage via search/recentlyViewed.ts, and this is only its reactive
+  // in-memory holder — it replaces FeedRoute's former component-local
+  // useState<RecentlyViewedEntry[]>, keeping record-reference nav data in
+  // Zustand per the AC-13 ownership rule.
+  recentItems: RecentlyViewedEntry[]
+  setRecentItems: (items: RecentlyViewedEntry[]) => void
 
   // Command palette
   commandPaletteOpen: boolean
@@ -60,6 +70,9 @@ export const useUiStore = create<UiState>((set) => ({
 
   selectedRecordId: null,
   selectRecord: (recordId) => set({ selectedRecordId: recordId }),
+
+  recentItems: [],
+  setRecentItems: (items) => set({ recentItems: items }),
 
   commandPaletteOpen: false,
   commandQuery: '',


### PR DESCRIPTION
## Summary

Remediates B67 **AC-13**'s sole outstanding violation. `RealtimeFeedProvider` held the visible feed-event list in a component `useState<FeedRealtimeEvent[]>` **in parallel** with the same data mirrored into the TanStack Query cache at `REALTIME_FEED_QUERY_KEY`. This makes the cache the **sole source of truth**.

### Primary — `RealtimeFeedProvider.tsx`
- Removed `useState<FeedRealtimeEvent[]>`; dropped `events` from the context value/type.
- New exported `useRealtimeFeedEvents()` hook subscribes consumers to the `REALTIME_FEED_QUERY_KEY` cache via `useQuery` (`staleTime: Infinity`; `queryFn` only ever returns the current cache — every write comes exclusively from the provider's `setQueryData`). It returns the cache array reference itself, so no copy can drift.
- The snapshot-seed effect and `mergeBufferedEvents` now write only to the cache. The live `feed_event` path (buffer via Zustand `feedBufferStore`), **both `startTransition` wrappers (AC-15)**, and the **banner/buffer semantics (AC-11)** are preserved exactly — only the merge write target changed from `useState` to `setQueryData`.
- Consumers (`FeedPane`, `FeedRoute`, `DocsRoute`) read via `useRealtimeFeedEvents()`.

### Secondary — `FeedRoute` `recentItems`
- Moved the `useState<RecentlyViewedEntry[]>` recently-viewed nav list into the Zustand `uiStore` per AC-13's UI-state ownership rule. The localStorage-backed `search/recentlyViewed.ts` module is unchanged as the durable store.

### Note on the directive's premise
The directive said to "preserve" `startTransition`/banner semantics — confirmed present in v4/main (an earlier stale branch lacked them). Both are preserved byte-for-byte; the live high-frequency `feed_event`→buffer path is completely untouched.

## Verification
- `tsc --noEmit` clean; `lint:adherence` clean; **278/278 vitest pass**.
- Existing K24 provider tests (no-auto-inject, `mergeBufferedEvents`, AC-9 dedup, AC-15 burst) adapted to read the visible list via the cache with identical behavioral assertions.
- New test asserts the consumer view **is** the cache array (`toEqual` + `toBe`) — no divergent local copy.
- AC-13 audit grep: zero `useState` holding record/feed server-state across ui-v2.

## Merge order
Lands **before** M51's detail-route client work (same files), per dispatch.

CCI-cb9719eaaf9e4c7b83917dac49e14163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>