### PR TITLE
fix(mcp-server): tracker.list total is a lower bound, not a page-scoped total (ENC-ISS-558)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-13.6",
-  "updated_at": "2026-07-13T07:28:00Z",
-  "last_change_summary": "ENC-TSK-N48: did_work/output_count added to the rhythm heavy-beat completion stanza (BRD DOC-44230223DD1C §4.1 amendment). All six enabled tenant lambda_function.py (corpus_entropy_engine, memory_consolidation, handoff_consolidation_engine, percolation_monitor, titan_embedding_backfill, graph_health_metrics) plus rhythm_cycle/tenant_invoker.py emit did_work (default status=='completed') + output_count; the beat reads did_work three-valued and emits a new tenant_no_work CloudWatch metric distinct from tenant_stall. 02-compute.yaml CEE_HARD_DISABLED 0→1 (temporary, io-approved) for the AC-4 proof window. No entity/field schema change; bumping per the lambda_function.py touch guard. Prior: ENC-TSK-N45 v4/main port (documents/search default sort); ENC-ISS-555 / ENC-TSK-N52 CEE orphan→lineage_unanchored; N51 percolation susceptibility-peak estimator.",
+  "version": "2026-07-13.7",
+  "updated_at": "2026-07-13T18:30:00Z",
+  "last_change_summary": "ENC-ISS-558: tracker_list's 'total'/'orphan_tasks' reporting contract fixed. Previously the raw tracker API's page_size/cursor were never forwarded (every call re-fetched the raw API's own default page and re-sliced it locally with _paginate()), so 'total' silently mislabeled one already-capped page as a full-project total (observed total=24 vs a true count >200). Now forwards page_size/cursor to the raw request and marks total_is_lower_bound=true (+ next_cursor) whenever more data remains outstanding, rather than exhausting by default -- tracker_list is the hot session-init read every agent hits at boot, unlike the sibling ENC-ISS-557 fix in sense.py (a once-per-tick background job where bounded exhaustion is cheap). Added opt-in exhaust=true (bounded, mirrors sense.py's guard) for callers needing an exact count. New entity mcp_server.tracker_list documents the contract. Prior: ENC-TSK-N48 did_work/output_count rhythm stanza; ENC-TSK-N45 v4/main port; N51 percolation susceptibility-peak estimator.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7977,6 +7977,40 @@
         "contract_parity": {
           "type": "rule",
           "definition": "required_fields/valid_initial_status match tracker_mutation lambda_function.py _handle_create_record and _DEFAULT_STATUS for task (title, acceptance_criteria; open), feature (title, user_story, acceptance_criteria; planned), and plan (title only; drafted) -- see test_creation_rules.py contract test."
+        }
+      }
+    },
+    "mcp_server.tracker_list": {
+      "description": "ENC-ISS-558: MCP search action tracker.list (tool tracker_list) 'total'/'orphan_tasks' reporting contract. The raw tracker API has no page-independent 'total' field -- only 'count' (this page) and 'next_cursor' (more data outstanding or not). Prior behavior never forwarded the caller's page_size/cursor to the raw request (every call re-fetched the raw API's own default page and re-sliced it locally with _paginate()), so a caller's cursor never advanced the underlying query and 'total' was really just that one default page's size, silently mislabeled as a full-project total (observed: total=24 vs a true count >200 with next_cursor outstanding on the identical filter). Contract decision: report-as-lower-bound by default rather than exhaust-by-default, because tracker_list is the hot session-init read every agent hits at boot (page_size=10 in the mandatory init sequence per DOC-FFB4C9D87BCC) -- forcing exhaustion there would multiply round trips across every agent session boot on the platform. Contrast with the sibling ENC-ISS-557 fix in rhythm_cycle/tiers/sense.py's _open_task_count(), a once-per-rhythm-cycle-tick background job where bounded exhaustion is cheap; that asymmetry is why the two sibling issues took different default contracts on the same underlying bug.",
+      "fields": {
+        "page_size": {
+          "type": "integer",
+          "definition": "Now forwarded to the raw tracker API request (previously silently dropped -- the root cause of the undercount). Clamped to [1, 100]."
+        },
+        "cursor": {
+          "type": "string",
+          "definition": "Now forwarded to the raw tracker API request as next_cursor (previously only used for a local re-slice over an unrelated single fetch, so it never actually advanced the underlying query)."
+        },
+        "exhaust": {
+          "type": "boolean",
+          "default": false,
+          "definition": "Opt-in bounded-exhaustion mode (ENC-ISS-558). Walks next_cursor via the raw API until it naturally empties or _TRACKER_LIST_MAX_EXHAUST_PAGES=50 is hit (mirrors sense.py's ENC-ISS-557 _MAX_PAGES guard). Default false -- leave off for hot-path/session-init reads; use for callers that need an exact count and can pay the extra round trips."
+        },
+        "total": {
+          "type": "integer",
+          "definition": "Count of records actually fetched in this call (one page by default, or the full walked set when exhaust=true). No longer presented as an implicit full-project total."
+        },
+        "total_is_lower_bound": {
+          "type": "boolean",
+          "definition": "Present and true whenever a next_cursor remains outstanding after whatever fetching this call did -- i.e. 'total' is a floor, not a measurement. Absent (not merely false) when the count is exact."
+        },
+        "exhaustion_truncated": {
+          "type": "boolean",
+          "definition": "Present and true only when exhaust=true hit the _TRACKER_LIST_MAX_EXHAUST_PAGES guard before the cursor naturally emptied -- the exhaustive walk itself was capped, so even the exhaust=true total is still a lower bound in this case."
+        },
+        "orphan_tasks_is_lower_bound": {
+          "type": "boolean",
+          "definition": "Same lower-bound semantics as total_is_lower_bound, applied to orphan_tasks -- orphan detection has the identical undercount failure mode as total when only a partial page was fetched."
         }
       }
     }

--- a/tools/enceladus-mcp-server/server.py
+++ b/tools/enceladus-mcp-server/server.py
@@ -3627,7 +3627,14 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="tracker_list",
-            description="Returns tracker records for a project, filterable by type and status. Paginated (default 25).",
+            description=(
+                "Returns tracker records for a project, filterable by type and status. Paginated (default 25). "
+                "ENC-ISS-558: 'total' reflects only the records actually fetched in this call, never the "
+                "full-project count. When more records exist beyond what was fetched, the response carries "
+                "total_is_lower_bound=true (and next_cursor) -- treat 'total' as a floor, not a measurement, "
+                "whenever that flag is present. Pass exhaust=true for a bounded, cursor-walked exact count "
+                "(more round trips; capped, see exhaustion_truncated)."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -3651,6 +3658,15 @@ async def list_tools() -> list[Tool]:
                     "cursor": {
                         "type": "string",
                         "description": "Pagination cursor from previous response's next_cursor.",
+                    },
+                    "exhaust": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, walk next_cursor to exhaustion (bounded, see ENC-ISS-558) before "
+                            "computing 'total', instead of reporting a lower bound. Costs one raw-API round "
+                            "trip per page -- expensive on large result sets, so leave false for hot-path / "
+                            "session-init reads and reserve for callers that need an exact count."
+                        ),
                     },
                 },
                 "required": ["project_id"],
@@ -5967,22 +5983,13 @@ async def _tracker_creation_rules(args: dict) -> list[TextContent]:
     return _result_text(resp)
 
 
-async def _tracker_list(args: dict) -> list[TextContent]:
-    project_id = args["project_id"]
-    record_type = args.get("record_type")
-    status_filter = args.get("status")
-    page_size = int(args.get("page_size", 25))
-    cursor = args.get("cursor")
-    query_params: Dict[str, Any] = {}
-    if record_type:
-        query_params["type"] = record_type
-    if status_filter:
-        query_params["status"] = status_filter
-    resp = _tracker_api_request("GET", f"/{project_id}", query=query_params or None)
-    if resp.get("error"):
-        return _result_text(resp)
-    items = resp.get("records", [])
-    # Orphan detection (ENC-FTR-013): flag tasks without Feature lineage
+# ENC-ISS-558: bounded exhaustion guard for tracker_list(exhaust=true), mirroring
+# sense.py's ENC-ISS-557 _MAX_PAGES pattern. Never walk next_cursor unbounded.
+_TRACKER_LIST_MAX_EXHAUST_PAGES = 50
+
+
+def _summarize_tracker_records(items: list) -> tuple:
+    """Build the compact summary shape plus an orphan count for a list of raw records."""
     orphan_count = 0
     summary = []
     for r in items:
@@ -6000,20 +6007,85 @@ async def _tracker_list(args: dict) -> list[TextContent]:
                 entry["orphan"] = True
                 orphan_count += 1
         summary.append(entry)
-    # Cursor pagination (ENC-TSK-820)
-    page, next_cursor, total = _paginate(
-        summary, page_size, cursor,
-        key_fn=lambda e: e.get("id", ""),
-    )
-    result: Dict[str, Any] = {"records": page, "count": len(page), "total": total}
+    return summary, orphan_count
+
+
+async def _tracker_list(args: dict) -> list[TextContent]:
+    project_id = args["project_id"]
+    record_type = args.get("record_type")
+    status_filter = args.get("status")
+    page_size = max(1, min(int(args.get("page_size", 25)), 100))
+    cursor = args.get("cursor")
+    exhaust = bool(args.get("exhaust", False))
+
+    def _fetch_page(page_cursor: Optional[str]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"page_size": page_size}
+        if record_type:
+            params["type"] = record_type
+        if status_filter:
+            params["status"] = status_filter
+        if page_cursor:
+            params["next_cursor"] = page_cursor
+        return _tracker_api_request("GET", f"/{project_id}", query=params)
+
+    # ENC-ISS-558: the raw tracker API has no page-independent 'total' field --
+    # only 'count' (this page) and 'next_cursor' (more data outstanding or not).
+    # Forward the caller's page_size/cursor to the RAW request (previously this
+    # was never done -- every call re-fetched the raw API's own default single
+    # page and re-sliced it locally, so a caller's cursor never actually moved
+    # the underlying query and 'total' was really just that one default page's
+    # size, mislabeled as a full-project total).
+    resp = _fetch_page(cursor)
+    if resp.get("error"):
+        return _result_text(resp)
+    first_page_items = resp.get("records", [])
+    next_cursor = resp.get("next_cursor")
+    all_items = list(first_page_items)
+    truncated = False
+
+    if exhaust:
+        pages_fetched = 1
+        walk_cursor = next_cursor
+        while walk_cursor:
+            if pages_fetched >= _TRACKER_LIST_MAX_EXHAUST_PAGES:
+                truncated = True
+                break
+            resp = _fetch_page(walk_cursor)
+            if resp.get("error"):
+                return _result_text(resp)
+            all_items.extend(resp.get("records", []))
+            pages_fetched += 1
+            walk_cursor = resp.get("next_cursor")
+        next_cursor = walk_cursor
+
+    page_summary, page_orphan_count = _summarize_tracker_records(first_page_items)
+    if exhaust:
+        total = len(all_items)
+        _, orphan_count = _summarize_tracker_records(all_items)
+    else:
+        total = len(first_page_items)
+        orphan_count = page_orphan_count
+
+    # Honest floor, never a silently-wrong measurement: 'total' (and
+    # 'orphan_tasks') only claim exactness when no next_cursor remains
+    # outstanding after whatever fetching this call actually did.
+    total_is_lower_bound = bool(next_cursor)
+
+    result: Dict[str, Any] = {"records": page_summary, "count": len(page_summary), "total": total}
+    if total_is_lower_bound:
+        result["total_is_lower_bound"] = True
     if next_cursor:
         result["next_cursor"] = next_cursor
+    if exhaust and truncated:
+        result["exhaustion_truncated"] = True
     if orphan_count > 0:
         result["orphan_tasks"] = orphan_count
         result["orphan_warning"] = (
             f"{orphan_count} task(s) have no parent or feature lineage. "
             "Consider linking them to a feature for traceability."
         )
+        if total_is_lower_bound:
+            result["orphan_tasks_is_lower_bound"] = True
     return _result_text(result)
 
 

--- a/tools/enceladus-mcp-server/test_tracker_list_lower_bound.py
+++ b/tools/enceladus-mcp-server/test_tracker_list_lower_bound.py
@@ -1,0 +1,197 @@
+"""Tests for tracker_list's ENC-ISS-558 lower-bound contract.
+
+The raw tracker API has no page-independent 'total' field -- only 'count'
+(this page) and 'next_cursor' (more data outstanding or not). These tests
+verify _tracker_list():
+  - forwards page_size/cursor to the raw request (the actual root cause of
+    the ~8x undercount -- previously never forwarded at all)
+  - marks 'total' with total_is_lower_bound=true whenever a next_cursor
+    remains outstanding, rather than presenting a page-scoped count as a
+    full-project total
+  - supports an opt-in exhaust=true bounded-exhaustion mode with an exact
+    total, or exhaustion_truncated=true if the page guard is hit first
+
+Related: ENC-ISS-558, ENC-ISS-557 (sibling fix, same pattern in sense.py)
+"""
+
+import asyncio
+import importlib.util
+import json
+import pathlib
+import sys
+from unittest.mock import patch
+
+MODULE_PATH = pathlib.Path(__file__).with_name("server.py")
+SPEC = importlib.util.spec_from_file_location("enceladus_server_tracker_list", MODULE_PATH)
+server = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = server
+SPEC.loader.exec_module(server)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _call_tracker_list(args: dict) -> dict:
+    content = _run(server._tracker_list(args))
+    assert content, "tracker_list returned empty content"
+    return json.loads(content[0].text)
+
+
+def _task(i: int) -> dict:
+    return {
+        "id": f"ENC-TSK-{i}",
+        "record_type": "task",
+        "status": "open",
+        "priority": "P2",
+        "title": f"task {i}",
+        "parent": "ENC-TSK-0",
+    }
+
+
+def test_no_next_cursor_reports_exact_total():
+    """Single raw page, nothing outstanding -> total is exact, no lower-bound flag."""
+    page = [_task(i) for i in range(24)]
+
+    def fake_request(method, path, payload=None, query=None):
+        assert query["page_size"] == 25
+        assert "next_cursor" not in query
+        return {"records": page, "count": len(page)}
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        result = _call_tracker_list({"project_id": "enceladus", "record_type": "task", "status": "open"})
+
+    assert result["total"] == 24
+    assert result["count"] == 24
+    assert "total_is_lower_bound" not in result
+    assert "next_cursor" not in result
+
+
+def test_outstanding_cursor_marks_total_as_lower_bound():
+    """This is the ENC-ISS-558 bug: raw API returns a full page AND a next_cursor,
+    meaning far more records exist than this one page. 'total' must never be
+    reported as an exact full-project count in this case."""
+    page = [_task(i) for i in range(200)]
+
+    def fake_request(method, path, payload=None, query=None):
+        return {"records": page, "count": len(page), "next_cursor": "opaque-cursor-1"}
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        result = _call_tracker_list(
+            {"project_id": "enceladus", "record_type": "task", "status": "open", "page_size": 200}
+        )
+
+    assert result["total"] == 200
+    assert result["total_is_lower_bound"] is True
+    assert result["next_cursor"] == "opaque-cursor-1"
+
+
+def test_page_size_and_cursor_are_forwarded_to_raw_request():
+    """Root-cause regression guard: previously page_size/cursor were never
+    forwarded to the raw API at all, so a caller's cursor never advanced the
+    underlying query -- every call re-fetched the same default page."""
+    captured = []
+
+    def fake_request(method, path, payload=None, query=None):
+        captured.append(dict(query))
+        return {"records": [], "count": 0}
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        _call_tracker_list(
+            {
+                "project_id": "enceladus",
+                "record_type": "task",
+                "status": "open",
+                "page_size": 50,
+                "cursor": "prior-cursor-token",
+            }
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["page_size"] == 50
+    assert captured[0]["next_cursor"] == "prior-cursor-token"
+    assert captured[0]["type"] == "task"
+    assert captured[0]["status"] == "open"
+
+
+def test_exhaust_walks_to_true_exact_total():
+    """exhaust=true walks next_cursor until the raw API naturally exhausts it,
+    producing an exact total with no lower-bound flag."""
+    pages = [
+        {"records": [_task(i) for i in range(200)], "count": 200, "next_cursor": "cursor-2"},
+        {"records": [_task(i) for i in range(200, 400)], "count": 200, "next_cursor": "cursor-3"},
+        {"records": [_task(i) for i in range(400, 437)], "count": 37},
+    ]
+    calls = {"n": 0}
+
+    def fake_request(method, path, payload=None, query=None):
+        resp = pages[calls["n"]]
+        calls["n"] += 1
+        return resp
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        result = _call_tracker_list(
+            {"project_id": "enceladus", "record_type": "task", "status": "open", "page_size": 200, "exhaust": True}
+        )
+
+    assert calls["n"] == 3
+    assert result["total"] == 437
+    assert "total_is_lower_bound" not in result
+    assert "exhaustion_truncated" not in result
+    assert "next_cursor" not in result
+
+
+def test_exhaust_hits_page_guard_and_marks_truncated():
+    """exhaust=true must never loop unbounded against the raw API -- if the
+    _TRACKER_LIST_MAX_EXHAUST_PAGES guard trips before the cursor naturally
+    empties, the result is still an honest lower bound, not a silent total."""
+    call_count = {"n": 0}
+
+    def fake_request(method, path, payload=None, query=None):
+        call_count["n"] += 1
+        return {"records": [_task(call_count["n"])], "count": 1, "next_cursor": f"cursor-{call_count['n']}"}
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        result = _call_tracker_list(
+            {"project_id": "enceladus", "record_type": "task", "status": "open", "exhaust": True}
+        )
+
+    assert call_count["n"] == server._TRACKER_LIST_MAX_EXHAUST_PAGES
+    assert result["total_is_lower_bound"] is True
+    assert result["exhaustion_truncated"] is True
+    assert result["next_cursor"]
+
+
+def test_orphan_count_also_marked_as_lower_bound_when_capped():
+    page = [_task(i) for i in range(5)]
+    page[0].pop("parent")  # one orphan in this page
+
+    def fake_request(method, path, payload=None, query=None):
+        return {"records": page, "count": len(page), "next_cursor": "more-out-there"}
+
+    with patch.object(server, "_tracker_api_request", side_effect=fake_request):
+        result = _call_tracker_list({"project_id": "enceladus", "record_type": "task", "status": "open"})
+
+    assert result["orphan_tasks"] == 1
+    assert result["orphan_tasks_is_lower_bound"] is True
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in list(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"  FAIL {name}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) FAILED")
+        sys.exit(1)
+    print("\nAll tests passed!")


### PR DESCRIPTION
## Summary

`_tracker_list()` issued one raw GET without forwarding the caller's `page_size`/`cursor`, then locally re-paginated that single already-capped page and reported its length as `total` — an ~8x undercount (observed `total=24` vs a true count `>200` with `next_cursor` still outstanding on the raw API), because a caller's cursor never actually advanced the underlying query.

**Contract decision (report-as-lower-bound, not exhaust-by-default):** `tracker.list` is the hot session-init read every agent hits at boot (`page_size=10` in the mandatory init sequence documented in DOC-FFB4C9D87BCC). Unlike the sibling fix in ENC-ISS-557 (`sense.py`'s `_open_task_count`, a once-per-rhythm-cycle-tick background job where bounded exhaustion is cheap), forcing exhaustion here would multiply round trips across every agent session boot on the platform. So the default behavior now:

- Forwards `page_size`/`cursor` to the raw tracker API request (root-cause fix — this was never done before, so a caller's cursor never moved the underlying query; every call re-fetched the same default page).
- Reports `total_is_lower_bound: true` (+ `next_cursor`) whenever the raw API signals more data exists beyond what was fetched, instead of silently presenting a page-scoped count as a full-project total.
- Applies the same lower-bound flag to `orphan_tasks` for the identical reason.
- Adds an opt-in `exhaust: true` parameter (bounded via `_TRACKER_LIST_MAX_EXHAUST_PAGES=50`, mirroring `sense.py`'s `_MAX_PAGES` guard) for callers that need an exact count and can afford the extra round trips.

This does **not** just raise `page_size` to a bigger cap (that repeats ISS-557's mistake one layer up) — it fixes the reporting contract itself: a read that can't cheaply know the true total now says so explicitly, rather than expressing a number that looks exactly like a measurement.

CCI-7ff8efbed8b94f96ba8b638319b0a081

## Test plan

- [x] `python3 -m pytest tools/enceladus-mcp-server/test_tracker_list_lower_bound.py -q` — 6 new tests covering: exact-total (no cursor), lower-bound marking (cursor outstanding), page_size/cursor forwarding regression guard, `exhaust=true` full walk, `exhaust=true` hitting the page guard (`exhaustion_truncated`), and orphan-count lower-bound marking.
- [x] `python3 -m pytest tools/enceladus-mcp-server/{test_code_mode,test_dynamic_toolsets,test_error_envelope_passthrough,test_coordination_cognito_session}.py -q` — 18 passed, no regressions.
- [ ] Live proof on gamma post-deploy (ENC-ISS-558 AC-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)