### PR TITLE
chore(iam): add gated patch workflow for CFN deploy role S3 lifecycle perms

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-s3-lifecycle-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-s3-lifecycle-patch.yml
@@ -1,0 +1,72 @@
+name: IAM CFN Deploy Role — S3 Lifecycle Config Patch
+
+# ENC-TSK-N70: the CFN deploy role (enceladus-cloudformation-deploy-github-role,
+# shared across prod and gamma CFN deploy workflows) never had s3:Get/PutLifecycleConfiguration
+# on jreese-net. tools/apply_rhythm_artifact_lifecycle.py (ENC-TSK-N49), which runs as a step
+# in the CloudFormation Compute Stack Deploy apply job, needs both to equalize the
+# rhythm-cycle artifact retention policy. Without this grant, that step fails AccessDenied
+# and drags the whole apply job's conclusion to failure even when the actual CFN change-set
+# execution succeeded.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "Grant s3:Get/PutLifecycleConfiguration on jreese-net to CFN deploy role (ENC-TSK-N49 unblock)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with S3 lifecycle-configuration permissions
+    # ENC-TSK-N70 / ENC-FTR-120: live IAM mutation (shared/global role object) — pauses on the v3-prod required-reviewer rule.
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — S3 lifecycle configuration read/write on jreese-net
+        run: |
+          set -euo pipefail
+          cat > /tmp/cfn-deploy-role-s3-lifecycle-policy.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "S3LifecycleConfigRhythmCycle",
+                "Effect": "Allow",
+                "Action": [
+                  "s3:GetLifecycleConfiguration",
+                  "s3:PutLifecycleConfiguration"
+                ],
+                "Resource": "arn:aws:s3:::jreese-net"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-s3-lifecycle-v1" \
+            --policy-document "file:///tmp/cfn-deploy-role-s3-lifecycle-policy.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --policy-name "enceladus-cfn-deploy-s3-lifecycle-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -254,6 +254,13 @@
         "patch-role"
       ],
       "notes": "ENC-TSK-L83: environment: v3-prod — grants appconfig profile/hosted-version/deployment ops on application fhhcl7m to the SHARED CFN deploy role (rhythm-tenants + appconfig-governance stack unblock)"
+    },
+    "iam-cfn-deploy-role-s3-lifecycle-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-N70: environment: v3-prod — patches the SHARED CFN deploy role object with s3:Get/PutLifecycleConfiguration on jreese-net (ENC-TSK-N49 rhythm-cycle artifact retention unblock); same pattern as iam-cfn-deploy-role-gamma-patch.yml"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `enceladus-cloudformation-deploy-github-role` (shared across all prod + gamma CFN deploy workflows) never had `s3:Get/PutLifecycleConfiguration` on `jreese-net`.
- `tools/apply_rhythm_artifact_lifecycle.py` (ENC-TSK-N49), a step in the CloudFormation Compute Stack Deploy apply job, needs both — without them the step fails `AccessDenied`, dragging the whole apply job's conclusion to `failure` even when the actual CFN change-set execution succeeds (observed on ENC-TSK-N69).
- Adds a new one-off `workflow_dispatch` patch workflow (`iam-cfn-deploy-role-s3-lifecycle-patch.yml`), matching the existing `iam-cfn-deploy-role-*-patch.yml` precedent exactly: `environment: v3-prod` gated, grants the two permissions via `aws iam put-role-policy`. Registered in `tools/prod_gate_baseline.json` so the prod-gate coverage guard stays green.
- **Merging this does not execute anything** — no push-deploy fires from this file (Channel C per DOC-B716E8FB10B6). The IAM mutation only happens if the workflow is manually dispatched and the `v3-prod` Environment reviewer approves it.
- IAM-only change. No application code. No component/Lambda/CFN-stack deploy triggered by this PR.
- io consent: DOC-B716E8FB10B6 protocol, scoped to this task, IAM-only/no-code/no-component-deploys.

## Test plan
- [x] `python3 tools/prod_gate_coverage_guard.py` — passes ("every workflow classified; every prod lane gated")
- [x] YAML + JSON both parse; diff to `prod_gate_baseline.json` is a single new entry (no reformatting churn)
- [ ] After merge: manually dispatch `iam-cfn-deploy-role-s3-lifecycle-patch.yml`, io approves the `v3-prod` Environment gate
- [ ] `aws iam get-role-policy --role-name enceladus-cloudformation-deploy-github-role --policy-name enceladus-cfn-deploy-s3-lifecycle-v1` confirms the statement
- [ ] Next gamma compute-stack deploy's "Equalize rhythm-cycle S3 artifact retention" step passes clean

CCI-1a17211e9b2e4459b9de038a48e8645a

ENC-TSK-N70

🤖 Generated with [Claude Code](https://claude.com/claude-code)