### PR TITLE
[ENC-TSK-N24] Heavy-tier onboarding: entropy/telemetry tenants (safety+budget flags off)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.8",
-  "updated_at": "2026-07-12T13:35:00Z",
-  "last_change_summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-12.9",
+  "updated_at": "2026-07-12T13:48:00Z",
+  "last_change_summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7968,7 +7968,7 @@
       }
     }
   },
-  "change_summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "change_summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "change_log": [
     {
       "version": "2026-07-12.4",
@@ -8394,6 +8394,11 @@
       "version": "2026-07-12.8",
       "date": "2026-07-12",
       "summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.9",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/corpus_entropy_engine/lambda_function.py
+++ b/backend/lambda/corpus_entropy_engine/lambda_function.py
@@ -214,7 +214,68 @@ def _publish_metrics(counts: Dict[str, int]) -> None:
 # Handler
 # ---------------------------------------------------------------------------
 
+# --- ENC-TSK-N24: rhythm heavy-beat completion-stanza contract --------------
+# When invoked as a rhythm tenant (backend/lambda/rhythm_cycle/tenant_invoker
+# .py), the invoke payload carries ``result_key`` — the exact S3 key this
+# tenant must write its completion stanza to. Scheduled EventBridge invokes
+# carry no result_key and skip the write. This is the ONE sanctioned direct-S3
+# write for this telemetry-only Lambda (OGTM posture otherwise unchanged).
+# A write failure is logged, never raised — the beat's silent-tenant detection
+# treats a missing stanza as silence, which is the honest signal.
+
+RHYTHM_TENANT_NAME = "corpus_entropy_engine"
+RHYTHM_RESULTS_BUCKET = os.environ.get("RHYTHM_RESULTS_BUCKET", "jreese-net")
+
+
+def _write_rhythm_stanza(event: Any, status: str, detail: Optional[Dict[str, Any]] = None) -> bool:
+    result_key = str((event or {}).get("result_key") or "").strip() if isinstance(event, dict) else ""
+    if not result_key:
+        return False
+    body = {
+        "tenant": RHYTHM_TENANT_NAME,
+        "status": status,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail or {},
+    }
+    try:
+        import boto3  # lazy, mirrors module idiom — keeps module import AWS-free
+
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=RHYTHM_RESULTS_BUCKET,
+            Key=result_key,
+            Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — stanza failure must never break the run
+        logger.warning("[ERROR] rhythm stanza write failed key=%s: %s", result_key, exc)
+        return False
+
+
 def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
+    """Entry point: run the entropy scan, then honor the rhythm
+    completion-stanza contract when invoked as a heavy-beat tenant
+    (ENC-TSK-N24). CEE_HARD_DISABLED skips report status=skipped — an explicit
+    deferral, never silence."""
+    try:
+        resp = _run_scan(event, context)
+    except Exception:
+        _write_rhythm_stanza(event, "failed", {})
+        raise
+    try:
+        body = json.loads(resp.get("body") or "{}")
+    except (TypeError, ValueError):
+        body = {}
+    status = "completed" if resp.get("statusCode") == 200 else "failed"
+    if body.get("skipped"):
+        status = "skipped"
+    detail = {"statusCode": resp.get("statusCode")}
+    detail.update({k: body.get(k) for k in ("counts", "reason") if k in body})
+    _write_rhythm_stanza(event, status, detail)
+    return resp
+
+
+def _run_scan(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
     event = event or {}
 
     if is_hard_disabled(os.environ):

--- a/backend/lambda/corpus_entropy_engine/test_lambda_function.py
+++ b/backend/lambda/corpus_entropy_engine/test_lambda_function.py
@@ -417,3 +417,55 @@ def test_handler_returns_500_on_unexpected_exception(monkeypatch):
     assert result["statusCode"] == 500
     body = json.loads(result["body"])
     assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-N24: heavy-beat completion-stanza contract (tenant_invoker.py)
+# ---------------------------------------------------------------------------
+
+
+def test_rhythm_stanza_no_result_key_is_noop():
+    from unittest import mock
+
+    with mock.patch("boto3.client") as client:
+        assert mod._write_rhythm_stanza({}, "completed", {}) is False
+        assert mod._write_rhythm_stanza(None, "completed", {}) is False
+        client.assert_not_called()
+
+
+def test_rhythm_stanza_result_key_writes_contract_stanza():
+    from unittest import mock
+
+    key = "gamma/rhythm-cycle/heavy_integrate/tenant-results/20260712-000000/corpus_entropy_engine.json"
+    with mock.patch("boto3.client") as client:
+        ok = mod._write_rhythm_stanza({"result_key": key}, "completed", {"counts": {"orphan": 1}})
+    assert ok is True
+    kwargs = client.return_value.put_object.call_args.kwargs
+    assert kwargs["Bucket"] == mod.RHYTHM_RESULTS_BUCKET
+    assert kwargs["Key"] == key
+    stanza = json.loads(kwargs["Body"].decode("utf-8"))
+    assert stanza["tenant"] == "corpus_entropy_engine"
+    assert stanza["status"] == "completed"
+    assert "completed_at" in stanza
+    assert stanza["detail"] == {"counts": {"orphan": 1}}
+
+
+def test_rhythm_stanza_hard_disabled_reports_skipped():
+    from unittest import mock
+
+    skipped = {
+        "statusCode": 200,
+        "body": json.dumps({"success": True, "skipped": True, "reason": "CEE_HARD_DISABLED"}),
+    }
+    with mock.patch.object(mod, "_run_scan", return_value=skipped):
+        with mock.patch.object(mod, "_write_rhythm_stanza") as stanza:
+            resp = mod.lambda_handler({"result_key": "k"}, None)
+    assert resp["statusCode"] == 200
+    assert stanza.call_args.args[1] == "skipped"
+
+
+def test_rhythm_stanza_write_failure_never_raises():
+    from unittest import mock
+
+    with mock.patch("boto3.client", side_effect=RuntimeError("boom")):
+        assert mod._write_rhythm_stanza({"result_key": "k"}, "completed", {}) is False

--- a/backend/lambda/percolation_monitor/lambda_function.py
+++ b/backend/lambda/percolation_monitor/lambda_function.py
@@ -327,7 +327,65 @@ def _publish_cloudwatch(
 # Handler
 # ---------------------------------------------------------------------------
 
+# --- ENC-TSK-N24: rhythm heavy-beat completion-stanza contract --------------
+# When invoked as a rhythm tenant (backend/lambda/rhythm_cycle/tenant_invoker
+# .py), the invoke payload carries ``result_key`` — the exact S3 key this
+# tenant must write its completion stanza to. Scheduled EventBridge invokes
+# carry no result_key and skip the write. Stanza shape mirrors
+# tenant_invoker.write_completion_stanza; a write failure is logged, never
+# raised — the beat's silent-tenant detection treats a missing stanza as
+# silence, which is the honest signal.
+
+RHYTHM_TENANT_NAME = "percolation_monitor"
+RHYTHM_RESULTS_BUCKET = os.environ.get("RHYTHM_RESULTS_BUCKET", "jreese-net")
+
+
+def _write_rhythm_stanza(event: Any, status: str, detail: Optional[Dict[str, Any]] = None) -> bool:
+    result_key = str((event or {}).get("result_key") or "").strip() if isinstance(event, dict) else ""
+    if not result_key:
+        return False
+    body = {
+        "tenant": RHYTHM_TENANT_NAME,
+        "status": status,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "detail": detail or {},
+    }
+    try:
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=RHYTHM_RESULTS_BUCKET,
+            Key=result_key,
+            Body=json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — stanza failure must never break the run
+        logger.warning("[ERROR] rhythm stanza write failed key=%s: %s", result_key, exc)
+        return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Entry point: run the percolation measurement, then honor the rhythm
+    completion-stanza contract when invoked as a heavy-beat tenant
+    (ENC-TSK-N24)."""
+    try:
+        resp = _run_percolation(event, context)
+    except Exception:
+        _write_rhythm_stanza(event, "failed", {})
+        raise
+    try:
+        body = json.loads(resp.get("body") or "{}")
+    except (TypeError, ValueError):
+        body = {}
+    status = "completed" if resp.get("statusCode") == 200 else "failed"
+    detail = {"statusCode": resp.get("statusCode")}
+    detail.update(
+        {k: body.get(k) for k in ("analytical_pc", "empirical_pc", "node_count", "edge_count") if k in body}
+    )
+    _write_rhythm_stanza(event, status, detail)
+    return resp
+
+
+def _run_percolation(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     logger.info("[START] Percolation monitor: project=%s table=%s", PROJECT_ID, PERCOLATION_TABLE)
     started = time.time()
 

--- a/backend/lambda/percolation_monitor/test_percolation.py
+++ b/backend/lambda/percolation_monitor/test_percolation.py
@@ -154,5 +154,39 @@ class FetchGraphSpuriousAttractorRateTest(unittest.TestCase):
         self.assertAlmostEqual(rate, 0.6)
 
 
+class RhythmStanzaTests(unittest.TestCase):
+    """ENC-TSK-N24: heavy-beat completion-stanza contract (tenant_invoker.py)."""
+
+    def test_no_result_key_is_noop(self):
+        from unittest import mock
+
+        with mock.patch.object(pm.boto3, "client") as client:
+            self.assertFalse(pm._write_rhythm_stanza({}, "completed", {}))
+            client.assert_not_called()
+
+    def test_result_key_writes_contract_stanza(self):
+        import json
+        from unittest import mock
+
+        key = "gamma/rhythm-cycle/heavy_integrate/tenant-results/20260712-000000/percolation_monitor.json"
+        with mock.patch.object(pm.boto3, "client") as client:
+            ok = pm._write_rhythm_stanza({"result_key": key}, "completed", {"analytical_pc": 0.31})
+        self.assertTrue(ok)
+        kwargs = client.return_value.put_object.call_args.kwargs
+        self.assertEqual(kwargs["Bucket"], pm.RHYTHM_RESULTS_BUCKET)
+        self.assertEqual(kwargs["Key"], key)
+        stanza = json.loads(kwargs["Body"].decode("utf-8"))
+        self.assertEqual(stanza["tenant"], "percolation_monitor")
+        self.assertEqual(stanza["status"], "completed")
+        self.assertIn("completed_at", stanza)
+        self.assertEqual(stanza["detail"], {"analytical_pc": 0.31})
+
+    def test_stanza_write_failure_never_raises(self):
+        from unittest import mock
+
+        with mock.patch.object(pm.boto3, "client", side_effect=RuntimeError("boom")):
+            self.assertFalse(pm._write_rhythm_stanza({"result_key": "k"}, "failed", {}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -2459,6 +2459,8 @@ Resources:
           COORDINATION_INTERNAL_API_KEY: !Ref CoordinationInternalApiKey
           COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
           PERCOLATION_TABLE: !Sub "enceladus-percolation-telemetry${EnvironmentSuffix}"
+          # ENC-TSK-N24: bucket for the rhythm heavy-beat completion stanza.
+          RHYTHM_RESULTS_BUCKET: !Ref S3Bucket
           CLOUDWATCH_NAMESPACE: Enceladus/Percolation
           PROJECT_ID: enceladus
           MC_TRIALS: "40"
@@ -2548,6 +2550,8 @@ Resources:
           COORDINATION_INTERNAL_API_KEY_PREVIOUS: !Ref CoordinationInternalApiKeyPrevious
           PROJECT_ID: enceladus
           CLOUDWATCH_NAMESPACE: Enceladus/CEE
+          # ENC-TSK-N24: bucket for the rhythm heavy-beat completion stanza.
+          RHYTHM_RESULTS_BUCKET: !Ref S3Bucket
           STAGNATION_THRESHOLD_DAYS: "14"
           COMPLIANCE_SCORE_THRESHOLD: "70"
           # ISS-465-style kill switch -- installed before the first scheduled
@@ -6454,6 +6458,13 @@ Resources:
                   - dynamodb:GetItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/enceladus-percolation-telemetry${EnvironmentSuffix}"
+              # ENC-TSK-N24: rhythm heavy-beat tenant completion stanza
+              # (tenant_invoker.py contract) — write-only, tenant-results scoped.
+              - Sid: RhythmStanzaWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}rhythm-cycle/*/tenant-results/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -6472,8 +6483,10 @@ Resources:
   # ENC-TSK-K41 / B66 Ph5: Corpus Entropy Engine execution role (gamma-only).
   # Reads the tracker/document/graph corpus exclusively over HTTPS via the
   # governed tracker/document/graph_query_api endpoints (internal-key auth,
-  # no IAM grant needed for that path); writes ONLY CloudWatch metrics. No
-  # DynamoDB, S3, or Secrets Manager grants -- this Lambda is telemetry-only
+  # no IAM grant needed for that path); writes CloudWatch metrics plus — since
+  # ENC-TSK-N24 — the ONE sanctioned direct-S3 write: the rhythm heavy-beat
+  # completion stanza (tenant_invoker.py contract), tenant-results scoped.
+  # No DynamoDB or Secrets Manager grants -- this Lambda is telemetry-only
   # and never mutates the corpus (OGTM).
   CorpusEntropyEngineRole:
     Type: AWS::IAM::Role
@@ -6505,6 +6518,13 @@ Resources:
                 Action:
                   - cloudwatch:PutMetricData
                 Resource: "*"
+              # ENC-TSK-N24: rhythm heavy-beat tenant completion stanza
+              # (tenant_invoker.py contract) — write-only, tenant-results scoped.
+              - Sid: RhythmStanzaWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${S3Bucket}/${S3EnvPrefix}rhythm-cycle/*/tenant-results/*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -7683,6 +7703,14 @@ Resources:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-handoff-consolidation-engine*"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-graph-health-metrics*"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-recompute-governance*"
+                  # ENC-TSK-N24 entropy/telemetry tenant families. The GDMP
+                  # grant exists so a future sanctioned enable is a flag flip;
+                  # the safety gates remain the manifest enabled=false flag and
+                  # the Lambda's own CEE_GDMP_HARD_DISABLED interlock — an IAM
+                  # grant alone invokes nothing.
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-corpus-entropy-engine*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-percolation-monitor*"
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-corpus-entropy-gdmp-remediation*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'

--- a/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
+++ b/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
@@ -1,30 +1,37 @@
 AWSTemplateFormatVersion: '2010-09-09'
+# ENC-TSK-N24: the original ENC-TSK-N18 top-level Description was 1181 chars,
+# over CloudFormation's 1024-char Description limit — CreateChangeSet rejected
+# the template with "Template format error: 'Description' length is greater
+# than 1024", which is why the enceladus-rhythm-tenants stack was never
+# created (N18's own deploy run failed earlier on missing params, masking
+# this). Long-form documentation lives in this comment block instead.
+#
+# Each key under `tenants` is one tenant record consumed by
+# backend/lambda/rhythm_cycle/tenant_invoker.py::get_manifest():
+#
+#   {
+#     "tenants": {
+#       "<name>": {
+#         "beat": "heavy_integrate" | "light_integrate",
+#         "enabled": false,               # kill switch; false = not invoked
+#         "function_name": "<lambda name>",
+#         "order": 10,                    # manifest ordering (ties -> name)
+#         "expected_output_contract": {}   # tenant-defined, opaque here
+#       }
+#     }
+#   }
+#
+# The `enabled` flag IS the addressable "rhythm.tenant.<name>.enabled" switch
+# from the BRD — AppConfig hosted config is a single JSON document rather
+# than flat key/value flags, so the flag is physically this nested boolean.
 Description: >
-  Enceladus Rhythm tenant manifest — ENC-TSK-N18 (DOC-44230223DD1C §4.1).
-  Adds a `rhythm-tenants` configuration profile under the EXISTING AppConfig
-  Application/Environment provisioned by 06-feature-flags.yaml, following the
-  precedent set by 09-appconfig-governance.yaml (additive, no other profile
-  touched). Each key under `tenants` is one tenant record consumed by
-  backend/lambda/rhythm_cycle/tenant_invoker.py::get_manifest():
-
-    {
-      "tenants": {
-        "<name>": {
-          "beat": "heavy_integrate" | "light_integrate",
-          "enabled": false,               # kill switch; false = not invoked
-          "function_name": "enceladus-tenant-<name>",
-          "order": 10,                    # manifest ordering (ties -> name)
-          "expected_output_contract": {}   # tenant-defined, opaque here
-        }
-      }
-    }
-
-  The `enabled` flag IS the addressable "rhythm.tenant.<name>.enabled" switch
-  from the BRD — AppConfig hosted config is a single JSON document rather
-  than flat key/value flags, so the flag is physically this nested boolean.
-
-  Ships with an EMPTY tenants object — zero enabled, invokable tenants by
-  default. No behavior change on gamma until ENC-TSK-N23/N24 populate it.
+  Enceladus Rhythm tenant manifest (ENC-TSK-N18/N23/N24, DOC-44230223DD1C
+  4.1). Adds a rhythm-tenants configuration profile under the EXISTING
+  AppConfig Application/Environment provisioned by 06-feature-flags.yaml,
+  following the 09-appconfig-governance.yaml precedent (additive, no other
+  profile touched). Tenant record shape, flag semantics, and per-tenant
+  rationale are documented in comments in this template and in
+  backend/lambda/rhythm_cycle/tenant_invoker.py.
 
 Parameters:
   EnvironmentSuffix:
@@ -99,13 +106,28 @@ Resources:
   # heavy window and bypass the contention deferral — remove the hook in the
   # same change that enables the tenant. The manifest entry reserves the
   # tenant slot and pins its expected-output contract now (ENC-TSK-N23 AC-1).
+  # ENC-TSK-N24 (PLN-078 W2b): entropy/telemetry tenants complete the heavy
+  # manifest. Real deployed Lambdas verified via `aws lambda list-functions`:
+  #   enceladus-corpus-entropy-engine-gamma, enceladus-percolation-monitor-
+  #   gamma, enceladus-corpus-entropy-gdmp-remediation-gamma.
+  #
+  # SAFETY — gdmp_remediation is enabled=FALSE and MUST STAY FALSE until the
+  # GDMP silent-data-loss defect (missing optimistic-concurrency on PATCH)
+  # clears: the mutation ramp is armed and CEE_GDMP_HARD_DISABLED is the
+  # sibling interlock. Do not flip this flag as part of routine onboarding.
+  #
+  # BUDGET — embedding_refresh and library_health_skillbuilder are wired
+  # unfunded (enabled=false, function_name="") pending the N09 budget gate
+  # (BRD section 5). Neither has a dedicated Lambda today;
+  # devops-titan-embedding-backfill is a BACKFILL utility, not a recurring
+  # refresh carrier, so it is deliberately NOT named as the function.
   RhythmTenantsInitialVersion:
     Type: AWS::AppConfig::HostedConfigurationVersion
     Properties:
       ApplicationId: !Ref AppConfigApplicationId
       ConfigurationProfileId: !Ref RhythmTenantsProfile
       ContentType: application/json
-      Description: "ENC-TSK-N23: consolidation-arc tenants (3 enabled; recompute_governance reserved, in-beat hook remains authoritative)"
+      Description: "ENC-TSK-N24: full heavy manifest (5 enabled; GDMP + embedding_refresh + library_health off per safety/budget gates)"
       Content: !Sub |
         {
           "tenants": {
@@ -155,6 +177,60 @@ Resources:
                 "min_metrics_per_window": 4,
                 "window_hours": 12
               }
+            },
+            "corpus_entropy_engine": {
+              "beat": "heavy_integrate",
+              "enabled": true,
+              "function_name": "enceladus-corpus-entropy-engine${EnvironmentSuffix}",
+              "order": 50,
+              "expected_output_contract": {
+                "artifact": "Enceladus/CEE entropy-category CloudWatch metrics + scan summary per window (orphan, stagnation, relational, retention, compliance_semantic)",
+                "categories_per_window": 5,
+                "window_hours": 12,
+                "mutation": "none - telemetry-only detector (ENC-TSK-K41); GDMP remediation is a separate gated tenant"
+              }
+            },
+            "percolation_monitor": {
+              "beat": "heavy_integrate",
+              "enabled": true,
+              "function_name": "enceladus-percolation-monitor${EnvironmentSuffix}",
+              "order": 60,
+              "expected_output_contract": {
+                "artifact": "percolation telemetry row (analytical_pc Molloy-Reed + empirical_pc Monte Carlo) in enceladus-percolation-telemetry + Enceladus/Percolation metrics",
+                "rows_per_window": 1,
+                "window_hours": 12
+              }
+            },
+            "gdmp_remediation": {
+              "beat": "heavy_integrate",
+              "enabled": false,
+              "function_name": "enceladus-corpus-entropy-gdmp-remediation${EnvironmentSuffix}",
+              "order": 70,
+              "expected_output_contract": {
+                "artifact": "GDMP Stage-1 remediation report per window when enabled",
+                "window_hours": 12,
+                "safety_gate": "DO NOT ENABLE: GDMP mutation ramp armed with missing optimistic-concurrency on PATCH (silent-data-loss defect); CEE_GDMP_HARD_DISABLED interlock in force; flag clears only with that defect fix"
+              }
+            },
+            "embedding_refresh": {
+              "beat": "heavy_integrate",
+              "enabled": false,
+              "function_name": "",
+              "order": 80,
+              "expected_output_contract": {
+                "note": "wired unfunded: no dedicated refresh lambda exists (devops-titan-embedding-backfill is a backfill utility, not a recurring refresh carrier); carrier + funding decided by N09 budget gate (BRD section 5)",
+                "budget_gate": "N09"
+              }
+            },
+            "library_health_skillbuilder": {
+              "beat": "heavy_integrate",
+              "enabled": false,
+              "function_name": "",
+              "order": 90,
+              "expected_output_contract": {
+                "note": "wired unfunded: no lambda exists; carrier + funding decided by N09 budget gate (BRD section 5)",
+                "budget_gate": "N09"
+              }
             }
           }
         }
@@ -178,7 +254,7 @@ Resources:
       ConfigurationProfileId: !Ref RhythmTenantsProfile
       ConfigurationVersion: !Ref RhythmTenantsInitialVersion
       DeploymentStrategyId: !Ref RhythmTenantsDeploymentStrategy
-      Description: "ENC-TSK-N23: activate consolidation-arc tenant manifest"
+      Description: "ENC-TSK-N24: activate full heavy tenant manifest"
 
 Outputs:
   RhythmTenantsProfileId:


### PR DESCRIPTION
## Summary

ENC-TSK-N24 (PLN-078 W2b): completes the heavy tenant manifest — 9 tenants total, 5 enabled — and fixes the ENC-TSK-N18 template defect that has blocked `enceladus-rhythm-tenants` stack creation since its introduction.

**Manifest (`11-appconfig-rhythm-tenants.yaml`)** — five new entries, function names verified via `aws lambda list-functions`:
- `corpus_entropy_engine` → `enceladus-corpus-entropy-engine-gamma`, **enabled**, order 50. Contract: 5 entropy-category metrics + scan summary per window; telemetry-only (K41), no mutation.
- `percolation_monitor` → `enceladus-percolation-monitor-gamma`, **enabled**, order 60. Contract: 1 telemetry row (analytical + empirical p_c) per window.
- `gdmp_remediation` → `enceladus-corpus-entropy-gdmp-remediation-gamma`, **enabled=FALSE (SAFETY)**, order 70. The GDMP mutation ramp is armed with a missing-optimistic-concurrency-on-PATCH silent-data-loss defect; `CEE_GDMP_HARD_DISABLED` is the sibling interlock. The safety gate is documented in the contract itself: do not flip until that defect clears.
- `embedding_refresh` and `library_health_skillbuilder` → **enabled=FALSE, `function_name:""`** (wired, unfunded) pending the N09 budget gate (BRD §5). Neither has a dedicated Lambda; `devops-titan-embedding-backfill` is a backfill utility, not a recurring refresh carrier, so it is deliberately NOT named — no new lambdas built per dispatch.

**N18 defect fix (unblocks stack creation)**: the template's top-level CFN `Description` was 1181 chars, over CloudFormation's 1024 limit — `CreateChangeSet` rejected every deploy with `Template format error: 'Description' length is greater than 1024`. This was masked in N18's own run, which failed earlier on missing `AppConfigApplicationId`/`AppConfigEnvironmentId` params (the stack has never been created, so push-triggered runs can't reuse stored values). Docs moved into YAML comments; Description now 464 chars. **Post-merge**: the stack still needs a one-time bootstrap `workflow_dispatch` of `cloudformation-rhythm-tenants-stack-deploy.yml` with `appconfig_application_id=fhhcl7m appconfig_environment_id=zecfu42` (06-feature-flags-gamma Outputs).

**Tenant-side stanza contract** — CEE and percolation_monitor handlers gain the same `_write_rhythm_stanza` helper + thin wrapper as N23 (PR #1023): `result_key`-gated, `completed`/`failed`, plus `skipped` for `CEE_HARD_DISABLED` deferrals; scheduled EventBridge invokes unaffected; for CEE this is the ONE sanctioned direct-S3 write (OGTM posture otherwise unchanged, role comment updated).

**IAM / env (`02-compute.yaml`)** — additive: `RhythmTenantInvoke` widened to the three real families (GDMP grant included so a future sanctioned enable is a flag flip — an IAM grant alone invokes nothing; the safety gates are the manifest flag + hard-disable env); CEE/PM roles gain tenant-results-scoped `s3:PutObject`; both functions gain `RHYTHM_RESULTS_BUCKET`.

**Governance dictionary** bumped to 2026-07-12.9 per the `lambda_function.py` touch guard (no entity/field schema change).

## Test plan

- [x] `pytest backend/lambda/rhythm_cycle/ -q` — 59 passed
- [x] `pytest backend/lambda/corpus_entropy_engine/test_lambda_function.py -q` — 37 passed (4 new stanza tests incl. skipped-stanza wrapper test)
- [x] `pytest backend/lambda/percolation_monitor/test_percolation.py -q` — 15 passed (3 new)
- [x] Templates YAML-validated; Description length 464 <= 1024; manifest JSON validated against the profile schema for both `EnvironmentSuffix` values (9 tenants, 5 enabled; every enabled entry has a non-empty function_name)
- [ ] CI green on this PR
- [ ] Post-merge: `_deploy.yml` (Gen2), `cloudformation-compute-stack-deploy.yml`, then bootstrap dispatch of `cloudformation-rhythm-tenants-stack-deploy.yml` (first CREATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-1f00686f5fc14cd8b4a5608e65c3edc0
