### PR TITLE
feat(cockpit): default /docs + /skills to newest-updated-first sort (ENC-TSK-N57)

### DIFF
--- a/frontend/ui-v2/src/routes/DocsRoute.test.ts
+++ b/frontend/ui-v2/src/routes/DocsRoute.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_DOCS_SORT, SORT_OPTIONS } from './DocsRoute'
+import { sortSearchHits } from '../search/sortSearchHits'
+import type { SearchResultHit } from '../types/search'
+
+/**
+ * ENC-TSK-N57 (ENC-TSK-N45/N56 UAT follow-up): /docs must default to
+ * most-recently-updated first. These tests pin the *default resolution* — that
+ * the initial sort is 'updated' and that resolving it through the shared
+ * sortSearchHits machinery yields newest-first. The ordering primitive itself
+ * (ISO desc, missing-timestamps-last) is covered by sortSearchHits.test.ts.
+ */
+describe('DocsRoute default sort', () => {
+  it('defaults to Last Updated (updated), newest-first', () => {
+    expect(DEFAULT_DOCS_SORT).toBe('updated')
+  })
+
+  it('exposes Last Updated as the first, default-labelled sort option', () => {
+    const first = SORT_OPTIONS[0]!
+    expect(first.value).toBe(DEFAULT_DOCS_SORT)
+    expect(first.label).toMatch(/default/i)
+    // The old 'Relevance (default)' label must no longer claim to be default.
+    const tier = SORT_OPTIONS.find((o) => o.value === 'tier')!
+    expect(tier.label).toBe('Relevance')
+  })
+
+  it('resolves the default sort to newest-updated-first ordering', () => {
+    const hits: SearchResultHit[] = [
+      { recordId: 'DOC-OLD', recordType: 'document', projectId: 'enceladus', title: 'Old', updatedAt: '2026-07-01T00:00:00Z' },
+      { recordId: 'DOC-NEW', recordType: 'document', projectId: 'enceladus', title: 'New', updatedAt: '2026-07-12T00:00:00Z' },
+      { recordId: 'DOC-NONE', recordType: 'document', projectId: 'enceladus', title: 'None' },
+      { recordId: 'DOC-MID', recordType: 'document', projectId: 'enceladus', title: 'Mid', updatedAt: '2026-07-06T00:00:00Z' },
+    ]
+    expect(sortSearchHits(hits, DEFAULT_DOCS_SORT).map((h) => h.recordId)).toEqual([
+      'DOC-NEW',
+      'DOC-MID',
+      'DOC-OLD',
+      'DOC-NONE',
+    ])
+  })
+})

--- a/frontend/ui-v2/src/routes/DocsRoute.tsx
+++ b/frontend/ui-v2/src/routes/DocsRoute.tsx
@@ -18,8 +18,16 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import type { SearchResultHit } from '../types/search'
 import './docs.css'
 
-const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
-  { value: 'tier', label: 'Relevance (default)' },
+// ENC-TSK-N57 (ENC-TSK-N45/N56 UAT follow-up): /docs defaults to most-recently
+// updated first, matching the N45 intent that every feed defaults to
+// time-last-updated, newest to oldest. Reuses the shared 'updated' FeedSort +
+// sortSearchHits('updated') ordering shipped by the N56 /feed fix — records with
+// no timestamp sort last so they never masquerade as the newest.
+export const DEFAULT_DOCS_SORT: FeedSort = 'updated'
+
+export const SORT_OPTIONS: { value: FeedSort; label: string }[] = [
+  { value: 'updated', label: 'Last Updated (default)' },
+  { value: 'tier', label: 'Relevance' },
   { value: 'title', label: 'Title' },
   { value: 'id', label: 'Document ID' },
 ]
@@ -38,7 +46,7 @@ export function DocsRoute() {
   useDocumentTitle('Docs')
   const [query, setQuery] = useState('')
   const [filterQuery, setFilterQuery] = useState<PropertyFilterQuery>({ tokens: [] })
-  const [sort, setSort] = useState<FeedSort>('tier')
+  const [sort, setSort] = useState<FeedSort>(DEFAULT_DOCS_SORT)
 
   const { data: projects = [] } = useQuery(projectRegistryQueryOptions)
   const events = useRealtimeFeedEvents()

--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.test.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ReactElement } from 'react'
 import type { SkillListItem } from '../api/skillLibrary'
-import { buildSkillLibraryColumns, sortSkillLibraryRows } from './SkillLibraryRoute'
+import { DEFAULT_SORT, buildSkillLibraryColumns, sortSkillLibraryRows } from './SkillLibraryRoute'
 
 const ITEMS: SkillListItem[] = [
   {
@@ -38,6 +38,30 @@ describe('sortSkillLibraryRows', () => {
   it('sorts by updated_at', () => {
     const sorted = sortSkillLibraryRows(ITEMS, { sortingField: 'updated_at', isDescending: false })
     expect(sorted.map((r) => r.document_id)).toEqual(['DOC-B', 'DOC-A'])
+  })
+
+  // ENC-TSK-N57: rows with a blank updated_at must sort LAST under the new
+  // default (updated_at descending) so they never masquerade as newest —
+  // mirroring sortSearchHits' missing-timestamp policy on /docs and /feed.
+  it('places blank updated_at rows last under updated_at descending', () => {
+    const withBlank: SkillListItem[] = [
+      ...ITEMS,
+      { ...ITEMS[0]!, document_id: 'DOC-BLANK', updated_at: '' },
+    ]
+    const sorted = sortSkillLibraryRows(withBlank, { sortingField: 'updated_at', isDescending: true })
+    expect(sorted.map((r) => r.document_id)).toEqual(['DOC-A', 'DOC-B', 'DOC-BLANK'])
+  })
+})
+
+describe('DEFAULT_SORT', () => {
+  it('defaults the Skill Library to Updated, newest-first (descending)', () => {
+    expect(DEFAULT_SORT).toEqual({ sortingField: 'updated_at', isDescending: true })
+  })
+
+  it('resolves the default to newest-updated-first row order', () => {
+    // DOC-A is updated 2026-07-03, DOC-B 2026-07-01 → DOC-A first under the default.
+    const sorted = sortSkillLibraryRows(ITEMS, DEFAULT_SORT)
+    expect(sorted.map((r) => r.document_id)).toEqual(['DOC-A', 'DOC-B'])
   })
 })
 

--- a/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
+++ b/frontend/ui-v2/src/routes/SkillLibraryRoute.tsx
@@ -69,7 +69,14 @@ export function buildSkillLibraryColumns(): TableColumnDefinition<SkillListItem>
 
 type SortState = { sortingField: string; isDescending: boolean }
 
-const DEFAULT_SORT: SortState = { sortingField: 'title', isDescending: false }
+// ENC-TSK-N57 (ENC-TSK-N45/N56 UAT follow-up): the Skill Library table defaults
+// to most-recently-updated first on initial load, matching the N45 intent that
+// every feed defaults to time-last-updated, newest to oldest. updated_at is an
+// ISO-8601 string, so sortSkillLibraryRows' lexicographic compare + reverse is a
+// correct chronological descending sort (blank timestamps sort last). The
+// click-to-toggle asc/desc behavior on any column header (onSortingChange) is
+// preserved untouched for user-initiated re-sorts.
+export const DEFAULT_SORT: SortState = { sortingField: 'updated_at', isDescending: true }
 
 export function sortSkillLibraryRows(rows: SkillListItem[], sort: SortState): SkillListItem[] {
   const field = sort.sortingField as keyof SkillListItem


### PR DESCRIPTION
## ENC-TSK-N57 — Cockpit /docs + /skills default newest-updated-first sort

UAT follow-up to ENC-TSK-N45 / ENC-TSK-N56. Two ui-v2 Cockpit surfaces still violated the N45 intent that *every feed defaults to newest-to-oldest*:

- **/docs** (`DocsRoute`): Sort control had no "Last Updated" option. Added it as the first, default-selected option (`DEFAULT_DOCS_SORT='updated'`), relabelled the old "Relevance (default)" → "Relevance". Reuses the shared `'updated'` `FeedSort` + `sortSearchHits('updated')` ordering shipped by N56 (ISO desc, missing-timestamps-last). **[AC-1]**
- **/skills** (`SkillLibraryRoute`): table defaulted alphabetical-by-name. Flipped `DEFAULT_SORT` → `{sortingField:'updated_at', isDescending:true}`. The click-to-toggle asc/desc behaviour (`onSortingChange`) is preserved untouched for user-initiated re-sorts. **[AC-2]**

### Verification (AC-3)
- `tsc --noEmit` exit 0
- `lint:adherence` (CI gate) exit 0 — eslint baseline unchanged (9 pre-existing problems, **0 introduced**; the 4 changed files are eslint-clean)
- `vitest` **312/312** (+6 new: 3× DocsRoute default-sort resolution; 3× SkillLibrary `DEFAULT_SORT` incl. blank-`updated_at`-sorts-last)
- `vite build` exit 0; compiled chunks verified to carry the new defaults

Scope: `frontend/ui-v2` only, gamma-only deploy (v4/main) per DOC-499FA089EC30 standing autonomy.

CCI-853e3448108f4943899202e0db03de89