### PR TITLE
[ENC-TSK-N29] Fix decide-beat escalation POST schema

### DIFF
--- a/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
+++ b/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
@@ -189,6 +189,67 @@ class DecideEscalationIdentityTests(unittest.TestCase):
         self.assertNotIn("sci", body)
 
 
+class DecideEscalationSchemaTests(unittest.TestCase):
+    """ENC-TSK-N29 / BRD §4.3: tracker_mutation._handle_escalation_request
+    (the real POST /{project}/escalation handler) fails-closed 400 on any
+    body that isn't {payload: dict, justification: str, target_record_id,
+    mutation_type, requested_by...}. The prior body sent a bare 'summary'
+    string and no 'payload' at all — every beat-originated escalation was
+    rejected before reaching io's queue. These assertions mirror the
+    handler's own validation order (tracker_mutation/lambda_function.py
+    _handle_escalation_request + _validate_deploy_arc_change_payload) without
+    importing that lambda directly.
+    """
+
+    # Mirrors backend/lambda/tracker_mutation/transition_type_matrix.py
+    # STRICTNESS_RANK keys (VALID_TRANSITION_TYPES) as of ENC-TSK-N29.
+    _VALID_TRANSITION_TYPES = {
+        "github_pr_deploy",
+        "lambda_deploy",
+        "web_deploy",
+        "code_only",
+        "no_code",
+    }
+
+    @mock.patch("tiers.decide.post_json", return_value={"escalation_id": "ENC-ESC-3"})
+    @mock.patch("tiers.decide.resolve_identity")
+    def test_escalation_body_matches_handler_schema(self, resolve_identity, post_json):
+        import tiers.decide as decide
+
+        resolve_identity.return_value = {
+            "session_id": "ENC-SES-099",
+            "agent_type_id": "ENC-AGT-00C",
+            "sci": "SCI-abc123",
+            "degraded": False,
+        }
+        decide._create_escalation("ENC-TSK-X99", "proposal needs io review")
+
+        _, body = post_json.call_args[0]
+
+        # _handle_escalation_request: target_record_id + mutation_type required.
+        self.assertEqual(body["target_record_id"], "ENC-TSK-X99")
+        self.assertIn(body["mutation_type"], {"deploy_arc_change", "direct_state_override"})
+
+        # payload must be a non-empty dict (bare 'summary' string is rejected).
+        self.assertIsInstance(body.get("payload"), dict)
+        self.assertTrue(body["payload"])
+
+        # justification must be a non-empty string.
+        self.assertIsInstance(body.get("justification"), str)
+        self.assertTrue(body["justification"].strip())
+
+        # mutation_type='deploy_arc_change' additionally requires
+        # payload.new_deploy_arc_type in VALID_TRANSITION_TYPES.
+        if body["mutation_type"] == "deploy_arc_change":
+            new_arc = body["payload"].get("new_deploy_arc_type")
+            self.assertIn(new_arc, self._VALID_TRANSITION_TYPES)
+
+        # N21 identity/sci fields must survive the schema realignment.
+        self.assertEqual(body["requested_by"]["session_id"], "ENC-SES-099")
+        self.assertTrue(body["requested_by"]["sci_present"])
+        self.assertEqual(body["sci"], "SCI-abc123")
+
+
 class DecideCursorPaginationTests(unittest.TestCase):
     """ENC-TSK-N20 / BRD DOC-44230223DD1C §4.4 (C4): cursor-exhausted
     paginated backlog read replacing the single-page + orphan-flag heuristic

--- a/backend/lambda/rhythm_cycle/tiers/decide.py
+++ b/backend/lambda/rhythm_cycle/tiers/decide.py
@@ -110,6 +110,16 @@ def _in_preapproved_scope(record_id: str, scopes: List[str]) -> bool:
     return False
 
 
+# ENC-TSK-N29: the mutation_type='deploy_arc_change' handler
+# (tracker_mutation._validate_deploy_arc_change_payload) requires
+# payload.new_deploy_arc_type to be a member of VALID_TRANSITION_TYPES. The
+# decide beat's dispatch proposals carry no specific target arc, so
+# out-of-scope escalations default to the strictest common transition type —
+# these escalations exist precisely because io review is required before
+# dispatch proceeds.
+_ESCALATION_DEFAULT_ARC_TYPE = "github_pr_deploy"
+
+
 def _create_escalation(target_record_id: str, summary: str) -> Dict[str, Any]:
     # TODO(ENC-TSK-N28 follow-up): escalation route shape unverified on gamma APIGW.
     # tracker_mutation's _RE_ESCALATION accepts /{project}/escalation (optional
@@ -131,10 +141,18 @@ def _create_escalation(target_record_id: str, summary: str) -> Dict[str, Any]:
     # pseudo-identity string, preserving prior behavior rather than raising.
     identity = resolve_identity()
     session_id = str(identity.get("session_id") or "") or "rhythm-decide-beat"
+    # ENC-TSK-N29 / BRD §4.3: tracker_mutation._handle_escalation_request
+    # requires a non-empty 'payload' dict and a non-empty 'justification'
+    # string — the prior bare 'summary' field satisfied neither and every
+    # beat-originated escalation POST failed 400 before reaching io's queue.
     body: Dict[str, Any] = {
-        "mutation_type": "deploy_arc_change",
         "target_record_id": target_record_id,
-        "summary": summary,
+        "mutation_type": "deploy_arc_change",
+        "payload": {
+            "new_deploy_arc_type": _ESCALATION_DEFAULT_ARC_TYPE,
+            "proposal_summary": summary,
+        },
+        "justification": summary,
         "requested_by_session": session_id,
         "requested_by": {
             "session_id": session_id,


### PR DESCRIPTION
## Summary
- `tiers/decide.py::_create_escalation` sent `mutation_type` + `target_record_id` + a bare `summary` string, but `tracker_mutation._handle_escalation_request` requires a non-empty `payload` dict and a `justification` string — every beat-originated escalation POST was rejected 400 before reaching io's queue.
- `mutation_type='deploy_arc_change'` additionally requires `payload.new_deploy_arc_type` to be a member of `VALID_TRANSITION_TYPES`; the decide beat has no specific target arc from the dispatch proposal, so it now defaults to the strictest common type (`github_pr_deploy`).
- Preserved the ENC-TSK-N21 identity fields (`requested_by_session`, `requested_by.{session_id,agent_type_id,sci_present}`, top-level `sci`) unchanged.
- Added `DecideEscalationSchemaTests` asserting the accepted body shape (payload dict, justification string, valid `new_deploy_arc_type`, surviving N21 identity fields).

## Test plan
- [x] `python3 -m pytest backend/lambda/rhythm_cycle/ -q` — 59 passed
- [x] No other files touched — no `lambda_function.py`/`tracker_ops.py`/`handlers.py`/`server.py`/`coordination_api/config.py` changes, so no governance dictionary bump required

CCI-2c52c76fc35c45bbb6b36541d3450f1d

🤖 Generated with [Claude Code](https://claude.com/claude-code)