### PR TITLE
fix(iam): grant CloudFormationDeployRole S3 lifecycle-config actions (ENC-ISS-556)

### DIFF
--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -953,6 +953,39 @@ Resources:
               - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-credentials-gamma"
               - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/user-preferences-gamma"
 
+  # ENC-ISS-556 / ENC-TSK-N60 -- cloudformation-compute-stack-deploy.yml's
+  # post-apply "Equalize rhythm-cycle S3 artifact retention (gamma, ENC-TSK-N49)"
+  # step calls s3:GetLifecycleConfiguration / s3:PutLifecycleConfiguration on
+  # arn:aws:s3:::jreese-net, but CloudFormationDeployRole was never granted
+  # either action -- the CFN change-sets still reach UPDATE_COMPLETE, only the
+  # post-apply step AccessDenieds, failing the Apply job on an otherwise-
+  # successful deploy. Same failure class as every other ManagedPolicy in this
+  # file: inline quota exhausted, and CloudFormationDeployRole has no
+  # iam:CreatePolicy so this resource cannot be created fresh by the deploy
+  # workflow (ENC-TSK-N34 hit the identical wall creating DynamoDbPitrOpsPolicy
+  # and its later policy-version widening -- this agent's AWS identity has an
+  # explicit deny on policy mutations). The live policy must be created and
+  # attached out-of-band by io, then brought under CFN management via
+  # --change-set-type IMPORT (DynamoDbPitrOpsPolicy precedent above), same
+  # ManagedPolicyName, before a normal stack update will reconcile cleanly.
+  S3RhythmCycleLifecyclePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-s3-lifecycle-ops
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: S3RhythmCycleLifecycleOps
+            Effect: Allow
+            Action:
+              - s3:GetLifecycleConfiguration
+              - s3:PutLifecycleConfiguration
+            Resource: "arn:aws:s3:::jreese-net"
+
   BackendDeployRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Summary
- Fixes ENC-ISS-556: `cloudformation-compute-stack-deploy.yml`'s post-apply "Equalize rhythm-cycle S3 artifact retention (gamma, ENC-TSK-N49)" step AccessDenied's on `s3:GetLifecycleConfiguration` against `arn:aws:s3:::jreese-net`. The CFN change-set still reaches `UPDATE_COMPLETE`; only the post-apply step fails, so the "Apply Data + Compute change-sets" job exits 1 on an otherwise-successful deploy.
- Adds `S3RhythmCycleLifecyclePolicy` (`AWS::IAM::ManagedPolicy`, name `enceladus-cfn-deploy-s3-lifecycle-ops`) attached to `CloudFormationDeployRole`, granting `s3:GetLifecycleConfiguration` + `s3:PutLifecycleConfiguration` scoped to `arn:aws:s3:::jreese-net`.

## ⚠️ Required out-of-band step before this can deploy cleanly
`CloudFormationDeployRole` has no `iam:CreatePolicy` (see `DOC-359655466119` Known Deploy Gotchas, and `ENC-TSK-N34`'s identical wall creating `DynamoDbPitrOpsPolicy`). A normal stack apply through the GitHub Actions deploy role **cannot** create this managed policy fresh. Per the `DynamoDbPitrOpsPolicy` precedent already in this file, io (or a terminal agent under `io-dev-admin` credentials) needs to run, out-of-band, before the roles-stack apply:

```
aws iam create-policy --policy-name enceladus-cfn-deploy-s3-lifecycle-ops --policy-document '{"Version":"2012-10-17","Statement":[{"Sid":"S3RhythmCycleLifecycleOps","Effect":"Allow","Action":["s3:GetLifecycleConfiguration","s3:PutLifecycleConfiguration"],"Resource":"arn:aws:s3:::jreese-net"}]}'
aws iam attach-role-policy --role-name enceladus-cloudformation-deploy-github-role --policy-arn arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-s3-lifecycle-ops
```

Then the roles-stack apply reconciles this resource via `--change-set-type IMPORT` targeting that exact ARN (same pattern as `DynamoDbPitrOpsPolicy`).

## Test plan
- [x] YAML structural validity checked (tag-tolerant parse; new resource registers correctly alongside the other 13 `Resources`)
- [ ] io runs the out-of-band `create-policy` + `attach-role-policy` commands above
- [ ] Roles-stack apply approved (v3-prod gate) and green
- [ ] A gamma compute-stack deploy's "Apply Data + Compute change-sets" job observed GREEN end-to-end (not just stack `UPDATE_COMPLETE`)

CCI-050b77c370c94fb7b782523a1f8918c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)