### PR TITLE
feat(rhythm-cycle): RhythmBeatsEnabled pause switch — disable all five gamma beat schedules (ENC-TSK-N78)

### DIFF
--- a/.github/workflows/cloudformation-compute-stack-deploy.yml
+++ b/.github/workflows/cloudformation-compute-stack-deploy.yml
@@ -379,12 +379,22 @@ jobs:
             # heavy_integrate, so this ends legacy+beat double-execution without
             # silencing the consolidation arc (DOC-0D9D3C2E62F3 section 5).
             RHYTHM_ABSORB_LEGACY="true"
+            # ENC-TSK-N78: io cost-stop directive 2026-08-01 — pause all five rhythm
+            # beat schedules on gamma (State=DISABLED, definitions preserved). Passed
+            # explicitly for the same stored-param reason as above. Deliberately NOT
+            # done via RHYTHM_CYCLE_ENABLED=false: that would flip RhythmAbsorbed
+            # false and resurrect the seven legacy crons (incl. gdmp-nightly under
+            # the armed GDMP mutation flag). Flip back to "true" to resume the mind.
+            RHYTHM_BEATS_ENABLED="false"
           else
             APPCFG_APP="5t3sqte"; APPCFG_ENV="bnwj3lj"
             RHYTHM_CYCLE_ENABLED="true"
             # ENC-TSK-N22: prod keeps the template default; RhythmAbsorbed additionally
             # requires a non-empty EnvironmentSuffix, so prod rules stay ENABLED either way.
             RHYTHM_ABSORB_LEGACY="false"
+            # ENC-TSK-N78: prod has no rhythm schedules (RhythmActive requires a
+            # non-empty suffix); explicit true keeps the stored param non-drifting.
+            RHYTHM_BEATS_ENABLED="true"
           fi
 
           aws cloudformation deploy \
@@ -405,6 +415,7 @@ jobs:
               SharedLayerArn="arn:aws:lambda:us-west-2:356364570033:layer:enceladus-shared:10" \
               RhythmCycleEnabled="${RHYTHM_CYCLE_ENABLED}" \
               RhythmAbsorbLegacy="${RHYTHM_ABSORB_LEGACY}" \
+              RhythmBeatsEnabled="${RHYTHM_BEATS_ENABLED}" \
               CursorWebhookSecret="${{ secrets.CURSOR_WEBHOOK_SECRET }}" 2>&1 | tee /tmp/plan-compute.log
               # ADE Component C (ENC-FTR-118): pass the Cursor webhook HMAC secret as a NoEcho
               # param so `aws cloudformation deploy` does not reuse/zero it (same value-strip class

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -180,6 +180,19 @@ Parameters:
       ENC-TSK-N19: when true (and RhythmActive), re-enable the absorbed legacy
       consolidation-arc schedules (RhythmAbsorbed condition). Default false.
 
+  # ENC-TSK-N78: io cost-stop pause switch for the rhythm pacemaker. When false,
+  # all five beat schedules go State=DISABLED (definitions and groups preserved;
+  # one-parameter resume). Independent of RhythmAbsorbLegacy on purpose: pausing
+  # the beats must NOT resurrect the seven absorbed legacy crons, so the two
+  # flags are separate axes (beats on/off vs legacy-absorption on/off).
+  RhythmBeatsEnabled:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >
+      ENC-TSK-N78: when false, all five rhythm beat schedules (sense/light/
+      decide/heavy/coherence) are DISABLED. Default true.
+
   # ENC-FTR-106 / ENC-TSK-N19 (C3): codifies the standing io-HOLD on the nightly
   # Crick-Mitchison unlearning pass as IaC, independent of the Rhythm conditions.
   # UNLEARNING_MUTATION_ENABLED env flag on UnlearningFunction is untouched (layer 2).
@@ -277,6 +290,13 @@ Conditions:
     - !Not [!Equals [!Ref EnvironmentSuffix, ""]]
     - !Equals [!Ref RhythmCycleEnabled, "true"]
     - !Equals [!Ref RhythmAbsorbLegacy, "true"]
+  # ENC-TSK-N78: beats run only when the rhythm substrate is active AND the
+  # pause switch is open. Inlines RhythmActive's sub-expressions for the same
+  # cfn_env_resolver.py reason documented on RhythmAbsorbed above (no !Condition).
+  RhythmBeatsActive: !And
+    - !Not [!Equals [!Ref EnvironmentSuffix, ""]]
+    - !Equals [!Ref RhythmCycleEnabled, "true"]
+    - !Equals [!Ref RhythmBeatsEnabled, "true"]
   # ENC-TSK-N19 (C3): independent of the Rhythm conditions -- codifies the
   # standing io-HOLD on the unlearning nightly pass (ENC-FTR-106).
   UnlearningEnabledCond: !Equals [!Ref UnlearningEnabled, "true"]
@@ -7829,7 +7849,8 @@ Resources:
       ScheduleExpressionTimezone: UTC
       FlexibleTimeWindow:
         Mode: "OFF"
-      State: ENABLED
+      # ENC-TSK-N78: io cost-stop pause switch — DISABLED preserves the schedule.
+      State: !If [RhythmBeatsActive, ENABLED, DISABLED]
       Target:
         Arn: !GetAtt RhythmCycleFunction.Arn
         RoleArn: !GetAtt RhythmSchedulerRole.Arn
@@ -7845,7 +7866,8 @@ Resources:
       ScheduleExpressionTimezone: UTC
       FlexibleTimeWindow:
         Mode: "OFF"
-      State: ENABLED
+      # ENC-TSK-N78: io cost-stop pause switch — DISABLED preserves the schedule.
+      State: !If [RhythmBeatsActive, ENABLED, DISABLED]
       Target:
         Arn: !GetAtt RhythmCycleFunction.Arn
         RoleArn: !GetAtt RhythmSchedulerRole.Arn
@@ -7861,7 +7883,8 @@ Resources:
       ScheduleExpressionTimezone: UTC
       FlexibleTimeWindow:
         Mode: "OFF"
-      State: ENABLED
+      # ENC-TSK-N78: io cost-stop pause switch — DISABLED preserves the schedule.
+      State: !If [RhythmBeatsActive, ENABLED, DISABLED]
       Target:
         Arn: !GetAtt RhythmCycleFunction.Arn
         RoleArn: !GetAtt RhythmSchedulerRole.Arn
@@ -7877,7 +7900,8 @@ Resources:
       ScheduleExpressionTimezone: UTC
       FlexibleTimeWindow:
         Mode: "OFF"
-      State: ENABLED
+      # ENC-TSK-N78: io cost-stop pause switch — DISABLED preserves the schedule.
+      State: !If [RhythmBeatsActive, ENABLED, DISABLED]
       Target:
         Arn: !GetAtt RhythmCycleFunction.Arn
         RoleArn: !GetAtt RhythmSchedulerRole.Arn
@@ -7893,7 +7917,8 @@ Resources:
       ScheduleExpressionTimezone: UTC
       FlexibleTimeWindow:
         Mode: "OFF"
-      State: ENABLED
+      # ENC-TSK-N78: io cost-stop pause switch — DISABLED preserves the schedule.
+      State: !If [RhythmBeatsActive, ENABLED, DISABLED]
       Target:
         Arn: !GetAtt RhythmCycleFunction.Arn
         RoleArn: !GetAtt RhythmSchedulerRole.Arn


### PR DESCRIPTION
## Summary

ENC-TSK-N78 — io cost-stop directive (2026-08-01): return gamma Lambda spend to the pre-incident baseline immediately. Follows directly on ENC-TSK-N22 (#1060), which removed the *legacy* half of the double execution; this pauses the rhythm half.

- New `RhythmBeatsEnabled` parameter (default `true`) + `RhythmBeatsActive` condition (inline sub-expressions, same `cfn_env_resolver.py` compatibility pattern as `RhythmAbsorbed`).
- All five beat schedules — `rhythm-sense-hourly` (24×/day), `rhythm-decide-act` (8×), `rhythm-light-integrate` (4×), `rhythm-heavy-integrate` (2×), `rhythm-coherence-point` (2×) — move to `State: !If [RhythmBeatsActive, ENABLED, DISABLED]`. Definitions and groups are preserved: resume is a one-parameter flip.
- Workflow passes `RhythmBeatsEnabled=false` (gamma) / `true` (prod) explicitly — stored-param-reuse lesson (ENC-LSN-053 AXIS-2 / ENC-TSK-H28). Prod has no rhythm schedules (`RhythmActive` requires a non-empty suffix).
- **Why not `RhythmCycleEnabled=false`:** that would flip `RhythmAbsorbed` false and resurrect the seven absorbed legacy crons — including `corpus-entropy-gdmp-nightly` while the GDMP mutation flag is armed with the known no-optimistic-concurrency defect (ENC-TSK-N24). The two flags are deliberately separate axes.

Trade-off, per io's explicit acceptance: the cognition layer re-dormants (N08 baseline-week clock stops) until `RHYTHM_BEATS_ENABLED` flips back.

## Verification plan (post-merge)

- AC-2: `aws scheduler get-schedule` shows all five `rhythm-*-gamma` schedules DISABLED.
- AC-3: no-regression — all seven absorbed legacy rules remain DISABLED.
- Known: the apply job will conclude failure on the pre-existing ENC-ISS-556 N49 step; deploy-success will go through a direct_state_override escalation like ENC-ESC-084.

CCI-409ff7f8c98b47d891daedb70738430f

🤖 Generated with [Claude Code](https://claude.com/claude-code)