### PR TITLE
ENC-TSK-N81: Escalations PWA all-projects pending inbox (ENC-ISS-594)

### DIFF
--- a/frontend/ui/src/api/escalations.test.ts
+++ b/frontend/ui/src/api/escalations.test.ts
@@ -1,0 +1,176 @@
+/**
+ * escalations API tests — ENC-TSK-N81 / ENC-ISS-594.
+ *
+ * The feed endpoint is single-project by construction (one tracker partition
+ * per project_id), so the cross-project inbox is assembled client-side. These
+ * tests pin the assembly itself: every project is queried, the pending queues
+ * merge newest-first, a failing project is isolated rather than fatal, and
+ * items always carry the project_id that decision routing depends on.
+ *
+ * Mocks: only the ./client network boundary — fetchEscalationsInbox and
+ * fetchEscalations run for real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EscalationItem } from './escalations'
+
+const { mockFetchWithAuth } = vi.hoisted(() => ({ mockFetchWithAuth: vi.fn() }))
+
+vi.mock('./client', () => ({ fetchWithAuth: mockFetchWithAuth }))
+
+import { fetchEscalations, fetchEscalationsInbox } from './escalations'
+
+function item(overrides: Partial<EscalationItem> = {}): EscalationItem {
+  return {
+    item_id: 'ENC-ESC-001',
+    project_id: 'enceladus',
+    status: 'requested',
+    mutation_type: 'direct_state_override',
+    target_record_id: 'ENC-TSK-001',
+    justification: 'because',
+    payload: {},
+    created_at: '2026-08-06T01:00:00Z',
+    updated_at: '2026-08-06T01:00:00Z',
+    ...overrides,
+  }
+}
+
+function ok(pending: EscalationItem[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      success: true,
+      project_id: pending[0]?.project_id ?? 'enceladus',
+      pending,
+      terminal: [],
+      count: pending.length,
+    }),
+  }
+}
+
+/** Resolve each project_id in the request URL to a canned response. */
+function routeByProject(table: Record<string, () => unknown>) {
+  return async (url: string) => {
+    const projectId = new URL(url, 'https://jreese.net').searchParams.get('project_id') ?? ''
+    const handler = table[projectId]
+    if (!handler) return ok([])
+    return handler()
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('fetchEscalations', () => {
+  it('passes the status filter through when supplied', async () => {
+    mockFetchWithAuth.mockResolvedValue(ok([]))
+    await fetchEscalations('intelligence', 'requested')
+    const url = String(mockFetchWithAuth.mock.calls[0][0])
+    expect(url).toContain('project_id=intelligence')
+    expect(url).toContain('status=requested')
+  })
+
+  it('omits the status param when not supplied', async () => {
+    mockFetchWithAuth.mockResolvedValue(ok([]))
+    await fetchEscalations('enceladus')
+    expect(String(mockFetchWithAuth.mock.calls[0][0])).not.toContain('status=')
+  })
+
+  it('throws on a non-ok response', async () => {
+    mockFetchWithAuth.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    await expect(fetchEscalations('enceladus')).rejects.toThrow('500')
+  })
+})
+
+describe('fetchEscalationsInbox', () => {
+  it('queries every project exactly once, filtered to pending', async () => {
+    mockFetchWithAuth.mockImplementation(routeByProject({}))
+    await fetchEscalationsInbox(['enceladus', 'intelligence', 'devops'])
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(3)
+    const urls = mockFetchWithAuth.mock.calls.map((c) => String(c[0]))
+    expect(urls.every((u) => u.includes('status=requested'))).toBe(true)
+    expect(urls.some((u) => u.includes('project_id=intelligence'))).toBe(true)
+  })
+
+  it('merges pending escalations across projects newest-first', async () => {
+    mockFetchWithAuth.mockImplementation(
+      routeByProject({
+        enceladus: () => ok([item({ item_id: 'ENC-ESC-009', created_at: '2026-08-06T02:00:00Z' })]),
+        intelligence: () =>
+          ok([
+            item({
+              item_id: 'INT-ESC-001',
+              project_id: 'intelligence',
+              created_at: '2026-08-06T06:39:41Z',
+            }),
+          ]),
+      }),
+    )
+    const result = await fetchEscalationsInbox(['enceladus', 'intelligence'])
+    expect(result.pending.map((e) => e.item_id)).toEqual(['INT-ESC-001', 'ENC-ESC-009'])
+    expect(result.scanned).toEqual(['enceladus', 'intelligence'])
+    expect(result.failed).toEqual([])
+  })
+
+  it('isolates a failing project instead of rejecting the whole inbox', async () => {
+    mockFetchWithAuth.mockImplementation(
+      routeByProject({
+        enceladus: () => ok([item()]),
+        intelligence: () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+    const result = await fetchEscalationsInbox(['enceladus', 'intelligence'])
+    expect(result.pending.map((e) => e.item_id)).toEqual(['ENC-ESC-001'])
+    expect(result.failed).toEqual(['intelligence'])
+    expect(result.scanned).toEqual(['enceladus'])
+  })
+
+  it('reports a non-ok project response as failed, not empty', async () => {
+    mockFetchWithAuth.mockImplementation(
+      routeByProject({
+        intelligence: () => ({ ok: false, status: 403, json: async () => ({}) }),
+      }),
+    )
+    const result = await fetchEscalationsInbox(['intelligence'])
+    expect(result.failed).toEqual(['intelligence'])
+    expect(result.scanned).toEqual([])
+  })
+
+  it('backfills project_id from the queried partition when the item omits it', async () => {
+    mockFetchWithAuth.mockImplementation(
+      routeByProject({
+        intelligence: () =>
+          ok([{ ...item({ item_id: 'INT-ESC-002' }), project_id: '' } as EscalationItem]),
+      }),
+    )
+    const result = await fetchEscalationsInbox(['intelligence'])
+    expect(result.pending[0].project_id).toBe('intelligence')
+  })
+
+  it('bounds concurrency so a large fan-out does not open every request at once', async () => {
+    let inFlight = 0
+    let peak = 0
+    mockFetchWithAuth.mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      inFlight -= 1
+      return ok([])
+    })
+    const projects = Array.from({ length: 25 }, (_, i) => `p${i}`)
+    await fetchEscalationsInbox(projects)
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(25)
+    expect(peak).toBeLessThanOrEqual(6)
+  })
+
+  it('returns an empty inbox for an empty project list without any request', async () => {
+    const result = await fetchEscalationsInbox([])
+    expect(result).toEqual({ pending: [], scanned: [], failed: [] })
+    expect(mockFetchWithAuth).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/ui/src/api/escalations.ts
+++ b/frontend/ui/src/api/escalations.ts
@@ -3,6 +3,14 @@ import { fetchWithAuth } from './client'
 // ENC-FTR-121 Ph3 (ENC-TSK-J70): io's escalation approval queue
 // (DOC-5B888FCA43B8 §5.7). All calls ride the Cognito session cookie —
 // the backend structurally rejects non-human credentials.
+//
+// ENC-TSK-N81 (ENC-ISS-594): the feed endpoint is single-project by
+// construction — it Queries one tracker partition keyed on project_id — so a
+// caller that names one project can only ever see that project's escalations.
+// Because approval is Cognito-human-only and non-delegable, invisible means
+// unapprovable, and non-ENC escalations were wedging at status=requested with
+// no UI path to decide them. fetchEscalationsInbox fans the same endpoint out
+// across every project and merges the pending queues into one inbox.
 
 export interface EscalationDiff {
   mutation_type: string
@@ -65,18 +73,90 @@ export interface EscalationDecisionResponse {
   retry?: string
 }
 
+/** Merged, cross-project pending queue plus the coverage it actually achieved. */
+export interface EscalationsInboxResponse {
+  pending: EscalationItem[]
+  /** Projects whose feed answered successfully. */
+  scanned: string[]
+  /** Projects whose feed failed; their escalations are NOT in `pending`. */
+  failed: string[]
+}
+
 export const escalationKeys = {
   feed: (projectId: string) => ['escalations', 'feed', projectId] as const,
+  inbox: (projectIds: string[]) =>
+    ['escalations', 'inbox', [...projectIds].sort().join(',')] as const,
 }
 
 export async function fetchEscalations(
   projectId = 'enceladus',
+  status?: string,
 ): Promise<EscalationsFeedResponse> {
-  const res = await fetchWithAuth(
-    `/api/v1/coordination/escalations?project_id=${encodeURIComponent(projectId)}`,
-  )
+  const query = new URLSearchParams({ project_id: projectId })
+  if (status) query.set('status', status)
+  const res = await fetchWithAuth(`/api/v1/coordination/escalations?${query}`)
   if (!res.ok) throw new Error(`Failed to fetch escalations: ${res.status}`)
   return res.json()
+}
+
+/** Cap on simultaneous feed requests so a 25-project fan-out stays polite. */
+const INBOX_CONCURRENCY = 6
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  async function run(): Promise<void> {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await worker(items[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, run))
+  return results
+}
+
+/**
+ * ENC-TSK-N81 (ENC-ISS-594): io's single approval inbox.
+ *
+ * Queries each project's pending feed and merges the results newest-first.
+ * A project that fails is reported in `failed` rather than rejecting the whole
+ * inbox — one bad partition must not hide the escalations that DID load, which
+ * is the same silent-invisibility failure this task exists to remove.
+ */
+export async function fetchEscalationsInbox(
+  projectIds: string[],
+): Promise<EscalationsInboxResponse> {
+  const scanned: string[] = []
+  const failed: string[] = []
+  const pending: EscalationItem[] = []
+
+  const feeds = await mapWithConcurrency(projectIds, INBOX_CONCURRENCY, async (projectId) => {
+    try {
+      return { projectId, feed: await fetchEscalations(projectId, 'requested') }
+    } catch {
+      return { projectId, feed: null }
+    }
+  })
+
+  for (const { projectId, feed } of feeds) {
+    if (!feed) {
+      failed.push(projectId)
+      continue
+    }
+    scanned.push(projectId)
+    // Trust the item's own project_id, but fall back to the partition we asked
+    // for — decision routing depends on this being right for non-ENC items.
+    for (const item of feed.pending ?? []) {
+      pending.push(item.project_id ? item : { ...item, project_id: projectId })
+    }
+  }
+
+  pending.sort((a, b) => String(b.created_at ?? '').localeCompare(String(a.created_at ?? '')))
+  return { pending, scanned, failed }
 }
 
 async function postDecision(

--- a/frontend/ui/src/pages/EscalationsPage.test.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.test.tsx
@@ -8,8 +8,14 @@
  *   - Approve / Deny / Deny-with-guidance wire to the API module.
  *   - Terminal escalations render inside the collapsed History section.
  *
+ * ENC-TSK-N81 / ENC-ISS-594 additionally covers:
+ *   - Pending merges every project's queue into one inbox (non-ENC included).
+ *   - Approve/deny route to the escalation's OWN project_id.
+ *   - A failing project degrades to a partial-result warning, not ErrorState.
+ *
  * Mocks: the api/escalations module is stubbed at the import boundary so the
  * page renders without the network; approval calls are asserted on the mock.
+ * The projects feed is stubbed too — it drives the pending fan-out.
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -20,20 +26,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { EscalationItem, EscalationsFeedResponse } from '../api/escalations'
 
-const { mockFetchEscalations, mockApprove, mockDeny } = vi.hoisted(() => ({
-  mockFetchEscalations: vi.fn(),
-  mockApprove: vi.fn(),
-  mockDeny: vi.fn(),
-}))
+const { mockFetchEscalations, mockFetchInbox, mockApprove, mockDeny, mockFetchProjects } =
+  vi.hoisted(() => ({
+    mockFetchEscalations: vi.fn(),
+    mockFetchInbox: vi.fn(),
+    mockApprove: vi.fn(),
+    mockDeny: vi.fn(),
+    mockFetchProjects: vi.fn(),
+  }))
 
 vi.mock('../api/escalations', async (importOriginal) => {
   const original = await importOriginal<typeof import('../api/escalations')>()
   return {
     ...original,
     fetchEscalations: mockFetchEscalations,
+    fetchEscalationsInbox: mockFetchInbox,
     approveEscalation: mockApprove,
     denyEscalation: mockDeny,
   }
+})
+
+// The projects feed drives the pending fan-out (ENC-TSK-N81).
+vi.mock('../api/feeds', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/feeds')>()
+  return { ...original, fetchProjects: mockFetchProjects }
 })
 
 import { EscalationsPage } from './EscalationsPage'
@@ -95,8 +111,26 @@ function renderPage() {
   return render(<EscalationsPage />, { wrapper })
 }
 
+function inbox(overrides: Partial<{
+  pending: EscalationItem[]
+  scanned: string[]
+  failed: string[]
+}> = {}) {
+  return {
+    pending: [pendingEscalation()],
+    scanned: ['enceladus', 'intelligence'],
+    failed: [],
+    ...overrides,
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
+  mockFetchProjects.mockResolvedValue({
+    generated_at: '2026-08-06T07:00:00Z',
+    projects: [{ project_id: 'enceladus' }, { project_id: 'intelligence' }],
+  })
+  mockFetchInbox.mockResolvedValue(inbox())
   mockFetchEscalations.mockResolvedValue(feed())
   mockApprove.mockResolvedValue({
     success: true,
@@ -127,8 +161,8 @@ describe('EscalationsPage', () => {
   })
 
   it('shows a prominent drift warning when expected_version mismatches', async () => {
-    mockFetchEscalations.mockResolvedValue(
-      feed({
+    mockFetchInbox.mockResolvedValue(
+      inbox({
         pending: [
           pendingEscalation({
             diff: {
@@ -199,8 +233,98 @@ describe('EscalationsPage', () => {
   })
 
   it('renders the empty state when nothing is pending', async () => {
+    mockFetchInbox.mockResolvedValue(inbox({ pending: [] }))
     mockFetchEscalations.mockResolvedValue(feed({ pending: [], terminal: [] }))
     renderPage()
     expect(await screen.findByText('No pending escalations.')).toBeInTheDocument()
+  })
+
+  // ENC-TSK-N81 / ENC-ISS-594 — the all-projects inbox.
+
+  it('fans the pending queue out across every project from the projects feed', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(mockFetchInbox).toHaveBeenCalledWith(['enceladus', 'intelligence'])
+  })
+
+  it('renders non-ENC escalations in the same pending inbox, labelled by project', async () => {
+    mockFetchInbox.mockResolvedValue(
+      inbox({
+        pending: [
+          pendingEscalation({
+            item_id: 'INT-ESC-001',
+            project_id: 'intelligence',
+            target_record_id: 'INT-TSK-182',
+            mutation_type: 'direct_state_override',
+          }),
+          pendingEscalation(),
+        ],
+      }),
+    )
+    renderPage()
+    const card = await screen.findByTestId('escalation-card-INT-ESC-001')
+    expect(within(card).getByTestId('escalation-project').textContent).toBe('intelligence')
+    expect(within(card).getByText('INT-TSK-182')).toBeInTheDocument()
+    // The ENC item still renders alongside it — one inbox, not a swap.
+    expect(screen.getByTestId('escalation-card-ENC-ESC-001')).toBeInTheDocument()
+  })
+
+  it('approves a non-ENC escalation against its OWN project_id', async () => {
+    mockFetchInbox.mockResolvedValue(
+      inbox({
+        pending: [pendingEscalation({ item_id: 'INT-ESC-001', project_id: 'intelligence' })],
+      }),
+    )
+    renderPage()
+    await screen.findByTestId('escalation-card-INT-ESC-001')
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(mockApprove).toHaveBeenCalledWith('intelligence', 'INT-ESC-001')
+  })
+
+  it('denies a non-ENC escalation against its OWN project_id', async () => {
+    mockFetchInbox.mockResolvedValue(
+      inbox({
+        pending: [pendingEscalation({ item_id: 'INT-ESC-004', project_id: 'intelligence' })],
+      }),
+    )
+    renderPage()
+    await screen.findByTestId('escalation-card-INT-ESC-004')
+    await userEvent.click(screen.getByRole('button', { name: 'Deny with guidance' }))
+    await userEvent.type(screen.getByLabelText('Guidance note'), 'Descope instead.')
+    await userEvent.click(screen.getByRole('button', { name: 'Send denial' }))
+    expect(mockDeny).toHaveBeenCalledWith('intelligence', 'INT-ESC-004', 'Descope instead.')
+  })
+
+  it('warns about unreadable projects instead of blanking the whole queue', async () => {
+    mockFetchInbox.mockResolvedValue(
+      inbox({ scanned: ['enceladus'], failed: ['intelligence'] }),
+    )
+    renderPage()
+    const warning = await screen.findByTestId('partial-failure-warning')
+    expect(warning.textContent).toContain('intelligence')
+    // The escalations that DID load are still decidable.
+    expect(screen.getByTestId('escalation-card-ENC-ESC-001')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).toBeNull()
+  })
+
+  it('states the coverage it actually achieved', async () => {
+    renderPage()
+    const coverage = await screen.findByTestId('inbox-coverage')
+    expect(coverage.textContent).toContain('2 projects')
+  })
+
+  it('keeps History project-scoped and switchable', async () => {
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(mockFetchEscalations).toHaveBeenCalledWith('enceladus')
+    await userEvent.selectOptions(screen.getByLabelText('History project'), 'intelligence')
+    expect(mockFetchEscalations).toHaveBeenCalledWith('intelligence')
+  })
+
+  it('falls back to the home project when the projects feed is unavailable', async () => {
+    mockFetchProjects.mockRejectedValue(new Error('feed down'))
+    renderPage()
+    await screen.findByTestId('escalation-card-ENC-ESC-001')
+    expect(mockFetchInbox).toHaveBeenCalledWith(['enceladus'])
   })
 })

--- a/frontend/ui/src/pages/EscalationsPage.tsx
+++ b/frontend/ui/src/pages/EscalationsPage.tsx
@@ -1,12 +1,14 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   approveEscalation,
   denyEscalation,
   escalationKeys,
   fetchEscalations,
+  fetchEscalationsInbox,
 } from '../api/escalations'
 import type { EscalationDiff, EscalationItem } from '../api/escalations'
+import { useProjects } from '../hooks/useProjects'
 import { LoadingState } from '../components/shared/LoadingState'
 import { ErrorState } from '../components/shared/ErrorState'
 import { EmptyState } from '../components/shared/EmptyState'
@@ -17,8 +19,16 @@ import { EmptyState } from '../components/shared/EmptyState'
 // a prominent drift warning when expected_version mismatches; io may still
 // approve (informed consent) or deny. Terminal escalations stay browsable in
 // a collapsed audit section.
+//
+// ENC-TSK-N81 (ENC-ISS-594): Pending is an ALL-PROJECTS inbox. This page used
+// to pin every call to a `PROJECT_ID = 'enceladus'` constant, so escalations
+// minted under any other project (INT-ESC-001..004) never rendered and — with
+// approval Cognito-human-only and non-delegable — were unapprovable forever.
+// Pending now fans out across the project list and each decision routes to the
+// escalation's OWN project_id. History stays project-scoped behind a selector:
+// one inbox is worth 25 requests, 25 full audit histories are not.
 
-const PROJECT_ID = 'enceladus'
+const HOME_PROJECT_ID = 'enceladus'
 
 const STATUS_COLORS: Record<string, string> = {
   requested: 'bg-amber-500/20 text-amber-300',
@@ -74,6 +84,17 @@ function DiffBlock({ diff }: { diff: EscalationDiff }) {
   )
 }
 
+function ProjectBadge({ projectId }: { projectId: string }) {
+  return (
+    <span
+      className="px-2 py-0.5 rounded text-xs font-medium bg-indigo-500/20 text-indigo-300"
+      data-testid="escalation-project"
+    >
+      {projectId}
+    </span>
+  )
+}
+
 function PendingCard({
   escalation,
   onApprove,
@@ -81,8 +102,8 @@ function PendingCard({
   busy,
 }: {
   escalation: EscalationItem
-  onApprove: (id: string) => void
-  onDeny: (id: string, guidanceNote?: string) => void
+  onApprove: (escalation: EscalationItem) => void
+  onDeny: (escalation: EscalationItem, guidanceNote?: string) => void
   busy: boolean
 }) {
   const [showGuidance, setShowGuidance] = useState(false)
@@ -95,8 +116,9 @@ function PendingCard({
       data-testid={`escalation-card-${escalation.item_id}`}
     >
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <span className="font-mono text-sm text-slate-200">{escalation.item_id}</span>
+          <ProjectBadge projectId={escalation.project_id} />
           <StatusBadge status={escalation.status} />
         </div>
         <span className="text-xs text-slate-500">{escalation.created_at}</span>
@@ -144,7 +166,7 @@ function PendingCard({
           />
           <div className="flex gap-2">
             <button
-              onClick={() => onDeny(escalation.item_id, guidanceNote.trim() || undefined)}
+              onClick={() => onDeny(escalation, guidanceNote.trim() || undefined)}
               disabled={busy}
               className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
             >
@@ -161,14 +183,14 @@ function PendingCard({
       ) : (
         <div className="flex gap-2">
           <button
-            onClick={() => onApprove(escalation.item_id)}
+            onClick={() => onApprove(escalation)}
             disabled={busy}
             className="px-3 py-1.5 rounded bg-emerald-600/80 hover:bg-emerald-600 text-sm text-white disabled:opacity-50"
           >
             Approve
           </button>
           <button
-            onClick={() => onDeny(escalation.item_id)}
+            onClick={() => onDeny(escalation)}
             disabled={busy}
             className="px-3 py-1.5 rounded bg-rose-600/80 hover:bg-rose-600 text-sm text-white disabled:opacity-50"
           >
@@ -191,18 +213,41 @@ export function EscalationsPage() {
   const queryClient = useQueryClient()
   const [actionError, setActionError] = useState('')
   const [lastOutcome, setLastOutcome] = useState('')
+  const [historyProject, setHistoryProject] = useState(HOME_PROJECT_ID)
 
-  const { data, isPending, isError } = useQuery({
-    queryKey: escalationKeys.feed(PROJECT_ID),
-    queryFn: () => fetchEscalations(PROJECT_ID),
+  // Project list drives the pending fan-out. It rides the static projects feed
+  // (CDN, no Lambda), and if it is unavailable we still show the home project
+  // rather than an empty inbox.
+  const { projects, isError: projectsError } = useProjects()
+  const projectIds = useMemo(() => {
+    const ids = projects.map((p) => p.project_id).filter(Boolean)
+    return ids.length ? Array.from(new Set([...ids, HOME_PROJECT_ID])).sort() : [HOME_PROJECT_ID]
+  }, [projects])
+
+  const {
+    data: inbox,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: escalationKeys.inbox(projectIds),
+    queryFn: () => fetchEscalationsInbox(projectIds),
     refetchInterval: 30_000,
   })
 
-  const refresh = () =>
-    queryClient.invalidateQueries({ queryKey: escalationKeys.feed(PROJECT_ID) })
+  const { data: history } = useQuery({
+    queryKey: escalationKeys.feed(historyProject),
+    queryFn: () => fetchEscalations(historyProject),
+    refetchInterval: 30_000,
+  })
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: escalationKeys.inbox(projectIds) })
+    queryClient.invalidateQueries({ queryKey: escalationKeys.feed(historyProject) })
+  }
 
   const approveMutation = useMutation({
-    mutationFn: (escalationId: string) => approveEscalation(PROJECT_ID, escalationId),
+    mutationFn: (escalation: EscalationItem) =>
+      approveEscalation(escalation.project_id, escalation.item_id),
     onSuccess: (result) => {
       setActionError('')
       setLastOutcome(
@@ -216,8 +261,13 @@ export function EscalationsPage() {
   })
 
   const denyMutation = useMutation({
-    mutationFn: ({ escalationId, guidanceNote }: { escalationId: string; guidanceNote?: string }) =>
-      denyEscalation(PROJECT_ID, escalationId, guidanceNote),
+    mutationFn: ({
+      escalation,
+      guidanceNote,
+    }: {
+      escalation: EscalationItem
+      guidanceNote?: string
+    }) => denyEscalation(escalation.project_id, escalation.item_id, guidanceNote),
     onSuccess: (result) => {
       setActionError('')
       setLastOutcome(`${result.escalation_id} ${result.status}.`)
@@ -227,11 +277,11 @@ export function EscalationsPage() {
   })
 
   if (isPending) return <LoadingState />
-  if (isError || !data) return <ErrorState />
+  if (isError || !inbox) return <ErrorState />
 
   const busy = approveMutation.isPending || denyMutation.isPending
-  const pending = data.pending ?? []
-  const terminal = data.terminal ?? []
+  const pending = inbox.pending
+  const terminal = history?.terminal ?? []
 
   return (
     <div className="p-4 space-y-4">
@@ -239,6 +289,25 @@ export function EscalationsPage() {
         Human-gated mutation overrides (ENC-FTR-121). Approval is non-delegable: decisions
         here are the sole origin of override authorization.
       </p>
+
+      {/* State the coverage rather than implying it. A queue that silently
+          scopes itself is how ENC-ISS-594 hid four escalations for a month. */}
+      <p className="text-xs text-slate-500" data-testid="inbox-coverage">
+        Pending across {inbox.scanned.length} project
+        {inbox.scanned.length === 1 ? '' : 's'}
+        {projectsError && ' (project list unavailable — showing enceladus only)'}
+      </p>
+
+      {inbox.failed.length > 0 && (
+        <div
+          className="bg-amber-500/10 border border-amber-500/40 rounded px-3 py-2 text-sm text-amber-300"
+          data-testid="partial-failure-warning"
+        >
+          ⚠ Could not read escalations for: {inbox.failed.join(', ')}. Any pending
+          escalation in {inbox.failed.length === 1 ? 'that project' : 'those projects'} is
+          not shown below.
+        </div>
+      )}
 
       {actionError && (
         <div className="bg-rose-500/10 border border-rose-500/40 rounded px-3 py-2 text-sm text-rose-300">
@@ -263,8 +332,10 @@ export function EscalationsPage() {
               key={escalation.item_id}
               escalation={escalation}
               busy={busy}
-              onApprove={(id) => approveMutation.mutate(id)}
-              onDeny={(id, guidanceNote) => denyMutation.mutate({ escalationId: id, guidanceNote })}
+              onApprove={(item) => approveMutation.mutate(item)}
+              onDeny={(item, guidanceNote) =>
+                denyMutation.mutate({ escalation: item, guidanceNote })
+              }
             />
           ))
         )}
@@ -274,6 +345,23 @@ export function EscalationsPage() {
         <summary className="text-sm font-semibold text-slate-400 cursor-pointer select-none">
           History ({terminal.length})
         </summary>
+        {/* Project-scoped on purpose: the audit trail is unbounded and pulling
+            every project's history on every poll is not worth it on mobile. */}
+        <label className="mt-3 flex items-center gap-2 text-xs text-slate-400">
+          Project
+          <select
+            value={historyProject}
+            onChange={(e) => setHistoryProject(e.target.value)}
+            aria-label="History project"
+            className="bg-slate-900 border border-slate-700 rounded px-2 py-1 text-slate-200"
+          >
+            {projectIds.map((projectId) => (
+              <option key={projectId} value={projectId}>
+                {projectId}
+              </option>
+            ))}
+          </select>
+        </label>
         <div className="mt-3 space-y-2">
           {terminal.map((escalation) => (
             <div


### PR DESCRIPTION
CCI-0fc48154b2dd42eeafc77383d7e0a321

Task: ENC-TSK-N81 · Issue: ENC-ISS-594 (P1) · Feature: ENC-FTR-121
Consent: DOC-B716E8FB10B6 (v3-Prod Surgical Deploy Brief), token supplied by io for this task.

## Problem

`EscalationsPage.tsx` pinned every call to `const PROJECT_ID = 'enceladus'`, and
`coordination_api._handle_escalations_feed` Queries a single tracker partition keyed on that
`project_id`. Escalations minted under any other project therefore never rendered.

Because FTR-121 approval is Cognito-human-only and non-delegable, invisible means
**unapprovable** — `INT-ESC-001..004` (intelligence) are wedged at `status=requested` with no UI
path to decide them.

## Change

Pending becomes one cross-project inbox:

- `fetchEscalationsInbox()` fans the existing per-project feed across the project list (bounded
  concurrency 6, `status=requested`) and merges newest-first.
- A failing project is isolated into a reported `failed` list instead of rejecting the inbox —
  one bad partition must not hide the escalations that *did* load, which is the same
  silent-invisibility failure this fixes.
- Each card carries a project badge; **approve/deny route to the escalation's own `project_id`**.
- The page states the coverage it achieved. A queue that silently scopes itself is what caused
  this issue; the scope is now disclosed rather than implied.
- History stays project-scoped behind a selector — one inbox is worth N requests, N full audit
  histories are not.

The project list rides the existing static projects feed (CDN, no Lambda). It excludes
`closed`/`archived` projects; that residual gap is called out in the follow-up below rather than
left silent.

## Channel (DOC-B716E8FB10B6 Step 1)

**Frontend-only, deliberately.** A backend all-projects mode would be the tidier long-run shape,
but the only prod Lambda channel available is `_deploy.yml ref=main -> v3-prod`, which rebuilds
all ~30 prod Lambdas from the ref — shipping a month of accumulated `main` drift under the banner
of a surgical fix. That is a hard stop under the brief's blast-radius and no-full-env-replace
invariants, and precisely the ENC-TSK-M44/M45 COE class.

This lands on the PWA lane alone (`ui-backend-deploy.yml`, push to `main` on `frontend/ui/**`,
ENC-TSK-J64 v3-prod Environment gate): one channel, one gate, zero Lambda churn.

COE registry guardrail checked anyway — stale but safe: both registry entries were since
backported to `main` (FTR-122 SCI via M44, FTR-121 escalations via M45) and both verify present
on `origin/main`.

## Verification

- 123/123 frontend tests pass; 26 on this surface, including a new `src/api/escalations.test.ts`
  that exercises the **real** merge, concurrency bound, and per-project failure isolation against
  a mocked network boundary.
- `eslint` clean on all changed files; `tsc -b` + `vite build` green.
- `check_governance_dictionary_sync.py`: no schema-affecting files changed.
- `prod_gate_coverage_guard.py`: every prod lane gated.
- Live validation on jreese.net follows io's Environment approval.

## Follow-up (not in this PR)

- Durable backend all-projects feed endpoint, covering closed/archived partitions too — belongs
  in the Lambda channel, post-cutover or under its own consent.
- Whether the `[ESCALATION]` SNS notify is ENC-scoped (the issue's VERIFY clause) — verified
  separately and reported on the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)