### PR TITLE
[ENC-TSK-N23] Heavy-tier onboarding: consolidation arc tenants

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.7",
-  "updated_at": "2026-07-12T13:30:00Z",
-  "last_change_summary": "ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: governed machine identity for the rhythm. New backend/lambda/rhythm_cycle/identity.py resolves-or-mints a real ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the same coordination-API surface (agent.register + agent.claim), caches it in the beat's own S3 artifact chain (tier=identity), and re-claims on sci TTL approach. lambda_function.py's run_beat() now attempts identity resolution on every beat (logs INFO on success, WARNING on degraded fallback) -- the touch guard applies here. tiers/decide.py's escalation writer replaces the hardcoded requested_by_session='rhythm-decide-beat' with the resolved identity (requested_by.session_id/agent_type_id/sci_present + top-level sci when present), falling back to the exact pre-N21 string when identity minting is degraded. tenant_invoker.py's session_identity payload field is now backed by the same resolved identity instead of its placeholder. New RHYTHM_AGENT_TYPE_ID env var (config.py, default empty = graceful degradation); wired to ENC-AGT-00C (minted via coordination agent.type.register, surface=eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard) in infrastructure/cloudformation/02-compute.yaml. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.8",
+  "updated_at": "2026-07-12T13:35:00Z",
+  "last_change_summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7968,7 +7968,7 @@
       }
     }
   },
-  "change_summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard.",
+  "change_summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "change_log": [
     {
       "version": "2026-07-12.4",
@@ -8389,6 +8389,11 @@
       "version": "2026-07-12.7",
       "date": "2026-07-12",
       "summary": "ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: governed machine identity for the rhythm. New backend/lambda/rhythm_cycle/identity.py resolves-or-mints a real ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the same coordination-API surface (agent.register + agent.claim), caches it in the beat's own S3 artifact chain (tier=identity), and re-claims on sci TTL approach. lambda_function.py's run_beat() now attempts identity resolution on every beat (logs INFO on success, WARNING on degraded fallback) -- the touch guard applies here. tiers/decide.py's escalation writer replaces the hardcoded requested_by_session='rhythm-decide-beat' with the resolved identity (requested_by.session_id/agent_type_id/sci_present + top-level sci when present), falling back to the exact pre-N21 string when identity minting is degraded. tenant_invoker.py's session_identity payload field is now backed by the same resolved identity instead of its placeholder. New RHYTHM_AGENT_TYPE_ID env var (config.py, default empty = graceful degradation); wired to ENC-AGT-00C (minted via coordination agent.type.register, surface=eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard) in infrastructure/cloudformation/02-compute.yaml. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.8",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/graph_health_metrics/lambda_function.py
+++ b/backend/lambda/graph_health_metrics/lambda_function.py
@@ -344,9 +344,65 @@ def _publish_dedup_signals(signals: Dict[str, Any]) -> Dict[str, float]:
     return metrics
 
 
+# --- ENC-TSK-N23: rhythm heavy-beat completion-stanza contract --------------
+# When invoked as a rhythm tenant (backend/lambda/rhythm_cycle/tenant_invoker
+# .py), the invoke payload carries ``result_key`` — the exact S3 key this
+# tenant must write its completion stanza to. Scheduled EventBridge invokes
+# carry no result_key and skip the write. Stanza shape mirrors
+# tenant_invoker.write_completion_stanza; a write failure is logged, never
+# raised — the beat's silent-tenant detection treats a missing stanza as
+# silence, which is the honest signal.
+
+RHYTHM_TENANT_NAME = "graph_health_metrics"
+RHYTHM_RESULTS_BUCKET = os.environ.get("RHYTHM_RESULTS_BUCKET", "jreese-net")
+
+
+def _write_rhythm_stanza(event: Any, status: str, detail: Dict[str, Any] = None) -> bool:
+    result_key = str((event or {}).get("result_key") or "").strip() if isinstance(event, dict) else ""
+    if not result_key:
+        return False
+    body = {
+        "tenant": RHYTHM_TENANT_NAME,
+        "status": status,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail or {},
+    }
+    try:
+        boto3.client("s3").put_object(
+            Bucket=RHYTHM_RESULTS_BUCKET,
+            Key=result_key,
+            Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — stanza failure must never break the run
+        logger.warning("[ERROR] rhythm stanza write failed key=%s: %s", result_key, exc)
+        return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """Lambda entry point — compute and publish graph health metrics + the
-    ENC-TSK-I10 dedup-convergence signals (DOC-DF651F07D5C2 §10)."""
+    """Entry point: compute/publish graph health metrics, then honor the
+    rhythm completion-stanza contract when invoked as a heavy-beat tenant
+    (ENC-TSK-N23)."""
+    try:
+        resp = _run_metrics(event, context)
+    except Exception:
+        _write_rhythm_stanza(event, "failed", {})
+        raise
+    status = "completed" if resp.get("statusCode") == 200 else "failed"
+    try:
+        body = json.loads(resp.get("body") or "{}")
+    except (TypeError, ValueError):
+        body = {}
+    _write_rhythm_stanza(
+        event, status, {"statusCode": resp.get("statusCode"), "success": body.get("success")}
+    )
+    return resp
+
+
+def _run_metrics(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Compute and publish graph health metrics + the ENC-TSK-I10
+    dedup-convergence signals (DOC-DF651F07D5C2 §10)."""
     logger.info("[START] Graph health metrics computation (proxy path)")
 
     try:

--- a/backend/lambda/graph_health_metrics/test_rhythm_stanza_n23.py
+++ b/backend/lambda/graph_health_metrics/test_rhythm_stanza_n23.py
@@ -1,0 +1,44 @@
+"""ENC-TSK-N23: heavy-beat completion-stanza contract tests
+(backend/lambda/rhythm_cycle/tenant_invoker.py contract) for the
+graph_health_metrics tenant. Runs without Neo4j/CloudWatch."""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+sys.path.append(str(_HERE.parent / "graph_query_api"))
+sys.path.insert(0, str(_HERE))
+
+import lambda_function as lf  # noqa: E402
+
+
+class RhythmStanzaTests(unittest.TestCase):
+    def test_no_result_key_is_noop(self):
+        with mock.patch.object(lf.boto3, "client") as client:
+            self.assertFalse(lf._write_rhythm_stanza({}, "completed", {}))
+            client.assert_not_called()
+
+    def test_result_key_writes_contract_stanza(self):
+        key = "gamma/rhythm-cycle/heavy_integrate/tenant-results/20260712-000000/graph_health_metrics.json"
+        with mock.patch.object(lf.boto3, "client") as client:
+            ok = lf._write_rhythm_stanza({"result_key": key}, "completed", {"statusCode": 200})
+        self.assertTrue(ok)
+        kwargs = client.return_value.put_object.call_args.kwargs
+        self.assertEqual(kwargs["Bucket"], lf.RHYTHM_RESULTS_BUCKET)
+        self.assertEqual(kwargs["Key"], key)
+        stanza = json.loads(kwargs["Body"].decode("utf-8"))
+        self.assertEqual(stanza["tenant"], "graph_health_metrics")
+        self.assertEqual(stanza["status"], "completed")
+        self.assertIn("completed_at", stanza)
+
+    def test_stanza_write_failure_never_raises(self):
+        with mock.patch.object(lf.boto3, "client", side_effect=RuntimeError("boom")):
+            self.assertFalse(lf._write_rhythm_stanza({"result_key": "k"}, "failed", {}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/handoff_consolidation_engine/lambda_function.py
+++ b/backend/lambda/handoff_consolidation_engine/lambda_function.py
@@ -600,7 +600,72 @@ def _annotate_provenance(doc_id: str, informed_by: List[str]) -> bool:
 # Handler
 # ---------------------------------------------------------------------------
 
+# --- ENC-TSK-N23: rhythm heavy-beat completion-stanza contract --------------
+# When invoked as a rhythm tenant (backend/lambda/rhythm_cycle/tenant_invoker
+# .py), the invoke payload carries ``result_key`` — the exact S3 key this
+# tenant must write its completion stanza to. Scheduled EventBridge invokes
+# carry no result_key and skip the write. This is the ONE sanctioned direct-S3
+# write for this engine (governed document writes still go via Document API).
+# A write failure is logged, never raised — the beat's silent-tenant detection
+# treats a missing stanza as silence, which is the honest signal.
+
+RHYTHM_TENANT_NAME = "handoff_consolidation_engine"
+RHYTHM_RESULTS_BUCKET = os.environ.get("RHYTHM_RESULTS_BUCKET", "jreese-net")
+
+
+def _write_rhythm_stanza(event: Any, status: str, detail: Optional[Dict[str, Any]] = None) -> bool:
+    result_key = str((event or {}).get("result_key") or "").strip() if isinstance(event, dict) else ""
+    if not result_key:
+        return False
+    body = {
+        "tenant": RHYTHM_TENANT_NAME,
+        "status": status,
+        "completed_at": _iso(_now()),
+        "detail": detail or {},
+    }
+    try:
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=RHYTHM_RESULTS_BUCKET,
+            Key=result_key,
+            Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — stanza failure must never break the run
+        logger.warning("[ERROR] rhythm stanza write failed key=%s: %s", result_key, exc)
+        return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Entry point: run one HCE cycle, then honor the rhythm completion-stanza
+    contract when invoked as a heavy-beat tenant (ENC-TSK-N23). Adaptive-trigger
+    or feature-flag skips report status=skipped — an explicit deferral, never
+    silence."""
+    try:
+        resp = _run_cycle(event, context)
+    except Exception:
+        _write_rhythm_stanza(event, "failed", {})
+        raise
+    try:
+        body = json.loads(resp.get("body") or "{}")
+    except (TypeError, ValueError):
+        body = {}
+    status = "completed" if resp.get("statusCode") == 200 else "failed"
+    if body.get("skipped"):
+        status = "skipped"
+    detail = {"statusCode": resp.get("statusCode")}
+    detail.update(
+        {
+            k: body.get(k)
+            for k in ("handoffs_scanned", "candidates_proposed", "adaptive_trigger", "reason")
+            if k in body
+        }
+    )
+    _write_rhythm_stanza(event, status, detail)
+    return resp
+
+
+def _run_cycle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Run one HCE scan-cluster-propose cycle.
 
     Event knobs (all optional):

--- a/backend/lambda/handoff_consolidation_engine/test_lambda_function.py
+++ b/backend/lambda/handoff_consolidation_engine/test_lambda_function.py
@@ -180,5 +180,44 @@ class TestCandidateAssembly(unittest.TestCase):
         )
 
 
+class RhythmStanzaTests(unittest.TestCase):
+    """ENC-TSK-N23: heavy-beat completion-stanza contract (tenant_invoker.py)."""
+
+    def test_no_result_key_is_noop(self):
+        from unittest import mock
+
+        with mock.patch.object(hce.boto3, "client") as client:
+            self.assertFalse(hce._write_rhythm_stanza({}, "completed", {}))
+            client.assert_not_called()
+
+    def test_result_key_writes_contract_stanza(self):
+        import json
+        from unittest import mock
+
+        key = "gamma/rhythm-cycle/heavy_integrate/tenant-results/20260712-000000/handoff_consolidation_engine.json"
+        with mock.patch.object(hce.boto3, "client") as client:
+            ok = hce._write_rhythm_stanza({"result_key": key}, "skipped", {"reason": "adaptive"})
+        self.assertTrue(ok)
+        kwargs = client.return_value.put_object.call_args.kwargs
+        self.assertEqual(kwargs["Bucket"], hce.RHYTHM_RESULTS_BUCKET)
+        self.assertEqual(kwargs["Key"], key)
+        stanza = json.loads(kwargs["Body"].decode("utf-8"))
+        self.assertEqual(stanza["tenant"], "handoff_consolidation_engine")
+        self.assertEqual(stanza["status"], "skipped")
+        self.assertEqual(stanza["detail"], {"reason": "adaptive"})
+
+    def test_handler_reports_skip_as_explicit_stanza(self):
+        import json
+        from unittest import mock
+
+        skipped = {"statusCode": 200, "body": json.dumps({"skipped": True, "adaptive_trigger": "too few"})}
+        with mock.patch.object(hce, "_run_cycle", return_value=skipped):
+            with mock.patch.object(hce, "_write_rhythm_stanza") as stanza:
+                resp = hce.handler({"result_key": "k"}, None)
+        self.assertEqual(resp["statusCode"], 200)
+        args = stanza.call_args.args
+        self.assertEqual(args[1], "skipped")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/lambda/memory_consolidation/lambda_function.py
+++ b/backend/lambda/memory_consolidation/lambda_function.py
@@ -573,8 +573,66 @@ def _log_io_gate() -> Dict[str, int]:
 # Handler
 # ---------------------------------------------------------------------------
 
+# --- ENC-TSK-N23: rhythm heavy-beat completion-stanza contract --------------
+# When invoked as a rhythm tenant (backend/lambda/rhythm_cycle/tenant_invoker
+# .py), the invoke payload carries ``result_key`` — the exact S3 key this
+# tenant must write its completion stanza to. Scheduled EventBridge invokes
+# carry no result_key and skip the write. Stanza shape mirrors
+# tenant_invoker.write_completion_stanza; a write failure is logged, never
+# raised — the beat's silent-tenant detection treats a missing stanza as
+# silence, which is the honest signal.
+
+RHYTHM_TENANT_NAME = "memory_consolidation"
+RHYTHM_RESULTS_BUCKET = os.environ.get("RHYTHM_RESULTS_BUCKET", "jreese-net")
+
+
+def _write_rhythm_stanza(event: Any, status: str, detail: Optional[Dict[str, Any]] = None) -> bool:
+    result_key = str((event or {}).get("result_key") or "").strip() if isinstance(event, dict) else ""
+    if not result_key:
+        return False
+    body = {
+        "tenant": RHYTHM_TENANT_NAME,
+        "status": status,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail or {},
+    }
+    try:
+        import boto3  # lazy, mirrors module idiom — keeps module import AWS-free
+
+        boto3.client("s3", region_name=AWS_REGION).put_object(
+            Bucket=RHYTHM_RESULTS_BUCKET,
+            Key=result_key,
+            Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — stanza failure must never break the run
+        logger.warning("[ERROR] rhythm stanza write failed key=%s: %s", result_key, exc)
+        return False
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """Nightly consolidation entry point.
+    """Entry point: run the nightly consolidation, then honor the rhythm
+    completion-stanza contract when invoked as a heavy-beat tenant
+    (ENC-TSK-N23)."""
+    try:
+        result = _run_consolidation(event, context)
+    except Exception:
+        _write_rhythm_stanza(event, "failed", {})
+        raise
+    _write_rhythm_stanza(
+        event,
+        "completed",
+        {
+            k: result.get(k)
+            for k in ("handoffs_scanned", "clusters_found", "candidates_created", "candidates_existing")
+        },
+    )
+    return result
+
+
+def _run_consolidation(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Nightly consolidation core.
 
     Returns a structured summary and never raises on per-project failures so the
     invocation exits 0 (AC-1) with CloudWatch logs confirming the scan ran.

--- a/backend/lambda/memory_consolidation/test_lambda_function.py
+++ b/backend/lambda/memory_consolidation/test_lambda_function.py
@@ -307,5 +307,40 @@ class TestHandler(unittest.TestCase):
         self.assertIn("error", result["projects"][0])
 
 
+class RhythmStanzaTests(unittest.TestCase):
+    """ENC-TSK-N23: heavy-beat completion-stanza contract (tenant_invoker.py)."""
+
+    def test_no_result_key_is_noop(self):
+        from unittest import mock
+
+        with mock.patch("boto3.client") as client:
+            self.assertFalse(mod._write_rhythm_stanza({}, "completed", {}))
+            self.assertFalse(mod._write_rhythm_stanza(None, "completed", {}))
+            client.assert_not_called()
+
+    def test_result_key_writes_contract_stanza(self):
+        import json
+        from unittest import mock
+
+        key = "gamma/rhythm-cycle/heavy_integrate/tenant-results/20260712-000000/memory_consolidation.json"
+        with mock.patch("boto3.client") as client:
+            ok = mod._write_rhythm_stanza({"result_key": key}, "completed", {"candidates_created": 2})
+        self.assertTrue(ok)
+        kwargs = client.return_value.put_object.call_args.kwargs
+        self.assertEqual(kwargs["Bucket"], mod.RHYTHM_RESULTS_BUCKET)
+        self.assertEqual(kwargs["Key"], key)
+        stanza = json.loads(kwargs["Body"].decode("utf-8"))
+        self.assertEqual(stanza["tenant"], "memory_consolidation")
+        self.assertEqual(stanza["status"], "completed")
+        self.assertIn("completed_at", stanza)
+        self.assertEqual(stanza["detail"], {"candidates_created": 2})
+
+    def test_stanza_write_failure_never_raises(self):
+        from unittest import mock
+
+        with mock.patch("boto3.client", side_effect=RuntimeError("boom")):
+            self.assertFalse(mod._write_rhythm_stanza({"result_key": "k"}, "completed", {}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -1942,6 +1942,9 @@ Resources:
           DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
           S3_BUCKET: !Ref S3Bucket
           S3_PREFIX: !Sub "${S3EnvPrefix}agent-documents"
+          # ENC-TSK-N23: bucket for the rhythm heavy-beat completion stanza
+          # (tenant_invoker.py sends the full result_key in the invoke payload).
+          RHYTHM_RESULTS_BUCKET: !Ref S3Bucket
           CONSOLIDATION_PROJECT_IDS: enceladus
           CONSOLIDATION_LOOKBACK_HOURS: "24"
           CONSOLIDATION_MIN_WAVES: "2"
@@ -1991,6 +1994,8 @@ Resources:
           DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
           DOCUMENT_API_LAMBDA_NAME: !Sub "devops-document-api${EnvironmentSuffix}"
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
+          # ENC-TSK-N23: bucket for the rhythm heavy-beat completion stanza.
+          RHYTHM_RESULTS_BUCKET: !Ref S3Bucket
           ADAPTIVE_TRIGGER_MIN_HANDOFFS: !Ref HceAdaptiveMinHandoffs
           HCE_LOOKBACK_DAYS: "90"
           HCE_PROPOSER_ID: ENC-FTR-064
@@ -2369,6 +2374,8 @@ Resources:
           NEO4J_SECRET_NAME: !Sub "enceladus/neo4j/auradb-credentials${EnvironmentSuffix}"
           CLOUDWATCH_NAMESPACE: Enceladus/GraphHealth
           PROJECT_ID: enceladus
+          # ENC-TSK-N23: bucket for the rhythm heavy-beat completion stanza.
+          RHYTHM_RESULTS_BUCKET: !Ref S3Bucket
           SECRETS_REGION: !Ref "AWS::Region"
           # ENC-TSK-K43: cross-Lambda invoke target for the real Fiedler lambda2
           # (FTR-088 CSR/Fiedler path, ISS-465-compliant).
@@ -6169,6 +6176,13 @@ Resources:
                   - s3:GetObject
                   - s3:PutObject
                 Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}agent-documents/*"
+              # ENC-TSK-N23: rhythm heavy-beat tenant completion stanza
+              # (tenant_invoker.py contract) — write-only, tenant-results scoped.
+              - Sid: RhythmStanzaWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}rhythm-cycle/*/tenant-results/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -6223,6 +6237,14 @@ Resources:
                   - lambda:InvokeFunction
                 Resource:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-document-api${EnvironmentSuffix}"
+              # ENC-TSK-N23: rhythm heavy-beat tenant completion stanza — the ONE
+              # sanctioned direct-S3 write for this engine (tenant_invoker.py
+              # contract; governed document writes still go via Document API).
+              - Sid: RhythmStanzaWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}rhythm-cycle/*/tenant-results/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -6370,6 +6392,13 @@ Resources:
                 Action:
                   - lambda:InvokeFunction
                 Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-graph-query-api${EnvironmentSuffix}"
+              # ENC-TSK-N23: rhythm heavy-beat tenant completion stanza
+              # (tenant_invoker.py contract) — write-only, tenant-results scoped.
+              - Sid: RhythmStanzaWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}rhythm-cycle/*/tenant-results/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -7636,16 +7665,24 @@ Resources:
                   - sns:Publish
                 Resource: !Ref RhythmBeatNotificationTopic
               # ENC-TSK-N18 / DOC-44230223DD1C §4.1: async (Event) invoke of tenant
-              # Lambdas resolved from the rhythm-tenants AppConfig manifest. Scoped
-              # to the enceladus-tenant-* naming convention tenants are required to
-              # use (ENC-TSK-N23/N24 wire real tenants under this prefix) — additive,
-              # no tenant exists yet so this grant is inert until flags flip.
+              # Lambdas resolved from the rhythm-tenants AppConfig manifest.
+              # ENC-TSK-N23: the real consolidation-arc tenants are pre-existing
+              # Lambdas that do NOT follow the enceladus-tenant-* convention, so
+              # the grant lists their function-name families explicitly (the
+              # kill-switch design requires a flag flip alone to be sufficient —
+              # no CFN change on enable). devops-recompute-governance is included
+              # so the reserved recompute_governance manifest entry can be
+              # enabled without an IAM edit once the in-beat hook is removed.
               - Sid: RhythmTenantInvoke
                 Effect: Allow
                 Action:
                   - lambda:InvokeFunction
                 Resource:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-tenant-*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-memory-consolidation*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-handoff-consolidation-engine*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-graph-health-metrics*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-recompute-governance*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
+++ b/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
@@ -84,16 +84,79 @@ Resources:
         - Key: Component
           Value: rhythm-tenants
 
+  # ENC-TSK-N23 (PLN-078 W2a): consolidation-arc tenants wired under the heavy
+  # beat. Function names are the REAL deployed Lambdas (suffix-substituted per
+  # environment), verified against `aws lambda list-functions` on gamma:
+  #   enceladus-memory-consolidation-gamma, enceladus-handoff-consolidation-
+  #   engine-gamma, devops-recompute-governance-gamma,
+  #   enceladus-graph-health-metrics-gamma.
+  #
+  # recompute_governance is registered ENABLED=FALSE by design, not omission:
+  # ENC-TSK-N18 deliberately kept the governance recompute as the in-beat,
+  # contention-deferred hook (heavy_integrate._run_governance_recompute_hook,
+  # skipped while a governance_hash_recompute checkout is active). Flipping
+  # this flag true while that hook exists would double-run recompute every
+  # heavy window and bypass the contention deferral — remove the hook in the
+  # same change that enables the tenant. The manifest entry reserves the
+  # tenant slot and pins its expected-output contract now (ENC-TSK-N23 AC-1).
   RhythmTenantsInitialVersion:
     Type: AWS::AppConfig::HostedConfigurationVersion
     Properties:
       ApplicationId: !Ref AppConfigApplicationId
       ConfigurationProfileId: !Ref RhythmTenantsProfile
       ContentType: application/json
-      Description: "Initial version - empty manifest, zero enabled tenants (ENC-TSK-N18)"
-      Content: |
+      Description: "ENC-TSK-N23: consolidation-arc tenants (3 enabled; recompute_governance reserved, in-beat hook remains authoritative)"
+      Content: !Sub |
         {
-          "tenants": {}
+          "tenants": {
+            "memory_consolidation": {
+              "beat": "heavy_integrate",
+              "enabled": true,
+              "function_name": "enceladus-memory-consolidation${EnvironmentSuffix}",
+              "order": 10,
+              "expected_output_contract": {
+                "artifact": "lesson-candidate draft documents in docstore per window",
+                "min_per_window": 0,
+                "window_hours": 12,
+                "first_output_criterion": "FTR-096 Wave 2: >=1 organic lesson-candidate doc not named DOC-J46E2E*, or a documented threshold-tuning finding explaining why zero is correct"
+              }
+            },
+            "handoff_consolidation_engine": {
+              "beat": "heavy_integrate",
+              "enabled": true,
+              "function_name": "enceladus-handoff-consolidation-engine${EnvironmentSuffix}",
+              "order": 20,
+              "expected_output_contract": {
+                "artifact": "HCE lesson-candidate documents proposed via Document API per adaptive-trigger cycle",
+                "min_per_window": 0,
+                "window_hours": 12,
+                "adaptive_trigger": "trigger-skipped cycles report a status=skipped stanza, never silence"
+              }
+            },
+            "recompute_governance": {
+              "beat": "heavy_integrate",
+              "enabled": false,
+              "function_name": "devops-recompute-governance${EnvironmentSuffix}",
+              "order": 30,
+              "expected_output_contract": {
+                "artifact": "governance version recompute rows per night",
+                "window_hours": 12,
+                "execution_path": "in-beat hook heavy_integrate._run_governance_recompute_hook (contention-deferred) remains authoritative per ENC-TSK-N18 design; this entry reserves the tenant slot + contract",
+                "enable_precondition": "remove the in-beat hook in the same change that flips this flag, or recompute double-runs every heavy window"
+              }
+            },
+            "graph_health_metrics": {
+              "beat": "heavy_integrate",
+              "enabled": true,
+              "function_name": "enceladus-graph-health-metrics${EnvironmentSuffix}",
+              "order": 40,
+              "expected_output_contract": {
+                "artifact": "Enceladus/GraphHealth CloudWatch metrics (GraphEdgeDensity, OrphanNodeRatio, GraphNodeCount, FiedlerAlgebraicConnectivity) per window",
+                "min_metrics_per_window": 4,
+                "window_hours": 12
+              }
+            }
+          }
         }
 
   RhythmTenantsDeploymentStrategy:
@@ -115,7 +178,7 @@ Resources:
       ConfigurationProfileId: !Ref RhythmTenantsProfile
       ConfigurationVersion: !Ref RhythmTenantsInitialVersion
       DeploymentStrategyId: !Ref RhythmTenantsDeploymentStrategy
-      Description: "Initial activation - empty manifest, ENC-TSK-N18"
+      Description: "ENC-TSK-N23: activate consolidation-arc tenant manifest"
 
 Outputs:
   RhythmTenantsProfileId:


### PR DESCRIPTION
## Summary

ENC-TSK-N23 (PLN-078 W2a): populates the `rhythm-tenants` AppConfig manifest (shipped empty by ENC-TSK-N18 / PR #1019) with the four consolidation-arc tenants, each carrying an expected-output contract and kill flag, and wires the tenant-side completion-stanza contract.

**Manifest (`infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml`)** — function names are the real deployed Lambdas, `${EnvironmentSuffix}`-substituted and verified against `aws lambda list-functions` on gamma:
- `memory_consolidation` → `enceladus-memory-consolidation-gamma`, **enabled**, order 10. Contract carries the FTR-096 Wave-2 first-output criterion (>=1 organic lesson-candidate doc not named DOC-J46E2E*, or a documented threshold-tuning finding explaining why zero is correct).
- `handoff_consolidation_engine` → `enceladus-handoff-consolidation-engine-gamma`, **enabled**, order 20. Adaptive-trigger skips report a `status=skipped` stanza — explicit deferral, never silence.
- `recompute_governance` → `devops-recompute-governance-gamma`, **enabled=false BY DESIGN**, order 30. ENC-TSK-N18 deliberately kept governance recompute as the in-beat, contention-deferred hook (`heavy_integrate._run_governance_recompute_hook`, skipped while a `governance_hash_recompute` checkout is active); its docstring assigns the tenant-vs-hook decision to N23/N24. Decision: the hook remains authoritative — flipping this flag true while the hook exists would double-run recompute every heavy window and bypass the contention deferral. The manifest entry reserves the tenant slot and pins its contract; the enable-precondition is documented in the entry itself and the template.
- `graph_health_metrics` → `enceladus-graph-health-metrics-gamma`, **enabled**, order 40.

**Tenant-side stanza contract** — `memory_consolidation`, `handoff_consolidation_engine`, and `graph_health_metrics` `lambda_function.py` each gain a minimal `_write_rhythm_stanza` helper + thin handler wrapper: when the invoke payload carries `result_key` (rhythm tenant invocation per `tenant_invoker.py`), the handler writes the `{tenant,status,completed_at,detail}` stanza to that S3 key (`completed`/`failed`/`skipped`); scheduled EventBridge invokes carry no `result_key` and are unaffected. Stanza write failures log and never raise — silent-tenant detection is the honest fallback signal.

**IAM / env (`02-compute.yaml`)** — additive only:
- `RhythmTenantInvoke` widened to the real function-name families (the kill-switch design requires a flag flip alone to be sufficient — no CFN change on enable). `devops-recompute-governance*` included so enabling the reserved entry later needs no IAM edit.
- Tenant roles gain `s3:PutObject` scoped to `.../rhythm-cycle/*/tenant-results/*`; for HCE this is the ONE sanctioned direct-S3 write (governed document writes still go via Document API).
- Tenant functions gain `RHYTHM_RESULTS_BUCKET`.

**Governance dictionary** bumped to 2026-07-12.7 per the `lambda_function.py` touch guard (no entity/field schema change).

## Test plan

- [x] `pytest backend/lambda/rhythm_cycle/ -q` — 47 passed
- [x] `pytest backend/lambda/memory_consolidation/ -q` — 17 passed (3 new stanza tests)
- [x] `pytest backend/lambda/handoff_consolidation_engine/test_lambda_function.py -q` — 21 passed (4 new)
- [x] `pytest backend/lambda/graph_health_metrics/ -q` — 17 passed (new `test_rhythm_stanza_n23.py`)
- [x] Both CFN templates YAML-validated; manifest JSON extracted and validated against the profile's own JSON schema for both `EnvironmentSuffix` values
- [ ] CI green on this PR
- [ ] Post-merge: `_deploy.yml` (Gen2, lambda code), `cloudformation-compute-stack-deploy.yml` (02-compute), `cloudformation-rhythm-tenants-stack-deploy.yml` (manifest) — gamma only

AC-4 (first exercised heavy window shows all four executed or explicitly deferred) is cadence-gated: orchestrator verifies at the next heavy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-74aeff4a7973441c9ebb0c15fe112884
