### PR TITLE
fix(ui-v2): B67 AC-4/AC-18 offline-path defects (ENC-TSK-N04)

### DIFF
--- a/frontend/ui-v2/src/api/mutations.test.ts
+++ b/frontend/ui-v2/src/api/mutations.test.ts
@@ -1,0 +1,82 @@
+/**
+ * ENC-TSK-N04 (B67 AC-18): offline queue engagement for tracker mutations.
+ * navigator.onLine can report true while fetch fails at the network layer
+ * (the W14-A forced-offline probe), so the queue must engage on a fetch
+ * TypeError too — while real HTTP failures (4xx/5xx) must still throw.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../offline/mutationQueue', () => ({
+  enqueueMutation: vi.fn(async (input: Record<string, unknown>) => ({
+    ...input,
+    id: 'queued-1',
+    enqueuedAt: '2026-07-12T00:00:00.000Z',
+  })),
+}))
+vi.mock('../store/offlineStore', () => ({
+  useOfflineStore: {
+    getState: () => ({ refreshPendingCount: vi.fn(async () => {}) }),
+  },
+}))
+
+import { patchTrackerRecord } from './mutations'
+import { enqueueMutation } from '../offline/mutationQueue'
+
+describe('patchTrackerRecord offline queue (B67 AC-18)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('queues the mutation when fetch fails at the network layer despite navigator.onLine=true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      }),
+    )
+
+    const result = await patchTrackerRecord('enceladus', 'task', 'ENC-TSK-1', {
+      action: 'note',
+      note: 'offline note',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.record_id).toBe('ENC-TSK-1')
+    expect(enqueueMutation).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(enqueueMutation).mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      body: { action: 'note', note: 'offline note' },
+    })
+  })
+
+  it('does NOT queue on an HTTP error response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ error: 'boom' }), { status: 500 })),
+    )
+
+    await expect(
+      patchTrackerRecord('enceladus', 'task', 'ENC-TSK-1', { action: 'note', note: 'x' }),
+    ).rejects.toThrow('boom')
+    expect(enqueueMutation).not.toHaveBeenCalled()
+  })
+
+  it('queues without touching the network when navigator.onLine is false', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true })
+
+    try {
+      const result = await patchTrackerRecord('enceladus', 'task', 'ENC-TSK-2', {
+        action: 'note',
+        note: 'fully offline',
+      })
+      expect(result.success).toBe(true)
+      expect(enqueueMutation).toHaveBeenCalledTimes(1)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
+    }
+  })
+})

--- a/frontend/ui-v2/src/api/mutations.ts
+++ b/frontend/ui-v2/src/api/mutations.ts
@@ -138,16 +138,39 @@ export async function patchTrackerRecord(
   }
 
   if (typeof navigator !== 'undefined' && !navigator.onLine && !options.skipOfflineQueue) {
-    await enqueueMutation({ url, method: 'PATCH', body, headers })
-    await useOfflineStore.getState().refreshPendingCount()
-    return {
-      success: true,
-      record_id: recordId,
-      updated_at: new Date().toISOString(),
-    }
+    return queuePatchForReplay(url, body, headers, recordId)
   }
 
-  return sendMutationRequest(url, 'PATCH', body, headers)
+  try {
+    return await sendMutationRequest(url, 'PATCH', body, headers)
+  } catch (error) {
+    // ENC-TSK-N04 (B67 AC-18): navigator.onLine is a liar — it can report
+    // true while every request fails at the network layer (lie-fi, DNS/proxy
+    // outage, request-level offline emulation; the W14-A probe hit exactly
+    // this: immediate "Failed to fetch" Flashbar, queue never engaged). A
+    // fetch() rejection is a TypeError by spec and never carries an HTTP
+    // status, so queueing here can't swallow a real 4xx/5xx/409/401 — those
+    // paths throw typed errors above and rethrow below.
+    if (error instanceof TypeError && !options.skipOfflineQueue) {
+      return queuePatchForReplay(url, body, headers, recordId)
+    }
+    throw error
+  }
+}
+
+async function queuePatchForReplay(
+  url: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string>,
+  recordId: string,
+): Promise<MutationResult> {
+  await enqueueMutation({ url, method: 'PATCH', body, headers })
+  await useOfflineStore.getState().refreshPendingCount()
+  return {
+    success: true,
+    record_id: recordId,
+    updated_at: new Date().toISOString(),
+  }
 }
 
 /**

--- a/frontend/ui-v2/src/offline/workboxStrategies.test.ts
+++ b/frontend/ui-v2/src/offline/workboxStrategies.test.ts
@@ -9,13 +9,15 @@ describe('WORKBOX_STRATEGY_MAP (B67 AC-17)', () => {
     expect(WORKBOX_STRATEGY_MAP).toHaveLength(6)
   })
 
-  it('covers CacheFirst, StaleWhileRevalidate, NetworkFirst, NetworkOnly, BackgroundSync', () => {
+  it('covers CacheFirst, StaleWhileRevalidate, NetworkFirst, NetworkOnly, app-layer queue', () => {
     const handlers = WORKBOX_STRATEGY_MAP.map((e) => e.handler)
     expect(handlers).toContain('CacheFirst')
     expect(handlers).toContain('StaleWhileRevalidate')
     expect(handlers.filter((h) => h.startsWith('NetworkFirst'))).toHaveLength(1)
     expect(handlers).toContain('NetworkOnly')
-    expect(handlers).toContain('NetworkOnly+BackgroundSync')
+    // ENC-TSK-N04 (B67 AC-18): mutation queue+replay moved to the app layer;
+    // a SW-level BackgroundSync on the same routes would double-replay.
+    expect(handlers).toContain('NetworkOnly+AppLayerQueue')
   })
 
   it('uses 3s app-shell network timeout per DOC-E470AC8CE9A8', () => {

--- a/frontend/ui-v2/src/offline/workboxStrategies.ts
+++ b/frontend/ui-v2/src/offline/workboxStrategies.ts
@@ -14,8 +14,11 @@ export const WORKBOX_STRATEGY_MAP = [
   },
   { id: 'auth', handler: 'NetworkOnly', routes: '/api/v1/auth*, /callback, /mobile/v1/auth*' },
   {
+    // ENC-TSK-N04 (B67 AC-18): queue+replay for this route class is the
+    // app-layer mutationQueue (If-Match aware, UI pendingCount), NOT Workbox
+    // BackgroundSync — a SW-level queue on the same routes would double-replay.
     id: 'mutations',
-    handler: 'NetworkOnly+BackgroundSync',
+    handler: 'NetworkOnly+AppLayerQueue',
     routes: 'PATCH|POST|DELETE /api/v1/tracker/*, /api/v1/documents/*',
   },
 ] as const

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.bootstrap.test.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.bootstrap.test.tsx
@@ -60,6 +60,7 @@ vi.mock('./appsyncRealtimeClient', () => ({
       stopCount += 1
     }
     manualRetry() {}
+    livenessKick() {}
     watchRecord() {
       return () => {}
     }

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.test.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.test.tsx
@@ -40,6 +40,7 @@ vi.mock('./appsyncRealtimeClient', () => ({
     start() {}
     stop() {}
     manualRetry() {}
+    livenessKick() {}
     watchRecord() {
       return () => {}
     }

--- a/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
+++ b/frontend/ui-v2/src/realtime/RealtimeFeedProvider.tsx
@@ -188,15 +188,26 @@ export function RealtimeFeedProvider({ children }: { children: ReactNode }) {
     clientRef.current = client
     client.start()
 
+    // ENC-TSK-N04 (B67 AC-4): refocus/online re-kicks use livenessKick, NOT
+    // manualRetry — manualRetry resets the backoff counter, so under tab
+    // churn the counter restarted mid-outage (the W14-A "backoff reset
+    // anomaly": 0.32s attempt right after a long pause) and the 12-attempt
+    // manual-retry bar could never be reached. Only the user-clicked Retry
+    // (manualReconnect below) resets the counter.
     const onVisibility = () => {
       if (document.visibilityState === 'visible') {
-        client.manualRetry()
+        client.livenessKick()
       }
     }
+    const onOnline = () => {
+      client.livenessKick()
+    }
     document.addEventListener('visibilitychange', onVisibility)
+    window.addEventListener('online', onOnline)
 
     return () => {
       document.removeEventListener('visibilitychange', onVisibility)
+      window.removeEventListener('online', onOnline)
       client.stop()
       clientRef.current = null
     }

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.test.ts
@@ -131,6 +131,78 @@ describe('AppSyncRealtimeClient', () => {
     client.stop()
   })
 
+  // ENC-TSK-N04 (B67 AC-4): the provider maps events 1:1 onto phases, so
+  // manual_retry_required must be the LAST event of the terminal sequence —
+  // the old order emitted 'disconnected' after it, clobbering the
+  // manual_retry phase and hiding the Retry affordance (W14-A silent halt).
+  it('emits manual_retry_required as the final terminal event, after disconnected', () => {
+    vi.useFakeTimers()
+    const events: string[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => events.push(event.type),
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    for (let i = 0; i <= MAX_AUTO_RECONNECT_ATTEMPTS; i++) {
+      MockWebSocket.instances.at(-1)?.close()
+      vi.advanceTimersByTime(BACKOFF_CAP_MS)
+    }
+
+    expect(events.at(-1)).toBe('manual_retry_required')
+    expect(events.at(-2)).toBe('disconnected')
+    client.stop()
+  })
+
+  // ENC-TSK-N04 (B67 AC-4): visibility/online re-kicks must not reset the
+  // backoff counter — W14-A observed the sequence restarting from attempt 1
+  // mid-outage (refocus fired manualRetry), which also kept the 12-attempt
+  // Retry bar forever out of reach under tab churn.
+  it('livenessKick reconnects immediately without resetting the attempt counter', () => {
+    vi.useFakeTimers()
+    const attempts: number[] = []
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: (event) => {
+        if (event.type === 'reconnecting') attempts.push(event.attempt)
+      },
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    MockWebSocket.instances.at(-1)?.close() // attempt 1 scheduled
+    vi.advanceTimersByTime(BACKOFF_CAP_MS)
+    MockWebSocket.instances.at(-1)?.close() // attempt 2 scheduled
+
+    client.livenessKick() // immediate reconnect, counter preserved
+    MockWebSocket.instances.at(-1)?.close() // fails again -> attempt 3, not 1
+
+    expect(attempts).toEqual([1, 2, 3])
+
+    client.manualRetry() // user-clicked Retry DOES reset
+    MockWebSocket.instances.at(-1)?.close()
+    expect(attempts).toEqual([1, 2, 3, 1])
+    client.stop()
+  })
+
+  it('livenessKick is a no-op while the socket is open', () => {
+    const client = new AppSyncRealtimeClient({
+      config,
+      lastCursor: 0,
+      onEvent: () => {},
+      webSocketFactory: (url, protocols) => new MockWebSocket(url, protocols) as unknown as WebSocket,
+    })
+
+    client.start()
+    expect(MockWebSocket.instances).toHaveLength(1)
+    client.livenessKick() // mock sockets report OPEN
+    expect(MockWebSocket.instances).toHaveLength(1)
+    client.stop()
+  })
+
   it('emits gap_too_large when cursor jump exceeds threshold', () => {
     let gap = false
     const client = new AppSyncRealtimeClient({

--- a/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
+++ b/frontend/ui-v2/src/realtime/appsyncRealtimeClient.ts
@@ -7,6 +7,15 @@ export const LIVENESS_CHECK_INTERVAL_MS = 15_000
 export const DEFAULT_CONNECTION_TIMEOUT_MS = 300_000
 export const BACKOFF_BASE_MS = 500
 export const BACKOFF_CAP_MS = 30_000
+/**
+ * ENC-TSK-N04 (B67 AC-4/W14-A): documented SERVER keepalive cadence. The B67
+ * spec text said 30s, but AppSync Events delivers `ka` at ~60s in practice
+ * (W14-A: 60.0s median over 59 keepalives on gamma). Nothing client-side
+ * depends on this number — liveness is governed by connectionTimeoutMs from
+ * connection_ack (default 300s, 5× margin over a 60s cadence) — this constant
+ * exists so the observed cadence is recorded where the watchdog lives.
+ */
+export const OBSERVED_SERVER_KA_CADENCE_MS = 60_000
 
 export type RealtimeClientEvent =
   | { type: 'connected' }
@@ -107,6 +116,26 @@ export class AppSyncRealtimeClient {
   manualRetry(): void {
     if (this.disposed || !this.config.enabled) return
     this.reconnectAttempt = 0
+    this.clearTimers()
+    this.discardSocket()
+    this.connect()
+  }
+
+  /**
+   * ENC-TSK-N04 (B67 AC-4): visibility/online re-kick. Reconnects immediately
+   * like manualRetry but WITHOUT resetting the backoff counter — the counter
+   * must keep counting consecutive failures across kicks, or the manual-retry
+   * bar at MAX_AUTO_RECONNECT_ATTEMPTS is never reached under tab-switch churn
+   * (W14-A observed the counter restarting from attempt 1 mid-outage, which is
+   * also the "backoff reset anomaly": refocus fired manualRetry). No-op while
+   * a connection is open or an attempt is already in flight. Kicking from the
+   * halted terminal state is allowed — a failed kick re-emits
+   * manual_retry_required, so the Retry affordance persists.
+   */
+  livenessKick(): void {
+    if (this.disposed || !this.config.enabled) return
+    const state = this.socket?.readyState
+    if (state === WebSocket.OPEN || state === WebSocket.CONNECTING) return
     this.clearTimers()
     this.discardSocket()
     this.connect()
@@ -365,8 +394,13 @@ export class AppSyncRealtimeClient {
 
     this.reconnectAttempt += 1
     if (this.reconnectAttempt > MAX_AUTO_RECONNECT_ATTEMPTS) {
-      this.onEvent({ type: 'manual_retry_required' })
+      // ENC-TSK-N04 (B67 AC-4): 'disconnected' must precede
+      // 'manual_retry_required'. The provider maps these 1:1 onto connection
+      // phases, so the old order set phase 'manual_retry' and then immediately
+      // clobbered it with 'disconnected' — the Retry affordance never rendered
+      // and the halt was silent (W14-A: 94s+ with no recovery path but reload).
       this.onEvent({ type: 'disconnected', reason: `manual retry required (${reason})` })
+      this.onEvent({ type: 'manual_retry_required' })
       return
     }
 

--- a/frontend/ui-v2/vite.config.ts
+++ b/frontend/ui-v2/vite.config.ts
@@ -151,6 +151,13 @@ export default defineConfig({
             urlPattern: ({ url }) => url.pathname.startsWith('/api/v1/deploy/'),
             handler: 'NetworkOnly',
           },
+          // ENC-TSK-N04 (B67 AC-18): mutations are NetworkOnly with NO Workbox
+          // BackgroundSync. Offline queue+replay for tracker/document
+          // mutations is owned by the app layer (src/offline/mutationQueue.ts
+          // via patchTrackerRecord) — it is If-Match/revision-conflict aware
+          // and drives the UI pendingCount, none of which a blind SW replay
+          // can do. Keeping the SW-level queue alongside it would replay the
+          // same mutation twice once the app layer queues on network failure.
           ...(['PATCH', 'POST', 'DELETE'] as const).map((method) => ({
             urlPattern: ({ url }: { url: URL }) =>
               (url.pathname.startsWith('/api/v1/tracker/') ||
@@ -158,12 +165,6 @@ export default defineConfig({
               !url.pathname.includes('/graphsearch'),
             handler: 'NetworkOnly' as const,
             method,
-            options: {
-              backgroundSync: {
-                name: 'enceladus-mutation-queue',
-                options: { maxRetentionTime: 24 * 60 },
-              },
-            },
           })),
         ],
       },


### PR DESCRIPTION
## ENC-TSK-N04 — B67 AC-4/AC-18 offline-path defects

Fixes the three W14-A offline-leg defects + reconciles the AC-18 discrepancy and ka-cadence measurement.

### Root causes & fixes
1. **Retry-at-12 never surfaces / silent halt** — `scheduleReconnect` emitted `manual_retry_required` then `disconnected`; the provider maps events 1:1 onto phases, so `manual_retry` was clobbered to `disconnected` one tick after being set and FeedPane's Retry block (gated on `phase === 'manual_retry'`) never rendered. Terminal emit order is now `disconnected` → `manual_retry_required`: the Retry affordance surfaces after the 12th consecutive failed attempt and persists (explicit terminal-state UI with manual recovery).
2. **Backoff-reset anomaly** — `visibilitychange` fired `manualRetry()` on every refocus, resetting the attempt counter mid-outage (W14-A: 0.32s attempt after a 67.7s pause = refocus re-kick after background-tab timer throttling) and keeping the 12-attempt bar unreachable under tab churn. Refocus/`online` re-kicks now use a new `livenessKick()` that reconnects immediately **without** resetting backoff; only the user-clicked Retry resets.
3. **AC-18 queue never engaged** — `patchTrackerRecord` queued only on `navigator.onLine === false`; a network-level fetch `TypeError` with `onLine` still true threw straight to the failure Flashbar. Mutations now queue on fetch `TypeError` too (HTTP 4xx/5xx/409/401 still throw). SW-level Workbox BackgroundSync removed from the mutation routes — with the app-layer queue engaging on network failure, a second SW queue would double-replay; the app-layer queue is the single replay authority (If-Match aware, drives UI pendingCount). `WORKBOX_STRATEGY_MAP` mutations entry: `NetworkOnly+AppLayerQueue`.
4. **ka cadence** — documented `OBSERVED_SERVER_KA_CADENCE_MS = 60_000` (W14-A: 60.0s median, n=59, vs 30s spec text). Liveness is `connectionTimeoutMs`-driven (from `connection_ack`, default 300s), so nothing depended on the 30s figure.

### Verification
- typecheck clean; vitest 306/306 (51 files) incl. 5 new tests (terminal emit order, livenessKick counter preservation + open-socket no-op, queue-on-TypeError, no-queue-on-HTTP-error, onLine=false fast path)
- `vite build` + bundle budget PASS; eslint findings identical to v4/main baseline (9 pre-existing, 0 new)
- Live forced-offline re-probe on gamma to follow post-deploy (AC-1/2/5 evidence)

Tracker: ENC-TSK-N04 · Session: ENC-SES-09A

CCI-0944dd48ccf34f37b46a35b7819752fa

🤖 Generated with [Claude Code](https://claude.com/claude-code)