### PR TITLE
ENC-TSK-M75: PWA UI polish — residual nav removal, opaque action bar, mobile header

### DIFF
--- a/frontend/design-system-2/v2/components/TopNavigation/TopNavigation.jsx
+++ b/frontend/design-system-2/v2/components/TopNavigation/TopNavigation.jsx
@@ -12,6 +12,19 @@ img.ev2-tn__mark{object-fit:contain}
 .ev2-tn__btn:hover{background:rgba(61,155,168,.1);color:var(--enc-teal-light,#7AC8D4)}
 .ev2-tn__badge{font-family:var(--font-mono,monospace);font-size:11px;color:var(--enc-teal,#3D9BA8)}
 .ev2-tn__avatar{width:26px;height:26px;border-radius:50%;background:var(--enc-teal,#3D9BA8);color:var(--enc-void,#0A0A0F);display:flex;align-items:center;justify-content:center;font-family:var(--font-heading,'Space Grotesk',sans-serif);font-weight:700;font-size:12px}
+/* ENC-TSK-M75: at narrow mobile widths (<=430px) the brand + version badge +
+   Menu/Search/Feed utility buttons overflowed the right edge and clipped
+   "Feed" offscreen. Condense the chrome so everything stays inside the
+   viewport: drop the build-version pill, collapse the wordmark to its mark
+   icon only (the icon still links home), and tighten the header/utility
+   spacing. Verified at 375px and 430px. */
+@media (max-width:30rem){
+.ev2-tn{gap:8px;padding:0 12px}
+.ev2-tn__version{display:none}
+.ev2-tn__title{display:none}
+.ev2-tn__util{gap:2px}
+.ev2-tn__btn{padding:6px 8px;font-size:12px;gap:5px}
+}
 `;
 (function(){if(typeof document!=='undefined'&&!document.getElementById('ev2-tn-css')){const s=document.createElement('style');s.id='ev2-tn-css';s.textContent=ev2TnCss;document.head.appendChild(s);}})();
 

--- a/frontend/ui-v2/src/components/recordDetailHub.css
+++ b/frontend/ui-v2/src/components/recordDetailHub.css
@@ -111,7 +111,12 @@
   bottom: 0;
   z-index: 20;
   padding: var(--space-3) var(--space-4);
-  background: var(--bg-elevated);
+  /* ENC-TSK-M75: was var(--bg-elevated) — an UNDEFINED token, so the bar
+   * rendered with no background (transparent) and page text (the DESCRIPTION
+   * heading) bled through and garbled the buttons on scroll. Use the opaque
+   * elevated-panel surface token so the bar fully occludes content beneath
+   * it. Opaque design-system surface (#1C2333), no transparency. */
+  background: var(--enc-surface-alt);
   border-top: var(--border-subtle);
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.28);
   max-width: 100%;

--- a/frontend/ui-v2/src/shell/AppShell.tsx
+++ b/frontend/ui-v2/src/shell/AppShell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { useEffect } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { AppLayout, Button, SideNavigation, TopNavigation } from '../design-system'
+import { AppLayout, SideNavigation, TopNavigation } from '../design-system'
 import { performLogout } from '../auth/logout'
 import { useUiStore } from '../store/uiStore'
 import { refreshApp } from '../offline/swUpdate'
@@ -38,13 +38,6 @@ const SIDEBAR_ITEMS = [
   { type: 'link' as const, text: 'Log out', href: LOGOUT_HREF },
 ]
 
-const MOBILE_NAV = [
-  { href: '/', label: 'Home' },
-  { href: '/projects', label: 'Projects' },
-  { href: '/feed', label: 'Feed' },
-  { href: '/docs', label: 'Docs' },
-]
-
 function resolveActiveHref(pathname: string): string {
   if (pathname === '/') return '/'
   const match = SIDEBAR_ITEMS.find(
@@ -57,39 +50,15 @@ function resolveActiveHref(pathname: string): string {
   return match?.href ?? pathname
 }
 
-function MobileBottomNav({
-  activeHref,
-  onNavigate,
-}: {
-  activeHref: string
-  onNavigate: (href: string) => void
-}) {
-  return (
-    <nav className="ev2-shell__bottom-nav" aria-label="Primary">
-      {MOBILE_NAV.map(({ href, label }) => {
-        const active = href === '/' ? activeHref === '/' : activeHref.startsWith(href)
-        return (
-          <div
-            key={href}
-            className={`ev2-shell__bottom-link${active ? ' ev2-shell__bottom-link--active' : ''}`}
-          >
-            <Button
-              variant={active ? 'primary' : 'normal'}
-              ariaLabel={label}
-              onClick={() => onNavigate(href)}
-            >
-              {label}
-            </Button>
-          </div>
-        )
-      })}
-    </nav>
-  )
-}
-
 /**
- * Cockpit shell on design-system-2 AppLayout: TopNavigation + SideNavigation tray +
- * Feed tools rail + mobile Button bottom bar.
+ * Cockpit shell on design-system-2 AppLayout: TopNavigation + SideNavigation
+ * tray + Feed tools rail.
+ *
+ * ENC-TSK-M75 (io UAT 2026-07-12): the mobile bottom nav bar
+ * (Home/Projects/Feed/Docs) was removed. Per io decision the TopNavigation
+ * "Menu" button + SideNavigation drawer is now the single primary navigation
+ * on ALL viewports, so the redundant bottom bar (which rendered inside the
+ * scroll flow on record detail pages) no longer exists.
  */
 export function AppShell({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
@@ -185,12 +154,6 @@ export function AppShell({ children }: { children: ReactNode }) {
         content={
           <div className="ev2-shell__content-wrap">
             <div className="ev2-shell__main">{children}</div>
-            <MobileBottomNav
-              activeHref={activeHref}
-              onNavigate={(href) => {
-                navigate({ to: href })
-              }}
-            />
           </div>
         }
         tools={<FeedPane onClose={() => setFeedRailOpen(false)} />}

--- a/frontend/ui-v2/src/shell/mobileViewport.test.ts
+++ b/frontend/ui-v2/src/shell/mobileViewport.test.ts
@@ -395,3 +395,54 @@ describe('search input + toolbar overflow floor (ENC-TSK-M38)', () => {
     expect(ruleMatch?.[1] ?? '').toMatch(/min-width:\s*(var\(--space-0\)|0)/)
   })
 })
+
+/**
+ * ENC-TSK-M75 (io UAT screenshot 2026-07-12, mobile record detail page) --
+ * three chrome/layout defects. Same static-source-assertion approach: jsdom
+ * has no cascade/layout, so these read the shipped stylesheets + component
+ * source and fail loudly if any fix is reverted.
+ */
+describe('PWA UI polish (ENC-TSK-M75)', () => {
+  const shellCss = stripCssComments(readSrc('shell/shell.css'))
+  const appShell = readSrc('shell/AppShell.tsx')
+  const hubCss = stripCssComments(readSrc('components/recordDetailHub.css'))
+  const topNav = readSrc('../../design-system-2/v2/components/TopNavigation/TopNavigation.jsx')
+
+  it('AC-1: the mobile bottom nav bar (Home/Projects/Feed/Docs) is fully removed', () => {
+    // No component, no MOBILE_NAV array, no render in AppShell...
+    expect(appShell).not.toMatch(/MobileBottomNav/)
+    expect(appShell).not.toMatch(/MOBILE_NAV/)
+    // ...and its stylesheet rules are gone too (the drawer is the sole nav).
+    expect(shellCss).not.toMatch(/\.ev2-shell__bottom-nav\s*\{/)
+    expect(shellCss).not.toMatch(/\.ev2-shell__bottom-link/)
+    // The drawer + Menu toggle remain the single nav surface.
+    expect(appShell).toMatch(/SideNavigation/)
+    expect(appShell).toMatch(/toggleSidebar/)
+  })
+
+  it('AC-2: the sticky action bar has an OPAQUE enc surface background (not the undefined --bg-elevated, no transparency)', () => {
+    const stickyMatch = hubCss.match(/\.ev2-rdh__actionbar--sticky\s*\{([^}]*)\}/)
+    expect(stickyMatch, 'expected a .ev2-rdh__actionbar--sticky rule').not.toBeNull()
+    const rule = stickyMatch?.[1] ?? ''
+    // background must be an opaque --enc-* surface token...
+    expect(rule).toMatch(/background:\s*var\(--enc-[a-z-]+\)/)
+    // ...never the undefined --bg-elevated token (renders transparent) or a
+    // literal transparent fill.
+    expect(rule).not.toMatch(/background:[^;]*--bg-elevated/)
+    expect(rule).not.toMatch(/background:\s*transparent/)
+    // still pinned + stacked above content, with content padding reserved.
+    expect(rule).toMatch(/position:\s*fixed/)
+    expect(rule).toMatch(/z-index:\s*\d+/)
+    expect(hubCss.match(/\.ev2-rdh\s*\{([^}]*)\}/)?.[1] ?? '').toMatch(/padding-bottom:/)
+  })
+
+  it('AC-3: TopNavigation condenses at <=430px so Search/Feed cannot overflow the right margin', () => {
+    // A narrow-viewport media query (30rem = 480px, covering 375 & 430)...
+    const mobileBlock = extractBlock(topNav, /@media\s*\(max-width:\s*30rem\)\s*\{/)
+    expect(mobileBlock.length, 'expected a <=30rem media block in TopNavigation').toBeGreaterThan(0)
+    // ...that drops the version pill and collapses the wordmark to its icon,
+    // freeing horizontal room for the Menu/Search/Feed utilities.
+    expect(mobileBlock).toMatch(/\.ev2-tn__version\{[^}]*display:\s*none/)
+    expect(mobileBlock).toMatch(/\.ev2-tn__title\{[^}]*display:\s*none/)
+  })
+})

--- a/frontend/ui-v2/src/shell/shell.css
+++ b/frontend/ui-v2/src/shell/shell.css
@@ -24,38 +24,10 @@
   min-height: 0;
 }
 
-.ev2-shell__bottom-nav {
-  display: none;
-  flex-shrink: 0;
-  align-items: stretch;
-  justify-content: space-around;
-  gap: var(--space-1);
-  padding: var(--space-2) var(--space-2) calc(var(--space-2) + env(safe-area-inset-bottom, var(--space-0)));
-  background: var(--enc-surface);
-  border-top: var(--border-subtle);
-  backdrop-filter: blur(var(--space-3));
-}
-
-.ev2-shell__bottom-link {
-  flex: 1;
-  min-width: var(--space-0);
-}
-
-.ev2-shell__bottom-link .ev2-btn {
-  width: 100%;
-  height: auto;
-  min-height: var(--v2-control-height);
-  flex-direction: column;
-  gap: var(--space-1);
-  padding: var(--space-2) var(--space-1);
-  font-size: var(--text-xs);
-  line-height: var(--lh-snug);
-}
-
-.ev2-shell__bottom-link--active .ev2-btn {
-  background: rgba(61, 155, 168, 0.12);
-  color: var(--enc-teal-light);
-}
+/* ENC-TSK-M75: the mobile bottom nav bar (Home/Projects/Feed/Docs) was
+ * removed — the TopNavigation "Menu" drawer is the single primary nav on all
+ * viewports now, so its .ev2-shell__bottom-nav / __bottom-link rules are
+ * gone with it. */
 
 /* Band-B fix (ENC-ISS-51x): this default MUST come before the mobile
  * media query below. `.ev2-shell__nav-scrim` has equal specificity in both
@@ -71,10 +43,6 @@
 }
 
 @media (max-width: 48rem) {
-  .ev2-shell__bottom-nav {
-    display: flex;
-  }
-
   /* ENC-TSK-M26 fix: the previous rule keyed drawer visibility off
      `.ev2-al__nav:not(.ev2-al__nav--collapsed)`. AppLayout's own base rule
      (`.ev2-al__nav--collapsed{display:none}`) only ever HIDES the nav; the
@@ -107,8 +75,12 @@
     display: none;
   }
 
+  /* ENC-TSK-M75: with the bottom nav bar removed, mobile content only needs
+   * a modest bottom breathing gap plus the device safe-area inset (record
+   * detail pages reserve their own extra clearance for the sticky action bar
+   * via .ev2-rdh padding-bottom). */
   .ev2-shell .ev2-al__content {
-    padding-bottom: calc(var(--space-12) + env(safe-area-inset-bottom, var(--space-0)));
+    padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom, var(--space-0)));
   }
 
   .ev2-shell__nav-scrim {


### PR DESCRIPTION
## Summary

Three chrome/layout defects from io's mobile UAT screenshot (record detail page). frontend/ui-v2 + design-system-2, tokens only.

**AC-1 — residual mid-page nav removed:** deleted the mobile bottom nav bar (`MobileBottomNav` / `MOBILE_NAV` Home/Projects/Feed/Docs) from `AppShell` and its `.ev2-shell__bottom-nav`/`__bottom-link` rules. Per io decision the TopNavigation **Menu → SideNavigation drawer** is now the single primary navigation on **all** viewports.

**AC-2 — action bar opacity:** `.ev2-rdh__actionbar--sticky` used `background: var(--bg-elevated)` — an **undefined token**, so the fixed bar rendered with no background (transparent) and page text (the DESCRIPTION heading) bled through and garbled the buttons on scroll. Switched to the opaque elevated-panel surface token `var(--enc-surface-alt)` (#1C2333). `position:fixed`/`z-index:20` retained; `.ev2-rdh` already reserves `padding-bottom` so content is never permanently occluded.

**AC-3 — mobile header overflow:** the design-system-2 `TopNavigation` had no responsive handling — brand + version pill + Menu/Search/Feed utilities overflowed at ≤430px, clipping "Feed". Added a `≤30rem` (480px) media query that drops the build-version pill and collapses the wordmark to its mark icon (still links home) while tightening spacing, keeping everything inside the viewport at 375px and 430px.

## Verification
- tsc clean; `lint:adherence` clean; **284/284 vitest** (incl. 3 new M75 static-CSS regression assertions in `mobileViewport.test.ts`); vite build within bundle budget.
- Rebased onto latest v4/main (includes M51 #1002) — clean, different files; tests re-run green.

## Merge order
M73 (AC-13, #1000) already merged. Rebased atop M51 (#1002). Layout/chrome only — disjoint from M51's realtime/state files.

CCI-e7937c4adcd344808af72b4116689b4a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>