### PR TITLE
ENC-TSK-M82: realtime bootstrap regression — decouple socket from snapshot query + truthful LIVE badge

### DIFF
--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.bootstrap.test.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.bootstrap.test.tsx
@@ -1,0 +1,135 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RealtimeFeedProvider } from './RealtimeFeedProvider'
+
+/**
+ * ENC-TSK-M82 (AC-2) — realtime bootstrap regression guard.
+ *
+ * The field defect: the AppSync client was NEVER constructed on PWA load even
+ * though the deployed bundle carried complete, enabled config (httpHost +
+ * realtimeHost + `da2-…` apiKey). Root cause: the connect effect depended on
+ * the (unstable) `snapshotQuery` result object, so it churned — tearing the
+ * socket down and rebuilding it on every snapshot state change — instead of
+ * initiating one stable connection on mount.
+ *
+ * These tests fail if RealtimeFeedProvider mounts without initiating a
+ * connection attempt, and if it rebuilds the client when the snapshot query
+ * settles (the exact coupling that caused the regression). No
+ * @testing-library/react in this package — react-dom/client createRoot + act,
+ * matching RealtimeFeedProvider.test.tsx.
+ */
+
+let constructCount = 0
+let startCount = 0
+let stopCount = 0
+let resolveSnapshot: (() => void) | null = null
+
+vi.mock('../api/appsyncConfig', () => ({
+  getAppSyncEventsConfig: () => ({
+    httpHost: 'oymlzdcptfhuff3egfyt473nrm.appsync-api.us-west-2.amazonaws.com',
+    realtimeHost: 'oymlzdcptfhuff3egfyt473nrm.appsync-realtime-api.us-west-2.amazonaws.com',
+    apiKey: 'da2-testkeytestkeytestkey',
+    region: 'us-west-2',
+    feedChannel: '/feed/updates',
+    enabled: true,
+  }),
+}))
+
+// Snapshot resolves only when the test allows it — this lets us drive the
+// pending→success transition explicitly and assert the socket is NOT rebuilt
+// when `snapshotQuery` changes identity.
+vi.mock('../api/feeds', () => ({
+  fetchFeedSnapshot: () =>
+    new Promise((resolve) => {
+      resolveSnapshot = () =>
+        resolve({ events: [], hydratedAt: '2026-07-12T00:00:00Z', source: 's3' as const })
+    }),
+}))
+
+vi.mock('./appsyncRealtimeClient', () => ({
+  AppSyncRealtimeClient: class {
+    constructor() {
+      constructCount += 1
+    }
+    start() {
+      startCount += 1
+    }
+    stop() {
+      stopCount += 1
+    }
+    manualRetry() {}
+    watchRecord() {
+      return () => {}
+    }
+  },
+}))
+
+vi.mock('../sync/cacheEngine', () => ({
+  getCacheEngine: () => ({
+    upsertTier1: () => Promise.resolve(),
+    markTombstone: () => Promise.resolve(),
+  }),
+  tier1FromFeedEvent: () => null,
+}))
+
+describe('RealtimeFeedProvider — bootstrap connection attempt (ENC-TSK-M82 AC-2)', () => {
+  let qc: QueryClient
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    constructCount = 0
+    startCount = 0
+    stopCount = 0
+    resolveSnapshot = null
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    qc.clear()
+  })
+
+  function mount() {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={qc}>
+          <RealtimeFeedProvider>
+            <div />
+          </RealtimeFeedProvider>
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  it('mounting the provider (config enabled) initiates a connection attempt', () => {
+    mount()
+    // The regression this guards: zero sockets constructed on load.
+    expect(constructCount).toBeGreaterThanOrEqual(1)
+    expect(startCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('constructs exactly ONE client on mount — the socket is not coupled to the snapshot query', async () => {
+    mount()
+    expect(constructCount).toBe(1)
+    expect(startCount).toBe(1)
+
+    // Drive the snapshot pending→success transition. Pre-fix, `snapshotQuery`
+    // was a connect-effect dependency, so this re-render tore down and rebuilt
+    // the client (constructCount would climb). The socket must stay put.
+    await act(async () => {
+      resolveSnapshot?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(constructCount).toBe(1)
+    expect(stopCount).toBe(0)
+  })
+})

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -91,6 +91,21 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
     retry: 2,
   })
 
+  // ENC-TSK-M82: the realtime socket is a LONG-LIVED connection whose lifecycle
+  // must be independent of the snapshot query. `snapshotQuery` is a TanStack
+  // Query result object that gets a NEW identity on every state change
+  // (pending→success, the 60s staleTime refetch, refetchOnWindowFocus, retries,
+  // and every explicit gap_too_large refetch). It used to be a dependency of
+  // the connect effect below, so each of those churned the effect: cleanup ran
+  // `client.stop()` (disposed=true + socket.close()) and a fresh client was
+  // built — flapping the socket and, under focus/visibility churn, leaving
+  // windows with NO live socket at all. The gap-recovery refetch now reaches
+  // the query through this ref, so it never forces the connect effect to re-run.
+  const refetchSnapshotRef = useRef(snapshotQuery.refetch)
+  useEffect(() => {
+    refetchSnapshotRef.current = snapshotQuery.refetch
+  }, [snapshotQuery.refetch])
+
   useEffect(() => {
     if (!snapshotQuery.data) return
     const seeded = snapshotToFeedState(snapshotQuery.data)
@@ -157,7 +172,7 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
           break
         case 'gap_too_large':
           setErrorMessage(event.signal.reason)
-          void snapshotQuery.refetch()
+          void refetchSnapshotRef.current()
           break
         default:
           break
@@ -185,6 +200,11 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
       client.stop()
       clientRef.current = null
     }
+    // ENC-TSK-M82: deps are all stable for the provider's lifetime (queryClient
+    // + zustand selector fns), so this effect runs exactly ONCE per mount and
+    // tears down only on unmount. The socket is no longer coupled to the
+    // snapshot query — mounting the provider always initiates a single, stable
+    // connection attempt (guarded by RealtimeFeedProvider.bootstrap.test.tsx).
   }, [
     queryClient,
     recordLatency,
@@ -192,7 +212,6 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
     setErrorMessage,
     setPhase,
     setReconnectAttempt,
-    snapshotQuery,
   ])
 
   const value: RealtimeFeedContextValue = {

--- a/frontend/ui-v2/src/realtime/transportStatus.test.ts
+++ b/frontend/ui-v2/src/realtime/transportStatus.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { feedTransportLabel } from './transportStatus'
+import type { RealtimeConnectionPhase } from '../types/feedEvents'
+
+/**
+ * ENC-TSK-M82 (AC-3): the header label must reflect ACTUAL transport state.
+ * `LIVE` is reserved for a real open WSS (phase 'connected' == connection_ack
+ * received); every fallback/degraded phase must read honestly as SNAPSHOT.
+ */
+describe('feedTransportLabel — truthful header transport label (ENC-TSK-M82)', () => {
+  it("says LIVE only when the socket is connected (connection_ack received)", () => {
+    expect(feedTransportLabel('connected')).toBe('LIVE')
+  })
+
+  it('says SNAPSHOT for every non-connected phase (S3 snapshot / delta-poll fallback)', () => {
+    const fallbackPhases: RealtimeConnectionPhase[] = [
+      'idle',
+      'connecting',
+      'reconnecting',
+      'disconnected',
+      'manual_retry',
+    ]
+    for (const phase of fallbackPhases) {
+      expect(feedTransportLabel(phase)).toBe('SNAPSHOT')
+    }
+  })
+
+  it('never claims LIVE while merely connecting — the exact masking defect io caught', () => {
+    // Before this task the eyebrow was a hardcoded `FEED · LIVE`, so a total
+    // transport failure (zero sockets) still rendered LIVE. A connecting/idle
+    // phase must NOT read LIVE.
+    expect(feedTransportLabel('connecting')).not.toBe('LIVE')
+    expect(feedTransportLabel('idle')).not.toBe('LIVE')
+  })
+})

--- a/frontend/ui-v2/src/realtime/transportStatus.ts
+++ b/frontend/ui-v2/src/realtime/transportStatus.ts
@@ -1,0 +1,18 @@
+import type { RealtimeConnectionPhase } from '../types/feedEvents'
+
+/**
+ * ENC-TSK-M82 (AC-3): the single source of truth for the feed header's
+ * transport label. The header must claim `LIVE` ONLY when the AppSync WSS is
+ * actually connected — i.e. the socket is open AND `connection_ack` has been
+ * received, which is precisely the moment the client emits `connected` and the
+ * connection store transitions to phase `'connected'`. Every other phase
+ * (idle, connecting, reconnecting, disconnected, manual_retry) means the feed
+ * is being served from the S3 snapshot + delta-poll fallback, so the label is
+ * an honest `SNAPSHOT` rather than a decorative, always-on `LIVE`.
+ *
+ * Before this task the eyebrow rendered a hardcoded `FEED · LIVE`, which masked
+ * a total transport failure from human observation (io probe 2026-07-12).
+ */
+export function feedTransportLabel(phase: RealtimeConnectionPhase): 'LIVE' | 'SNAPSHOT' {
+  return phase === 'connected' ? 'LIVE' : 'SNAPSHOT'
+}

--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -8,6 +8,7 @@ import { RecordCard } from '../components/RecordCard'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { formatRelativeTime } from '../format/relativeTime'
 import { useRealtimeFeed, useRealtimeFeedEvents } from '../realtime/RealtimeFeedProvider'
+import { feedTransportLabel } from '../realtime/transportStatus'
 import { applyPropertyFilter } from '../search/applyPropertyFilter'
 import { FeedPropertyFilter } from '../search/FeedPropertyFilter'
 import {
@@ -135,6 +136,7 @@ export function FeedRoute() {
   const suggestionsKey = searchSuggestions.map((row) => row.value).join(',')
   const { markKeystroke } = useKeystrokeSuggestionTelemetry(suggestionsKey)
 
+  const transportPhase = useFeedConnectionStore((s) => s.phase)
   const keystrokeP50 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p50Ms)
   const keystrokeP95 = useFeedConnectionStore((s) => s.keystrokeSuggestion.p95Ms)
   const localP50 = useFeedConnectionStore((s) => s.requestFirstPageLocal.p50Ms)
@@ -311,7 +313,11 @@ export function FeedRoute() {
   return (
     <div className="feed-route">
       <header className="feed-route__header">
-        <p className="feed-route__eyebrow">FEED · LIVE</p>
+        {/* ENC-TSK-M82 (AC-3): truthful transport label — `LIVE` only while the
+            WSS is actually connected (connection_ack + open socket ⇒ phase
+            'connected'); the S3 snapshot/delta fallback reads honestly as
+            SNAPSHOT instead of a hardcoded, always-on LIVE. */}
+        <p className="feed-route__eyebrow">FEED · {feedTransportLabel(transportPhase)}</p>
         <h1 className="feed-route__title">Results</h1>
         <p className="feed-route__subtitle">
           Search across every governed record type. Filters and scroll position are preserved on


### PR DESCRIPTION
## ENC-TSK-M82 — PWA realtime bootstrap regression (+ truthful LIVE badge)

CCI-471f0eaee0144c1ba0e7473e8fe44f73

### Root cause (AC-1)
The `RealtimeFeedProvider` connect effect listed `snapshotQuery` (a TanStack Query result object) in its dependency array. That object changes identity on every snapshot state change (pending→success, 60s `staleTime` refetch, `refetchOnWindowFocus`, retries, `gap_too_large` refetch), so the effect churned — cleanup ran `client.stop()` (`disposed=true` + `socket.close()`) then rebuilt a fresh client. The long-lived WSS was coupled to the snapshot-query lifecycle and flapped, torn down before `connection_ack`; under focus/visibility churn it left windows with no live socket.

Bisect result: the bootstrap path was **intact** across #1000/#1002/#1003 — provider still mounted in `main.tsx` (unchanged since M37), connect effect byte-identical pre/post M73, and `config.enabled === true` proven from the live deployed bundle (httpHost + realtimeHost + `da2-…` apiKey all baked). The defect was the snapshot-query coupling, not a mount/config regression (confirms io verdict (b): runtime defect).

### Fix (AC-2)
Connect effect now depends only on stable values (`queryClient` + zustand selectors) → runs exactly once per mount → one stable connection attempt, torn down only on unmount. `gap_too_large` recovery reaches the snapshot refetch via a ref. Regression guard added (`RealtimeFeedProvider.bootstrap.test.tsx`): fails if the provider mounts without initiating a connection attempt, and if the client is rebuilt when the snapshot query settles.

### Badge truthfulness (AC-3)
The feed header eyebrow was a hardcoded `FEED · LIVE`. New `feedTransportLabel(phase)` returns `LIVE` only when `phase==='connected'` (connection_ack + open socket), else `SNAPSHOT`; unit-tested. `FeedRoute` renders the truthful label.

### Verification
- `npm run typecheck` — clean
- `npm test` — 289 passed (incl. new bootstrap + transportStatus guards)
- `npm run lint:adherence` — clean
- `npm run build` — within bundle budget

Live-socket verification deliberately deferred to the W4-A re-run / cowork probe (agent sessions take non-browser legs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)