### PR TITLE
[ENC-TSK-N30] rhythm-tenants: predefined AppConfig.AllAtOnce deployment strategy

### DIFF
--- a/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
+++ b/infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml
@@ -235,17 +235,15 @@ Resources:
           }
         }
 
-  RhythmTenantsDeploymentStrategy:
-    Type: AWS::AppConfig::DeploymentStrategy
-    Properties:
-      Name: !Sub "enceladus-rhythm-tenants-immediate${EnvironmentSuffix}"
-      Description: Immediate activation, no bake time - matches feature-flags/governance precedent.
-      ReplicateTo: NONE
-      DeploymentDurationInMinutes: 0
-      FinalBakeTimeInMinutes: 0
-      GrowthFactor: 100
-      GrowthType: LINEAR
-
+  # ENC-TSK-N30: the custom RhythmTenantsDeploymentStrategy resource is
+  # replaced by AWS's predefined "AppConfig.AllAtOnce" strategy (immediate
+  # activation, no bake — identical semantics to the removed resource:
+  # duration 0, bake 0, growth 100). Creating a custom strategy required the
+  # account-scoped appconfig:CreateDeploymentStrategy grant the CFN deploy
+  # role lacks (N24 bootstrap run 29195465126 403'd on it); referencing the
+  # predefined strategy removes that grant class permanently. Predefined
+  # strategy IDs are valid values for AWS::AppConfig::Deployment
+  # DeploymentStrategyId, mirroring StartDeployment semantics.
   RhythmTenantsInitialDeployment:
     Type: AWS::AppConfig::Deployment
     Properties:
@@ -253,8 +251,8 @@ Resources:
       EnvironmentId: !Ref AppConfigEnvironmentId
       ConfigurationProfileId: !Ref RhythmTenantsProfile
       ConfigurationVersion: !Ref RhythmTenantsInitialVersion
-      DeploymentStrategyId: !Ref RhythmTenantsDeploymentStrategy
-      Description: "ENC-TSK-N24: activate full heavy tenant manifest"
+      DeploymentStrategyId: "AppConfig.AllAtOnce"
+      Description: "ENC-TSK-N30: activate full heavy tenant manifest (predefined AllAtOnce strategy)"
 
 Outputs:
   RhythmTenantsProfileId:


### PR DESCRIPTION
## Summary

ENC-TSK-N30 (PLN-078 W2d): removes the `RhythmTenantsDeploymentStrategy` resource from `infrastructure/cloudformation/11-appconfig-rhythm-tenants.yaml` and points `RhythmTenantsInitialDeployment` at AWS's **predefined `AppConfig.AllAtOnce` strategy** — identical semantics to the removed resource (immediate activation, no bake: duration 0, bake 0, growth 100).

**Why**: the N24 bootstrap CREATE (run 29195465126) failed with two 403s on `enceladus-cloudformation-deploy-github-role`. One of them — account-scoped `appconfig:CreateDeploymentStrategy` — is not granted by the `iam-cfn-deploy-role-appconfig-patch` lane at all (its grants are scoped under `application/fhhcl7m`). Referencing the predefined strategy removes that grant class permanently. The other 403 (`appconfig:CreateConfigurationProfile`) is handled separately via the IAM patch lane (PR #913 + io-approved patch run).

**Bootstrap path after this merges** (per recon): the deploy workflow already self-heals the `ROLLBACK_COMPLETE` stack on gamma (auto `delete-stack` + wait before redeploy, fail-closed on prod), so once the IAM patch run is green, a single `workflow_dispatch` of `cloudformation-rhythm-tenants-stack-deploy.yml` (ref `v4/main`, `appconfig_application_id=fhhcl7m`, `appconfig_environment_id=zecfu42`) deletes the dead stack and re-CREATEs.

Template-only diff (1 file, +11/-13): no lambda code, no manifest content change (9 tenants / 5 enabled intact), no dictionary-guard trip.

## Test plan

- [x] Template YAML-validated: 3 resources (strategy resource gone), top-level Description 464 chars, `DeploymentStrategyId: AppConfig.AllAtOnce`, manifest JSON intact and schema-valid
- [ ] CI green on this PR
- [ ] Post-merge push run of the rhythm-tenants workflow will still fail pre-IAM-patch (profile 403) — expected; AC-3 stamps from the post-patch bootstrap re-dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CCI-7828f00091884e0597bcf671494b074f
