### PR TITLE
[ENC-TSK-N20] Canonical cursor-paginated Lyapunov read (C4)

### DIFF
--- a/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
+++ b/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
@@ -91,8 +91,11 @@ class TrackerUrlShapeTests(unittest.TestCase):
         import tiers.decide as decide
 
         with mock.patch.object(decide, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
-            leaves = decide._open_leaf_tasks()
-        self.assertEqual(leaves, [])
+            backlog = decide._open_leaf_tasks()
+        self.assertEqual(backlog["leaves"], [])
+        self.assertEqual(backlog["page_count"], 1)
+        self.assertIsNone(backlog["cursor_terminus"])
+        self.assertFalse(backlog["truncated"])
         url, params = get_json.call_args[0]
         self.assertEqual(url, "https://x/api/v1/tracker/records")
         self.assertEqual(params["project_id"], decide.PROJECT_ID)
@@ -106,6 +109,99 @@ class TrackerUrlShapeTests(unittest.TestCase):
         url = post_json.call_args[0][0]
         self.assertEqual(url, "https://x/api/v1/coordination/dispatch-plan/dry-run")
         self.assertNotIn("/api/v1/api/v1", url)
+
+
+class DecideCursorPaginationTests(unittest.TestCase):
+    """ENC-TSK-N20 / BRD DOC-44230223DD1C §4.4 (C4): cursor-exhausted
+    paginated backlog read replacing the single-page + orphan-flag heuristic
+    (ENC-ISS-542)."""
+
+    def test_pagination_exhaustion_accumulates_across_pages(self):
+        import tiers.decide as decide
+
+        responses = [
+            {"records": [{"item_id": "ENC-TSK-A1"}, {"item_id": "ENC-TSK-A2"}], "next_cursor": "cur-1"},
+            {"records": [{"item_id": "ENC-TSK-A3"}], "next_cursor": "cur-2"},
+            {"records": [{"item_id": "ENC-TSK-A4"}]},  # no next_cursor -> natural exhaustion
+        ]
+        with mock.patch.object(decide, "TRACKER_API_BASE", "https://x/api/v1/tracker"), mock.patch.object(
+            decide, "get_json", side_effect=responses
+        ) as get_json:
+            backlog = decide._open_leaf_tasks()
+
+        self.assertEqual(len(backlog["leaves"]), 4)
+        self.assertEqual(backlog["page_count"], 3)
+        self.assertIsNone(backlog["cursor_terminus"])
+        self.assertFalse(backlog["truncated"])
+        # Second and third calls must forward the cursor from the prior response.
+        self.assertEqual(get_json.call_args_list[1][0][1]["next_cursor"], "cur-1")
+        self.assertEqual(get_json.call_args_list[2][0][1]["next_cursor"], "cur-2")
+        # First call must not carry a next_cursor param at all.
+        self.assertNotIn("next_cursor", get_json.call_args_list[0][0][1])
+
+    def test_leaf_filter_is_explicit_parent_absence_not_orphan_flag(self):
+        import tiers.decide as decide
+
+        records = [
+            {"item_id": "ENC-TSK-B1"},  # no parent key at all -> leaf
+            {"item_id": "ENC-TSK-B2", "parent": ""},  # empty parent -> leaf
+            {"item_id": "ENC-TSK-B3", "parent": "ENC-TSK-PARENT"},  # has parent -> not a leaf
+            {"item_id": "ENC-TSK-B4", "orphan": False},  # orphan flag false but no parent -> leaf
+            {"item_id": "ENC-TSK-B5", "orphan": True, "parent": "ENC-TSK-PARENT2"},  # orphan flag true but has parent -> not a leaf
+        ]
+        with mock.patch.object(decide, "TRACKER_API_BASE", "https://x/api/v1/tracker"), mock.patch.object(
+            decide, "get_json", return_value={"records": records}
+        ):
+            backlog = decide._open_leaf_tasks()
+
+        leaf_ids = {r["item_id"] for r in backlog["leaves"]}
+        self.assertEqual(leaf_ids, {"ENC-TSK-B1", "ENC-TSK-B2", "ENC-TSK-B4"})
+
+    def test_max_pages_guard_truncates_and_marks_artifact(self):
+        import tiers.decide as decide
+
+        def _always_more(url, params):
+            # Every page reports a record and a next_cursor that never empties,
+            # simulating a pathological/never-terminating tracker response.
+            return {"records": [{"item_id": "ENC-TSK-C1"}], "next_cursor": "cur-forever"}
+
+        with mock.patch.object(decide, "TRACKER_API_BASE", "https://x/api/v1/tracker"), mock.patch.object(
+            decide, "get_json", side_effect=_always_more
+        ) as get_json:
+            backlog = decide._open_leaf_tasks()
+
+        self.assertEqual(get_json.call_count, decide._MAX_PAGES)
+        self.assertEqual(backlog["page_count"], decide._MAX_PAGES)
+        self.assertTrue(backlog["truncated"])
+        self.assertEqual(backlog["cursor_terminus"], "cur-forever")
+        # Never loops unbounded — accumulates exactly one leaf per page.
+        self.assertEqual(len(backlog["leaves"]), decide._MAX_PAGES)
+
+    @mock.patch("tiers.decide._dispatch_plan_dry_run", return_value={"dispatches": []})
+    @mock.patch("tiers.decide.write_artifact")
+    @mock.patch("tiers.decide.read_latest", return_value={})
+    @mock.patch("tiers.decide.publish_lyapunov")
+    @mock.patch("tiers.decide._notify_beat")
+    def test_run_decide_artifact_records_pagination_fields(
+        self, _notify, _publish, read_latest, write_artifact, _dispatch
+    ):
+        import tiers.decide as decide
+
+        write_artifact.return_value = {"timestamped_key": "k", "latest_key": "l", "bytes": "1"}
+        read_latest.return_value = {}
+        backlog = {
+            "leaves": [{"item_id": "ENC-TSK-D1"}],
+            "page_count": 2,
+            "cursor_terminus": None,
+            "truncated": False,
+        }
+        with mock.patch.object(decide, "_open_leaf_tasks", return_value=backlog):
+            artifact = decide.run_decide()
+
+        self.assertEqual(artifact["backlog_open_leaves"], 1)
+        self.assertEqual(artifact["backlog_page_count"], 2)
+        self.assertIsNone(artifact["backlog_cursor_terminus"])
+        self.assertFalse(artifact["backlog_pagination_truncated"])
 
 
 if __name__ == "__main__":

--- a/backend/lambda/rhythm_cycle/tiers/decide.py
+++ b/backend/lambda/rhythm_cycle/tiers/decide.py
@@ -24,16 +24,69 @@ from metrics import publish_lyapunov
 logger = logging.getLogger(__name__)
 _sns = boto3.client("sns")
 
+# ENC-TSK-N20 / BRD DOC-44230223DD1C §4.4 (C4): defensive cap on pagination
+# depth. Never loop unbounded against the tracker API; if this is hit the
+# read is marked truncated in the decide artifact rather than silently
+# returning a partial count as if it were complete.
+_MAX_PAGES = 50
 
-def _open_leaf_tasks() -> List[Dict[str, Any]]:
+
+def _open_leaf_tasks() -> Dict[str, Any]:
+    """Cursor-exhausted paginated read of the open task backlog.
+
+    ENC-TSK-N20 / BRD §4.4 (C4): the prior implementation (ENC-ISS-542) issued
+    a single page_size=100 request with no cursor follow-through and filtered
+    leaves using the legacy `orphan` flag heuristic — silently truncating the
+    backlog on any project with more than 100 open tasks, and undercounting
+    whenever the orphan flag lagged reality. This version pages until the
+    tracker API's cursor (`next_cursor`) is exhausted, or the `_MAX_PAGES`
+    guard above is hit, and defines a leaf as a record with no `parent` field
+    set at all (explicit parent-absence) rather than the orphan flag.
+
+    Returns a dict: {leaves, page_count, cursor_terminus, truncated}.
+    cursor_terminus is the final outstanding next_cursor value if pagination
+    was cut short by the max_pages guard, else None (natural exhaustion) —
+    this is what makes the metric's completeness auditable from the decide
+    artifact (BRD §4.4).
+    """
     if not TRACKER_API_BASE:
-        return []
+        return {"leaves": [], "page_count": 0, "cursor_terminus": None, "truncated": False}
+
     # ENC-TSK-N28: gamma tracker API serves /records?project_id=... (the
     # /{project_id}/records path shape 404s).
     url = f"{TRACKER_API_BASE}/records"
-    data = get_json(url, {"project_id": PROJECT_ID, "status": "open", "record_type": "task", "page_size": 100})
-    records = data.get("records") or []
-    return [r for r in records if not r.get("parent") and r.get("orphan")]
+    leaves: List[Dict[str, Any]] = []
+    cursor = ""
+    page_count = 0
+    truncated = False
+
+    for _ in range(_MAX_PAGES):
+        params: Dict[str, Any] = {
+            "project_id": PROJECT_ID,
+            "status": "open",
+            "record_type": "task",
+            "page_size": 100,
+        }
+        if cursor:
+            params["next_cursor"] = cursor
+        data = get_json(url, params)
+        page_count += 1
+        records = data.get("records") or []
+        leaves.extend(r for r in records if not r.get("parent"))
+        cursor = data.get("next_cursor") or ""
+        if not cursor:
+            break
+    else:
+        # Loop ran out of iterations without the cursor naturally emptying —
+        # more pages remain beyond the defensive cap.
+        truncated = bool(cursor)
+
+    return {
+        "leaves": leaves,
+        "page_count": page_count,
+        "cursor_terminus": cursor or None,
+        "truncated": truncated,
+    }
 
 
 def _dispatch_plan_dry_run(snapshot: Dict[str, Any]) -> Dict[str, Any]:
@@ -90,7 +143,8 @@ def run_decide() -> Dict[str, Any]:
     prior_decide = read_latest("decide") or {}
     prior_leaves = int(prior_decide.get("backlog_open_leaves") or 0)
 
-    leaves = _open_leaf_tasks()
+    backlog = _open_leaf_tasks()
+    leaves = backlog["leaves"]
     leaf_count = len(leaves)
     delta = leaf_count - prior_leaves
     grooming = bool(os.environ.get("RHYTHM_GROOMING_EVENT", "").lower() in ("1", "true", "yes"))
@@ -126,6 +180,12 @@ def run_decide() -> Dict[str, Any]:
         "escalation_ids": escalated,
         "backlog_open_leaves": leaf_count,
         "backlog_open_leaves_delta": delta,
+        # ENC-TSK-N20 / BRD §4.4: page count + cursor terminus make the
+        # completeness of the Lyapunov read auditable from the artifact
+        # itself, rather than assumed.
+        "backlog_page_count": backlog["page_count"],
+        "backlog_cursor_terminus": backlog["cursor_terminus"],
+        "backlog_pagination_truncated": backlog["truncated"],
         "grooming": grooming,
     }
     keys = write_artifact("decide", artifact, datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary
- Replaces decide.py's single-page (page_size=100, no cursor) backlog read + orphan-flag heuristic with a cursor-exhausted paginated tracker read (BRD DOC-44230223DD1C section 4.4, conflict C4; ENC-ISS-542: list absence is never truth).
- Leaf tasks are now filtered by explicit parent-absence (no `parent` field set), not the legacy `orphan` flag.
- The decide artifact now records `backlog_page_count`, `backlog_cursor_terminus`, and `backlog_pagination_truncated` so the Lyapunov metric's completeness is auditable from the artifact itself.
- Pagination is bounded defensively at `_MAX_PAGES = 50`; if hit, the read is marked truncated rather than silently returning a partial count as complete. The 3-consecutive-non-decreasing pathology alarm (CloudWatch-side) is untouched — same `backlog_open_leaves` / `backlog_open_leaves_delta` metrics feed it.

CCI-bc286ce44a394d1e9c87cd5ee82c7ab9

Note: ENC-TSK-N21 will follow on this same file (backend/lambda/rhythm_cycle/tiers/decide.py).

## Test plan
- [x] `python3 -m pytest backend/lambda/rhythm_cycle/ -q` — 13 passed (4 new: pagination exhaustion/cursor-forwarding, leaf-filter explicit-parent-absence, max_pages guard/truncation, run_decide artifact field wiring)
- [ ] Gamma deploy green (post-merge, orchestrator-driven)
- [ ] Live decide beat artifact shows new fields (post-merge validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)