### PR TITLE
[ENC-TSK-N27] Coherence snapshots + Lyapunov pathology alarm

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -7789,14 +7789,28 @@ Resources:
         RoleArn: !GetAtt RhythmSchedulerRole.Arn
         Input: '{"tier":"coherence"}'
 
+  # ENC-TSK-N27 (N10 AC-2): backlog_open_leaves_delta is the per-Decide-beat
+  # Lyapunov delta already emitted by metrics.publish_lyapunov() (decide.py).
+  # "Non-decreasing" means delta >= 0 (the backlog failed to shrink that beat,
+  # including a flat/zero-delta beat -- not just strict growth). We alarm on
+  # the raw per-beat metric with ComparisonOperator=GreaterThanOrEqualToThreshold
+  # (Threshold=0) rather than metric-math DIFF(), since decide.py already
+  # computes the delta itself -- this is "the closest achievable with standard
+  # alarm math" for a pre-differenced metric. Statistic=Maximum + Period=10800
+  # (matches the 3h decide cadence, see RhythmDecideSchedule cron) +
+  # EvaluationPeriods=3 means: alarm if delta >= 0 held for 3 consecutive
+  # decide beats in a row (a genuine 9h stall/growth in convergence).
+  # Originally added under ENC-TSK-K93 with ComparisonOperator=GreaterThanThreshold
+  # (delta > 0 only), which misses the flat/delta==0 pathology case; corrected here.
   RhythmPathologyAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: RhythmActive
     Properties:
       AlarmName: !Sub "enceladus-rhythm-pathology${EnvironmentSuffix}"
       AlarmDescription: >-
-        ENC-TSK-K93: three consecutive non-decreasing Decide beats on
-        backlog_open_leaves_delta (Lyapunov pathology).
+        ENC-TSK-N27/K93: three consecutive non-decreasing Decide beats on
+        backlog_open_leaves_delta (Lyapunov pathology). Non-decreasing means
+        delta >= 0 (no convergence progress that beat).
       Namespace: Enceladus/Rhythm
       MetricName: backlog_open_leaves_delta
       Dimensions:
@@ -7810,7 +7824,7 @@ Resources:
       Period: 10800
       EvaluationPeriods: 3
       Threshold: 0
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       AlarmActions:
         - !Ref RhythmBeatNotificationTopic


### PR DESCRIPTION
## Summary
- N10 AC-1 (coherence snapshots at 00:00/12:00 UTC): verified already live — `tiers/coherence.py` writes snapshot artifacts via `artifact_store.write_artifact` at each coherence beat, and `RhythmCoherenceSchedule` (cron `0 0,12 * * ? *`, State ENABLED) is gated by `RhythmActive` (gamma + `RhythmCycleEnabled=true`, default true). No code change needed.
- N10 AC-2 (Lyapunov pathology alarm): the alarm resource already existed from ENC-TSK-K93 (`RhythmPathologyAlarm` in `infrastructure/cloudformation/02-compute.yaml`) but used `ComparisonOperator: GreaterThanThreshold`, which only fires when `backlog_open_leaves_delta` is strictly increasing — missing the flat/`delta==0` "non-decreasing" pathology case the AC calls for. Fixed to `GreaterThanOrEqualToThreshold` (delta >= 0 held for 3 consecutive 3h decide-beat periods = 9h stall/growth) and documented the exact semantics inline. `decide.py` (reserved by concurrent ENC-TSK-N20) was not touched — only referenced the existing `metrics.publish_lyapunov()` emission.

## Deploy effect
Additive-only change to `infrastructure/cloudformation/02-compute.yaml` (comment + `AlarmDescription` + one `ComparisonOperator` value); no new resources, no Python changes. Triggers `cloudformation-compute-stack-deploy.yml` on merge to `v4/main` (gamma).

## Test plan
- [x] `pytest backend/lambda/rhythm_cycle/ -q` — 43 passed (no Python changed; run as regression check)
- [x] `cfn-lint infrastructure/cloudformation/02-compute.yaml` — no new errors/warnings introduced near the edited resource (pre-existing SnapStart/S3-action warnings unrelated)
- [ ] Live: gamma deploy green (DPL evidence) + `aws cloudwatch describe-alarms` shows `enceladus-rhythm-pathology-gamma` armed (post-merge)

CCI-e7b5cee3cc6f42d69594cfaad5e6baf9

🤖 Generated with [Claude Code](https://claude.com/claude-code)