### PR TITLE
ENC-TSK-M74: server-side page cap + cursor continuation on GET /api/v1/feed

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-11.9",
-  "updated_at": "2026-07-12T00:50:00Z",
-  "last_change_summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.1",
+  "updated_at": "2026-07-12T01:20:00Z",
+  "last_change_summary": "ENC-TSK-M74: GET /api/v1/feed bare full-refresh now applies a server-side page cap (MAX_FEED_PAGE_RECORDS=75 records total across tasks/issues/features/lessons/plans, most-recently-updated first) and returns a top-level next_cursor (string|null, opaque base64, byte-compatible with the /api/v1/feed/corpus cursor contract) for continuation. Collapses the feed p95 driver (was ~919 uncapped records). Per-record output byte-identical; delta/corpus/snapshot paths unchanged. No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -8354,6 +8354,11 @@
       "version": "2026-07-11.9",
       "date": "2026-07-12",
       "summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.1",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M74: GET /api/v1/feed bare full-refresh now applies a server-side page cap (MAX_FEED_PAGE_RECORDS=75 records total across tasks/issues/features/lessons/plans, most-recently-updated first) and returns a top-level next_cursor (string|null, opaque base64, byte-compatible with the /api/v1/feed/corpus cursor contract) for continuation. Collapses the feed p95 driver (was ~919 uncapped records). Per-record output byte-identical; delta/corpus/snapshot paths unchanged. No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/feed_query/feed_page.py
+++ b/backend/lambda/feed_query/feed_page.py
@@ -1,0 +1,144 @@
+"""Server-side page cap + cursor continuation for GET /api/v1/feed (ENC-TSK-M74).
+
+The bare full-refresh response is a single synchronous Lambda payload composed of
+five typed arrays (tasks/issues/features/lessons/plans). Left uncapped it grew to
+~919 records (697 tasks with full history), and that hydration volume + multi-MB
+serialization on a 256MB Lambda was the measured dominant term in feed p95
+(~4.90s vs a <500ms bar). No consumer reads 919 records in a feed view, so this
+module caps the page to ``MAX_FEED_PAGE_RECORDS`` records TOTAL across the five
+arrays and hands back a continuation cursor.
+
+The cursor field name (``next_cursor``) and its opaque-base64 semantics are
+byte-compatible with the corpus endpoint (``corpus.encode_cursor`` /
+``corpus.decode_cursor``, ENC-TSK-L23) that the client already loops on in
+``corpusSeed.ts`` (B67 AC-9's getNextPageParam contract) -- so a direct/legacy
+consumer of bare /feed can page through with the exact same pattern.
+
+Ordering preserves the ``feed_source=opensearch`` selection intent: OpenSearch
+selects the top-N most-recently-updated keys per (project, record_type); the
+honest cross-type merge is a single global sort by (updated_at DESC,
+record_key ASC). Per-record output is byte-identical: this module only truncates
+the set and never mutates a record dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from corpus import decode_cursor, encode_cursor, tracker_record_key
+
+DEFAULT_MAX_FEED_PAGE_RECORDS = 75
+
+# (array-attribute-name, id-key) in the fixed order the response arrays appear.
+_ARRAY_SPECS: Tuple[Tuple[str, str], ...] = (
+    ("tasks", "task_id"),
+    ("issues", "issue_id"),
+    ("features", "feature_id"),
+    ("lessons", "lesson_id"),
+    ("plans", "plan_id"),
+)
+
+
+def _record_key(record: Dict[str, Any], id_key: str) -> str:
+    return tracker_record_key(
+        str(record.get("project_id") or ""),
+        str(record.get(id_key) or ""),
+    )
+
+
+def _flatten_ordered(
+    arrays: Dict[str, List[Dict[str, Any]]]
+) -> List[Tuple[str, str, str, Dict[str, Any]]]:
+    """Flatten the five typed arrays into one globally ordered list.
+
+    Each element is ``(updated_at, record_key, array_name, record)``. Ordering is
+    a stable two-pass sort producing (updated_at DESC, record_key ASC): records
+    sharing an updated_at keep record_key ascending; records with an empty
+    updated_at sort last (they are the first dropped when the cap bites).
+    """
+    flat: List[Tuple[str, str, str, Dict[str, Any]]] = []
+    for array_name, id_key in _ARRAY_SPECS:
+        for record in arrays.get(array_name, []) or []:
+            updated_at = str(record.get("updated_at") or "")
+            flat.append((updated_at, _record_key(record, id_key), array_name, record))
+    # Stable: secondary key first (record_key asc), then primary (updated_at desc).
+    flat.sort(key=lambda t: t[1])
+    flat.sort(key=lambda t: t[0], reverse=True)
+    return flat
+
+
+def _resplit(
+    window: List[Tuple[str, str, str, Dict[str, Any]]]
+) -> Dict[str, List[Dict[str, Any]]]:
+    out: Dict[str, List[Dict[str, Any]]] = {name: [] for name, _ in _ARRAY_SPECS}
+    for _updated_at, _key, array_name, record in window:
+        out[array_name].append(record)
+    return out
+
+
+def apply_page_cap(
+    tasks: List[Dict[str, Any]],
+    issues: List[Dict[str, Any]],
+    features: List[Dict[str, Any]],
+    lessons: List[Dict[str, Any]],
+    plans: List[Dict[str, Any]],
+    *,
+    cursor: Optional[str] = None,
+    cap: int = DEFAULT_MAX_FEED_PAGE_RECORDS,
+) -> Tuple[
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    Optional[str],
+]:
+    """Cap the full-refresh page and compute a continuation cursor.
+
+    Returns ``(tasks, issues, features, lessons, plans, next_cursor)`` where the
+    five arrays together hold at most ``cap`` records (the globally most-recent
+    window after any ``cursor``), and ``next_cursor`` is an opaque token when more
+    records remain past the window, else ``None``.
+
+    A malformed/undecodable ``cursor`` is treated as no cursor (start from the
+    top) -- the caller validates and 400s explicitly before reaching here, so
+    this is a defensive fallback only.
+    """
+    arrays = {
+        "tasks": tasks,
+        "issues": issues,
+        "features": features,
+        "lessons": lessons,
+        "plans": plans,
+    }
+    ordered = _flatten_ordered(arrays)
+
+    start_index = 0
+    if cursor:
+        decoded = decode_cursor(cursor)
+        if decoded is not None:
+            _sort_value, cursor_key = decoded
+            for idx, (_updated_at, record_key, _name, _record) in enumerate(ordered):
+                if record_key == cursor_key:
+                    start_index = idx + 1
+                    break
+
+    if cap <= 0:
+        window = ordered[start_index:]
+    else:
+        window = ordered[start_index : start_index + cap]
+
+    next_cursor: Optional[str] = None
+    if cap > 0 and window and (start_index + cap) < len(ordered):
+        last_updated_at, last_key, _name, _record = window[-1]
+        next_cursor = encode_cursor(last_updated_at, last_key)
+
+    split = _resplit(window)
+    return (
+        split["tasks"],
+        split["issues"],
+        split["features"],
+        split["lessons"],
+        split["plans"],
+        next_cursor,
+    )

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -50,6 +50,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 import corpus as feed_corpus
 import delta as feed_delta
+import feed_page
 
 try:
     import jwt
@@ -435,6 +436,16 @@ MAX_ISSUES_FULL_REFRESH = 10
 MAX_FEATURES_FULL_REFRESH = 10
 MAX_LESSONS_FULL_REFRESH = 10
 MAX_PLANS_FULL_REFRESH = 10
+
+# ENC-TSK-M74: global cap on the bare GET /api/v1/feed full-refresh page. The
+# per-type caps above are applied PER ACTIVE PROJECT, so the merged page still
+# grew to ~919 records across projects -- the measured dominant term in feed p95
+# (hydration + multi-MB serialization on a 256MB Lambda). This caps the merged
+# page to the N most-recently-updated records TOTAL and returns a continuation
+# cursor (feed_page.apply_page_cap) reusing the corpus next_cursor contract. No
+# consumer reads 919 records in a feed view; full corpus stays available via the
+# already-paginated /api/v1/feed/corpus SWR path.
+MAX_FEED_PAGE_RECORDS = 75
 
 
 def _cap_by_updated_at(records: List[Dict[str, Any]], cap: int) -> List[Dict[str, Any]]:
@@ -2134,12 +2145,35 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     # exception class + message instead of escaping the handler and letting
     # Lambda runtime return the opaque {"message":"Internal Server Error"}
     # that made the live 500 impossible to diagnose from the client side.
+    # ENC-TSK-M74: continuation cursor for the server-side page cap. Validate
+    # up front so a malformed cursor 400s before any query work, matching the
+    # /feed/corpus contract (opaque base64; same encode/decode as corpus.py).
+    feed_cursor = str(qs.get("cursor") or "").strip()
+    if feed_cursor and feed_corpus.decode_cursor(feed_cursor) is None:
+        return _error(400, "Invalid cursor")
+
     try:
         try:
             tasks, issues, features, lessons, plans = _query_all_records()
         except Exception as exc:
             logger.error("feed query failed: %s", exc)
             return _error(500, "Failed to query feed data. Please try again.")
+
+        # --- ENC-TSK-M74 server-side page cap + continuation cursor ---
+        # Cap the merged page to MAX_FEED_PAGE_RECORDS most-recently-updated
+        # records BEFORE the (edge attach + serialization) tail so those costs
+        # only ever process the capped window -- this collapses the feed p95
+        # term. next_cursor is computed on the pre-scope window so continuation
+        # is stable regardless of any subscription scope applied below.
+        tasks, issues, features, lessons, plans, feed_next_cursor = feed_page.apply_page_cap(
+            tasks,
+            issues,
+            features,
+            lessons,
+            plans,
+            cursor=feed_cursor or None,
+            cap=MAX_FEED_PAGE_RECORDS,
+        )
 
         # --- Attach typed relationship edges + context node scores (ENC-TSK-A57/K26) ---
         try:
@@ -2219,6 +2253,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "plans": plans,
                 "subscription": subscription_meta,
                 "feed_source": _last_feed_query_source,
+                "next_cursor": feed_next_cursor,
             },
         )
     except Exception as outer_exc:  # noqa: BLE001

--- a/backend/lambda/feed_query/test_feed_page.py
+++ b/backend/lambda/feed_query/test_feed_page.py
@@ -1,0 +1,129 @@
+"""Unit tests for the server-side feed page cap + cursor continuation (ENC-TSK-M74)."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import feed_page  # noqa: E402
+from corpus import decode_cursor  # noqa: E402
+
+
+def _rec(id_key: str, rid: str, updated_at: str, project_id: str = "enceladus") -> dict:
+    return {id_key: rid, "project_id": project_id, "updated_at": updated_at, "title": rid}
+
+
+def _tasks(n: int, *, base_ts: str = "2026-07-10T") -> list:
+    # Descending timestamps so record order is unambiguous: T00 newest .. Tnn oldest.
+    return [_rec("task_id", f"ENC-TSK-{i:03d}", f"{base_ts}{(59 - i) % 60:02d}:00:00Z") for i in range(n)]
+
+
+def _all(tasks=None, issues=None, features=None, lessons=None, plans=None):
+    return (tasks or [], issues or [], features or [], lessons or [], plans or [])
+
+
+def _count(*arrays) -> int:
+    return sum(len(a) for a in arrays)
+
+
+def test_below_cap_returns_everything_and_null_cursor():
+    tasks = _tasks(10)
+    t, i, f, l, p, cur = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)
+    assert _count(t, i, f, l, p) == 10
+    assert cur is None
+
+
+def test_exactly_at_cap_returns_null_cursor():
+    tasks = _tasks(75)
+    t, i, f, l, p, cur = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)
+    assert _count(t, i, f, l, p) == 75
+    assert cur is None
+
+
+def test_over_cap_truncates_and_emits_cursor():
+    tasks = _tasks(76)
+    t, i, f, l, p, cur = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)
+    assert _count(t, i, f, l, p) == 75
+    assert cur is not None
+    assert decode_cursor(cur) is not None
+
+
+def test_cap_is_global_across_typed_arrays():
+    # 50 tasks + 50 issues -> 100 records, cap 75 keeps 75 total across arrays.
+    tasks = [_rec("task_id", f"ENC-TSK-{i:03d}", f"2026-07-10T{i:02d}:00:00Z") for i in range(50)]
+    issues = [_rec("issue_id", f"ENC-ISS-{i:03d}", f"2026-07-09T{i:02d}:00:00Z") for i in range(50)]
+    t, i, f, l, p, cur = feed_page.apply_page_cap(*_all(tasks=tasks, issues=issues), cap=75)
+    assert _count(t, i, f, l, p) == 75
+    assert cur is not None
+
+
+def test_ordering_is_recency_desc_with_record_key_tiebreak():
+    # Two records share a timestamp; record_key (tracker:project:id) breaks the tie ASC.
+    tasks = [
+        _rec("task_id", "ENC-TSK-BBB", "2026-07-10T09:00:00Z"),
+        _rec("task_id", "ENC-TSK-AAA", "2026-07-10T09:00:00Z"),
+        _rec("task_id", "ENC-TSK-CCC", "2026-07-10T12:00:00Z"),
+    ]
+    t, *_ = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)
+    ids = [r["task_id"] for r in t]
+    assert ids == ["ENC-TSK-CCC", "ENC-TSK-AAA", "ENC-TSK-BBB"]
+
+
+def test_ordering_is_deterministic_across_input_permutations():
+    import random
+
+    tasks = _tasks(40)
+    shuffled = tasks[:]
+    random.Random(7).shuffle(shuffled)
+    a = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)[0]
+    b = feed_page.apply_page_cap(*_all(tasks=shuffled), cap=75)[0]
+    assert [r["task_id"] for r in a] == [r["task_id"] for r in b]
+
+
+def test_empty_updated_at_sorts_last():
+    tasks = [
+        _rec("task_id", "ENC-TSK-NEW", "2026-07-10T10:00:00Z"),
+        {"task_id": "ENC-TSK-NOTS", "project_id": "enceladus", "title": "x"},  # no updated_at
+    ]
+    t, *_ = feed_page.apply_page_cap(*_all(tasks=tasks), cap=1)
+    assert [r["task_id"] for r in t] == ["ENC-TSK-NEW"]
+
+
+def test_cursor_continuation_no_overlap_no_gap_full_traversal():
+    tasks = _tasks(160)
+    seen = []
+    cursor = None
+    pages = 0
+    while True:
+        t, i, f, l, p, cursor = feed_page.apply_page_cap(
+            *_all(tasks=tasks), cursor=cursor, cap=75
+        )
+        pages += 1
+        seen.extend(r["task_id"] for r in (t + i + f + l + p))
+        if cursor is None:
+            break
+        assert pages < 10  # guard against infinite loop
+    # Full traversal reconstructs the full set exactly once, in stable order.
+    assert len(seen) == 160
+    assert len(set(seen)) == 160
+    single = feed_page.apply_page_cap(*_all(tasks=tasks), cap=0)[0]
+    assert seen == [r["task_id"] for r in single]
+
+
+def test_per_record_output_is_byte_identical():
+    # The record dicts returned must be the very same objects, unmutated.
+    tasks = _tasks(3)
+    before = [dict(r) for r in tasks]
+    t, *_ = feed_page.apply_page_cap(*_all(tasks=tasks), cap=75)
+    for original, returned in zip(before, sorted(t, key=lambda r: r["task_id"])):
+        assert returned == original
+
+
+def test_invalid_cursor_falls_back_to_top_defensively():
+    tasks = _tasks(10)
+    t, *_rest, cur = feed_page.apply_page_cap(*_all(tasks=tasks), cursor="!!!not-base64!!!", cap=75)
+    # Undecodable cursor -> start from top (handler 400s before this in practice).
+    assert len(t) == 10
+    assert cur is None

--- a/backend/lambda/feed_query/test_lambda_function.py
+++ b/backend/lambda/feed_query/test_lambda_function.py
@@ -62,6 +62,92 @@ def test_invalid_since_returns_400(monkeypatch):
     assert "since" in payload["error"]
 
 
+# --- ENC-TSK-M74: server-side page cap + continuation cursor on bare /api/v1/feed ---
+
+def _feed_full_event(cursor: str | None = None) -> dict:
+    qs: dict = {}
+    if cursor is not None:
+        qs["cursor"] = cursor
+    return {
+        "requestContext": {"http": {"method": "GET"}},
+        "rawPath": "/api/v1/feed",
+        "headers": {"Cookie": "enceladus_id_token=test-token"},
+        "queryStringParameters": qs,
+    }
+
+
+def _many_tasks(n: int) -> list:
+    # Descending timestamps so ordering is unambiguous.
+    return [
+        {
+            "task_id": f"ENC-TSK-{i:03d}",
+            "project_id": "enceladus",
+            "updated_at": f"2026-07-10T{(59 - (i % 60)):02d}:00:00Z",
+            "title": f"t{i}",
+        }
+        for i in range(n)
+    ]
+
+
+def test_full_refresh_caps_page_and_returns_next_cursor(monkeypatch):
+    monkeypatch.setattr(feed_query, "_verify_token", lambda _token: {"sub": "u-1"})
+    monkeypatch.setattr(feed_query, "MAX_FEED_PAGE_RECORDS", 75)
+    monkeypatch.setattr(
+        feed_query,
+        "_query_all_records",
+        lambda: (_many_tasks(120), [], [], [], []),
+    )
+
+    resp = feed_query.lambda_handler(_feed_full_event(), None)
+    assert resp["statusCode"] == 200
+    payload = json.loads(resp["body"])
+    total = sum(len(payload[k]) for k in ("tasks", "issues", "features", "lessons", "plans"))
+    assert total == 75
+    assert payload["next_cursor"]  # non-null when more remain
+    assert "feed_source" in payload
+
+    # Page 2 continues after the cursor with no overlap and drains the tail.
+    resp2 = feed_query.lambda_handler(_feed_full_event(cursor=payload["next_cursor"]), None)
+    payload2 = json.loads(resp2["body"])
+    total2 = sum(len(payload2[k]) for k in ("tasks", "issues", "features", "lessons", "plans"))
+    assert total2 == 45
+    assert payload2["next_cursor"] is None
+    page1_ids = {t["task_id"] for t in payload["tasks"]}
+    page2_ids = {t["task_id"] for t in payload2["tasks"]}
+    assert not (page1_ids & page2_ids)
+    assert len(page1_ids | page2_ids) == 120
+
+
+def test_full_refresh_below_cap_null_cursor(monkeypatch):
+    monkeypatch.setattr(feed_query, "_verify_token", lambda _token: {"sub": "u-1"})
+    monkeypatch.setattr(
+        feed_query,
+        "_query_all_records",
+        lambda: (_many_tasks(10), [], [], [], []),
+    )
+    resp = feed_query.lambda_handler(_feed_full_event(), None)
+    payload = json.loads(resp["body"])
+    assert len(payload["tasks"]) == 10
+    assert payload["next_cursor"] is None
+
+
+def test_full_refresh_invalid_cursor_returns_400(monkeypatch):
+    monkeypatch.setattr(feed_query, "_verify_token", lambda _token: {"sub": "u-1"})
+    called = {"n": 0}
+
+    def _boom():
+        called["n"] += 1
+        return ([], [], [], [], [])
+
+    monkeypatch.setattr(feed_query, "_query_all_records", _boom)
+    resp = feed_query.lambda_handler(_feed_full_event(cursor="!!!bad!!!"), None)
+    assert resp["statusCode"] == 400
+    payload = json.loads(resp["body"])
+    assert "cursor" in payload["error"].lower()
+    # 400s before any query work.
+    assert called["n"] == 0
+
+
 def _corpus_get_event(**params: str) -> dict:
     return {
         "requestContext": {"http": {"method": "GET"}},


### PR DESCRIPTION
## ENC-TSK-M74 — Feed p95 closure: server-side page cap + cursor continuation

CCI-6f04803f8474474ab179382c976efbb2

### What
The bare `GET /api/v1/feed` full-refresh page grew to ~919 records (697 tasks with
full history). Hydration + multi-MB serialization on the 256MB Lambda is the measured
dominant term in feed p95 (~4.90s vs a <500ms bar; per ENC-TSK-M64 baseline probe).

This caps the merged page to the **75 most-recently-updated records total** across the
five typed arrays (tasks/issues/features/lessons/plans) and returns a top-level
`next_cursor` (opaque base64, **byte-compatible with the `/api/v1/feed/corpus` cursor
contract** the client already loops on — B67 AC-9's getNextPageParam). The cap runs
**before** the edge-attach + serialization tail so those costs only ever process the
capped window — this collapses the p95 term.

### How
- New `feed_page.py` helper: flatten → global sort `(updated_at DESC, record_key ASC)`
  → apply cursor + cap → re-split into the five typed arrays → `next_cursor`.
- `lambda_function.py`: `MAX_FEED_PAGE_RECORDS=75`, cursor validation (400 on malformed,
  reusing `corpus.decode_cursor`), cap applied after `_query_all_records()`, `next_cursor`
  added to the response body.
- Ordering preserves the OpenSearch-selection recency intent; **per-record output is
  byte-identical** (records never mutated; only the set is truncated + a top-level field added).
- **Untouched:** `/feed/delta`, `/feed/corpus` SWR seed, `/feed/tasks.json` snapshot,
  `/feed/refresh`, subscriptions.

### Tests
`test_feed_page.py` (10) + handler tests in `test_lambda_function.py`: cap boundary
(75/76→cursor, <75→null), cursor continuation (no overlap/gap, full traversal reconstructs
the full set), ordering stability/determinism, empty-`updated_at` last, per-record
byte-identity, invalid-cursor 400 before any query work. **65/65 pass.**

Governance dictionary bumped `2026-07-12.1` per the `lambda_function.py` touch guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
