### PR TITLE
[ENC-TSK-N18] Rhythm tenant invoker + AppConfig tenant flags + completion-stanza contract

### DIFF
--- a/.github/workflows/cloudformation-rhythm-tenants-stack-deploy.yml
+++ b/.github/workflows/cloudformation-rhythm-tenants-stack-deploy.yml
@@ -1,0 +1,230 @@
+name: CloudFormation Rhythm Tenants Stack Deploy
+
+# ENC-TSK-N18: 11-appconfig-rhythm-tenants.yaml is a new, additive AppConfig
+# configuration profile (rhythm-tenants) under the existing Application/
+# Environment from 06-feature-flags.yaml. Mirrors
+# cloudformation-appconfig-governance-stack-deploy.yml (09-appconfig-
+# governance.yaml's workflow) exactly — same plan/apply split with a GitHub
+# Environment gate (ENC-TSK-J63 / ENC-FTR-120).
+#
+# Bootstrap note: on first CREATE for a given stack, AppConfigApplicationId /
+# AppConfigEnvironmentId must be supplied (no stored prior value to reuse —
+# same gap 09's workflow docstring calls out). Pass them once via
+# workflow_dispatch inputs; subsequent pushes reuse the stack's stored values.
+
+on:
+  push:
+    branches:
+      - main
+      - 'v4/**'
+    paths:
+      - "infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml"
+      - ".github/workflows/cloudformation-rhythm-tenants-stack-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      stack_name:
+        description: "CloudFormation stack name for 11-appconfig-rhythm-tenants template"
+        type: string
+        required: false
+        default: "enceladus-rhythm-tenants"
+      appconfig_application_id:
+        description: "AppConfig Application ID (06-feature-flags Outputs.ApplicationId) — required on first CREATE only"
+        type: string
+        required: false
+        default: ""
+      appconfig_environment_id:
+        description: "AppConfig Environment ID (06-feature-flags Outputs.EnvironmentId) — required on first CREATE only"
+        type: string
+        required: false
+        default: ""
+      reason:
+        description: "Why this deploy is being triggered"
+        type: string
+        required: false
+        default: "manual rhythm-tenants stack deploy"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cloudformation-rhythm-tenants-stack-deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  TEMPLATE_FILE: infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
+  ENVIRONMENT_SUFFIX: ${{ startsWith(github.ref, 'refs/heads/v4/') && '-gamma' || '' }}
+  DEFAULT_STACK_NAME: enceladus-rhythm-tenants
+
+jobs:
+  plan:
+    name: Plan Rhythm Tenants stack change-set
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_name: ${{ steps.params.outputs.stack_name }}
+      has_changes: ${{ steps.changeset.outputs.has_changes }}
+      changeset_arn: ${{ steps.changeset.outputs.changeset_arn }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC CloudFormation role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Resolve deployment parameters
+        id: params
+        run: |
+          set -euo pipefail
+          stack_name="${{ github.event.inputs.stack_name || env.DEFAULT_STACK_NAME }}${ENVIRONMENT_SUFFIX}"
+          echo "stack_name=${stack_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Clean up ROLLBACK_COMPLETE stack if present (gamma self-heal, prod fail-closed)
+        run: |
+          set -euo pipefail
+          stack_name="${{ steps.params.outputs.stack_name }}"
+          status=$(aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${stack_name}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          if [ "${status}" = "ROLLBACK_COMPLETE" ]; then
+            if [ "${ENVIRONMENT_SUFFIX}" = "-gamma" ]; then
+              echo "Stack ${stack_name} is in ROLLBACK_COMPLETE — deleting before redeploy (gamma self-heal)"
+              aws cloudformation delete-stack \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              aws cloudformation wait stack-delete-complete \
+                --region "${AWS_REGION}" \
+                --stack-name "${stack_name}"
+              echo "Stack deleted successfully"
+            else
+              echo "::error::Prod stack ${stack_name} is in ROLLBACK_COMPLETE — refusing to auto-delete a prod stack; remediate manually."
+              exit 1
+            fi
+          fi
+
+      - name: Create Rhythm Tenants stack change-set (no execute)
+        id: changeset
+        run: |
+          set -euo pipefail
+
+          param_overrides="EnvironmentSuffix=${ENVIRONMENT_SUFFIX}"
+          if [ -n "${{ github.event.inputs.appconfig_application_id }}" ]; then
+            param_overrides="${param_overrides} AppConfigApplicationId=${{ github.event.inputs.appconfig_application_id }}"
+          fi
+          if [ -n "${{ github.event.inputs.appconfig_environment_id }}" ]; then
+            param_overrides="${param_overrides} AppConfigEnvironmentId=${{ github.event.inputs.appconfig_environment_id }}"
+          fi
+
+          aws cloudformation deploy \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ steps.params.outputs.stack_name }}" \
+            --template-file "${TEMPLATE_FILE}" \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --no-execute-changeset \
+            --s3-bucket enceladus-cfn-staging-us-west-2 \
+            --s3-prefix 11-appconfig-rhythm-tenants/ \
+            --parameter-overrides ${param_overrides} 2>&1 | tee /tmp/plan.log
+
+          if grep -q "No changes to deploy" /tmp/plan.log; then
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "changeset_arn=" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## Rhythm Tenants stack plan — ${{ steps.params.outputs.stack_name }}"
+              echo "No changes to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changeset_arn=$(grep -oE 'arn:aws:cloudformation:[^ "]*changeSet/[^ "]*' /tmp/plan.log | head -1)
+          if [ -z "${changeset_arn}" ]; then
+            echo "::error::Change-set creation output did not contain a change-set ARN."
+            exit 1
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+          echo "changeset_arn=${changeset_arn}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write change-set summary for the approval screen
+        if: steps.changeset.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## Rhythm Tenants stack plan — ${{ steps.params.outputs.stack_name }}"
+            echo ""
+            echo "Change-set: \`${{ steps.changeset.outputs.changeset_arn }}\`"
+            echo ""
+            echo '```'
+            aws cloudformation describe-change-set \
+              --region "${AWS_REGION}" \
+              --change-set-name "${{ steps.changeset.outputs.changeset_arn }}" \
+              --query 'Changes[].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType,Replacement:ResourceChange.Replacement}' \
+              --output table
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  apply:
+    name: Apply Rhythm Tenants stack change-set
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # ENC-FTR-120: v3-prod carries a required-reviewer rule (io); v4-gamma has
+    # none. A main-branch run therefore pauses here as a rejectable request.
+    environment: ${{ startsWith(github.ref, 'refs/heads/v4/') && 'v4-gamma' || 'v3-prod' }}
+
+    steps:
+      - name: Configure AWS credentials (environment-scoped OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CLOUDFORMATION_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Execute reviewed change-set
+        id: deploy
+        run: |
+          set -euo pipefail
+          changeset_type=$(aws cloudformation describe-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}" \
+            --query 'ChangeSetType' --output text 2>/dev/null || echo "UPDATE")
+          aws cloudformation execute-change-set \
+            --region "${AWS_REGION}" \
+            --change-set-name "${{ needs.plan.outputs.changeset_arn }}"
+          if [ "${changeset_type}" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          else
+            aws cloudformation wait stack-update-complete \
+              --region "${AWS_REGION}" \
+              --stack-name "${{ needs.plan.outputs.stack_name }}"
+          fi
+
+      - name: Report stack events on failure
+        if: failure() && steps.deploy.conclusion == 'failure'
+        run: |
+          echo "=== Stack events (last 20) ==="
+          aws cloudformation describe-stack-events \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'StackEvents[:20].{Time:Timestamp,Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+            --output table || echo "(describe-stack-events unavailable)"
+
+      - name: Report deployed stack state
+        run: |
+          set -euo pipefail
+          aws cloudformation describe-stacks \
+            --region "${AWS_REGION}" \
+            --stack-name "${{ needs.plan.outputs.stack_name }}" \
+            --query 'Stacks[0].{StackName:StackName,StackStatus:StackStatus,LastUpdatedTime:LastUpdatedTime}' \
+            --output table

--- a/backend/lambda/rhythm_cycle/tenant_invoker.py
+++ b/backend/lambda/rhythm_cycle/tenant_invoker.py
@@ -1,0 +1,350 @@
+"""Rhythm tenant orchestration — ENC-TSK-N18 / BRD DOC-44230223DD1C §4.1.
+
+Heavy Integrate and Light Integrate become tenant ORCHESTRATORS: each beat
+resolves an ordered tenant manifest from AppConfig (application/environment
+shared with the rest of Enceladus per enceladus_shared.appconfig_flags idiom;
+dedicated configuration profile ``rhythm-tenants``, env-overridable — mirrors
+coordination_api/budget_hierarchy.py's ``_appconfig_budget_config`` pattern
+but adds an in-invocation cache since this fires on every beat). One boolean
+flag per tenant addresses as ``rhythm.tenant.<name>.enabled`` (physically the
+``enabled`` key nested under ``tenants.<name>`` in the profile JSON, since
+AppConfig hosted config is a single JSON document, not flat key/value flags).
+
+For each enabled tenant the beat fires an ASYNCHRONOUS (InvocationType=Event)
+Lambda invoke with a uniform payload and never waits — the beat must stay
+under a minute; tenants own their own timeouts. Tenants report completion by
+writing a JSON "stanza" (write_completion_stanza) to a per-beat S3 result
+prefix. The *next* occurrence of the same beat (12h later for heavy, 6h for
+light) aggregates the previous window's stanzas against the manifest it
+invoked, tracks a per-tenant consecutive-silence streak in the beat's own S3
+artifact (mirrors the existing deferral_streaks idiom previously in
+heavy_integrate.py), and emits an Enceladus/Rhythm CloudWatch stall metric
+once a tenant has been silent for two consecutive windows.
+
+A tenant's ``enabled`` flag doubles as its kill switch: flipping it false in
+AppConfig removes it from the manifest with no redeploy.
+
+The manifest ships with ZERO enabled tenants by default — this module is
+mechanism only. Wiring real tenants into the ``rhythm-tenants`` AppConfig
+profile is ENC-TSK-N23/N24's job.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+from artifact_store import read_latest
+from config import CLOUDWATCH_NAMESPACE, PROJECT_ID, S3_BUCKET, TIER_PREDECESSOR, artifact_prefix
+
+logger = logging.getLogger(__name__)
+
+_lambda = boto3.client("lambda")
+_s3 = boto3.client("s3")
+_cw = boto3.client("cloudwatch")
+
+# --- AppConfig retrieval: same extension/URL idiom as enceladus_shared
+# ---     .appconfig_flags / budget_hierarchy._appconfig_budget_config, but
+# ---     targeting a dedicated "rhythm-tenants" configuration profile, with
+# ---     an in-invocation cache (ENC-TSK-N18 requires caching; the beat can
+# ---     call get_manifest() more than once per invocation).
+_APPCONFIG_PORT = os.environ.get("AWS_APPCONFIG_EXTENSION_HTTP_PORT", "2772")
+_APPCONFIG_CONFIGURATION = os.environ.get("RHYTHM_TENANTS_APPCONFIG_CONFIGURATION", "rhythm-tenants")
+_CACHE: Dict[str, Any] = {}
+_CACHE_AT: float = 0.0
+_CACHE_TTL: float = float(os.environ.get("AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS", "45"))
+
+# Two consecutive silent windows before a tenant is considered stalled
+# (DOC-44230223DD1C §4.1: "two consecutive silent windows").
+STALL_THRESHOLD = 2
+
+# ENC-TSK-N21 will replace this with a real governed-identity mint; the
+# payload field is designed now so tenants can start reading it today.
+SESSION_IDENTITY_PLACEHOLDER = os.environ.get(
+    "RHYTHM_TENANT_SESSION_IDENTITY", "rhythm-cycle-beat-unidentified"
+)
+
+
+def _fetch_tenant_config() -> Dict[str, Any]:
+    app = os.environ.get("APPCONFIG_APPLICATION", "")
+    env = os.environ.get("APPCONFIG_ENVIRONMENT", "")
+    if not app or not env:
+        return {}
+    url = (
+        f"http://localhost:{_APPCONFIG_PORT}/applications/{app}/environments/{env}"
+        f"/configurations/{_APPCONFIG_CONFIGURATION}"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=1) as resp:  # noqa: S310 - localhost extension
+            data = json.loads(resp.read())
+        return data if isinstance(data, dict) else {}
+    except (urllib.error.URLError, OSError, ValueError):
+        return {}
+
+
+def _tenant_config() -> Dict[str, Any]:
+    global _CACHE, _CACHE_AT
+    now = time.monotonic()
+    if not _CACHE or now - _CACHE_AT >= _CACHE_TTL:
+        fresh = _fetch_tenant_config()
+        if fresh:
+            _CACHE = fresh
+            _CACHE_AT = now
+    return _CACHE
+
+
+@dataclass
+class TenantDef:
+    name: str
+    beat: str
+    function_name: str
+    order: int = 0
+    expected_output_contract: Dict[str, Any] = field(default_factory=dict)
+
+
+def get_manifest(beat_type: str) -> List[TenantDef]:
+    """Ordered, enabled-only tenant manifest for ``beat_type``.
+
+    Reads the ``tenants`` object from the ``rhythm-tenants`` AppConfig
+    profile: ``{"tenants": {"<name>": {"beat": ..., "enabled": ..., ...}}}``.
+    A tenant is included only if its ``beat`` matches and ``enabled`` is
+    true — the same flag is the kill switch. Ordering is by explicit
+    ``order`` (ties broken by name) so manifest order never depends on JSON
+    key order.
+    """
+    tenants = (_tenant_config().get("tenants") or {})
+    out: List[TenantDef] = []
+    if not isinstance(tenants, dict):
+        return out
+    for name, raw in tenants.items():
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("beat") != beat_type:
+            continue
+        if not bool(raw.get("enabled", False)):
+            continue
+        function_name = str(raw.get("function_name") or "").strip()
+        if not function_name:
+            logger.warning("rhythm tenant %s enabled but missing function_name; skipping", name)
+            continue
+        out.append(
+            TenantDef(
+                name=str(name),
+                beat=beat_type,
+                function_name=function_name,
+                order=int(raw.get("order") or 0),
+                expected_output_contract=dict(raw.get("expected_output_contract") or {}),
+            )
+        )
+    out.sort(key=lambda t: (t.order, t.name))
+    return out
+
+
+def result_prefix_for(beat_type: str, beat_ts: datetime) -> str:
+    """Per-beat S3 result prefix tenants write completion stanzas under."""
+    ts = beat_ts.astimezone(timezone.utc)
+    return (
+        f"{artifact_prefix()}/{beat_type}/tenant-results/"
+        f"{ts.year:04d}{ts.month:02d}{ts.day:02d}-{ts.hour:02d}{ts.minute:02d}{ts.second:02d}"
+    )
+
+
+def invoke_tenants(
+    beat_type: str,
+    beat_ts: datetime,
+    predecessor_artifact_key: Optional[str],
+    manifest: Optional[List[TenantDef]] = None,
+) -> Dict[str, Any]:
+    """Fire-and-forget (Event) invoke every enabled tenant for this beat.
+
+    Never blocks on and never raises for an individual tenant's invoke
+    failure — logs and continues, since the beat must stay under a minute
+    and tenants own their own completion/timeout handling.
+    """
+    manifest = get_manifest(beat_type) if manifest is None else manifest
+    prefix = result_prefix_for(beat_type, beat_ts)
+    beat_iso = beat_ts.astimezone(timezone.utc).isoformat()
+    invoked: List[Dict[str, Any]] = []
+
+    for tenant in manifest:
+        result_key = f"{prefix}/{tenant.name}.json"
+        payload = {
+            "beat_id": f"{beat_type}-{beat_iso}",
+            "beat_type": beat_type,
+            "beat_at": beat_iso,
+            "predecessor_artifact_key": predecessor_artifact_key,
+            "expected_output_contract": tenant.expected_output_contract,
+            # ENC-TSK-N21 governed-identity field; placeholder until it lands.
+            "session_identity": SESSION_IDENTITY_PLACEHOLDER,
+            "result_key": result_key,
+        }
+        try:
+            _lambda.invoke(
+                FunctionName=tenant.function_name,
+                InvocationType="Event",
+                Payload=json.dumps(payload).encode("utf-8"),
+            )
+            invoked.append({"name": tenant.name, "function_name": tenant.function_name, "result_key": result_key})
+        except Exception as exc:  # noqa: BLE001 - one tenant's failure must never break the beat
+            logger.warning(
+                "async invoke failed tenant=%s fn=%s: %s", tenant.name, tenant.function_name, exc
+            )
+
+    return {
+        "beat_type": beat_type,
+        "result_prefix": prefix,
+        "invoked_tenants": invoked,
+        "manifest_size": len(manifest),
+    }
+
+
+def write_completion_stanza(
+    result_key: str, tenant_name: str, status: str, detail: Optional[Dict[str, Any]] = None
+) -> None:
+    """Contract helper for tenant Lambdas: write their completion stanza.
+
+    Not yet called by any tenant in this repo (ENC-TSK-N23/N24 wires real
+    tenants) — the shape is fixed now so the contract doesn't move under
+    them later. ``result_key`` is the value the beat sent as
+    ``payload["result_key"]``.
+    """
+    body = {
+        "tenant": tenant_name,
+        "status": status,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail or {},
+    }
+    _s3.put_object(
+        Bucket=S3_BUCKET,
+        Key=result_key,
+        Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _list_stanza_tenants(result_prefix: str) -> List[str]:
+    if not result_prefix:
+        return []
+    prefix = result_prefix.rstrip("/") + "/"
+    found: List[str] = []
+    token: Optional[str] = None
+    while True:
+        kwargs: Dict[str, Any] = {"Bucket": S3_BUCKET, "Prefix": prefix}
+        if token:
+            kwargs["ContinuationToken"] = token
+        try:
+            resp = _s3.list_objects_v2(**kwargs)
+        except Exception as exc:
+            logger.warning("list_objects_v2 failed prefix=%s: %s", result_prefix, exc)
+            return found
+        for obj in resp.get("Contents", []):
+            key = obj.get("Key", "")
+            name = key[len(prefix):]
+            if name.endswith(".json"):
+                name = name[: -len(".json")]
+            if name:
+                found.append(name)
+        token = resp.get("NextContinuationToken")
+        if not token:
+            break
+    return found
+
+
+def check_silent_tenants(
+    prior_invoked_names: List[str],
+    prior_result_prefix: Optional[str],
+    prior_streaks: Dict[str, int],
+) -> Dict[str, Any]:
+    """Compare the previous window's invoked tenants against the completion
+    stanzas actually found under its result prefix.
+
+    Returns updated per-tenant consecutive-silence streaks plus which
+    tenants just reached/crossed ``STALL_THRESHOLD``.
+    """
+    reported = set(_list_stanza_tenants(prior_result_prefix)) if prior_result_prefix else set()
+    invoked_set = set(prior_invoked_names)
+    streaks = {k: v for k, v in (prior_streaks or {}).items() if k in invoked_set}
+    silent: List[str] = []
+    stalled: List[str] = []
+
+    for name in prior_invoked_names:
+        if name in reported:
+            streaks[name] = 0
+        else:
+            streaks[name] = int(streaks.get(name, 0)) + 1
+            silent.append(name)
+            if streaks[name] >= STALL_THRESHOLD:
+                stalled.append(name)
+
+    return {
+        "silent_tenants": silent,
+        "stalled_tenants": stalled,
+        "tenant_silence_streaks": streaks,
+        "reporting_tenants": sorted(reported & invoked_set),
+    }
+
+
+def emit_stall_metrics(beat_type: str, stalled_tenants: List[str]) -> None:
+    """Emit an Enceladus/Rhythm CloudWatch metric per tenant that just
+    crossed the stall threshold, suitable for alarming."""
+    for name in stalled_tenants:
+        try:
+            _cw.put_metric_data(
+                Namespace=CLOUDWATCH_NAMESPACE,
+                MetricData=[
+                    {
+                        "MetricName": "tenant_stall",
+                        "Dimensions": [
+                            {"Name": "Tier", "Value": beat_type},
+                            {"Name": "ProjectId", "Value": PROJECT_ID},
+                            {"Name": "Tenant", "Value": name},
+                        ],
+                        "Value": 1.0,
+                        "Unit": "Count",
+                    }
+                ],
+            )
+        except Exception as exc:
+            logger.warning("tenant_stall metric emission failed tenant=%s: %s", name, exc)
+
+
+def run_tenant_orchestration(beat_type: str, beat_ts: datetime) -> Dict[str, Any]:
+    """Single entry point tier beats call: aggregate the previous window's
+    tenant reports (silent-tenant + stall detection), then fire this
+    window's asynchronous tenant invocations. Never blocks/raises past a
+    handled tenant failure."""
+    predecessor_tier = TIER_PREDECESSOR.get(beat_type)
+    predecessor_artifact = read_latest(predecessor_tier) if predecessor_tier else None
+    predecessor_key = None
+    if predecessor_artifact:
+        predecessor_key = predecessor_artifact.get("timestamped_key") or predecessor_artifact.get("latest_key")
+
+    prior = read_latest(beat_type) or {}
+    prior_orch = prior.get("tenant_orchestration") or {}
+
+    silence = check_silent_tenants(
+        prior_invoked_names=[t["name"] for t in (prior_orch.get("invoked_tenants") or [])],
+        prior_result_prefix=prior_orch.get("result_prefix"),
+        prior_streaks=prior_orch.get("tenant_silence_streaks") or {},
+    )
+    emit_stall_metrics(beat_type, silence["stalled_tenants"])
+
+    invocation = invoke_tenants(beat_type, beat_ts, predecessor_key)
+    invocation.update(
+        {
+            "tenant_silence_streaks": silence["tenant_silence_streaks"],
+            "silent_tenants_last_window": silence["silent_tenants"],
+            "stalled_tenants": silence["stalled_tenants"],
+            "reporting_tenants_last_window": silence["reporting_tenants"],
+        }
+    )
+    return invocation

--- a/backend/lambda/rhythm_cycle/test_tenant_invoker.py
+++ b/backend/lambda/rhythm_cycle/test_tenant_invoker.py
@@ -1,0 +1,251 @@
+"""Unit tests for tenant_invoker (ENC-TSK-N18)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import tenant_invoker  # noqa: E402
+
+
+TENANT_CONFIG = {
+    "tenants": {
+        "zeta": {
+            "beat": "heavy_integrate",
+            "enabled": True,
+            "function_name": "enceladus-tenant-zeta",
+            "order": 20,
+        },
+        "alpha": {
+            "beat": "heavy_integrate",
+            "enabled": True,
+            "function_name": "enceladus-tenant-alpha",
+            "order": 10,
+            "expected_output_contract": {"schema_version": 1},
+        },
+        "killed": {
+            "beat": "heavy_integrate",
+            "enabled": False,
+            "function_name": "enceladus-tenant-killed",
+            "order": 5,
+        },
+        "wrong_beat": {
+            "beat": "light_integrate",
+            "enabled": True,
+            "function_name": "enceladus-tenant-wrong-beat",
+            "order": 1,
+        },
+        "missing_function_name": {
+            "beat": "heavy_integrate",
+            "enabled": True,
+            "order": 1,
+        },
+    }
+}
+
+
+class ManifestResolutionTests(unittest.TestCase):
+    @mock.patch.object(tenant_invoker, "_tenant_config", return_value=TENANT_CONFIG)
+    def test_filters_by_beat_and_orders(self, _cfg):
+        manifest = tenant_invoker.get_manifest("heavy_integrate")
+        names = [t.name for t in manifest]
+        # alpha (order 10) before zeta (order 20); wrong_beat excluded (light);
+        # killed excluded (enabled=False); missing_function_name excluded.
+        self.assertEqual(names, ["alpha", "zeta"])
+        self.assertEqual(manifest[0].expected_output_contract, {"schema_version": 1})
+
+    @mock.patch.object(tenant_invoker, "_tenant_config", return_value=TENANT_CONFIG)
+    def test_kill_flag_removes_tenant(self, _cfg):
+        manifest = tenant_invoker.get_manifest("heavy_integrate")
+        names = {t.name for t in manifest}
+        self.assertNotIn("killed", names)
+
+    @mock.patch.object(tenant_invoker, "_tenant_config", return_value={})
+    def test_empty_config_yields_empty_manifest(self, _cfg):
+        self.assertEqual(tenant_invoker.get_manifest("heavy_integrate"), [])
+
+    @mock.patch.object(tenant_invoker, "_tenant_config", return_value=TENANT_CONFIG)
+    def test_light_beat_filters_independently(self, _cfg):
+        manifest = tenant_invoker.get_manifest("light_integrate")
+        self.assertEqual([t.name for t in manifest], ["wrong_beat"])
+
+
+class InvokeTenantsTests(unittest.TestCase):
+    @mock.patch.object(tenant_invoker, "get_manifest")
+    @mock.patch.object(tenant_invoker, "_lambda")
+    def test_zero_enabled_tenants_makes_no_invoke_calls(self, mock_lambda, mock_manifest):
+        mock_manifest.return_value = []
+        result = tenant_invoker.invoke_tenants(
+            "heavy_integrate", datetime(2026, 7, 12, tzinfo=timezone.utc), "some/predecessor/key.json"
+        )
+        mock_lambda.invoke.assert_not_called()
+        self.assertEqual(result["invoked_tenants"], [])
+        self.assertEqual(result["manifest_size"], 0)
+
+    @mock.patch.object(tenant_invoker, "_lambda")
+    def test_uniform_payload_shape_and_async_invocation_type(self, mock_lambda):
+        manifest = [
+            tenant_invoker.TenantDef(
+                name="alpha",
+                beat="heavy_integrate",
+                function_name="enceladus-tenant-alpha",
+                order=1,
+                expected_output_contract={"schema_version": 1},
+            )
+        ]
+        beat_ts = datetime(2026, 7, 12, 6, 0, 0, tzinfo=timezone.utc)
+        result = tenant_invoker.invoke_tenants(
+            "heavy_integrate", beat_ts, "rhythm-cycle/decide/latest.json", manifest=manifest
+        )
+        mock_lambda.invoke.assert_called_once()
+        _, kwargs = mock_lambda.invoke.call_args
+        self.assertEqual(kwargs["FunctionName"], "enceladus-tenant-alpha")
+        self.assertEqual(kwargs["InvocationType"], "Event")
+        import json as _json
+
+        payload = _json.loads(kwargs["Payload"])
+        for field in (
+            "beat_id",
+            "beat_type",
+            "beat_at",
+            "predecessor_artifact_key",
+            "expected_output_contract",
+            "session_identity",
+            "result_key",
+        ):
+            self.assertIn(field, payload)
+        self.assertEqual(payload["predecessor_artifact_key"], "rhythm-cycle/decide/latest.json")
+        self.assertEqual(result["invoked_tenants"][0]["name"], "alpha")
+
+    @mock.patch.object(tenant_invoker, "_lambda")
+    def test_one_tenant_invoke_failure_does_not_raise_or_block_others(self, mock_lambda):
+        mock_lambda.invoke.side_effect = [Exception("boom"), None]
+        manifest = [
+            tenant_invoker.TenantDef(name="bad", beat="heavy_integrate", function_name="fn-bad", order=1),
+            tenant_invoker.TenantDef(name="good", beat="heavy_integrate", function_name="fn-good", order=2),
+        ]
+        result = tenant_invoker.invoke_tenants(
+            "heavy_integrate", datetime.now(timezone.utc), None, manifest=manifest
+        )
+        invoked_names = [t["name"] for t in result["invoked_tenants"]]
+        self.assertEqual(invoked_names, ["good"])
+
+
+class SilentTenantDetectionTests(unittest.TestCase):
+    @mock.patch.object(tenant_invoker, "_list_stanza_tenants", return_value=["alpha"])
+    def test_reporting_tenant_resets_streak(self, _list):
+        result = tenant_invoker.check_silent_tenants(
+            prior_invoked_names=["alpha", "beta"],
+            prior_result_prefix="rhythm-cycle/heavy_integrate/tenant-results/x",
+            prior_streaks={"alpha": 1, "beta": 1},
+        )
+        self.assertEqual(result["tenant_silence_streaks"]["alpha"], 0)
+        self.assertEqual(result["tenant_silence_streaks"]["beta"], 2)
+        self.assertEqual(result["silent_tenants"], ["beta"])
+        self.assertEqual(result["reporting_tenants"], ["alpha"])
+
+    @mock.patch.object(tenant_invoker, "_list_stanza_tenants", return_value=[])
+    def test_stall_threshold_crossed_at_two_consecutive_silences(self, _list):
+        result = tenant_invoker.check_silent_tenants(
+            prior_invoked_names=["gamma"],
+            prior_result_prefix="rhythm-cycle/heavy_integrate/tenant-results/x",
+            prior_streaks={"gamma": 1},
+        )
+        self.assertEqual(result["tenant_silence_streaks"]["gamma"], 2)
+        self.assertEqual(result["stalled_tenants"], ["gamma"])
+
+    @mock.patch.object(tenant_invoker, "_list_stanza_tenants", return_value=[])
+    def test_first_silent_window_does_not_yet_stall(self, _list):
+        result = tenant_invoker.check_silent_tenants(
+            prior_invoked_names=["gamma"], prior_result_prefix="p", prior_streaks={}
+        )
+        self.assertEqual(result["tenant_silence_streaks"]["gamma"], 1)
+        self.assertEqual(result["stalled_tenants"], [])
+
+    def test_no_prior_result_prefix_treats_all_as_silent(self):
+        result = tenant_invoker.check_silent_tenants(
+            prior_invoked_names=["gamma"], prior_result_prefix=None, prior_streaks={}
+        )
+        self.assertEqual(result["silent_tenants"], ["gamma"])
+
+    @mock.patch.object(tenant_invoker, "_list_stanza_tenants", return_value=[])
+    def test_streaks_drop_tenants_no_longer_invoked(self, _list):
+        result = tenant_invoker.check_silent_tenants(
+            prior_invoked_names=["gamma"], prior_result_prefix="p", prior_streaks={"retired_tenant": 5, "gamma": 0}
+        )
+        self.assertNotIn("retired_tenant", result["tenant_silence_streaks"])
+
+
+class StallMetricTests(unittest.TestCase):
+    @mock.patch.object(tenant_invoker, "_cw")
+    def test_emits_one_metric_per_stalled_tenant(self, mock_cw):
+        tenant_invoker.emit_stall_metrics("heavy_integrate", ["gamma", "delta"])
+        self.assertEqual(mock_cw.put_metric_data.call_count, 2)
+        _, kwargs = mock_cw.put_metric_data.call_args_list[0]
+        self.assertEqual(kwargs["Namespace"], tenant_invoker.CLOUDWATCH_NAMESPACE)
+        self.assertEqual(kwargs["MetricData"][0]["MetricName"], "tenant_stall")
+
+    @mock.patch.object(tenant_invoker, "_cw")
+    def test_no_stalled_tenants_emits_nothing(self, mock_cw):
+        tenant_invoker.emit_stall_metrics("heavy_integrate", [])
+        mock_cw.put_metric_data.assert_not_called()
+
+    @mock.patch.object(tenant_invoker, "_cw")
+    def test_metric_emission_failure_does_not_raise(self, mock_cw):
+        mock_cw.put_metric_data.side_effect = Exception("cw down")
+        tenant_invoker.emit_stall_metrics("heavy_integrate", ["gamma"])  # should not raise
+
+
+class RunTenantOrchestrationTests(unittest.TestCase):
+    @mock.patch.object(tenant_invoker, "invoke_tenants")
+    @mock.patch.object(tenant_invoker, "emit_stall_metrics")
+    @mock.patch.object(tenant_invoker, "check_silent_tenants")
+    @mock.patch.object(tenant_invoker, "read_latest")
+    def test_wires_predecessor_key_and_prior_streaks_through(
+        self, mock_read_latest, mock_check_silent, mock_emit, mock_invoke
+    ):
+        def read_latest_side_effect(tier):
+            if tier == "decide":  # TIER_PREDECESSOR["heavy_integrate"]
+                return {"timestamped_key": "rhythm-cycle/decide/2026/07/12/060000.json"}
+            if tier == "heavy_integrate":
+                return {
+                    "tenant_orchestration": {
+                        "invoked_tenants": [{"name": "alpha"}],
+                        "result_prefix": "rhythm-cycle/heavy_integrate/tenant-results/prior",
+                        "tenant_silence_streaks": {"alpha": 1},
+                    }
+                }
+            return None
+
+        mock_read_latest.side_effect = read_latest_side_effect
+        mock_check_silent.return_value = {
+            "silent_tenants": [],
+            "stalled_tenants": [],
+            "tenant_silence_streaks": {"alpha": 0},
+            "reporting_tenants": ["alpha"],
+        }
+        mock_invoke.return_value = {"beat_type": "heavy_integrate", "result_prefix": "new", "invoked_tenants": []}
+
+        beat_ts = datetime.now(timezone.utc)
+        result = tenant_invoker.run_tenant_orchestration("heavy_integrate", beat_ts)
+
+        mock_check_silent.assert_called_once_with(
+            prior_invoked_names=["alpha"],
+            prior_result_prefix="rhythm-cycle/heavy_integrate/tenant-results/prior",
+            prior_streaks={"alpha": 1},
+        )
+        mock_invoke.assert_called_once_with(
+            "heavy_integrate", beat_ts, "rhythm-cycle/decide/2026/07/12/060000.json"
+        )
+        self.assertEqual(result["tenant_silence_streaks"], {"alpha": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/rhythm_cycle/tiers/heavy_integrate.py
+++ b/backend/lambda/rhythm_cycle/tiers/heavy_integrate.py
@@ -1,18 +1,27 @@
-"""Heavy Integrate — full sweeps + contention deferral (ENC-TSK-K89/K90)."""
+"""Heavy Integrate — tenant orchestration beat (ENC-TSK-K89/K90, ENC-TSK-N18).
+
+Scope execution (embeddings/summarization/library_health) moved from
+in-beat stub marking to asynchronous tenant invocation via tenant_invoker —
+see DOC-44230223DD1C §4.1. The governance-hash recompute hook stays in-beat
+(it may become the first wired tenant later; ENC-TSK-N23/N24 decide), with
+its contention-deferral behavior against an active governance_hash_recompute
+checkout preserved from the prior implementation.
+"""
 
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, Set
 
+import tenant_invoker
 from artifact_store import read_latest, write_artifact
 from config import COORDINATION_API_BASE, PROJECT_ID
 from http_client import post_json
 
 logger = logging.getLogger(__name__)
 
-DEFERRAL_ALERT_THRESHOLD = 3
+BEAT_TYPE = "heavy_integrate"
 
 
 def _active_checkout_components(sense: Dict[str, Any]) -> Set[str]:
@@ -23,51 +32,40 @@ def _active_checkout_components(sense: Dict[str, Any]) -> Set[str]:
     return comps
 
 
-def _prior_deferrals() -> Dict[str, int]:
-    prior = read_latest("heavy_integrate") or {}
-    return dict(prior.get("deferral_streaks") or {})
+def _run_governance_recompute_hook(blocked: Set[str]) -> Dict[str, Any]:
+    """In-beat governance-hash recompute hook (preserved from the prior
+    executed_scopes-driven implementation, contention-deferred the same way:
+    skipped while governance_hash_recompute is an actively checked-out
+    component)."""
+    if "governance_hash_recompute" in blocked or not COORDINATION_API_BASE:
+        return {}
+    try:
+        # ENC-TSK-N18 fix: COORDINATION_API_BASE already ends in /api/v1 —
+        # the old f"{COORDINATION_API_BASE}/api/v1/governance/recompute"
+        # double-prefixed and 404'd.
+        return post_json(
+            f"{COORDINATION_API_BASE}/governance/recompute",
+            {"project_id": PROJECT_ID, "trigger": "rhythm-heavy-integrate"},
+        )
+    except Exception as exc:
+        logger.warning("hash recompute hook failed: %s", exc)
+        return {"error": str(exc)}
 
 
 def run_heavy_integrate() -> Dict[str, Any]:
     sense = read_latest("sense") or {}
     blocked = _active_checkout_components(sense)
-    streaks = _prior_deferrals()
+    beat_ts = datetime.now(timezone.utc)
 
-    scopes = ["embeddings", "summarization", "governance_hash_recompute", "library_health"]
-    deferred: List[str] = []
-    executed: List[str] = []
-
-    for scope in scopes:
-        if scope in blocked:
-            deferred.append(scope)
-            streaks[scope] = int(streaks.get(scope, 0)) + 1
-        else:
-            executed.append(scope)
-            streaks[scope] = 0
-
-    chronic = [s for s, n in streaks.items() if n >= DEFERRAL_ALERT_THRESHOLD]
-
-    recompute_result: Dict[str, Any] = {}
-    if "governance_hash_recompute" in executed and COORDINATION_API_BASE:
-        try:
-            recompute_result = post_json(
-                f"{COORDINATION_API_BASE}/api/v1/governance/recompute",
-                {"project_id": PROJECT_ID, "trigger": "rhythm-heavy-integrate"},
-            )
-        except Exception as exc:
-            logger.warning("hash recompute hook failed: %s", exc)
-            recompute_result = {"error": str(exc)}
+    recompute_result = _run_governance_recompute_hook(blocked)
+    tenant_orchestration = tenant_invoker.run_tenant_orchestration(BEAT_TYPE, beat_ts)
 
     report = {
-        "beat_type": "heavy_integrate",
-        "executed_scopes": executed,
-        "deferred_scopes": deferred,
-        "deferral_count": len(deferred),
-        "deferral_streaks": streaks,
-        "chronic_deferral_alert": chronic,
-        "embedding_refresh_window": True,
+        "beat_type": BEAT_TYPE,
         "recompute_backlog": recompute_result,
+        "tenant_orchestration": tenant_orchestration,
+        "embedding_refresh_window": True,
     }
-    keys = write_artifact("heavy_integrate", report, datetime.now(timezone.utc))
+    keys = write_artifact(BEAT_TYPE, report, beat_ts)
     report.update(keys)
     return report

--- a/backend/lambda/rhythm_cycle/tiers/light_integrate.py
+++ b/backend/lambda/rhythm_cycle/tiers/light_integrate.py
@@ -1,4 +1,9 @@
-"""Light Integrate — delta-only consolidation (ENC-TSK-K88)."""
+"""Light Integrate — delta-only consolidation + tenant orchestration
+(ENC-TSK-K88, ENC-TSK-N18).
+
+Scope execution routes through the same tenant_invoker mechanism as
+Heavy Integrate — see DOC-44230223DD1C §4.1.
+"""
 
 from __future__ import annotations
 
@@ -9,11 +14,14 @@ from typing import Any, Dict, List
 import boto3
 from boto3.dynamodb.conditions import Attr
 
+import tenant_invoker
 from artifact_store import read_latest, write_artifact
 from config import PROJECTS_TABLE
 
 logger = logging.getLogger(__name__)
 _ddb = boto3.resource("dynamodb")
+
+BEAT_TYPE = "light_integrate"
 
 
 def _changed_since(iso_ts: str) -> List[str]:
@@ -36,17 +44,21 @@ def _changed_since(iso_ts: str) -> List[str]:
 
 
 def run_light_integrate() -> Dict[str, Any]:
-    prior = read_latest("light_integrate") or {}
+    prior = read_latest(BEAT_TYPE) or {}
     since = str(prior.get("beat_at") or "")
     changed = _changed_since(since)
+    beat_ts = datetime.now(timezone.utc)
+
+    tenant_orchestration = tenant_invoker.run_tenant_orchestration(BEAT_TYPE, beat_ts)
 
     report = {
-        "beat_type": "light_integrate",
+        "beat_type": BEAT_TYPE,
         "changed_record_ids": changed,
         "delta_count": len(changed),
         "actions": ["fsrs_decay_tick", "incremental_doc_summary", "changed_graph_touch"],
+        "tenant_orchestration": tenant_orchestration,
         "embedding_refresh": False,
     }
-    keys = write_artifact("light_integrate", report, datetime.now(timezone.utc))
+    keys = write_artifact(BEAT_TYPE, report, beat_ts)
     report.update(keys)
     return report

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -7490,6 +7490,13 @@ Resources:
       Role: !GetAtt RhythmCycleRole.Arn
       Layers:
         - !Ref SharedLayerArn
+        # ENC-TSK-N18 / DOC-44230223DD1C §4.1: AppConfig extension layer, for
+        # tenant_invoker's rhythm-tenants manifest resolution (arch-conditional,
+        # same pattern as every other AppConfig-reading function below).
+        - !If
+          - HasAppConfigLayer
+          - !If [IsGamma, !Ref AppConfigExtensionLayerArnArm64, !Ref AppConfigExtensionLayerArnX86]
+          - !Ref AWS::NoValue
       Environment:
         Variables:
           PROJECT_ID: enceladus
@@ -7504,6 +7511,12 @@ Resources:
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
           PRE_APPROVED_DISPATCH_SCOPES: '["ENC-PLN-068","ENC-TSK-K"]'
           RHYTHM_SNS_TOPIC_ARN: !Ref RhythmBeatNotificationTopic
+          # ENC-TSK-N18: tenant_invoker AppConfig wiring. Configuration profile
+          # is additive/separate from feature-flags (see 10-appconfig-rhythm-
+          # tenants.yaml) — ships with zero enabled tenants.
+          APPCONFIG_APPLICATION: !If [HasAppConfigLayer, !Ref AppConfigApplicationId, !Ref "AWS::NoValue"]
+          APPCONFIG_ENVIRONMENT: !If [HasAppConfigLayer, !Ref AppConfigEnvironmentId, !Ref "AWS::NoValue"]
+          RHYTHM_TENANTS_APPCONFIG_CONFIGURATION: rhythm-tenants
       Tags:
         - Key: Project
           Value: enceladus
@@ -7565,6 +7578,28 @@ Resources:
                 Action:
                   - sns:Publish
                 Resource: !Ref RhythmBeatNotificationTopic
+              # ENC-TSK-N18 / DOC-44230223DD1C §4.1: async (Event) invoke of tenant
+              # Lambdas resolved from the rhythm-tenants AppConfig manifest. Scoped
+              # to the enceladus-tenant-* naming convention tenants are required to
+              # use (ENC-TSK-N23/N24 wire real tenants under this prefix) — additive,
+              # no tenant exists yet so this grant is inert until flags flip.
+              - Sid: RhythmTenantInvoke
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-tenant-*"
+        - PolicyName: AppConfigAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: AppConfigRead
+                Effect: Allow
+                Action:
+                  - appconfig:GetConfiguration
+                  - appconfig:GetLatestConfiguration
+                  - appconfig:StartConfigurationSession
+                Resource: "*"
 
   RhythmBeatNotificationTopic:
     Type: AWS::SNS::Topic

--- a/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
+++ b/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Enceladus Rhythm tenant manifest — ENC-TSK-N18 (DOC-44230223DD1C §4.1).
+  Adds a `rhythm-tenants` configuration profile under the EXISTING AppConfig
+  Application/Environment provisioned by 06-feature-flags.yaml, following the
+  precedent set by 09-appconfig-governance.yaml (additive, no other profile
+  touched). Each key under `tenants` is one tenant record consumed by
+  backend/lambda/rhythm_cycle/tenant_invoker.py::get_manifest():
+
+    {
+      "tenants": {
+        "<name>": {
+          "beat": "heavy_integrate" | "light_integrate",
+          "enabled": false,               # kill switch; false = not invoked
+          "function_name": "enceladus-tenant-<name>",
+          "order": 10,                    # manifest ordering (ties -> name)
+          "expected_output_contract": {}   # tenant-defined, opaque here
+        }
+      }
+    }
+
+  The `enabled` flag IS the addressable "rhythm.tenant.<name>.enabled" switch
+  from the BRD — AppConfig hosted config is a single JSON document rather
+  than flat key/value flags, so the flag is physically this nested boolean.
+
+  Ships with an EMPTY tenants object — zero enabled, invokable tenants by
+  default. No behavior change on gamma until ENC-TSK-N23/N24 populate it.
+
+Parameters:
+  EnvironmentSuffix:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "-gamma"]
+  AppConfigApplicationId:
+    Type: String
+    Description: >-
+      AppConfig Application ID from the 06-feature-flags stack Outputs
+      (ApplicationId). Pass via --parameter-overrides.
+  AppConfigEnvironmentId:
+    Type: String
+    Description: >-
+      AppConfig Environment ID from the 06-feature-flags stack Outputs
+      (EnvironmentId). Pass via --parameter-overrides.
+
+Resources:
+  RhythmTenantsProfile:
+    Type: AWS::AppConfig::ConfigurationProfile
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      Name: rhythm-tenants
+      LocationUri: hosted
+      Description: >-
+        Ordered tenant manifest for the rhythm_cycle Heavy/Light Integrate
+        beats (ENC-TSK-N18). One record per tenant; `enabled` is the kill
+        switch. Wiring real tenants is ENC-TSK-N23/N24.
+      Validators:
+        - Type: JSON_SCHEMA
+          Content: |
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "type": "object",
+              "properties": {
+                "tenants": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "beat": { "type": "string", "enum": ["heavy_integrate", "light_integrate"] },
+                      "enabled": { "type": "boolean" },
+                      "function_name": { "type": "string" },
+                      "order": { "type": "number" },
+                      "expected_output_contract": { "type": "object" }
+                    },
+                    "required": ["beat", "enabled", "function_name"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: rhythm-tenants
+
+  RhythmTenantsInitialVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      ConfigurationProfileId: !Ref RhythmTenantsProfile
+      ContentType: application/json
+      Description: "Initial version - empty manifest, zero enabled tenants (ENC-TSK-N18)"
+      Content: |
+        {
+          "tenants": {}
+        }
+
+  RhythmTenantsDeploymentStrategy:
+    Type: AWS::AppConfig::DeploymentStrategy
+    Properties:
+      Name: !Sub "enceladus-rhythm-tenants-immediate${EnvironmentSuffix}"
+      Description: Immediate activation, no bake time - matches feature-flags/governance precedent.
+      ReplicateTo: NONE
+      DeploymentDurationInMinutes: 0
+      FinalBakeTimeInMinutes: 0
+      GrowthFactor: 100
+      GrowthType: LINEAR
+
+  RhythmTenantsInitialDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties:
+      ApplicationId: !Ref AppConfigApplicationId
+      EnvironmentId: !Ref AppConfigEnvironmentId
+      ConfigurationProfileId: !Ref RhythmTenantsProfile
+      ConfigurationVersion: !Ref RhythmTenantsInitialVersion
+      DeploymentStrategyId: !Ref RhythmTenantsDeploymentStrategy
+      Description: "Initial activation - empty manifest, ENC-TSK-N18"
+
+Outputs:
+  RhythmTenantsProfileId:
+    Value: !Ref RhythmTenantsProfile
+    Export:
+      Name: !Sub "${AWS::StackName}-RhythmTenantsProfileId"

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -99,6 +99,13 @@
       ],
       "notes": "ENC-TSK-L82; mirrors cloudformation-monitoring-stack-deploy.yml plan/apply split; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
     },
+    "cloudformation-rhythm-tenants-stack-deploy.yml": {
+      "class": "conditional",
+      "gated_jobs": [
+        "apply"
+      ],
+      "notes": "ENC-TSK-N18; mirrors cloudformation-appconfig-governance-stack-deploy.yml plan/apply split for the new 11-appconfig-rhythm-tenants.yaml stack; apply environment by ref (v4/* -> v4-gamma, else v3-prod); ROLLBACK_COMPLETE cleanup is gamma-self-heal / prod-fail-closed"
+    },
     "cloudformation-ui-cdn-stack-deploy.yml": {
       "class": "conditional",
       "gated_jobs": [


### PR DESCRIPTION
## Summary

Implements BRD DOC-44230223DD1C §4.1: Heavy Integrate and Light Integrate beats become tenant orchestrators.

- New `backend/lambda/rhythm_cycle/tenant_invoker.py`: resolves an ordered, kill-flag-filtered tenant manifest from a dedicated AppConfig `rhythm-tenants` profile (mirrors the `enceladus_shared.appconfig_flags` / `budget_hierarchy._appconfig_budget_config` idiom, in-invocation cached), fires asynchronous `InvocationType=Event` Lambda invokes with a uniform payload (beat id + ISO ts, predecessor artifact S3 key, expected-output contract, placeholder governed-session-identity field for ENC-TSK-N21), and never blocks on tenant completion.
- Completion-stanza contract: tenants write a JSON stanza to a per-beat S3 result prefix (`write_completion_stanza`); the *next* occurrence of the same beat aggregates against the manifest it invoked, tracks per-tenant consecutive-silence streaks in the beat's own artifact, and emits an `Enceladus/Rhythm` CloudWatch `tenant_stall` metric after two consecutive silent windows.
- `tiers/heavy_integrate.py`: removed the no-op `executed_scopes`/`deferred_scopes` stub logic for embeddings/summarization/library_health, routed through `tenant_invoker`. Preserved the governance-hash recompute hook in-beat (contention-deferral against an active `governance_hash_recompute` checkout kept), and fixed the pre-existing double `/api/v1` prefix bug in its recompute URL.
- `tiers/light_integrate.py`: same `tenant_invoker` wiring for its scopes.
- `infrastructure/cloudformation/02-compute.yaml`: additive-only — AppConfig extension layer + env vars on `RhythmCycleFunction`, plus a `lambda:InvokeFunction` grant on `RhythmCycleRole` scoped to the `enceladus-tenant-*` naming convention. No EventBridge rule `State` fields touched (ENC-TSK-N19 territory) — rebased cleanly on latest `v4/main`, no overlap.
- `infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml` (new): additive AppConfig configuration profile under the existing Application/Environment (06-feature-flags.yaml), following the 09-appconfig-governance.yaml precedent. Ships with an **empty tenants manifest** — zero enabled, invokable tenants by default. No behavior change on gamma until ENC-TSK-N23/N24 populate it.
- `.github/workflows/cloudformation-rhythm-tenants-stack-deploy.yml` (new): plan/apply deploy workflow for the new stack, mirroring the appconfig-governance one.
- `backend/lambda/rhythm_cycle/test_tenant_invoker.py` (new): manifest resolution/ordering, kill-flag filtering, uniform async-invoke payload shape, per-tenant invoke-failure isolation, silent-tenant streak tracking, and stall-metric threshold behavior.

## Manifest / flag design (per BRD §4.1)

One `rhythm-tenants` AppConfig profile, one JSON doc: `{"tenants": {"<name>": {"beat", "enabled", "function_name", "order", "expected_output_contract"}}}`. The `enabled` flag *is* `rhythm.tenant.<name>.enabled` from the BRD and doubles as the kill switch (flip false, no redeploy). Ordering is explicit (`order`, ties by name) so it never depends on JSON key order.

## Known gaps / notes for reviewers

- Governed tracker arc (checkout/worklog/status-advance via MCP) is blocked: `checkout.task` returned `PERMISSION_DENIED: "Unauthorized: valid session or internal key required"` across 3 attempts with different arg shapes, despite a fresh `agent.register` + `agent.claim` (session ENC-SES-09F) succeeding immediately before. No `CCI-...` token could be minted as a result — flagging in case `PR Commit Gate` needs it and rejects this PR; that would itself be useful confirmation of the gate behavior.
- AC-4 (merge + gamma deploy green) will be evidenced via this PR's own CI once merged.

## Test plan

- [x] `python3 -m pytest backend/lambda/rhythm_cycle/ -q` — 25 passed (22 new/rhythm_cycle-scoped tests + 3 pre-existing from ENC-TSK-N28, all green together post-rebase)
- [ ] CI green on this PR (Governance Dictionary Guard, Lambda Workflow Coverage Guard, Secrets Guardrail, CI)
- [ ] Gamma Gen2 deploy green post-merge (`_deploy.yml` → `Deploy Lambda Artifacts (Gen2)`, branch `v4/main`)
- [ ] `cloudformation-compute-stack-deploy.yml` green post-merge (02-compute.yaml touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-03d6868218b748e086f51be2cc28f2a3 (minted by orchestrator ENC-SES-09B holding the ENC-TSK-N18 checkout; commit b6e1cda2)