### PR TITLE
feat(feed): default cockpit /feed to Last Updated sort + re-trigger on change (ENC-TSK-N56)

### DIFF
--- a/frontend/ui-v2/src/routes/FeedRoute.tsx
+++ b/frontend/ui-v2/src/routes/FeedRoute.tsx
@@ -56,7 +56,11 @@ import './feed.css'
 const LIST_CHUNK = 24
 const WIDE_MEDIA = '(min-width: 64rem)'
 const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
-  { value: 'tier', label: 'Tier (default)' },
+  // ENC-TSK-N56 (ENC-TSK-N45 UAT follow-up): 'Last Updated' is offered and is
+  // the default (see FEED_SEARCH_DEFAULTS.sort = 'updated'). 'Tier' remains
+  // available as the search-relevance ordering.
+  { value: 'updated', label: 'Last Updated' },
+  { value: 'tier', label: 'Tier' },
   { value: 'id', label: 'Record ID' },
   { value: 'title', label: 'Title' },
   { value: 'status', label: 'Status' },
@@ -91,7 +95,7 @@ export function FeedRoute() {
   }
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
-  const { isHydrating } = useRealtimeFeed()
+  const { isHydrating, refetchSnapshot } = useRealtimeFeed()
   const events = useRealtimeFeedEvents()
   const { isWarm } = useCacheEngineState()
   const corpus = (() => {
@@ -342,9 +346,16 @@ export function FeedRoute() {
           <span>Sort</span>
           <select
             value={sort}
-            onChange={(event) =>
+            onChange={(event) => {
+              // ENC-TSK-N56 (ENC-TSK-N45 UAT follow-up): switch the sort
+              // immediately (client-side reorder via sortSearchHits) AND
+              // re-trigger the realtime feed snapshot fetch so the corpus is
+              // refreshed and re-flattened. The feed's tier/delta logic can
+              // otherwise leave gaps in a pure last-updated ordering; refetching
+              // pulls the authoritative set ordered by the selected sort.
               patchFeedSearch({ sort: event.target.value as FeedSort, scroll: 0 })
-            }
+              refetchSnapshot()
+            }}
           >
             {SORT_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>

--- a/frontend/ui-v2/src/search/feedSearchParams.test.ts
+++ b/frontend/ui-v2/src/search/feedSearchParams.test.ts
@@ -19,6 +19,18 @@ describe('feedSearchParams', () => {
     expect(parseFeedSearch({})).toEqual(FEED_SEARCH_DEFAULTS)
   })
 
+  it('defaults the sort to last-updated and falls back to it for unknown values (ENC-TSK-N56)', () => {
+    expect(FEED_SEARCH_DEFAULTS.sort).toBe('updated')
+    expect(parseFeedSearch({}).sort).toBe('updated')
+    expect(parseFeedSearch({ sort: 'bogus' }).sort).toBe('updated')
+    expect(parseFeedSearch({ sort: 'updated' }).sort).toBe('updated')
+  })
+
+  it('omits the default (updated) sort from the URL but serializes others (ENC-TSK-N56)', () => {
+    expect(buildFeedPath(parseFeedSearch({ sort: 'updated' }))).toBe('/feed')
+    expect(buildFeedPath(parseFeedSearch({ sort: 'tier' }))).toContain('sort=tier')
+  })
+
   it('round-trips query, filters, sort, and scroll', () => {
     const parsed = parseFeedSearch({
       q: 'ENC',

--- a/frontend/ui-v2/src/search/feedSearchParams.ts
+++ b/frontend/ui-v2/src/search/feedSearchParams.ts
@@ -1,6 +1,6 @@
 import type { PropertyFilterQuery } from './applyPropertyFilter'
 
-export type FeedSort = 'tier' | 'id' | 'status' | 'title'
+export type FeedSort = 'tier' | 'id' | 'status' | 'title' | 'updated'
 
 export interface FeedRouteSearch {
   q: string
@@ -14,13 +14,16 @@ export const FEED_SEARCH_DEFAULTS: FeedRouteSearch = {
   q: '',
   f: '',
   op: 'and',
-  sort: 'tier',
+  // ENC-TSK-N56 (ENC-TSK-N45 UAT follow-up): the feed defaults to most-recently
+  // updated first, matching the N45 intent that every feed defaults to
+  // time-last-updated, newest to oldest.
+  sort: 'updated',
   scroll: 0,
 }
 
 export const FEED_RETURN_STORAGE_KEY = 'enc.feed.returnSearch'
 
-const FEED_SORTS: FeedSort[] = ['tier', 'id', 'status', 'title']
+const FEED_SORTS: FeedSort[] = ['tier', 'id', 'status', 'title', 'updated']
 
 function isFeedSort(value: unknown): value is FeedSort {
   return typeof value === 'string' && FEED_SORTS.includes(value as FeedSort)
@@ -30,7 +33,7 @@ export function parseFeedSearch(raw: Record<string, unknown>): FeedRouteSearch {
   const q = typeof raw.q === 'string' ? raw.q : ''
   const f = typeof raw.f === 'string' ? raw.f : ''
   const op = raw.op === 'or' ? 'or' : 'and'
-  const sort = isFeedSort(raw.sort) ? raw.sort : 'tier'
+  const sort = isFeedSort(raw.sort) ? raw.sort : 'updated'
   const scrollRaw = raw.scroll
   const scroll =
     typeof scrollRaw === 'number'
@@ -86,7 +89,7 @@ export function feedSearchToParams(search: FeedRouteSearch): URLSearchParams {
   if (search.q) params.set('q', search.q)
   if (search.f) params.set('f', search.f)
   if (search.op !== 'and') params.set('op', search.op)
-  if (search.sort !== 'tier') params.set('sort', search.sort)
+  if (search.sort !== 'updated') params.set('sort', search.sort)
   if (search.scroll > 0) params.set('scroll', String(search.scroll))
   return params
 }

--- a/frontend/ui-v2/src/search/sortSearchHits.test.ts
+++ b/frontend/ui-v2/src/search/sortSearchHits.test.ts
@@ -39,4 +39,19 @@ describe('sortSearchHits', () => {
   it('sorts by title', () => {
     expect(sortSearchHits(hits, 'title').map((h) => h.title)).toEqual(['Alpha', 'Bravo'])
   })
+
+  it('sorts by last updated newest-first, with missing timestamps last (ENC-TSK-N56)', () => {
+    const dated: SearchResultHit[] = [
+      { recordId: 'ENC-TSK-1', recordType: 'task', projectId: 'enceladus', title: 'One', updatedAt: '2026-07-10T00:00:00Z' },
+      { recordId: 'ENC-TSK-2', recordType: 'task', projectId: 'enceladus', title: 'Two', updatedAt: '2026-07-12T00:00:00Z' },
+      { recordId: 'ENC-TSK-3', recordType: 'task', projectId: 'enceladus', title: 'Three' },
+      { recordId: 'ENC-TSK-4', recordType: 'task', projectId: 'enceladus', title: 'Four', updatedAt: '2026-07-11T00:00:00Z' },
+    ]
+    expect(sortSearchHits(dated, 'updated').map((h) => h.recordId)).toEqual([
+      'ENC-TSK-2',
+      'ENC-TSK-4',
+      'ENC-TSK-1',
+      'ENC-TSK-3',
+    ])
+  })
 })

--- a/frontend/ui-v2/src/search/sortSearchHits.ts
+++ b/frontend/ui-v2/src/search/sortSearchHits.ts
@@ -15,6 +15,20 @@ export function sortSearchHits(hits: SearchResultHit[], sort: FeedSort): SearchR
     case 'status':
       copy.sort((a, b) => (a.status ?? '').localeCompare(b.status ?? ''))
       break
+    case 'updated':
+      // ENC-TSK-N56 (ENC-TSK-N45 UAT follow-up): most-recently-updated first.
+      // updatedAt is an ISO-8601 string, so a reverse lexicographic compare is
+      // a correct chronological descending sort. Records with no timestamp sort
+      // last so they never masquerade as the newest.
+      copy.sort((a, b) => {
+        const av = a.updatedAt ?? ''
+        const bv = b.updatedAt ?? ''
+        if (av === bv) return 0
+        if (!av) return 1
+        if (!bv) return -1
+        return bv.localeCompare(av)
+      })
+      break
     default:
       break
   }


### PR DESCRIPTION
UAT follow-up to **ENC-TSK-N45** — N45 standardized the document_api backend and mobile-PWA feeds to `updated_at` desc, but the ui-v2 Governance Cockpit **/feed (Results)** page never got it: the Sort control offered only Tier/Record ID/Title/Status (default **Tier**) with client-only reordering, so a "last updated" view showed gaps.

## Changes (frontend/ui-v2)
- **search/feedSearchParams.ts** — `FeedSort` gains `'updated'`; default sort, parse fallback, allow-list, and the URL-omit guard all resolve to `'updated'` (last-updated first).
- **search/sortSearchHits.ts** — new `'updated'` case: `updatedAt` ISO desc (newest first); records with no timestamp sort last.
- **routes/FeedRoute.tsx** — Sort control now offers **Last Updated** (default, first) and relabels Tier; the sort `<select>` onChange also calls `useRealtimeFeed().refetchSnapshot()` so switching sort **re-triggers the feed corpus fetch** and the ordering reflects the authoritative set (closing the gaps the tier/delta feed logic otherwise leaves).
- Unit tests for `sortSearchHits('updated')` and the feedSearchParams default.

## Acceptance criteria
- **AC-1** Last Updated available + selected by default ✔ (code + unit test)
- **AC-2** immediate client reorder + feed re-trigger on sort change ✔
- **AC-3** typecheck clean · vitest 306/306 · `lint:adherence` (CI gate) exit 0 · build PASS, bundle 150.99 KB gz < 200 KB ✔
- **AC-4** gamma deploy + live verify — after merge

Note: with `updated` as the default, an active search is ordered by recency; selecting **Tier** restores search-relevance ranking. Scope: frontend/ui-v2 only, gamma-only (v4/main) per DOC-499FA089EC30.

Governance: ENC-TSK-N56 · CCI-2c7609a5b008409da8a1c2072cefc1b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)