### PR TITLE
fix(ui-v2): session-first Coordination Sessions tab cards (ENC-TSK-M97)

### DIFF
--- a/frontend/ui-v2/src/format/agentTypeLabel.test.ts
+++ b/frontend/ui-v2/src/format/agentTypeLabel.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentType } from '../api/coordination'
+import {
+  formatAgentTypeSecondary,
+  formatSessionCardDescription,
+} from './agentTypeLabel'
+
+const agentType: AgentType = {
+  agent_type_id: 'ENC-AGT-003',
+  surface: 'Claude Desktop',
+  model: 'Opus 4.8',
+  cost_tier: 'premium',
+  status: 'active',
+  usage_count: 2,
+}
+
+describe('formatAgentTypeSecondary', () => {
+  it('joins governed id with roster surface/model', () => {
+    expect(formatAgentTypeSecondary('ENC-AGT-003', agentType)).toBe(
+      'ENC-AGT-003 · Claude Desktop / Opus 4.8',
+    )
+  })
+
+  it('returns the governed id alone when the roster row is missing', () => {
+    expect(formatAgentTypeSecondary('ENC-AGT-005')).toBe('ENC-AGT-005')
+  })
+
+  it('does not uppercase or substitute legacy raw ids', () => {
+    expect(formatAgentTypeSecondary('desktop')).toBe('desktop')
+  })
+})
+
+describe('formatSessionCardDescription', () => {
+  it('keeps runtime as a separate trailing segment', () => {
+    expect(formatSessionCardDescription('ENC-AGT-003', 'cc-desktop', agentType)).toBe(
+      'ENC-AGT-003 · Claude Desktop / Opus 4.8 · Runtime: cc-desktop',
+    )
+  })
+})

--- a/frontend/ui-v2/src/format/agentTypeLabel.ts
+++ b/frontend/ui-v2/src/format/agentTypeLabel.ts
@@ -1,0 +1,36 @@
+import type { AgentType } from '../api/coordination'
+
+/**
+ * Secondary agent-type metadata for session cards (ENC-TSK-M97 / FTR-130 UAT #1).
+ * Always leads with the governed ENC-AGT-* id from the sessions API payload;
+ * appends the agent-types roster surface/model label when the roster resolves.
+ * Never substitutes runtime/surface tokens when the id or roster row is missing.
+ */
+export function formatAgentTypeSecondary(
+  agentTypeId: string,
+  agentType?: AgentType,
+): string {
+  const id = agentTypeId.trim()
+  if (!id) return '—'
+
+  if (agentType?.agent_type_id === id) {
+    const surface = agentType.surface?.trim()
+    const model = agentType.model?.trim()
+    const label = [surface, model].filter(Boolean).join(' / ')
+    return label ? `${id} · ${label}` : id
+  }
+
+  return id
+}
+
+/** Join agent-type metadata with the unchanged runtime line from the API payload. */
+export function formatSessionCardDescription(
+  agentTypeId: string,
+  runtime: string | undefined,
+  agentType?: AgentType,
+): string | undefined {
+  const parts = [formatAgentTypeSecondary(agentTypeId, agentType)]
+  const runtimeLine = runtime?.trim()
+  if (runtimeLine) parts.push(`Runtime: ${runtimeLine}`)
+  return parts.join(' · ')
+}

--- a/frontend/ui-v2/src/routes/CoordinationRoute.tsx
+++ b/frontend/ui-v2/src/routes/CoordinationRoute.tsx
@@ -24,11 +24,14 @@ import {
   fetchCoordinationRequests,
   fetchEscalations,
   fetchLessons,
+  type AgentSession,
   type AgentType,
   type CoordinationRequest,
   type EscalationRecord,
   type LessonRecord,
 } from '../api/coordination'
+import { sessionHref } from '../api/sessions'
+import { formatSessionCardDescription } from '../format/agentTypeLabel'
 import type { PropertyFilterQuery } from '../../../design-system-2/v2/components/PropertyFilter/PropertyFilter.jsx'
 import { applyTokens } from './applyCoordinationFilter'
 import './coordination.css'
@@ -87,6 +90,10 @@ export function CoordinationRoute() {
   const escalations = applyTokens(escalationsQuery.data ?? [], filterQuery)
   const crqDocs = applyTokens(crqQuery.data ?? [], filterQuery)
 
+  const agentTypeById = new Map(
+    (agentTypesQuery.data ?? []).map((agentType) => [agentType.agent_type_id, agentType]),
+  )
+
   const tabs = [
     {
       id: 'sessions',
@@ -103,12 +110,19 @@ export function CoordinationRoute() {
             items={sessions}
             getKey={(row) => row.session_id}
             estimateSize={96}
-            renderItem={(row) => (
+            renderItem={(row: AgentSession) => (
               <RecordCard
                 recordId={row.session_id}
-                kindLabel={row.agent_type_id}
-                description={row.runtime ? `Runtime: ${row.runtime}` : undefined}
+                recordType="session"
+                kindLabel="Session"
+                title={row.session_id}
+                description={formatSessionCardDescription(
+                  row.agent_type_id,
+                  row.runtime,
+                  agentTypeById.get(row.agent_type_id),
+                )}
                 status={row.status}
+                href={sessionHref(row.session_id)}
                 variant="standard"
               />
             )}


### PR DESCRIPTION
## Summary

- Fix FTR-130 UAT finding #1: Coordination > Sessions tab cards now headline `ENC-SES-*` (session identity) instead of `agent_type_id`.
- Agent type is demoted to secondary description metadata (`ENC-AGT-* · surface / model`) resolved from the agent-types roster; runtime and status chips unchanged.
- Root cause was UI-only: `RecordCard.kindLabel` was wired to `row.agent_type_id` (line 109); the raw `DESKTOP` headline came from legacy payload `agent_type_id: "desktop"` on `ENC-SES-00H` uppercased by `.ev2-rc__kind { text-transform: uppercase }`. No API change.

CCI-dccbed2db3c240be80ef0b9c53d76c20

## Test plan

- [x] `npm test -- --run src/format/agentTypeLabel.test.ts`
- [ ] `_ui_deploy` green on merge (gamma; M88 viewer gate)
- [ ] io UAT: `/coordination` Sessions tab shows session-first cards (AC-3)


Made with [Cursor](https://cursor.com)