### PR TITLE
fix(infra): restore Bedrock coordination-api env vars on gamma (v4/main)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -63,6 +63,25 @@ Parameters:
     Type: String
     Default: "112392089"
     Description: GitHub App installation ID for NX-2021-L org.
+  # ENC-TSK-N69: aws_bedrock_agent coordination provider config. Confirmed operational
+  # 2026-04-06 (DOC-649C1FB90947 / DISPATCH-GAMMA probe) but only ever set out-of-band
+  # on the live Lambda -- a later compute-stack deploy (Environment is a full replace)
+  # silently wiped them, regressing capabilities.get to status=misconfigured even
+  # though the Bedrock agent/alias/IAM grant were never touched. Codifying here so a
+  # future deploy can no longer strip it. Ported from the rejected v3-prod attempt
+  # (ENC-TSK-N68) -- this task targets gamma via v4/main per DOC-499FA089EC30.
+  BedrockAgentId:
+    Type: String
+    Default: CMSD8RSEHG
+    Description: AWS Bedrock Agent ID for the aws_bedrock_agent coordination provider.
+  BedrockAgentAliasId:
+    Type: String
+    Default: YQHCD7GRWO
+    Description: AWS Bedrock Agent alias ID ("enceladus-prod") for coordination dispatch.
+  BedrockAgentRuntimeRegion:
+    Type: String
+    Default: us-west-2
+    Description: Region hosting the Bedrock agent runtime (agent itself lives in us-west-2, not the coordination Lambda's default us-east-1).
   # ENC-TSK-F57 AC-2 / ENC-ISS-280: CoordinationInternalApiKey{,Previous} must be referenceable
   # by CFN env vars so that stack deploys don't strip the out-of-band live values. Deploy
   # workflow is expected to pass real values via --parameter-overrides (empty defaults would
@@ -331,6 +350,10 @@ Resources:
           # ADE Component C: Cursor webhook HMAC verification secret (POST /api/v1/cursor/webhook)
           CURSOR_WEBHOOK_SECRET: !Ref CursorWebhookSecret
           COMPONENTS_TABLE: !Sub "component-registry${EnvironmentSuffix}"
+          # ENC-TSK-N69: aws_bedrock_agent provider config (see Parameters block for context).
+          BEDROCK_AGENT_ID: !Ref BedrockAgentId
+          BEDROCK_AGENT_ALIAS_ID: !Ref BedrockAgentAliasId
+          BEDROCK_AGENT_RUNTIME_REGION: !Ref BedrockAgentRuntimeRegion
           # ENC-TSK-M27 (ENC-FTR-130): io-queue paused-approvals reuses the same
           # GitHub App installation-token path already wired into DeployDecideFunction
           # (below) -- these were NOT previously set on this function; the GET


### PR DESCRIPTION
## Summary
- Redirect of ENC-TSK-N68: that attempt targeted `main` (v3-prod) and io correctly rejected the apply request per DOC-499FA089EC30 (v3-prod is frozen during current dev; gamma-only via v4/main).
- Same fix, correct target: the `aws_bedrock_agent` coordination provider was confirmed operational 2026-04-06 (DOC-649C1FB90947: agent `CMSD8RSEHG`, alias `YQHCD7GRWO`, region `us-west-2`), but `BEDROCK_AGENT_ID`/`BEDROCK_AGENT_ALIAS_ID`/`BEDROCK_AGENT_RUNTIME_REGION` were only ever set out-of-band on the live Lambda and got wiped by a later compute-stack deploy (CFN `Environment` is a full replace).
- This PR codifies the three values as CFN Parameters on v4/main's `02-compute.yaml`, with defaults matching the confirmed-live resources. No app code changes, no new IAM grants (bedrock:InvokeAgent already present on both prod and gamma roles).

## Test plan
- [x] Template parses; cfn-lint shows no new findings from this diff
- [ ] Merge triggers CloudFormation Compute Stack Deploy on v4/main -> v4-gamma environment (ungated) -> apply executes automatically
- [ ] Verify `devops-coordination-api-gamma` Lambda has the 3 `BEDROCK_*` env vars
- [ ] Gamma coordination API `capabilities.get` reports `aws_bedrock_agent` status=active

CCI-586958797828474b90154f98cfbf1f4e

ENC-TSK-N69

🤖 Generated with [Claude Code](https://claude.com/claude-code)