### PR TITLE
fix(ui-v2/realtime): stop illegal client ka op + socket lifecycle races (ENC-TSK-M96)

### DIFF
--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
@@ -4,6 +4,7 @@ import {
   BACKOFF_BASE_MS,
   BACKOFF_CAP_MS,
   GAP_CURSOR_THRESHOLD,
+  LIVENESS_CHECK_INTERVAL_MS,
   MAX_AUTO_RECONNECT_ATTEMPTS,
 } from './appsyncRealtimeClient'
 import type { AppSyncEventsConfig } from '../api/appsyncConfig'
@@ -161,6 +162,160 @@ describe('AppSyncRealtimeClient', () => {
     })
 
     expect(gap).toBe(true)
+    client.stop()
+  })
+})
+
+describe('AppSyncRealtimeClient — realtime channel protocol compliance (ENC-TSK-M96)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    MockWebSocket.instances = []
+  })
+
+  function newClient(onEvent: (type: string) => void = () => {}, lastCursor = 0) {
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor,
+      onEvent: (event) => onEvent(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+    client.start()
+    const socket = MockWebSocket.instances.at(-1)!
+    socket.open()
+    socket.emit({ type: 'connection_ack', connectionTimeoutMs: 300_000 })
+    return { client, socket }
+  }
+
+  it('never sends a client ka frame — AppSync Events rejects it with UnsupportedOperation', () => {
+    vi.useFakeTimers()
+    const { client, socket } = newClient()
+
+    vi.advanceTimersByTime(10 * 60_000)
+    const kaFrames = socket.sent.map((raw) => JSON.parse(raw)).filter((f) => f.type === 'ka')
+    expect(kaFrames).toEqual([])
+    client.stop()
+  })
+
+  it('id-less error frames (operation-level rejections) do not downgrade the transport', () => {
+    const events: string[] = []
+    const { client, socket } = newClient((t) => events.push(t))
+
+    socket.emit({
+      type: 'error',
+      errors: [
+        {
+          errorType: 'UnsupportedOperation',
+          message: 'Operation not supported through the realtime channel',
+        },
+      ],
+    })
+    expect(events).not.toContain('disconnected')
+
+    // The subscription is still live: a subsequent data frame must deliver.
+    socket.emit({
+      type: 'data',
+      event: JSON.stringify({
+        eventId: 'evt-after-error',
+        recordId: 'ENC-TSK-1',
+        record_type: 'task',
+        action: 'updated',
+        actorType: 'agent',
+        actorId: 'ENC-SES-1',
+        summary: 'updated task',
+        cursor: 1_700_000_000_000,
+        channels: ['/feed/updates'],
+      }),
+    })
+    expect(events).toContain('feed_event')
+    client.stop()
+  })
+
+  it('an error naming the primary subscription id still disconnects', () => {
+    const events: string[] = []
+    const { client, socket } = newClient((t) => events.push(t))
+
+    const subscribeFrame = socket.sent
+      .map((raw) => JSON.parse(raw))
+      .find((f) => f.type === 'subscribe' && f.channel === '/feed/updates')
+    socket.emit({ type: 'error', id: subscribeFrame.id, errors: [{ errorType: 'Unauthorized' }] })
+    expect(events).toContain('disconnected')
+    client.stop()
+  })
+
+  it('forces a reconnect when the server blows the connectionTimeoutMs ka window', () => {
+    vi.useFakeTimers()
+    const events: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => events.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack', connectionTimeoutMs: 1_000 })
+
+    vi.advanceTimersByTime(LIVENESS_CHECK_INTERVAL_MS + 1_000)
+    expect(socket.readyState).toBe(3)
+    expect(events).toContain('reconnecting')
+    client.stop()
+  })
+
+  it('keeps the server-silence watchdog fed by incoming ka frames', () => {
+    vi.useFakeTimers()
+    const events: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => events.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+    client.start()
+    const socket = MockWebSocket.instances[0]
+    socket.open()
+    socket.emit({ type: 'connection_ack', connectionTimeoutMs: 60_000 })
+
+    for (let i = 0; i < 8; i++) {
+      vi.advanceTimersByTime(30_000)
+      socket.emit({ type: 'ka' })
+    }
+    expect(socket.readyState).toBe(MockWebSocket.OPEN)
+    expect(events).not.toContain('reconnecting')
+    client.stop()
+  })
+
+  it("a replaced socket's late close does not tear down the live connection (manualRetry)", () => {
+    const events: string[] = []
+    const { client, socket: first } = newClient((t) => events.push(t))
+    expect(events).toEqual(['connected'])
+
+    // manualRetry discards the first socket (its close fires synchronously in
+    // the mock — the worst-case ordering) and dials a second one.
+    client.manualRetry()
+    const second = MockWebSocket.instances.at(-1)!
+    expect(second).not.toBe(first)
+    second.open()
+    second.emit({ type: 'connection_ack', connectionTimeoutMs: 300_000 })
+
+    // The abandoned socket's close must not have scheduled a rival reconnect.
+    expect(events).toEqual(['connected', 'connected'])
+    const subscribed = second.sent
+      .map((raw) => JSON.parse(raw))
+      .some((f) => f.type === 'subscribe' && f.channel === '/feed/updates')
+    expect(subscribed).toBe(true)
+    client.stop()
+  })
+
+  it('ignores frames from a socket that has been replaced', () => {
+    const events: string[] = []
+    const { client, socket: first } = newClient((t) => events.push(t))
+
+    client.manualRetry()
+    // A zombie ack from the abandoned socket must not subscribe anything.
+    first.readyState = MockWebSocket.OPEN
+    first.emit({ type: 'connection_ack', connectionTimeoutMs: 300_000 })
+    expect(events.filter((t) => t === 'connected')).toHaveLength(1)
     client.stop()
   })
 })

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
@@ -3,7 +3,8 @@ import type { FeedRealtimeEvent, GapTooLargeSignal } from '../types/feedEvents'
 
 export const GAP_CURSOR_THRESHOLD = 1_000_000_000 // ~1000 events at 1ms cursor spacing
 export const MAX_AUTO_RECONNECT_ATTEMPTS = 12
-export const HEARTBEAT_INTERVAL_MS = 30_000
+export const LIVENESS_CHECK_INTERVAL_MS = 15_000
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 300_000
 export const BACKOFF_BASE_MS = 500
 export const BACKOFF_CAP_MS = 30_000
 
@@ -65,7 +66,9 @@ export class AppSyncRealtimeClient {
 
   private socket: WebSocket | null = null
   private subscriptionId: string | null = null
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private livenessTimer: ReturnType<typeof setInterval> | null = null
+  private lastServerFrameAt = 0
+  private connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempt = 0
   private disposed = false
@@ -97,10 +100,7 @@ export class AppSyncRealtimeClient {
   stop(): void {
     this.disposed = true
     this.clearTimers()
-    if (this.socket) {
-      this.socket.close()
-      this.socket = null
-    }
+    this.discardSocket()
   }
 
   /** User-initiated retry resets backoff and reconnects immediately. */
@@ -108,11 +108,22 @@ export class AppSyncRealtimeClient {
     if (this.disposed || !this.config.enabled) return
     this.reconnectAttempt = 0
     this.clearTimers()
-    if (this.socket) {
-      this.socket.close()
-      this.socket = null
-    }
+    this.discardSocket()
     this.connect()
+  }
+
+  /**
+   * ENC-TSK-M96: detach BEFORE closing. WebSocket.close() completes
+   * asynchronously, so a replaced socket's onclose used to fire after the new
+   * socket was already live — killing the fresh liveness timer and scheduling
+   * a competing reconnect. Nulling this.socket first lets the identity guards
+   * in the handlers ignore every event from a socket we've abandoned.
+   */
+  private discardSocket(): void {
+    const socket = this.socket
+    if (!socket) return
+    this.socket = null
+    socket.close()
   }
 
   getLastCursor(): number {
@@ -130,16 +141,15 @@ export class AppSyncRealtimeClient {
     const channel = `/records/${recordId}`
     const id = crypto.randomUUID()
     this.extraSubscriptions.set(id, { channel, onEvent })
-    this.sendSubscribeFrame(id, channel)
+    if (this.socket) this.sendSubscribeFrame(this.socket, id, channel)
     return () => {
       this.extraSubscriptions.delete(id)
       this.sendUnsubscribeFrame(id)
     }
   }
 
-  private sendSubscribeFrame(id: string, channel: string): void {
-    const socket = this.socket
-    if (!socket || socket.readyState !== WebSocket.OPEN) return
+  private sendSubscribeFrame(socket: WebSocket, id: string, channel: string): void {
+    if (socket.readyState !== WebSocket.OPEN) return
     socket.send(
       JSON.stringify({
         type: 'subscribe',
@@ -171,11 +181,12 @@ export class AppSyncRealtimeClient {
 
     const socket = this.socket
     socket.onopen = () => {
+      if (this.socket !== socket) return
       socket.send(JSON.stringify({ type: 'connection_init' }))
     }
 
     socket.onmessage = (message) => {
-      this.handleMessage(message.data)
+      this.handleMessage(socket, message.data)
     }
 
     socket.onerror = () => {
@@ -183,17 +194,28 @@ export class AppSyncRealtimeClient {
     }
 
     socket.onclose = () => {
-      this.clearHeartbeat()
+      // ENC-TSK-M96: a socket we already replaced closing late must not tear
+      // down the live connection's liveness timer or spawn a rival reconnect.
+      if (this.socket !== socket) return
+      this.clearLiveness()
       if (!this.disposed) {
         this.scheduleReconnect('socket closed')
       }
     }
   }
 
-  private handleMessage(raw: unknown): void {
+  private handleMessage(socket: WebSocket, raw: unknown): void {
+    if (this.socket !== socket) return
     if (typeof raw !== 'string') return
+    this.lastServerFrameAt = Date.now()
 
-    let frame: { type?: string; id?: string; event?: unknown; errors?: unknown }
+    let frame: {
+      type?: string
+      id?: string
+      event?: unknown
+      errors?: unknown
+      connectionTimeoutMs?: number
+    }
     try {
       frame = JSON.parse(raw) as { type?: string; id?: string; event?: unknown }
     } catch {
@@ -202,13 +224,16 @@ export class AppSyncRealtimeClient {
 
     if (frame.type === 'connection_ack') {
       this.reconnectAttempt = 0
-      this.subscribe()
+      if (typeof frame.connectionTimeoutMs === 'number' && frame.connectionTimeoutMs > 0) {
+        this.connectionTimeoutMs = frame.connectionTimeoutMs
+      }
+      this.subscribe(socket)
       // ENC-TSK-L29: re-establish any per-record watches after (re)connect —
       // AppSync subscriptions do not survive a socket replacement.
       for (const [id, sub] of this.extraSubscriptions) {
-        this.sendSubscribeFrame(id, sub.channel)
+        this.sendSubscribeFrame(socket, id, sub.channel)
       }
-      this.startHeartbeat()
+      this.startLiveness()
       this.onEvent({ type: 'connected' })
       return
     }
@@ -218,7 +243,14 @@ export class AppSyncRealtimeClient {
     }
 
     if (frame.type === 'error') {
-      this.onEvent({ type: 'disconnected', reason: JSON.stringify(frame.errors ?? frame) })
+      // ENC-TSK-M96: an id-less error is AppSync rejecting a single operation
+      // (the W9-A UnsupportedOperation class) — the connection and any
+      // established subscriptions remain live, so downgrading the transport
+      // here is a false alarm. Only an error naming our primary subscription
+      // means the feed is actually dead.
+      if (frame.id && frame.id === this.subscriptionId) {
+        this.onEvent({ type: 'disconnected', reason: JSON.stringify(frame.errors ?? frame) })
+      }
       return
     }
 
@@ -285,9 +317,12 @@ export class AppSyncRealtimeClient {
     }
   }
 
-  private subscribe(): void {
-    const socket = this.socket
-    if (!socket || socket.readyState !== WebSocket.OPEN) return
+  // ENC-TSK-M96: subscribe on the socket whose connection_ack we are handling,
+  // not on whatever this.socket points at. During reconnect churn those could
+  // differ, and sending to a still-CONNECTING replacement silently dropped the
+  // subscribe — leaving an acked socket that receives keepalives but no data.
+  private subscribe(socket: WebSocket): void {
+    if (socket.readyState !== WebSocket.OPEN) return
 
     this.subscriptionId = crypto.randomUUID()
     socket.send(
@@ -304,13 +339,25 @@ export class AppSyncRealtimeClient {
     )
   }
 
-  private startHeartbeat(): void {
-    this.clearHeartbeat()
-    this.heartbeatTimer = setInterval(() => {
-      if (this.socket?.readyState === WebSocket.OPEN) {
-        this.socket.send(JSON.stringify({ type: 'ka' }))
+  /**
+   * ENC-TSK-M96: the AppSync Events realtime protocol has NO client→server
+   * keepalive — the old 30s `{"type":"ka"}` heartbeat was rejected with an
+   * UnsupportedOperation error frame on every beat (the exact 129-byte frames
+   * W9-A captured). Liveness is the server's job: it must deliver `ka` within
+   * connectionTimeoutMs (from connection_ack). We only watch for its silence
+   * and force a reconnect when the window is blown.
+   */
+  private startLiveness(): void {
+    this.clearLiveness()
+    this.lastServerFrameAt = Date.now()
+    this.livenessTimer = setInterval(() => {
+      const socket = this.socket
+      if (!socket || socket.readyState !== WebSocket.OPEN) return
+      if (Date.now() - this.lastServerFrameAt > this.connectionTimeoutMs) {
+        // onclose handles reconnect scheduling.
+        socket.close()
       }
-    }, HEARTBEAT_INTERVAL_MS)
+    }, LIVENESS_CHECK_INTERVAL_MS)
   }
 
   private scheduleReconnect(reason: string): void {
@@ -332,15 +379,15 @@ export class AppSyncRealtimeClient {
     this.reconnectTimer = setTimeout(() => this.connect(), delayMs)
   }
 
-  private clearHeartbeat(): void {
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer)
-      this.heartbeatTimer = null
+  private clearLiveness(): void {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer)
+      this.livenessTimer = null
     }
   }
 
   private clearTimers(): void {
-    this.clearHeartbeat()
+    this.clearLiveness()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null


### PR DESCRIPTION
## ENC-TSK-M96 — Realtime delivery dead at AppSync channel (P0)

The client sent a non-protocol `{"type":"ka"}` heartbeat every 30s over the `aws-appsync-event-ws` channel; AppSync Events rejects each beat with the exact 129-byte `UnsupportedOperation` error frame W9-A captured, and the client maps any error frame to `disconnected` — falsely downgrading LIVE→SNAPSHOT while the subscription is provably alive (live wire probes: data frame delivered 5.5s after the error on the same socket). Separately, reconnect lifecycle races (a replaced socket's async `onclose` killing fresh timers and `subscribe()` aimed at a still-CONNECTING `this.socket` with no retry) can strand long sessions on an acked-but-unsubscribed socket: keepalives flow, zero data frames — the W9-A steady state (213 ka / 4 errors / 0 data).

Server side is healthy and untouched: publisher `published=1 failed=0` (including the version_seq 629 event W9-A missed), namespaces/auth/endpoint all verified live.

### Changes (client-only)
- Remove the client→server ka heartbeat; add a server-silence watchdog on the `connectionTimeoutMs` advertised in `connection_ack`
- Identity-guard `onopen`/`onmessage`/`onclose`; discard sockets before closing so late closes from replaced sockets are inert
- `subscribe` targets the socket whose `connection_ack` is being handled
- id-less error frames (operation-level rejections) no longer flip the transport to disconnected; only errors naming the primary subscription do
- 7 regression tests (no-ka guarantee, error-frame semantics, liveness watchdog, replaced-socket guards)

Tests: realtime suite 14/14, full ui-v2 296/296. Zero new tsc/lint findings vs clean v4/main.

Gates: M92 AC-3 (criterion_index 2), B67 AC-3/AC-8/AC-23/AC-24, M51, M79 AC-1.

CCI-5c1d95a7261941419c4383cf5398eb80

🤖 Generated with [Claude Code](https://claude.com/claude-code)