### PR TITLE
fix(graph_sync): project close/terminal status transitions (ENC-TSK-N03, ENC-ISS-543)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.4",
-  "updated_at": "2026-07-12T06:10:00Z",
-  "last_change_summary": "ENC-TSK-M92 (P0): tracker_mutation._handle_pwa_action() — the PWA close/note/reopen/worklog button path (POST /{project}/{type}/{id}/action) — now splices _version_seq_update_parts() into all four mutating branches, stamping version_seq/feed_scope identically to _handle_log (M79) and the generic PATCH path. Previously NONE of these branches stamped version_seq/feed_scope, so a gamma-native human UI write (e.g. io's [USER] worklog note on ENC-TSK-L83, 2026-07-12T05:29:31Z) LANDED but never re-surfaced in the feed delta projection (version-seq-index GSI), pinning /api/v1/feed/delta latest_version_seq at 622. M79 fixed only the MCP/checkout worklog path (_handle_log); this closes the human-UI half. No new field/entity added to the tracker record shape (version_seq/feed_scope already exist per ENC-TSK-L27); bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.5",
+  "updated_at": "2026-07-12T10:40:00Z",
+  "last_change_summary": "ENC-TSK-N03 / ENC-ISS-543: graph_sync close-transition projection fix -- _coalesce_status_for_projection() recovers typed status.S from NewImage with OldImage fallback on MODIFY, TERMINAL_STATUSES preserved on checkout-only MODIFY (checkout-release after close no longer regresses the node), explicit SET n.status on every node upsert (SET n += props never fixes an omitted key), and the handler now raises when a failed record lacks a batchItemFailures identifier. Repair tool tools/graph_status_drift_reconcile.py added. No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -8374,6 +8374,11 @@
       "version": "2026-07-12.2",
       "date": "2026-07-12",
       "summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.5",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N03 / ENC-ISS-543: graph_sync close-transition projection fix -- _coalesce_status_for_projection() recovers typed status.S from NewImage with OldImage fallback on MODIFY, TERMINAL_STATUSES preserved on checkout-only MODIFY (checkout-release after close no longer regresses the node), explicit SET n.status on every node upsert (SET n += props never fixes an omitted key), and the handler now raises when a failed record lacks a batchItemFailures identifier. Repair tool tools/graph_status_drift_reconcile.py added. No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/graph_sync/lambda_function.py
+++ b/backend/lambda/graph_sync/lambda_function.py
@@ -418,6 +418,65 @@ NODE_PROPERTIES = [
     "item_id_provenance",
 ]
 
+# ENC-ISS-543: terminal lifecycle values that MUST project to Neo4j on close paths.
+# Matches tracker/checkout terminal sets (task->closed, feature->production/deprecated,
+# plan->complete, issue->closed, etc.).
+TERMINAL_STATUSES = frozenset({
+    "closed", "completed", "complete", "production", "deprecated", "archived",
+    "superseded",
+})
+
+
+def _is_terminal_status(value: Any) -> bool:
+    return str(value or "").strip().lower() in TERMINAL_STATUSES
+
+
+def _typed_string_field(image: Dict[str, Any], field: str) -> str:
+    """Read a DynamoDB stream String ('S') field directly from a typed image."""
+    typed = (image or {}).get(field) or {}
+    if isinstance(typed, dict) and "S" in typed:
+        return str(typed["S"]).strip()
+    return ""
+
+
+def _coalesce_status_for_projection(
+    record: Dict[str, Any],
+    old_record: Dict[str, Any],
+    new_image: Dict[str, Any],
+    old_image: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Ensure ``status`` is present for Neo4j MERGE on close / checkout-release paths.
+
+    ENC-ISS-543: close transitions are often followed within seconds by a
+    checkout-release MODIFY. Neo4j uses ``SET n += $props`` which never clears
+    stale properties — if ``status`` is absent from the deserialized projection
+    record, the node keeps the pre-close status (one write behind canonical).
+    Recover ``status`` from the typed NewImage first, then OldImage.
+    """
+    merged = dict(record)
+    status = str(merged.get("status") or "").strip()
+    if not status:
+        status = _typed_string_field(new_image, "status")
+    old_status = str(old_record.get("status") or _typed_string_field(old_image, "status") or "").strip()
+    if not status and _is_terminal_status(old_status):
+        # ENC-ISS-543 mechanism 3: checkout-release MODIFY immediately after close —
+        # OldImage already reflects the terminal status even when the deserialized
+        # NewImage omits ``status``.
+        status = old_status
+    if not status:
+        status = old_status
+    if status:
+        merged["status"] = status
+
+    new_status = str(merged.get("status") or "").strip()
+    if new_status and (_is_terminal_status(new_status) or new_status != old_status):
+        logger.info(
+            "[INFO] Status projection %s -> %s (record_id=%s)",
+            old_status or "<none>", new_status,
+            _bare_id(str(merged.get("record_id") or merged.get("item_id") or "")),
+        )
+    return merged
+
 
 PlaceholderRef = Tuple[str, str]
 
@@ -536,12 +595,20 @@ def _upsert_node(tx, record: Dict[str, Any]) -> None:
     props = {k: record.get(k) for k in NODE_PROPERTIES if record.get(k) is not None}
     props["record_id"] = record_id
 
+    # ENC-ISS-543: ``SET n += $props`` alone leaves stale ``status`` when a later
+    # checkout-release MODIFY omits the field from the deserialized dict. Always
+    # bind terminal / lifecycle status explicitly so close transitions MERGE.
+    status_val = props.get("status")
     cypher = (
         f"MERGE (n:{label} {{record_id: $record_id}}) "
         "SET n += $props "
         "SET n.is_placeholder = false"
     )
-    tx.run(cypher, record_id=record_id, props=props)
+    params: Dict[str, Any] = {"record_id": record_id, "props": props}
+    if status_val is not None and str(status_val).strip() != "":
+        cypher += " SET n.status = $status_val"
+        params["status_val"] = str(status_val).strip()
+    tx.run(cypher, **params)
 
 
 def _upsert_project_node(tx, project_id: str) -> None:
@@ -1546,10 +1613,12 @@ def _process_record(driver, stream_record: Dict) -> None:
         if not new_image:
             return
 
-        record = _normalize_record_for_graph(_deser_image(new_image))
-        record_type = record.get("record_type", "")
         old_image = dynamodb.get("OldImage", {})
         old_record = _normalize_record_for_graph(_deser_image(old_image)) if old_image else {}
+        record = _normalize_record_for_graph(_deser_image(new_image))
+        if event_name == "MODIFY":
+            record = _coalesce_status_for_projection(record, old_record, new_image, old_image)
+        record_type = record.get("record_type", "")
         stale_placeholder_refs = _collect_placeholder_target_refs(old_record) - _collect_placeholder_target_refs(record)
 
         # ENC-FTR-049: Handle typed relationship records
@@ -1768,6 +1837,15 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             logger.exception("[ERROR] Failed to process %s record identifier=%s", source, identifier)
             if identifier:
                 failed_identifiers.append(identifier)
+            else:
+                # ENC-ISS-543: a missing failure identifier silently drops the
+                # record (Lambda returns 200, source deletes it). Fail closed.
+                logger.error(
+                    "[ERROR] %s record failed but has no batchItemFailures identifier; "
+                    "raising to avoid silent graph drift",
+                    source,
+                )
+                raise
 
     logger.info("[INFO] Batch complete: processed=%d, errors=%d, total=%d", processed, errors, len(records))
 

--- a/backend/lambda/graph_sync/test_close_status_projection_iss543.py
+++ b/backend/lambda/graph_sync/test_close_status_projection_iss543.py
@@ -1,0 +1,75 @@
+"""ENC-ISS-543: close / checkout-release stream paths must MERGE terminal status."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _ddb_string(value: str) -> dict:
+    return {"S": value}
+
+
+def _task_new_image(status: str, *, include_status_typed: bool = True) -> dict:
+    image = {
+        "record_type": _ddb_string("task"),
+        "record_id": _ddb_string("task#ENC-TSK-M27"),
+        "project_id": _ddb_string("enceladus"),
+        "title": _ddb_string("carrier"),
+        "updated_at": _ddb_string("2026-07-12T10:10:59Z"),
+        "active_agent_session": {"BOOL": False},
+        "checkout_state": _ddb_string("checked_in"),
+    }
+    if include_status_typed:
+        image["status"] = _ddb_string(status)
+    return image
+
+
+class TestCloseStatusProjectionIss543(unittest.TestCase):
+    def setUp(self):
+        import lambda_function as lf
+        self.lf = lf
+
+    def test_coalesce_recovers_status_from_typed_new_image(self):
+        new_image = _task_new_image("closed")
+        # Simulate a deserialize gap: status missing from dict but present typed.
+        record = {"record_type": "task", "record_id": "task#ENC-TSK-M27", "project_id": "enceladus"}
+        merged = self.lf._coalesce_status_for_projection(record, {}, new_image, {})
+        self.assertEqual(merged["status"], "closed")
+
+    def test_coalesce_preserves_terminal_status_from_old_image_on_checkout_release(self):
+        """Mechanism 3: checkout-release MODIFY may omit status in the deserialized
+        dict; OldImage already carries the terminal status from the close write."""
+        new_image = _task_new_image("closed", include_status_typed=False)
+        old_image = _task_new_image("closed")
+        old_record = self.lf._normalize_record_for_graph(self.lf._deser_image(old_image))
+        record = self.lf._normalize_record_for_graph(self.lf._deser_image(new_image))
+        merged = self.lf._coalesce_status_for_projection(record, old_record, new_image, old_image)
+        self.assertEqual(merged["status"], "closed")
+
+    def test_upsert_node_sets_status_explicitly(self):
+        captured = {}
+
+        def _capture_run(cypher, **params):
+            captured["cypher"] = cypher
+            captured["params"] = params
+
+        tx = MagicMock()
+        tx.run.side_effect = _capture_run
+        record = {
+            "record_type": "task",
+            "record_id": "task#ENC-TSK-M27",
+            "project_id": "enceladus",
+            "title": "carrier",
+            "status": "closed",
+            "updated_at": "2026-07-12T10:11:00Z",
+        }
+        self.lf._upsert_node(tx, record)
+        self.assertIn("SET n.status = $status_val", captured["cypher"])
+        self.assertEqual(captured["params"]["status_val"], "closed")
+
+    def test_terminal_status_detection(self):
+        self.assertTrue(self.lf._is_terminal_status("closed"))
+        self.assertTrue(self.lf._is_terminal_status("production"))
+        self.assertFalse(self.lf._is_terminal_status("in-progress"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/graph_status_drift_reconcile.py
+++ b/tools/graph_status_drift_reconcile.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""ENC-ISS-543: repair stale Neo4j node ``status`` vs canonical DynamoDB.
+
+Scans tracker rows (read-only), compares canonical ``status`` to
+graph_query_api keyword hits, and for mismatches issues a governed PATCH
+touch (re-set ``updated_at`` note) so graph_sync re-projects the node.
+
+Requires TRACKER_API_KEY (X-Coordination-Internal-Key) in the environment.
+
+Usage:
+    export TRACKER_API_KEY=...
+    python3 tools/graph_status_drift_reconcile.py \\
+        --tracker-table devops-project-tracker-gamma \\
+        --base-url https://enceladus-gamma.jreese.net/api/v1 \\
+        --apply
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Any, Dict, Optional
+
+import boto3
+import requests
+
+REGION = "us-west-2"
+PROJECTABLE_TYPES = ("task", "issue", "feature", "plan", "lesson")
+
+
+def _make_session() -> requests.Session:
+    key = os.environ.get("TRACKER_API_KEY", "")
+    if not key:
+        print("[ERROR] TRACKER_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+    session = requests.Session()
+    session.headers.update({"X-Coordination-Internal-Key": key})
+    return session
+
+
+def _http(session: requests.Session, method: str, url: str, body: Optional[dict] = None):
+    try:
+        resp = session.request(method, url, json=body, timeout=30)
+    except requests.RequestException as exc:
+        return 0, {"error": str(exc)}
+    try:
+        return resp.status_code, resp.json()
+    except ValueError:
+        return resp.status_code, {}
+
+
+def _bare_id(record_id: str) -> str:
+    return record_id.split("#", 1)[-1] if "#" in record_id else record_id
+
+
+def _graph_status(session: requests.Session, base_url: str, project_id: str, item_id: str) -> Optional[str]:
+    code, body = _http(
+        session,
+        "GET",
+        f"{base_url}/tracker/graphsearch",
+        None,
+    )
+    # graphsearch is GET with query params
+    try:
+        resp = session.get(
+            f"{base_url}/tracker/graphsearch",
+            params={"project_id": project_id, "search_type": "keyword", "query": item_id, "limit": 5},
+            timeout=30,
+        )
+        data = resp.json()
+    except (requests.RequestException, ValueError):
+        return None
+    for node in data.get("nodes") or []:
+        if node.get("record_id") == item_id:
+            return str(node.get("status") or "").strip() or None
+    return None
+
+
+def _touch_record(session: requests.Session, base_url: str, project_id: str, record_type: str, item_id: str) -> bool:
+    code, body = _http(
+        session,
+        "PATCH",
+        f"{base_url}/tracker/{project_id}/{record_type}/{item_id}",
+        {
+            "field": "last_update_note",
+            "value": "graph_status_drift_reconcile touch (ENC-ISS-543)",
+            "write_source": {"provider": "graph_status_drift_reconcile", "channel": "tool"},
+        },
+    )
+    return code in (200, 201) and body.get("success") is not False
+
+
+def scan_table(table_name: str):
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    table = ddb.Table(table_name)
+    kwargs: Dict[str, Any] = {}
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            rid = str(item.get("record_id") or "")
+            if rid.startswith("COUNTER-"):
+                continue
+            yield item
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reconcile Neo4j status drift vs canonical DDB")
+    parser.add_argument("--tracker-table", default="devops-project-tracker-gamma")
+    parser.add_argument("--base-url", default="https://enceladus-gamma.jreese.net/api/v1")
+    parser.add_argument("--project-id", default="enceladus")
+    parser.add_argument("--apply", action="store_true", help="Issue PATCH touches for mismatches")
+    parser.add_argument("--limit", type=int, default=0, help="Max mismatches to fix (0=all)")
+    args = parser.parse_args()
+
+    session = _make_session()
+    mismatches = []
+    scanned = 0
+
+    for item in scan_table(args.tracker_table):
+        record_type = str(item.get("record_type") or "").strip()
+        if record_type not in PROJECTABLE_TYPES:
+            continue
+        item_id = _bare_id(str(item.get("record_id") or item.get("item_id") or ""))
+        if not item_id:
+            continue
+        canonical_status = str(item.get("status") or "").strip()
+        if not canonical_status:
+            continue
+        scanned += 1
+        graph_st = _graph_status(session, args.base_url, args.project_id, item_id)
+        if graph_st == canonical_status:
+            continue
+        mismatches.append((record_type, item_id, graph_st, canonical_status))
+        print(f"[DRIFT] {item_id}: graph={graph_st!r} canonical={canonical_status!r}")
+
+    print(f"[INFO] scanned={scanned} mismatches={len(mismatches)}")
+    if not args.apply or not mismatches:
+        return 0
+
+    fixed = 0
+    for record_type, item_id, _g, _c in mismatches:
+        if args.limit and fixed >= args.limit:
+            break
+        if _touch_record(session, args.base_url, args.project_id, record_type, item_id):
+            fixed += 1
+            print(f"[FIX] touched {item_id}")
+            time.sleep(0.2)
+        else:
+            print(f"[WARN] touch failed for {item_id}", file=sys.stderr)
+    print(f"[INFO] touched={fixed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Fixes ENC-ISS-543 (P1): the Neo4j graph projection systematically missed close/status transitions — 7 confirmed false-opens 07-02→07-12, each graph node one write behind canonical.

Root causes addressed:
- **Mechanism b**: `SET n += $props` never fixes an omitted `status` key → every node upsert now issues an explicit `SET n.status = $status_val`.
- **Mechanism c (primary)**: a checkout-release MODIFY seconds after a close overwrote the projection with pre-close state → `_coalesce_status_for_projection()` reads typed `status.S` from NewImage with OldImage fallback and preserves terminal status (`TERMINAL_STATUSES` frozenset) on checkout-only MODIFY.
- **Batch hardening**: handler now raises when a failed record lacks a `batchItemFailures` identifier (silent-drop path).
- **Repair tool**: `tools/graph_status_drift_reconcile.py` scans DynamoDB canonical status vs the graph projection and reconciles drift.

## Tests
- `test_close_status_projection_iss543.py`: 4/4 (mirrors the L74 batch suite)
- Combined with L74 batch suite: 13/13
- Full graph_sync suite: 109/109

## Deploy note (pre-deploy STOP)
ESM verification (AC-7): the CANONICAL `devops-project-tracker` graph projection is consumed by **`devops-graph-sync`** (prod-frozen name) via `devops-graph-sync-queue.fifo` — no canonical-stream ESM reaches the gamma function. Deploy beyond gamma requires an io waiver per the PLN-006 gamma-only invariant.

Task: ENC-TSK-N03 · Issue: ENC-ISS-543 · Plan: ENC-PLN-006

CCI-1f883009154a42c7bb00aa0d8c2488a1

🤖 Generated with [Claude Code](https://claude.com/claude-code)