### PR TITLE
ENC-TSK-M79: stamp version_seq/feed_scope on worklog-append (_handle_log)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.2",
-  "updated_at": "2026-07-12T02:30:00Z",
-  "last_change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.3",
+  "updated_at": "2026-07-12T02:40:00Z",
+  "last_change_summary": "ENC-TSK-M79: tracker_mutation._handle_log() (POST /{project}/{type}/{id}/log worklog-append handler used by append_worklog/checkout-service) now splices _version_seq_update_parts() into its UpdateExpression, stamping version_seq/feed_scope identically to the generic single-field PATCH path (_handle_update_field). Previously a pure worklog append never touched version_seq/feed_scope, so the record never re-surfaced in the feed delta projection (version-seq-index GSI, ENC-TSK-L27) until some other field-level PATCH also landed. No new field/entity added to the tracker record shape (version_seq/feed_scope already exist per ENC-TSK-L27); bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3578,7 +3578,7 @@
       }
     },
     "feed_query.delta": {
-      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path.",
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path. ENC-TSK-M79: tracker_mutation's write paths that stamp version_seq/feed_scope on every mutating UpdateExpression are _stamp_version_seq_on_create_item (record creation) and _version_seq_update_parts (spliced into both the generic single-field PATCH path, _handle_update_field, and the worklog-append path, _handle_log). Before M79, _handle_log's UpdateExpression omitted version_seq/feed_scope entirely, so a pure worklog append (no field PATCH) never re-surfaced the record in this delta projection — fixed by splicing _version_seq_update_parts() into _handle_log identically to the PATCH path's idiom.",
       "fields": {
         "since": {
           "type": "integer",
@@ -7970,6 +7970,11 @@
   },
   "change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
   "change_log": [
+    {
+      "version": "2026-07-12.3",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M79: tracker_mutation._handle_log() now stamps version_seq/feed_scope via _version_seq_update_parts(), mirroring the generic PATCH path's (_handle_update_field) existing idiom (same allocator, same UpdateExpression splice, same import path — enceladus_shared.version_seq with the version_seq_util.py bundled fallback). Closes a gap where a pure worklog append never re-surfaced its record in the GET /api/v1/feed/delta projection (version-seq-index GSI, ENC-TSK-L27) unless a separate field PATCH also landed on the same record. Repo-file edit only, no new entity/field added to the tracker record shape."
+    },
     {
       "version": "2026-07-08.05",
       "date": "2026-07-08",

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -5898,21 +5898,31 @@ def _handle_log(
         "description": _ser_s(description),
     }}
 
+    update_expr = (
+        "SET updated_at = :now, last_update_note = :note, "
+        "write_source = :wsrc, "
+        "sync_version = if_not_exists(sync_version, :zero) + :one, "
+        "history = list_append(if_not_exists(history, :empty), :hentry)"
+    )
+    attr_values = {
+        ":now": _ser_s(now), ":note": _ser_s(description),
+        ":wsrc": _build_write_source(body),
+        ":zero": {"N": "0"}, ":one": {"N": "1"},
+        ":hentry": {"L": [history_entry]}, ":empty": {"L": []},
+    }
+
+    # ENC-TSK-M79: a pure worklog append must also stamp version_seq/feed_scope
+    # so the record re-surfaces in the feed delta projection (version-seq-index
+    # GSI) — mirrors the generic single-field PATCH path's idiom exactly.
+    vseq_expr, vseq_vals = _version_seq_update_parts()
+    update_expr += vseq_expr
+    attr_values.update(vseq_vals)
+
     try:
         ddb.update_item(
             TableName=DYNAMODB_TABLE, Key=key,
-            UpdateExpression=(
-                "SET updated_at = :now, last_update_note = :note, "
-                "write_source = :wsrc, "
-                "sync_version = if_not_exists(sync_version, :zero) + :one, "
-                "history = list_append(if_not_exists(history, :empty), :hentry)"
-            ),
-            ExpressionAttributeValues={
-                ":now": _ser_s(now), ":note": _ser_s(description),
-                ":wsrc": _build_write_source(body),
-                ":zero": {"N": "0"}, ":one": {"N": "1"},
-                ":hentry": {"L": [history_entry]}, ":empty": {"L": []},
-            },
+            UpdateExpression=update_expr,
+            ExpressionAttributeValues=attr_values,
         )
     except Exception as exc:
         logger.error("update_item (log) failed: %s", exc)

--- a/backend/lambda/tracker_mutation/test_worklog_versionseq_m79.py
+++ b/backend/lambda/tracker_mutation/test_worklog_versionseq_m79.py
@@ -1,0 +1,187 @@
+"""test_worklog_versionseq_m79.py — _handle_log() version_seq/feed_scope stamping (ENC-TSK-M79).
+
+Prior to this fix, `_handle_log()` (POST /{project}/{type}/{id}/log — the shared
+worklog-append handler used by append_worklog/checkout-service) never stamped
+version_seq/feed_scope on the updated record, so a pure worklog append never
+re-surfaced the record in the feed delta projection (version-seq-index GSI).
+This mirrors the generic single-field PATCH path's existing idiom: splice
+`_version_seq_update_parts()` into the UpdateExpression/ExpressionAttributeValues.
+
+Covers:
+  * The allocator (`allocate_version_seq`) is invoked exactly once per
+    `_handle_log()` call.
+  * Both `version_seq` and `feed_scope` land in the UpdateExpression/values
+    passed to `ddb.update_item`.
+  * The persisted record actually carries `version_seq` (N) and
+    `feed_scope` (S, "global") after the call, identically to what the
+    generic PATCH path stamps on create/update.
+
+Run: python3 -m pytest test_worklog_versionseq_m79.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+sys.path.insert(0, os.path.dirname(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "tracker_mutation_worklog_versionseq",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+tm = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules[_spec.name] = tm
+_spec.loader.exec_module(tm)
+
+PROVIDER = "github"
+
+
+def _body(provider=PROVIDER, **extra):
+    body = {"write_source": {"provider": provider, "channel": "mcp_server"}}
+    body.update(extra)
+    return body
+
+
+class VersionSeqStampingBase(unittest.TestCase):
+    """moto-backed tracker table (mirrors test_worklog_mirror_l35.py fixtures)."""
+
+    def setUp(self):
+        self._moto = mock_aws()
+        self._moto.start()
+        self.addCleanup(self._moto.stop)
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        self.ddb.create_table(
+            TableName=tm.DYNAMODB_TABLE,
+            AttributeDefinitions=[
+                {"AttributeName": "project_id", "AttributeType": "S"},
+                {"AttributeName": "record_id", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "project_id", "KeyType": "HASH"},
+                {"AttributeName": "record_id", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        for table, key in (
+            (tm.CHECKOUT_TOKENS_TABLE, "pk"),
+            (tm.AGENT_SESSIONS_TABLE, "session_id"),
+            (tm.PROJECTS_TABLE, "project_id"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(tm, "_ddb", self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def put_plan(self, item_id="ENC-PLN-901"):
+        self.ddb.put_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Item={
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": f"plan#{item_id}"},
+                "item_id": {"S": item_id},
+                "record_type": {"S": "plan"},
+                "status": {"S": "drafted"},
+                "title": {"S": "M79 version_seq worklog test plan"},
+                "history": {"L": []},
+            },
+        )
+
+    def get_plan_item(self, item_id="ENC-PLN-901"):
+        resp = self.ddb.get_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Key={"project_id": {"S": "enceladus"}, "record_id": {"S": f"plan#{item_id}"}},
+        )
+        return resp.get("Item") or {}
+
+
+class HandleLogVersionSeqTests(VersionSeqStampingBase):
+    def test_worklog_append_stamps_version_seq_and_feed_scope_on_record(self):
+        # Persisted-state assertion: after a plain worklog append, the record
+        # itself carries version_seq/feed_scope — the actual feed-visibility
+        # fix, not just an UpdateExpression string check.
+        self.put_plan()
+        resp = tm._handle_log(
+            "enceladus", "plan", "ENC-PLN-901",
+            _body(description="worklog entry that must re-surface in the feed"),
+        )
+        self.assertEqual(resp["statusCode"], 200)
+
+        item = self.get_plan_item()
+        self.assertIn("version_seq", item)
+        self.assertEqual(item["version_seq"]["N"], "1")
+        self.assertIn("feed_scope", item)
+        self.assertEqual(item["feed_scope"]["S"], "global")
+
+    def test_allocator_invoked_exactly_once_per_log_call(self):
+        self.put_plan()
+        with mock.patch.object(
+            tm, "allocate_version_seq", wraps=tm.allocate_version_seq
+        ) as spy:
+            resp = tm._handle_log(
+                "enceladus", "plan", "ENC-PLN-901",
+                _body(description="single-allocation check"),
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        spy.assert_called_once()
+
+    def test_update_expression_carries_both_version_seq_and_feed_scope_attrs(self):
+        # Assert the UpdateExpression/ExpressionAttributeValues actually
+        # passed to ddb.update_item include both attrs — mirrors the generic
+        # PATCH path's `_version_seq_update_parts()` splice idiom exactly.
+        self.put_plan()
+        real_ddb = self.ddb
+        captured = {}
+
+        class _SpyDdb:
+            """Pass-through proxy: forwards every call to the real (moto) client,
+            capturing only the update_item call that targets our test record so
+            the allocator's own counter-row update_item calls aren't confused
+            with the record's own write."""
+
+            def update_item(self, **kwargs):
+                if kwargs.get("Key", {}).get("record_id", {}).get("S") == "plan#ENC-PLN-901":
+                    captured["UpdateExpression"] = kwargs["UpdateExpression"]
+                    captured["ExpressionAttributeValues"] = kwargs["ExpressionAttributeValues"]
+                return real_ddb.update_item(**kwargs)
+
+            def __getattr__(self, name):
+                return getattr(real_ddb, name)
+
+        with mock.patch.object(tm, "_ddb", _SpyDdb()):
+            resp = tm._handle_log(
+                "enceladus", "plan", "ENC-PLN-901",
+                _body(description="expression shape check"),
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertIn("version_seq = :vseq", captured["UpdateExpression"])
+        self.assertIn("feed_scope = :fscope", captured["UpdateExpression"])
+        self.assertIn(":vseq", captured["ExpressionAttributeValues"])
+        self.assertIn(":fscope", captured["ExpressionAttributeValues"])
+        self.assertEqual(captured["ExpressionAttributeValues"][":fscope"], {"S": "global"})
+
+    def test_sequential_worklog_appends_allocate_monotonically_increasing_seq(self):
+        self.put_plan()
+        tm._handle_log("enceladus", "plan", "ENC-PLN-901", _body(description="first"))
+        tm._handle_log("enceladus", "plan", "ENC-PLN-901", _body(description="second"))
+        item = self.get_plan_item()
+        self.assertEqual(item["version_seq"]["N"], "2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the primary secondary-bug from ENC-ISS-534. `_handle_log()` (POST /{project}/{type}/{id}/log, the shared worklog-append handler used by append_worklog/checkout-service) never stamped `version_seq`/`feed_scope`, so a pure worklog append never re-surfaced the record in the feed delta projection (version-seq-index GSI, ENC-TSK-L27).

Fix splices `_version_seq_update_parts()` into `_handle_log`'s UpdateExpression identically to the generic single-field PATCH path (`_handle_update_field`). Adds `test_worklog_versionseq_m79.py` (4 tests: allocator called exactly once, both attrs in UpdateExpression, persisted record carries version_seq/feed_scope, monotonic seq). Full tracker_mutation suite 480 passed; 2 pre-existing failures reproduced byte-identically on clean base, unrelated. `governance_data_dictionary.json` bumped 2026-07-12.2 → .3 in the same commit per the touch guard.

CCI-e0c7181ef5e5442a843910e383a9d1da

Task: ENC-TSK-M79 · Issue: ENC-ISS-534. AC-1 (live gamma verification that a worklog-only append advances latest_version_seq in GET /api/v1/feed/delta) is post-deploy and intentionally not stamped here — it lands with the W4-A re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)