### PR TITLE
fix(infra): restore Bedrock coordination-api env vars in 02-compute.yaml

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -63,6 +63,24 @@ Parameters:
     Type: String
     Default: "112392089"
     Description: GitHub App installation ID for NX-2021-L org.
+  # ENC-TSK-N68: aws_bedrock_agent coordination provider config. Confirmed operational
+  # 2026-04-06 (DOC-649C1FB90947 / DISPATCH-GAMMA probe) but only ever set out-of-band
+  # on the live Lambda -- a later compute-stack deploy (Environment is a full replace)
+  # silently wiped them, regressing capabilities.get to status=misconfigured even
+  # though the Bedrock agent/alias/IAM grant were never touched. Codifying here so a
+  # future deploy can no longer strip it.
+  BedrockAgentId:
+    Type: String
+    Default: CMSD8RSEHG
+    Description: AWS Bedrock Agent ID for the aws_bedrock_agent coordination provider.
+  BedrockAgentAliasId:
+    Type: String
+    Default: YQHCD7GRWO
+    Description: AWS Bedrock Agent alias ID ("enceladus-prod") for coordination dispatch.
+  BedrockAgentRuntimeRegion:
+    Type: String
+    Default: us-west-2
+    Description: Region hosting the Bedrock agent runtime (agent itself lives in us-west-2, not the coordination Lambda's default us-east-1).
   # ENC-TSK-F57 AC-2 / ENC-ISS-280: CoordinationInternalApiKey{,Previous} must be referenceable
   # by CFN env vars so that stack deploys don't strip the out-of-band live values. Deploy
   # workflow is expected to pass real values via --parameter-overrides (empty defaults would
@@ -186,6 +204,10 @@ Resources:
           # tracker_mutation; the Cognito approval flow invokes it directly.
           TRACKER_MUTATION_LAMBDA_NAME: !Sub "devops-tracker-mutation-api${EnvironmentSuffix}"
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-N68: aws_bedrock_agent provider config (see Parameters block for context).
+          BEDROCK_AGENT_ID: !Ref BedrockAgentId
+          BEDROCK_AGENT_ALIAS_ID: !Ref BedrockAgentAliasId
+          BEDROCK_AGENT_RUNTIME_REGION: !Ref BedrockAgentRuntimeRegion
           # ENC-TSK-I37 / ENC-FTR-117: Agent ID v3 identity stores (server-side allocator path)
           AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
           AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"


### PR DESCRIPTION
## Summary
- The `aws_bedrock_agent` coordination provider was confirmed operational on 2026-04-06 (DOC-649C1FB90947: agent `CMSD8RSEHG`, alias `YQHCD7GRWO` "enceladus-prod", region `us-west-2`), but `BEDROCK_AGENT_ID`/`BEDROCK_AGENT_ALIAS_ID`/`BEDROCK_AGENT_RUNTIME_REGION` were only ever set on the live Lambda out-of-band.
- CloudFormation's `Environment` property is a full replace, so a later compute-stack deploy silently wiped them — live `capabilities.get` now reports `aws_bedrock_agent` status=`misconfigured`, even though the Bedrock agent, alias, and IAM grant (`bedrock:InvokeAgent` on `agent-alias/*`) are all still live and healthy.
- This PR codifies the three values as CFN Parameters with defaults matching the confirmed-live resources so they survive future deploys. No code, no new IAM grants — pure config restore.

## Test plan
- [x] `python3 -c "import yaml; ..."` — template parses, all 3 new params resolve
- [x] `cfn-lint` — no new findings introduced by this diff (pre-existing findings elsewhere in the 3900-line template are unrelated)
- [ ] After merge: CloudFormation Compute Stack Deploy workflow plan job creates a change-set adding only the 3 new parameters + 3 new env vars (no replacement/deletion of other resources)
- [ ] After apply-job approval (v3-prod environment, reviewer: io): verify `devops-coordination-api` Lambda has the 3 `BEDROCK_*` env vars via `aws lambda get-function-configuration`
- [ ] `coordination(capabilities.get)` reports `providers.aws_bedrock_agent.status=active`

CCI-68c9448a60954e448d8296ee3d0be650

ENC-TSK-N68

🤖 Generated with [Claude Code](https://claude.com/claude-code)