### PR TITLE
fix(rhythm-cycle): sense open_task_count exhausts cursor instead of capping at 200 (ENC-ISS-557)

### DIFF
--- a/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
+++ b/backend/lambda/rhythm_cycle/test_rhythm_cycle.py
@@ -86,7 +86,10 @@ class LegacyInventoryTests(unittest.TestCase):
 
 class SenseConstraintTests(unittest.TestCase):
     @mock.patch("tiers.sense.write_artifact")
-    @mock.patch("tiers.sense._open_task_count", return_value=5)
+    @mock.patch(
+        "tiers.sense._open_task_count",
+        return_value={"count": 5, "truncated": False, "page_count": 1, "cursor_terminus": None},
+    )
     @mock.patch("tiers.sense._checkout_census", return_value=[])
     @mock.patch("tiers.sense._session_census", return_value=[])
     @mock.patch("tiers.sense.read_latest", return_value={"open_task_count": 3})
@@ -100,6 +103,25 @@ class SenseConstraintTests(unittest.TestCase):
         snap = run_sense()
         self.assertFalse(snap["constraints"]["embeddings"])
         self.assertEqual(snap["open_task_delta"], 2)
+        self.assertEqual(snap["open_task_count"], 5)
+        self.assertFalse(snap["open_task_count_truncated"])
+
+    @mock.patch("tiers.sense.write_artifact")
+    @mock.patch(
+        "tiers.sense._open_task_count",
+        return_value={"count": 10000, "truncated": True, "page_count": 50, "cursor_terminus": "c50"},
+    )
+    @mock.patch("tiers.sense._checkout_census", return_value=[])
+    @mock.patch("tiers.sense._session_census", return_value=[])
+    @mock.patch("tiers.sense.read_latest", return_value={"open_task_count": 0})
+    def test_sense_snapshot_marks_truncated_count_as_floor(
+        self, _read_latest, _sess, _checkout, _open, write_artifact
+    ):
+        from tiers.sense import run_sense
+
+        write_artifact.return_value = {"timestamped_key": "k", "latest_key": "l", "bytes": "10"}
+        snap = run_sense()
+        self.assertTrue(snap["open_task_count_truncated"])
 
 
 class TrackerUrlShapeTests(unittest.TestCase):
@@ -117,8 +139,11 @@ class TrackerUrlShapeTests(unittest.TestCase):
         import tiers.sense as sense
 
         with mock.patch.object(sense, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
-            count = sense._open_task_count()
-        self.assertEqual(count, 7)
+            result = sense._open_task_count()
+        self.assertEqual(result["count"], 7)
+        self.assertEqual(result["page_count"], 1)
+        self.assertFalse(result["truncated"])
+        self.assertIsNone(result["cursor_terminus"])
         url, params = get_json.call_args[0]
         self.assertEqual(url, f"https://x/api/v1/tracker/{sense.PROJECT_ID}")
         self.assertEqual(params["type"], "task")
@@ -126,6 +151,39 @@ class TrackerUrlShapeTests(unittest.TestCase):
         self.assertEqual(params["page_size"], 200)
         self.assertNotIn("record_type", params)
         self.assertNotIn("project_id", params)
+
+    def test_sense_open_task_count_follows_cursor_to_exhaustion(self):
+        """ENC-ISS-557: a next_cursor on a page_size=200 response must not be
+        dropped -- the prior implementation returned "count" (page-scoped)
+        as if it were the total, plateauing at 200 forever once the real
+        backlog exceeded one page."""
+        import tiers.sense as sense
+
+        pages = [
+            {"count": 200, "next_cursor": "c1"},
+            {"count": 200, "next_cursor": "c2"},
+            {"count": 43, "next_cursor": ""},
+        ]
+        with mock.patch.object(sense, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
+            with mock.patch.object(sense, "get_json", side_effect=pages) as get_json:
+                result = sense._open_task_count()
+        self.assertEqual(result["count"], 443)
+        self.assertEqual(result["page_count"], 3)
+        self.assertFalse(result["truncated"])
+        self.assertIsNone(result["cursor_terminus"])
+        second_call_params = get_json.call_args_list[1][0][1]
+        self.assertEqual(second_call_params["next_cursor"], "c1")
+
+    def test_sense_open_task_count_marks_truncated_at_max_pages(self):
+        import tiers.sense as sense
+
+        page = {"count": 200, "next_cursor": "still-more"}
+        with mock.patch.object(sense, "TRACKER_API_BASE", "https://x/api/v1/tracker"):
+            with mock.patch.object(sense, "get_json", return_value=page):
+                result = sense._open_task_count()
+        self.assertEqual(result["page_count"], sense._MAX_PAGES)
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["cursor_terminus"], "still-more")
 
     @mock.patch("tiers.decide.get_json", return_value={"records": []})
     def test_decide_open_leaf_tasks_url_shape(self, get_json):

--- a/backend/lambda/rhythm_cycle/tiers/sense.py
+++ b/backend/lambda/rhythm_cycle/tiers/sense.py
@@ -66,22 +66,65 @@ def _checkout_census() -> List[Dict[str, Any]]:
     return hits
 
 
-def _open_task_count() -> int:
+
+# ENC-ISS-557 / BRD §4.4 (C4): defensive cap on pagination depth, mirroring
+# decide.py's _open_leaf_tasks guard. Never loop unbounded against the
+# tracker API; if this is hit the count is marked truncated rather than
+# silently presented as exact.
+_MAX_PAGES = 50
+
+
+def _open_task_count() -> Dict[str, Any]:
+    """Cursor-exhausted paginated count of the open task backlog.
+
+    ENC-ISS-557: the prior implementation (ENC-ISS-553 fix) issued a single
+    page_size=200 request and returned "count" (items in that one page) as
+    if it were the true total -- silently plateauing at 200 forever once the
+    real backlog passed that size. This version pages via `next_cursor`
+    until the tracker API exhausts it, or the `_MAX_PAGES` guard is hit, same
+    pattern as decide.py's `_open_leaf_tasks`. sense stays within its
+    cheap-reads-only mandate: this is still plain HTTP pagination, no
+    embeddings/graph writes/LLM calls, just more of the same call.
+
+    Returns {count, truncated, page_count, cursor_terminus}. truncated=True
+    means _MAX_PAGES was hit before the cursor naturally emptied, so `count`
+    is a floor, not an exact total.
+    """
     if not TRACKER_API_BASE:
-        return 0
+        return {"count": 0, "truncated": False, "page_count": 0, "cursor_terminus": None}
+
     # ENC-ISS-553: N28's /records?project_id=... shape (#1016) live-probed a
     # 200 response but never checked the payload -- tracker_mutation's
     # _RE_PROJECT regex matches the literal "records" segment as {projectId},
     # so it silently queried a nonexistent project and always returned
     # {"records": [], "count": 0}. The real route is {TRACKER_API_BASE}/
     # {PROJECT_ID} with query param "type" (the handler reads "type", not
-    # "record_type" -- confirmed live). The raw list handler has no
-    # page-independent "total" field, only "count" (items in this page), so
-    # page_size is raised to 200 -- tracker_mutation's documented page_size
-    # cap -- rather than 1, which always undercounted to at most 1.
+    # "record_type" -- confirmed live).
     url = f"{TRACKER_API_BASE}/{PROJECT_ID}"
-    data = get_json(url, {"status": "open", "type": "task", "page_size": 200})
-    return int(data.get("total") or data.get("count") or 0)
+    count = 0
+    cursor = ""
+    page_count = 0
+    truncated = False
+
+    for _ in range(_MAX_PAGES):
+        params: Dict[str, Any] = {"status": "open", "type": "task", "page_size": 200}
+        if cursor:
+            params["next_cursor"] = cursor
+        data = get_json(url, params)
+        page_count += 1
+        count += int(data.get("count") or 0)
+        cursor = data.get("next_cursor") or ""
+        if not cursor:
+            break
+    else:
+        truncated = bool(cursor)
+
+    return {
+        "count": count,
+        "truncated": truncated,
+        "page_count": page_count,
+        "cursor_terminus": cursor or None,
+    }
 
 
 def run_sense() -> Dict[str, Any]:
@@ -90,7 +133,8 @@ def run_sense() -> Dict[str, Any]:
 
     sessions = _session_census()
     checkouts = _checkout_census()
-    open_count = _open_task_count()
+    task_count = _open_task_count()
+    open_count = task_count["count"]
     delta = open_count - prior_open
 
     snapshot = {
@@ -98,6 +142,7 @@ def run_sense() -> Dict[str, Any]:
         "session_census": sessions,
         "active_checkouts": checkouts,
         "open_task_count": open_count,
+        "open_task_count_truncated": task_count["truncated"],
         "open_task_delta": delta,
         "queue_depth": open_count,
         "constraints": {"embeddings": False, "graph_writes": False, "llm_calls": False},


### PR DESCRIPTION
## Summary
- `sense.py`'s `_open_task_count()` issued a single `page_size=200` request and returned the page-scoped `count` as if it were the true total, silently plateauing at 200 once the real open-task backlog passed one page. Live-confirmed post-deploy: sense reported `open_task_count=200` while a direct curl of the same route showed a non-empty `next_cursor`.
- Fixed by paging via `next_cursor` to exhaustion (or a defensive `_MAX_PAGES=50` guard), mirroring `decide.py`'s existing `_open_leaf_tasks` pattern. Still plain HTTP GET pagination — no embeddings/graph writes/LLM calls — so it stays within sense's cheap-reads-only design mandate at 24 fires/day.
- Added `open_task_count_truncated` to the sense snapshot as an explicit floor/has-more marker for the residual case where `_MAX_PAGES` itself is hit before the cursor naturally empties, so downstream consumers (dashboard, N08's baseline) can tell an exact count from a floor.

## Coordination note
ENC-ISS-558 (MCP `tracker.list` total field) is a separate, still-open issue targeting a different layer (`tools/enceladus-mcp-server/server.py`), not `sense.py`'s direct tracker API read. No shared contract had landed at the time of this fix, so there was nothing to adopt; if 558 later defines a canonical floor/has-more shape, this snapshot's `{open_task_count, open_task_count_truncated}` fields already carry the needed data to adapt.

## Test plan
- [x] `python3 -m unittest test_rhythm_cycle -v` — 21/21 passing, including new cursor-follow-through and truncation-guard cases for `sense._open_task_count`
- [ ] Live post-fix sense beat captured after deploy (tracked in ENC-TSK-N59 acceptance criteria)

CCI-89abd6f21ff245be9020e255f6ff6f5a

🤖 Generated with [Claude Code](https://claude.com/claude-code)