### PR TITLE
ENC-TSK-M76: feed p95 closure II — push page cap upstream (hydrate only the page)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.1",
-  "updated_at": "2026-07-12T01:20:00Z",
-  "last_change_summary": "ENC-TSK-M74: GET /api/v1/feed bare full-refresh now applies a server-side page cap (MAX_FEED_PAGE_RECORDS=75 records total across tasks/issues/features/lessons/plans, most-recently-updated first) and returns a top-level next_cursor (string|null, opaque base64, byte-compatible with the /api/v1/feed/corpus cursor contract) for continuation. Collapses the feed p95 driver (was ~919 uncapped records). Per-record output byte-identical; delta/corpus/snapshot paths unchanged. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.2",
+  "updated_at": "2026-07-12T02:30:00Z",
+  "last_change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7968,7 +7968,7 @@
       }
     }
   },
-  "change_summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
   "change_log": [
     {
       "version": "2026-07-08.05",
@@ -8359,6 +8359,11 @@
       "version": "2026-07-12.1",
       "date": "2026-07-12",
       "summary": "ENC-TSK-M74: GET /api/v1/feed bare full-refresh now applies a server-side page cap (MAX_FEED_PAGE_RECORDS=75 records total across tasks/issues/features/lessons/plans, most-recently-updated first) and returns a top-level next_cursor (string|null, opaque base64, byte-compatible with the /api/v1/feed/corpus cursor contract) for continuation. Collapses the feed p95 driver (was ~919 uncapped records). Per-record output byte-identical; delta/corpus/snapshot paths unchanged. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.2",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/feed_query/lambda_function.py
+++ b/backend/lambda/feed_query/lambda_function.py
@@ -1336,7 +1336,10 @@ def _get_graph_query_lambda_client():
 
 
 def _query_all_records_via_opensearch(
-    projects: List[Dict[str, str]], cutoff: dt.datetime
+    projects: List[Dict[str, str]],
+    cutoff: dt.datetime,
+    page_size: Optional[int] = None,
+    cursor: Optional[str] = None,
 ) -> Optional[Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]]:
     """OpenSearch-tier fast path for the full feed refresh (ENC-TSK-M39).
 
@@ -1365,11 +1368,31 @@ def _query_all_records_via_opensearch(
     if not project_ids:
         return [], [], [], [], []
 
-    payload = {
+    # ENC-TSK-M76: upstream page-cap mode. When page_size is provided, ask the
+    # selection tier for page_size+1 candidates per (project,type) WITH their
+    # updated_at (plus an updated_at<=before cursor bound for deep pages),
+    # merge them into one global (updated_at DESC, record_key ASC) order --
+    # the exact ordering feed_page.apply_page_cap uses -- keep only the window
+    # strictly after the request cursor, and hydrate ONLY that <=page_size+1
+    # page instead of the whole corpus. Absent page_size this is the legacy
+    # ENC-TSK-M39 full-selection path, byte-identical.
+    page_mode = page_size is not None
+    cursor_sort: Optional[str] = None
+    cursor_key: Optional[str] = None
+    if page_mode and cursor:
+        decoded = feed_corpus.decode_cursor(cursor)
+        if decoded is not None:
+            cursor_sort, cursor_key = decoded
+
+    payload: Dict[str, Any] = {
         "action": "feed_selection",
         "project_ids": project_ids,
         "caps": _FEED_RECORD_TYPE_CAPS,
     }
+    if page_mode:
+        payload["page_size"] = int(page_size)
+        if cursor_sort:
+            payload["before"] = cursor_sort
     try:
         response = _get_graph_query_lambda_client().invoke(
             FunctionName=GRAPH_QUERY_API_FUNCTION,
@@ -1390,29 +1413,70 @@ def _query_all_records_via_opensearch(
         return None
 
     selection = result.get("selection") or {}
-    changed_keys: List[Dict[str, Dict[str, str]]] = []
+
+    if not page_mode:
+        changed_keys: List[Dict[str, Dict[str, str]]] = []
+        for pid in project_ids:
+            for rtype in _FEED_RECORD_TYPE_CAPS:
+                for bare_id in selection.get(f"{pid}#{rtype}", []) or []:
+                    changed_keys.append({
+                        "project_id": {"S": pid},
+                        "record_id": {"S": f"{rtype}#{bare_id}"},
+                    })
+        if not changed_keys:
+            return [], [], [], [], []
+        tasks, issues, features, lessons, plans, _closed_ids = _hydrate_records_via_batch_get(changed_keys, cutoff)
+        return tasks, issues, features, lessons, plans
+
+    # --- page-cap mode: global merge -> strict-after-cursor -> cap -> hydrate only the page ---
+    candidates: List[Tuple[str, str, Dict[str, Dict[str, str]]]] = []
     for pid in project_ids:
         for rtype in _FEED_RECORD_TYPE_CAPS:
-            for bare_id in selection.get(f"{pid}#{rtype}", []) or []:
-                changed_keys.append({
-                    "project_id": {"S": pid},
-                    "record_id": {"S": f"{rtype}#{bare_id}"},
-                })
+            for entry in selection.get(f"{pid}#{rtype}", []) or []:
+                if not isinstance(entry, dict):
+                    continue
+                bare_id = str(entry.get("id") or "")
+                if not bare_id:
+                    continue
+                updated_at = str(entry.get("updated_at") or "")
+                record_key = feed_corpus.tracker_record_key(pid, bare_id)
+                ddb_key = {"project_id": {"S": pid}, "record_id": {"S": f"{rtype}#{bare_id}"}}
+                candidates.append((updated_at, record_key, ddb_key))
 
-    if not changed_keys:
+    # Global order (updated_at DESC, record_key ASC) -- matches feed_page._flatten_ordered.
+    candidates.sort(key=lambda c: c[1])
+    candidates.sort(key=lambda c: c[0], reverse=True)
+
+    if cursor_sort is not None and cursor_key is not None:
+        def _strictly_after(cand: Tuple[str, str, Dict[str, Dict[str, str]]]) -> bool:
+            updated_at, record_key, _ = cand
+            if updated_at != cursor_sort:
+                return updated_at < cursor_sort  # older == later in DESC order
+            return record_key > cursor_key       # same updated_at: larger key is later
+        candidates = [c for c in candidates if _strictly_after(c)]
+
+    page_keys = [c[2] for c in candidates[: int(page_size) + 1]]
+    logger.info(
+        "feed_query: opensearch upstream page-cap hydrating keys=%d (page_size=%s, candidates=%d)",
+        len(page_keys), page_size, len(candidates),
+    )
+    if not page_keys:
         return [], [], [], [], []
-
-    tasks, issues, features, lessons, plans, _closed_ids = _hydrate_records_via_batch_get(changed_keys, cutoff)
+    tasks, issues, features, lessons, plans, _closed_ids = _hydrate_records_via_batch_get(page_keys, cutoff)
     return tasks, issues, features, lessons, plans
 
 
-def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+def _query_all_records(
+    cursor: Optional[str] = None, page_size: Optional[int] = None
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
     global _last_feed_query_source
     projects = _get_active_projects()
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=CLOSED_ITEM_MAX_AGE_DAYS)
 
     try:
-        opensearch_result = _query_all_records_via_opensearch(projects, cutoff)
+        opensearch_result = _query_all_records_via_opensearch(
+            projects, cutoff, page_size=page_size, cursor=cursor
+        )
     except Exception as exc:  # noqa: BLE001 — never let the fast path take the feed down
         logger.warning("feed_query: OpenSearch-tier path raised unexpectedly, falling back to DDB fan-out: %s", exc)
         opensearch_result = None
@@ -1422,7 +1486,18 @@ def _query_all_records() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Li
         return opensearch_result
 
     _last_feed_query_source = "ddb_fanout"
-    return _query_all_records_via_ddb(projects, cutoff)
+    ddb_result = _query_all_records_via_ddb(projects, cutoff)
+    if page_size is not None:
+        # ENC-TSK-M76: cap the DDB fallback to the SAME page window so both
+        # sources return the identical <=page_size+1 set from _query_all_records
+        # (the handler's retained apply_page_cap then trims both to the final
+        # page identically). The DDB fan-out is still bounded upstream by its
+        # existing per-type/per-project caps.
+        t, i, f, l, p, _nc = feed_page.apply_page_cap(
+            *ddb_result, cursor=cursor, cap=int(page_size) + 1
+        )
+        return t, i, f, l, p
+    return ddb_result
 
 
 def _query_all_records_via_ddb(
@@ -2154,12 +2229,20 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
     try:
         try:
-            tasks, issues, features, lessons, plans = _query_all_records()
+            # ENC-TSK-M76: push the page cap UPSTREAM into the selection tier --
+            # _query_all_records now hydrates only the page window (<=cap+1
+            # records after the cursor) instead of the whole ~919-record corpus.
+            # The retained apply_page_cap below stays the final cap + cursor +
+            # next_cursor authority (M74 safety net); because the returned window
+            # is already strictly-after-cursor, it re-caps to the identical page.
+            tasks, issues, features, lessons, plans = _query_all_records(
+                cursor=feed_cursor or None, page_size=MAX_FEED_PAGE_RECORDS
+            )
         except Exception as exc:
             logger.error("feed query failed: %s", exc)
             return _error(500, "Failed to query feed data. Please try again.")
 
-        # --- ENC-TSK-M74 server-side page cap + continuation cursor ---
+        # --- ENC-TSK-M74 server-side page cap + continuation cursor (retained safety net) ---
         # Cap the merged page to MAX_FEED_PAGE_RECORDS most-recently-updated
         # records BEFORE the (edge attach + serialization) tail so those costs
         # only ever process the capped window -- this collapses the feed p95

--- a/backend/lambda/feed_query/test_lambda_function.py
+++ b/backend/lambda/feed_query/test_lambda_function.py
@@ -95,7 +95,7 @@ def test_full_refresh_caps_page_and_returns_next_cursor(monkeypatch):
     monkeypatch.setattr(
         feed_query,
         "_query_all_records",
-        lambda: (_many_tasks(120), [], [], [], []),
+        lambda cursor=None, page_size=None: (_many_tasks(120), [], [], [], []),
     )
 
     resp = feed_query.lambda_handler(_feed_full_event(), None)
@@ -123,7 +123,7 @@ def test_full_refresh_below_cap_null_cursor(monkeypatch):
     monkeypatch.setattr(
         feed_query,
         "_query_all_records",
-        lambda: (_many_tasks(10), [], [], [], []),
+        lambda cursor=None, page_size=None: (_many_tasks(10), [], [], [], []),
     )
     resp = feed_query.lambda_handler(_feed_full_event(), None)
     payload = json.loads(resp["body"])
@@ -939,7 +939,7 @@ def test_query_all_records_uses_opensearch_result_when_available(monkeypatch):
     monkeypatch.setattr(
         feed_query,
         "_query_all_records_via_opensearch",
-        lambda _projects, _cutoff: (["t"], ["i"], ["f"], ["l"], ["p"]),
+        lambda _projects, _cutoff, page_size=None, cursor=None: (["t"], ["i"], ["f"], ["l"], ["p"]),
     )
 
     def _boom(*_a, **_k):
@@ -954,7 +954,7 @@ def test_query_all_records_uses_opensearch_result_when_available(monkeypatch):
 
 def test_query_all_records_falls_back_to_ddb_when_opensearch_returns_none(monkeypatch):
     monkeypatch.setattr(feed_query, "_get_active_projects", lambda: [{"project_id": "enceladus"}])
-    monkeypatch.setattr(feed_query, "_query_all_records_via_opensearch", lambda _p, _c: None)
+    monkeypatch.setattr(feed_query, "_query_all_records_via_opensearch", lambda _p, _c, page_size=None, cursor=None: None)
     monkeypatch.setattr(
         feed_query,
         "_query_all_records_via_ddb",
@@ -969,7 +969,7 @@ def test_query_all_records_falls_back_to_ddb_when_opensearch_returns_none(monkey
 def test_query_all_records_falls_back_to_ddb_when_opensearch_raises(monkeypatch):
     monkeypatch.setattr(feed_query, "_get_active_projects", lambda: [{"project_id": "enceladus"}])
 
-    def _raise(_p, _c):
+    def _raise(_p, _c, page_size=None, cursor=None):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(feed_query, "_query_all_records_via_opensearch", _raise)
@@ -982,3 +982,113 @@ def test_query_all_records_falls_back_to_ddb_when_opensearch_raises(monkeypatch)
     result = feed_query._query_all_records()
     assert result == ([], [], [], [], [])
     assert feed_query._last_feed_query_source == "ddb_fanout"
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-M76 — upstream page cap: the OpenSearch selection path must hydrate
+# ONLY the page window (<=page_size+1 keys after the cursor), not the corpus.
+# ---------------------------------------------------------------------------
+import datetime as _dt
+
+
+class _FakePayload:
+    def __init__(self, data):
+        self._d = json.dumps(data).encode("utf-8")
+
+    def read(self):
+        return self._d
+
+
+class _FakeLambdaClient:
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def invoke(self, **kw):
+        self.calls.append(json.loads(kw["Payload"].decode("utf-8")))
+        return {"Payload": _FakePayload(self._result)}
+
+
+_M76_SELECTION = {
+    "enceladus#task": [
+        {"id": "ENC-TSK-001", "updated_at": "2026-07-10T09:00:00Z"},
+        {"id": "ENC-TSK-002", "updated_at": "2026-07-10T05:00:00Z"},
+    ],
+    "enceladus#issue": [
+        {"id": "ENC-ISS-001", "updated_at": "2026-07-10T08:00:00Z"},
+        {"id": "ENC-ISS-002", "updated_at": "2026-07-10T02:00:00Z"},
+    ],
+    "enceladus#feature": [
+        {"id": "ENC-FTR-001", "updated_at": "2026-07-10T07:00:00Z"},
+    ],
+}
+# Global (updated_at desc) order: TSK-001(09) ISS-001(08) FTR-001(07) TSK-002(05) ISS-002(02)
+
+
+def _record_ids(keys):
+    return [k["record_id"]["S"] for k in keys]
+
+
+def _setup_opensearch(monkeypatch, selection=_M76_SELECTION):
+    monkeypatch.setattr(feed_query, "GRAPH_QUERY_API_FUNCTION", "fake-graph-fn")
+    client = _FakeLambdaClient({"ok": True, "selection": selection})
+    monkeypatch.setattr(feed_query, "_get_graph_query_lambda_client", lambda: client)
+    captured = {"keys": None}
+
+    def _fake_hydrate(keys, cutoff):
+        captured["keys"] = list(keys)
+        return [], [], [], [], [], []
+
+    monkeypatch.setattr(feed_query, "_hydrate_records_via_batch_get", _fake_hydrate)
+    return client, captured
+
+
+def test_m76_opensearch_hydrates_only_page_first_page(monkeypatch):
+    client, captured = _setup_opensearch(monkeypatch)
+    projects = [{"project_id": "enceladus"}]
+    cutoff = _dt.datetime(2020, 1, 1, tzinfo=_dt.timezone.utc)
+
+    feed_query._query_all_records_via_opensearch(projects, cutoff, page_size=3, cursor=None)
+
+    # 5 candidates, page_size=3 -> hydrate exactly page_size+1 = 4 keys (NOT all 5).
+    assert captured["keys"] is not None
+    assert len(captured["keys"]) == 4
+    assert _record_ids(captured["keys"]) == [
+        "task#ENC-TSK-001", "issue#ENC-ISS-001", "feature#ENC-FTR-001", "task#ENC-TSK-002",
+    ]
+    # page_size + before were threaded to the selection tier; no before on page 1.
+    assert client.calls[0]["page_size"] == 3
+    assert "before" not in client.calls[0]
+
+
+def test_m76_opensearch_cursor_strictly_after_no_dup_no_gap(monkeypatch):
+    client, captured = _setup_opensearch(monkeypatch)
+    projects = [{"project_id": "enceladus"}]
+    cutoff = _dt.datetime(2020, 1, 1, tzinfo=_dt.timezone.utc)
+
+    # Cursor at ISS-001 (2nd global item). The page after it must be exactly
+    # FTR-001, TSK-002, ISS-002 -- no ISS-001 (no dup), no skipped record (no gap).
+    cursor = feed_query.feed_corpus.encode_cursor(
+        "2026-07-10T08:00:00Z", feed_query.feed_corpus.tracker_record_key("enceladus", "ENC-ISS-001")
+    )
+    feed_query._query_all_records_via_opensearch(projects, cutoff, page_size=3, cursor=cursor)
+
+    assert _record_ids(captured["keys"]) == [
+        "feature#ENC-FTR-001", "task#ENC-TSK-002", "issue#ENC-ISS-002",
+    ]
+    # cursor's updated_at is threaded to the selection tier as the range bound.
+    assert client.calls[0]["before"] == "2026-07-10T08:00:00Z"
+
+
+def test_m76_hydration_scales_with_page_not_corpus(monkeypatch):
+    # A corpus-sized selection (200 candidates) must still hydrate only page+1.
+    big = {"enceladus#task": [
+        {"id": f"ENC-TSK-{i:03d}", "updated_at": f"2026-07-10T{(59 - (i % 60)):02d}:00:00Z"}
+        for i in range(200)
+    ]}
+    client, captured = _setup_opensearch(monkeypatch, selection=big)
+    projects = [{"project_id": "enceladus"}]
+    cutoff = _dt.datetime(2020, 1, 1, tzinfo=_dt.timezone.utc)
+
+    feed_query._query_all_records_via_opensearch(projects, cutoff, page_size=75, cursor=None)
+    assert len(captured["keys"]) == 76  # page_size + 1, NOT 200

--- a/backend/lambda/graph_query_api/lambda_function.py
+++ b/backend/lambda/graph_query_api/lambda_function.py
@@ -1735,7 +1735,20 @@ def _handle_feed_selection(event: Dict) -> Dict[str, Any]:
     caps = event.get("caps") or {}
     if not isinstance(project_ids, list) or not project_ids or not isinstance(caps, dict) or not caps:
         return {"ok": False, "error": "project_ids (non-empty list) and caps (non-empty dict) are required"}
-    selection, error = opensearch_keyword.feed_selection_msearch(project_ids, caps)
+    # ENC-TSK-M76: optional upstream page-cap mode. When feed_query passes
+    # page_size, each sub-query fetches page_size+1 hits WITH updated_at (and
+    # an optional updated_at<=before range bound for deep pages) so feed_query
+    # can hydrate ONLY the page instead of the whole corpus. Absent page_size
+    # this is byte-identical to the ENC-TSK-M39 legacy selection.
+    raw_page_size = event.get("page_size")
+    page_size: Optional[int] = None
+    if isinstance(raw_page_size, int) and raw_page_size > 0:
+        page_size = raw_page_size
+    before = event.get("before")
+    before = str(before) if before else None
+    selection, error = opensearch_keyword.feed_selection_msearch(
+        project_ids, caps, page_size=page_size, before=before
+    )
     if error:
         return {"ok": False, "error": error}
     return {"ok": True, "selection": selection}

--- a/backend/lambda/graph_query_api/opensearch_keyword.py
+++ b/backend/lambda/graph_query_api/opensearch_keyword.py
@@ -236,8 +236,11 @@ def hybrid_keyword_ranks(
 
 
 def feed_selection_msearch(
-    project_ids: List[str], caps: Dict[str, int]
-) -> Tuple[Dict[str, List[str]], Optional[str]]:
+    project_ids: List[str],
+    caps: Dict[str, int],
+    page_size: Optional[int] = None,
+    before: Optional[str] = None,
+) -> Tuple[Dict[str, Any], Optional[str]]:
     """Top-N most-recently-updated record IDs per (project_id, record_type).
 
     ENC-TSK-M39: the selection-tier query behind feed_query's OpenSearch fast
@@ -246,31 +249,50 @@ def feed_selection_msearch(
     directly; this is the query builder + response parser that call uses.
 
     One ``_msearch`` round trip covers every (project_id, record_type) pair --
-    each header/query line requests only ``_id`` sorted by updated_at desc,
-    capped at caps[record_type]. Returns ({"{project_id}#{record_type}":
-    [bare_id, ...]}, error_message); error_message is set (dict empty) on any
-    failure so the caller can fall back to its DDB fan-out.
+    each header/query line requests ``_id`` sorted by updated_at desc.
+
+    Two modes:
+      * LEGACY (page_size is None) -- each sub-query is capped at
+        caps[record_type] and returns only ``_id``; the result is
+        ({"{project_id}#{record_type}": [bare_id, ...]}, error). Preserved
+        byte-for-byte for any caller not on the ENC-TSK-M76 upstream-cap path.
+      * PAGE-CAP (page_size given, ENC-TSK-M76) -- each sub-query fetches
+        ``page_size + 1`` hits WITH their ``updated_at`` (needed so feed_query
+        can merge every pair into one global (updated_at desc) order and cap
+        to exactly the page), and, when a ``before`` cursor bound is supplied,
+        adds ``range: updated_at <= before`` so deep-page selection stays
+        correct while still fetching only page_size+1 per pair. Result is
+        ({"{project_id}#{record_type}": [{"id": bare_id, "updated_at": ..}]}, error).
+        Fetching page_size+1 per (pair) guarantees the union contains the true
+        global top-(page_size+1) most-recent records after the cursor, since
+        the target page is at most page_size records.
+
+    error_message is set (dict empty) on any failure so the caller can fall
+    back to its DDB fan-out.
     """
     if not project_ids or not caps or not opensearch_configured():
         return {}, "opensearch_not_configured" if not opensearch_configured() else "no_input"
 
+    page_mode = page_size is not None
+    per_pair_size = max(1, int(page_size) + 1) if page_mode else None
+
     pairs = [(pid, rtype) for pid in project_ids for rtype in caps]
     lines: List[str] = []
     for pid, rtype in pairs:
-        lines.append(json.dumps({"index": READ_ALIAS}))
-        lines.append(json.dumps({
-            "size": max(1, int(caps[rtype])),
-            "_source": False,
+        query_filter: List[Dict[str, Any]] = [
+            {"term": {"project_id": pid}},
+            {"term": {"record_type": rtype}},
+        ]
+        if page_mode and before:
+            query_filter.append({"range": {"updated_at": {"lte": before}}})
+        header = {
+            "size": per_pair_size if page_mode else max(1, int(caps[rtype])),
+            "_source": ["updated_at"] if page_mode else False,
             "sort": [{"updated_at": "desc"}],
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"term": {"project_id": pid}},
-                        {"term": {"record_type": rtype}},
-                    ]
-                }
-            },
-        }))
+            "query": {"bool": {"filter": query_filter}},
+        }
+        lines.append(json.dumps({"index": READ_ALIAS}))
+        lines.append(json.dumps(header))
     body = "\n".join(lines) + "\n"
 
     try:
@@ -288,7 +310,7 @@ def feed_selection_msearch(
     if len(responses) != len(pairs):
         return {}, f"msearch response count mismatch: expected {len(pairs)} got {len(responses)}"
 
-    selection: Dict[str, List[str]] = {}
+    selection: Dict[str, Any] = {}
     for (pid, rtype), sub_resp in zip(pairs, responses):
         if sub_resp.get("error"):
             logger.warning(
@@ -297,13 +319,25 @@ def feed_selection_msearch(
             )
             continue
         hits = (sub_resp.get("hits") or {}).get("hits") or []
-        bare_ids: List[str] = []
-        for hit in hits:
-            doc_id = str(hit.get("_id") or "")
-            if doc_id.count("#") >= 2:
-                bare_ids.append(doc_id.split("#", 2)[2])
-        if bare_ids:
-            selection[f"{pid}#{rtype}"] = bare_ids
+        if page_mode:
+            ranked: List[Dict[str, str]] = []
+            for hit in hits:
+                doc_id = str(hit.get("_id") or "")
+                if doc_id.count("#") < 2:
+                    continue
+                bare_id = doc_id.split("#", 2)[2]
+                updated_at = str((hit.get("_source") or {}).get("updated_at") or "")
+                ranked.append({"id": bare_id, "updated_at": updated_at})
+            if ranked:
+                selection[f"{pid}#{rtype}"] = ranked
+        else:
+            bare_ids: List[str] = []
+            for hit in hits:
+                doc_id = str(hit.get("_id") or "")
+                if doc_id.count("#") >= 2:
+                    bare_ids.append(doc_id.split("#", 2)[2])
+            if bare_ids:
+                selection[f"{pid}#{rtype}"] = bare_ids
 
     return selection, None
 

--- a/backend/lambda/graph_query_api/test_feed_selection_m39.py
+++ b/backend/lambda/graph_query_api/test_feed_selection_m39.py
@@ -39,7 +39,7 @@ class TestHandleFeedSelection(unittest.TestCase):
                 "project_ids": ["enceladus"],
                 "caps": {"task": 100},
             })
-        fn.assert_called_once_with(["enceladus"], {"task": 100})
+        fn.assert_called_once_with(["enceladus"], {"task": 100}, page_size=None, before=None)
         self.assertTrue(result["ok"])
         self.assertEqual(result["selection"], {"enceladus#task": ["ENC-TSK-001"]})
 
@@ -69,3 +69,95 @@ class TestDispatch(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFeedSelectionPageCapM76(unittest.TestCase):
+    """ENC-TSK-M76: upstream page-cap mode threads page_size + before into the
+    selection tier and returns ranked {id, updated_at} dicts so feed_query can
+    hydrate only the page."""
+
+    def test_handler_passes_page_size_and_before_through(self):
+        with mock.patch.object(
+            lf.opensearch_keyword,
+            "feed_selection_msearch",
+            return_value=({"enceladus#task": [{"id": "ENC-TSK-001", "updated_at": "2026-07-10T00:00:00Z"}]}, None),
+        ) as fn:
+            result = lf._handle_feed_selection({
+                "project_ids": ["enceladus"],
+                "caps": {"task": 100},
+                "page_size": 75,
+                "before": "2026-07-11T00:00:00Z",
+            })
+        fn.assert_called_once_with(
+            ["enceladus"], {"task": 100}, page_size=75, before="2026-07-11T00:00:00Z"
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            result["selection"],
+            {"enceladus#task": [{"id": "ENC-TSK-001", "updated_at": "2026-07-10T00:00:00Z"}]},
+        )
+
+    def test_handler_ignores_non_positive_page_size(self):
+        with mock.patch.object(
+            lf.opensearch_keyword, "feed_selection_msearch", return_value=({}, None)
+        ) as fn:
+            lf._handle_feed_selection({"project_ids": ["enceladus"], "caps": {"task": 5}, "page_size": 0})
+        # page_size<=0 falls back to legacy mode (None).
+        fn.assert_called_once_with(["enceladus"], {"task": 5}, page_size=None, before=None)
+
+
+class TestFeedSelectionMsearchPageCapM76(unittest.TestCase):
+    """The msearch builder itself in page-cap mode."""
+
+    def _fake_responses(self, per_pair):
+        # one sub-response per (project,type) pair; per_pair maps rtype -> [(id, updated_at)]
+        import opensearch_keyword as ok
+        return per_pair, ok
+
+    def test_page_mode_fetches_page_size_plus_one_with_updated_at_and_range(self):
+        import opensearch_keyword as ok
+        captured = {}
+
+        def fake_request(method, path, body=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["body"] = body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body
+            # Respond with one hit per pair (single project, single type here).
+            return 200, {"responses": [
+                {"hits": {"hits": [
+                    {"_id": "enceladus#task#ENC-TSK-001", "_source": {"updated_at": "2026-07-10T09:00:00Z"}},
+                ]}},
+            ]}
+
+        with mock.patch.object(ok, "opensearch_configured", return_value=True), \
+             mock.patch.object(ok, "opensearch_request", side_effect=fake_request):
+            selection, error = ok.feed_selection_msearch(
+                ["enceladus"], {"task": 100}, page_size=75, before="2026-07-11T00:00:00Z"
+            )
+        self.assertIsNone(error)
+        # ranked dict shape, not a bare id list
+        self.assertEqual(
+            selection, {"enceladus#task": [{"id": "ENC-TSK-001", "updated_at": "2026-07-10T09:00:00Z"}]}
+        )
+        # query header requested page_size+1, _source updated_at, and the range bound
+        body = captured["body"]
+        self.assertIn('"size": 76', body)
+        self.assertIn('"_source": ["updated_at"]', body)
+        self.assertIn('"lte": "2026-07-11T00:00:00Z"', body)
+
+    def test_legacy_mode_unchanged_bare_id_lists(self):
+        import opensearch_keyword as ok
+
+        def fake_request(method, path, body=None):
+            b = body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body
+            # legacy header must NOT carry a range bound or _source updated_at
+            assert '"_source": false' in b.lower()
+            return 200, {"responses": [
+                {"hits": {"hits": [{"_id": "enceladus#task#ENC-TSK-001"}]}},
+            ]}
+
+        with mock.patch.object(ok, "opensearch_configured", return_value=True), \
+             mock.patch.object(ok, "opensearch_request", side_effect=fake_request):
+            selection, error = ok.feed_selection_msearch(["enceladus"], {"task": 10})
+        self.assertIsNone(error)
+        self.assertEqual(selection, {"enceladus#task": ["ENC-TSK-001"]})


### PR DESCRIPTION
## Summary

M74 capped the `GET /api/v1/feed` page **post-hydration**: feed_query still ran OpenSearch selection + BatchGet over the full ~919-record corpus, then trimmed to 75. Payload dropped 10–20× but p95 only 4.90→3.97s (~19%) — **hydration/selection**, not serialization, is the dominant term. This pushes the cap **upstream** so hydration touches only the page.

### graph_query_api (`feed_selection_msearch` + `_handle_feed_selection`)
- New optional `page_size` + `before` params. In page-cap mode each per-(project, record_type) msearch sub-query fetches `page_size+1` hits **with** `updated_at` (`_source:["updated_at"]`) plus an `updated_at<=before` range bound when a cursor is supplied; returns `{pid#rtype:[{id,updated_at}]}`. Legacy mode (no `page_size`) is byte-identical to ENC-TSK-M39.
- **Correctness:** fetching `page_size+1` per pair guarantees the union contains the true global top-`(page_size+1)` records strictly after the cursor (the target page is ≤`page_size` records) — no dups/gaps at page boundaries.

### feed_query (`_query_all_records_via_opensearch` / `_query_all_records` / handler)
- Page-cap mode: decode the request cursor, pass `page_size`+`before` to the selection tier, merge every pair into one global (updated_at DESC, record_key ASC) order — the **exact** ordering `feed_page.apply_page_cap` uses — keep only the window strictly after the cursor, and **hydrate only** those ≤`page_size+1` keys. A CloudWatch log line emits the hydration key count (~919 → ≤76).
- The cold-start snapshot (`/feed/tasks.json`) keeps FULL behavior (capping it would break the client seed) — only the bare `GET /api/v1/feed` path caps.
- **M74's `apply_page_cap` retained unchanged** as the final cap + cursor + next_cursor authority (safety net); the returned window is already strict-after-cursor so it re-caps to the identical page with no double-skip.
- DDB fallback capped identically to the same page window before return.

Per-record output contract + 5-list/next_cursor response shape **byte-identical**.

## Tests
7 new unit tests (msearch page-cap query shape, handler param threading, hydrate-only-the-page, cursor strict-after no-dup/no-gap, hydration-scales-with-page-not-corpus). Full suites green: feed_query 70, graph selection 22.

## Post-merge
Gamma Gen2 deploy → live p95 over ≥20 req (feed_source=opensearch), annotated vs deploy.history. Close if <500ms; else commit the selection/hydration/serialization profile breakdown per AC-3. Rollback vs M74 baseline p95~3.97s → dedicated revert task.

Note: `/api/v1/feed` is under concurrent W4-A live measurement — my deploys will appear in its deploy.history annotations (expected, handled on their side).

CCI-b4d30c64f0c547e08b8bf019cd326712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>