### PR TITLE
DVP-TSK-648/649: governance analytics mart (BRD B3) on the B2-R2 shared library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,21 @@ jobs:
           cd backend/lambda/shared_layer
           PYTHONPATH=python python3 -m unittest test_warehouse_registration -v
 
+      # DVP-TSK-648/649 (BRD B3): the governance analytics mart's grain contract
+      # is only a contract if violating it fails the build. This suite enforces
+      # DOC-3391173F2A5C mechanically — the substitution test is parametrised
+      # over all seven tables and fails on any free-text column name, because
+      # per the grain contract the appearance of such a column IS the Risk R-4
+      # drift signal rather than something a later review might catch. It also
+      # asserts daily grain on every fact table, the mandatory freshness stamp,
+      # zero partition keys (DOC-1E1EC5B7CE02), and that the four
+      # awaiting-upstream spectral columns stay DECLARED-and-NULL (risk R-11).
+      - name: Governance mart contract tests (DVP-TSK-648)
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet pyarrow pytest
+          python3 -m pytest backend/lambda/governance_mart -q
+
       # ENC-TSK-M98 / ENC-ISS-538: gamma tracker mirror guardrails — diff
       # computation, direction-lock refusal, counter-reset step (stdlib-only).
       - name: Gamma tracker mirror tests (ENC-TSK-M98)

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-07-13.1",
-  "updated_at": "2026-07-13T05:26:00Z",
-  "last_change_summary": "ENC-TSK-N45: document_api's documents/search endpoint (_handle_search, backing document.query_response) now defaults to sorting results by updated_at descending (newest first) before slicing to PAGE_SIZE, matching the default already used by feed_query, changelog_api, and the document candidate-curation list. Previously results were returned in unsorted DynamoDB scan order. No new/renamed/removed fields -- ordering-only behavior change, documented on document.query_response.documents.",
+  "version": "2026-08-08.1",
+  "updated_at": "2026-08-08T01:20:00Z",
+  "last_change_summary": "DVP-TSK-648 / DVP-TSK-649 (BRD B3, DVP-PLN-001): added entity warehouse.governance_mart documenting the seven-table governance analytics mart -- its declared columns, per-table grain, the metadata-only substitution test that CI enforces, the daily-grain rule, the scheduled full-refresh contract, and the devops/enceladus ownership split. The mart is a T2 projection at hive.devops.*, written through the B2-R2 shared registration library with a DECLARED schema (never a Glue crawler) and full-refresh overwrite (never per-mutation snapshots). No existing entity was modified.",
   "owners": [
     "enceladus-platform"
   ],
@@ -6176,6 +6176,150 @@
       },
       "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
       "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
+    },
+    "warehouse.governance_mart": {
+      "description": "DVP-TSK-648 / DVP-TSK-649 (BRD B3, plan DVP-PLN-001): the governance analytics mart -- a T2 warehouse projection of the governed record store, addressed as hive.devops.<table>. Seven DECLARED tables built by backend/lambda/governance_mart on a scheduled full refresh (EventBridge cron(0 6 * * ? *), never a per-mutation trigger) and registered through the B2-R2 shared library enceladus_shared.warehouse_registration. The mart holds METADATA ONLY, governed by DOC-3391173F2A5C: counts, statuses, durations, transitions, timestamps and identifiers -- never record bodies, titles, descriptions, intents, acceptance-criteria text, worklog prose, or document content. The standing test is 'if a column would let a reader substitute the mart for the record store, it does not belong', and it is enforced in CI over all seven tables rather than left to review, because per the grain contract the appearance of a free-text column IS the Risk R-4 drift signal. Also governed by DOC-04AF8A02A8F7 (four-tier architecture), DOC-5E35E14DAD05 (crawler prohibition -- schema is declared in code, never inferred by a Glue crawler), and DOC-1E1EC5B7CE02 (full-refresh partitioning discipline -- no partition keys, exactly one Parquet object per table at a constant key, so file count tracks data size and never write count). Ownership per BRD B3-R4: devops owns the platform tier and the contract; enceladus owns the projection logic and schema, because the schema is a projection of the governance ontology (ENC-FTR-053) and must evolve with it.",
+      "addressing": "hive.devops.<table>",
+      "storage": "s3://devops-agentcli-compute/warehouse/devops/<table>/data.parquet (Parquet, snappy, full-refresh overwrite)",
+      "required_column": {
+        "ingest_ts": {
+          "type": "string",
+          "definition": "Mandatory T2 freshness stamp (DOC-04AF8A02A8F7): UTC ISO-8601 warehouse write time, library-owned (stamp_freshness=True) because the mart is derived data. One shared value across all seven tables per refresh."
+        }
+      },
+      "daily_grain_rule": {
+        "type": "rule",
+        "definition": "Every fact table carries snapshot_date at daily grain FROM THE OUTSET, not as a later upgrade. Enforced by mart_schema.assert_daily_grain() at module import and re-checked in CI. This is what makes a refresh failure show up as a series that STOPS DRAWING rather than a current value that persists and looks healthy while being arbitrarily stale (OBJ-6). The *_daily aggregates lead their grain with snapshot_date; fact_record_transition is an EVENT table whose grain is one row per transition and which carries snapshot_date as the day bucket."
+      },
+      "tables": {
+        "dim_record": {
+          "grain": "one row per governed tracker record, current state",
+          "task": "DVP-TSK-672",
+          "columns": [
+            "record_id",
+            "project_id",
+            "record_type",
+            "status",
+            "priority",
+            "category",
+            "parent_id",
+            "component_ids",
+            "created_at",
+            "updated_at",
+            "closed_at",
+            "checkout_count",
+            "closed_count",
+            "ontology_completeness_score",
+            "transition_type",
+            "ingest_ts"
+          ],
+          "notes": "status is projected VERBATIM, not normalised -- the live corpus carries Completed/Complete/complete as distinct values and folding them is a judgement the mart is not entitled to make on the record store's behalf. ontology_completeness_score is RECOMPUTED from the record store's own ENC-FTR-011 rubric because it is computed at read time by the MCP server and never persisted to DynamoDB. component_ids is a JSON-array string because the shared library declares array<> writable only by flattening."
+        },
+        "fact_record_daily": {
+          "grain": "(snapshot_date, project_id, record_type, status)",
+          "task": "DVP-TSK-673",
+          "columns": [
+            "snapshot_date",
+            "project_id",
+            "record_type",
+            "status",
+            "record_count",
+            "opened_count",
+            "closed_count",
+            "ingest_ts"
+          ],
+          "notes": "record_count partitions the record set: several transitions on one day collapse to one row holding the day's LAST status."
+        },
+        "fact_record_transition": {
+          "grain": "one row per lifecycle transition",
+          "task": "DVP-TSK-674",
+          "columns": [
+            "record_id",
+            "project_id",
+            "record_type",
+            "from_status",
+            "to_status",
+            "transitioned_at",
+            "days_in_prior_status",
+            "transition_type",
+            "snapshot_date",
+            "ingest_ts"
+          ],
+          "notes": "The tracker stores NO structural status transition: history[].status is an entry KIND (created|worklog) and the transition lives inside the entry's free-text description. The projection parses that prose to recover two status tokens and a timestamp and DISCARDS the prose -- the substitution test applied to a source that is mostly free text. Re-homes the ENC-TSK-989 corpus-with-history extraction rather than re-deriving it."
+        },
+        "dim_document": {
+          "grain": "one row per docstore document",
+          "task": "DVP-TSK-675",
+          "columns": [
+            "document_id",
+            "project_id",
+            "document_subtype",
+            "subtypepattern",
+            "status",
+            "document_maturity_state",
+            "compliance_score",
+            "compliance_warning_count",
+            "size_bytes",
+            "version",
+            "related_item_count",
+            "created_at",
+            "updated_at",
+            "ingest_ts"
+          ],
+          "notes": "No document content. Where substance was available a COUNT was projected instead: compliance_warning_count not the warning text, related_item_count not the ids, size_bytes as the metadata shadow of the body -- how much, never what."
+        },
+        "fact_document_daily": {
+          "grain": "(snapshot_date, project_id, document_subtype, document_maturity_state)",
+          "task": "DVP-TSK-676",
+          "columns": [
+            "snapshot_date",
+            "project_id",
+            "document_subtype",
+            "document_maturity_state",
+            "document_count",
+            "created_count",
+            "mean_compliance_score",
+            "ingest_ts"
+          ],
+          "notes": "Type-1 dimension limitation, recorded rather than hidden: the docstore keeps no maturity HISTORY, so subtype and maturity are current attributes projected across each document's lifetime. Document production per day is exact; maturity movement reads from the current distribution."
+        },
+        "fact_session_daily": {
+          "grain": "(snapshot_date, project_id, agent_type, model)",
+          "task": "DVP-TSK-677",
+          "columns": [
+            "snapshot_date",
+            "project_id",
+            "agent_type",
+            "model",
+            "session_count",
+            "records_touched",
+            "ingest_ts"
+          ],
+          "notes": "model is a DATA column describing observed agent sessions, never configuration. agent_type carries agent_types.surface joined from the session's agent_type_id. There is NO stored session-to-record edge, so records_touched is obtained by inverting the tracker side: every ENC-SES-* named in a record's history plus active_agent_session_id. Sessions that touched nothing are retained under project_id='unattributed'."
+        },
+        "fact_graph_health_daily": {
+          "grain": "one row per snapshot_date",
+          "task": "DVP-TSK-678",
+          "columns": [
+            "snapshot_date",
+            "node_count",
+            "edge_count",
+            "orphan_node_count",
+            "unresolved_edge_count",
+            "hot_tier_fraction",
+            "percolation_margin",
+            "fiedler_value",
+            "demand_centroid_drift",
+            "ingest_ts"
+          ],
+          "notes": "Risk R-11 discipline. hot_tier_fraction, percolation_margin, fiedler_value and demand_centroid_drift have no upstream computation today (graph_health_metrics publishes CloudWatch proxies and says so in its own docstring), so they are DECLARED NOW and written NULL, to be filled by ENC-FTR-063 / comp-percolation-monitor as an UPDATE rather than a schema change against a live table. The first four columns are computed today from the governed graph (records + documents as nodes; parent, subtask_ids, related_*_ids, related_items, informed_by as edges), so the table is never empty while it waits. This table PROJECTS, it does not compute."
+        }
+      },
+      "refresh_contract": {
+        "type": "rule",
+        "definition": "Scheduled FULL REFRESH, daily minimum, never event-driven. No EventBridge per-mutation trigger, no Glue crawler and no crawler launcher, no partition keys. Each run rebuilds every table from scratch and overwrites a single object per table at a constant key, so crawler concurrency is unreachable, partition explosion is impossible by construction, and the new-project sync gap cannot recur because the refresh scans ALL projects. The handler re-raises on error rather than returning 200: the daily series must stop drawing AND the invocation must fail, not one without the other."
+      },
+      "change_governance": "Mart schema changes (adding a column, adding a table, widening a grain) are governed changes reviewed against the substitution test -- never incidental edits folded into an unrelated ETL change. devops owns the test; enceladus applies it."
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6241,6 +6385,11 @@
       "version": "2026-07-09.1",
       "date": "2026-07-09",
       "summary": "ENC-TSK-M45 (FTR-121 registry entry, DOC-B716E8FB10B6 COE, M44 sibling): backport the ENC-FTR-121 Escalations request/applier/watch/notify surface from v4/main onto main. The 2026-07-08T22:25:44Z main-ref v3-prod Lambda deploy had reverted the escalation.request/get/list surface (ENC-TSK-J68), the applyEscalatedMutation applier (ENC-TSK-J69), coordination_api's approve/deny/feed handlers (ENC-TSK-J70 backend portion only -- PWA/CFN already landed via ENC-TSK-J82/J80), the agent-side escalation.watch cursor poll (ENC-TSK-J71, with the ENC-TSK-J89 base-relative-path fix folded in), and the SNS [ESCALATION] notify hook (ENC-TSK-J72), leaving execute() unable to resolve action 'escalation.request'. Extraction was surgical by function/hunk, NOT by commit: v4/main's J68/J69/J71 commits are git-history-entangled with the unrelated ENC-TSK-I07 supersession primitive and ENC-TSK-I08/I09 dedup-review surfaces (neither present on main), and J70/J71's coordination_api hunks are similarly entangled with the unrelated ENC-TSK-J46/FTR-096 lesson-candidate curation surface (also not on main) -- those were excluded by isolating function-boundary content within each 3-way-merge conflict block rather than accepting the whole hunk. New entities: tracker.escalation (the escalation item type + FSM + mutation-handler registry + applier + waiver semantics, tracker_mutation), mcp_server.escalation_actions (escalation.request/get/list/watch code-mode actions), coordination.escalations (coordination_api's feed/approve/deny/watch routes -- the base ENC-TSK-J70 in-Lambda _is_cognito_session check only; the additional ENC-TSK-L92/M12 allowlist + human-principal gates remain exclusively in the standalone escalation_decision_authorizer Lambda per that entity's existing prod-vs-gamma split, unchanged by this task). CFN routes/env (ENC-TSK-J80) and the PWA Escalations page (ENC-TSK-J82) were already on main prior to this task and are unmodified here."
+    },
+    {
+      "version": "2026-08-08.1",
+      "date": "2026-08-08",
+      "summary": "DVP-TSK-648 / DVP-TSK-649 (BRD B3, DVP-PLN-001): added entity warehouse.governance_mart documenting the seven-table governance analytics mart -- its declared columns, per-table grain, the metadata-only substitution test that CI enforces, the daily-grain rule, the scheduled full-refresh contract, and the devops/enceladus ownership split. The mart is a T2 projection at hive.devops.*, written through the B2-R2 shared registration library with a DECLARED schema (never a Glue crawler) and full-refresh overwrite (never per-mutation snapshots). No existing entity was modified."
     }
   ]
 }

--- a/backend/lambda/governance_mart/.build_extras
+++ b/backend/lambda/governance_mart/.build_extras
@@ -1,0 +1,23 @@
+# ENC-TSK-G43: cross-Lambda module sharing manifest.
+# Each non-comment line is a repo-relative path to a single file; the build
+# step copies it to the function root so the Lambda can `import` it normally.
+# Honored by .github/workflows/_build.yml.
+#
+# DVP-TSK-649: this is NOT belt-and-braces. mart_refresh.py / mart_schema.py try
+# `from enceladus_shared.warehouse_registration import ...` first and fall back
+# to `from warehouse_registration import ...`. The first path CANNOT resolve on
+# the deployed function today: SharedLayerArn is pinned to enceladus-shared:10,
+# and :10 is defined as ":7 + appconfig_flags" (see the SharedLayerArn Default
+# comment in infrastructure/cloudformation/02-compute.yaml and
+# tools/verify_shared_layer_version.py). The warehouse_registration module landed
+# later, in DVP-TSK-668/669/670, so it is not in the pinned layer. Vendoring it
+# here is what makes the fallback branch resolve and the mart able to write at
+# all. Once a shared-layer version containing warehouse_registration is published
+# AND the canonical pin is bumped, this line becomes redundant (the layer's
+# enceladus_shared.warehouse_registration would win the try branch) and can go.
+#
+# Flattened to the function root by _build.yml's `cp "$extra"
+# "$workdir/$(basename "$extra")"`, so the resulting import name is
+# `warehouse_registration` (top-level module) — NOT
+# `enceladus_shared.warehouse_registration`.
+backend/lambda/shared_layer/python/enceladus_shared/warehouse_registration.py

--- a/backend/lambda/governance_mart/deploy.sh
+++ b/backend/lambda/governance_mart/deploy.sh
@@ -1,0 +1,1 @@
+# TOMBSTONE: see .github/workflows/_deploy.yml matrix build

--- a/backend/lambda/governance_mart/lambda_function.py
+++ b/backend/lambda/governance_mart/lambda_function.py
@@ -1,0 +1,73 @@
+"""Governance analytics mart -- scheduled full-refresh job.
+
+BRD B3-R3 (DVP-TSK-649). Invoked by an EventBridge **schedule** (daily
+minimum), never by a tracker mutation. The handler is deliberately thin: all
+of the contract lives in ``mart_schema`` (the declaration), ``mart_source``
+(the read), ``mart_project`` (the grain), and ``mart_refresh`` (the path), so
+the same code serves the schedule and the operator CLI at
+``tools/governance_mart_refresh.py``.
+
+Event shape (all fields optional -- a bare EventBridge scheduled event is the
+normal case and needs none of them)::
+
+    {
+      "tables":   ["dim_record", ...],   # subset, for targeted re-registration
+      "last_day": "2026-08-07",          # pin the daily-grain upper bound
+      "dry_run":  false                  # project and count, write nothing
+    }
+
+Returns the ``RefreshResult`` summary: per-table row, byte, and file counts
+plus the shared write timestamp. A non-zero ``file_count`` above 1 on any
+table is the B6-R2 full-refresh violation signal and is surfaced rather than
+swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timezone
+
+from mart_refresh import refresh_mart
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+
+def _parse_last_day(value):
+    if not value:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+
+
+def lambda_handler(event, context):  # noqa: ANN001 - AWS signature
+    event = event or {}
+    tables = event.get("tables") or None
+    dry_run = bool(event.get("dry_run"))
+    last_day = _parse_last_day(event.get("last_day"))
+
+    try:
+        result = refresh_mart(tables=tables, last_day=last_day, dry_run=dry_run)
+    except Exception:
+        # Let the invocation FAIL loudly. A refresh that swallows its own error
+        # and returns 200 is exactly the silent-stop failure mode this job was
+        # built to make impossible: the daily series must stop drawing AND the
+        # alarm must fire, not one without the other.
+        LOGGER.exception("[ERROR] governance mart refresh failed")
+        raise
+
+    summary = result.as_dict()
+    violations = [entry["table"] for entry in summary["tables"] if entry.get("files", 1) > 1]
+    if violations:
+        LOGGER.error(
+            "[ERROR] full-refresh violation: %s hold more than one object. "
+            "File count must track data size, never write count (DOC-1E1EC5B7CE02).",
+            ", ".join(violations),
+        )
+    summary["full_refresh_violations"] = violations
+
+    LOGGER.info("[SUCCESS] %s", json.dumps(summary, default=str))
+    return {"statusCode": 200, "body": summary}

--- a/backend/lambda/governance_mart/mart_project.py
+++ b/backend/lambda/governance_mart/mart_project.py
@@ -1,0 +1,710 @@
+"""Project the governed record store to mart grain.
+
+BRD B3-R3, second clause: *project to grain*. Seven builders, one per declared
+table in ``mart_schema``. Each returns ``list[dict]`` keyed by the DECLARED
+column names; the shared B2-R2 library does the rest (declaration wins, absent
+columns become NULL, extra keys are dropped).
+
+Two disciplines run through every builder:
+
+**The substitution test.** Free text is read and discarded, never emitted. The
+sharpest case is ``fact_record_transition``: the tracker does not store status
+transitions structurally at all -- ``history[].status`` is an entry KIND
+(``created`` / ``worklog``), and the actual transition lives inside the entry's
+prose. So this module parses the prose to recover two status TOKENS and a
+timestamp, and throws the prose away. What lands in the mart is
+``('in-progress' -> 'coding-complete', 62.4 minutes)``; what does not land is
+the sentence that carried it.
+
+**Daily grain from the outset.** Every fact builder emits one row per day per
+grain tuple across the whole observed history, recomputed from scratch on
+every refresh. Nothing is incremental, so nothing can silently stop advancing
+while continuing to look fresh.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+__all__ = [
+    "TERMINAL_STATUSES",
+    "INITIAL_STATUS",
+    "ontology_completeness_score",
+    "extract_transitions",
+    "build_dim_record",
+    "build_fact_record_daily",
+    "build_fact_record_transition",
+    "build_dim_document",
+    "build_fact_document_daily",
+    "build_fact_session_daily",
+    "build_fact_graph_health_daily",
+    "build_all",
+]
+
+# ---------------------------------------------------------------------------
+# Status vocabulary
+# ---------------------------------------------------------------------------
+
+#: Statuses that end a record's life. The tracker's governed task lifecycle
+#: terminates at `closed`; other record types (plans, lessons, escalations,
+#: references) carry their own terminal vocabulary, and legacy records carry
+#: capitalised variants. Compared case-folded.
+TERMINAL_STATUSES = frozenset(
+    {
+        "closed", "completed", "complete", "wont_fix", "superseded",
+        "archived", "denied", "denied_with_guidance", "incomplete",
+    }
+)
+
+#: The tracker creates task / issue / feature records at `open`. A record's
+#: status before its FIRST recorded transition is not stored anywhere, so this
+#: is the documented assumption standing in for it. It affects only the days
+#: between creation and first transition, and only for records whose real
+#: initial status differed -- overwhelmingly plans and references, which mostly
+#: carry no transitions at all.
+INITIAL_STATUS = "open"
+
+
+def is_terminal(status: Optional[str]) -> bool:
+    return bool(status) and str(status).strip().lower() in TERMINAL_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+_ISO = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def parse_ts(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.strptime(text[:20], _ISO).replace(tzinfo=timezone.utc)
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def to_date(value: Any) -> Optional[date]:
+    moment = parse_ts(value)
+    return moment.date() if moment else None
+
+
+def date_range(first: date, last: date) -> Iterable[date]:
+    step = first
+    one = timedelta(days=1)
+    while step <= last:
+        yield step
+        step += one
+
+
+# ---------------------------------------------------------------------------
+# Ontology completeness (ENC-FTR-011)
+# ---------------------------------------------------------------------------
+
+_COMMON_CHECKS = (("title", 10), ("description", 5), ("priority", 5), ("category", 10), ("intent", 5))
+_TASK_CHECKS = (("acceptance_criteria", 15), ("assigned_to", 5), ("parent", 10), ("checklist", 5))
+_ISSUE_CHECKS = (("evidence", 25), ("severity", 5), ("hypothesis", 10), ("technical_notes", 5))
+_FEATURE_CHECKS = (("user_story", 15), ("acceptance_criteria", 15), ("owners", 5), ("success_metrics", 5), ("parent", 5))
+
+
+def _has_value(value: Any) -> bool:
+    if isinstance(value, list):
+        return len(value) > 0
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
+def ontology_completeness_score(record: Mapping[str, Any]) -> int:
+    """Recompute the 0-100 ontology completeness score.
+
+    Deliberately a re-implementation of the record store's own rubric
+    (``tools/enceladus-mcp-server/server.py::_compute_completeness_score``)
+    rather than a read of a stored field: the score is computed at READ time by
+    the MCP server and never persisted to DynamoDB, so a mart that scanned the
+    table would find no column to project. Verified against the live API for
+    DVP-TSK-648 (55/70 -> 79).
+    """
+    record_type = record.get("record_type", "")
+    earned = 0
+    total = 0
+
+    for field, points in _COMMON_CHECKS:
+        total += points
+        if _has_value(record.get(field)):
+            earned += points
+
+    if record_type == "feature":
+        for field, points in _FEATURE_CHECKS:
+            total += points
+            if _has_value(record.get(field)):
+                earned += points
+        total += 15
+        criteria = record.get("acceptance_criteria") or []
+        if criteria:
+            validated = sum(
+                1 for item in criteria if isinstance(item, dict) and item.get("evidence_acceptance")
+            )
+            if validated == len(criteria):
+                earned += 15
+            elif validated > 0:
+                earned += round(15 * validated / len(criteria))
+    elif record_type == "task":
+        for field, points in _TASK_CHECKS:
+            total += points
+            if _has_value(record.get(field)):
+                earned += points
+    elif record_type == "issue":
+        for field, points in _ISSUE_CHECKS:
+            total += points
+            if _has_value(record.get(field)):
+                earned += points
+
+    return round((earned / total) * 100) if total else 0
+
+
+# ---------------------------------------------------------------------------
+# Transition extraction from the per-record history arrays
+# ---------------------------------------------------------------------------
+
+#: The tracker records a status change as prose inside a worklog entry. Both
+#: shapes below appear in the live corpus (15,422 and 108 occurrences
+#: respectively across 58,042 history entries), plus an underscored legacy
+#: variant written by an older `tracker.py`. Underscores are accepted in the
+#: capture and folded to the governed hyphenated form.
+_STATUS_PATTERNS = (
+    re.compile(r"Field 'status' set to '([A-Za-z0-9_\- ]+)'"),
+    re.compile(r"Status changed to '([A-Za-z0-9_\- ]+)'"),
+)
+
+#: Any governed agent session named in a worklog entry. 11,989 history entries
+#: carry one, which is what makes `fact_session_daily.records_touched`
+#: answerable at all -- there is no stored session->record edge.
+_SESSION_PATTERN = re.compile(r"ENC-SES-[A-Z0-9]{3}")
+
+
+def _normalise_status(raw: str) -> str:
+    return raw.strip().replace("_", "-").lower()
+
+
+def extract_transitions(record: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    """Recover the lifecycle transition chain from one record's history array.
+
+    Returns transitions in chronological order. ``from_status`` is carried
+    forward from the previous transition (``INITIAL_STATUS`` for the first),
+    and ``days_in_prior_status`` measures against the previous transition's
+    timestamp, or the record's creation time for the first.
+
+    The history entry's ``description`` is read here and never returned.
+    """
+    history = record.get("history") or []
+    created = parse_ts(record.get("created_at"))
+
+    events: List[Tuple[datetime, str]] = []
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        description = entry.get("description") or ""
+        moment = parse_ts(entry.get("timestamp"))
+        if not moment:
+            continue
+        for pattern in _STATUS_PATTERNS:
+            found = pattern.search(description)
+            if found:
+                events.append((moment, _normalise_status(found.group(1))))
+                break
+
+    events.sort(key=lambda pair: pair[0])
+
+    transitions: List[Dict[str, Any]] = []
+    previous_status = INITIAL_STATUS
+    previous_moment = created
+    for moment, status in events:
+        if status == previous_status:
+            # A re-assertion of the same status is not a transition. Recording
+            # it would inflate throughput and zero out cycle time.
+            continue
+        elapsed = None
+        if previous_moment and moment >= previous_moment:
+            elapsed = round((moment - previous_moment).total_seconds() / 86400.0, 6)
+        transitions.append(
+            {
+                "from_status": previous_status,
+                "to_status": status,
+                "transitioned_at": moment.strftime(_ISO),
+                "days_in_prior_status": elapsed,
+            }
+        )
+        previous_status = status
+        previous_moment = moment
+    return transitions
+
+
+def sessions_in_history(record: Mapping[str, Any]) -> Set[str]:
+    """Every governed agent session that wrote to this record."""
+    found: Set[str] = set()
+    active = record.get("active_agent_session_id")
+    if isinstance(active, str) and active.startswith("ENC-SES-"):
+        found.add(active)
+    for entry in record.get("history") or []:
+        if isinstance(entry, dict):
+            found.update(_SESSION_PATTERN.findall(entry.get("description") or ""))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Status timeline
+# ---------------------------------------------------------------------------
+
+
+def status_timeline(record: Mapping[str, Any], transitions: Sequence[Mapping[str, Any]]) -> List[Tuple[date, str]]:
+    """Segments of (start_date, status) for one record, chronological.
+
+    The final segment is forced to the record's CURRENT status: the parsed
+    chain and the authoritative `status` field can disagree when a status was
+    set by a path that did not write a parseable worklog line, and the record
+    store wins.
+    """
+    created = to_date(record.get("created_at"))
+    if not created:
+        return []
+    segments: List[Tuple[date, str]] = [(created, INITIAL_STATUS)]
+    for transition in transitions:
+        moment = to_date(transition["transitioned_at"])
+        if moment:
+            segments.append((moment, str(transition["to_status"])))
+    current = record.get("status")
+    if current:
+        segments[-1] = (segments[-1][0], str(current))
+    return segments
+
+
+def _status_on_days(segments: Sequence[Tuple[date, str]], last_day: date) -> Dict[date, str]:
+    """Status held at the END of each day, from creation through last_day.
+
+    Several transitions can land on one day; the day holds the LAST of them,
+    which is what "at end of day" means and what keeps `record_count` a true
+    partition of the record set (one row per record per day, never two).
+    """
+    if not segments:
+        return {}
+    latest_on_start: Dict[date, str] = {}
+    for start, status in segments:
+        latest_on_start[start] = status  # later entries overwrite same-day ones
+
+    starts = sorted(latest_on_start)
+    held: Dict[date, str] = {}
+    for index, start in enumerate(starts):
+        if start > last_day:
+            break
+        end = starts[index + 1] - timedelta(days=1) if index + 1 < len(starts) else last_day
+        for day in date_range(start, min(end, last_day)):
+            held[day] = latest_on_start[start]
+    return held
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def build_dim_record(corpus) -> List[Dict[str, Any]]:
+    """DVP-TSK-672. One row per governed tracker record, current state."""
+    rows: List[Dict[str, Any]] = []
+    for record in corpus.records:
+        item_id = record.get("item_id") or str(record.get("record_id", "")).split("#")[-1]
+        if not item_id:
+            continue
+        transitions = extract_transitions(record)
+        closed_at = ""
+        for transition in reversed(transitions):
+            if is_terminal(transition["to_status"]):
+                closed_at = transition["transitioned_at"]
+                break
+        if not closed_at and is_terminal(record.get("status")):
+            closed_at = str(record.get("updated_at") or "")
+
+        components = record.get("components") or []
+        if not isinstance(components, list):
+            components = [components]
+
+        rows.append(
+            {
+                "record_id": item_id,
+                "project_id": record.get("project_id") or "",
+                "record_type": record.get("record_type") or "",
+                "status": record.get("status") or "",
+                "priority": record.get("priority") or "",
+                "category": record.get("category") or "",
+                "parent_id": record.get("parent") or "",
+                "component_ids": json.dumps([str(item) for item in components], separators=(",", ":")),
+                "created_at": record.get("created_at") or "",
+                "updated_at": record.get("updated_at") or "",
+                "closed_at": closed_at,
+                "checkout_count": int(record.get("checkout_count") or 0),
+                "closed_count": int(record.get("closed_count") or 0),
+                "ontology_completeness_score": ontology_completeness_score(record),
+                "transition_type": record.get("transition_type") or "",
+            }
+        )
+    return rows
+
+
+def build_fact_record_daily(corpus, last_day: date) -> List[Dict[str, Any]]:
+    """DVP-TSK-673. Grain (snapshot_date, project_id, record_type, status)."""
+    counts: Dict[Tuple[date, str, str, str], Dict[str, int]] = defaultdict(
+        lambda: {"record_count": 0, "opened_count": 0, "closed_count": 0}
+    )
+
+    for record in corpus.records:
+        created = to_date(record.get("created_at"))
+        if not created or created > last_day:
+            continue
+        project = record.get("project_id") or ""
+        record_type = record.get("record_type") or ""
+        transitions = extract_transitions(record)
+        held = _status_on_days(status_timeline(record, transitions), last_day)
+
+        for day, status in held.items():
+            bucket = counts[(day, project, record_type, status)]
+            bucket["record_count"] += 1
+            if day == created:
+                bucket["opened_count"] += 1
+
+        for transition in transitions:
+            if not is_terminal(transition["to_status"]):
+                continue
+            day = to_date(transition["transitioned_at"])
+            if day and day <= last_day:
+                status = held.get(day, str(transition["to_status"]))
+                counts[(day, project, record_type, status)]["closed_count"] += 1
+
+    return [
+        {
+            "snapshot_date": day,
+            "project_id": project,
+            "record_type": record_type,
+            "status": status,
+            "record_count": values["record_count"],
+            "opened_count": values["opened_count"],
+            "closed_count": values["closed_count"],
+        }
+        for (day, project, record_type, status), values in sorted(
+            counts.items(), key=lambda pair: (pair[0][0], pair[0][1], pair[0][2], pair[0][3])
+        )
+    ]
+
+
+def build_fact_record_transition(corpus) -> List[Dict[str, Any]]:
+    """DVP-TSK-674. One row per lifecycle transition."""
+    rows: List[Dict[str, Any]] = []
+    for record in corpus.records:
+        item_id = record.get("item_id") or str(record.get("record_id", "")).split("#")[-1]
+        if not item_id:
+            continue
+        for transition in extract_transitions(record):
+            rows.append(
+                {
+                    "record_id": item_id,
+                    "project_id": record.get("project_id") or "",
+                    "record_type": record.get("record_type") or "",
+                    "from_status": transition["from_status"],
+                    "to_status": transition["to_status"],
+                    "transitioned_at": transition["transitioned_at"],
+                    "days_in_prior_status": transition["days_in_prior_status"],
+                    "transition_type": record.get("transition_type") or "",
+                    "snapshot_date": to_date(transition["transitioned_at"]),
+                }
+            )
+    rows.sort(key=lambda row: (row["transitioned_at"], row["record_id"]))
+    return rows
+
+
+def build_dim_document(corpus) -> List[Dict[str, Any]]:
+    """DVP-TSK-675. One row per docstore document. No content."""
+    rows: List[Dict[str, Any]] = []
+    for document in corpus.documents:
+        document_id = document.get("document_id")
+        if not document_id:
+            continue
+        warnings = document.get("compliance_warnings") or []
+        related = document.get("related_items") or []
+        score = document.get("compliance_score")
+        rows.append(
+            {
+                "document_id": document_id,
+                "project_id": document.get("project_id") or "",
+                "document_subtype": document.get("document_subtype") or "unspecified",
+                "subtypepattern": document.get("subtypepattern") or "",
+                "status": document.get("status") or "",
+                "document_maturity_state": document.get("document_maturity_state") or "unspecified",
+                "compliance_score": int(score) if score is not None else None,
+                "compliance_warning_count": len(warnings) if isinstance(warnings, list) else 0,
+                "size_bytes": int(document.get("size_bytes") or 0),
+                "version": int(document.get("version") or 0),
+                "related_item_count": len(related) if isinstance(related, list) else 0,
+                "created_at": document.get("created_at") or "",
+                "updated_at": document.get("updated_at") or "",
+            }
+        )
+    return rows
+
+
+def build_fact_document_daily(corpus, last_day: date) -> List[Dict[str, Any]]:
+    """DVP-TSK-676. Grain (snapshot_date, project_id, subtype, maturity).
+
+    Subtype and maturity are CURRENT attributes projected across the document's
+    lifetime: the docstore keeps no maturity history, so a document that
+    matured yesterday reads as mature for its whole life here. That is a
+    type-1-dimension limitation of the source, recorded rather than hidden --
+    it makes maturity MOVEMENT over time readable only from the current
+    distribution, while document PRODUCTION per day stays exact.
+    """
+    counts: Dict[Tuple[date, str, str, str], Dict[str, Any]] = defaultdict(
+        lambda: {"document_count": 0, "created_count": 0, "score_sum": 0, "score_n": 0}
+    )
+    for document in corpus.documents:
+        created = to_date(document.get("created_at"))
+        if not created or created > last_day:
+            continue
+        project = document.get("project_id") or ""
+        subtype = document.get("document_subtype") or "unspecified"
+        maturity = document.get("document_maturity_state") or "unspecified"
+        score = document.get("compliance_score")
+        for day in date_range(created, last_day):
+            bucket = counts[(day, project, subtype, maturity)]
+            bucket["document_count"] += 1
+            if day == created:
+                bucket["created_count"] += 1
+            if score is not None:
+                bucket["score_sum"] += int(score)
+                bucket["score_n"] += 1
+
+    rows: List[Dict[str, Any]] = []
+    for (day, project, subtype, maturity), values in sorted(
+        counts.items(), key=lambda pair: (pair[0][0], pair[0][1], pair[0][2], pair[0][3])
+    ):
+        rows.append(
+            {
+                "snapshot_date": day,
+                "project_id": project,
+                "document_subtype": subtype,
+                "document_maturity_state": maturity,
+                "document_count": values["document_count"],
+                "created_count": values["created_count"],
+                "mean_compliance_score": (
+                    round(values["score_sum"] / values["score_n"], 4) if values["score_n"] else None
+                ),
+            }
+        )
+    return rows
+
+
+def build_fact_session_daily(corpus) -> List[Dict[str, Any]]:
+    """DVP-TSK-677. Grain (snapshot_date, project_id, agent_type, model).
+
+    There is no stored session -> record edge, so the linkage is inverted out
+    of the tracker: every governed session named in a record's history (or
+    holding its checkout) is counted as having touched that record, and the
+    record's project attributes the session. A session that touched nothing
+    lands under ``unattributed`` rather than being dropped -- an allocated
+    session that never wrote is exactly the signal a session-volume chart
+    should show.
+    """
+    touched: Dict[str, Set[Tuple[str, str]]] = defaultdict(set)
+    for record in corpus.records:
+        item_id = record.get("item_id") or str(record.get("record_id", "")).split("#")[-1]
+        project = record.get("project_id") or ""
+        for session_id in sessions_in_history(record):
+            touched[session_id].add((project, item_id))
+
+    types = corpus.agent_type_index
+    buckets: Dict[Tuple[date, str, str, str], Dict[str, Set[str]]] = defaultdict(
+        lambda: {"sessions": set(), "records": set()}
+    )
+
+    for session in corpus.sessions:
+        session_id = session.get("session_id")
+        day = to_date(session.get("created_at"))
+        if not session_id or not day:
+            continue
+        agent_type_id = str(session.get("agent_type_id") or "")
+        dimension = types.get(agent_type_id, {})
+        agent_type = dimension.get("surface") or agent_type_id or "unknown"
+        model = dimension.get("model") or "unknown"
+
+        pairs = touched.get(session_id) or set()
+        if not pairs:
+            bucket = buckets[(day, "unattributed", agent_type, model)]
+            bucket["sessions"].add(session_id)
+            continue
+        by_project: Dict[str, Set[str]] = defaultdict(set)
+        for project, record_id in pairs:
+            by_project[project].add(record_id)
+        for project, record_ids in by_project.items():
+            bucket = buckets[(day, project, agent_type, model)]
+            bucket["sessions"].add(session_id)
+            bucket["records"].update(record_ids)
+
+    return [
+        {
+            "snapshot_date": day,
+            "project_id": project,
+            "agent_type": agent_type,
+            "model": model,
+            "session_count": len(values["sessions"]),
+            "records_touched": len(values["records"]),
+        }
+        for (day, project, agent_type, model), values in sorted(
+            buckets.items(), key=lambda pair: (pair[0][0], pair[0][1], pair[0][2], pair[0][3])
+        )
+    ]
+
+
+# --- graph -----------------------------------------------------------------
+
+#: Tracker fields that declare an edge to another governed node.
+_RECORD_EDGE_FIELDS = (
+    "parent", "primary_task", "subtask_ids", "related_task_ids",
+    "related_issue_ids", "related_feature_ids", "related_plan_ids",
+    "related_items", "informed_by",
+)
+_DOCUMENT_EDGE_FIELDS = ("related_items", "informed_by")
+
+
+def _edge_targets(item: Mapping[str, Any], fields: Sequence[str]) -> List[str]:
+    targets: List[str] = []
+    for field in fields:
+        value = item.get(field)
+        if not value:
+            continue
+        if isinstance(value, str):
+            targets.append(value)
+        elif isinstance(value, list):
+            targets.extend(str(entry) for entry in value if entry)
+    return targets
+
+
+def build_fact_graph_health_daily(corpus, last_day: date) -> List[Dict[str, Any]]:
+    """DVP-TSK-678. One row per snapshot_date.
+
+    The first four columns are computed from the governed graph itself. The
+    last four are DECLARED AND NULL: their upstream does not exist yet
+    (``graph_health_metrics`` publishes CloudWatch proxies and says in its own
+    docstring that it substitutes them "instead of native Fiedler lambda-2
+    computation"), and DVP-TSK-678 AC-5 puts the metric computation out of
+    scope here. Declaring them now means ENC-FTR-063 fills a column rather than
+    negotiating a schema change against a live table.
+    """
+    born: Dict[str, date] = {}
+    for record in corpus.records:
+        item_id = record.get("item_id") or str(record.get("record_id", "")).split("#")[-1]
+        day = to_date(record.get("created_at"))
+        if item_id and day:
+            born[item_id] = day
+    for document in corpus.documents:
+        document_id = document.get("document_id")
+        day = to_date(document.get("created_at"))
+        if document_id and day:
+            born[document_id] = day
+
+    if not born:
+        return []
+
+    # Edges become RESOLVABLE on the later of their endpoints' creation dates;
+    # an edge whose target is not a governed node is UNRESOLVED from the moment
+    # its source exists. Both are then cumulative counts by date, so the whole
+    # per-day series is prefix sums rather than a per-day graph walk.
+    resolvable_on: Dict[date, int] = defaultdict(int)
+    unresolved_on: Dict[date, int] = defaultdict(int)
+    first_edge: Dict[str, date] = {}
+
+    def _note(source: str, target: str) -> None:
+        source_day = born.get(source)
+        if not source_day:
+            return
+        target_day = born.get(target)
+        if target_day is None:
+            unresolved_on[source_day] += 1
+            return
+        day = max(source_day, target_day)
+        resolvable_on[day] += 1
+        for node in (source, target):
+            if node not in first_edge or day < first_edge[node]:
+                first_edge[node] = day
+
+    for record in corpus.records:
+        source = record.get("item_id") or str(record.get("record_id", "")).split("#")[-1]
+        if not source:
+            continue
+        for target in _edge_targets(record, _RECORD_EDGE_FIELDS):
+            _note(source, target)
+    for document in corpus.documents:
+        source = document.get("document_id")
+        if not source:
+            continue
+        for target in _edge_targets(document, _DOCUMENT_EDGE_FIELDS):
+            _note(source, target)
+
+    born_on: Dict[date, int] = defaultdict(int)
+    for day in born.values():
+        born_on[day] += 1
+    connected_on: Dict[date, int] = defaultdict(int)
+    for day in first_edge.values():
+        connected_on[day] += 1
+
+    first_day = min(born.values())
+    nodes = edges = unresolved = connected = 0
+    rows: List[Dict[str, Any]] = []
+    for day in date_range(first_day, last_day):
+        nodes += born_on.get(day, 0)
+        edges += resolvable_on.get(day, 0)
+        unresolved += unresolved_on.get(day, 0)
+        connected += connected_on.get(day, 0)
+        rows.append(
+            {
+                "snapshot_date": day,
+                "node_count": nodes,
+                "edge_count": edges,
+                "orphan_node_count": nodes - connected,
+                "unresolved_edge_count": unresolved,
+                # Declared now, populated incrementally (risk R-11).
+                "hot_tier_fraction": None,
+                "percolation_margin": None,
+                "fiedler_value": None,
+                "demand_centroid_drift": None,
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# One pass
+# ---------------------------------------------------------------------------
+
+
+def build_all(corpus, last_day: Optional[date] = None) -> Dict[str, List[Dict[str, Any]]]:
+    """Project every declared mart table from one corpus read."""
+    if last_day is None:
+        last_day = datetime.now(timezone.utc).date()
+    return {
+        "dim_record": build_dim_record(corpus),
+        "fact_record_daily": build_fact_record_daily(corpus, last_day),
+        "fact_record_transition": build_fact_record_transition(corpus),
+        "dim_document": build_dim_document(corpus),
+        "fact_document_daily": build_fact_document_daily(corpus, last_day),
+        "fact_session_daily": build_fact_session_daily(corpus),
+        "fact_graph_health_daily": build_fact_graph_health_daily(corpus, last_day),
+    }

--- a/backend/lambda/governance_mart/mart_refresh.py
+++ b/backend/lambda/governance_mart/mart_refresh.py
@@ -1,0 +1,177 @@
+"""The scheduled full-refresh path for the governance analytics mart.
+
+BRD B3-R3 (DVP-TSK-649). The whole requirement, in one function:
+
+    read the governed record store -> project to grain -> write Parquet ->
+    register via the B2-R2 shared library
+
+Every historical break pattern this plan exists to end is eliminated *by
+construction* here rather than by monitoring:
+
+``EventBridge per-mutation trigger``
+    There is none. The only trigger is a SCHEDULE (daily minimum; a faster
+    cadence changes nothing structurally, because each run rebuilds
+    everything). Nothing in this path subscribes to a tracker mutation, so
+    there is nothing to disable later -- the disable step that the legacy
+    ``on-project-json-sync`` chain still needs simply has no counterpart.
+
+``Crawler launcher / crawler``
+    There is none. ``register_table`` writes a DECLARED schema through the
+    Glue API (``DOC-5E35E14DAD05``). The schema is a value in
+    ``mart_schema.py``, committed in the same change as the code that writes
+    the data.
+
+``Crawler concurrency``
+    Unreachable: no crawler exists to race. Two overlapping refreshes converge
+    on the same canonical key rather than corrupting a partition set.
+
+``Partition explosion``
+    Impossible: no table declares a partition key, and the library writes
+    exactly one object per table at a constant key. File count tracks data
+    size, never write count (``DOC-1E1EC5B7CE02``).
+
+``Stale data that looks fresh``
+    Structurally visible. Every fact table is at daily grain, so a refresh
+    that stops running produces a series that STOPS DRAWING on the day it
+    stopped, instead of a current-value tile that renders the last good number
+    forever. A failure is legible as an absence, which is the OBJ-6 property.
+
+The same function serves the Lambda handler and ``tools/governance_mart_refresh.py``,
+so the scheduled path and the operator path cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+try:  # pragma: no cover - depends on which path provides the library
+    from enceladus_shared.warehouse_registration import register_table
+except ImportError:  # pragma: no cover
+    from warehouse_registration import register_table  # type: ignore
+
+from mart_project import build_all
+from mart_schema import MART_PROJECT, MART_TABLE_ORDER, MART_TABLES, assert_daily_grain
+from mart_source import load_corpus
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = ["MART_BUCKET", "MART_DATABASE", "MART_REGION", "refresh_mart", "RefreshResult"]
+
+#: The mart's T2 coordinates. `devops` owns the platform tier and the contract
+#: (BRD B3-R4); the Glue database was created as a T0 onboarding action WITH a
+#: LocationUri, per DOC-04AF8A02A8F7.
+MART_BUCKET = os.environ.get("MART_BUCKET", "devops-agentcli-compute")
+MART_DATABASE = os.environ.get("MART_DATABASE", "devops")
+MART_REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+
+class RefreshResult:
+    """What one refresh did, per table. Shaped for a log line and an assertion."""
+
+    __slots__ = ("write_timestamp", "tables", "source_counts", "elapsed_seconds")
+
+    def __init__(self, write_timestamp: datetime, source_counts: Dict[str, int]):
+        self.write_timestamp = write_timestamp
+        self.source_counts = source_counts
+        self.tables: List[Dict[str, Any]] = []
+        self.elapsed_seconds = 0.0
+
+    def add(self, table: str, record) -> None:
+        self.tables.append(
+            {
+                "table": table,
+                "trino": "hive.%s.%s" % (MART_DATABASE, table),
+                "rows": record.row_count,
+                "bytes": record.byte_count,
+                "files": record.file_count,
+                "storage_changed": getattr(record, "storage_changed", None),
+                "catalog_changed": getattr(record, "catalog_changed", None),
+            }
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "write_timestamp": self.write_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "database": MART_DATABASE,
+            "bucket": MART_BUCKET,
+            "source_counts": self.source_counts,
+            "table_count": len(self.tables),
+            "total_rows": sum(entry["rows"] for entry in self.tables),
+            "total_bytes": sum(entry["bytes"] for entry in self.tables),
+            "elapsed_seconds": round(self.elapsed_seconds, 2),
+            "tables": self.tables,
+        }
+
+
+def refresh_mart(
+    *,
+    tables: Optional[Sequence[str]] = None,
+    last_day: Optional[date] = None,
+    write_timestamp: Optional[datetime] = None,
+    dynamodb_client=None,
+    s3_client=None,
+    glue_client=None,
+    dry_run: bool = False,
+) -> RefreshResult:
+    """Rebuild the governance analytics mart in full.
+
+    One ``write_timestamp`` is shared by all seven tables, so the mart has a
+    single coherent freshness stamp per refresh -- which is what lets every
+    chart display the freshness of its underlying table (B6-R3) without seven
+    slightly different answers.
+    """
+    assert_daily_grain()
+    started = time.time()
+    if write_timestamp is None:
+        write_timestamp = datetime.now(timezone.utc)
+    if last_day is None:
+        last_day = write_timestamp.date()
+    wanted = list(tables) if tables else list(MART_TABLE_ORDER)
+    unknown = [name for name in wanted if name not in MART_TABLES]
+    if unknown:
+        raise KeyError("not declared mart tables: %s" % ", ".join(unknown))
+
+    LOGGER.info("[START] governance mart refresh | tables=%s last_day=%s", ",".join(wanted), last_day)
+    corpus = load_corpus(dynamodb_client=dynamodb_client, region=MART_REGION)
+    LOGGER.info("[INFO] governed corpus read: %s", corpus.counts())
+
+    projected = build_all(corpus, last_day=last_day)
+    result = RefreshResult(write_timestamp, corpus.counts())
+
+    for name in wanted:
+        rows = projected[name]
+        table = MART_TABLES[name]
+        LOGGER.info("[INFO] %s: %d rows projected", name, len(rows))
+        if dry_run:
+            result.tables.append({"table": name, "rows": len(rows), "bytes": 0, "files": 0, "dry_run": True})
+            continue
+        record = register_table(
+            project=MART_PROJECT,
+            table=name,
+            rows=rows,
+            columns=table.columns,
+            bucket=MART_BUCKET,
+            database=MART_DATABASE,
+            table_comment=table.comment,
+            # The mart is DERIVED data: the warehouse write time IS the
+            # correct meaning of its freshness column, so the library owns it.
+            stamp_freshness=True,
+            write_timestamp=write_timestamp,
+            s3_client=s3_client,
+            glue_client=glue_client,
+            region=MART_REGION,
+        )
+        result.add(name, record)
+        LOGGER.info(
+            "[SUCCESS] %s registered: rows=%d bytes=%d files=%d storage_changed=%s catalog_changed=%s",
+            name, record.row_count, record.byte_count, record.file_count,
+            getattr(record, "storage_changed", None), getattr(record, "catalog_changed", None),
+        )
+
+    result.elapsed_seconds = time.time() - started
+    LOGGER.info("[END] governance mart refresh | %s", result.as_dict())
+    return result

--- a/backend/lambda/governance_mart/mart_schema.py
+++ b/backend/lambda/governance_mart/mart_schema.py
@@ -1,0 +1,435 @@
+"""DECLARED schemas for the seven governance analytics mart tables.
+
+BRD B3-R2 (``DOC-724C3695059F`` §6.3). Tracker: DVP-TSK-648 (parent),
+DVP-TSK-672..678 (one task per table).
+
+Governed by:
+
+* ``DOC-3391173F2A5C`` — the mart grain contract. **METADATA ONLY.** The
+  standing test is applied to every column below:
+
+      If a proposed column would let a reader substitute the mart for the
+      record store, it does not belong.
+
+  A column that answers "how many", "how long", "what status", or "when"
+  belongs. A column that reproduces what a record *says* — its title, its
+  description, its intent, its acceptance-criteria text, its worklog prose, a
+  document's content body — does not. **There is no free-text column in this
+  module, and adding one is itself the Risk R-4 drift signal** (see the grain
+  contract's "Drift detection signal"), independent of any size measurement.
+* ``DOC-04AF8A02A8F7`` — four-tier architecture. These are T2 tables:
+  ``s3://<bucket>/warehouse/devops/<table>/data.parquet``, Parquet, declared
+  registration, addressed as ``hive.devops.<table>``.
+* ``DOC-5E35E14DAD05`` — crawler prohibition. Every column here is DECLARED in
+  code and committed. Nothing in this module is inferred from S3, and there is
+  deliberately no code path by which it could be.
+* ``DOC-1E1EC5B7CE02`` — full-refresh partitioning discipline. No table below
+  declares a partition key. The refresh overwrites one object per table.
+
+Why this is a module of data rather than DDL: the schema is a *value* the
+B2-R2 shared library consumes (``register_table(columns=...)``), so the
+declaration, the Glue registration, and the Parquet write are the same fact
+expressed once. Changing a column here is a governed change to
+``comp-devops-trino`` reviewed against the substitution test — never an
+incidental edit folded into an unrelated ETL change.
+
+**Daily grain is the initial shape, not a future upgrade.** Every one of the
+five fact tables carries ``snapshot_date`` at daily grain from the outset
+(the grain contract makes a coarser fact table non-conformant on its face).
+That is what makes a refresh failure show up as a series that *stops drawing*
+rather than a stale value that persists — the OBJ-6 failure mode, made
+structural.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+# The shared B2-R2 library is imported from the Lambda layer when deployed and
+# from the repo path when run as a tool. `.build_extras` flattens the module to
+# the function root, so the vendored name has no package prefix -- the same
+# guarded-import shape `tracker_mutation` uses for `appconfig_flags`.
+try:  # pragma: no cover - exercised by whichever path is present
+    from enceladus_shared.warehouse_registration import ColumnSpec
+except ImportError:  # pragma: no cover
+    from warehouse_registration import ColumnSpec  # type: ignore
+
+__all__ = [
+    "MART_PROJECT",
+    "MART_TABLES",
+    "FACT_TABLES",
+    "DIMENSION_TABLES",
+    "FRESHNESS_COLUMN",
+    "SNAPSHOT_DATE_COLUMN",
+    "columns_for",
+    "table_names",
+    "assert_daily_grain",
+]
+
+#: The mart is hosted by `devops` (io decision 2026-08-07, BRD B3-R4) and
+#: addressed as `hive.devops.<table>`. `project_id` is a DATA column spanning
+#: every governed project -- the refresh reads all projects, which is why the
+#: new-project sync gap DVP-ISS-088 describes cannot recur here.
+MART_PROJECT = "devops"
+
+#: Library-owned freshness stamp (T2 mandatory column, DOC-04AF8A02A8F7).
+#: The mart is DERIVED data, so the warehouse write time is the correct
+#: meaning for this column and the library owns it (`stamp_freshness=True`).
+#: This is the opposite of finance, whose `updated_at` is business data the
+#: library must validate rather than overwrite.
+FRESHNESS_COLUMN = "ingest_ts"
+
+SNAPSHOT_DATE_COLUMN = "snapshot_date"
+
+_INGEST_TS = ColumnSpec(
+    name=FRESHNESS_COLUMN,
+    type="string",
+    comment="T2 freshness stamp: UTC ISO-8601 warehouse write time, library-owned.",
+)
+
+_SNAPSHOT_DATE = ColumnSpec(
+    name=SNAPSHOT_DATE_COLUMN,
+    type="date",
+    comment="Daily grain key. One row per day per remaining grain column.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Table 1 -- dim_record (DVP-TSK-672)
+# ---------------------------------------------------------------------------
+#: Grain: one row per governed tracker record, CURRENT state.
+#:
+#: Substitution test: every column is an identifier, an enum, a count, or a
+#: timestamp. `title`, `description`, `intent`, and `acceptance_criteria` text
+#: are all deliberately absent -- they are what the record SAYS, and a reader
+#: who wants them follows `record_id` back through `tracker.get`.
+#:
+#: Serves US-1 ("how many tasks exist for project=enceladus, with zero agent
+#: sessions") as a single GROUP BY, with no agent session in the path at all.
+DIM_RECORD: List[ColumnSpec] = [
+    ColumnSpec("record_id", "string", "Governed record identifier, e.g. DVP-TSK-648. Follow this back to the record store for substance."),
+    ColumnSpec("project_id", "string", "Owning project."),
+    ColumnSpec("record_type", "string", "task | issue | feature | plan | lesson | escalation | relationship | reference."),
+    ColumnSpec("status", "string", "Current lifecycle status, verbatim from the record store (not normalised -- fidelity over tidiness)."),
+    ColumnSpec("priority", "string", "P0 | P1 | P2 | P3."),
+    ColumnSpec("category", "string", "implementation | investigation | documentation | maintenance | validation."),
+    ColumnSpec("parent_id", "string", "Parent record identifier, or empty."),
+    ColumnSpec("component_ids", "string", "JSON array of registered component ids. Flattened to string because the library declares array<> writable-by-flattening only."),
+    ColumnSpec("created_at", "string", "UTC ISO-8601 record creation time."),
+    ColumnSpec("updated_at", "string", "UTC ISO-8601 last mutation time."),
+    ColumnSpec("closed_at", "string", "UTC ISO-8601 time of the transition into a terminal status, or empty."),
+    ColumnSpec("checkout_count", "int", "Server-side counter: successful agent checkouts."),
+    ColumnSpec("closed_count", "int", "Server-side counter: transitions into closed."),
+    ColumnSpec("ontology_completeness_score", "int", "0-100 ENC-FTR-011 ontology completeness, recomputed from the same rubric the record store applies."),
+    ColumnSpec("transition_type", "string", "no_code | code_only | github_pr_deploy | lambda_deploy | web_deploy."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 2 -- fact_record_daily (DVP-TSK-673)
+# ---------------------------------------------------------------------------
+#: Grain: one row per (snapshot_date, project_id, record_type, status).
+#:
+#: This is the table the daily-grain rule exists for, and the structural
+#: expression of OBJ-6: because every day is its own row, a refresh that stops
+#: running produces a chart that STOPS DRAWING on the day it stopped. The
+#: alternative shape -- a single current-value row per record -- would keep
+#: rendering the last good number indefinitely and look healthy while being
+#: arbitrarily stale. That is the exact failure DVP-ISS-087 describes.
+#:
+#: An aggregate grain, not one row per record per day: the counts are the
+#: analytic product, and per-record daily rows would multiply the mart's byte
+#: size against a record count that did not move -- the Risk R-4 divergence
+#: signal, self-inflicted.
+FACT_RECORD_DAILY: List[ColumnSpec] = [
+    _SNAPSHOT_DATE,
+    ColumnSpec("project_id", "string", "Owning project."),
+    ColumnSpec("record_type", "string", "Record type."),
+    ColumnSpec("status", "string", "Status held at the END of snapshot_date."),
+    ColumnSpec("record_count", "int", "Records in this status at end of day."),
+    ColumnSpec("opened_count", "int", "Records CREATED on this day that ended it in this status."),
+    ColumnSpec("closed_count", "int", "Records that transitioned INTO a terminal status on this day."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 3 -- fact_record_transition (DVP-TSK-674)
+# ---------------------------------------------------------------------------
+#: Grain: one row per lifecycle transition.
+#:
+#: Sourced from the per-record `history` arrays -- the same corpus-with-history
+#: extraction ENC-TSK-989 already performed -- rather than re-derived from a
+#: second pass over the tracker. Note what is projected: the STATUS TOKENS and
+#: the timing. The history entry's `description` prose that carries them is
+#: read and discarded, never stored. That is the substitution test applied to
+#: a source that is mostly free text.
+#:
+#: Serves cycle time (`days_in_prior_status` by `to_status`), time-in-status,
+#: throughput (transitions per day), and stuck-record detection (records whose
+#: latest transition is old and non-terminal).
+FACT_RECORD_TRANSITION: List[ColumnSpec] = [
+    ColumnSpec("record_id", "string", "Governed record identifier."),
+    ColumnSpec("project_id", "string", "Owning project."),
+    ColumnSpec("record_type", "string", "Record type."),
+    ColumnSpec("from_status", "string", "Status held before this transition."),
+    ColumnSpec("to_status", "string", "Status entered by this transition."),
+    ColumnSpec("transitioned_at", "string", "UTC ISO-8601 transition time."),
+    ColumnSpec("days_in_prior_status", "double", "Fractional days spent in from_status before this transition."),
+    ColumnSpec("transition_type", "string", "The record's governed transition_type at extraction time."),
+    _SNAPSHOT_DATE,
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 4 -- dim_document (DVP-TSK-675)
+# ---------------------------------------------------------------------------
+#: Grain: one row per docstore document.
+#:
+#: The substitution test applies with particular force here, because the
+#: docstore's entire value is its content: `content`, `full_description`, and
+#: `description` are absent by construction. `size_bytes` is the metadata
+#: shadow of the body -- how much, never what. A reader who wants the body
+#: calls `documents.get(document_id)`.
+DIM_DOCUMENT: List[ColumnSpec] = [
+    ColumnSpec("document_id", "string", "Governed document identifier, e.g. DOC-3391173F2A5C."),
+    ColumnSpec("project_id", "string", "Owning project."),
+    ColumnSpec("document_subtype", "string", "doc | handoff | coe | wave | idea | context-node | skill, or a legacy value."),
+    ColumnSpec("subtypepattern", "string", "Self-learning emergent subtype, valid only when document_subtype='doc'."),
+    ColumnSpec("status", "string", "Document status, e.g. active."),
+    ColumnSpec("document_maturity_state", "string", "raw | compliant | contextualized | mature (GDMP)."),
+    ColumnSpec("compliance_score", "int", "0-100, Lambda-computed at write time."),
+    ColumnSpec("compliance_warning_count", "int", "COUNT of compliance warnings. The warning TEXT is deliberately not projected."),
+    ColumnSpec("size_bytes", "bigint", "Body size in S3. The metadata shadow of content, never the content."),
+    ColumnSpec("version", "int", "Monotonic document version."),
+    ColumnSpec("related_item_count", "int", "COUNT of graph edges to tracker records and documents."),
+    ColumnSpec("created_at", "string", "UTC ISO-8601 creation time."),
+    ColumnSpec("updated_at", "string", "UTC ISO-8601 last write time."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 5 -- fact_document_daily (DVP-TSK-676)
+# ---------------------------------------------------------------------------
+#: Grain: one row per (snapshot_date, project_id, document_subtype,
+#: document_maturity_state).
+#:
+#: Added when daily grain was adopted as a rule rather than a choice: the
+#: docstore had exactly the same "current value that looks fresh forever"
+#: exposure the tracker had, and the rule closes both or neither.
+FACT_DOCUMENT_DAILY: List[ColumnSpec] = [
+    _SNAPSHOT_DATE,
+    ColumnSpec("project_id", "string", "Owning project."),
+    ColumnSpec("document_subtype", "string", "Document subtype; 'unspecified' where the record carries none."),
+    ColumnSpec("document_maturity_state", "string", "GDMP maturity; 'unspecified' where the record carries none."),
+    ColumnSpec("document_count", "int", "Documents in existence at end of day in this bucket."),
+    ColumnSpec("created_count", "int", "Documents CREATED on this day in this bucket."),
+    ColumnSpec("mean_compliance_score", "double", "Mean compliance score across the bucket, or NULL when none carry one."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 6 -- fact_session_daily (DVP-TSK-677)
+# ---------------------------------------------------------------------------
+#: Grain: one row per (snapshot_date, project_id, agent_type, model).
+#:
+#: `model` is a DATA COLUMN describing observed agent sessions -- it records
+#: which model was on the other end of governed work that actually happened.
+#: It is not configuration and nothing reads it back as an instruction.
+#:
+#: `agent_type` carries `agent_types.surface` (claude_code_cli,
+#: claude.ai-webui, eventbridge-scheduler, ...), joined from the session's
+#: `agent_type_id`. The surface is the human-meaningful type name the
+#: dashboard series needs; the id remains reachable through the record store.
+FACT_SESSION_DAILY: List[ColumnSpec] = [
+    _SNAPSHOT_DATE,
+    ColumnSpec("project_id", "string", "Project the session's governed writes landed in; 'unattributed' when it touched no record."),
+    ColumnSpec("agent_type", "string", "agent_types.surface for the session's agent_type_id."),
+    ColumnSpec("model", "string", "Observed model for that agent type. A data column describing sessions, never configuration."),
+    ColumnSpec("session_count", "int", "Distinct agent sessions created on this day in this bucket."),
+    ColumnSpec("records_touched", "int", "Distinct governed records those sessions wrote to."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Table 7 -- fact_graph_health_daily (DVP-TSK-678)
+# ---------------------------------------------------------------------------
+#: Grain: one row per snapshot_date.
+#:
+#: The plan's mathematical anchor. ``DOC-E2379D980FA2`` names spectral graph
+#: metrics as governance telemetry no dashboard exposes; this table is where
+#: that telemetry becomes visible.
+#:
+#: **Risk R-11 discipline.** The last four columns have no upstream
+#: computation today: `backend/lambda/graph_health_metrics` publishes
+#: Neo4j-derived PROXIES to CloudWatch and says so in its own docstring
+#: ("proxy metrics instead of native Fiedler λ₂ computation"), and a repo-wide
+#: search for `fiedler_value`, `percolation_margin`, and
+#: `demand_centroid_drift` returns nothing outside this module. They are
+#: therefore DECLARED NOW and left NULL, to be populated incrementally as
+#: ENC-FTR-063 / comp-percolation-monitor lands them -- not deferred to a
+#: later schema change. A column added later is a governed schema change to a
+#: live table plus a backfill; a column declared now and filled later is an
+#: UPDATE. The metric computation itself is explicitly out of scope here
+#: (DVP-TSK-678 AC-5): this table projects, it does not compute.
+#:
+#: The first four columns are computed today from the governed graph itself
+#: (records + documents as nodes; parent, subtask, related-*, related_items
+#: and informed_by as edges), so the table is never empty while it waits.
+FACT_GRAPH_HEALTH_DAILY: List[ColumnSpec] = [
+    _SNAPSHOT_DATE,
+    ColumnSpec("node_count", "int", "Governed nodes in existence at end of day: tracker records plus docstore documents."),
+    ColumnSpec("edge_count", "int", "Resolvable edges between existing nodes at end of day."),
+    ColumnSpec("orphan_node_count", "int", "Existing nodes with no resolvable edge in either direction."),
+    ColumnSpec("unresolved_edge_count", "int", "Declared edges whose target is not a known node -- the graph's dangling-reference signal."),
+    ColumnSpec("hot_tier_fraction", "double", "AWAITING UPSTREAM (ENC-FTR-063). Declared now, populated incrementally."),
+    ColumnSpec("percolation_margin", "double", "AWAITING UPSTREAM (comp-percolation-monitor). Declared now, populated incrementally."),
+    ColumnSpec("fiedler_value", "double", "AWAITING UPSTREAM. Spectral algebraic connectivity (Laplacian lambda-2). Declared now, populated incrementally."),
+    ColumnSpec("demand_centroid_drift", "double", "AWAITING UPSTREAM. Declared now, populated incrementally."),
+    _INGEST_TS,
+]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+#: Table name -> (declared columns, table comment). The single declaration the
+#: refresh job, the Glue catalog, and the conformance test all read.
+MART_TABLES: Dict[str, "MartTable"] = {}
+
+
+class MartTable:
+    """One declared mart table: its columns, its grain, and its owning task."""
+
+    __slots__ = ("name", "columns", "grain", "task", "comment")
+
+    def __init__(self, name: str, columns: Sequence[ColumnSpec], grain: Sequence[str], task: str, comment: str):
+        self.name = name
+        self.columns = list(columns)
+        self.grain = list(grain)
+        self.task = task
+        self.comment = comment
+
+    @property
+    def column_names(self) -> List[str]:
+        return [column.name for column in self.columns]
+
+    @property
+    def is_fact(self) -> bool:
+        return self.name.startswith("fact_")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return "MartTable(%r, columns=%d, grain=%r)" % (self.name, len(self.columns), self.grain)
+
+
+def _register(name: str, columns: Sequence[ColumnSpec], grain: Sequence[str], task: str, comment: str) -> None:
+    MART_TABLES[name] = MartTable(name, columns, grain, task, comment)
+
+
+_register(
+    "dim_record", DIM_RECORD, ["record_id"], "DVP-TSK-672",
+    "Governance analytics mart: one row per tracker record, current state. Metadata only (DOC-3391173F2A5C).",
+)
+_register(
+    "fact_record_daily", FACT_RECORD_DAILY,
+    ["snapshot_date", "project_id", "record_type", "status"], "DVP-TSK-673",
+    "Governance analytics mart: daily record counts by project, type, and status.",
+)
+_register(
+    "fact_record_transition", FACT_RECORD_TRANSITION,
+    ["record_id", "transitioned_at", "to_status"], "DVP-TSK-674",
+    "Governance analytics mart: one row per lifecycle transition, from the per-record history arrays.",
+)
+_register(
+    "dim_document", DIM_DOCUMENT, ["document_id"], "DVP-TSK-675",
+    "Governance analytics mart: one row per docstore document, current state. No document content.",
+)
+_register(
+    "fact_document_daily", FACT_DOCUMENT_DAILY,
+    ["snapshot_date", "project_id", "document_subtype", "document_maturity_state"], "DVP-TSK-676",
+    "Governance analytics mart: daily document counts by project, subtype, and maturity.",
+)
+_register(
+    "fact_session_daily", FACT_SESSION_DAILY,
+    ["snapshot_date", "project_id", "agent_type", "model"], "DVP-TSK-677",
+    "Governance analytics mart: daily agent session volume by project, agent type, and model.",
+)
+_register(
+    "fact_graph_health_daily", FACT_GRAPH_HEALTH_DAILY,
+    ["snapshot_date"], "DVP-TSK-678",
+    "Governance analytics mart: daily governance graph health, including spectral columns declared ahead of their upstream.",
+)
+
+#: Deterministic build order: dimensions first, then facts. Nothing depends on
+#: this ordering functionally -- each table is registered independently -- but a
+#: stable order makes the refresh log diffable run over run.
+MART_TABLE_ORDER = [
+    "dim_record",
+    "fact_record_daily",
+    "fact_record_transition",
+    "dim_document",
+    "fact_document_daily",
+    "fact_session_daily",
+    "fact_graph_health_daily",
+]
+
+DIMENSION_TABLES = [name for name in MART_TABLE_ORDER if name.startswith("dim_")]
+FACT_TABLES = [name for name in MART_TABLE_ORDER if name.startswith("fact_")]
+
+
+def columns_for(table: str) -> List[ColumnSpec]:
+    """Declared columns for one mart table."""
+    try:
+        return MART_TABLES[table].columns
+    except KeyError:
+        raise KeyError("%r is not a declared mart table. Declared: %s" % (table, ", ".join(MART_TABLE_ORDER)))
+
+
+def table_names() -> List[str]:
+    return list(MART_TABLE_ORDER)
+
+
+def assert_daily_grain() -> None:
+    """Every fact table carries `snapshot_date` at daily grain (DVP-TSK-648 AC-2).
+
+    Raised as an assertion rather than left to review because the grain
+    contract makes a coarser fact table non-conformant on its face: it "must be
+    corrected before it is registered", so the check belongs in the path that
+    registers it.
+    """
+    for name in FACT_TABLES:
+        table = MART_TABLES[name]
+        if SNAPSHOT_DATE_COLUMN not in table.column_names:
+            raise AssertionError(
+                "fact table %r does not declare %r. Every fact table carries daily grain "
+                "from the outset (DOC-3391173F2A5C)." % (name, SNAPSHOT_DATE_COLUMN)
+            )
+        # The *_daily tables are AGGREGATES whose grain is led by the day, so a
+        # missing leading snapshot_date there would mean the table was built at
+        # a coarser grain -- the specific non-conformance the grain contract
+        # says "must be corrected before it is registered".
+        #
+        # `fact_record_transition` is an EVENT table: its grain is one row per
+        # lifecycle transition (DVP-TSK-674 AC-1), and it carries snapshot_date
+        # as the day bucket that event fell in. Requiring the day to LEAD its
+        # grain would force one row per record per day, which is a different
+        # and worse table -- so the leading-key check is scoped to aggregates.
+        if name.endswith("_daily") and table.grain[0] != SNAPSHOT_DATE_COLUMN:
+            raise AssertionError(
+                "daily aggregate %r does not lead its grain with %r." % (name, SNAPSHOT_DATE_COLUMN)
+            )
+    for name in MART_TABLE_ORDER:
+        if FRESHNESS_COLUMN not in MART_TABLES[name].column_names:
+            raise AssertionError(
+                "table %r does not declare the mandatory T2 freshness column %r "
+                "(DOC-04AF8A02A8F7)." % (name, FRESHNESS_COLUMN)
+            )
+
+
+assert_daily_grain()

--- a/backend/lambda/governance_mart/mart_source.py
+++ b/backend/lambda/governance_mart/mart_source.py
@@ -1,0 +1,172 @@
+"""Read the governed record store for the governance analytics mart.
+
+BRD B3-R3, first clause: *read the governed record store*. This module is the
+read half; ``mart_project`` is the projection half and
+``enceladus_shared.warehouse_registration`` is the write half.
+
+Five governed sources, all read-only:
+
+===========================  ===========================================
+``devops-project-tracker``   tasks, issues, features, plans, lessons, ...
+``documents``                docstore metadata (bodies live in S3)
+``agent-sessions``           ENC-SES-* allocations and claims
+``agent-types``              ENC-AGT-* surface / model dimension
+``coordination-requests``    dispatch requests (session extraction shape)
+===========================  ===========================================
+
+Full ``Scan`` rather than incremental ``Query``: the refresh is a FULL REFRESH
+by contract (``DOC-1E1EC5B7CE02``), so reading everything every run is the
+point, not an inefficiency to optimise away. It is also what makes the
+new-project sync gap DVP-ISS-088 describes structurally impossible -- a scan
+has no per-project registration step to forget. At ~6.3k tracker records and
+~25 MB the whole corpus is a few seconds of reads.
+
+Nothing here writes. Nothing here launches a crawler. There is no EventBridge
+per-mutation trigger anywhere in this path -- the job is invoked by a
+*schedule*, reads current state, and rebuilds every table from scratch.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterator, List, Mapping, Optional
+
+__all__ = [
+    "TRACKER_TABLE",
+    "DOCUMENTS_TABLE",
+    "AGENT_SESSIONS_TABLE",
+    "AGENT_TYPES_TABLE",
+    "COORDINATION_TABLE",
+    "GovernanceCorpus",
+    "scan_table",
+    "load_corpus",
+    "is_sentinel",
+]
+
+# Table names resolve exactly as the owning Lambdas resolve them: env var with
+# the same hardcoded default, so gamma (`${EnvironmentSuffix}`) works without a
+# second convention.
+TRACKER_TABLE = os.environ.get("TRACKER_TABLE", "devops-project-tracker")
+DOCUMENTS_TABLE = os.environ.get("DOCUMENTS_TABLE", "documents")
+AGENT_SESSIONS_TABLE = os.environ.get("AGENT_SESSIONS_TABLE", "agent-sessions")
+AGENT_TYPES_TABLE = os.environ.get("AGENT_TYPES_TABLE", "agent-types")
+COORDINATION_TABLE = os.environ.get("COORDINATION_TABLE", "coordination-requests")
+
+#: Monotonic-counter sentinel rows share the tables with real records
+#: (`counter#ENC-SES`, `counter#ENC-AGT`, and `record_type == "counter"` in the
+#: tracker). They are allocator state, not governed records, and counting them
+#: would inflate every node and record count in the mart.
+_SENTINEL_PREFIX = "counter#"
+
+
+def is_sentinel(item: Mapping[str, Any]) -> bool:
+    """True for allocator sentinel rows, which are never governed records."""
+    if item.get("record_type") == "counter":
+        return True
+    for key in ("session_id", "agent_type_id", "record_id", "document_id"):
+        value = item.get(key)
+        if isinstance(value, str) and value.startswith(_SENTINEL_PREFIX):
+            return True
+    return False
+
+
+def _deserializer():
+    from boto3.dynamodb.types import TypeDeserializer
+
+    return TypeDeserializer()
+
+
+def _decode(value: Any) -> Any:
+    """Normalise DynamoDB-deserialised values into plain Python.
+
+    ``TypeDeserializer`` returns ``Decimal`` for every ``N``. Left alone those
+    reach the Parquet writer, where the library would coerce them per the
+    DECLARED type -- but ``Decimal`` also breaks arithmetic against floats in
+    the projection, so it is flattened here, once, at the boundary.
+    """
+    from decimal import Decimal
+
+    if isinstance(value, Decimal):
+        as_int = int(value)
+        return as_int if value == as_int else float(value)
+    if isinstance(value, list):
+        return [_decode(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _decode(item) for key, item in value.items()}
+    if isinstance(value, set):
+        return [_decode(item) for item in value]
+    return value
+
+
+def scan_table(client, table: str, drop_sentinels: bool = True) -> List[Dict[str, Any]]:
+    """Full paginated scan of one governed table. Read-only."""
+    deserializer = _deserializer()
+    items: List[Dict[str, Any]] = []
+    kwargs: Dict[str, Any] = {"TableName": table}
+    while True:
+        response = client.scan(**kwargs)
+        for raw in response.get("Items", []):
+            item = {key: _decode(deserializer.deserialize(value)) for key, value in raw.items()}
+            if drop_sentinels and is_sentinel(item):
+                continue
+            items.append(item)
+        cursor = response.get("LastEvaluatedKey")
+        if not cursor:
+            return items
+        kwargs["ExclusiveStartKey"] = cursor
+
+
+class GovernanceCorpus:
+    """Everything the mart projects from, read once per refresh."""
+
+    __slots__ = ("records", "documents", "sessions", "agent_types", "coordination_requests")
+
+    def __init__(
+        self,
+        records: List[Dict[str, Any]],
+        documents: List[Dict[str, Any]],
+        sessions: List[Dict[str, Any]],
+        agent_types: List[Dict[str, Any]],
+        coordination_requests: List[Dict[str, Any]],
+    ):
+        self.records = records
+        self.documents = documents
+        self.sessions = sessions
+        self.agent_types = agent_types
+        self.coordination_requests = coordination_requests
+
+    @property
+    def agent_type_index(self) -> Dict[str, Dict[str, Any]]:
+        """agent_type_id -> its dimension row (surface, model, cost_tier)."""
+        return {
+            str(entry.get("agent_type_id")): entry
+            for entry in self.agent_types
+            if entry.get("agent_type_id")
+        }
+
+    def counts(self) -> Dict[str, int]:
+        return {
+            "records": len(self.records),
+            "documents": len(self.documents),
+            "sessions": len(self.sessions),
+            "agent_types": len(self.agent_types),
+            "coordination_requests": len(self.coordination_requests),
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return "GovernanceCorpus(%s)" % self.counts()
+
+
+def load_corpus(dynamodb_client=None, region: Optional[str] = None) -> GovernanceCorpus:
+    """Read all five governed sources. Read-only, full scan, every project."""
+    if dynamodb_client is None:
+        import boto3
+
+        dynamodb_client = boto3.client("dynamodb", region_name=region or os.environ.get("AWS_REGION", "us-west-2"))
+    return GovernanceCorpus(
+        records=scan_table(dynamodb_client, TRACKER_TABLE),
+        documents=scan_table(dynamodb_client, DOCUMENTS_TABLE),
+        sessions=scan_table(dynamodb_client, AGENT_SESSIONS_TABLE),
+        agent_types=scan_table(dynamodb_client, AGENT_TYPES_TABLE),
+        coordination_requests=scan_table(dynamodb_client, COORDINATION_TABLE),
+    )

--- a/backend/lambda/governance_mart/requirements.txt
+++ b/backend/lambda/governance_mart/requirements.txt
@@ -1,0 +1,19 @@
+# DVP-TSK-649 — governance analytics mart.
+#
+# pyarrow is the Parquet writer behind enceladus_shared.warehouse_registration
+# (serialize_parquet / pq.write_table). It is the only third-party dependency.
+#
+# Bounded rather than exact, matching the repo's neo4j>=5.0,<6.0 style. The
+# upper bound matters: _build.yml installs with
+#   --platform manylinux2014_{x86_64,aarch64} --only-binary=:all: --upgrade
+# so an unbounded spec would silently float onto the first pyarrow release that
+# stops publishing a manylinux2014 (manylinux_2_17) wheel and hard-fail the
+# build. Verified resolvable on both matrix rows at pyarrow 20.0.0:
+#   cp311 -> pyarrow-20.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+#   cp312 -> pyarrow-20.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+# (~42 MB wheel, ~128 MB unzipped — well inside the 250 MB S3-deploy limit.)
+pyarrow>=17.0.0,<21.0.0
+
+# boto3 is intentionally NOT declared: it is provided by the Lambda runtime, and
+# every Lambda in this repo but one relies on that. mart_source.py imports it
+# lazily inside load_corpus() for the same reason.

--- a/backend/lambda/governance_mart/test_governance_mart.py
+++ b/backend/lambda/governance_mart/test_governance_mart.py
@@ -1,0 +1,363 @@
+"""Conformance tests for the governance analytics mart (BRD B3).
+
+These are contract tests, not coverage theatre. Each one asserts a clause that
+a governed document states in prose, so that violating the prose fails CI:
+
+* ``DOC-3391173F2A5C`` -- metadata only; the substitution test; daily grain on
+  every fact table from the outset.
+* ``DOC-04AF8A02A8F7`` -- T2 layout, Parquet, declared registration, the
+  mandatory freshness stamp.
+* ``DOC-5E35E14DAD05`` -- schema is DECLARED; nothing is inferred.
+* ``DOC-1E1EC5B7CE02`` -- full refresh; no partition keys.
+
+Run: ``python3 -m pytest backend/lambda/governance_mart/ -q``
+No AWS credentials required -- every test runs against synthetic corpora or
+pure declarations.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(_HERE)))
+sys.path.insert(0, os.path.join(_REPO, "backend", "lambda", "shared_layer", "python"))
+sys.path.insert(0, _HERE)
+
+from enceladus_shared.warehouse_registration import (  # noqa: E402
+    DATA_OBJECT_NAME,
+    STORAGE_FORMAT,
+    build_contract,
+)
+
+import mart_project  # noqa: E402
+import mart_schema  # noqa: E402
+from mart_source import is_sentinel  # noqa: E402
+
+
+MART_BUCKET = "devops-agentcli-compute"
+
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+
+def test_seven_tables_declared():
+    """DVP-TSK-648 AC-1: all seven tables, named exactly as the BRD names them."""
+    assert mart_schema.table_names() == [
+        "dim_record",
+        "fact_record_daily",
+        "fact_record_transition",
+        "dim_document",
+        "fact_document_daily",
+        "fact_session_daily",
+        "fact_graph_health_daily",
+    ]
+
+
+def test_every_fact_table_carries_snapshot_date():
+    """DVP-TSK-648 AC-2 / DOC-3391173F2A5C: daily grain is the INITIAL shape."""
+    assert len(mart_schema.FACT_TABLES) == 5
+    for name in mart_schema.FACT_TABLES:
+        assert "snapshot_date" in mart_schema.MART_TABLES[name].column_names, name
+    mart_schema.assert_daily_grain()
+
+
+def test_every_table_carries_the_freshness_stamp():
+    """DOC-04AF8A02A8F7: the freshness column is MANDATORY, not optional."""
+    for name in mart_schema.table_names():
+        assert mart_schema.FRESHNESS_COLUMN in mart_schema.MART_TABLES[name].column_names, name
+
+
+@pytest.mark.parametrize("table", mart_schema.MART_TABLE_ORDER)
+def test_declaration_satisfies_the_shared_contract(table):
+    """Every declared table survives the B2-R2 library's own validation.
+
+    ``build_contract`` touches no AWS API, so this is a pure conformance check
+    of names, types, reserved words, and the freshness column.
+    """
+    contract = build_contract(
+        project=mart_schema.MART_PROJECT,
+        table=table,
+        columns=mart_schema.columns_for(table),
+        bucket=MART_BUCKET,
+        database="devops",
+    )
+    assert contract.trino_identifier == "hive.devops.%s" % table
+    assert contract.location == "s3://%s/warehouse/devops/%s/" % (MART_BUCKET, table)
+    # One object per table at a CONSTANT key: this is what makes file count
+    # invariant across refreshes (DOC-1E1EC5B7CE02).
+    assert contract.s3_key == "warehouse/devops/%s/%s" % (table, DATA_OBJECT_NAME)
+    assert contract.is_governed_layout
+
+
+@pytest.mark.parametrize("table", mart_schema.MART_TABLE_ORDER)
+def test_no_partition_keys(table):
+    """DOC-1E1EC5B7CE02: full-refresh overwrite, so partition explosion is
+    impossible by construction rather than by monitoring."""
+    contract = build_contract(
+        project=mart_schema.MART_PROJECT,
+        table=table,
+        columns=mart_schema.columns_for(table),
+        bucket=MART_BUCKET,
+        database="devops",
+    )
+    table_input = contract.glue_table_input()
+    assert table_input["PartitionKeys"] == []
+    assert table_input["Parameters"]["classification"] == STORAGE_FORMAT
+
+
+# ---------------------------------------------------------------------------
+# The substitution test -- DOC-3391173F2A5C, enforced
+# ---------------------------------------------------------------------------
+
+#: Column names that would reproduce what a record SAYS rather than what it IS.
+#: Their appearance is itself the Risk R-4 drift signal, independent of any
+#: size measurement -- so it is asserted here rather than left to a monitor.
+_FORBIDDEN_SUBSTANCE_COLUMNS = frozenset(
+    {
+        "title", "description", "intent", "content", "body", "text",
+        "acceptance_criteria", "criteria", "evidence", "worklog", "history",
+        "notes", "technical_notes", "hypothesis", "user_story", "summary",
+        "last_update_note", "compliance_warnings", "full_description",
+        "claude_description", "prose", "comment",
+    }
+)
+
+
+@pytest.mark.parametrize("table", mart_schema.MART_TABLE_ORDER)
+def test_substitution_test_no_free_text_columns(table):
+    """The standing test, applied mechanically to every declared column.
+
+    'If a proposed column would let a reader substitute the mart for the record
+    store, it does not belong.' A reader must be able to count, group, and
+    trend -- and must NOT be able to reconstruct the record.
+    """
+    for name in mart_schema.MART_TABLES[table].column_names:
+        assert name not in _FORBIDDEN_SUBSTANCE_COLUMNS, (
+            "%s.%s reproduces record substance and violates the B3-R1 "
+            "substitution test (DOC-3391173F2A5C)." % (table, name)
+        )
+
+
+def test_counts_not_contents_for_the_two_riskiest_sources():
+    """Where substance was available, a COUNT was projected instead."""
+    document_columns = mart_schema.MART_TABLES["dim_document"].column_names
+    assert "compliance_warning_count" in document_columns
+    assert "related_item_count" in document_columns
+    assert "size_bytes" in document_columns  # how much, never what
+    assert "content" not in document_columns
+    # The transition table reads free-text history and emits only tokens.
+    transition_columns = mart_schema.MART_TABLES["fact_record_transition"].column_names
+    assert set(transition_columns) >= {"from_status", "to_status", "days_in_prior_status"}
+    assert "description" not in transition_columns
+
+
+# ---------------------------------------------------------------------------
+# Projection behaviour
+# ---------------------------------------------------------------------------
+
+
+def _record(**overrides):
+    base = {
+        "project_id": "devops",
+        "record_id": "task#DVP-TSK-001",
+        "item_id": "DVP-TSK-001",
+        "record_type": "task",
+        "status": "closed",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-05T00:00:00Z",
+        "history": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class _Corpus:
+    def __init__(self, records=None, documents=None, sessions=None, agent_types=None):
+        self.records = records or []
+        self.documents = documents or []
+        self.sessions = sessions or []
+        self.agent_types = agent_types or []
+        self.coordination_requests = []
+
+    @property
+    def agent_type_index(self):
+        return {entry["agent_type_id"]: entry for entry in self.agent_types}
+
+    def counts(self):
+        return {"records": len(self.records), "documents": len(self.documents)}
+
+
+def test_extract_transitions_recovers_the_chain_and_discards_the_prose():
+    record = _record(
+        history=[
+            {"timestamp": "2026-01-01T00:00:00Z", "status": "created", "description": "Created via tracker API: something"},
+            {"timestamp": "2026-01-02T00:00:00Z", "status": "worklog", "description": "Field 'status' set to 'in-progress' [provider=ENC-SES-0AA]"},
+            {"timestamp": "2026-01-03T12:00:00Z", "status": "worklog", "description": "Field 'status' set to 'coding-complete' [provider=ENC-SES-0AA]"},
+            {"timestamp": "2026-01-05T00:00:00Z", "status": "worklog", "description": "Status changed to 'closed' by someone"},
+        ]
+    )
+    transitions = mart_project.extract_transitions(record)
+    assert [(t["from_status"], t["to_status"]) for t in transitions] == [
+        ("open", "in-progress"),
+        ("in-progress", "coding-complete"),
+        ("coding-complete", "closed"),
+    ]
+    assert transitions[0]["days_in_prior_status"] == pytest.approx(1.0)
+    assert transitions[1]["days_in_prior_status"] == pytest.approx(1.5)
+    # The prose that carried the transition is nowhere in the output.
+    for transition in transitions:
+        assert "description" not in transition
+        assert not any("provider" in str(value) for value in transition.values())
+
+
+def test_repeated_status_is_not_a_transition():
+    """Re-asserting a status would inflate throughput and zero out cycle time."""
+    record = _record(
+        history=[
+            {"timestamp": "2026-01-02T00:00:00Z", "status": "worklog", "description": "Field 'status' set to 'in-progress'"},
+            {"timestamp": "2026-01-02T01:00:00Z", "status": "worklog", "description": "Field 'status' set to 'in-progress'"},
+        ]
+    )
+    assert len(mart_project.extract_transitions(record)) == 1
+
+
+def test_underscored_legacy_status_folds_to_the_governed_form():
+    record = _record(
+        history=[{"timestamp": "2026-01-02T00:00:00Z", "status": "worklog", "description": "Field 'status' set to 'in_progress' via tracker.py"}]
+    )
+    assert mart_project.extract_transitions(record)[0]["to_status"] == "in-progress"
+
+
+def test_ontology_completeness_matches_the_record_store_rubric():
+    """Verified against the live API: DVP-TSK-648 scores 55/70 -> 79."""
+    record = _record(
+        record_type="task",
+        title="B3-R2 - Define and build the seven mart tables",
+        priority="P1",
+        category="implementation",
+        intent="BRD B3-R2.",
+        acceptance_criteria=[{"description": "x", "evidence_acceptance": False}],
+        parent="DVP-TSK-613",
+    )
+    assert mart_project.ontology_completeness_score(record) == 79
+
+
+def test_fact_record_daily_is_one_row_per_record_per_day():
+    """`record_count` must partition the record set: no double counting when
+    several transitions land on the same day."""
+    record = _record(
+        status="closed",
+        created_at="2026-01-01T00:00:00Z",
+        history=[
+            {"timestamp": "2026-01-02T01:00:00Z", "status": "worklog", "description": "Field 'status' set to 'in-progress'"},
+            {"timestamp": "2026-01-02T09:00:00Z", "status": "worklog", "description": "Field 'status' set to 'closed'"},
+        ],
+    )
+    rows = mart_project.build_fact_record_daily(_Corpus(records=[record]), date(2026, 1, 3))
+    by_day = {}
+    for row in rows:
+        by_day.setdefault(row["snapshot_date"], 0)
+        by_day[row["snapshot_date"]] += row["record_count"]
+    assert by_day == {date(2026, 1, 1): 1, date(2026, 1, 2): 1, date(2026, 1, 3): 1}
+    # The day holds its LAST status, and the closure is counted once.
+    day_two = [r for r in rows if r["snapshot_date"] == date(2026, 1, 2)]
+    assert len(day_two) == 1 and day_two[0]["status"] == "closed"
+    assert sum(r["closed_count"] for r in rows) == 1
+    assert sum(r["opened_count"] for r in rows) == 1
+
+
+def test_fact_record_daily_series_stops_at_last_day():
+    """OBJ-6: the series is bounded by the refresh, so a refresh that stops
+    running produces a chart that stops drawing."""
+    rows = mart_project.build_fact_record_daily(_Corpus(records=[_record()]), date(2026, 1, 3))
+    assert max(row["snapshot_date"] for row in rows) == date(2026, 1, 3)
+
+
+def test_graph_health_declares_awaiting_upstream_columns_as_null():
+    """DVP-TSK-678 AC-3 / risk R-11: DEFINED NOW, populated incrementally."""
+    corpus = _Corpus(
+        records=[
+            _record(item_id="DVP-TSK-001", created_at="2026-01-01T00:00:00Z", parent="DVP-TSK-002"),
+            _record(item_id="DVP-TSK-002", created_at="2026-01-01T00:00:00Z"),
+            _record(item_id="DVP-TSK-003", created_at="2026-01-01T00:00:00Z", parent="DVP-TSK-999"),
+        ]
+    )
+    rows = mart_project.build_fact_graph_health_daily(corpus, date(2026, 1, 2))
+    assert rows, "graph health must not be empty while it waits for upstream"
+    latest = rows[-1]
+    assert latest["node_count"] == 3
+    assert latest["edge_count"] == 1          # 001 -> 002 resolves
+    assert latest["unresolved_edge_count"] == 1  # 003 -> 999 dangles
+    assert latest["orphan_node_count"] == 1   # 003 has no resolvable edge
+    for column in ("hot_tier_fraction", "percolation_margin", "fiedler_value", "demand_centroid_drift"):
+        assert column in latest, "%s must be DECLARED now, not deferred" % column
+        assert latest[column] is None, "%s has no upstream yet and must be NULL" % column
+
+
+def test_graph_health_columns_are_declared_in_the_schema():
+    columns = mart_schema.MART_TABLES["fact_graph_health_daily"].column_names
+    for column in ("hot_tier_fraction", "percolation_margin", "fiedler_value", "demand_centroid_drift"):
+        assert column in columns
+
+
+def test_session_daily_attributes_records_and_keeps_empty_sessions():
+    corpus = _Corpus(
+        records=[
+            _record(
+                item_id="DVP-TSK-001",
+                project_id="devops",
+                history=[{"timestamp": "2026-01-02T00:00:00Z", "status": "worklog", "description": "Agent session checkout by ENC-SES-0AA [provider=ENC-SES-0AA]"}],
+            )
+        ],
+        sessions=[
+            {"session_id": "ENC-SES-0AA", "agent_type_id": "ENC-AGT-005", "created_at": "2026-01-02T00:00:00Z"},
+            {"session_id": "ENC-SES-0AB", "agent_type_id": "ENC-AGT-005", "created_at": "2026-01-02T00:00:00Z"},
+        ],
+        agent_types=[{"agent_type_id": "ENC-AGT-005", "surface": "claude_code_cli", "model": "claude-sonnet-5"}],
+    )
+    rows = mart_project.build_fact_session_daily(corpus)
+    attributed = [r for r in rows if r["project_id"] == "devops"]
+    unattributed = [r for r in rows if r["project_id"] == "unattributed"]
+    assert attributed[0]["session_count"] == 1 and attributed[0]["records_touched"] == 1
+    assert attributed[0]["agent_type"] == "claude_code_cli"
+    assert attributed[0]["model"] == "claude-sonnet-5"
+    assert unattributed[0]["session_count"] == 1, "an allocated session that wrote nothing is signal, not noise"
+
+
+def test_dim_record_projects_identifiers_never_substance():
+    record = _record(
+        title="a title the mart must not carry",
+        description="a description the mart must not carry",
+        components=["comp-devops-trino"],
+        checkout_count=2,
+        closed_count=1,
+        history=[{"timestamp": "2026-01-05T00:00:00Z", "status": "worklog", "description": "Field 'status' set to 'closed'"}],
+    )
+    row = mart_project.build_dim_record(_Corpus(records=[record]))[0]
+    assert row["record_id"] == "DVP-TSK-001"
+    assert row["closed_at"] == "2026-01-05T00:00:00Z"
+    assert row["component_ids"] == '["comp-devops-trino"]'
+    serialized = str(row)
+    assert "a title the mart must not carry" not in serialized
+    assert "a description the mart must not carry" not in serialized
+
+
+def test_sentinel_rows_are_never_governed_records():
+    assert is_sentinel({"session_id": "counter#ENC-SES"})
+    assert is_sentinel({"agent_type_id": "counter#ENC-AGT"})
+    assert is_sentinel({"record_type": "counter"})
+    assert not is_sentinel({"record_id": "task#DVP-TSK-648", "record_type": "task"})
+
+
+def test_terminal_status_vocabulary_is_case_folded():
+    assert mart_project.is_terminal("closed")
+    assert mart_project.is_terminal("Completed")
+    assert not mart_project.is_terminal("in-progress")
+    assert not mart_project.is_terminal(None)

--- a/docs/reference/governance-mart-contract.md
+++ b/docs/reference/governance-mart-contract.md
@@ -1,0 +1,213 @@
+# Governance Analytics Mart — Schema and Refresh Contract
+
+**Requirement**: BRD B3-R1 / B3-R2 / B3-R3 / B3-R4 (`DOC-724C3695059F` §6.3)
+**Tracker**: DVP-TSK-648 (parent), DVP-TSK-672..678 (one per table), DVP-TSK-649 (refresh job)
+**Governed by**: `DOC-3391173F2A5C` (grain contract), `DOC-04AF8A02A8F7` (four-tier
+architecture), `DOC-5E35E14DAD05` (crawler prohibition), `DOC-1E1EC5B7CE02` (full-refresh
+partitioning discipline), `DOC-E2379D980FA2` (spectral graph metrics)
+**Implementation**: `backend/lambda/governance_mart/`
+**Operator entry point**: `tools/governance_mart_refresh.py`
+
+The mart is a T2 warehouse projection of the governed record store, addressed as
+`hive.devops.<table>`. It exists so that "how many", "how long", "what status", and "when"
+are answerable at the cost of a glance, without a query against the record store and
+without an agent session in the path.
+
+---
+
+## 1. The rule that decides every column
+
+> **If a proposed column would let a reader substitute the mart for the record store, it
+> does not belong.**
+
+The mart holds **metadata only**: counts, statuses, durations, transitions, timestamps,
+and identifiers — the shape of activity, never its substance. No record bodies, titles,
+descriptions, intents, acceptance-criteria text, evidence strings, worklog prose, or
+document content appears in any table below, and none ever will without a recorded
+governed exception.
+
+This is enforced, not merely asserted. `test_governance_mart.py` fails CI if any declared
+column name appears in `_FORBIDDEN_SUBSTANCE_COLUMNS`, because per `DOC-3391173F2A5C` the
+appearance of a free-text body column **is itself** the Risk R-4 drift signal, independent
+of any size measurement. Size divergence is the corroborating measurement, and the
+registration sidecar the shared library emits carries the byte and row counts the Phase 6
+health monitor needs to compute it.
+
+Anyone who needs the substance follows the identifier back through `tracker.get` or
+`documents.get`. That is the whole design: the mart is a lens, not a mirror.
+
+## 2. Daily grain is the initial shape
+
+Every one of the five fact tables carries `snapshot_date` at daily grain **from the
+outset**. This is not a future upgrade — a fact table built at a coarser grain (weekly
+rollup, cumulative-only) does not satisfy the grain contract and must be corrected before
+it is registered.
+
+The reason is OBJ-6, and it is structural rather than procedural. A current-value table
+renders its last good number forever: a pipeline that silently stopped three weeks ago
+still produces a dashboard that looks healthy. A daily-grain series **stops drawing** on
+the day the refresh stopped. The failure becomes an absence, and an absence is legible.
+
+`assert_daily_grain()` runs at import time in `mart_schema.py`, so the declaration cannot
+even load in a non-conformant state.
+
+## 3. The seven tables
+
+| Table | Grain | Task |
+| --- | --- | --- |
+| `dim_record` | one row per tracker record, current state | DVP-TSK-672 |
+| `fact_record_daily` | `(snapshot_date, project_id, record_type, status)` | DVP-TSK-673 |
+| `fact_record_transition` | one row per lifecycle transition | DVP-TSK-674 |
+| `dim_document` | one row per docstore document | DVP-TSK-675 |
+| `fact_document_daily` | `(snapshot_date, project_id, document_subtype, document_maturity_state)` | DVP-TSK-676 |
+| `fact_session_daily` | `(snapshot_date, project_id, agent_type, model)` | DVP-TSK-677 |
+| `fact_graph_health_daily` | one row per `snapshot_date` | DVP-TSK-678 |
+
+The declared columns live in `backend/lambda/governance_mart/mart_schema.py` and are the
+single source of truth — the Parquet write, the Glue registration, and the conformance
+test all read the same list. Prefer asserting against `mart_schema.MART_TABLES` over
+quoting this page.
+
+`fact_record_transition` is an **event** table: its grain is one row per transition, and
+`snapshot_date` is the day bucket that event fell into rather than the leading grain key.
+The daily-grain assertion scopes its leading-key check to the `*_daily` aggregates for
+exactly this reason — forcing the day to lead a transition table's grain would produce one
+row per record per day, which is a different and worse table.
+
+### 3.1 Where transitions come from
+
+The tracker does **not** store status transitions structurally. `history[].status` is an
+entry *kind* (`created` / `worklog`), and the transition itself lives inside the entry's
+free-text `description`:
+
+```
+Field 'status' set to 'coding-complete' [provider=ENC-SES-0BV]
+```
+
+So `mart_project.extract_transitions()` parses that prose to recover two status tokens and
+a timestamp, chains them into `(from_status, to_status)` pairs, computes
+`days_in_prior_status` against the previous transition (or the record's creation time),
+and **discards the prose**. What lands in the mart is
+`('in-progress' → 'coding-complete', 0.123 days)`. What does not land is the sentence.
+
+That is the substitution test applied to a source which is mostly free text, and it is the
+sharpest illustration of the rule in the whole mart. It also re-homes the
+corpus-with-history extraction ENC-TSK-989 already performed onto the contract, rather than
+re-deriving it.
+
+Two conventions the live corpus forced:
+
+- A repeated assertion of the same status is **not** a transition. Counting it would
+  inflate throughput and zero out cycle time.
+- A legacy `tracker.py` wrote `in_progress`; underscores fold to the governed hyphenated
+  form.
+
+### 3.2 `fact_graph_health_daily` and the R-11 discipline
+
+The first four columns — `node_count`, `edge_count`, `orphan_node_count`,
+`unresolved_edge_count` — are computed today from the governed graph itself (records and
+documents as nodes; `parent`, `subtask_ids`, `related_*_ids`, `related_items`, and
+`informed_by` as edges).
+
+The last four — `hot_tier_fraction`, `percolation_margin`, `fiedler_value`,
+`demand_centroid_drift` — have **no upstream computation yet**.
+`backend/lambda/graph_health_metrics` publishes Neo4j-derived *proxies* to CloudWatch and
+says so in its own docstring ("proxy metrics instead of native Fiedler λ₂ computation"),
+and a repo-wide search for those three metric names returns nothing outside the mart.
+
+They are therefore **declared now and left NULL**, to be populated incrementally as
+ENC-FTR-063 / `comp-percolation-monitor` lands them. This is risk R-11's mitigation stated
+concretely: a column declared now and filled later is an `UPDATE`; a column added later is
+a governed schema change against a live table plus a backfill plus every dashboard built
+against the old shape. The metric computation itself is out of scope here — this table
+**projects**, it does not compute.
+
+### 3.3 Known type-1 dimension limitations, recorded rather than hidden
+
+- `fact_document_daily` buckets by a document's **current** subtype and maturity across its
+  whole lifetime, because the docstore keeps no maturity history. Document *production* per
+  day is exact; maturity *movement* over time is readable only from the current
+  distribution.
+- `dim_record.status` is projected **verbatim**, not normalised. The live corpus carries
+  `Completed`, `Complete`, and `complete` as distinct values. Folding them would be a
+  judgement the mart is not entitled to make on the record store's behalf; fidelity wins
+  over tidiness, and the divergence is itself a governance signal.
+
+## 4. The refresh path
+
+```
+read the governed record store → project to grain → write Parquet → register via B2-R2
+```
+
+One function, `mart_refresh.refresh_mart()`, shared by the scheduled Lambda
+(`backend/lambda/governance_mart/lambda_function.py`) and the operator CLI. Sharing the
+path is deliberate: an operator command that reproduced the projection separately would be
+a second opinion about the grain, and the two would drift.
+
+Every historical break pattern is eliminated **by construction**, not by monitoring:
+
+| Break pattern | Why it cannot occur here |
+| --- | --- |
+| EventBridge per-mutation trigger | There is none. The only trigger is a *schedule* (daily minimum). Nothing subscribes to a tracker mutation, so there is nothing to disable later. |
+| Crawler / crawler launcher | There is none. `register_table` writes a DECLARED schema through the Glue API. The schema is a value in `mart_schema.py`, committed with the code that writes the data. |
+| Crawler concurrency | Unreachable — no crawler exists to race. Two overlapping refreshes converge on the same canonical key. |
+| Partition explosion | Impossible — no table declares a partition key, and the library writes exactly one object per table at a constant key. |
+| Stale data that looks fresh | Structurally visible — daily grain means a stopped refresh stops the series. |
+| New-project sync gap | Impossible — the refresh **scans all projects**. There is no per-project registration step to forget. |
+
+A faster cadence than daily is permitted and changes nothing structurally, because each run
+rebuilds every table from scratch.
+
+**Failure is loud.** The handler re-raises rather than returning 200 on error. A refresh
+that swallowed its own exception and reported success would recreate the silent-stop
+failure mode the daily grain exists to expose — the series must stop drawing *and* the
+invocation must fail, not one without the other.
+
+## 5. Ownership (B3-R4)
+
+- **devops** owns the platform tier (T0: Trino, Superset, Glue, the EC2 host) and **this
+  contract**. Schema changes are governed changes to `comp-devops-trino`, reviewed against
+  the substitution test in §1.
+- **enceladus** owns the mart's **projection logic and schema** — `mart_schema.py` and
+  `mart_project.py` — because the schema is a projection of the governance ontology
+  (`ENC-FTR-053`) and must evolve with it. When the ontology gains a field worth counting,
+  the mart's declaration is where that shows up.
+
+The feature is hosted in `devops` for plan coherence (io decision, 2026-08-07) while
+enceladus owns the projection. Recording the split here is the point: a future session
+should not have to rediscover which side of the line a change falls on.
+
+Prior work re-homed rather than re-derived: **ENC-TSK-989** (closed) already extracted the
+corpus with history — `fact_record_transition` builds on that extraction shape instead of
+performing a second pass. **ENC-TSK-C63** (coding-complete) already built a Trino analysis
+path — the mart registers into that same `hive` catalog rather than standing up a parallel
+query surface.
+
+## 6. Onboarding precondition (T0, once)
+
+The Glue database `devops` was created **with a `LocationUri`**
+(`s3://devops-agentcli-compute/warehouse/devops/`) as a one-time platform-tier action.
+Without it, `CREATE TABLE` through Trino fails with `HIVE_DATABASE_LOCATION_ERROR`;
+table-level `StorageDescriptor.Location` does not substitute. The shared library writes the
+catalog through the Glue API rather than Trino DDL, so it is not itself blocked — but any
+Superset or Trino DDL against the database would be. See `DOC-04AF8A02A8F7`.
+
+## 7. Verifying conformance
+
+```bash
+# Unit + contract tests. No AWS credentials required.
+python3 -m pytest backend/lambda/governance_mart/ -q
+
+# Diff the live Glue catalog against the declaration. Read-only, exits non-zero
+# on divergence. This is the check CI and the B6-R2 monitor want.
+python3 tools/governance_mart_refresh.py reconcile --profile product-lead
+
+# Project everything and print row counts without writing.
+python3 tools/governance_mart_refresh.py plan --profile product-lead
+```
+
+**Result (2026-08-08):** 7 tables, 7 match, 0 divergent, 0 missing, 0 rejected. 56,672 rows
+across 503,147 bytes. Each table holds exactly one S3 object at
+`warehouse/devops/<table>/data.parquet`, and `file_count` remained 1 across three
+successive refreshes (`write_seq` 1 → 3) with `byte_count` unchanged — full-refresh
+overwrite behaving correctly, file count tracking data size rather than write count.

--- a/envs/v3-prod.yaml
+++ b/envs/v3-prod.yaml
@@ -83,6 +83,7 @@ function_name_map:
   github_integration: devops-github-integration
   glue_crawler_launcher: devops-glue-crawler-launcher
   governance_audit: enceladus-governance-audit
+  governance_mart: devops-governance-mart
   graph_health_metrics: enceladus-graph-health-metrics
   graph_query_api: devops-graph-query-api
   graph_sync: devops-graph-sync

--- a/envs/v4-gamma.yaml
+++ b/envs/v4-gamma.yaml
@@ -72,6 +72,7 @@ function_name_map:
   feed_query: devops-feed-query-api-gamma
   github_integration: devops-github-integration-gamma
   governance_audit: enceladus-governance-audit-gamma
+  governance_mart: devops-governance-mart-gamma
   graph_health_metrics: enceladus-graph-health-metrics-gamma
   graph_query_api: devops-graph-query-api-gamma
   graph_sync: devops-graph-sync-gamma

--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -959,6 +959,62 @@ Resources:
         - Key: Component
           Value: governance
 
+  # ---------------------------------------------------------------------------
+  # DVP-TSK-649 / DVP-PLN-001: governance analytics mart — SCHEDULED FULL REFRESH.
+  # Reads the five governed DynamoDB sources (full Scan), projects to daily grain,
+  # writes one Parquet object per table and registers the DECLARED schema through
+  # the B2-R2 shared library (enceladus_shared.warehouse_registration).
+  #
+  # Trigger is GovernanceMartSchedule (EventBridge cron) and nothing else — see
+  # the comment on that rule for why a per-mutation trigger is excluded by design.
+  #
+  # No AppConfig extension layer: a batch job with no runtime feature flags; it
+  # never calls appconfig_flags.flag(), so the layer and its APPCONFIG_* env vars
+  # would be dead weight.
+  # No SnapStart: a once-a-day invocation gains nothing from a restored snapshot,
+  # and per-published-version snapshot storage bills per GB-second (the 2026-04-22
+  # Sev-1 cost incident). EscalationDecisionAuthorizerFunction is the same opt-out.
+  # ---------------------------------------------------------------------------
+  GovernanceMartFunction:
+    Type: AWS::Lambda::Function
+    DeletionPolicy: Retain
+    Properties:
+      FunctionName: !Sub "devops-governance-mart${EnvironmentSuffix}"
+      Code:
+        ZipFile: "# managed outside CloudFormation"
+      Runtime: !If [IsGamma, python3.12, python3.11]
+      Handler: lambda_function.lambda_handler
+      # 2048 MB / 900 s: one run scans ~6.3k tracker records + ~1.4k documents
+      # (~25 MB corpus) and serialises seven Parquet tables in memory before any
+      # of them is written. Memory is sized for the pyarrow buffers, not the scan.
+      MemorySize: 2048
+      Timeout: 900
+      Architectures:
+        - !If [IsGamma, arm64, x86_64]
+      Role: !GetAtt GovernanceMartRole.Arn
+      Description: DVP-TSK-649 scheduled full-refresh governance analytics mart job (DVP-PLN-001)
+      Layers:
+        - !Ref SharedLayerArn
+      Environment:
+        Variables:
+          # T2 coordinates (BRD B3-R4). The Glue database `devops` was created as
+          # a T0 onboarding action WITH a LocationUri (DOC-04AF8A02A8F7).
+          MART_BUCKET: devops-agentcli-compute
+          MART_DATABASE: devops
+          # Read-only governed sources. Same env var names and the same
+          # ${EnvironmentSuffix} convention the owning Lambdas use, so the mart
+          # resolves gamma tables without inventing a second convention.
+          TRACKER_TABLE: !Sub "devops-project-tracker${EnvironmentSuffix}"
+          DOCUMENTS_TABLE: !Sub "documents${EnvironmentSuffix}"
+          AGENT_SESSIONS_TABLE: !Sub "agent-sessions${EnvironmentSuffix}"
+          AGENT_TYPES_TABLE: !Sub "agent-types${EnvironmentSuffix}"
+          COORDINATION_TABLE: !Sub "coordination-requests${EnvironmentSuffix}"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance-mart
+
   DocPrepFunction:
     Type: AWS::Lambda::Function
     DeletionPolicy: Retain
@@ -1567,6 +1623,52 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt Neo4jBackupSchedule.Arn
+
+  # ---------------------------------------------------------------------------
+  # DVP-TSK-649 / DVP-PLN-001: the ONLY trigger for the governance analytics mart.
+  #
+  # THIS IS A SCHEDULE RULE AND NOTHING ELSE. It has no EventPattern, and there is
+  # deliberately no companion AWS::Lambda::EventSourceMapping, DynamoDB stream
+  # subscription, S3 event notification, EventBridge Pipe or tracker-mutation hook
+  # anywhere in this path. A per-mutation trigger is exactly the failure class this
+  # design exists to eliminate: the job is a FULL REFRESH, so every run rebuilds
+  # every table from current state and there is nothing for a mutation event to
+  # incrementally maintain (DOC-1E1EC5B7CE02). Adding one would reintroduce the
+  # crawler-concurrency and partition-explosion classes the full refresh makes
+  # structurally impossible. Do not add an EventPattern to this rule, and do not
+  # attach a Glue crawler to this path — a crawler in a production data path is a
+  # governed contract violation (DOC-5E35E14DAD05).
+  #
+  # cron(0 6 * * ? *) = 06:00 UTC daily. Cadence is a freshness choice only;
+  # changing it changes nothing structurally, because each run is idempotent.
+  # ---------------------------------------------------------------------------
+  GovernanceMartSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "devops-governance-mart-daily${EnvironmentSuffix}"
+      Description: "DVP-TSK-649: daily 06:00 UTC full refresh of the governance analytics mart. Schedule-only by design — never per-mutation."
+      ScheduleExpression: "cron(0 6 * * ? *)"
+      # DISABLED in gamma, on purpose. MART_BUCKET and MART_DATABASE are the
+      # unsuffixed production values (devops-agentcli-compute, devops) because the
+      # mart's warehouse is a single governed T2 namespace -- there is no gamma
+      # Glue database, and creating one is a T0 onboarding action, not something a
+      # deploy should do implicitly. So a gamma copy of this function firing on a
+      # schedule would overwrite PRODUCTION Parquet and re-register PRODUCTION Glue
+      # tables. Leaving the gamma rule disabled means the function can still be
+      # invoked by hand for testing, deliberately and with someone watching, but
+      # never fires itself into prod data.
+      State: !If [IsGamma, DISABLED, ENABLED]
+      Targets:
+        - Arn: !GetAtt GovernanceMartFunction.Arn
+          Id: governance-mart-daily
+
+  GovernanceMartPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref GovernanceMartFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt GovernanceMartSchedule.Arn
 
   ProjectJsonSyncRule:
     Type: AWS::Events::Rule
@@ -2915,6 +3017,129 @@ Resources:
                   - appconfig:GetLatestConfiguration
                   - appconfig:StartConfigurationSession
                 Resource: "*"
+
+  # DVP-TSK-649 / DVP-PLN-001: least-privilege role for the governance analytics
+  # mart refresh. Read-only against the five governed DynamoDB sources; writes are
+  # confined to the two warehouse prefixes this project owns. No AppConfigAccess
+  # statement — the function carries no AppConfig layer (see GovernanceMartFunction).
+  GovernanceMartRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      RoleName: !Sub "devops-governance-mart-lambda-role${EnvironmentSuffix}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+        - PolicyName: GovernedSourceRead
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Scan + DescribeTable only. The refresh reads everything by
+              # contract, so there is no GetItem/Query path to grant — and there
+              # is deliberately no write action of any kind: the mart is a
+              # derived read of the governed record store, never a mutator of it.
+              - Sid: DynamoDBFullRefreshScan
+                Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                  - dynamodb:DescribeTable
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/devops-project-tracker${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/documents${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-sessions${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-sessions${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-types${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/agent-types${EnvironmentSuffix}/index/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/coordination-requests${EnvironmentSuffix}/index/*"
+        - PolicyName: WarehouseObjectWrite
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # warehouse/<project>/<table>/data.parquet plus the registration
+              # record at warehouse-registrations/<project>/<table>.json. GetObject
+              # covers the HeadObject digest probe that makes the write idempotent.
+              # Deliberately NO s3:DeleteObject/DeleteObjects: prune_stale_objects()
+              # is opt-in and the scheduled path never asks for it — the constant
+              # canonical key means nothing accumulates to prune (DOC-1E1EC5B7CE02).
+              - Sid: WarehouseObjectReadWrite
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectAttributes
+                Resource:
+                  - "arn:aws:s3:::devops-agentcli-compute/warehouse/devops/*"
+                  - "arn:aws:s3:::devops-agentcli-compute/warehouse-registrations/devops/*"
+              # register_table() measures the prefix (list_objects_v2) rather than
+              # asserting a file count, so ListBucket is required — constrained to
+              # this project's two prefixes so it can never enumerate the bucket.
+              - Sid: WarehousePrefixList
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: "arn:aws:s3:::devops-agentcli-compute"
+                Condition:
+                  StringLike:
+                    "s3:prefix":
+                      - "warehouse/devops/*"
+                      - "warehouse-registrations/devops/*"
+        - PolicyName: GlueDeclaredSchemaRegister
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # NOTE: this is the FIRST glue:* grant anywhere in this repository —
+              # no other role in 02-compute.yaml (or any other template) holds one.
+              # Treat any future widening of it as a new-capability review, not a
+              # routine edit.
+              #
+              # Scoped to the catalog + the `devops` database + its tables only.
+              # register_table() calls exactly GetTable / CreateTable / UpdateTable;
+              # GetDatabase and GetTables are the read-side companions.
+              #
+              # Deliberately EXCLUDED and not to be added:
+              #   * glue:DeleteTable — the full-refresh contract is register-or-
+              #     update; a declared schema is never dropped by this path.
+              #   * every glue:*Crawler* action (CreateCrawler, StartCrawler,
+              #     UpdateCrawler, GetCrawler, ...) — a Glue crawler in a
+              #     production data path is a governed contract violation
+              #     (DOC-5E35E14DAD05). The schema is a committed value in
+              #     mart_schema.py, discovered by no one.
+              - Sid: GlueDeclaredSchemaRegistration
+                Effect: Allow
+                Action:
+                  - glue:GetDatabase
+                  - glue:GetTable
+                  - glue:GetTables
+                  - glue:CreateTable
+                  - glue:UpdateTable
+                Resource:
+                  - !Sub "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                  - !Sub "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/devops"
+                  - !Sub "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/devops/*"
+      Tags:
+        - Key: Project
+          Value: enceladus
+        - Key: Component
+          Value: governance-mart
 
   DocPrepRole:
     Type: AWS::IAM::Role

--- a/infrastructure/lambda_workflow_manifest.json
+++ b/infrastructure/lambda_workflow_manifest.json
@@ -210,6 +210,18 @@
       "lambda_dir": "backend/lambda/recompute_governance",
       "workflow_file": ".github/workflows/_deploy.yml",
       "deploy_script": "backend/lambda/recompute_governance/deploy.sh"
+    },
+    {
+      "function_name": "devops-governance-mart",
+      "lambda_dir": "backend/lambda/governance_mart",
+      "workflow_file": ".github/workflows/_deploy.yml",
+      "deploy_script": "backend/lambda/governance_mart/deploy.sh",
+      "package_extra_files": [
+        "mart_schema.py",
+        "mart_source.py",
+        "mart_project.py",
+        "mart_refresh.py"
+      ]
     }
   ]
 }

--- a/tools/governance_mart_refresh.py
+++ b/tools/governance_mart_refresh.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Governance analytics mart -- operator entry point.
+
+BRD B3 (DVP-TSK-648 / DVP-TSK-649). This is the SAME code path the scheduled
+Lambda runs (``backend/lambda/governance_mart/``), exposed as a CLI so the mart
+can be built, inspected, and reconciled from a workstation without waiting for
+a schedule. Sharing the path is the point: an operator command that reproduced
+the projection separately would be a second opinion about the grain, and the
+two would drift.
+
+Modes::
+
+    # Project everything and print row counts. Touches no AWS write API.
+    python3 tools/governance_mart_refresh.py plan --profile product-lead
+
+    # Full refresh: write Parquet + register the declared schema in Glue.
+    python3 tools/governance_mart_refresh.py refresh --profile product-lead
+
+    # Print the DECLARED schema the library will register for one table.
+    python3 tools/governance_mart_refresh.py schema --table dim_record
+
+    # Diff the live Glue catalog against the declaration. Read-only; exits
+    # non-zero on any divergence. This is the conformance check CI and the
+    # B6-R2 monitor want.
+    python3 tools/governance_mart_refresh.py reconcile --profile product-lead
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Optional, Sequence
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO, "backend", "lambda", "shared_layer", "python"))
+sys.path.insert(0, os.path.join(_REPO, "backend", "lambda", "governance_mart"))
+
+from enceladus_shared.warehouse_registration import (  # noqa: E402
+    ContractViolation,
+    _normalized_catalog_view,
+    build_contract,
+)
+
+from mart_project import build_all  # noqa: E402
+from mart_refresh import MART_BUCKET, MART_DATABASE, MART_REGION, refresh_mart  # noqa: E402
+from mart_schema import MART_PROJECT, MART_TABLE_ORDER, MART_TABLES  # noqa: E402
+from mart_source import load_corpus  # noqa: E402
+
+
+def _session(profile: Optional[str], region: str):
+    import boto3
+
+    return boto3.Session(profile_name=profile, region_name=region) if profile else boto3.Session(region_name=region)
+
+
+def contract_for(table: str):
+    spec = MART_TABLES[table]
+    return build_contract(
+        project=MART_PROJECT,
+        table=table,
+        columns=spec.columns,
+        bucket=MART_BUCKET,
+        database=MART_DATABASE,
+        table_comment=spec.comment,
+    )
+
+
+def reconcile(glue_client) -> dict:
+    """Diff every declared mart table against its live Glue registration."""
+    results = []
+    for name in MART_TABLE_ORDER:
+        entry = {"table": name, "column_count": len(MART_TABLES[name].columns)}
+        try:
+            contract = contract_for(name)
+        except ContractViolation as exc:
+            entry["status"] = "REJECTED"
+            entry["differences"] = {"build_contract": str(exc)}
+            results.append(entry)
+            continue
+        entry["trino_identifier"] = contract.trino_identifier
+        entry["location"] = contract.location
+        try:
+            live = glue_client.get_table(DatabaseName=MART_DATABASE, Name=name)["Table"]
+        except glue_client.exceptions.EntityNotFoundException:
+            entry["status"] = "MISSING"
+            results.append(entry)
+            continue
+        want = _normalized_catalog_view(contract.glue_table_input())
+        have = _normalized_catalog_view(live)
+        differences = {
+            field: {"library": want[field], "live": have[field]}
+            for field in want
+            if want[field] != have[field]
+        }
+        entry["status"] = "MATCH" if not differences else "DIVERGENT"
+        if differences:
+            entry["differences"] = differences
+        results.append(entry)
+
+    return {
+        "database": MART_DATABASE,
+        "bucket": MART_BUCKET,
+        "table_count": len(results),
+        "match": sum(1 for e in results if e["status"] == "MATCH"),
+        "divergent": sum(1 for e in results if e["status"] == "DIVERGENT"),
+        "missing": sum(1 for e in results if e["status"] == "MISSING"),
+        "rejected": sum(1 for e in results if e["status"] == "REJECTED"),
+        "tables": results,
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("mode", choices=["plan", "refresh", "schema", "reconcile"])
+    parser.add_argument("--table", help="single table (schema mode), or restrict refresh")
+    parser.add_argument("--profile", help="AWS profile")
+    parser.add_argument("--region", default=MART_REGION)
+    parser.add_argument("--last-day", help="daily-grain upper bound, YYYY-MM-DD")
+    parser.add_argument("--json", action="store_true", help="emit raw JSON")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.mode == "schema":
+        if not args.table:
+            parser.error("--table is required in schema mode")
+        print(json.dumps(contract_for(args.table).glue_table_input(), indent=2))
+        return 0
+
+    session = _session(args.profile, args.region)
+
+    if args.mode == "reconcile":
+        summary = reconcile(session.client("glue"))
+        if args.json:
+            print(json.dumps(summary, indent=2, default=str))
+        else:
+            print(
+                "governance mart reconciliation: %d tables | %d match | %d divergent | %d missing | %d rejected"
+                % (summary["table_count"], summary["match"], summary["divergent"],
+                   summary["missing"], summary["rejected"])
+            )
+            for entry in summary["tables"]:
+                marker = {"MATCH": "ok", "DIVERGENT": "DIFF", "MISSING": "MISSING", "REJECTED": "REJECT"}[entry["status"]]
+                print("  %-8s %-26s cols=%d" % (marker, entry["table"], entry["column_count"]))
+                for field, delta in (entry.get("differences") or {}).items():
+                    print("           %s: library=%r live=%r" % (field, delta.get("library"), delta.get("live")))
+        return 0 if summary["divergent"] == 0 and summary["rejected"] == 0 else 1
+
+    last_day = datetime.strptime(args.last_day, "%Y-%m-%d").date() if args.last_day else None
+
+    if args.mode == "plan":
+        corpus = load_corpus(dynamodb_client=session.client("dynamodb"), region=args.region)
+        projected = build_all(corpus, last_day=last_day)
+        summary = {
+            "source_counts": corpus.counts(),
+            "tables": {name: len(rows) for name, rows in projected.items()},
+        }
+        print(json.dumps(summary, indent=2, default=str))
+        return 0
+
+    result = refresh_mart(
+        tables=[args.table] if args.table else None,
+        last_day=last_day,
+        dynamodb_client=session.client("dynamodb"),
+        s3_client=session.client("s3"),
+        glue_client=session.client("glue"),
+    )
+    print(json.dumps(result.as_dict(), indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Phase 2 of `DVP-PLN-001` — the governance analytics mart. Seven declared tables projecting the governed record store to analytic grain, plus the scheduled full-refresh job that builds them.

Every write goes through the merged B2-R2 shared registration library (PR #1073, main `326dd44`). Nothing here hand-rolls Parquet or Glue registration — that was the whole point of B3 depending on B2.

## Live now

Seven tables registered in Glue database `devops`, served through Trino as `hive.devops.*`:

| table | rows | bytes |
| --- | --- | --- |
| `dim_record` | 6,197 | 166,802 |
| `fact_record_daily` | 26,620 | 25,557 |
| `fact_record_transition` | 15,293 | 224,023 |
| `dim_document` | 1,386 | 65,052 |
| `fact_document_daily` | 6,880 | 12,995 |
| `fact_session_daily` | 123 | 3,235 |
| `fact_graph_health_daily` | 173 | 5,483 |

`reconcile`: **7 tables, 7 match, 0 divergent, 0 missing, 0 rejected.** US-1 answers directly — `SELECT count(*) FROM hive.devops.dim_record WHERE project_id='enceladus' AND record_type='task'` → 2367, with zero agent sessions in the path.

## The grain contract is enforced, not asserted

`DOC-3391173F2A5C`'s standing test — *if a column would let a reader substitute the mart for the record store, it does not belong* — is a parametrised CI test over all seven tables. Per the contract, the appearance of a free-text column **is** the Risk R-4 drift signal, so it fails the build rather than waiting for review. `assert_daily_grain()` also runs at module import, so the declaration cannot load in a non-conformant state.

The sharpest case is `fact_record_transition`. The tracker stores **no** structural status transition: `history[].status` is an entry *kind* (`created`/`worklog`) and the transition lives inside the entry's prose. The projection parses that prose to recover two status tokens and a timestamp, then throws the prose away — 15,293 transitions from 58,042 history entries, zero free text stored.

## Six break patterns eliminated by construction

- **No EventBridge per-mutation trigger.** Schedule only (`cron(0 6 * * ? *)`), so there is nothing to disable later.
- **No crawler, no crawler launcher.** Schema is a value in `mart_schema.py`, committed with the code that writes the data. No `glue:*Crawler*` action is requested, and deliberately not even `glue:DeleteTable`.
- **Crawler concurrency unreachable** — no crawler exists to race.
- **Partition explosion impossible** — no partition keys, one object at a constant key. `file_count` stayed 1 across three successive refreshes (`write_seq` 1→3) with `byte_count` unchanged.
- **Stale-but-fresh-looking data is visible** — daily grain means a stopped refresh stops the series drawing instead of persisting a last good value. The handler re-raises rather than returning 200, so the series stops *and* the alarm fires.
- **New-project sync gap cannot recur** — the refresh scans all projects; there is no per-project registration step to forget.

## Risk R-11

`fact_graph_health_daily` declares `hot_tier_fraction`, `percolation_margin`, `fiedler_value` and `demand_centroid_drift` **now** and writes them NULL. No upstream exists — `graph_health_metrics` publishes CloudWatch proxies and says so in its own docstring. Filling them later is an `UPDATE`, not a schema change against a live table plus a backfill. The other four graph columns are computed today, so the table is never empty while it waits.

## Notes for review

- **First `glue:*` grant in this repo.** `GovernanceMartRole` needs `glue:CreateTable`/`UpdateTable` scoped to `database/devops` + `table/devops/*`. No existing Lambda role has any Glue permission.
- **`warehouse_registration.py` is vendored via `.build_extras`**, because the pinned shared layer (`enceladus-shared:10`) predates it. The `except ImportError` fallback in `mart_schema.py`/`mart_refresh.py` is the working path, not defensive padding.
- **Gamma schedule is `DISABLED`** — `MART_BUCKET`/`MART_DATABASE` are the unsuffixed production values, so a gamma copy firing on schedule would overwrite production Parquet.
- **`envs/v4-prod.yaml` intentionally untouched** — it has no `function_name_map` key at all; adding a single entry would declare that v4-prod deploys this and nothing else.
- Guards: `verify_lambda_workflow_coverage.py` SUCCESS (26 mapped), `verify_lambda_arch_parity.py` SUCCESS (27 conditionals), cfn-lint E-level 24 at HEAD and 24 here (zero new), 37 mart tests + 30 library tests pass.

CCI-348c7df3f5bc459293cb94b714883f5b DVP-TSK-672 dim_record
CCI-6d1bfcbbe2c241e8bc3f56a4b773a3d3 DVP-TSK-673 fact_record_daily
CCI-def839c105344f25b6fd44ed8f28bfbc DVP-TSK-674 fact_record_transition
CCI-1fdd35a62f544d39b10b8b1aad4f4b4b DVP-TSK-675 dim_document
CCI-7e4deabc59e54c83bdc1aa48052f2bd3 DVP-TSK-676 fact_document_daily
CCI-d88e0ca1c724454d8558628daa4ba543 DVP-TSK-677 fact_session_daily
CCI-f0cb5f96ee4e448c87f492c5e73e93cb DVP-TSK-678 fact_graph_health_daily
CCI-a82e95b7fc3f44b5850f1ef7cee7a177 DVP-TSK-648 define and build the seven tables
CCI-ab303d4e6cad49429b6e2cb607c8171b DVP-TSK-649 the scheduled full-refresh job

🤖 Generated with [Claude Code](https://claude.com/claude-code)