### PR TITLE
ENC-TSK-M92: stamp version_seq/feed_scope on PWA action path (_handle_pwa_action)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.3",
-  "updated_at": "2026-07-12T02:40:00Z",
-  "last_change_summary": "ENC-TSK-M79: tracker_mutation._handle_log() (POST /{project}/{type}/{id}/log worklog-append handler used by append_worklog/checkout-service) now splices _version_seq_update_parts() into its UpdateExpression, stamping version_seq/feed_scope identically to the generic single-field PATCH path (_handle_update_field). Previously a pure worklog append never touched version_seq/feed_scope, so the record never re-surfaced in the feed delta projection (version-seq-index GSI, ENC-TSK-L27) until some other field-level PATCH also landed. No new field/entity added to the tracker record shape (version_seq/feed_scope already exist per ENC-TSK-L27); bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.4",
+  "updated_at": "2026-07-12T06:10:00Z",
+  "last_change_summary": "ENC-TSK-M92 (P0): tracker_mutation._handle_pwa_action() — the PWA close/note/reopen/worklog button path (POST /{project}/{type}/{id}/action) — now splices _version_seq_update_parts() into all four mutating branches, stamping version_seq/feed_scope identically to _handle_log (M79) and the generic PATCH path. Previously NONE of these branches stamped version_seq/feed_scope, so a gamma-native human UI write (e.g. io's [USER] worklog note on ENC-TSK-L83, 2026-07-12T05:29:31Z) LANDED but never re-surfaced in the feed delta projection (version-seq-index GSI), pinning /api/v1/feed/delta latest_version_seq at 622. M79 fixed only the MCP/checkout worklog path (_handle_log); this closes the human-UI half. No new field/entity added to the tracker record shape (version_seq/feed_scope already exist per ENC-TSK-L27); bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -3578,7 +3578,7 @@
       }
     },
     "feed_query.delta": {
-      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path. ENC-TSK-M79: tracker_mutation's write paths that stamp version_seq/feed_scope on every mutating UpdateExpression are _stamp_version_seq_on_create_item (record creation) and _version_seq_update_parts (spliced into both the generic single-field PATCH path, _handle_update_field, and the worklog-append path, _handle_log). Before M79, _handle_log's UpdateExpression omitted version_seq/feed_scope entirely, so a pure worklog append (no field PATCH) never re-surfaced the record in this delta projection — fixed by splicing _version_seq_update_parts() into _handle_log identically to the PATCH path's idiom.",
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path. ENC-TSK-M79: tracker_mutation's write paths that stamp version_seq/feed_scope on every mutating UpdateExpression are _stamp_version_seq_on_create_item (record creation) and _version_seq_update_parts (spliced into both the generic single-field PATCH path, _handle_update_field, and the worklog-append path, _handle_log). Before M79, _handle_log's UpdateExpression omitted version_seq/feed_scope entirely, so a pure worklog append (no field PATCH) never re-surfaced the record in this delta projection — fixed by splicing _version_seq_update_parts() into _handle_log identically to the PATCH path's idiom. ENC-TSK-M92 (P0): the M79 fix covered only the MCP/checkout worklog path; the PWA close/note/reopen/worklog button routes through a SEPARATE handler, _handle_pwa_action, whose four mutating branches also omitted version_seq/feed_scope. So a gamma-native human UI write landed but never re-surfaced here (latest_version_seq pinned at 622 despite live writes). M92 splices _version_seq_update_parts() into all four _handle_pwa_action branches (close spliced inside SET, before its ADD closed_count clause). With M92, EVERY tracker write path that mutates a record stamps version_seq/feed_scope: create, generic PATCH, worklog-append (_handle_log), and PWA action (_handle_pwa_action).",
       "fields": {
         "since": {
           "type": "integer",
@@ -7970,6 +7970,11 @@
   },
   "change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
   "change_log": [
+    {
+      "version": "2026-07-12.4",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M92 (P0): tracker_mutation._handle_pwa_action() now stamps version_seq/feed_scope via _version_seq_update_parts() in all four mutating branches (close/note/reopen/worklog), mirroring _handle_log (M79) and the generic PATCH path. Closes the realtime-publish gap M79 could not: the PWA close/note/reopen/worklog button routes through _handle_pwa_action, NOT _handle_log, so a gamma-native human UI write (io's [USER] worklog note on ENC-TSK-L83, 05:29:31Z) landed but never entered the feed delta projection (version-seq-index GSI), pinning /api/v1/feed/delta at 622. The close branch splices the vseq clause inside SET, before its ADD closed_count clause. Repo-file edit only, no new entity/field added to the tracker record shape."
+    },
     {
       "version": "2026-07-12.3",
       "date": "2026-07-12",

--- a/backend/lambda/tracker_mutation/lambda_function.py
+++ b/backend/lambda/tracker_mutation/lambda_function.py
@@ -5643,19 +5643,27 @@ def _handle_pwa_action(project_id: str, record_type: str, record_id: str, body: 
                 "sync_version = sync_version + :one, "
                 "#history = list_append(#history, :entry)"
             )
+            # ENC-TSK-M92: stamp version_seq/feed_scope so this gamma-native PWA
+            # write re-surfaces in the feed-delta projection (version-seq-index
+            # GSI) — same idiom as _handle_log (M79) and the generic PATCH path.
+            # The vseq clause MUST stay inside SET, spliced BEFORE any ADD clause.
+            _vseq_expr, _vseq_vals = _version_seq_update_parts()
+            pwa_close_update_expr += _vseq_expr
             if record_type == "task" and closed_status == "closed":
                 pwa_close_update_expr += " ADD closed_count :one"
+            _pwa_close_vals = {
+                ":status": {"S": closed_status}, ":ts": {"S": now},
+                ":note": {"S": description}, ":one": {"N": "1"},
+                ":entry": {"L": [history_entry]},
+                ":expected": {"N": str(current_version)},
+            }
+            _pwa_close_vals.update(_vseq_vals)
             ddb.update_item(
                 TableName=DYNAMODB_TABLE, Key=key,
                 UpdateExpression=pwa_close_update_expr,
                 ConditionExpression="sync_version = :expected",
                 ExpressionAttributeNames={"#status": "status", "#history": "history"},
-                ExpressionAttributeValues={
-                    ":status": {"S": closed_status}, ":ts": {"S": now},
-                    ":note": {"S": description}, ":one": {"N": "1"},
-                    ":entry": {"L": [history_entry]},
-                    ":expected": {"N": str(current_version)},
-                },
+                ExpressionAttributeValues=_pwa_close_vals,
             )
             return _response(200, {
                 "success": True, "action": "close", "record_id": record_id,
@@ -5680,22 +5688,28 @@ def _handle_pwa_action(project_id: str, record_type: str, record_id: str, body: 
                 "timestamp": {"S": now}, "status": {"S": "reopened"},
                 "description": {"S": description},
             }}
+            # ENC-TSK-M92: stamp version_seq/feed_scope so the reopen re-surfaces
+            # in the feed-delta projection (version-seq-index GSI).
+            _vseq_expr, _vseq_vals = _version_seq_update_parts()
+            _reopen_vals = {
+                ":new_status": {"S": default_status}, ":ts": {"S": now},
+                ":note": {"S": description}, ":one": {"N": "1"},
+                ":entry": {"L": [history_entry]},
+                ":expected": {"N": str(current_version)},
+                ":closed_val": {"S": closed_status},
+            }
+            _reopen_vals.update(_vseq_vals)
             ddb.update_item(
                 TableName=DYNAMODB_TABLE, Key=key,
                 UpdateExpression=(
                     "SET #status = :new_status, updated_at = :ts, last_update_note = :note, "
                     "sync_version = sync_version + :one, "
                     "#history = list_append(#history, :entry)"
+                    + _vseq_expr
                 ),
                 ConditionExpression="sync_version = :expected AND #status = :closed_val",
                 ExpressionAttributeNames={"#status": "status", "#history": "history"},
-                ExpressionAttributeValues={
-                    ":new_status": {"S": default_status}, ":ts": {"S": now},
-                    ":note": {"S": description}, ":one": {"N": "1"},
-                    ":entry": {"L": [history_entry]},
-                    ":expected": {"N": str(current_version)},
-                    ":closed_val": {"S": closed_status},
-                },
+                ExpressionAttributeValues=_reopen_vals,
             )
             _emit_reopen_event(project_id, record_type, record_id, closed_status, default_status, now)
             return _response(200, {
@@ -5711,20 +5725,29 @@ def _handle_pwa_action(project_id: str, record_type: str, record_id: str, body: 
                 "timestamp": {"S": now}, "status": {"S": "worklog"},
                 "description": {"S": f"[USER] {note_text}"},
             }}
+            # ENC-TSK-M92: THE load-bearing fix. This is the branch io's L83 note
+            # traversed (the `[USER] ` prefix is produced only here) — it landed
+            # but never published because version_seq/feed_scope were not stamped,
+            # pinning /api/v1/feed/delta at 622. Stamp them so the append surfaces
+            # in the version-seq-index GSI, exactly as _handle_log/M79 does.
+            _vseq_expr, _vseq_vals = _version_seq_update_parts()
+            _worklog_vals = {
+                ":note": {"S": note_text}, ":ts": {"S": now},
+                ":one": {"N": "1"}, ":entry": {"L": [history_entry]},
+                ":expected": {"N": str(current_version)},
+            }
+            _worklog_vals.update(_vseq_vals)
             ddb.update_item(
                 TableName=DYNAMODB_TABLE, Key=key,
                 UpdateExpression=(
                     "SET updated_at = :ts, last_update_note = :note, "
                     "sync_version = sync_version + :one, "
                     "#history = list_append(#history, :entry)"
+                    + _vseq_expr
                 ),
                 ConditionExpression="sync_version = :expected",
                 ExpressionAttributeNames={"#history": "history"},
-                ExpressionAttributeValues={
-                    ":note": {"S": note_text}, ":ts": {"S": now},
-                    ":one": {"N": "1"}, ":entry": {"L": [history_entry]},
-                    ":expected": {"N": str(current_version)},
-                },
+                ExpressionAttributeValues=_worklog_vals,
             )
             return _response(200, {
                 "success": True, "action": "worklog", "record_id": record_id,
@@ -5733,18 +5756,24 @@ def _handle_pwa_action(project_id: str, record_type: str, record_id: str, body: 
 
         else:  # note
             now = _now_z()
+            # ENC-TSK-M92: stamp version_seq/feed_scope so a PWA "note" write
+            # re-surfaces in the feed-delta projection (version-seq-index GSI).
+            _vseq_expr, _vseq_vals = _version_seq_update_parts()
+            _note_vals = {
+                ":note": {"S": note_text}, ":ts": {"S": now},
+                ":one": {"N": "1"}, ":expected": {"N": str(current_version)},
+            }
+            _note_vals.update(_vseq_vals)
             ddb.update_item(
                 TableName=DYNAMODB_TABLE, Key=key,
                 UpdateExpression=(
                     "SET #update = :note, updated_at = :ts, "
                     "sync_version = sync_version + :one"
+                    + _vseq_expr
                 ),
                 ConditionExpression="sync_version = :expected",
                 ExpressionAttributeNames={"#update": "update"},
-                ExpressionAttributeValues={
-                    ":note": {"S": note_text}, ":ts": {"S": now},
-                    ":one": {"N": "1"}, ":expected": {"N": str(current_version)},
-                },
+                ExpressionAttributeValues=_note_vals,
             )
             return _response(200, {
                 "success": True, "action": "note", "record_id": record_id,

--- a/backend/lambda/tracker_mutation/test_pwa_action_versionseq_m92.py
+++ b/backend/lambda/tracker_mutation/test_pwa_action_versionseq_m92.py
@@ -1,0 +1,220 @@
+"""test_pwa_action_versionseq_m92.py — _handle_pwa_action() version_seq/feed_scope stamping (ENC-TSK-M92).
+
+ROOT CAUSE this guards (P0): the PWA close/note/reopen/worklog button routes
+through `_handle_pwa_action()`, NOT through `_handle_log()` (the MCP/checkout
+path M79 patched). Prior to this fix none of `_handle_pwa_action`'s four
+mutating branches stamped version_seq/feed_scope, so a gamma-native human UI
+write LANDED (record updated, history appended) but never re-surfaced in the
+feed-delta projection (version-seq-index GSI). Live symptom: io's worklog note
+on ENC-TSK-L83 (2026-07-12T05:29:31Z, the `[USER] `-prefixed worklog branch)
+landed but /api/v1/feed/delta latest_version_seq stayed pinned at 622.
+
+The danger this class carries (per M92 AC-4): the socket connects and the UI
+renders, so the system LOOKS healthy while carrying zero realtime traffic — a
+silent non-publish. These tests fail if any PWA mutation stops advancing
+version_seq, so the class cannot recur undetected.
+
+Covers all four branches (worklog / note / close / reopen):
+  * Persisted record carries version_seq (N) and feed_scope (S, "global").
+  * The allocator (allocate_version_seq) is invoked exactly once per call.
+  * Both attrs land in the UpdateExpression/values passed to ddb.update_item
+    (worklog branch — the load-bearing path).
+  * version_seq advances monotonically across successive PWA writes.
+  * close still increments closed_count atomically (ADD clause preserved
+    alongside the spliced SET vseq clause).
+
+Run: python3 -m pytest test_pwa_action_versionseq_m92.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+sys.path.insert(0, os.path.dirname(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "tracker_mutation_pwa_versionseq",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+tm = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules[_spec.name] = tm
+_spec.loader.exec_module(tm)
+
+
+class PwaActionVersionSeqBase(unittest.TestCase):
+    """moto-backed tracker table (mirrors test_worklog_versionseq_m79.py fixtures)."""
+
+    def setUp(self):
+        self._moto = mock_aws()
+        self._moto.start()
+        self.addCleanup(self._moto.stop)
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        self.ddb.create_table(
+            TableName=tm.DYNAMODB_TABLE,
+            AttributeDefinitions=[
+                {"AttributeName": "project_id", "AttributeType": "S"},
+                {"AttributeName": "record_id", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "project_id", "KeyType": "HASH"},
+                {"AttributeName": "record_id", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        for table, key in (
+            (tm.CHECKOUT_TOKENS_TABLE, "pk"),
+            (tm.AGENT_SESSIONS_TABLE, "session_id"),
+            (tm.PROJECTS_TABLE, "project_id"),
+        ):
+            self.ddb.create_table(
+                TableName=table,
+                AttributeDefinitions=[{"AttributeName": key, "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+        patcher = mock.patch.object(tm, "_ddb", self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def put_task(self, item_id="ENC-TSK-901", status="in-progress"):
+        self.ddb.put_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Item={
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": f"task#{item_id}"},
+                "item_id": {"S": item_id},
+                "record_type": {"S": "task"},
+                "status": {"S": status},
+                "title": {"S": "M92 pwa version_seq test task"},
+                "sync_version": {"N": "0"},
+                "history": {"L": []},
+            },
+        )
+
+    def get_task(self, item_id="ENC-TSK-901"):
+        resp = self.ddb.get_item(
+            TableName=tm.DYNAMODB_TABLE,
+            Key={"project_id": {"S": "enceladus"}, "record_id": {"S": f"task#{item_id}"}},
+        )
+        return resp.get("Item") or {}
+
+
+class WorklogBranchTests(PwaActionVersionSeqBase):
+    def test_worklog_stamps_version_seq_and_feed_scope_on_record(self):
+        # The load-bearing path: io's L83 note traversed this branch.
+        self.put_task()
+        resp = tm._handle_pwa_action(
+            "enceladus", "task", "ENC-TSK-901",
+            {"note": "human worklog note that must publish to the feed"},
+            "worklog",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        item = self.get_task()
+        self.assertEqual(item["version_seq"]["N"], "1")
+        self.assertEqual(item["feed_scope"]["S"], "global")
+        # The [USER] prefix that identified this branch in the live evidence.
+        self.assertEqual(
+            item["history"]["L"][-1]["M"]["description"]["S"],
+            "[USER] human worklog note that must publish to the feed",
+        )
+
+    def test_allocator_invoked_exactly_once_per_call(self):
+        self.put_task()
+        with mock.patch.object(
+            tm, "allocate_version_seq", wraps=tm.allocate_version_seq
+        ) as spy:
+            resp = tm._handle_pwa_action(
+                "enceladus", "task", "ENC-TSK-901",
+                {"note": "single-allocation check"}, "worklog",
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        spy.assert_called_once()
+
+    def test_update_expression_carries_both_version_seq_and_feed_scope(self):
+        self.put_task()
+        real_ddb = self.ddb
+        captured = {}
+
+        class _SpyDdb:
+            def update_item(self, **kwargs):
+                if kwargs.get("Key", {}).get("record_id", {}).get("S") == "task#ENC-TSK-901":
+                    captured["UpdateExpression"] = kwargs["UpdateExpression"]
+                    captured["ExpressionAttributeValues"] = kwargs["ExpressionAttributeValues"]
+                return real_ddb.update_item(**kwargs)
+
+            def __getattr__(self, name):
+                return getattr(real_ddb, name)
+
+        with mock.patch.object(tm, "_ddb", _SpyDdb()):
+            resp = tm._handle_pwa_action(
+                "enceladus", "task", "ENC-TSK-901",
+                {"note": "expression shape check"}, "worklog",
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertIn("version_seq = :vseq", captured["UpdateExpression"])
+        self.assertIn("feed_scope = :fscope", captured["UpdateExpression"])
+        self.assertEqual(captured["ExpressionAttributeValues"][":fscope"], {"S": "global"})
+
+    def test_sequential_worklogs_advance_version_seq_monotonically(self):
+        self.put_task()
+        tm._handle_pwa_action("enceladus", "task", "ENC-TSK-901", {"note": "first"}, "worklog")
+        tm._handle_pwa_action("enceladus", "task", "ENC-TSK-901", {"note": "second"}, "worklog")
+        item = self.get_task()
+        self.assertEqual(item["version_seq"]["N"], "2")
+
+
+class NoteBranchTests(PwaActionVersionSeqBase):
+    def test_note_stamps_version_seq_and_feed_scope(self):
+        self.put_task()
+        resp = tm._handle_pwa_action(
+            "enceladus", "task", "ENC-TSK-901",
+            {"note": "a pending-update note"}, "note",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        item = self.get_task()
+        self.assertEqual(item["version_seq"]["N"], "1")
+        self.assertEqual(item["feed_scope"]["S"], "global")
+
+
+class CloseBranchTests(PwaActionVersionSeqBase):
+    def test_close_stamps_version_seq_and_preserves_closed_count_add(self):
+        # Regression: the spliced SET vseq clause must not break the ` ADD
+        # closed_count :one` clause (SET ... , version_seq=:vseq ADD ...).
+        self.put_task(status="in-progress")
+        resp = tm._handle_pwa_action(
+            "enceladus", "task", "ENC-TSK-901", {}, "close",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        item = self.get_task()
+        self.assertEqual(item["status"]["S"], "closed")
+        self.assertEqual(item["version_seq"]["N"], "1")
+        self.assertEqual(item["feed_scope"]["S"], "global")
+        self.assertEqual(item["closed_count"]["N"], "1")
+
+
+class ReopenBranchTests(PwaActionVersionSeqBase):
+    def test_reopen_stamps_version_seq_and_feed_scope(self):
+        self.put_task(status="closed")
+        resp = tm._handle_pwa_action(
+            "enceladus", "task", "ENC-TSK-901", {}, "reopen",
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        item = self.get_task()
+        self.assertEqual(item["status"]["S"], "open")
+        self.assertEqual(item["version_seq"]["N"], "1")
+        self.assertEqual(item["feed_scope"]["S"], "global")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ENC-TSK-M92 (P0) — realtime publish path dead

CCI-f9e4f51e22b54a30b893e50bbda826ae

### Root cause
The PWA close/note/reopen/**worklog** button routes through `_handle_pwa_action`
(POST `/{project}/{type}/{id}/action`), a **separate** handler from `_handle_log`
(the MCP/checkout worklog path M79 patched). None of `_handle_pwa_action`'s four
mutating branches stamped `version_seq`/`feed_scope`, so a gamma-native human UI
write **landed** (record updated, history appended) but never re-surfaced in the
feed delta projection (`version-seq-index` GSI).

**Decisive evidence:** io's `[USER]`-prefixed worklog note on ENC-TSK-L83
(2026-07-12T05:29:31Z) — the `[USER] ` prefix is produced *only* by this branch —
landed but `/api/v1/feed/delta` `latest_version_seq` stayed pinned at 622.

### Fix
Splice `_version_seq_update_parts()` into all four branches (worklog, note, close,
reopen) — identical allocator/idiom to `_handle_log` (M79) and the generic PATCH
path. The `close` branch splices the vseq clause **inside SET, before** its
` ADD closed_count :one` clause so both survive.

### Tests (AC-4 regression guard)
`test_pwa_action_versionseq_m92.py` (moto-backed): all four branches persist
`version_seq`(N)/`feed_scope="global"`, allocator called once per call, both attrs
in the UpdateExpression, `version_seq` advances monotonically, close still
increments `closed_count`. Suite: **483 passed** + the 2 pre-existing
MagicMock-ddb failures (`test_counter_fields`, `test_if_match_l47`) reproduced
byte-identically on clean `origin/v4/main`.

### Dictionary guard
`governance_data_dictionary.json` 2026-07-12.3 → .4 (change_log + `feed_query.delta`
addendum), per the `lambda_function.py` touch guard.

AC-2/AC-3 (live gamma before/after `version_seq` + WS end-to-end) are post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)