### PR TITLE
feat(dynamodb): enable PITR on all 21 gamma DynamoDB tables (ENC-TSK-N34)

### DIFF
--- a/infrastructure/cloudformation/01-data.yaml
+++ b/infrastructure/cloudformation/01-data.yaml
@@ -38,6 +38,8 @@ Resources:
     Properties:
       TableName: !Sub "coordination-requests${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: request_id
           AttributeType: S
@@ -81,6 +83,8 @@ Resources:
     Properties:
       TableName: !Sub "devops-project-tracker${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       AttributeDefinitions:
@@ -156,6 +160,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-relationships${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       AttributeDefinitions:
@@ -180,6 +186,8 @@ Resources:
     Properties:
       TableName: !Sub "projects${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: project_id
@@ -208,6 +216,8 @@ Resources:
     Properties:
       TableName: !Sub "documents${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       DeletionProtectionEnabled: !If [IsProduction, true, false]
@@ -249,6 +259,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-drift-telemetry${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: wave_id
           AttributeType: S
@@ -282,6 +294,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-stigmergic-trace${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: trace_id
           AttributeType: S
@@ -318,6 +332,8 @@ Resources:
     Properties:
       TableName: !Sub "devops-deployment-manager${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: project_id
           AttributeType: S
@@ -357,6 +373,8 @@ Resources:
     Properties:
       TableName: !Sub "governance-policies${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: policy_id
           AttributeType: S
@@ -424,6 +442,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-compliance-violations${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: violation_id
           AttributeType: S
@@ -481,6 +501,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-id-counters${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: counter_key
           AttributeType: S
@@ -503,6 +525,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-id-idempotency${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: idempotency_key
           AttributeType: S
@@ -529,6 +553,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-id-violations${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: caller_identity
           AttributeType: S
@@ -784,6 +810,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-sessions${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: session_id
@@ -813,6 +841,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-types${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: agent_type_id
@@ -843,6 +873,8 @@ Resources:
     Properties:
       TableName: !Sub "agent-credentials${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       DeletionProtectionEnabled: !If [IsProduction, true, false]
       AttributeDefinitions:
         - AttributeName: credential_id
@@ -872,6 +904,8 @@ Resources:
     Properties:
       TableName: !Sub "user-preferences${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: sub
           AttributeType: S
@@ -896,6 +930,8 @@ Resources:
     Properties:
       TableName: !Sub "governance-version${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: version_id
           AttributeType: S
@@ -919,6 +955,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-percolation-telemetry${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: pk
           AttributeType: S
@@ -943,6 +981,8 @@ Resources:
     Properties:
       TableName: !Sub "enceladus-convergence-telemetry${EnvironmentSuffix}"
       BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       AttributeDefinitions:
         - AttributeName: attribute_name
           AttributeType: S


### PR DESCRIPTION
## Summary
- Enables PITR on the 20 gamma DynamoDB tables that don't already have it (`ComponentRegistryTable` already had it — untouched).
- Gamma-only, ungated lane per DOC-499FA089EC30 — no prod content, no reviewer gate.

## Dependency
- IAM coverage for the newly-flagged tables (including `-gamma` ARN variants) was already granted via the `DynamoDbPitrOpsPolicy` managed policy in #1030. That policy is shared across gamma and prod since it's the same live IAM role — no additional IAM change needed here.
- Merge order: this is independent of #1030's merge (different branch, different stack), but the actual gamma CFN apply should follow #1030's IAM import landing, to avoid the AccessDenied/rollback failure mode described in ENC-TSK-N34 AC-1.

## Test plan
- [x] `cfn-lint` clean (only pre-existing warnings unrelated to this diff).
- [ ] Post-merge: `aws dynamodb describe-continuous-backups --table-name <each>-gamma` returns `PointInTimeRecoveryStatus=ENABLED` for all 21 gamma tables (AC-4 evidence).

Related: ENC-TSK-N34, DOC-0EA2B77D863F (handoff), DOC-499FA089EC30

Note: this PR and #1030 are two branches/commits produced by the same tracker task (ENC-TSK-N34) -- the checkout lifecycle mints one CCI per task-committed transition, not per commit, so the same token is used on both PRs. Task history records both commit SHAs.

commit-complete-id: CCI-274439f8213144d9aa6c93bab4b5a4d1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
