### PR TITLE
feat(rhythm-cycle): absorb the seven legacy consolidation-arc rules on gamma (ENC-TSK-N22)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -371,9 +371,20 @@ jobs:
             APPCFG_APP="fhhcl7m"; APPCFG_ENV="zecfu42"
             # ENC-TSK-L54: scheduler IAM landed (enceladus-cfn-deploy-scheduler-v1 on CFN deploy role).
             RHYTHM_CYCLE_ENABLED="true"
+            # ENC-TSK-N22 / ENC-PLN-078 W1e: absorb the seven legacy consolidation-arc
+            # EventBridge rules into the Rhythm Cycle (RhythmAbsorbed => State=DISABLED).
+            # Must be passed explicitly: the gamma stack stores the N19 value (false) and
+            # `aws cloudformation deploy` reuses stored params over template Defaults
+            # (ENC-LSN-053 AXIS-2 / ENC-TSK-H28). Tenant invocation is unconditional in
+            # heavy_integrate, so this ends legacy+beat double-execution without
+            # silencing the consolidation arc (DOC-0D9D3C2E62F3 section 5).
+            RHYTHM_ABSORB_LEGACY="true"
           else
             APPCFG_APP="5t3sqte"; APPCFG_ENV="bnwj3lj"
             RHYTHM_CYCLE_ENABLED="true"
+            # ENC-TSK-N22: prod keeps the template default; RhythmAbsorbed additionally
+            # requires a non-empty EnvironmentSuffix, so prod rules stay ENABLED either way.
+            RHYTHM_ABSORB_LEGACY="false"
           fi
 
           aws cloudformation deploy \
@@ -393,6 +404,7 @@ jobs:
               EnceladusCognitoClientSecret="${{ secrets.ENCELADUS_COGNITO_CLIENT_SECRET }}" \
               SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10" \
               RhythmCycleEnabled="${RHYTHM_CYCLE_ENABLED}" \
+              RhythmAbsorbLegacy="${RHYTHM_ABSORB_LEGACY}" \
               CursorWebhookSecret="${{ secrets.CURSOR_WEBHOOK_SECRET }}" 2>&1 | tee /tmp/plan-compute.log
               # ADE Component C (ENC-FTR-118): pass the Cursor webhook HMAC secret as a NoEcho
               # param so `aws cloudformation deploy` does not reuse/zero it (same value-strip class


### PR DESCRIPTION
## Summary

ENC-TSK-N22 / ENC-PLN-078 W1e — the active P0 cost-bleed fix. Passes `RhythmAbsorbLegacy` explicitly in the 02-compute deploy `--parameter-overrides` (gamma `true`, prod `false`), following the existing `RhythmCycleEnabled` pattern.

- The gamma stack stores the N19 value (`false`), and `aws cloudformation deploy` reuses stored parameters over template Defaults (ENC-LSN-053 AXIS-2 / ENC-TSK-H28) — so a Default-only flip would plan "No changes to deploy". The override must be explicit, and this workflow file is itself in the deploy push-paths, so this merge triggers the gamma deploy.
- Flipping the parameter makes the `RhythmAbsorbed` condition true on gamma, setting the seven absorbed legacy consolidation-arc EventBridge rules to `State: DISABLED`: enceladus-graph-health-daily-gamma, enceladus-percolation-nightly-gamma, enceladus-corpus-entropy-nightly-gamma, enceladus-corpus-entropy-gdmp-nightly-gamma, enceladus-memory-consolidation-nightly-gamma, enceladus-handoff-consolidation-engine-schedule-gamma, devops-recompute-governance-backstop-gamma.
- This ends 17 days of legacy-cron + beat-invoker double execution (~$13/day per io's Cost Explorer review) **without** silencing the consolidation arc — tenant invocation is unconditional in `heavy_integrate.run_heavy_integrate()` (DOC-0D9D3C2E62F3 section 5).
- Prod is structurally unaffected: `RhythmAbsorbed` also requires a non-empty `EnvironmentSuffix`, and the explicit `false` keeps the stored prod value inert.

## Verification plan (post-merge)

- AC-2: live `aws events list-rules` showing all seven absorbed rules DISABLED on gamma.
- AC-3: next heavy-beat artifact at `s3://jreese-net/gamma/rhythm-cycle/heavy_integrate/latest.json` showing memory_consolidation + HCE invoked, none silent.
- ENC-TSK-N76 follows up with the measured cost decrease.

CCI-67f04e56183e45f3973302f82cda11d8

🤖 Generated with [Claude Code](https://claude.com/claude-code)