### PR TITLE
feat(iam): codify appconfig-governance deploy-role grants (ENC-TSK-N31)

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -835,6 +835,75 @@ Resources:
               - cloudfront:PublishFunction
             Resource: "arn:aws:cloudfront::356364570033:function/enceladus-ui-v2-spa-rewrite*"
 
+  # ENC-TSK-N31 codify: enceladus-cfn-deploy-appconfig-governance-v1 was
+  # attached out-of-band by io (PLN-078 worklog 2026-07-12) after the
+  # CloudFormationDeployRole inline-policy quota (10,240B) was exhausted.
+  # DISTINCT ManagedPolicyName (not "-v1") is deliberate -- a name
+  # collision with the manual policy would fail the apply. io detaches
+  # and deletes the manual v1 policy only after this CFN-managed policy
+  # is confirmed attached via list-attached-role-policies; detaching
+  # first would drop the live AppConfig deploy grant mid-flight. Same
+  # attached-managed-policy pattern as UiCdnDeployPolicy above.
+  # Statement 2 resources are scoped to the gamma application id
+  # (fhhcl7m), not a cross-application wildcard: bootstrap run
+  # 29201683093 proved AWS authorizes appconfig:CreateHostedConfiguration
+  # Version against the specific APPLICATION arn, not configurationprofile/*
+  # or application/*. deploymentstrategy/AppConfig.AllAtOnce is included
+  # because the CFN deployment handler tags the deployment ARN on
+  # read-back (ENC-TSK-N31 intent, superseding an earlier description
+  # draft that omitted it).
+  # ENC-TSK-N34 (PITR rollout) separately proposes widening this same
+  # role's DynamoDB grant via a new ManagedPolicy in this neighborhood --
+  # no shared resource name, but flagged here for merge adjacency.
+  AppConfigGovernanceDeployPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-appconfig-governance-cfn
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AppConfigApplicationProfileEnvironmentCrud
+            Effect: Allow
+            Action:
+              - appconfig:GetApplication
+              - appconfig:UpdateApplication
+              - appconfig:DeleteApplication
+              - appconfig:CreateConfigurationProfile
+              - appconfig:GetConfigurationProfile
+              - appconfig:UpdateConfigurationProfile
+              - appconfig:DeleteConfigurationProfile
+              - appconfig:ListConfigurationProfiles
+              - appconfig:CreateEnvironment
+              - appconfig:GetEnvironment
+              - appconfig:UpdateEnvironment
+              - appconfig:DeleteEnvironment
+              - appconfig:ListEnvironments
+            Resource:
+              - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:application/fhhcl7m"
+              - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:application/fhhcl7m/*"
+          - Sid: AppConfigHostedVersionAndDeployment
+            Effect: Allow
+            Action:
+              - appconfig:CreateHostedConfigurationVersion
+              - appconfig:GetHostedConfigurationVersion
+              - appconfig:DeleteHostedConfigurationVersion
+              - appconfig:ListHostedConfigurationVersions
+              - appconfig:StartDeployment
+              - appconfig:GetDeployment
+              - appconfig:StopDeployment
+              - appconfig:ListDeployments
+              - appconfig:ListTagsForResource
+              - appconfig:TagResource
+              - appconfig:UntagResource
+            Resource:
+              - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:application/fhhcl7m"
+              - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:application/fhhcl7m/*"
+              - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:deploymentstrategy/AppConfig.AllAtOnce"
+
   BackendDeployRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Summary
- Adds `AppConfigGovernanceDeployPolicy` (AWS::IAM::ManagedPolicy) attached to `CloudFormationDeployRole`, codifying the out-of-band manual policy `enceladus-cfn-deploy-appconfig-governance-v1` that io attached after the role's inline-policy quota (10,240B) was exhausted.
- Scoped to the gamma application id (`fhhcl7m`), not a cross-application wildcard, per bootstrap run 29201683093 (AWS authorizes `appconfig:CreateHostedConfigurationVersion` against the specific APPLICATION arn). Includes `deploymentstrategy/AppConfig.AllAtOnce` since the CFN deployment handler tags the deployment ARN on read-back.
- Distinct `ManagedPolicyName` (`enceladus-cfn-deploy-appconfig-governance-cfn`) to avoid an AlreadyExists collision with the manual v1 policy. Manual v1 stays attached until io confirms this managed policy is live and detaches it separately.
- Mirrors `UiCdnDeployPolicy`'s shape/precedent in the same file.

## Test plan
- [x] `cfn-lint` run against modified template — zero new findings vs. an unmodified baseline (same pre-existing warning count, unrelated to this change)
- [x] YAML parse check
- [ ] Roles-stack apply (gated on io reviewer approval per v3-prod environment)
- [ ] Post-apply: `aws iam list-attached-role-policies --role-name enceladus-cloudformation-deploy-github-role` confirms the CFN-managed policy attached

CCI-db8311439b6146108461e680ceec62c0

🤖 Generated with [Claude Code](https://claude.com/claude-code)