### PR TITLE
feat(dynamodb): enable PITR on existing prod tables (ENC-TSK-N34)

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -36,6 +36,8 @@ Resources:
     Properties:
       TableName: !Sub "coordination-requests${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: request_id
           AttributeType: S
@@ -79,6 +81,8 @@ Resources:
     Properties:
       TableName: !Sub "devops-project-tracker${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       AttributeDefinitions:
@@ -130,6 +134,8 @@ Resources:
     Properties:
       TableName: !Sub "projects${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: project_id
@@ -158,6 +164,8 @@ Resources:
     Properties:
       TableName: !Sub "documents${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       DeletionProtectionEnabled: !If [IsProduction, true, false]
@@ -192,6 +200,8 @@ Resources:
     Properties:
       TableName: !Sub "devops-deployment-manager${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: project_id
           AttributeType: S
@@ -258,6 +268,8 @@ Resources:
     Properties:
       TableName: !Sub "governance-policies${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: policy_id
           AttributeType: S
@@ -325,6 +337,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-compliance-violations${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: violation_id
           AttributeType: S
@@ -378,6 +392,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-sessions${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: session_id
@@ -402,6 +418,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-types${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: agent_type_id
@@ -564,6 +582,8 @@ Resources:
     Properties:
       TableName: !Sub "governance-version${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: version_id
           AttributeType: S

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -904,6 +904,55 @@ Resources:
               - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:application/fhhcl7m/*"
               - !Sub "arn:aws:appconfig:us-west-2:${AWS::AccountId}:deploymentstrategy/AppConfig.AllAtOnce"
 
+  # ENC-TSK-N34 -- DynamoDB PITR pre-flight (AC-1). CloudFormationDeployRole's
+  # DynamoDBTableOps grant is scoped to table/enceladus-*, table/devops-* only;
+  # 9 prod tables (11 incl. gamma-only names) fall outside both prefixes.
+  # Same failure class as every other ManagedPolicy in this file: inline quota
+  # exhausted, and CloudFormationDeployRole has no iam:CreatePolicy so this
+  # resource cannot be created fresh by the deploy workflow. The live policy
+  # (enceladus-cfn-deploy-ddb-pitr-ops, PolicyId ANPAVF6H3ZWYQRAFAVJLK) was
+  # created and attached out-of-band by io on 2026-07-13; this resource is
+  # brought under CFN management via --change-set-type IMPORT (see the
+  # BackendDeployRole import precedent above), same name, no manual/CFN
+  # name-collision handling needed since the import targets this exact ARN.
+  DynamoDbPitrOpsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-ddb-pitr-ops
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DynamoDbContinuousBackupsOps
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeContinuousBackups
+              - dynamodb:UpdateContinuousBackups
+            Resource:
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/coordination-requests"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/coordination-requests-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-policies"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-policies-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/component-registry"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/component-registry-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-compliance-violations"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-compliance-violations-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-sessions"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-sessions-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-types"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-types-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-credentials-gamma"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/user-preferences-gamma"
+
   BackendDeployRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Summary
- Enables PITR (`PointInTimeRecoverySpecification`) on the 10 DynamoDB tables that already exist in prod (`ComponentRegistryTable` already had it — untouched).
- Adds a new `AWS::IAM::ManagedPolicy` (`DynamoDbPitrOpsPolicy`) granting only `dynamodb:DescribeContinuousBackups` + `dynamodb:UpdateContinuousBackups`, exact non-wildcarded ARNs, on exactly the tables that need it. `CloudFormationDeployRole`'s existing `DynamoDBTableOps` grant only covers `table/enceladus-*` and `table/devops-*`.

## Scope guarantee
- **Prod-existing tables only.** No new table is created in prod. No `v4/main` content is merged here.
- Additive-only diff: every change is a new 2-line property or one new resource. Nothing existing is modified or removed.

## Sequencing (AC-1, ENC-TSK-N34)
1. ✅ Done: `enceladus-cfn-deploy-ddb-pitr-ops` was created and attached out-of-band by io (`CloudFormationDeployRole` has no `iam:CreatePolicy` — same failure class as every prior `ManagedPolicy` in this file, see the code comment for the precedent chain).
2. **Next, before merge**: io runs the `--change-set-type IMPORT` sequence (mirrors the `BackendDeployRole` import already codified in this file) against stack `enceladus-github-roles`, importing `DynamoDbPitrOpsPolicy` at the same live ARN, so this PR's template matches reality with zero drift.
3. After merge: the gated `cloudformation-github-roles-stack-deploy.yml` and data-stack workflows pause at the v3-prod required-reviewer gate for io's approval, per DOC-499FA089EC30.

## Pre-approval checklist (DOC-B716E8FB10B6 lesson applied)
- [x] `04-github-roles.yaml` diff is additive-only — one new `ManagedPolicy`, nothing else touched.
- [x] `01-data.yaml` diff is additive-only — `PointInTimeRecoverySpecification` added to 10 existing resources, no `TableName`/key schema/other property touched.
- [ ] io: confirm `main`'s current template state still matches live prod at merge time (re-run `aws dynamodb list-tables` / `aws iam get-role-policy` if this PR sits for more than a day).
- [x] No Lambda/whole-env deploy involved — this is CFN-only (DynamoDB + IAM), so the specific SCI-revert failure mode from the COE does not apply here.

## Test plan
- [x] `cfn-lint` clean on both changed files (only pre-existing warnings unrelated to this diff — verified none land on the added lines).
- [ ] io: review diff, run the IAM import, approve the gated stack applies.
- [ ] Post-merge: `aws dynamodb describe-continuous-backups --table-name <each>` returns `PointInTimeRecoveryStatus=ENABLED` for all 10 tables (AC-5 evidence).

Related: ENC-TSK-N34, ENC-TSK-N31, DOC-0EA2B77D863F (handoff), DOC-499FA089EC30, DOC-B716E8FB10B6

commit-complete-id: CCI-274439f8213144d9aa6c93bab4b5a4d1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
