### PR TITLE
[ENC-TSK-N28] Fix rhythm beat tracker API path 404s (sense/decide)

### DIFF
--- a/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
+++ b/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
@@ -71,5 +71,42 @@ class SenseConstraintTests(unittest.TestCase):
         self.assertEqual(snap["open_task_delta"], 2)
 
 
+class TrackerUrlShapeTests(unittest.TestCase):
+    """ENC-TSK-N28: tracker reads must use /records?project_id=, and the
+    dispatch-plan URL must not double the /api/v1 prefix."""
+
+    @mock.patch("tiers.sense.get_json", return_value={"total": 7})
+    def test_sense_open_task_count_url_shape(self, get_json):
+        import tiers.sense as sense
+
+        with mock.patch.object(sense, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
+            count = sense._open_task_count()
+        self.assertEqual(count, 7)
+        url, params = get_json.call_args[0]
+        self.assertEqual(url, "https://x/api/v1/tracker/records")
+        self.assertEqual(params["project_id"], sense.PROJECT_ID)
+
+    @mock.patch("tiers.decide.get_json", return_value={"records": []})
+    def test_decide_open_leaf_tasks_url_shape(self, get_json):
+        import tiers.decide as decide
+
+        with mock.patch.object(decide, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
+            leaves = decide._open_leaf_tasks()
+        self.assertEqual(leaves, [])
+        url, params = get_json.call_args[0]
+        self.assertEqual(url, "https://x/api/v1/tracker/records")
+        self.assertEqual(params["project_id"], decide.PROJECT_ID)
+
+    @mock.patch("tiers.decide.post_json", return_value={"dispatches": []})
+    def test_decide_dispatch_plan_no_double_prefix(self, post_json):
+        import tiers.decide as decide
+
+        with mock.patch.object(decide, "COORDINATION_API_BASE", "https://x/api/v1"):
+            decide._dispatch_plan_dry_run({"beat_type": "sense"})
+        url = post_json.call_args[0][0]
+        self.assertEqual(url, "https://x/api/v1/coordination/dispatch-plan/dry-run")
+        self.assertNotIn("/api/v1/api/v1", url)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/lambda/rhythm_cycle/tiers/decide.py
+++ b/backend/lambda/rhythm_cycle/tiers/decide.py
@@ -28,8 +28,10 @@ _sns = boto3.client("sns")
 def _open_leaf_tasks() -> List[Dict[str, Any]]:
     if not TRACKER_API_BASE:
         return []
-    url = f"{TRACKER_API_BASE}/{PROJECT_ID}/records"
-    data = get_json(url, {"status": "open", "record_type": "task", "page_size": 100})
+    # ENC-TSK-N28: gamma tracker API serves /records?project_id=... (the
+    # /{project_id}/records path shape 404s).
+    url = f"{TRACKER_API_BASE}/records"
+    data = get_json(url, {"project_id": PROJECT_ID, "status": "open", "record_type": "task", "page_size": 100})
     records = data.get("records") or []
     return [r for r in records if not r.get("parent") and r.get("orphan")]
 
@@ -37,7 +39,8 @@ def _open_leaf_tasks() -> List[Dict[str, Any]]:
 def _dispatch_plan_dry_run(snapshot: Dict[str, Any]) -> Dict[str, Any]:
     if not COORDINATION_API_BASE:
         return {"dry_run": True, "dispatches": [], "reason": "coordination_api_unconfigured"}
-    url = f"{COORDINATION_API_BASE}/api/v1/coordination/dispatch-plan/dry-run"
+    # ENC-TSK-N28: COORDINATION_API_BASE already ends in /api/v1 — do not re-prefix.
+    url = f"{COORDINATION_API_BASE}/coordination/dispatch-plan/dry-run"
     try:
         return post_json(url, {"project_id": PROJECT_ID, "sense_snapshot": snapshot})
     except Exception as exc:
@@ -54,6 +57,10 @@ def _in_preapproved_scope(record_id: str, scopes: List[str]) -> bool:
 
 
 def _create_escalation(target_record_id: str, summary: str) -> Dict[str, Any]:
+    # TODO(ENC-TSK-N28 follow-up): escalation route shape unverified on gamma APIGW.
+    # tracker_mutation's _RE_ESCALATION accepts /{project}/escalation (optional
+    # /api/v1/tracker prefix), but no explicit RouteKey exists in
+    # infrastructure/cloudformation — orchestrator ENC-SES-09B to confirm live shape.
     url = f"{TRACKER_API_BASE}/{PROJECT_ID}/escalation"
     return post_json(
         url,

--- a/backend/lambda/rhythm_cycle/tiers/sense.py
+++ b/backend/lambda/rhythm_cycle/tiers/sense.py
@@ -69,8 +69,10 @@ def _checkout_census() -> List[Dict[str, Any]]:
 def _open_task_count() -> int:
     if not TRACKER_API_BASE:
         return 0
-    url = f"{TRACKER_API_BASE}/{PROJECT_ID}/records"
-    data = get_json(url, {"status": "open", "record_type": "task", "page_size": 1})
+    # ENC-TSK-N28: gamma tracker API serves /records?project_id=... (the
+    # /{project_id}/records path shape 404s).
+    url = f"{TRACKER_API_BASE}/records"
+    data = get_json(url, {"project_id": PROJECT_ID, "status": "open", "record_type": "task", "page_size": 1})
     return int(data.get("total") or data.get("count") or 0)
 
 


### PR DESCRIPTION
## Summary
- `sense.py/_open_task_count` and `decide.py/_open_leaf_tasks`: tracker reads now use `{TRACKER_API_BASE}/records` with `project_id` as a query param — the `/{project_id}/records` path shape 404s on gamma (live-probed 200 on the query-param shape).
- `decide.py/_dispatch_plan_dry_run`: dropped the duplicated `/api/v1` prefix (`COORDINATION_API_BASE` already ends in `/api/v1`).
- `decide.py/_create_escalation`: left as-is with a TODO — no explicit APIGW RouteKey for the escalation POST was found in `infrastructure/cloudformation`; orchestrator ENC-SES-09B follow-up.
- `tiers/heavy_integrate.py` deliberately untouched (its double-prefix fix belongs to ENC-TSK-N18).
- Added `TrackerUrlShapeTests` (3 tests, mocked `http_client`); `pytest backend/lambda/rhythm_cycle/` 9 passed.

## Governance
Task: ENC-TSK-N28 (P0, PLN-078 W0a)
Commit gate token: CCI-d45a9f44dc9c4e2c88cedde01ff0d805

🤖 Generated with [Claude Code](https://claude.com/claude-code)