### PR TITLE
[ENC-TSK-N21] Governed beat identity via FTR-117 arc (C5)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.6",
-  "updated_at": "2026-07-12T12:45:00Z",
-  "last_change_summary": "ENC-TSK-N26: pre-cutover baseline capture tooling added to backend/lambda/rhythm_cycle/ -- new baseline.py module + a 'baseline_capture' entry in lambda_function.py's TIER_HANDLERS (standalone on-demand event mode, not part of the scheduled harmonic beat chain -- no TIER_ORDER/TIER_PREDECESSOR entry, no schedule resource). Writes one Sense-adjacent artifact covering percolation telemetry export, a fixed-query retrieval-quality run, a lesson citation-rate proxy, and corpus invariants, each independently degrading to an honest 'unavailable + reason' rather than failing the run. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.7",
+  "updated_at": "2026-07-12T13:30:00Z",
+  "last_change_summary": "ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: governed machine identity for the rhythm. New backend/lambda/rhythm_cycle/identity.py resolves-or-mints a real ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the same coordination-API surface (agent.register + agent.claim), caches it in the beat's own S3 artifact chain (tier=identity), and re-claims on sci TTL approach. lambda_function.py's run_beat() now attempts identity resolution on every beat (logs INFO on success, WARNING on degraded fallback) -- the touch guard applies here. tiers/decide.py's escalation writer replaces the hardcoded requested_by_session='rhythm-decide-beat' with the resolved identity (requested_by.session_id/agent_type_id/sci_present + top-level sci when present), falling back to the exact pre-N21 string when identity minting is degraded. tenant_invoker.py's session_identity payload field is now backed by the same resolved identity instead of its placeholder. New RHYTHM_AGENT_TYPE_ID env var (config.py, default empty = graceful degradation); wired to ENC-AGT-00C (minted via coordination agent.type.register, surface=eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard) in infrastructure/cloudformation/02-compute.yaml. No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -8384,6 +8384,11 @@
       "version": "2026-07-12.6",
       "date": "2026-07-12",
       "summary": "ENC-TSK-N26: pre-cutover baseline capture tooling added to backend/lambda/rhythm_cycle/ -- new baseline.py module + a 'baseline_capture' entry in lambda_function.py's TIER_HANDLERS (standalone on-demand event mode, not part of the scheduled harmonic beat chain -- no TIER_ORDER/TIER_PREDECESSOR entry, no schedule resource). Writes one Sense-adjacent artifact covering percolation telemetry export, a fixed-query retrieval-quality run, a lesson citation-rate proxy, and corpus invariants, each independently degrading to an honest 'unavailable + reason' rather than failing the run. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.7",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: governed machine identity for the rhythm. New backend/lambda/rhythm_cycle/identity.py resolves-or-mints a real ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the same coordination-API surface (agent.register + agent.claim), caches it in the beat's own S3 artifact chain (tier=identity), and re-claims on sci TTL approach. lambda_function.py's run_beat() now attempts identity resolution on every beat (logs INFO on success, WARNING on degraded fallback) -- the touch guard applies here. tiers/decide.py's escalation writer replaces the hardcoded requested_by_session='rhythm-decide-beat' with the resolved identity (requested_by.session_id/agent_type_id/sci_present + top-level sci when present), falling back to the exact pre-N21 string when identity minting is degraded. tenant_invoker.py's session_identity payload field is now backed by the same resolved identity instead of its placeholder. New RHYTHM_AGENT_TYPE_ID env var (config.py, default empty = graceful degradation); wired to ENC-AGT-00C (minted via coordination agent.type.register, surface=eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard) in infrastructure/cloudformation/02-compute.yaml. No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/rhythm_cycle/config.py
+++ b/backend/lambda/rhythm_cycle/config.py
@@ -17,6 +17,14 @@ COORDINATION_API_BASE = os.environ.get("COORDINATION_API_BASE", "").rstrip("/")
 GRAPH_QUERY_API_BASE = os.environ.get("GRAPH_QUERY_API_BASE", "").rstrip("/")
 INTERNAL_KEY = os.environ.get("COORDINATION_INTERNAL_API_KEY", "")
 
+# ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: agent_type_id for the rhythm's own
+# governed identity (identity.py). Default empty means identity minting is
+# skipped and beats gracefully degrade to their pre-N21 behavior (see
+# identity.resolve_identity) — this is expected until an ENC-AGT id is minted
+# and wired in here (or via the RHYTHM_AGENT_TYPE_ID Lambda env var).
+RHYTHM_AGENT_TYPE_ID = os.environ.get("RHYTHM_AGENT_TYPE_ID", "")
+RHYTHM_RUNTIME = os.environ.get("RHYTHM_RUNTIME", "lambda")
+
 CLOUDWATCH_NAMESPACE = os.environ.get("CLOUDWATCH_NAMESPACE", "Enceladus/Rhythm")
 SNS_TOPIC_ARN = os.environ.get("RHYTHM_SNS_TOPIC_ARN", "")
 

--- a/backend/lambda/rhythm_cycle/identity.py
+++ b/backend/lambda/rhythm_cycle/identity.py
@@ -1,0 +1,177 @@
+"""Governed machine identity for the rhythm cycle beat (ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3).
+
+Prior to this module, the rhythm wrote escalations under a hardcoded
+pseudo-identity (``requested_by_session="rhythm-decide-beat"``) that never
+resolved to a real governed ENC-SES session and could never carry a Session
+Claim ID (sci). That is a dead end under the FTR-122 SCI gate contract: any
+beat-originated write that must present a real session + sci would 403/fail
+closed the moment the gate's grandfather window closes.
+
+This module resolves-or-mints a governed identity for the rhythm Lambda
+itself, using the same coordination-API HTTP surface (COORDINATION_API_BASE +
+config.internal_headers()) the beat already reaches for dispatch-plan
+dry-runs (tiers/decide.py):
+
+* ``POST {COORDINATION_API_BASE}/coordination/agents/sessions`` — agent.register
+* ``POST {COORDINATION_API_BASE}/coordination/agents/sessions/claim`` — agent.claim,
+  which mints the session's Session Claim ID (sci)
+
+The resolved identity (session_id, agent_type_id, sci, sci_issued_at,
+sci_ttl_seconds) is cached in the beat's own S3 artifact chain (tier=
+"identity", via artifact_store) so that successor beat invocations reuse it
+rather than re-minting a session on every cold start, and the sci is
+re-claimed once its TTL is close to elapsing.
+
+Identity minting is entirely best-effort: RHYTHM_AGENT_TYPE_ID unset,
+COORDINATION_API_BASE unset, or any HTTP failure all degrade to
+``{"session_id": "", "sci": "", "degraded": True, ...}`` with a logged
+WARNING rather than a raised exception — a coordination-API outage or an
+un-minted agent type must never block a beat from running.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from artifact_store import read_latest, write_artifact
+from config import COORDINATION_API_BASE, RHYTHM_AGENT_TYPE_ID, RHYTHM_RUNTIME
+from http_client import post_json
+
+logger = logging.getLogger(__name__)
+
+_IDENTITY_TIER = "identity"
+
+# Re-claim this many seconds before the cached sci's TTL actually elapses, so
+# a long-running beat never straddles expiry mid-invocation (agent_id_alloc's
+# SCI_TTL_SECONDS default is 86400 — a 300s skew is a small fraction of that).
+_SCI_RENEW_SKEW_SECONDS = 300
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _sci_expired(cached: Dict[str, Any]) -> bool:
+    issued = _parse_iso(str(cached.get("sci_issued_at") or ""))
+    ttl = int(cached.get("sci_ttl_seconds") or 0)
+    if issued is None or ttl <= 0:
+        return True
+    age = (_now() - issued).total_seconds()
+    return age >= max(ttl - _SCI_RENEW_SKEW_SECONDS, 0)
+
+
+def _degraded(reason: str, session_id: str = "") -> Dict[str, Any]:
+    logger.warning("rhythm identity resolution degraded: %s", reason)
+    return {
+        "session_id": session_id,
+        "agent_type_id": RHYTHM_AGENT_TYPE_ID,
+        "sci": "",
+        "sci_issued_at": "",
+        "sci_ttl_seconds": 0,
+        "degraded": True,
+        "reason": reason,
+    }
+
+
+def _register_session() -> Dict[str, Any]:
+    """POST {COORDINATION_API_BASE}/coordination/agents/sessions — agent.register."""
+    url = f"{COORDINATION_API_BASE}/coordination/agents/sessions"
+    resp = post_json(
+        url,
+        {
+            "agent_type_id": RHYTHM_AGENT_TYPE_ID,
+            "runtime": RHYTHM_RUNTIME,
+            "parent_session_id": "root",
+        },
+    )
+    return resp.get("session") or {}
+
+
+def _claim_session(session_id: str) -> Dict[str, Any]:
+    """POST {COORDINATION_API_BASE}/coordination/agents/sessions/claim — agent.claim."""
+    url = f"{COORDINATION_API_BASE}/coordination/agents/sessions/claim"
+    return post_json(
+        url,
+        {"session_id": session_id, "expected_agent_type_id": RHYTHM_AGENT_TYPE_ID},
+    )
+
+
+def _mint_identity() -> Dict[str, Any]:
+    session = _register_session()
+    session_id = str(session.get("session_id") or "")
+    if not session_id:
+        raise RuntimeError("agent.register returned no session_id")
+    claim = _claim_session(session_id)
+    sci = str(claim.get("sci") or "")
+    if not sci:
+        raise RuntimeError(f"agent.claim for {session_id} returned no sci")
+    return {
+        "session_id": session_id,
+        "agent_type_id": RHYTHM_AGENT_TYPE_ID,
+        "sci": sci,
+        "sci_issued_at": str(claim.get("sci_issued_at") or ""),
+        "sci_ttl_seconds": int(claim.get("sci_ttl_seconds") or 0),
+        "degraded": False,
+        "reason": "",
+    }
+
+
+def _reclaim_identity(session_id: str) -> Dict[str, Any]:
+    claim = _claim_session(session_id)
+    sci = str(claim.get("sci") or "")
+    if not sci:
+        raise RuntimeError(f"re-claim of {session_id} returned no sci")
+    return {
+        "session_id": session_id,
+        "agent_type_id": RHYTHM_AGENT_TYPE_ID,
+        "sci": sci,
+        "sci_issued_at": str(claim.get("sci_issued_at") or ""),
+        "sci_ttl_seconds": int(claim.get("sci_ttl_seconds") or 0),
+        "degraded": False,
+        "reason": "",
+    }
+
+
+def resolve_identity() -> Dict[str, Any]:
+    """Resolve-or-mint the rhythm's governed identity, cached in the beat artifact chain.
+
+    Returns a dict with session_id/agent_type_id/sci/sci_issued_at/sci_ttl_seconds
+    and degraded=False on success. On any failure (unconfigured, gated agent
+    type, HTTP error) returns degraded=True with an empty sci (and, when a
+    prior session_id is cached, that session_id is carried through so callers
+    can log which identity they *would* have used) — callers must treat
+    ``degraded`` (or an empty ``sci``) as "identity unavailable" and fall back
+    to their pre-N21 behavior rather than raise.
+    """
+    if not COORDINATION_API_BASE:
+        return _degraded("COORDINATION_API_BASE unconfigured")
+    if not RHYTHM_AGENT_TYPE_ID:
+        return _degraded(
+            "RHYTHM_AGENT_TYPE_ID unset — rhythm_cycle agent type not minted/wired "
+            "(see ENC-TSK-N21 report; escalations fall back to pre-N21 behavior)"
+        )
+
+    cached = read_latest(_IDENTITY_TIER) or {}
+    session_id = str(cached.get("session_id") or "")
+
+    if session_id and not _sci_expired(cached):
+        return cached
+
+    try:
+        identity = _reclaim_identity(session_id) if session_id else _mint_identity()
+    except Exception as exc:  # noqa: BLE001 - identity minting must never block a beat
+        return _degraded(str(exc), session_id=session_id)
+
+    write_artifact(_IDENTITY_TIER, identity, _now())
+    return identity

--- a/backend/lambda/rhythm_cycle/lambda_function.py
+++ b/backend/lambda/rhythm_cycle/lambda_function.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict
 from artifact_store import read_latest
 from baseline import run_baseline_capture
 from config import TIER_PREDECESSOR
+from identity import resolve_identity
 from legacy_schedules import inventory_document
 from metrics import publish_beat_metrics
 from tiers.coherence import run_coherence
@@ -54,6 +55,23 @@ def run_beat(tier: str) -> Dict[str, Any]:
         pred_art = read_latest(predecessor)
         if pred_art is None:
             logger.warning("Predecessor artifact missing for tier=%s pred=%s", tier, predecessor)
+
+    # ENC-TSK-N21 / BRD §4.3: resolve-or-mint the rhythm's governed identity on
+    # every beat (cheap — cached in the "identity" S3 artifact tier and only
+    # re-mints/re-claims on cold cache or sci-TTL expiry). Never blocks the
+    # beat: identity.resolve_identity() degrades gracefully and logs its own
+    # WARNING on failure. Logged here (not just at escalation time) so every
+    # beat's CloudWatch log — not only decide's — shows an identity
+    # resolution attempt, which is this task's live-validation signal.
+    identity = resolve_identity()
+    if identity.get("degraded"):
+        logger.warning(
+            "rhythm identity resolution degraded for tier=%s: %s", tier, identity.get("reason")
+        )
+    else:
+        logger.info(
+            "rhythm identity resolved for tier=%s session_id=%s", tier, identity.get("session_id")
+        )
 
     started = time.perf_counter()
     result = TIER_HANDLERS[tier]()

--- a/backend/lambda/rhythm_cycle/tenant_invoker.py
+++ b/backend/lambda/rhythm_cycle/tenant_invoker.py
@@ -45,6 +45,7 @@ import boto3
 
 from artifact_store import read_latest
 from config import CLOUDWATCH_NAMESPACE, PROJECT_ID, S3_BUCKET, TIER_PREDECESSOR, artifact_prefix
+from identity import resolve_identity
 
 logger = logging.getLogger(__name__)
 
@@ -67,11 +68,22 @@ _CACHE_TTL: float = float(os.environ.get("AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_
 # (DOC-44230223DD1C §4.1: "two consecutive silent windows").
 STALL_THRESHOLD = 2
 
-# ENC-TSK-N21 will replace this with a real governed-identity mint; the
-# payload field is designed now so tenants can start reading it today.
+# ENC-TSK-N21: fallback used when governed-identity resolution is degraded
+# (RHYTHM_AGENT_TYPE_ID unset or the coordination API unreachable) — same
+# string the "session_identity" payload field carried before N21 landed.
 SESSION_IDENTITY_PLACEHOLDER = os.environ.get(
     "RHYTHM_TENANT_SESSION_IDENTITY", "rhythm-cycle-beat-unidentified"
 )
+
+
+def _session_identity() -> str:
+    """ENC-TSK-N21 / BRD §4.3: resolve the rhythm's governed ENC-SES identity
+    for the ``session_identity`` tenant-invoke payload field. Falls back to
+    SESSION_IDENTITY_PLACEHOLDER when identity resolution is degraded — never
+    raises, since one tenant's identity curiosity must never block a beat.
+    """
+    identity = resolve_identity()
+    return str(identity.get("session_id") or "") or SESSION_IDENTITY_PLACEHOLDER
 
 
 def _fetch_tenant_config() -> Dict[str, Any]:
@@ -174,6 +186,9 @@ def invoke_tenants(
     prefix = result_prefix_for(beat_type, beat_ts)
     beat_iso = beat_ts.astimezone(timezone.utc).isoformat()
     invoked: List[Dict[str, Any]] = []
+    # Resolved once per invoke_tenants call — every tenant in this beat shares
+    # the same governed identity (or the same degraded fallback).
+    session_identity = _session_identity()
 
     for tenant in manifest:
         result_key = f"{prefix}/{tenant.name}.json"
@@ -183,8 +198,9 @@ def invoke_tenants(
             "beat_at": beat_iso,
             "predecessor_artifact_key": predecessor_artifact_key,
             "expected_output_contract": tenant.expected_output_contract,
-            # ENC-TSK-N21 governed-identity field; placeholder until it lands.
-            "session_identity": SESSION_IDENTITY_PLACEHOLDER,
+            # ENC-TSK-N21 / BRD §4.3: governed rhythm identity (ENC-SES id, or
+            # SESSION_IDENTITY_PLACEHOLDER on degraded resolution).
+            "session_identity": session_identity,
             "result_key": result_key,
         }
         try:

--- a/backend/lambda/rhythm_cycle/test_identity.py
+++ b/backend/lambda/rhythm_cycle/test_identity.py
@@ -1,0 +1,147 @@
+"""Unit tests for identity (ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import identity  # noqa: E402
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+class ResolveIdentityConfigGateTests(unittest.TestCase):
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "")
+    def test_degraded_when_coordination_api_unconfigured(self):
+        result = identity.resolve_identity()
+        self.assertTrue(result["degraded"])
+        self.assertEqual(result["session_id"], "")
+        self.assertEqual(result["sci"], "")
+
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "")
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    def test_degraded_when_agent_type_unset(self):
+        result = identity.resolve_identity()
+        self.assertTrue(result["degraded"])
+        self.assertIn("RHYTHM_AGENT_TYPE_ID", result["reason"])
+
+
+class ResolveIdentityMintTests(unittest.TestCase):
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "ENC-AGT-00C")
+    @mock.patch.object(identity, "write_artifact")
+    @mock.patch.object(identity, "post_json")
+    @mock.patch.object(identity, "read_latest", return_value=None)
+    def test_mints_new_identity_when_no_cache(self, _read_latest, post_json, write_artifact):
+        post_json.side_effect = [
+            {"session": {"session_id": "ENC-SES-099"}},
+            {"sci": "SCI-abc123", "sci_issued_at": _iso(datetime.now(timezone.utc)), "sci_ttl_seconds": 86400},
+        ]
+        result = identity.resolve_identity()
+
+        self.assertFalse(result["degraded"])
+        self.assertEqual(result["session_id"], "ENC-SES-099")
+        self.assertEqual(result["sci"], "SCI-abc123")
+        register_call, claim_call = post_json.call_args_list
+        self.assertEqual(register_call.args[0], "https://x/api/v1/coordination/agents/sessions")
+        self.assertEqual(register_call.args[1]["agent_type_id"], "ENC-AGT-00C")
+        self.assertEqual(claim_call.args[0], "https://x/api/v1/coordination/agents/sessions/claim")
+        self.assertEqual(claim_call.args[1]["session_id"], "ENC-SES-099")
+        write_artifact.assert_called_once()
+        self.assertEqual(write_artifact.call_args.args[0], "identity")
+
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "ENC-AGT-00C")
+    @mock.patch.object(identity, "write_artifact")
+    @mock.patch.object(identity, "post_json")
+    def test_uses_cached_identity_when_sci_not_expired(self, post_json, _write_artifact):
+        cached = {
+            "session_id": "ENC-SES-100",
+            "agent_type_id": "ENC-AGT-00C",
+            "sci": "SCI-cached",
+            "sci_issued_at": _iso(datetime.now(timezone.utc) - timedelta(hours=1)),
+            "sci_ttl_seconds": 86400,
+            "degraded": False,
+        }
+        with mock.patch.object(identity, "read_latest", return_value=cached):
+            result = identity.resolve_identity()
+
+        self.assertEqual(result, cached)
+        post_json.assert_not_called()
+
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "ENC-AGT-00C")
+    @mock.patch.object(identity, "write_artifact")
+    @mock.patch.object(identity, "post_json")
+    def test_reclaims_when_sci_close_to_ttl_expiry(self, post_json, write_artifact):
+        cached = {
+            "session_id": "ENC-SES-101",
+            "agent_type_id": "ENC-AGT-00C",
+            "sci": "SCI-stale",
+            # issued nearly a full TTL ago — inside the renew skew window.
+            "sci_issued_at": _iso(datetime.now(timezone.utc) - timedelta(seconds=86400 - 60)),
+            "sci_ttl_seconds": 86400,
+            "degraded": False,
+        }
+        post_json.return_value = {
+            "sci": "SCI-fresh",
+            "sci_issued_at": _iso(datetime.now(timezone.utc)),
+            "sci_ttl_seconds": 86400,
+        }
+        with mock.patch.object(identity, "read_latest", return_value=cached):
+            result = identity.resolve_identity()
+
+        self.assertFalse(result["degraded"])
+        self.assertEqual(result["session_id"], "ENC-SES-101")
+        self.assertEqual(result["sci"], "SCI-fresh")
+        # Only the claim endpoint is hit on re-claim — no re-register.
+        post_json.assert_called_once()
+        self.assertEqual(
+            post_json.call_args.args[0], "https://x/api/v1/coordination/agents/sessions/claim"
+        )
+        write_artifact.assert_called_once()
+
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "ENC-AGT-00C")
+    @mock.patch.object(identity, "write_artifact")
+    @mock.patch.object(identity, "post_json")
+    def test_degraded_on_http_failure_never_raises_and_keeps_prior_session_id(
+        self, post_json, write_artifact
+    ):
+        cached = {
+            "session_id": "ENC-SES-102",
+            "sci_issued_at": _iso(datetime.now(timezone.utc) - timedelta(seconds=86400)),
+            "sci_ttl_seconds": 86400,
+        }
+        post_json.side_effect = RuntimeError("HTTP 500 from claim endpoint")
+        with mock.patch.object(identity, "read_latest", return_value=cached):
+            result = identity.resolve_identity()  # must not raise
+
+        self.assertTrue(result["degraded"])
+        self.assertEqual(result["session_id"], "ENC-SES-102")
+        self.assertEqual(result["sci"], "")
+        write_artifact.assert_not_called()
+
+    @mock.patch.object(identity, "COORDINATION_API_BASE", "https://x/api/v1")
+    @mock.patch.object(identity, "RHYTHM_AGENT_TYPE_ID", "ENC-AGT-00C")
+    @mock.patch.object(identity, "write_artifact")
+    @mock.patch.object(identity, "post_json")
+    @mock.patch.object(identity, "read_latest", return_value=None)
+    def test_degraded_when_register_returns_no_session_id(self, _read_latest, post_json, write_artifact):
+        post_json.return_value = {"session": {}}
+        result = identity.resolve_identity()
+        self.assertTrue(result["degraded"])
+        write_artifact.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
+++ b/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
@@ -47,6 +47,37 @@ class HandlerTests(unittest.TestCase):
         self.assertGreaterEqual(len(resp["legacy_jobs"]), 3)
 
 
+class RunBeatIdentityResolutionTests(unittest.TestCase):
+    """ENC-TSK-N21 / BRD §4.3: every beat attempts identity resolution (the
+    live-validation signal for this task), regardless of tier or outcome."""
+
+    @mock.patch("lambda_function.publish_beat_metrics")
+    @mock.patch("lambda_function.read_latest", return_value={"ok": True})
+    @mock.patch("lambda_function.TIER_HANDLERS", {"sense": lambda: {"bytes": 1}})
+    @mock.patch("lambda_function.resolve_identity")
+    def test_resolve_identity_called_and_logged_for_every_beat(
+        self, resolve_identity, _read_latest, _publish
+    ):
+        resolve_identity.return_value = {"session_id": "ENC-SES-099", "degraded": False}
+        with self.assertLogs(level="INFO") as logs:
+            lambda_function.run_beat("sense")
+        resolve_identity.assert_called_once()
+        self.assertTrue(any("identity resolved" in line for line in logs.output))
+
+    @mock.patch("lambda_function.publish_beat_metrics")
+    @mock.patch("lambda_function.read_latest", return_value={"ok": True})
+    @mock.patch("lambda_function.TIER_HANDLERS", {"sense": lambda: {"bytes": 1}})
+    @mock.patch("lambda_function.resolve_identity")
+    def test_degraded_identity_logs_warning_but_beat_still_runs(
+        self, resolve_identity, _read_latest, _publish
+    ):
+        resolve_identity.return_value = {"degraded": True, "reason": "RHYTHM_AGENT_TYPE_ID unset"}
+        with self.assertLogs(level="WARNING") as logs:
+            result = lambda_function.run_beat("sense")
+        self.assertTrue(any("degraded" in line for line in logs.output))
+        self.assertEqual(result["bytes"], 1)
+
+
 class LegacyInventoryTests(unittest.TestCase):
     def test_inventory_covers_embedding_jobs(self):
         tiers = {row["rhythm_tier"] for row in LEGACY_SCHEDULE_INVENTORY}
@@ -109,6 +140,53 @@ class TrackerUrlShapeTests(unittest.TestCase):
         url = post_json.call_args[0][0]
         self.assertEqual(url, "https://x/api/v1/coordination/dispatch-plan/dry-run")
         self.assertNotIn("/api/v1/api/v1", url)
+
+
+class DecideEscalationIdentityTests(unittest.TestCase):
+    """ENC-TSK-N21 / BRD §4.3: escalation writes must carry the rhythm's
+    resolved governed identity (session_id + sci) instead of the old
+    hardcoded requested_by_session="rhythm-decide-beat" pseudo-identity."""
+
+    @mock.patch("tiers.decide.post_json", return_value={"escalation_id": "ENC-ESC-1"})
+    @mock.patch("tiers.decide.resolve_identity")
+    def test_escalation_carries_minted_identity_and_sci(self, resolve_identity, post_json):
+        import tiers.decide as decide
+
+        resolve_identity.return_value = {
+            "session_id": "ENC-SES-099",
+            "agent_type_id": "ENC-AGT-00C",
+            "sci": "SCI-abc123",
+            "degraded": False,
+        }
+        decide._create_escalation("ENC-TSK-X99", "some proposal")
+
+        _, body = post_json.call_args[0]
+        self.assertEqual(body["requested_by_session"], "ENC-SES-099")
+        self.assertEqual(body["requested_by"]["session_id"], "ENC-SES-099")
+        self.assertEqual(body["requested_by"]["agent_type_id"], "ENC-AGT-00C")
+        self.assertTrue(body["requested_by"]["sci_present"])
+        self.assertEqual(body["sci"], "SCI-abc123")
+        self.assertNotEqual(body["requested_by_session"], "rhythm-decide-beat")
+
+    @mock.patch("tiers.decide.post_json", return_value={"escalation_id": "ENC-ESC-2"})
+    @mock.patch("tiers.decide.resolve_identity")
+    def test_escalation_falls_back_to_pre_n21_identity_when_degraded(self, resolve_identity, post_json):
+        import tiers.decide as decide
+
+        resolve_identity.return_value = {
+            "session_id": "",
+            "agent_type_id": "",
+            "sci": "",
+            "degraded": True,
+            "reason": "RHYTHM_AGENT_TYPE_ID unset",
+        }
+        decide._create_escalation("ENC-TSK-X99", "some proposal")
+
+        _, body = post_json.call_args[0]
+        self.assertEqual(body["requested_by_session"], "rhythm-decide-beat")
+        self.assertEqual(body["requested_by"]["session_id"], "rhythm-decide-beat")
+        self.assertFalse(body["requested_by"]["sci_present"])
+        self.assertNotIn("sci", body)
 
 
 class DecideCursorPaginationTests(unittest.TestCase):

--- a/backend/lambda/rhythm_cycle/tiers/decide.py
+++ b/backend/lambda/rhythm_cycle/tiers/decide.py
@@ -19,6 +19,7 @@ from config import (
     pre_approved_scopes,
 )
 from http_client import get_json, post_json
+from identity import resolve_identity
 from metrics import publish_lyapunov
 
 logger = logging.getLogger(__name__)
@@ -115,15 +116,35 @@ def _create_escalation(target_record_id: str, summary: str) -> Dict[str, Any]:
     # /api/v1/tracker prefix), but no explicit RouteKey exists in
     # infrastructure/cloudformation — orchestrator ENC-SES-09B to confirm live shape.
     url = f"{TRACKER_API_BASE}/{PROJECT_ID}/escalation"
-    return post_json(
-        url,
-        {
-            "mutation_type": "deploy_arc_change",
-            "target_record_id": target_record_id,
-            "summary": summary,
-            "requested_by_session": "rhythm-decide-beat",
+
+    # ENC-TSK-N21 / BRD §4.3: the prior hardcoded requested_by_session=
+    # "rhythm-decide-beat" never resolved to a real governed session and could
+    # never carry a Session Claim ID (sci) — any beat-originated escalation
+    # would fail closed once the FTR-122 SCI gate tightens past its
+    # grandfather window. identity.resolve_identity() resolves-or-mints (and
+    # caches across beats) a real ENC-SES session + sci for the rhythm's own
+    # identity; tracker_mutation's escalation.request handler reads the
+    # session id from requested_by.session_id (falling back to
+    # write_source.provider) and records requested_by.sci_present. When
+    # identity resolution is degraded (RHYTHM_AGENT_TYPE_ID unset or the
+    # coordination API unreachable) this falls back to the exact pre-N21
+    # pseudo-identity string, preserving prior behavior rather than raising.
+    identity = resolve_identity()
+    session_id = str(identity.get("session_id") or "") or "rhythm-decide-beat"
+    body: Dict[str, Any] = {
+        "mutation_type": "deploy_arc_change",
+        "target_record_id": target_record_id,
+        "summary": summary,
+        "requested_by_session": session_id,
+        "requested_by": {
+            "session_id": session_id,
+            "agent_type_id": str(identity.get("agent_type_id") or ""),
+            "sci_present": bool(identity.get("sci")),
         },
-    )
+    }
+    if identity.get("sci"):
+        body["sci"] = identity["sci"]
+    return post_json(url, body)
 
 
 def _notify_beat(proposals: List[Dict[str, Any]], escalations: List[str]) -> None:

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -7561,6 +7561,13 @@ Resources:
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
           PRE_APPROVED_DISPATCH_SCOPES: '["ENC-PLN-068","ENC-TSK-K"]'
           RHYTHM_SNS_TOPIC_ARN: !Ref RhythmBeatNotificationTopic
+          # ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: rhythm_cycle governed agent
+          # type, minted via coordination agent.type.register (surface=
+          # eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard).
+          # Empty default in identity.py degrades gracefully (identity minting
+          # skipped, escalations fall back to pre-N21 behavior) if this is ever
+          # unset — see backend/lambda/rhythm_cycle/identity.py.
+          RHYTHM_AGENT_TYPE_ID: ENC-AGT-00C
           # ENC-TSK-N18: tenant_invoker AppConfig wiring. Configuration profile
           # is additive/separate from feature-flags (see 10-appconfig-rhythm-
           # tenants.yaml) — ships with zero enabled tenants.


### PR DESCRIPTION
## Summary
- Adds `backend/lambda/rhythm_cycle/identity.py`: resolves-or-mints a governed ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the coordination-API `agent.register`/`agent.claim` surface, cached in the beat's own S3 artifact chain (tier=`identity`) and re-claimed as the sci TTL approaches expiry.
- `tiers/decide.py`'s escalation writer drops the hardcoded `requested_by_session="rhythm-decide-beat"` in favor of the resolved identity (`requested_by.session_id`/`agent_type_id`/`sci_present` + top-level `sci` when present), falling back to the exact pre-N21 string when identity minting is degraded (graceful degradation, never blocks the beat).
- `tenant_invoker.py`'s `session_identity` tenant-invoke payload field (placeholder since ENC-TSK-N18) is now backed by the same resolved identity.
- `lambda_function.py`'s `run_beat()` attempts identity resolution on every beat and logs INFO (resolved) or WARNING (degraded) — this is the live-validation signal for this task.
- New `RHYTHM_AGENT_TYPE_ID` env var (`config.py`, default empty = graceful degradation). Attempted `coordination agent.type.register` this session (surface=`eventbridge-scheduler`, model=`lambda-rhythm`, cost_tier=`standard`) — it succeeded and minted **ENC-AGT-00C**, wired as the default in `infrastructure/cloudformation/02-compute.yaml`.
- `governance_data_dictionary.json` bumped to `2026-07-12.7` per the `lambda_function.py` touch guard (no entity/field schema change).

## Acceptance Criteria
- AC-1: Rhythm registers/claims governed identity per FTR-117 arc; identity + sci persisted in beat artifact chain — `identity.py` `resolve_identity()`.
- AC-2: Hardcoded `rhythm-decide-beat` removed; escalation writes carry minted ENC-SES identity — `tiers/decide.py::_create_escalation`.
- AC-3: Tests green (58/58, `python3 -m pytest backend/lambda/rhythm_cycle/ -q`); merge/deploy evidence to follow post-merge.

CCI-96ed7499f3a749d790ffd83f338fa6b1

## Test plan
- [x] `python3 -m pytest backend/lambda/rhythm_cycle/ -q` — 58 passed
- [x] `py_compile` on all touched modules
- [x] CloudFormation YAML parses (permissive-tag loader sanity check)
- [ ] Post-merge: gamma `_deploy.yml` green; next scheduled beat's CloudWatch log shows an identity-resolution attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>