### PR TITLE
fix(cfn): grant rhythm role invoke on devops-titan-embedding-backfill (ENC-TSK-N43, ENC-ISS-549)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -7711,6 +7711,13 @@ Resources:
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-corpus-entropy-engine*"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-percolation-monitor*"
                   - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:enceladus-corpus-entropy-gdmp-remediation*"
+                  # ENC-ISS-549: embedding_refresh tenant (ENC-TSK-N32, enabled
+                  # in 11-appconfig-rhythm-tenants.yaml) invokes
+                  # devops-titan-embedding-backfill; N32 wired the manifest but
+                  # omitted this grant, so the heavy beat's async invoke was
+                  # AccessDenied and the tenant was silently dropped. Grant added
+                  # here to match the intentional enablement.
+                  - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:devops-titan-embedding-backfill*"
         - PolicyName: AppConfigAccess
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
## ENC-TSK-N43 — fix ENC-ISS-549 (embedding_refresh IAM invoke gap)

`embedding_refresh` was **intentionally enabled** by ENC-TSK-N32 in `11-appconfig-rhythm-tenants.yaml`, but the matching `lambda:InvokeFunction` grant was omitted from `RhythmTenantInvoke` in `02-compute.yaml`. The heavy beat's async invoke of `devops-titan-embedding-backfill-gamma` therefore returned `AccessDenied` and the tenant was silently dropped (`manifest_size` 6 vs `invoked_tenants` 5), observed live at 2026-07-13T00:45Z (DOC-2ADECC07A4F2).

**Change:** add `function:devops-titan-embedding-backfill*` to the `RhythmTenantInvoke` resource list. One-line IAM grant matching the intentional enablement — not a behavior change beyond letting the already-enabled tenant actually run.

Merge to v4/main auto-triggers `cloudformation-compute-stack-deploy` (v4-gamma environment, no reviewer). Post-deploy the grant is verifiable via `aws iam get-role-policy --role-name enceladus-rhythm-cycle-role-gamma --policy-name RhythmCyclePolicy`.

CCI-7d3d9f4acfee41cea87e036ad027d140

🤖 Generated with [Claude Code](https://claude.com/claude-code)