### PR TITLE
fix(gen2-deploy): deny-trip breakers + prune budget; V4Gamma lambda-lifecycle grants (ENC-TSK-N80)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -407,6 +407,18 @@ jobs:
           # literal "true" means no snapshots (fail toward no-cache).
           enable_snapstart = os.environ.get('ENABLE_SNAPSTART', 'false').strip().lower() == 'true'
 
+          # ENC-TSK-N80: hygiene must never re-approach the 1h OIDC credential
+          # lifetime (run 30974760724: 3,939 denied deletes stretched the job to
+          # 65 min and user_preferences_api died on ExpiredToken). Three bounds:
+          # deny-trip breakers (a missing IAM verb is role-wide — one denial
+          # proves every later attempt futile this run), a per-function delete
+          # cap, and a global prune wall-clock budget measured from script start.
+          _script_t0 = time.monotonic()
+          PRUNE_MAX_PER_FN = 25
+          PRUNE_TIME_BUDGET_S = 300
+          _prune_denied = threading.Event()
+          _heal_denied = threading.Event()
+
           CODEDEPLOY_CONFIG_MAP = {
               'Canary10Percent5Minutes':        'CodeDeployDefault.LambdaCanary10Percent5Minutes',
               'Canary10Percent10Minutes':       'CodeDeployDefault.LambdaCanary10Percent10Minutes',
@@ -499,7 +511,16 @@ jobs:
               CodeDeploy CurrentVersion, so in-flight canaries stay intact). Versions
               referenced by any alias are additionally protected server-side — Lambda
               rejects their deletion, which lands in the warn path. Strictly
-              non-fatal: cost hygiene must never fail a deploy."""
+              non-fatal: cost hygiene must never fail a deploy.
+              ENC-TSK-N80: deny-tripped, capped at PRUNE_MAX_PER_FN deletions per
+              function, and skipped entirely once PRUNE_TIME_BUDGET_S has elapsed
+              since script start — the backlog drains across deploys instead of
+              one run racing the credential lifetime."""
+              if _prune_denied.is_set():
+                  return
+              if time.monotonic() - _script_t0 > PRUNE_TIME_BUDGET_S:
+                  log(f'  ~ {mapped_name}: prune skipped (run past {PRUNE_TIME_BUDGET_S}s prune budget)')
+                  return
               try:
                   r = subprocess.run(
                       ['aws', 'lambda', 'list-versions-by-function',
@@ -516,8 +537,13 @@ jobs:
                   stale = [str(v) for v in versions if str(v) not in keep]
                   if not stale:
                       return
+                  # ENC-TSK-N80: bounded drain — at most PRUNE_MAX_PER_FN per run.
+                  deferred = max(0, len(stale) - PRUNE_MAX_PER_FN)
+                  stale = stale[:PRUNE_MAX_PER_FN]
                   deleted = 0
                   for v in stale:
+                      if _prune_denied.is_set():
+                          return
                       d = subprocess.run(
                           ['aws', 'lambda', 'delete-function',
                            '--function-name', mapped_name, '--qualifier', v,
@@ -525,9 +551,18 @@ jobs:
                           capture_output=True, text=True)
                       if d.returncode == 0:
                           deleted += 1
+                      elif 'AccessDeniedException' in (d.stderr or ''):
+                          # Role-wide gap: one denial proves all later attempts futile.
+                          _prune_denied.set()
+                          log(f'::warning::prune disabled for this run — deploy role lacks lambda:DeleteFunction '
+                              f'(version-qualified). Apply the grant via iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml '
+                              f'(durable fix: 04-github-roles.yaml V4GammaLambdaLifecycle). First denial: {mapped_name}:{v}')
+                          return
                       else:
                           log(f'  [warn] prune {mapped_name}: version {v} not deleted: {(d.stderr or "").strip().splitlines()[-1] if d.stderr else d.returncode}')
-                  log(f'  ~ {mapped_name}: pruned {deleted}/{len(stale)} stale version(s); kept {{{", ".join(sorted(keep, key=int))}}}')
+                  log(f'  ~ {mapped_name}: pruned {deleted}/{len(stale)} stale version(s)'
+                      + (f' ({deferred} deferred to later runs)' if deferred else '')
+                      + f'; kept {{{", ".join(sorted(keep, key=int))}}}')
               except Exception as e:
                   log(f'  [warn] prune {mapped_name}: {e}')
 
@@ -551,7 +586,7 @@ jobs:
               # incident: 209 drifted versions on enceladus-mcp-code-gamma). Heals
               # out-of-band drift on every deploy. Non-fatal: a failed heal costs one
               # bounded version-cache until the next prune, never a blocked deploy.
-              if not enable_snapstart:
+              if not enable_snapstart and not _heal_denied.is_set():
                   cfg = subprocess.run(
                       ['aws', 'lambda', 'get-function-configuration',
                        '--function-name', mapped_name, '--region', region,
@@ -566,7 +601,14 @@ jobs:
                           what=f'snapstart-heal {mapped_name}')
                       if heal is None or heal.returncode != 0:
                           detail = (heal.stderr.strip().splitlines()[-1] if heal and heal.stderr else 'skip marker')
-                          log(f'  [warn] {mapped_name}: SnapStart heal failed ({detail}) — new version will snapshot, bounded by prune')
+                          if heal is not None and 'AccessDeniedException' in (heal.stderr or ''):
+                              # ENC-TSK-N80: role-wide gap — trip once, warn once.
+                              _heal_denied.set()
+                              log(f'::warning::SnapStart heal disabled for this run — deploy role lacks '
+                                  f'lambda:UpdateFunctionConfiguration. Apply the grant via '
+                                  f'iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml. First denial: {mapped_name}')
+                          else:
+                              log(f'  [warn] {mapped_name}: SnapStart heal failed ({detail}) — new version will snapshot, bounded by prune')
                       else:
                           subprocess.run(
                               ['aws', 'lambda', 'wait', 'function-updated-v2',

--- a/.github/workflows/iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml
+++ b/.github/workflows/iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml
@@ -1,0 +1,83 @@
+name: IAM V4Gamma Deploy Role — Lambda Lifecycle Patch
+
+# ENC-TSK-N80 / ENC-ISS-591: GitHubActions-V4Gamma-DeployRole lacked
+# lambda:UpdateFunctionConfiguration and lambda:DeleteFunction, leaving the
+# _deploy.yml SnapStart heal + version prune inert (run 30974760724: 3,939
+# denied deletions). Durable fix in 04-github-roles.yaml (Sids
+# V4GammaLambdaLifecycle / V4GammaLambdaVersionPrune); this one-off dispatch
+# applies the grant live ahead of the next github-roles stack deploy, mirroring
+# the iam-cfn-deploy-role-*-patch precedent.
+#
+# Scope guarantee: DeleteFunction is granted on VERSION-QUALIFIED gamma ARNs
+# only (function:*-gamma:*) — the role can delete stale published versions but
+# is structurally unable to delete a whole function.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "ENC-TSK-N80 — grant lambda lifecycle verbs to V4Gamma deploy role for SnapStart heal + version prune (ENC-ISS-591)"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch V4Gamma deploy role with lambda lifecycle verbs
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Apply inline policy — Lambda lifecycle (heal + prune)
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          cat > /tmp/v4gamma-deploy-role-lambda-lifecycle.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "V4GammaLambdaLifecycle",
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:UpdateFunctionConfiguration"
+                ],
+                "Resource": "arn:aws:lambda:us-west-2:${ACCOUNT_ID}:function:*-gamma"
+              },
+              {
+                "Sid": "V4GammaLambdaVersionPrune",
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:DeleteFunction"
+                ],
+                "Resource": "arn:aws:lambda:us-west-2:${ACCOUNT_ID}:function:*-gamma:*"
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "GitHubActions-V4Gamma-DeployRole" \
+            --policy-name "enceladus-v4gamma-deploy-lambda-lifecycle-v1" \
+            --policy-document "file:///tmp/v4gamma-deploy-role-lambda-lifecycle.json"
+
+      - name: Verify inline policy attached
+        run: |
+          aws iam get-role-policy \
+            --role-name "GitHubActions-V4Gamma-DeployRole" \
+            --policy-name "enceladus-v4gamma-deploy-lambda-lifecycle-v1" \
+            --query '{RoleName:RoleName,PolicyName:PolicyName}' \
+            --output table

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -1032,6 +1032,24 @@ Resources:
                   - lambda:CreateAlias
                   - lambda:UpdateAlias
                 Resource: "*"
+              # ENC-TSK-N80 / ENC-ISS-591: lifecycle hygiene verbs for _deploy.yml's
+              # SnapStart heal + version prune. UpdateFunctionConfiguration on the
+              # bare gamma function ARNs only; DeleteFunction on VERSION-QUALIFIED
+              # gamma ARNs only — the role can delete stale versions but is
+              # structurally unable to delete a whole function (an unqualified
+              # delete-function targets the bare ARN, which this does not grant).
+              # One-off live application ahead of the next roles-stack deploy:
+              # .github/workflows/iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml
+              - Sid: V4GammaLambdaLifecycle
+                Effect: Allow
+                Action:
+                  - lambda:UpdateFunctionConfiguration
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*-gamma"
+              - Sid: V4GammaLambdaVersionPrune
+                Effect: Allow
+                Action:
+                  - lambda:DeleteFunction
+                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*-gamma:*"
               # S3 read for artifact version probing (belt-and-suspenders;
               # update-function-code fetches via Lambda service role, but
               # the resolve-job S3 probe runs under this env's job context

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -142,6 +142,13 @@
       ],
       "notes": "ENC-PLN-068: environment: v3-prod — grant EventBridge Scheduler ops to CloudFormationDeployRole for Rhythm Cycle"
     },
+    "iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "ENC-TSK-N80 / ENC-ISS-591: environment: v3-prod — grants lambda:UpdateFunctionConfiguration (function:*-gamma) + lambda:DeleteFunction (VERSION-QUALIFIED function:*-gamma:* only) to GitHubActions-V4Gamma-DeployRole for the _deploy.yml SnapStart heal + version prune. Gamma-scoped grant on a gamma-dedicated role object, but executes under the shared backend admin role — io-gated and classed prod-mutating per the iam-*-patch precedent family."
+    },
     "iam-cfn-deploy-role-gamma-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
## Summary

ENC-TSK-N80 — fast-follow to #1067, fixing the two defects run 30974760724 exposed (ENC-ISS-591 thread):

1. **Unbounded denied hygiene stretched the job past credential lifetime.** 3,939 denied prune deletions ran the deploy job to 65 min; `user_preferences_api` then failed its S3 staging copy with `ExpiredToken` (1h OIDC session). Now: the first `AccessDenied` on delete-version or update-function-configuration trips a **run-global breaker** (one `::warning` naming the missing verb + the patch workflow, zero further attempts), prune is **capped at 25 deletions per function per run**, and a **300s wall-clock budget** skips pruning entirely on a long run. The ~6–8k stale-version backlog drains across deploys instead of one run racing the clock.
2. **The role can't execute the hygiene.** `04-github-roles.yaml` adds `V4GammaLambdaLifecycle` (`lambda:UpdateFunctionConfiguration` on `function:*-gamma`) and `V4GammaLambdaVersionPrune` (`lambda:DeleteFunction` on **version-qualified** `function:*-gamma:*` only — the role can prune stale versions but structurally cannot delete a whole function). Since 04-github-roles has no auto-deploy lane, `iam-v4gamma-deploy-role-lambda-lifecycle-patch.yml` (new, mirrors the `iam-cfn-deploy-role-*-patch` precedent, v3-prod gate) applies the grant live.

Validated: workflow YAMLs parse, CFN template parses (8 resources), embedded 507-line deploy script compiles.

## Verification plan (post-merge)

Merge push triggers the Gen2 run: deploy job back to normal minutes with ≤1 deny warning per verb; `user_preferences_api` redeploys. Then the patch workflow dispatch (v3-prod approval) applies the grant; `get-role-policy` verifies; subsequent runs heal mcp-code SnapStart and begin draining the version backlog.

CCI-f23641ced6014ec497d247cebfd606e5

🤖 Generated with [Claude Code](https://claude.com/claude-code)