### PR TITLE
Fix ENC-ISS-554: quarantine degenerate Fiedler lambda2

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-12.10",
-  "updated_at": "2026-07-12T23:58:00Z",
-  "last_change_summary": "ENC-TSK-N32: embedding_refresh rhythm tenant activated (PLN-078 W4a, N09 activation) onto the bounded devops-titan-embedding-backfill carrier. titan_embedding_backfill/lambda_function.py gains tenant-mode: detects the rhythm-beat payload (result_key present, per tenant_invoker.py), applies EMBEDDING_REFRESH_MAX_PER_RUN (default 500) as event.limit when tenant-invoked without an explicit limit (runaway-cost backstop), and writes the heavy-beat completion-stanza {tenant,status,completed_at,detail:{processed,skipped,errors,missing_node}} to result_key (mirrors the ENC-TSK-N23/N24 contract). One-shot invocation + UAT probe paths unchanged; per-record embedding_text_hash skip-gating keeps a per-window refresh budget-safe. Manifest 11-appconfig-rhythm-tenants.yaml: embedding_refresh enabled=true with function_name devops-titan-embedding-backfill${EnvironmentSuffix}, and library_health_skillbuilder removed (ENC-TSK-N33 scope, not a lambda tenant) -> 8 tenants, 6 enabled. No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "version": "2026-07-13.1",
+  "updated_at": "2026-07-13T06:40:00Z",
+  "last_change_summary": "ENC-TSK-N54 (ENC-ISS-554): graph_health_metrics/lambda_function.py and graph_query_api/graph_health_metric.py quarantine degenerate Fiedler lambda2 readings -- compute_fiedler_value now rejects any lambda2 <= 1e-9 as ok=False with an explicit invalid_reason (sample_capped_degenerate vs genuine_disconnection_suspected) instead of a confident zero, and graph_health_metrics no longer silently substitutes the GraphEdgeDensity proxy under the FiedlerAlgebraicConnectivity metric name on fetch failure (omits the key instead). No entity/field schema change; bumping per the lambda_function.py touch guard.",
   "owners": [
     "enceladus-platform"
   ],
@@ -8399,6 +8399,11 @@
       "version": "2026-07-12.9",
       "date": "2026-07-12",
       "summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-13.1",
+      "date": "2026-07-13",
+      "summary": "ENC-TSK-N54 (ENC-ISS-554): graph_health_metrics/lambda_function.py and graph_query_api/graph_health_metric.py quarantine degenerate Fiedler lambda2 readings -- compute_fiedler_value now rejects any lambda2 <= 1e-9 as ok=False with an explicit invalid_reason (sample_capped_degenerate vs genuine_disconnection_suspected) instead of a confident zero, and graph_health_metrics no longer silently substitutes the GraphEdgeDensity proxy under the FiedlerAlgebraicConnectivity metric name on fetch failure (omits the key instead). No entity/field schema change; bumping per the lambda_function.py touch guard."
     }
   ]
 }

--- a/backend/lambda/graph_health_metrics/lambda_function.py
+++ b/backend/lambda/graph_health_metrics/lambda_function.py
@@ -12,15 +12,23 @@ devops-graph-query-api's action='publish_graph_health' entrypoint (see
 _fetch_real_fiedler_value) -- that entrypoint uses a BOUNDED induced subgraph
 + scipy.sparse.linalg.eigsh, which is the only tractable eigensolver at
 Enceladus's ~1,500-node scale (dense Jacobi over the unbounded full graph this
-Lambda already queries would be O(n^3) and infeasible in pure Python). Falls
-back to the original GraphEdgeDensity proxy only if that invoke fails.
+Lambda already queries would be O(n^3) and infeasible in pure Python).
+
+ENC-ISS-554: the real Fiedler path is estimator-gated (graph_query_api's
+compute_fiedler_value rejects a degenerate/non-positive lambda2 -- likely a
+LAPLACIAN_MAX_VERTICES sampling artifact at corpus scale -- as an explicit
+failure rather than a confident zero). On any failure of that invoke
+(estimator-rejected or otherwise), FiedlerAlgebraicConnectivity is simply
+omitted from this interval's published batch. It no longer silently
+aliases the GraphEdgeDensity value under the Fiedler metric name.
 
 Metrics published:
   - GraphEdgeDensity (edges / nodes) in Enceladus/GraphHealth
   - OrphanNodeRatio (orphan nodes / total nodes) in Enceladus/GraphHealth
   - GraphNodeCount (total node count) in Enceladus/GraphHealth
-  - FiedlerAlgebraicConnectivity (real lambda2 via graph_query_api; proxy
-    GraphEdgeDensity value on invoke failure) in Enceladus/GraphHealth
+  - FiedlerAlgebraicConnectivity (real lambda2 via graph_query_api; omitted
+    this interval on any failure -- never a proxy substitute) in
+    Enceladus/GraphHealth
 
 Triggered by EventBridge on a daily schedule.
 
@@ -193,19 +201,29 @@ def _compute_metrics(driver) -> Dict[str, float]:
 
         # ENC-TSK-K43 (B66 Ph5): real Fiedler lambda2 via the FTR-088 CSR/
         # Fiedler path (cross-Lambda invoke into graph_query_api, see
-        # _fetch_real_fiedler_value). Falls back to the original GraphEdgeDensity
-        # proxy (the pre-K43 ENC-TSK-C10 placeholder, documented above) only if
-        # the invoke fails -- never blocks the rest of this Lambda's metrics.
+        # _fetch_real_fiedler_value).
+        #
+        # ENC-ISS-554: this used to fall back to the GraphEdgeDensity proxy
+        # (the pre-K43 ENC-TSK-C10 placeholder) under the FiedlerAlgebraicConnectivity
+        # name whenever the invoke failed -- but a different metric's value
+        # silently relabeled as lambda2 is exactly the "confident lie" pattern
+        # this issue quarantines, not just the degenerate-zero case. On any
+        # failure (invoke error, or the estimator itself reporting an
+        # explicit invalid_reason for a degenerate/untrustworthy lambda2) this
+        # metric is simply omitted from the published batch for this interval
+        # -- silence beats a confident-but-wrong reading, matching the
+        # skip-on-failure behavior graph_query_api's own FiedlerValue metric
+        # already has via run_publish_graph_health.
         fiedler = _fetch_real_fiedler_value()
         if fiedler.get("ok"):
             metrics["FiedlerAlgebraicConnectivity"] = fiedler["lambda2"]
         else:
             logger.warning(
-                "[WARNING] real Fiedler lambda2 unavailable (%s); falling back to "
-                "GraphEdgeDensity proxy for FiedlerAlgebraicConnectivity",
+                "[WARNING] real Fiedler lambda2 unavailable (%s); omitting "
+                "FiedlerAlgebraicConnectivity this interval rather than "
+                "publishing a mislabeled proxy value",
                 fiedler.get("error"),
             )
-            metrics["FiedlerAlgebraicConnectivity"] = metrics["GraphEdgeDensity"]
 
     return metrics
 

--- a/backend/lambda/graph_health_metrics/test_fiedler_k43.py
+++ b/backend/lambda/graph_health_metrics/test_fiedler_k43.py
@@ -6,8 +6,13 @@ GraphEdgeDensity (documented in the ENC-TSK-C10 module docstring as a stopgap
 while GDS was unavailable). K43 replaces it with the REAL Fiedler lambda2 via
 a cross-Lambda invoke into devops-graph-query-api's action='publish_graph_health'
 entrypoint (the FTR-088 CSR/Fiedler path, ISS-465-compliant -- no GDS
-projection), falling back to the GraphEdgeDensity proxy only if that invoke
-fails.
+projection).
+
+ENC-ISS-554: the GraphEdgeDensity-proxy fallback on invoke failure was
+removed -- a different metric's value silently relabeled as lambda2 is a
+confident-lie pattern in its own right. FiedlerAlgebraicConnectivity is now
+simply omitted from the published batch on any failure (invoke error, or the
+estimator's own explicit rejection of a degenerate lambda2).
 
 Covers:
   - _fetch_real_fiedler_value: successful invoke parses the nested
@@ -16,9 +21,9 @@ Covers:
     project_id result all degrade to {"ok": False, ...} rather than raising.
   - _compute_metrics: FiedlerAlgebraicConnectivity carries the REAL lambda2
     on a successful invoke (and is NOT equal to the GraphEdgeDensity proxy
-    when the two values differ), and falls back to the GraphEdgeDensity
-    proxy when the invoke fails -- preserving the pre-K43 degrade behavior
-    exactly (never blocks GraphNodeCount/GraphEdgeDensity/OrphanNodeRatio).
+    when the two values differ), and is omitted entirely (not a proxy
+    substitute) when the invoke fails or the estimator rejects a degenerate
+    value -- never blocks GraphNodeCount/GraphEdgeDensity/OrphanNodeRatio.
 """
 from __future__ import annotations
 
@@ -179,12 +184,31 @@ class ComputeMetricsTests(unittest.TestCase):
         # proving this is no longer the GraphEdgeDensity alias.
         self.assertNotEqual(metrics["FiedlerAlgebraicConnectivity"], metrics["GraphEdgeDensity"])
 
-    def test_fiedler_algebraic_connectivity_falls_back_to_proxy_on_failure(self):
+    def test_fiedler_algebraic_connectivity_omitted_on_failure(self):
+        # ENC-ISS-554: no more silent GraphEdgeDensity-under-Fiedler-name
+        # substitution -- a failed/degenerate real-lambda2 fetch means the
+        # metric is simply absent from this interval's batch (silence beats
+        # a confident-but-mislabeled reading), and the other metrics are
+        # still published normally.
         driver = _Driver(node_count=10, edge_count=20, orphan_count=1)  # GraphEdgeDensity = 2.0
         lf._fetch_real_fiedler_value = lambda: {"ok": False, "error": "graph_query_api unavailable"}
         metrics = lf._compute_metrics(driver)
-        self.assertEqual(metrics["FiedlerAlgebraicConnectivity"], metrics["GraphEdgeDensity"])
-        self.assertEqual(metrics["FiedlerAlgebraicConnectivity"], 2.0)
+        self.assertNotIn("FiedlerAlgebraicConnectivity", metrics)
+        self.assertEqual(metrics["GraphEdgeDensity"], 2.0)
+
+    def test_fiedler_algebraic_connectivity_omitted_on_estimator_rejected_degenerate_value(self):
+        # The estimator itself (graph_query_api.compute_fiedler_value) now
+        # rejects a degenerate lambda2 as ok=False with an invalid_reason
+        # rather than ok=True/lambda2=0.0 -- confirm that flows through here
+        # as an omission too, not a published zero.
+        driver = _Driver(node_count=10, edge_count=20, orphan_count=1)
+        lf._fetch_real_fiedler_value = lambda: {
+            "ok": False,
+            "error": "lambda2=0.0 is degenerate for an induced subgraph capped at n=500 vertices (limit=500)",
+            "invalid_reason": "sample_capped_degenerate",
+        }
+        metrics = lf._compute_metrics(driver)
+        self.assertNotIn("FiedlerAlgebraicConnectivity", metrics)
 
     def test_other_metrics_unaffected_by_fiedler_fetch(self):
         driver = _Driver(node_count=50, edge_count=75, orphan_count=3)

--- a/backend/lambda/graph_query_api/graph_health_metric.py
+++ b/backend/lambda/graph_query_api/graph_health_metric.py
@@ -56,6 +56,18 @@ DEFAULT_K = 3
 # CloudWatch PutMetricData accepts at most 20 MetricDatum entries per call.
 _CLOUDWATCH_BATCH_SIZE = 20
 
+# ENC-ISS-554: floor below which a computed eigenvalue is treated as
+# degenerate rather than a trustworthy positive lambda2. eigsh/eigh on an
+# INDUCED SUBGRAPH capped at LAPLACIAN_MAX_VERTICES vertices can legitimately
+# compute a near-zero second eigenvalue when the cap truncates the true graph
+# short (real neighbors of a selected vertex fall outside the sample, leaving
+# it isolated within the induced subgraph even though it is well-connected in
+# the full graph) -- a real number, not an exception or a hardcoded default,
+# but not a trustworthy reading of the full graph's algebraic connectivity
+# either. Treating any lambda2 at or below this floor as ok=False (rather
+# than a confident zero) is the quarantine.
+_LAMBDA2_DEGENERATE_EPSILON = 1e-9
+
 
 def compute_fiedler_value(
     driver: Any,
@@ -107,11 +119,46 @@ def compute_fiedler_value(
 
     lambda2 = float(eigenvalues[1])
     laplacian_meta = result.get("laplacian") or {}
+    n = laplacian_meta.get("n")
+
+    if lambda2 <= _LAMBDA2_DEGENERATE_EPSILON:
+        # ENC-ISS-554 quarantine: a degenerate lambda2 must never be reported
+        # as ok=True. Distinguish (for the error message only -- both cases
+        # return ok=False identically) a capped/non-representative sample
+        # from a full vertex set that came back genuinely disconnected.
+        capped = isinstance(n, int) and isinstance(limit, int) and n >= limit
+        if capped:
+            reason = (
+                f"lambda2={lambda2!r} is degenerate for an induced subgraph capped at "
+                f"n={n} vertices (limit={limit}); this is very likely a sampling artifact "
+                "-- the vertex cap truncates the corpus, stranding real neighbors outside "
+                "the sample and producing spurious isolated components even though the "
+                "full graph is connected -- not a measurement of the full graph's "
+                "algebraic connectivity"
+            )
+            invalid_reason = "sample_capped_degenerate"
+        else:
+            reason = (
+                f"lambda2={lambda2!r} is degenerate for a full (uncapped, n={n}) vertex "
+                "set; this would indicate genuine full-graph disconnection and needs "
+                "manual review rather than being published as a routine reading"
+            )
+            invalid_reason = "genuine_disconnection_suspected"
+        return {
+            "ok": False,
+            "error": reason,
+            "invalid_reason": invalid_reason,
+            "lambda2_raw": lambda2,
+            "n": n,
+            "limit": limit,
+            "project_id": project_id,
+        }
+
     return {
         "ok": True,
         "lambda2": lambda2,
         "lambda0": float(eigenvalues[0]),
-        "n": laplacian_meta.get("n"),
+        "n": n,
         "edge_count": laplacian_meta.get("edge_count"),
         "eig_method": laplacian_meta.get("eig_method"),
         "normalization": laplacian_meta.get("normalization"),

--- a/backend/lambda/graph_query_api/test_graph_health_metric_k43.py
+++ b/backend/lambda/graph_query_api/test_graph_health_metric_k43.py
@@ -101,6 +101,46 @@ class TestComputeFiedlerValue(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIn("lambda2", result["error"])
 
+    def test_degenerate_lambda2_at_capped_sample_size_is_rejected_ac2(self):
+        # ENC-ISS-554: eigenvalues[1] == 0.0 with n == limit means the
+        # LAPLACIAN_MAX_VERTICES cap was hit -- the sample is very likely a
+        # non-representative induced-subgraph artifact, not a genuine
+        # full-graph disconnection reading. Must be ok=False, never a
+        # confident zero.
+        # Use a raw fn (not the shared fixture helper) so laplacian.n can be
+        # pinned to the requested limit, exercising the "capped" branch.
+        def _fn(driver, project_id, params):
+            return {
+                "eigenvalues": [0.0, 0.0, 0.1],
+                "laplacian": {"n": params["limit"], "edge_count": 3, "eig_method": "eigsh_SA", "normalization": "combinatorial"},
+            }
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=_fn, limit=500)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["invalid_reason"], "sample_capped_degenerate")
+        self.assertEqual(result["lambda2_raw"], 0.0)
+        self.assertNotIn("lambda2", result)  # never publishable as a reading
+
+    def test_degenerate_lambda2_below_cap_flags_genuine_disconnection_ac2(self):
+        # n < limit means the full vertex set was captured (no truncation);
+        # a degenerate lambda2 here is a real disconnection signal, still
+        # never published as ok=True, but distinguishable in the reason.
+        def _fn(driver, project_id, params):
+            return {
+                "eigenvalues": [0.0, 0.0, 0.2],
+                "laplacian": {"n": 12, "edge_count": 10, "eig_method": "dense_eigh", "normalization": "combinatorial"},
+            }
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=_fn, limit=500)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["invalid_reason"], "genuine_disconnection_suspected")
+
+    def test_positive_lambda2_still_succeeds_ac2(self):
+        # Sanity check: the epsilon gate does not reject legitimate positive
+        # readings.
+        fn = _fake_query_laplacian_fn({"enceladus": [0.0, 0.42, 1.1]})
+        result = ghm.compute_fiedler_value(object(), "enceladus", query_laplacian_fn=fn)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["lambda2"], 0.42)
+
     def test_never_touches_gds_projection_helpers(self):
         # AC-2 hard gate: the module's *code* (not its explanatory docstrings/
         # comments) must never invoke a GDS/AGA symbol -- only the injected


### PR DESCRIPTION
## Summary

- Root cause: `_laplacian_select_vertices`'s default vertex-selection path (`ORDER BY rid LIMIT 500`) truncates the ~2988-node gamma corpus to a lexicographically-first 500-node sample; `_query_laplacian` then computes the **strict induced subgraph** Laplacian over just those nodes. This routinely strands real neighbors outside the sample, producing spurious isolated components even though the true graph is fully connected (orphan-ratio ~0.0001, ENC-ISS-555). scipy's eigsh/eigh legitimately compute a near-zero second eigenvalue for that artifact -- a real, non-exception, non-hardcoded number, but a measurement of the wrong graph.
- `compute_fiedler_value` had no validity check on the eigenvalue itself (only `len(eigenvalues) >= 2`), so this degenerate reading flowed through as `ok=True` and got published to CloudWatch as a confident zero via two paths (graph_query_api's own `FiedlerValue` metric, and graph_health_metrics' legacy `FiedlerAlgebraicConnectivity` metric via cross-Lambda invoke).
- Corroborating evidence: ENC-TSK-K50 (closed deploy-success 2026-07-02) implemented the "real lambda2" wiring but its own worklog admits it never observed a live positive datapoint before closing -- blocked on a missing IAM permission. The fix was never actually validated against live gamma data.
- Verdict on the historical regime jumps (2.1 -> 3.7 -> 1.7 -> 4.0 -> 0.0): **not real structural movement** -- same failure mode at partial severity. Corpus size permanently exceeds the 500-vertex cap and churns continuously, so which specific 500-node lexicographic slice gets sampled (and which real edges get severed by that slice's boundary) varies run to run.

## Changes

- `backend/lambda/graph_query_api/graph_health_metric.py`: `compute_fiedler_value` now rejects any `lambda2 <= 1e-9` as `ok=False` with an explicit `invalid_reason` (`sample_capped_degenerate` when `n >= limit`, else `genuine_disconnection_suspected`), instead of a confident zero.
- `backend/lambda/graph_health_metrics/lambda_function.py`: stops silently substituting the `GraphEdgeDensity` proxy under the `FiedlerAlgebraicConnectivity` metric name on any real-fiedler-fetch failure (that mislabeling is its own confident-lie pattern) -- omits the key instead so CloudWatch simply gets no datapoint that interval.
- Test coverage added for the degenerate-capped case, the degenerate-uncapped case, and the omission-not-substitution behavior in both Lambdas' test suites.

Scope note: a deeper fix (representative/connectivity-aware vertex sampling, or raising the vertex cap) is out of scope for this P1 quarantine fix and is flagged as follow-up -- not attempted here per the tuning-against-a-broken-instrument caution.

CCI-958efd96f2344a4685761ac4fddd6812

## Test plan

- [x] `pytest backend/lambda/graph_query_api/` -- 326 passed, 14 subtests passed
- [x] `pytest backend/lambda/graph_health_metrics/` -- 18 passed
- [ ] Live gamma post-deploy: invoke `publish_graph_health` and confirm either a positive lambda2 or the explicit invalid marker (AC-3, tracked in ENC-TSK-N54)

ENC-TSK-N54 / ENC-ISS-554