### PR TITLE
feat(tools): gamma tracker mirror-sync tool + io-gated workflow (ENC-TSK-M98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
           python3 -m pip install --quiet pyyaml
           python3 tools/test_synthetic_strip_proof.py
 
+      # ENC-TSK-M98 / ENC-ISS-538: gamma tracker mirror guardrails — diff
+      # computation, direction-lock refusal, counter-reset step (stdlib-only).
+      - name: Gamma tracker mirror tests (ENC-TSK-M98)
+        run: |
+          set -euo pipefail
+          python3 tools/test_gamma_tracker_mirror.py
+
       # ENC-TSK-J65 / ENC-FTR-120: no agent-reachable git operation may mutate
       # v3-prod without the environment reviewer gate. Fail-closed: unclassified
       # workflows and ungated prod-mutating jobs fail CI here.

--- a/.github/workflows/gamma-tracker-mirror.yml
+++ b/.github/workflows/gamma-tracker-mirror.yml
@@ -1,0 +1,147 @@
+name: Gamma Tracker Mirror (canonical -> gamma, io-gated)
+
+# ENC-TSK-M98 / ENC-ISS-538 — the codified canonical→gamma tracker mirror.
+# Gamma's tracker is a DISPOSABLE MIRROR (io direction 2026-07-12): every run
+# overwrites gamma from canonical, deletes gamma-native extras (pre-delete
+# snapshot first), and wipes enceladus-id-counters-gamma +
+# enceladus-id-idempotency-gamma so the ID service cold-seeds next-mint from
+# the freshly mirrored canonical high-water (the ISS-538 self-heal).
+#
+# Fail-closed posture (cfn-resource-import.yml lineage):
+#   1. dry_run job ALWAYS runs: scan + diff manifest artifact, zero writes.
+#   2. execute runs ONLY when execute=true AND confirm phrase typed verbatim.
+#   3. execute is bound to the `gamma-mirror` GitHub Environment.
+#      >>> io ONE-TIME SETUP (before first execute — ENC-TSK-N01): add a
+#      >>> required_reviewers protection rule to the gamma-mirror environment.
+#      >>> GitHub auto-creates referenced environments UNPROTECTED; until the
+#      >>> rule is added, the typed confirm phrase is the only human gate.
+#   4. The tool itself carries a direction lock: source hard-coded to
+#      devops-project-tracker, every write target must end in -gamma.
+#
+# IAM: the assumed role needs dynamodb:Scan on devops-project-tracker (read),
+# Scan/BatchWriteItem/DescribeTable on devops-project-tracker-gamma,
+# enceladus-id-counters-gamma, enceladus-id-idempotency-gamma (write), and
+# s3:PutObject on the snapshot prefix if snapshot_s3_uri is supplied. If the
+# CFN role lacks these data-plane grants, the run fails closed at phase 1 —
+# grant via an iam patch workflow before ENC-TSK-N01.
+#
+# First execute is io-supervised under ENC-TSK-N01. Agents: never run
+# --execute from a terminal; this workflow is the only sanctioned path.
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: "false = dry run only (manifest artifact). true = ARM the mirror (still requires confirm phrase + gamma-mirror Environment approval)."
+        type: boolean
+        default: false
+        required: true
+      confirm:
+        description: "Type OVERWRITE-GAMMA (verbatim) to allow the execute job to run."
+        type: string
+        required: false
+        default: ""
+      snapshot_s3_uri:
+        description: "Optional s3://bucket/prefix for the pre-delete snapshot (also always uploaded as a run artifact)."
+        type: string
+        required: false
+        default: ""
+      throttle_ms:
+        description: "Sleep between write batches in ms (stream/CDC burst control, ENC-TSK-M99 decision)."
+        type: string
+        required: false
+        default: "0"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: gamma-tracker-mirror
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  dry_run:
+    name: "Dry run: diff manifest (no writes)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install boto3
+        run: python3 -m pip install --quiet boto3
+
+      - name: Unit self-check (fail-closed)
+        run: python3 tools/test_gamma_tracker_mirror.py
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Scan + diff (dry run, zero writes)
+        run: |
+          set -euo pipefail
+          python3 tools/gamma-tracker-mirror.py --manifest-out gamma-mirror-manifest.json
+          python3 - <<'EOF'
+          import json
+          c = json.load(open("gamma-mirror-manifest.json"))["counts"]
+          print(f"::notice::mirror dry-run: canonical={c['canonical_items']} gamma={c['gamma_items_before']} adds={c['adds']} changed={c['changed']} deletes={c['deletes']} (gamma-native {c['gamma_native_deletes']})")
+          EOF
+
+      - name: Upload diff manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: gamma-mirror-manifest-dryrun
+          path: gamma-mirror-manifest.json
+          retention-days: 90
+
+  execute:
+    name: "EXECUTE mirror (io-gated)"
+    needs: dry_run
+    if: ${{ inputs.execute == true && inputs.confirm == 'OVERWRITE-GAMMA' }}
+    runs-on: ubuntu-latest
+    environment: gamma-mirror
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install boto3
+        run: python3 -m pip install --quiet boto3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Execute mirror (fresh scan; direction-locked)
+        run: |
+          set -euo pipefail
+          EXTRA=""
+          if [ -n "${{ inputs.snapshot_s3_uri }}" ]; then
+            EXTRA="--snapshot-s3-uri ${{ inputs.snapshot_s3_uri }}"
+          fi
+          python3 tools/gamma-tracker-mirror.py --execute \
+            --manifest-out gamma-mirror-manifest.json \
+            --snapshot-dir mirror-snapshot \
+            --throttle-ms "${{ inputs.throttle_ms }}" \
+            $EXTRA
+
+      - name: Upload manifest + pre-delete snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gamma-mirror-execute-evidence
+          path: |
+            gamma-mirror-manifest.json
+            mirror-snapshot/
+          retention-days: 90

--- a/tools/gamma-tracker-mirror.py
+++ b/tools/gamma-tracker-mirror.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""ENC-TSK-M98 / ENC-ISS-538 — canonical → gamma tracker mirror (overwrite sync).
+
+Gamma's tracker is a DISPOSABLE MIRROR of canonical (io direction 2026-07-12):
+every sync fully overwrites gamma; gamma-native records are destroyed. This tool
+is the sole codified sync path. Phases (execute mode):
+
+  1. MIRROR      — scan canonical devops-project-tracker, BatchWriteItem overwrite
+                   every item into devops-project-tracker-gamma.
+  2. DELETE      — delete gamma keys absent from the canonical snapshot (the
+                   gamma-native / collision records), AFTER dumping each doomed
+                   item to a local snapshot dir (optionally uploaded to S3).
+  3. COUNTERS    — delete ALL rows in enceladus-id-counters-gamma and wipe
+                   enceladus-id-idempotency-gamma. The ID service (ENC-TSK-L06)
+                   cold-seeds its next-mint from a decode-max scan of the tracker
+                   table, so post-mirror the freshly copied canonical high-water
+                   IS the seed — the collision mechanism becomes self-healing.
+  4. VERIFY      — item counts match, aux tables empty. Non-zero exit on mismatch.
+
+Fail-closed guardrails (non-negotiable, ENC-TSK-M98 AC):
+  * DIRECTION LOCK — source is hard-coded to the canonical table; every write
+    target must end in "-gamma". Any tampering aborts before any AWS call.
+  * DRY-RUN DEFAULT — without --execute the tool only scans and writes a local
+    diff manifest (adds / changed / unchanged / deletes, gamma-native deletes
+    flagged). Zero mutations.
+  * --execute is a separate explicit flag; the GitHub workflow additionally
+    gates it behind a typed confirm phrase and the gamma-mirror Environment.
+
+Never run --execute from an agent terminal: execution is ENC-TSK-N01,
+io-supervised, via .github/workflows/gamma-tracker-mirror.yml only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+CANONICAL_TABLE = "devops-project-tracker"          # hard-coded source of truth
+GAMMA_TABLE = "devops-project-tracker-gamma"
+GAMMA_COUNTERS_TABLE = "enceladus-id-counters-gamma"
+GAMMA_IDEMPOTENCY_TABLE = "enceladus-id-idempotency-gamma"
+DEFAULT_REGION = "us-west-2"
+
+BATCH_MAX = 25  # DynamoDB BatchWriteItem hard limit
+
+Key = Tuple[str, str]
+
+
+class DirectionLockError(RuntimeError):
+    """Raised when the source/dest table wiring violates the mirror direction."""
+
+
+def assert_direction_lock(source: str, dest: str, aux_tables: List[str]) -> None:
+    """Abort unless data flows canonical → gamma. Source must be the canonical
+    table verbatim; every mutated table must end in -gamma; source and dest may
+    never be the same table."""
+    if source != CANONICAL_TABLE:
+        raise DirectionLockError(
+            f"source table must be {CANONICAL_TABLE!r} verbatim, got {source!r}"
+        )
+    for t in [dest, *aux_tables]:
+        if not t.endswith("-gamma"):
+            raise DirectionLockError(
+                f"write target {t!r} does not end in '-gamma' — refusing to mutate"
+            )
+    if dest == source:
+        raise DirectionLockError("source and dest are the same table")
+
+
+def item_key(item: Dict[str, Any]) -> Key:
+    return (item["project_id"]["S"], item["record_id"]["S"])
+
+
+def scan_table(client, table: str) -> Dict[Key, Dict[str, Any]]:
+    items: Dict[Key, Dict[str, Any]] = {}
+    kwargs: Dict[str, Any] = {"TableName": table, "ConsistentRead": True}
+    while True:
+        resp = client.scan(**kwargs)
+        for it in resp.get("Items", []):
+            items[item_key(it)] = it
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            return items
+        kwargs["ExclusiveStartKey"] = last
+
+
+def compute_diff(
+    canonical: Dict[Key, Dict[str, Any]], gamma: Dict[Key, Dict[str, Any]]
+) -> Dict[str, List[Key]]:
+    """Classify keys: adds (canonical-only), changed / unchanged (both), and
+    deletes (gamma-only — the gamma-native records the mirror will destroy)."""
+    adds, changed, unchanged, deletes = [], [], [], []
+    for k, item in canonical.items():
+        if k not in gamma:
+            adds.append(k)
+        elif gamma[k] == item:
+            unchanged.append(k)
+        else:
+            changed.append(k)
+    deletes = [k for k in gamma if k not in canonical]
+    return {
+        "adds": sorted(adds),
+        "changed": sorted(changed),
+        "unchanged": sorted(unchanged),
+        "deletes": sorted(deletes),
+    }
+
+
+def _s(item: Dict[str, Any], attr: str) -> str:
+    return item.get(attr, {}).get("S", "")
+
+
+def build_manifest(
+    diff: Dict[str, List[Key]],
+    canonical: Dict[Key, Dict[str, Any]],
+    gamma: Dict[Key, Dict[str, Any]],
+    mode: str,
+) -> Dict[str, Any]:
+    delete_detail = []
+    for k in diff["deletes"]:
+        it = gamma[k]
+        delete_detail.append(
+            {
+                "project_id": k[0],
+                "record_id": k[1],
+                "item_id": _s(it, "item_id"),
+                "record_type": _s(it, "record_type"),
+                "title": _s(it, "title")[:120],
+                "created_at": _s(it, "created_at"),
+                # a gamma-only key with a tracker item_id is a gamma-native mint —
+                # exactly the ENC-ISS-538 collision class
+                "gamma_native_record": bool(_s(it, "item_id")),
+            }
+        )
+    changed_detail = [
+        {"project_id": k[0], "record_id": k[1], "canonical_title": _s(canonical[k], "title")[:80]}
+        for k in diff["changed"]
+    ]
+    return {
+        "tool": "gamma-tracker-mirror",
+        "task": "ENC-TSK-M98",
+        "issue": "ENC-ISS-538",
+        "mode": mode,
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_table": CANONICAL_TABLE,
+        "dest_table": GAMMA_TABLE,
+        "counts": {
+            "canonical_items": len(canonical),
+            "gamma_items_before": len(gamma),
+            "adds": len(diff["adds"]),
+            "changed": len(diff["changed"]),
+            "unchanged": len(diff["unchanged"]),
+            "deletes": len(diff["deletes"]),
+            "gamma_native_deletes": sum(1 for d in delete_detail if d["gamma_native_record"]),
+        },
+        "deletes": delete_detail,
+        "changed": changed_detail,
+    }
+
+
+def snapshot_deletes(
+    gamma: Dict[Key, Dict[str, Any]], deletes: List[Key], snapshot_dir: str
+) -> Path:
+    """Dump every to-be-deleted gamma item (full DynamoDB JSON) before deletion."""
+    out_dir = Path(snapshot_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = out_dir / f"gamma-mirror-predelete-{stamp}.jsonl"
+    with open(path, "w") as fh:
+        for k in deletes:
+            fh.write(json.dumps(gamma[k], separators=(",", ":")) + "\n")
+    return path
+
+
+def upload_snapshot(s3_client, path: Path, s3_uri: str) -> str:
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"--snapshot-s3-uri must start with s3://, got {s3_uri!r}")
+    bucket, _, prefix = s3_uri[5:].partition("/")
+    key = f"{prefix.rstrip('/')}/{path.name}" if prefix else path.name
+    s3_client.upload_file(str(path), bucket, key)
+    return f"s3://{bucket}/{key}"
+
+
+def _batch_write(client, table: str, requests: List[Dict[str, Any]], throttle_ms: int) -> None:
+    """BatchWriteItem in chunks of 25 with unprocessed-item retry + backoff."""
+    for i in range(0, len(requests), BATCH_MAX):
+        chunk = requests[i : i + BATCH_MAX]
+        pending = {table: chunk}
+        attempt = 0
+        while pending:
+            resp = client.batch_write_item(RequestItems=pending)
+            pending = resp.get("UnprocessedItems") or {}
+            if pending:
+                attempt += 1
+                if attempt > 8:
+                    raise RuntimeError(f"batch_write_item to {table}: unprocessed items after 8 retries")
+                time.sleep(min(2**attempt * 0.05, 2.0))
+        if throttle_ms:
+            time.sleep(throttle_ms / 1000.0)
+
+
+def mirror_puts(client, canonical: Dict[Key, Dict[str, Any]], throttle_ms: int) -> None:
+    reqs = [{"PutRequest": {"Item": it}} for it in canonical.values()]
+    _batch_write(client, GAMMA_TABLE, reqs, throttle_ms)
+
+
+def delete_extras(client, deletes: List[Key], throttle_ms: int) -> None:
+    reqs = [
+        {"DeleteRequest": {"Key": {"project_id": {"S": p}, "record_id": {"S": r}}}}
+        for (p, r) in deletes
+    ]
+    _batch_write(client, GAMMA_TABLE, reqs, throttle_ms)
+
+
+def wipe_table(client, table: str, throttle_ms: int = 0) -> int:
+    """Delete every item in `table` (key schema discovered via describe_table).
+    Used for the counter + idempotency reset (phase 3). Direction lock applies."""
+    if not table.endswith("-gamma"):
+        raise DirectionLockError(f"wipe_table refused: {table!r} does not end in '-gamma'")
+    key_attrs = [k["AttributeName"] for k in client.describe_table(TableName=table)["Table"]["KeySchema"]]
+    deleted = 0
+    kwargs: Dict[str, Any] = {"TableName": table, "ConsistentRead": True}
+    while True:
+        resp = client.scan(**kwargs)
+        items = resp.get("Items", [])
+        if items:
+            reqs = [
+                {"DeleteRequest": {"Key": {a: it[a] for a in key_attrs}}} for it in items
+            ]
+            _batch_write(client, table, reqs, throttle_ms)
+            deleted += len(items)
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            return deleted
+        kwargs["ExclusiveStartKey"] = last
+
+
+def count_items(client, table: str) -> int:
+    n = 0
+    kwargs: Dict[str, Any] = {"TableName": table, "Select": "COUNT", "ConsistentRead": True}
+    while True:
+        resp = client.scan(**kwargs)
+        n += resp["Count"]
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            return n
+        kwargs["ExclusiveStartKey"] = last
+
+
+def verify(client) -> List[str]:
+    problems = []
+    canonical_n = count_items(client, CANONICAL_TABLE)
+    gamma_n = count_items(client, GAMMA_TABLE)
+    # canonical is live-minting; allow gamma <= canonical but never extras
+    if gamma_n > canonical_n:
+        problems.append(f"gamma has {gamma_n} items > canonical {canonical_n} — extras survived")
+    if gamma_n < canonical_n:
+        print(f"[INFO] canonical grew during mirror ({canonical_n} vs {gamma_n} mirrored) — expected drift, next sync picks it up")
+    for t in (GAMMA_COUNTERS_TABLE, GAMMA_IDEMPOTENCY_TABLE):
+        n = count_items(client, t)
+        if n:
+            problems.append(f"{t} still holds {n} items after wipe")
+    return problems
+
+
+def main(argv: List[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--execute", action="store_true",
+                    help="Perform the mirror. WITHOUT this flag the tool is a dry run: scan + manifest only, zero writes.")
+    ap.add_argument("--manifest-out", default="gamma-mirror-manifest.json")
+    ap.add_argument("--snapshot-dir", default="mirror-snapshot",
+                    help="Local dir receiving the pre-delete dump of doomed gamma items (execute mode).")
+    ap.add_argument("--snapshot-s3-uri", default="",
+                    help="Optional s3://bucket/prefix also receiving the pre-delete dump.")
+    ap.add_argument("--region", default=DEFAULT_REGION)
+    ap.add_argument("--throttle-ms", type=int, default=0,
+                    help="Sleep between write batches (stream/CDC burst control, ENC-TSK-M99).")
+    args = ap.parse_args(argv)
+
+    try:
+        assert_direction_lock(
+            CANONICAL_TABLE, GAMMA_TABLE, [GAMMA_COUNTERS_TABLE, GAMMA_IDEMPOTENCY_TABLE]
+        )
+    except DirectionLockError as e:
+        print(f"[ERROR] direction lock: {e}")
+        return 2
+
+    import boto3  # deferred so unit tests import this module without boto3 installed
+
+    client = boto3.client("dynamodb", region_name=args.region)
+
+    print(f"[START] scanning {CANONICAL_TABLE} + {GAMMA_TABLE}")
+    canonical = scan_table(client, CANONICAL_TABLE)
+    gamma = scan_table(client, GAMMA_TABLE)
+    diff = compute_diff(canonical, gamma)
+    mode = "execute" if args.execute else "dry-run"
+    manifest = build_manifest(diff, canonical, gamma, mode)
+    Path(args.manifest_out).write_text(json.dumps(manifest, indent=1))
+    c = manifest["counts"]
+    print(f"[INFO] canonical={c['canonical_items']} gamma={c['gamma_items_before']} "
+          f"adds={c['adds']} changed={c['changed']} unchanged={c['unchanged']} "
+          f"deletes={c['deletes']} (gamma-native {c['gamma_native_deletes']})")
+    print(f"[INFO] manifest -> {args.manifest_out}")
+
+    if not args.execute:
+        print("[SUCCESS] dry run complete — no writes performed. Re-run with --execute via the io-gated workflow.")
+        return 0
+
+    if diff["deletes"]:
+        snap = snapshot_deletes(gamma, diff["deletes"], args.snapshot_dir)
+        print(f"[INFO] pre-delete snapshot -> {snap} ({len(diff['deletes'])} items)")
+        if args.snapshot_s3_uri:
+            import boto3 as _b3
+            uri = upload_snapshot(_b3.client("s3", region_name=args.region), snap, args.snapshot_s3_uri)
+            print(f"[INFO] snapshot uploaded -> {uri}")
+
+    print(f"[INFO] phase 1: overwriting {len(canonical)} items into {GAMMA_TABLE}")
+    mirror_puts(client, canonical, args.throttle_ms)
+    print(f"[INFO] phase 2: deleting {len(diff['deletes'])} gamma-only items")
+    delete_extras(client, diff["deletes"], args.throttle_ms)
+    print(f"[INFO] phase 3: wiping {GAMMA_COUNTERS_TABLE} + {GAMMA_IDEMPOTENCY_TABLE}")
+    n1 = wipe_table(client, GAMMA_COUNTERS_TABLE, args.throttle_ms)
+    n2 = wipe_table(client, GAMMA_IDEMPOTENCY_TABLE, args.throttle_ms)
+    print(f"[INFO] wiped counters={n1} idempotency={n2}")
+
+    problems = verify(client)
+    if problems:
+        for p in problems:
+            print(f"[ERROR] verify: {p}")
+        return 3
+    print("[SUCCESS] mirror complete: gamma == canonical snapshot; counters reset for cold-seed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -126,7 +126,7 @@
       "gated_jobs": [
         "patch-role"
       ],
-      "notes": "ENC-TSK-J64: environment: v3-prod \u2014 despite the name it patches the SHARED CFN deploy role object"
+      "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"
     },
     "iam-cfn-deploy-role-nat-gateway-patch.yml": {
       "class": "prod-mutating",
@@ -207,7 +207,7 @@
     },
     "sync-architecture-doc.yml": {
       "class": "inert",
-      "notes": "docstore document write via internal key; no runtime-infrastructure mutation \u2014 flagged for awareness, out of the v3-prod runtime invariant's scope"
+      "notes": "docstore document write via internal key; no runtime-infrastructure mutation — flagged for awareness, out of the v3-prod runtime invariant's scope"
     },
     "sync-main-to-v4main.yml": {
       "class": "inert",
@@ -218,7 +218,7 @@
       "gated_jobs": [
         "deploy"
       ],
-      "notes": "ENC-TSK-J64: environment: v3-prod \u2014 the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"
+      "notes": "ENC-TSK-J64: environment: v3-prod — the DPL submit is the irrevocable prod trigger (orchestrator deploys the queued request with no further gate)"
     },
     "ui-gamma-deploy.yml": {
       "class": "already-gated",
@@ -240,6 +240,13 @@
         "wire-notification"
       ],
       "notes": "ENC-TSK-J65: environment chosen from environment_suffix input (-gamma -> v4-gamma, '' -> v3-prod). Caught by the guard's own first fail-closed run."
+    },
+    "gamma-tracker-mirror.yml": {
+      "class": "gamma-only",
+      "gated_jobs": [
+        "execute"
+      ],
+      "notes": "ENC-TSK-M98 / ENC-ISS-538 canonical->gamma tracker mirror. Mutates ONLY -gamma DynamoDB tables (in-tool direction lock: source hard-coded to devops-project-tracker read-only, every write target must end -gamma). dry_run job is read-only; execute job requires typed confirm phrase OVERWRITE-GAMMA AND environment: gamma-mirror (io one-time setup: add required_reviewers to gamma-mirror before first execute, ENC-TSK-N01)."
     }
   }
 }

--- a/tools/test_gamma_tracker_mirror.py
+++ b/tools/test_gamma_tracker_mirror.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""ENC-TSK-M98 unit tests: diff computation, direction-lock refusal, counter reset.
+
+Self-running (python3 tools/test_gamma_tracker_mirror.py), stdlib-only — the
+tool defers its boto3 import so no AWS SDK is needed here (ci.yml convention).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "gamma_tracker_mirror", Path(__file__).parent / "gamma-tracker-mirror.py"
+)
+gtm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gtm)
+
+
+def item(pid, rid, title="t", extra=None):
+    it = {
+        "project_id": {"S": pid},
+        "record_id": {"S": rid},
+        "item_id": {"S": rid.split("#")[-1]},
+        "title": {"S": title},
+    }
+    if extra:
+        it.update(extra)
+    return it
+
+
+class TestDirectionLock(unittest.TestCase):
+    def test_happy_path(self):
+        gtm.assert_direction_lock(
+            "devops-project-tracker",
+            "devops-project-tracker-gamma",
+            ["enceladus-id-counters-gamma", "enceladus-id-idempotency-gamma"],
+        )
+
+    def test_refuses_non_gamma_dest(self):
+        with self.assertRaises(gtm.DirectionLockError):
+            gtm.assert_direction_lock(
+                "devops-project-tracker", "devops-project-tracker", []
+            )
+
+    def test_refuses_tampered_source(self):
+        with self.assertRaises(gtm.DirectionLockError):
+            gtm.assert_direction_lock(
+                "devops-project-tracker-gamma", "devops-project-tracker-gamma", []
+            )
+
+    def test_refuses_non_gamma_aux_table(self):
+        with self.assertRaises(gtm.DirectionLockError):
+            gtm.assert_direction_lock(
+                "devops-project-tracker",
+                "devops-project-tracker-gamma",
+                ["enceladus-id-counters"],  # canonical counters must never be wiped
+            )
+
+    def test_wipe_table_refuses_non_gamma(self):
+        with self.assertRaises(gtm.DirectionLockError):
+            gtm.wipe_table(None, "devops-project-tracker")
+
+    def test_main_exits_2_when_dest_wiring_tampered(self):
+        # the runtime-detectable tamper: a write target losing its -gamma suffix
+        original = gtm.GAMMA_TABLE
+        gtm.GAMMA_TABLE = "devops-project-tracker"
+        try:
+            self.assertEqual(gtm.main([]), 2)
+        finally:
+            gtm.GAMMA_TABLE = original
+
+
+class TestComputeDiff(unittest.TestCase):
+    def test_classification(self):
+        canonical = {
+            ("enceladus", "task#ENC-TSK-M96"): item("enceladus", "task#ENC-TSK-M96", "real"),
+            ("enceladus", "task#ENC-TSK-A01"): item("enceladus", "task#ENC-TSK-A01", "same"),
+            ("enceladus", "issue#ENC-ISS-390"): item("enceladus", "issue#ENC-ISS-390", "governance_hash does not rotate"),
+        }
+        gamma = {
+            ("enceladus", "task#ENC-TSK-A01"): item("enceladus", "task#ENC-TSK-A01", "same"),
+            ("enceladus", "issue#ENC-ISS-390"): item("enceladus", "issue#ENC-ISS-390", "Gamma oracle fixture A"),
+            ("enceladus", "task#ENC-TSK-L85"): item("enceladus", "task#ENC-TSK-L85", "M92 throwaway carrier"),
+        }
+        diff = gtm.compute_diff(canonical, gamma)
+        self.assertEqual(diff["adds"], [("enceladus", "task#ENC-TSK-M96")])
+        self.assertEqual(diff["changed"], [("enceladus", "issue#ENC-ISS-390")])
+        self.assertEqual(diff["unchanged"], [("enceladus", "task#ENC-TSK-A01")])
+        self.assertEqual(diff["deletes"], [("enceladus", "task#ENC-TSK-L85")])
+
+    def test_manifest_flags_gamma_native_deletes(self):
+        canonical = {}
+        gamma = {
+            ("enceladus", "task#ENC-TSK-L85"): item("enceladus", "task#ENC-TSK-L85", "M92 throwaway carrier"),
+            ("enceladus", "counter#task"): {  # legacy counter row: no item_id → not a record
+                "project_id": {"S": "enceladus"},
+                "record_id": {"S": "counter#task"},
+                "next_num": {"N": "2173"},
+            },
+        }
+        diff = gtm.compute_diff(canonical, gamma)
+        manifest = gtm.build_manifest(diff, canonical, gamma, "dry-run")
+        self.assertEqual(manifest["counts"]["deletes"], 2)
+        self.assertEqual(manifest["counts"]["gamma_native_deletes"], 1)
+        flagged = {d["record_id"]: d["gamma_native_record"] for d in manifest["deletes"]}
+        self.assertTrue(flagged["task#ENC-TSK-L85"])
+        self.assertFalse(flagged["counter#task"])
+        self.assertEqual(manifest["mode"], "dry-run")
+        self.assertEqual(manifest["source_table"], "devops-project-tracker")
+
+
+class FakeDdb:
+    """Minimal DynamoDB client fake: paginated scan + capture of batch deletes."""
+
+    def __init__(self, table_name, key_attrs, pages):
+        self.table_name = table_name
+        self.key_attrs = key_attrs
+        self.pages = pages  # list of item-lists; each scan call pops one
+        self.scan_calls = 0
+        self.deleted_keys = []
+
+    def describe_table(self, TableName):
+        assert TableName == self.table_name
+        return {"Table": {"KeySchema": [{"AttributeName": a, "KeyType": "HASH"} for a in self.key_attrs]}}
+
+    def scan(self, **kwargs):
+        page = self.pages[self.scan_calls]
+        self.scan_calls += 1
+        resp = {"Items": page, "Count": len(page)}
+        if self.scan_calls < len(self.pages):
+            resp["LastEvaluatedKey"] = {"marker": {"S": str(self.scan_calls)}}
+        return resp
+
+    def batch_write_item(self, RequestItems):
+        for table, reqs in RequestItems.items():
+            assert table == self.table_name
+            assert len(reqs) <= 25
+            for r in reqs:
+                self.deleted_keys.append(r["DeleteRequest"]["Key"])
+        return {"UnprocessedItems": {}}
+
+
+class TestCounterReset(unittest.TestCase):
+    def test_wipe_table_deletes_every_row_across_pages(self):
+        rows_p1 = [{"counter_key": {"S": f"enceladus#{t}"}} for t in ("task", "issue", "lesson")]
+        rows_p2 = [{"counter_key": {"S": "mod#plan"}}]
+        fake = FakeDdb("enceladus-id-counters-gamma", ["counter_key"], [rows_p1, rows_p2])
+        n = gtm.wipe_table(fake, "enceladus-id-counters-gamma")
+        self.assertEqual(n, 4)
+        self.assertEqual(
+            sorted(k["counter_key"]["S"] for k in fake.deleted_keys),
+            ["enceladus#issue", "enceladus#lesson", "enceladus#task", "mod#plan"],
+        )
+
+    def test_wipe_table_empty_table_is_noop(self):
+        fake = FakeDdb("enceladus-id-idempotency-gamma", ["idempotency_key"], [[]])
+        self.assertEqual(gtm.wipe_table(fake, "enceladus-id-idempotency-gamma"), 0)
+        self.assertEqual(fake.deleted_keys, [])
+
+    def test_batch_chunking_over_25(self):
+        rows = [{"counter_key": {"S": f"p#{i}"}} for i in range(60)]
+        fake = FakeDdb("x-gamma", ["counter_key"], [rows])
+        self.assertEqual(gtm.wipe_table(fake, "x-gamma"), 60)
+        self.assertEqual(len(fake.deleted_keys), 60)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False).result
+    print(f"[{'SUCCESS' if result.wasSuccessful() else 'ERROR'}] gamma-tracker-mirror tests: "
+          f"{result.testsRun} run, {len(result.failures)} failures, {len(result.errors)} errors")
+    sys.exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
## ENC-TSK-M98 — ISS-538 R2: canonical→gamma tracker mirror

Gamma's tracker is a **disposable mirror** (io direction 2026-07-12). This PR codifies the sync:

- **tools/gamma-tracker-mirror.py** — three phases: (1) scan canonical → BatchWriteItem overwrite into `devops-project-tracker-gamma`; (2) delete gamma-only keys, dumping every doomed item to a local snapshot (optional S3 upload) first; (3) wipe `enceladus-id-counters-gamma` + `enceladus-id-idempotency-gamma` so the ID service cold-seeds next-mint from the freshly mirrored canonical high-water — the ENC-ISS-538 collision mechanism becomes self-healing.
- **Guardrails**: direction lock (source hard-coded, every write target must end `-gamma`), dry-run DEFAULT emitting a diff manifest (adds/changed/deletes, gamma-native deletes flagged), `--execute` separate explicit flag, batch retry/backoff, `--throttle-ms` for the ENC-TSK-M99 stream-burst decision.
- **.github/workflows/gamma-tracker-mirror.yml** — `workflow_dispatch`; dry_run job ALWAYS runs and uploads the manifest artifact; execute job requires typed `OVERWRITE-GAMMA` confirm AND `environment: gamma-mirror`. ⚠ **io one-time setup before first execute (ENC-TSK-N01): add required_reviewers protection to the `gamma-mirror` environment** (GitHub auto-creates referenced environments unprotected).
- **ci.yml** — runs the 11 new unit tests (diff computation, direction-lock refusal, counter reset).
- **prod_gate_baseline.json** — classifies the new workflow `gamma-only` (FTR-120 guard).

Do NOT dispatch the workflow's execute leg from this PR — first run is io-supervised under ENC-TSK-N01.

Tracker: ENC-TSK-M98 (code_only) / ENC-ISS-538. Session: ENC-SES-095.
CCI-87e76201a9e74e429cd1b75cb59ba4d4

🤖 Generated with [Claude Code](https://claude.com/claude-code)