### PR TITLE
fix(ci): restore compute deploy workflow YAML (ENC-TSK-N49 hotfix)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -479,6 +479,8 @@ jobs:
         run: |
           set -euo pipefail
           python3 tools/apply_rhythm_artifact_lifecycle.py --env-prefix gamma
+
+      - name: Report stack events on failure
         if: failure()
         run: |
           for s in "${{ needs.plan.outputs.data_stack_name }}" "${{ needs.plan.outputs.stack_name }}"; do


### PR DESCRIPTION
## Summary
Fixes invalid YAML in `cloudformation-compute-stack-deploy.yml` introduced by #1039 — the rhythm lifecycle step accidentally absorbed the failure-report step's `if`/`run` keys, causing immediate workflow rejection (0s runs).

## Test plan
- [x] YAML structure restored (separate lifecycle + failure-report steps)
- [ ] Merge and verify compute workflow parses on push
- [ ] Lifecycle script runs on next gamma compute deploy

Task: ENC-TSK-N55

CCI-a1d3ecec27f144209cc5e6771172348b