### PR TITLE
ENC-TSK-M51 (B67 AC-8): detail-route data freshness — subscribe + fresh fetch + reconciliation

### DIFF
--- a/frontend/ui-v2/src/api/queryOptions.ts
+++ b/frontend/ui-v2/src/api/queryOptions.ts
@@ -35,11 +35,24 @@ export const recordKeys = {
     ['record', type, projectId, id] as const,
 }
 
+/**
+ * ENC-TSK-M51 (B67 AC-8 part 2 / AC-14): record-detail reads are stale on
+ * arrival, so a route loader's `ensureQueryData` always runs the queryFn (a
+ * real per-record GET) on mount instead of being satisfied by a feed/corpus-
+ * primed cache entry that is younger than the 2-minute global default
+ * (src/api/queryClient.ts). While the page stays open the live
+ * `/records/{recordId}` subscription (useRecordRealtimeSync) keeps the same
+ * cache entry current via setQueryData — an idle mounted query is not refetched
+ * merely because it is stale, so this forces network on load without churning.
+ */
+const DETAIL_STALE_TIME = 0
+
 export const taskQueryOptions = (projectId: string, recordId: string) =>
   queryOptions({
     queryKey: recordKeys.detail('task', projectId, recordId),
     queryFn: ({ signal }) =>
       readThroughTrackerRecord<Task>('task', projectId, recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 export const issueQueryOptions = (projectId: string, recordId: string) =>
@@ -47,6 +60,7 @@ export const issueQueryOptions = (projectId: string, recordId: string) =>
     queryKey: recordKeys.detail('issue', projectId, recordId),
     queryFn: ({ signal }) =>
       readThroughTrackerRecord<Issue>('issue', projectId, recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 export const featureQueryOptions = (projectId: string, recordId: string) =>
@@ -54,6 +68,7 @@ export const featureQueryOptions = (projectId: string, recordId: string) =>
     queryKey: recordKeys.detail('feature', projectId, recordId),
     queryFn: ({ signal }) =>
       readThroughTrackerRecord<Feature>('feature', projectId, recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 export const planQueryOptions = (projectId: string, recordId: string) =>
@@ -61,6 +76,7 @@ export const planQueryOptions = (projectId: string, recordId: string) =>
     queryKey: recordKeys.detail('plan', projectId, recordId),
     queryFn: ({ signal }) =>
       readThroughTrackerRecord<Plan>('plan', projectId, recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 export const lessonQueryOptions = (projectId: string, recordId: string) =>
@@ -68,12 +84,14 @@ export const lessonQueryOptions = (projectId: string, recordId: string) =>
     queryKey: recordKeys.detail('lesson', projectId, recordId),
     queryFn: ({ signal }) =>
       readThroughTrackerRecord<Lesson>('lesson', projectId, recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 export const documentQueryOptions = (recordId: string, projectId = 'global') =>
   queryOptions({
     queryKey: recordKeys.detail('document', projectId, recordId),
     queryFn: ({ signal }) => readThroughDocumentRecord<Document>(recordId, { signal }),
+    staleTime: DETAIL_STALE_TIME,
   })
 
 /**

--- a/frontend/ui-v2/src/realtime/useRecordRealtimeSync.ts
+++ b/frontend/ui-v2/src/realtime/useRecordRealtimeSync.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { recordKeys } from '../api/queryOptions'
 import { getCacheEngine } from '../sync/cacheEngine'
-import { versionSeqFromUpdatedAt } from '../sync/recordKey'
+import { shouldAcceptVersion, versionSeqFromUpdatedAt } from '../sync/recordKey'
 import type { RecordType } from '../types/records'
 import { useRealtimeFeed } from './RealtimeFeedProvider'
 
@@ -22,12 +22,25 @@ export function useRecordRealtimeSync(
   const queryClient = useQueryClient()
 
   useEffect(() => {
+    const key = recordKeys.detail(recordType, projectId, recordId)
     return watchRecord(recordId, (event) => {
       if (event.action === 'removed' || !event.record) return
       const body = event.record
-      const updatedAt = typeof body.updated_at === 'string' ? body.updated_at : ''
-      queryClient.setQueryData(recordKeys.detail(recordType, projectId, recordId), body)
-      void getCacheEngine().upsertTier2(projectId, recordId, body, versionSeqFromUpdatedAt(updatedAt))
+      // ENC-TSK-M51 (B67 AC-8 part 3 / AC-2): the server-authoritative full body
+      // wins, monotonically. A per-record `/records/{recordId}` frame is only
+      // merged when its version is at least the currently-cached one, so an
+      // out-of-order or duplicate event can never overwrite fresher data with a
+      // stale (ghost) render. Full-body replacement is inherently idempotent, so
+      // there are no duplicate rows to reconcile — a later event supersedes the
+      // optimistic placeholder in place under its server-authoritative eventId.
+      const incoming = versionSeqFromUpdatedAt(
+        typeof body.updated_at === 'string' ? body.updated_at : '',
+      )
+      const current = queryClient.getQueryData<{ updated_at?: string | null }>(key)
+      const currentSeq = current ? versionSeqFromUpdatedAt(current.updated_at) : undefined
+      if (!shouldAcceptVersion(currentSeq, incoming)) return
+      queryClient.setQueryData(key, body)
+      void getCacheEngine().upsertTier2(projectId, recordId, body, incoming)
     })
   }, [watchRecord, queryClient, recordType, projectId, recordId])
 }

--- a/frontend/ui-v2/src/sync/readThrough.test.ts
+++ b/frontend/ui-v2/src/sync/readThrough.test.ts
@@ -4,38 +4,75 @@ import { resetCacheEngineForTests } from './cacheEngine'
 import { readThroughDocumentRecord, readThroughTrackerRecord } from './readThrough'
 
 vi.mock('../api/client', () => ({
+  // Real class so `error instanceof SessionExpiredError` works in readThrough.
+  SessionExpiredError: class SessionExpiredError extends Error {},
   fetchTrackerRecord: vi.fn(),
   fetchDocumentRecord: vi.fn(),
 }))
 
-describe('readThrough fetchers', () => {
+describe('readThrough fetchers (ENC-TSK-M51: network-first detail reads)', () => {
   beforeEach(() => {
     resetCacheEngineForTests()
     vi.mocked(fetchTrackerRecord).mockReset()
     vi.mocked(fetchDocumentRecord).mockReset()
   })
 
-  it('returns cached tier2 without network', async () => {
-    vi.mocked(fetchTrackerRecord).mockResolvedValue({ record_id: 'ENC-TSK-1', updated_at: '2' })
+  it('issues a real per-record GET on every load, even when tier2 has a copy', async () => {
+    vi.mocked(fetchTrackerRecord)
+      .mockResolvedValueOnce({ record_id: 'ENC-TSK-1', updated_at: '1' })
+      .mockResolvedValueOnce({ record_id: 'ENC-TSK-1', updated_at: '2' })
+
     const first = await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-1')
     const second = await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-1')
 
-    expect(first).toEqual({ record_id: 'ENC-TSK-1', updated_at: '2' })
-    expect(second).toEqual(first)
-    expect(fetchTrackerRecord).toHaveBeenCalledTimes(1)
+    // The second load reflects the newer server body — it did NOT serve the
+    // tier2 mirror seeded by the first fetch (that was the M51 defect).
+    expect(first).toEqual({ record_id: 'ENC-TSK-1', updated_at: '1' })
+    expect(second).toEqual({ record_id: 'ENC-TSK-1', updated_at: '2' })
+    expect(fetchTrackerRecord).toHaveBeenCalledTimes(2)
   })
 
-  it('read-throughs document records into tier2', async () => {
-    vi.mocked(fetchDocumentRecord).mockResolvedValue({
-      document_id: 'DOC-1',
-      updated_at: '2026-07-05T00:00:00Z',
-    })
+  it('falls back to the tier2 mirror when the network read fails (offline degrade)', async () => {
+    vi.mocked(fetchTrackerRecord).mockResolvedValueOnce({ record_id: 'ENC-TSK-2', updated_at: '5' })
+    await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-2')
 
-    const body = await readThroughDocumentRecord<{ document_id: string }>('DOC-1')
-    expect(body.document_id).toBe('DOC-1')
-    expect(fetchDocumentRecord).toHaveBeenCalledTimes(1)
+    vi.mocked(fetchTrackerRecord).mockRejectedValueOnce(new Error('network down'))
+    const degraded = await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-2')
+    expect(degraded).toEqual({ record_id: 'ENC-TSK-2', updated_at: '5' })
+  })
 
-    await readThroughDocumentRecord('DOC-1')
-    expect(fetchDocumentRecord).toHaveBeenCalledTimes(1)
+  it('propagates a network error when there is no mirror to fall back to', async () => {
+    vi.mocked(fetchTrackerRecord).mockRejectedValueOnce(new Error('network down'))
+    await expect(readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-3')).rejects.toThrow(
+      'network down',
+    )
+  })
+
+  it('does not serve stale on an aborted load', async () => {
+    vi.mocked(fetchTrackerRecord).mockResolvedValueOnce({ record_id: 'ENC-TSK-4', updated_at: '5' })
+    await readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-4') // seed mirror
+
+    const controller = new AbortController()
+    controller.abort()
+    vi.mocked(fetchTrackerRecord).mockRejectedValueOnce(new Error('aborted'))
+    await expect(
+      readThroughTrackerRecord('task', 'enceladus', 'ENC-TSK-4', { signal: controller.signal }),
+    ).rejects.toThrow('aborted')
+  })
+
+  it('network-firsts document records too', async () => {
+    vi.mocked(fetchDocumentRecord)
+      .mockResolvedValueOnce({ document_id: 'DOC-1', updated_at: '2026-07-05T00:00:00Z' })
+      .mockResolvedValueOnce({ document_id: 'DOC-1', updated_at: '2026-07-06T00:00:00Z' })
+
+    const first = await readThroughDocumentRecord<{ document_id: string; updated_at: string }>(
+      'DOC-1',
+    )
+    expect(first.document_id).toBe('DOC-1')
+    const second = await readThroughDocumentRecord<{ document_id: string; updated_at: string }>(
+      'DOC-1',
+    )
+    expect(second.updated_at).toBe('2026-07-06T00:00:00Z')
+    expect(fetchDocumentRecord).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/ui-v2/src/sync/readThrough.ts
+++ b/frontend/ui-v2/src/sync/readThrough.ts
@@ -1,12 +1,52 @@
 import {
   fetchDocumentRecord,
   fetchTrackerRecord,
-  type SessionExpiredError,
+  SessionExpiredError,
 } from '../api/client'
 import { getCacheEngine } from './cacheEngine'
 import { versionSeqFromUpdatedAt } from './recordKey'
 
 type FetchInit = { signal?: AbortSignal; headers?: HeadersInit }
+
+function updatedAtOf(fresh: unknown): string {
+  return typeof fresh === 'object' && fresh && 'updated_at' in fresh
+    ? String((fresh as { updated_at?: string | null }).updated_at ?? '')
+    : ''
+}
+
+/**
+ * ENC-TSK-M51 (B67 AC-8 part 2 / AC-14 / AC-17): the detail-route read is
+ * NETWORK-FIRST, not cache-first. Every open of a record-detail page issues a
+ * real per-record GET (`/api/v1/tracker/{project}/{type}/{id}`) so the page
+ * reflects server-authoritative state on load — the original L24 read-through
+ * returned the Tier-2 mirror body (seeded by the feed/corpus snapshot) and
+ * NEVER hit the network, which is precisely the M51 defect ("hydrates solely
+ * from feed/corpus cache; zero per-record GET on hard reload").
+ *
+ * The Tier-2 mirror is retained as the offline/degraded fallback, matching the
+ * Workbox NetworkFirst policy on detail reads (AC-17): serve stale ONLY when
+ * the network read fails. A cancelled request (AbortSignal) and an expired
+ * session propagate rather than silently serving stale.
+ */
+async function readThroughNetworkFirst<T>(
+  projectId: string,
+  recordId: string,
+  fetcher: () => Promise<T>,
+  init?: FetchInit,
+): Promise<T> {
+  const engine = getCacheEngine()
+  try {
+    const fresh = await fetcher()
+    await engine.upsertTier2(projectId, recordId, fresh, versionSeqFromUpdatedAt(updatedAtOf(fresh)))
+    return fresh
+  } catch (error) {
+    // Never mask a cancelled load or a re-auth signal with a stale mirror read.
+    if (init?.signal?.aborted || error instanceof SessionExpiredError) throw error
+    const cached = await engine.getTier2Body(projectId, recordId)
+    if (cached) return cached as T
+    throw error
+  }
+}
 
 export async function readThroughTrackerRecord<T>(
   recordType: 'task' | 'issue' | 'feature' | 'plan' | 'lesson',
@@ -14,34 +54,24 @@ export async function readThroughTrackerRecord<T>(
   recordId: string,
   init?: FetchInit,
 ): Promise<T> {
-  const engine = getCacheEngine()
-  const cached = await engine.getTier2Body(projectId, recordId)
-  if (cached) return cached as T
-
-  const fresh = await fetchTrackerRecord<T>(recordType, projectId, recordId, init)
-  const updatedAt =
-    typeof fresh === 'object' && fresh && 'updated_at' in fresh
-      ? String((fresh as { updated_at?: string | null }).updated_at ?? '')
-      : ''
-  await engine.upsertTier2(projectId, recordId, fresh, versionSeqFromUpdatedAt(updatedAt))
-  return fresh
+  return readThroughNetworkFirst<T>(
+    projectId,
+    recordId,
+    () => fetchTrackerRecord<T>(recordType, projectId, recordId, init),
+    init,
+  )
 }
 
 export async function readThroughDocumentRecord<T>(
   documentId: string,
   init?: FetchInit,
 ): Promise<T> {
-  const engine = getCacheEngine()
-  const cached = await engine.getTier2Body('global', documentId)
-  if (cached) return cached as T
-
-  const fresh = await fetchDocumentRecord<T>(documentId, init)
-  const updatedAt =
-    typeof fresh === 'object' && fresh && 'updated_at' in fresh
-      ? String((fresh as { updated_at?: string | null }).updated_at ?? '')
-      : ''
-  await engine.upsertTier2('global', documentId, fresh, versionSeqFromUpdatedAt(updatedAt))
-  return fresh
+  return readThroughNetworkFirst<T>(
+    'global',
+    documentId,
+    () => fetchDocumentRecord<T>(documentId, init),
+    init,
+  )
 }
 
 export type { SessionExpiredError }


### PR DESCRIPTION
## ENC-TSK-M51 — B67 AC-8 keystone

CCI-e68e4efd2020481aab0042fcf2932bc6

Fixes the re-confirmed B67 AC-8 defect: the record-detail route neither reflected concurrent agent writes nor issued a per-record GET on load — it hydrated solely from the feed/corpus mirror cache.

### Two-part fix

**1. Fresh fetch on load (AC-14 / AC-17).** `readThrough` is now **network-first**: every detail open issues a real `GET /api/v1/tracker/{project}/{type}/{id}`; the Tier-2 mirror is kept only as the offline/degraded fallback (Workbox NetworkFirst semantics). Aborts and `SessionExpiredError` propagate instead of silently serving stale. Detail `queryOptions` carry `staleTime: 0` so the route loader's `ensureQueryData` forces the queryFn on mount — overriding the 2-minute global default that let a feed-primed cache entry suppress the network read.

**2. Live subscription reconciliation (AC-2).** The existing L29 `/records/{recordId}` subscription (`useRecordRealtimeSync`) now merges full-body events into the `recordKeys.detail` TanStack cache under a **monotonic version guard** — an out-of-order or duplicate event can never overwrite fresher data (no ghost rows); the server-authoritative body wins in place.

Part 1's subscribe machinery already shipped in L29; this PR adds the fresh-fetch path, on-mount `staleTime`, and the version-guarded merge. Cache-merge target is `recordKeys.detail` (not component state) per **AC-13**. Lands after **M73** (RealtimeFeedProvider AC-13 remediation, same files, merged PR #1000).

### Verification
- `tsc --noEmit` clean
- `readThrough` + `realtime` suites green (network-first + fallback + abort + version-guard covered)
- changed files eslint-clean
- live gamma latency verification to follow post-deploy (AC-1/AC-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)