### PR TITLE
fix(iam): switch S3 lifecycle-config CFN-role patch to a managed policy

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-s3-lifecycle-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-s3-lifecycle-patch.yml
@@ -38,7 +38,14 @@ jobs:
       - name: Verify caller identity
         run: aws sts get-caller-identity
 
-      - name: Apply inline policy — S3 lifecycle configuration read/write on jreese-net
+      # ENC-TSK-N70: the role's aggregate inline-policy size is already at AWS's 10,240-byte
+      # ceiling (8 existing inline policies from prior one-off patches) -- a first attempt at
+      # this fix via put-role-policy failed LimitExceeded (run 29316730253, no mutation occurred).
+      # Several sibling permissions (e.g. enceladus-cfn-deploy-appconfig-governance-v1) are live
+      # as standalone customer-managed policies for the same reason, so this follows that
+      # established, already-working pattern instead: create-policy + attach-role-policy, which
+      # draws from the separate (much larger) managed-policy quota and touches nothing existing.
+      - name: Create managed policy — S3 lifecycle configuration read/write on jreese-net
         run: |
           set -euo pipefail
           cat > /tmp/cfn-deploy-role-s3-lifecycle-policy.json <<'JSON'
@@ -58,15 +65,22 @@ jobs:
           }
           JSON
 
-          aws iam put-role-policy \
-            --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-s3-lifecycle-v1" \
-            --policy-document "file:///tmp/cfn-deploy-role-s3-lifecycle-policy.json"
+          if aws iam get-policy --policy-arn "arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-s3-lifecycle-v1" >/dev/null 2>&1; then
+            echo "Managed policy already exists, skipping create-policy."
+          else
+            aws iam create-policy \
+              --policy-name "enceladus-cfn-deploy-s3-lifecycle-v1" \
+              --policy-document "file:///tmp/cfn-deploy-role-s3-lifecycle-policy.json" \
+              --description "s3:Get/PutLifecycleConfiguration on jreese-net for the CFN deploy role (ENC-TSK-N70 / ENC-TSK-N49 rhythm-cycle unblock)"
+          fi
 
-      - name: Verify inline policy attached
-        run: |
-          aws iam get-role-policy \
+          aws iam attach-role-policy \
             --role-name "enceladus-cloudformation-deploy-github-role" \
-            --policy-name "enceladus-cfn-deploy-s3-lifecycle-v1" \
-            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --policy-arn "arn:aws:iam::356364570033:policy/enceladus-cfn-deploy-s3-lifecycle-v1"
+
+      - name: Verify managed policy attached
+        run: |
+          aws iam list-attached-role-policies \
+            --role-name "enceladus-cloudformation-deploy-github-role" \
+            --query "AttachedPolicies[?PolicyName=='enceladus-cfn-deploy-s3-lifecycle-v1']" \
             --output table


### PR DESCRIPTION
## Summary
- Follow-up to #1052 (ENC-TSK-N70): the merged `iam-cfn-deploy-role-s3-lifecycle-patch.yml` was dispatched, io approved the v3-prod Environment gate, but the job failed: `aws iam put-role-policy` returned `LimitExceeded` — the role's aggregate inline-policy size is already at AWS's 10,240-byte ceiling from 8 prior one-off patches. **No mutation occurred.**
- Confirmed several sibling grants (e.g. `enceladus-cfn-deploy-appconfig-governance-v1`) are actually live as standalone customer-managed policies on this same role despite their source workflow files still showing `put-role-policy` — this exact wall has been hit before and worked around the same way each time.
- This PR switches the workflow to `create-policy` + `attach-role-policy` (managed policy), matching that established pattern. Draws from the separate managed-policy quota, touches nothing already on the role.
- Still IAM-only, no code, no component/Lambda/CFN-stack deploy.

## Test plan
- [x] YAML parses
- [ ] Merge triggers nothing (Channel C)
- [ ] Re-dispatch the workflow; io approves v3-prod Environment gate
- [ ] `aws iam list-attached-role-policies` confirms `enceladus-cfn-deploy-s3-lifecycle-v1` attached
- [ ] Next gamma compute-stack deploy's rhythm-cycle step passes clean

CCI-02c88e3c9b8d4e40ba8e41ea324788a0

ENC-TSK-N71

🤖 Generated with [Claude Code](https://claude.com/claude-code)