### PR TITLE
ENC-TSK-N82: backport K34 bundled-only governance dictionary serving to main (ENC-ISS-599/600)

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-08-08.6",
-  "updated_at": "2026-08-08T03:40:00Z",
-  "last_change_summary": "DVP-TSK-703 (DVP-PLN-001): REPOINTED ONLY -- no entity, field, enum or contract was added, removed or altered. warehouse.adhoc_promotion and warehouse.platform_health now name their implementation in NX-2021-L/devops (services/lambda/adhoc_promotion, services/lambda/platform_health) rather than in this repo, correcting a repo-ownership error: both operate on data.jreese.net -- the Trino catalog, the hive.adhoc namespace, the warehouse prefixes and EC2 i-0f3a4d5aa1c11dd86 -- which is platform, not a projection of the governance ontology. Both still write through the B2-R2 library enceladus_shared.warehouse_registration, which remains canonical HERE and is fetched by devops at a pinned, sha256-verified commit rather than copied, so the single-registration-path contract is unchanged. warehouse.governance_mart is untouched and stays in this repo per BRD B3-R4. PREVIOUS: DVP-TSK-696 (BRD B6-R2, DVP-PLN-001): extended entity warehouse.platform_health with checks 6, 7, 8 and a NINTH -- container health read from the kernel log rather than Docker's RestartCount (which read 0 through seven OOM kills), the hive.adhoc quota with its explicit empty case, burstable CPU credits thresholded against surplus BURN because CpuCredits=unlimited makes the failure economic rather than a performance cliff, and IAM/configuration drift, which must be scheduled because the 2026-08-06 severance arrived through create-policy-version and a hand-edited .env, neither of which any PR-triggered guard can observe. No existing entity was modified. PREVIOUS: DVP-TSK-695 (BRD B6-R2, DVP-PLN-001) extended entity warehouse.platform_health with checks 2, 3 and 4 -- the enforcement arm of the warehouse contract, making B2-R3 (no crawlers, scanned in every region), B5-R4 (namespace isolation, legacy tables reported rather than allowlisted) and B2-R6 (Parquet, read from the SerDe rather than the crawler-written classification hint) mechanical rather than prose. No existing entity was modified. PREVIOUS: DVP-TSK-694 / DVP-TSK-665 (BRD B6-R2, DVP-PLN-001) added entity warehouse.platform_health documenting the source-agnostic platform health monitor -- its schedule-only invocation contract, the observe-never-remediate posture its IAM shape enforces, the error-as-a-third-state rule, the platform-health/ surface and its two T2 daily-grain projections, and checks 1 (freshness against a declared SLA) and 5 (full-refresh consistency). No existing entity was modified. PREVIOUS: DVP-TSK-661 / 685 / 686 / 687 (BRD B5-R2, DVP-PLN-001) added entity warehouse.adhoc_promotion documenting the ad-hoc promotion transform -- the single gate out of the hive.adhoc quarantine namespace into a governed schema. Records the contract for its two actions (plan, promote), the mandatory human actor block enforcing decision D-4, the all-or-nothing coercion semantics including the lossy-coercion rule, and the offending-row report shape. No existing entity was modified.",
+  "version": "2026-08-08.7",
+  "updated_at": "2026-08-08T03:53:42Z",
+  "last_change_summary": "ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600, DOC-B716E8FB10B6 COE lineage, M44/M45 sibling): backport the ENC-TSK-K34 bundled-only dictionary serving (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E) from v4/main onto main -- coordination_api._load_governance_dictionary no longer scans the governance-policies DynamoDB mirror (frozen at 2026-06-30.09/121 entities since the document outgrew DynamoDB's 400KB item cap; no production S3->DDB trigger ever existed either); the bundled file is now the sole authoritative source on main, matching v4/main. Also imports the 37 entity keys present in S3-live 2026-08-08.01 (sha256 5b0d150a3d4bb7230d5798c6d8ddb9fd10fad86d3f5c9e3545b08d4dbc0ad726) but absent from this bundle -- the SCI-enforcement, agent-identity, escalations, graph_query_api, mcp_server and corpus governance that went invisible to every MCP agent when the mirror froze. Merge policy: bundle wins on shared keys per the K34 deploy-coupling doctrine (15 shared keys differ from S3-live: api.error_envelope, component_registry.component, coordination.agent_session, coordination.agent_session_idle_sweep, coordination.agent_type, coordination.escalations, coordination.request, coordination.session_claim_id, deploy.spec, document.query_response, tracker.feature, tracker.graphsearch, tracker.issue, tracker.plan, tracker.task; the S3-side copies remain recoverable under governance/history/). A section-13 HANDOFF requests io push this reconciled content to S3-live to restore exact S3<->served entity-key parity. No pre-existing bundle entity was modified. PREVIOUS: DVP-TSK-703 (DVP-PLN-001): REPOINTED ONLY -- no entity, field, enum or contract was added, removed or altered. warehouse.adhoc_promotion and warehouse.platform_health now name their implementation in NX-2021-L/devops (services/lambda/adhoc_promotion, services/lambda/platform_health) rather than in this repo, correcting a repo-ownership error: both operate on data.jreese.net -- the Trino catalog, the hive.adhoc namespace, the warehouse prefixes and EC2 i-0f3a4d5aa1c11dd86 -- which is platform, not a projection of the governance ontology. Both still write through the B2-R2 library enceladus_shared.warehouse_registration, which remains canonical HERE and is fetched by devops at a pinned, sha256-verified commit rather than copied, so the single-registration-path contract is unchanged. warehouse.governance_mart is untouched and stays in this repo per BRD B3-R4. PREVIOUS: DVP-TSK-696 (BRD B6-R2, DVP-PLN-001): extended entity warehouse.platform_health with checks 6, 7, 8 and a NINTH -- container health read from the kernel log rather than Docker's RestartCount (which read 0 through seven OOM kills), the hive.adhoc quota with its explicit empty case, burstable CPU credits thresholded against surplus BURN because CpuCredits=unlimited makes the failure economic rather than a performance cliff, and IAM/configuration drift, which must be scheduled because the 2026-08-06 severance arrived through create-policy-version and a hand-edited .env, neither of which any PR-triggered guard can observe. No existing entity was modified. PREVIOUS: DVP-TSK-695 (BRD B6-R2, DVP-PLN-001) extended entity warehouse.platform_health with checks 2, 3 and 4 -- the enforcement arm of the warehouse contract, making B2-R3 (no crawlers, scanned in every region), B5-R4 (namespace isolation, legacy tables reported rather than allowlisted) and B2-R6 (Parquet, read from the SerDe rather than the crawler-written classification hint) mechanical rather than prose. No existing entity was modified. PREVIOUS: DVP-TSK-694 / DVP-TSK-665 (BRD B6-R2, DVP-PLN-001) added entity warehouse.platform_health documenting the source-agnostic platform health monitor -- its schedule-only invocation contract, the observe-never-remediate posture its IAM shape enforces, the error-as-a-third-state rule, the platform-health/ surface and its two T2 daily-grain projections, and checks 1 (freshness against a declared SLA) and 5 (full-refresh consistency). No existing entity was modified. PREVIOUS: DVP-TSK-661 / 685 / 686 / 687 (BRD B5-R2, DVP-PLN-001) added entity warehouse.adhoc_promotion documenting the ad-hoc promotion transform -- the single gate out of the hive.adhoc quarantine namespace into a governed schema. Records the contract for its two actions (plan, promote), the mandatory human actor block enforcing decision D-4, the all-or-nothing coercion semantics including the lossy-coercion rule, and the offending-row report shape. No existing entity was modified.",
   "owners": [
     "enceladus-platform"
   ],
@@ -54,8 +54,8 @@
             "closed",
             "deployed"
           ],
-          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' \u2014 backward compat read supported; new tasks must use 'pr'.",
-          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) \u2014 direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface \u2014 the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
         },
         "priority": {
           "type": "enum",
@@ -105,8 +105,8 @@
             "no_code",
             "code_only"
           ],
-          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called \u2014 treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only \u2014 once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
-          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation \u2014 those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
         },
         "transition_evidence": {
           "type": "object",
@@ -115,7 +115,7 @@
           "properties": {
             "deploy_evidence": {
               "type": "object",
-              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response \u2014 do not construct manually.",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
               "required_fields": {
                 "id": {
                   "type": "integer",
@@ -141,14 +141,14 @@
                   "enum": [
                     "completed"
                   ],
-                  "definition": "GitHub Actions job status. Must be 'completed' \u2014 in-progress or queued jobs are rejected."
+                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
                 },
                 "conclusion": {
                   "type": "enum",
                   "enum": [
                     "success"
                   ],
-                  "definition": "GitHub Actions job conclusion. Must be 'success' \u2014 failure, cancelled, skipped, and timed_out are all rejected."
+                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
                 },
                 "started_at": {
                   "type": "string",
@@ -239,7 +239,7 @@
                 },
                 "github_verified": {
                   "type": "boolean",
-                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually \u2014 the service stamps this field."
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
                 }
               },
               "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
@@ -249,12 +249,12 @@
               "constraints": {
                 "min_length": 1
               },
-              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed \u2014 the string is stored as-is for audit traceability.",
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
               "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
             },
             "user_initiated": {
               "type": "boolean",
-              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication \u2014 rejected with HTTP 403 if internal API key is used.",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
               "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
             },
             "user_note": {
@@ -268,7 +268,7 @@
             "merge_evidence": {
               "type": "string_or_object",
               "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
-              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields \u2014 merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
             }
           }
         },
@@ -284,7 +284,7 @@
         },
         "parent": {
           "type": "string",
-          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API \u2014 any string is accepted; interpretation is by convention.",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
           "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
         },
         "subtask_ids": {
@@ -292,8 +292,8 @@
           "items": {
             "type": "string"
           },
-          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out \u2014 tracker mutation rejects removal attempts to prevent subtask gate bypass.",
-          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed \u2014 only appended. To bypass: use the PWA user_initiated path."
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
         },
         "related_task_ids": {
           "type": "array",
@@ -343,7 +343,7 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
           "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
           "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
@@ -355,9 +355,9 @@
           "writable_by": [
             "server"
           ],
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a75: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable \u2014 tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
           "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
-          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started \u2014 this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
           "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
         }
       }
@@ -437,7 +437,7 @@
         "technical_notes": {
           "type": "string",
           "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
-          "usage_guidance": "Include investigation context \u2014 what was tried, what was observed, relevant stack traces or log lines."
+          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
         },
         "location_hint": {
           "type": "string",
@@ -600,7 +600,7 @@
         },
         "agents_md_section": {
           "type": "string",
-          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md \u00a76 Tracker Operations \u2014 ID Boundary Rule'."
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
         }
       }
     },
@@ -636,7 +636,7 @@
         },
         "edge_density_requirements": {
           "type": "object",
-          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) \u2014 each must have at least one entry."
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
         },
         "format_constraint": {
           "type": "string",
@@ -756,7 +756,7 @@
             "format": "ISO 8601 datetime"
           },
           "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
-          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet \u2014 consuming agents should check."
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
         },
         "claimed_by": {
           "type": "string",
@@ -781,7 +781,7 @@
         "reply_author": {
           "type": "string",
           "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
-          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side \u2014 must be non-empty."
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
         },
         "reply_timestamp": {
           "type": "string",
@@ -889,7 +889,7 @@
         "confirm_subtype": {
           "type": "boolean",
           "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
-          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB \u2014 request-only flag. Also forwarded by MCP server _documents_put."
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
         },
         "semantic_guard_patterns": {
           "type": "string",
@@ -998,7 +998,7 @@
             "review",
             "monitoring"
           ],
-          "definition": "Optional classification of the agent layer role within this wave. Informational \u2014 not enforced by document_api.",
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
           "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
         }
       }
@@ -1027,7 +1027,7 @@
       }
     },
     "document.context-node": {
-      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed \u2014 graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis \u2014 Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -1135,7 +1135,7 @@
         },
         "file_name": {
           "type": "string",
-          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational \u2014 sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
           "context": "direct Lambda invocation payload"
         },
         "content_hash": {
@@ -1267,7 +1267,7 @@
       }
     },
     "deploy.spec": {
-      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD \u2014 orchestrator skips CodeBuild and finalizes inline.",
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
       "fields": {
         "status": {
           "type": "enum",
@@ -1293,8 +1293,8 @@
             "standard",
             "record_only"
           ],
-          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline \u2014 used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
-          "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. As of ENC-ISS-452, the record_only check runs BEFORE the NON_UI_SERVICE_GROUP_BY_TYPE branch, so lambda_update (and other non-UI types) also take the record_only path \u2014 _finalize_record_only() is called for any deployment_type when deploy_mode='record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. As of ENC-ISS-452, the record_only check runs BEFORE the NON_UI_SERVICE_GROUP_BY_TYPE branch, so lambda_update (and other non-UI types) also take the record_only path — _finalize_record_only() is called for any deployment_type when deploy_mode='record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
         },
         "non_ui_targets": {
           "type": "object",
@@ -2114,7 +2114,7 @@
       "fields": {
         "get_compact_context": {
           "type": "tool",
-          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval \u2014 when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
           "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
         },
         "get_issue_context": {
@@ -2141,7 +2141,7 @@
         },
         "freshness": {
           "type": "behavior",
-          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 \u00a74.1). S3 cached reads reserved for future cross-platform agent support."
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
         }
       }
     },
@@ -2212,7 +2212,7 @@
         },
         "dual_append_behavior": {
           "type": "rule",
-          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort \u2014 handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
           "governing_feature": "ENC-FTR-077"
         },
         "feature_flag": {
@@ -2369,7 +2369,7 @@
       }
     },
     "checkout_service.advance_request": {
-      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance \u2014 mismatch returns 409.",
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
       "fields": {
         "target_status": {
           "type": "enum",
@@ -2395,7 +2395,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) \u2014 see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2451,7 +2451,7 @@
       }
     },
     "checkout_service.transition_type_matrix": {
-      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup \u2014 no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
       "fields": {
         "github_pr_deploy": {
           "type": "arc_spec",
@@ -2512,7 +2512,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} \u2014 GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -2554,14 +2554,14 @@
             "coding-updates",
             "closed"
           ],
-          "auth_requirement": "Cognito session cookie (enceladus_id_token) only \u2014 internal API key rejected with HTTP 403",
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
           "gate_requirements": {
             "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
             "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
           },
-          "checkout_behavior": "borrow-and-restore \u2014 tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
           "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
-          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) \u2014 NOT routed through checkout service gate matrix",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
           "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
         },
         "lambda_deploy": {
@@ -2590,7 +2590,7 @@
       }
     },
     "component_registry.component": {
-      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-J40 (PLN-060 Pile B): added a 6th field, deploy_targets, to the same capability-declaration set -- consumed by tools/assert_deploy_target_coverage.py to fail closed on blast-radius-scoped deploys when a component's declared targets are narrower than a merge's actual diff. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement \u2014 the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict \u2014 see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). Associates a system component with its required transition_type, enforced by the checkout service when tasks declare that component in task.components. ENC-TSK-E68 (ENC-PLN-031): extended with 5 capability-declaration fields (required_iam_actions, required_env_secrets, required_apigw_routes, required_cfn_resources, required_lambda_env_vars) that the continuous deploy capability auditor (ENC-TSK-E69) and pre-merge guard (ENC-TSK-E70) consume as source-of-truth to detect drift between declared and deployed state. ENC-TSK-J40 (PLN-060 Pile B): added a 6th field, deploy_targets, to the same capability-declaration set -- consumed by tools/assert_deploy_target_coverage.py to fail closed on blast-radius-scoped deploys when a component's declared targets are narrower than a merge's actual diff. ENC-TSK-F50 / ENC-ISS-270 (DOC-240A67973B13): introduced `required_transition_type` as the first-class invariant field that checkout_service reads for strictness enforcement — the legacy `transition_type` field is retained for back-compat documentation but is NOT read by the strictness path post-F50. Coordination API enforces `required_transition_type` presence at create time (Option A strict — see checkout_service.required_transition_type_enforcement entity for the 5-surface defense-in-depth contract).",
       "fields": {
         "component_id": {
           "type": "string",
@@ -2629,7 +2629,7 @@
             "code_only",
             "no_code"
           ],
-          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement \u2014 see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
+          "definition": "Legacy/documentation field describing the component's native deploy style. Post-ENC-TSK-F50, NOT read by checkout_service for strictness enforcement — see required_transition_type for the governed invariant. Still settable at create time (with Cognito / checkout-service-assistant auth for non-default values) and updatable via PATCH for documentation consistency."
         },
         "required_transition_type": {
           "type": "string",
@@ -2648,9 +2648,9 @@
             "code_only": 2,
             "no_code": 3
           },
-          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field \u2014 not the legacy transition_type \u2014 and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
-          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent \u2014 same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
-          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) \u2014 raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
+          "definition": "The least-strict task.transition_type permitted to modify this component (ENC-TSK-F50 / ENC-ISS-270). Checkout service reads THIS field — not the legacy transition_type — and raises HTTP 500 COMPONENT_MISCONFIGURED if it is missing or carries an invalid enum value. Strictness ladder: github_pr_deploy(0 strictest) < lambda_deploy(1) = web_deploy(1) < code_only(2) < no_code(3 least strict). A task.transition_type with lower or equal rank to the required_transition_type of every declared component is permitted; higher rank (less strict) is rejected.",
+          "usage_guidance": "REQUIRED at create time (POST /api/v1/coordination/components). Absent or null/empty returns HTTP 400 with field=required_transition_type (Option A strict, documented in checkout_service.required_transition_type_enforcement). PATCH may UPDATE the field to any valid enum value but MAY NOT UNSET it to null/empty/absent — same 400 rejection. PATCH that modifies required_transition_type requires Cognito session (PWA) or checkout-service-assistant key, parallel to the transition_type PATCH guard. See DOC-240A67973B13 for the per-component governance-intent review that drives the initial seed + AC-2 backfill.",
+          "enforcement_surface": "checkout_service._get_required_transition_type (backend/lambda/checkout_service/lambda_function.py) — raises ComponentMisconfiguredError on missing/invalid; _handle_checkout and _handle_advance translate the exception into the standard api.error_envelope with code=COMPONENT_MISCONFIGURED, component_id, remediation_url, and remediation_guidance."
         },
         "description": {
           "type": "string",
@@ -2693,9 +2693,9 @@
             "archived"
           ],
           "default": "proposed",
-          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a73: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum \u2014 v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
           "transition_table": {
-            "description": "Authoritative forward-transition config per DOC-546B896390EA \u00a73.2. Read at runtime by the component transition validator \u2014 no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
             "transitions": {
               "proposed": [
                 "approved",
@@ -2728,11 +2728,11 @@
             }
           },
           "hard_blocks": [
-            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA \u00a77.4, DD-3).",
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
             "archived->any: archived is a permanent terminal state. No recovery path exists."
           ],
           "authority_matrix": {
-            "description": "Per DOC-546B896390EA \u00a73.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
             "rules": {
               "proposed->approved": "io only",
               "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
@@ -2749,18 +2749,18 @@
             }
           },
           "gate_conditions": {
-            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA \u00a73.4.",
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
             "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
             "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
             "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
-            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (\u00a78)."
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
           },
-          "usage_guidance": "Authoritative spec in DOC-546B896390EA \u00a73. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value \u2014 the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
         },
         "alarm_arn": {
           "type": "string",
           "required": false,
-          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA \u00a78 and \u00a76. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
           "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
           "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
         },
@@ -2871,7 +2871,7 @@
       }
     },
     "component_registry.graph_edges": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a74: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec \u2014 DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
       "edges": {
         "DESIGNS": {
           "forward": "component -[DESIGNS]-> task",
@@ -2925,17 +2925,17 @@
           ],
           "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
           "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
-          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition \u2014 deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
           "write_action": "component.add_edge with edge_type=DEPLOYS"
         }
       },
       "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
       "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
       "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
-      "spec_source": "DOC-546B896390EA \u00a74 (edge type spec), \u00a73.4 (gate conditions), DD-7 (cardinality rationale)."
+      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
     },
     "component_registry.opacity_model": {
-      "description": "ENC-FTR-076 v2 / DOC-546B896390EA \u00a77: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces \u2014 agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
       "status_classification": {
         "OPAQUE_STATUSES": [
           "archived"
@@ -2953,7 +2953,7 @@
         ]
       },
       "read_endpoint_behavior": {
-        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path \u2014 agents must not be able to infer existence via response timing, body, or headers.",
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
         "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
         "PERMITTED": "Return full record."
       },
@@ -2966,12 +2966,12 @@
         "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
         "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
       },
-      "reverted_event_note": "reverted is NOT a member of any status set \u2014 it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
       "enforcement_surfaces": [
         "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
         "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
       ],
-      "spec_source": "DOC-546B896390EA \u00a77 (opacity model), \u00a73.1 (state inventory), DD-2 (reverted-is-event)."
+      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
     },
     "checkout_service.required_transition_type_enforcement": {
       "description": "Five-surface defense-in-depth contract for required_transition_type on component_registry.component (ENC-TSK-F50 / ENC-ISS-270). Mirrors the governance.ogtm pattern (ENC-FTR-066): every component record must carry required_transition_type, and every write path into the component registry validates its presence and type. Governance-intent source: DOC-240A67973B13 (AC-1 per-component review document).",
@@ -3107,12 +3107,12 @@
         },
         "child_source": {
           "type": "string",
-          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked \u2014 no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
           "value": "task.subtask_ids"
         },
         "not_found_behavior": {
           "type": "string",
-          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default \u2014 the parent cannot advance if we cannot verify child status.",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
           "value": "block"
         },
         "shortened_arc_handling": {
@@ -3135,7 +3135,7 @@
       "fields": {
         "endpoint": {
           "type": "string",
-          "definition": "POST /api/v1/feed/refresh \u2014 triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
         },
         "response_success": {
           "type": "object",
@@ -3431,7 +3431,7 @@
         },
         "response_envelope": {
           "type": "object",
-          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape \u2014 they do not abort the batch."
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
         }
       },
       "covered_lambdas": [
@@ -3768,7 +3768,7 @@
             "min": 0.0,
             "max": 1.0
           },
-          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted \u2014 ephemeral per-query.",
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
           "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
         },
         "structural_importance": {
@@ -3796,7 +3796,7 @@
             "opus"
           ],
           "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
-          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only \u2014 does not affect assembly behavior. Populated by context-node-sync Lambda."
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
         }
       }
     },
@@ -3809,7 +3809,7 @@
             "required": true,
             "min_length": 1
           },
-          "definition": "Concise lesson statement. Mutable \u2014 can be refined for clarity.",
+          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
           "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
         },
         "observation": {
@@ -3840,9 +3840,9 @@
             "item_format": "tracker_id",
             "append_only": true
           },
-          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only \u2014 new evidence can be added, existing entries cannot be removed.",
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
           "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
-          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature, PLN\u2192Plan, LSN\u2192Lesson, DOC\u2192Document, GEN\u2192Generation, DPL\u2192DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
         },
         "analysis_reference": {
           "type": "string",
@@ -3950,7 +3950,7 @@
           },
           "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
           "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
-          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges \u2014 because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
         },
         "governance_proposal": {
           "type": "object",
@@ -3965,7 +3965,7 @@
               "rejection_reason": "string (nullable)"
             }
           },
-          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval \u2014 no automatic approvals ever.",
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
           "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
         },
         "lesson_version": {
@@ -4228,7 +4228,7 @@
           "items": {
             "type": "string"
           },
-          "definition": "Array of record IDs (tasks, issues, features \u2014 not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
           "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
         },
         "attached_documents": {
@@ -4258,7 +4258,7 @@
         },
         "plan.add_objective": {
           "type": "execute_action",
-          "definition": "Append a single task ID to objectives_set. Idempotent \u2014 returns already_present if duplicate.",
+          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
           "arguments": {
             "record_id": "plan ID",
             "objective_task_id": "task ID to add",
@@ -4275,12 +4275,12 @@
             "objective_task_id": "task ID to remove",
             "governance_hash": "required"
           },
-          "guard_conditions": "Cannot remove closed objectives \u2014 permanent evidence of completed work.",
+          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
           "authority_envelope": "any governed session"
         },
         "plan.reorder_objectives": {
           "type": "execute_action",
-          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order \u2014 no additions or deletions).",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
           "arguments": {
             "record_id": "plan ID",
             "ordered_objective_ids": "array of all current objective IDs in new order",
@@ -4307,23 +4307,23 @@
       }
     },
     "tracker.plan.relationship_types": {
-      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix \u2192 label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
       "fields": {
         "plan-contains": {
           "type": "relationship",
-          "definition": "Plan \u2192 task/issue/feature. Indicates the target record is an objective of this plan.",
+          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
           "inverse": "contained-by-plan",
-          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK\u2192Task, ISS\u2192Issue, FTR\u2192Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
         },
         "plan-attached-doc": {
           "type": "relationship",
-          "definition": "Plan \u2192 document. Attaches a document as reference material for the plan.",
+          "definition": "Plan → document. Attaches a document as reference material for the plan.",
           "inverse": "doc-attached-to-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
         },
         "plan-implements": {
           "type": "relationship",
-          "definition": "Plan \u2192 feature. The plan is the implementation vehicle for this feature.",
+          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
           "inverse": "implemented-by-plan",
           "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
         }
@@ -4504,11 +4504,11 @@
         },
         "approve_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
         },
         "reject_route": {
           "type": "string",
-          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only \u2014 internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
         },
         "sns_notification": {
           "type": "object",
@@ -4541,7 +4541,7 @@
         },
         "race_fix_invariant": {
           "type": "string",
-          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge \u2014 it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
         },
         "orphan_purge_on_edge_removal": {
           "type": "string",
@@ -4596,7 +4596,7 @@
       }
     },
     "tracker.pathway_traversed": {
-      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection \u2014 graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation \u2014 tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability \u2014 graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
       "fields": {
         "edge_label": {
           "type": "string",
@@ -4604,11 +4604,11 @@
         },
         "relationship_type": {
           "type": "string",
-          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) \u2014 the lowercase tracker_mutation relationship_type keys."
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
         },
         "scoring_exclusion": {
           "type": "boolean",
-          "definition": "true \u2014 excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
         },
         "ogtm_compliance": {
           "type": "object",
@@ -4617,7 +4617,7 @@
       }
     },
     "graph_query_api.vector_read": {
-      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector \u2014 the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
       "fields": {
         "offset": {
           "type": "integer",
@@ -4647,7 +4647,7 @@
       }
     },
     "graph_query_api.pathway_telemetry": {
-      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response \u2014 this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
       "fields": {
         "request_params": {
           "type": "object",
@@ -4668,7 +4668,7 @@
       }
     },
     "governance.authority": {
-      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions \u2014 all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
       "fields": {
         "governed_files": {
           "type": "array",
@@ -4687,12 +4687,12 @@
         "mutation_execution_path": {
           "type": "string",
           "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
-          "value": "coordination_lead \u2192 codex_terminal_agent \u2192 s3:PutObject (io-dev-admin IAM)"
+          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
         },
         "agent_delegation_protocol": {
           "type": "string",
           "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
-          "reference": "agents.md \u00a713 Governance File Authority"
+          "reference": "agents.md §13 Governance File Authority"
         },
         "handoff_block_fields": {
           "type": "object",
@@ -4704,7 +4704,7 @@
             },
             "content_source": {
               "type": "string",
-              "definition": "Where the updated content lives \u2014 repo file path + commit SHA, or a document ID from the document store."
+              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
             },
             "s3_target": {
               "type": "string",
@@ -4731,7 +4731,7 @@
       }
     },
     "docstore.document": {
-      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
       "fields": {
         "document_maturity_state": {
           "type": "enum",
@@ -4744,7 +4744,7 @@
           "default": "raw",
           "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
           "write_authority": "Any governed session or CEE automation.",
-          "state_transitions": "raw \u2192 compliant (CEE), compliant \u2192 contextualized (HCE proposal + coordination lead), contextualized \u2192 mature (CEE graph traversal confirmation).",
+          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
           "governing_feature": "ENC-FTR-065"
         },
         "compliance_score": {
@@ -4778,7 +4778,7 @@
       }
     },
     "document.graph_edges": {
-      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe \u2192 GraphSyncQueue \u2192 graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
       "fields": {
         "BELONGS_TO": {
           "type": "edge",
@@ -4916,7 +4916,7 @@
       }
     },
     "tracker.stack_generation": {
-      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 \u00a74.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
       "fields": {
         "status": {
           "type": "enum",
@@ -4965,7 +4965,7 @@
         },
         "title": {
           "type": "string",
-          "definition": "Human-readable generation title (e.g. 'v3 \u2014 Production Generation')."
+          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
         },
         "production_stack": {
           "type": "string",
@@ -4986,7 +4986,7 @@
       }
     },
     "tracker.deployment_decision": {
-      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 \u00a74.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
       "fields": {
         "status": {
           "type": "enum",
@@ -5081,7 +5081,7 @@
       }
     },
     "gmf.graph_edges": {
-      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 \u00a78.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
       "fields": {
         "SUCCEEDS": {
           "type": "edge",
@@ -5118,7 +5118,7 @@
       }
     },
     "docstore.evolution_chapter": {
-      "description": "Evolution chapter document subtype (DOC-63420302EF65 \u00a74.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
       "fields": {
         "document_subtype": {
           "type": "enum",
@@ -5185,12 +5185,12 @@
       }
     },
     "retrieval.hybrid_pipeline": {
-      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match \u2014 fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword title/intent/description match — fused via Reciprocal Rank Fusion (k=60). Implemented as a new `hybrid` search_type in backend/lambda/graph_query_api/lambda_function.py and surfaced through the MCP server's get_compact_context tool. Backward-compatible: when target nodes lack embeddings the vector signal is empty and RRF degrades to graph + keyword only; when GDS is not installed on AuraDB the graph signal degrades to a per-relationship-type weighted edge-walk in native Cypher.",
       "fields": {
         "rrf_k": {
           "type": "integer",
-          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based \u2014 signals do not need score normalization.",
-          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner \u2014 k=60 was selected as the Phase 1 retrieval contract baseline."
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
         },
         "signals": {
           "type": "array",
@@ -5200,28 +5200,28 @@
         "graph_edge_weights": {
           "type": "object",
           "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
-          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics \u2014 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
         },
         "fallback_modes": {
           "type": "object",
-          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None \u2014 RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
         },
         "fsrs_t3_threshold": {
           "type": "number",
           "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
-          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected \u2014 T3 only filters retrieval surfaces."
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
         },
         "gds_availability_probe": {
           "type": "object",
-          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation \u2014 see aga_sessions_contract for the second-order requirement."
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
         },
         "aga_sessions_contract": {
           "type": "object",
-          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) \u2014 the Sessions-based GDS compute plane \u2014 not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties \u2014 so nodeId\u2192record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
         },
         "bolt_pool_resilience": {
           "type": "object",
-          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention \u2014 AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s\u2192180s in deploy.sh and CFN baseline 10s\u2192180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B \u00a7'The Method Being Called'). Cypher fallback remains a real runtime, not an error path \u2014 any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
         },
         "iam_contract": {
           "type": "array",
@@ -5303,7 +5303,7 @@
       }
     },
     "deploy.parity_validator": {
-      "description": "ENC-FTR-091 / ENC-TSK-F87 \u2014 v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
       "fields": {
         "function_name": {
           "type": "string",
@@ -5316,12 +5316,12 @@
         "detection_rules": {
           "type": "array",
           "item_type": "string",
-          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent \u2014 autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent \u2014 autonomous fix. ISS-279: enceladus-mcp-code-gamma missing \u2014 flag only. ISS-296: function_name_map gaps \u2014 flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas \u2014 flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api \u2014 flag only."
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
         },
         "iam_contract": {
           "type": "array",
           "item_type": "string",
-          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead \u2014 read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
         },
         "readiness_doc": {
           "type": "object",
@@ -5330,7 +5330,7 @@
       }
     },
     "auth.github_installation_token": {
-      "description": "Response contract for GET /api/v1/auth/github-token \u2014 vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
       "fields": {
         "token": {
           "type": "string",
@@ -5351,7 +5351,7 @@
         },
         "env_fallback": {
           "type": "string",
-          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) \u2192 True, anything else \u2192 False."
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
         },
         "default": {
           "type": "boolean",
@@ -5364,12 +5364,12 @@
             "env_fallback",
             "default"
           ],
-          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly \u2014 always call flag()."
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
         }
       }
     },
     "monitoring.continuous_drift_audit": {
-      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 \u2014 Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
       "fields": {
         "trigger": {
           "type": "string",
@@ -5390,12 +5390,12 @@
         },
         "alert_channel": {
           "type": "string",
-          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) \u2014 <ISO timestamp>."
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
         }
       }
     },
     "monitoring.mentions_drift_audit": {
-      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 \u2014 Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
       "governing_feature": "ENC-FTR-098",
       "governing_task": "ENC-TSK-G43",
       "fields": {
@@ -5421,7 +5421,7 @@
         },
         "iam_scope": {
           "type": "string",
-          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design \u2014 ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
         }
       }
     },
@@ -5572,7 +5572,7 @@
         },
         "agent_type_id": {
           "type": "string",
-          "definition": "Foreign key to coordination.agent_type (ENC-AGT-NNN) \u2014 the agent type this session is typed as."
+          "definition": "Foreign key to coordination.agent_type (ENC-AGT-NNN) — the agent type this session is typed as."
         },
         "parent_session_id": {
           "type": "string",
@@ -5642,15 +5642,15 @@
           "enum": [
             "governance-version-current"
           ],
-          "usage_guidance": "Partition key. Always 'governance-version-current' \u2014 single-item canonical record."
+          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
         },
         "governance_revision": {
           "type": "string",
-          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md \u00a713."
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
         },
         "governance_hash": {
           "type": "string",
-          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per \u00a74.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
         },
         "generation": {
           "type": "integer",
@@ -5675,7 +5675,7 @@
       }
     },
     "recompute_governance.event_handler": {
-      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes \u00a74.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
       "fields": {
         "trigger": {
           "type": "object",
@@ -5695,7 +5695,7 @@
         },
         "recursion_invariant": {
           "type": "object",
-          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject \u2014 prevents ObjectCreated loops."
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
         },
         "env_vars": {
           "type": "object",
@@ -5793,7 +5793,7 @@
       }
     },
     "coordination.agent_session_idle_sweep": {
-      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8. Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose last lifecycle transition (claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent \u2014 already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge.",
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8. Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose last lifecycle transition (claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent — already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge.",
       "fields": {
         "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
           "type": "boolean",
@@ -5809,7 +5809,7 @@
         },
         "summary": {
           "type": "object",
-          "definition": "Return value (CloudWatch only \u2014 no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
+          "definition": "Return value (CloudWatch only — no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped}."
         }
       }
     },
@@ -5924,7 +5924,7 @@
       }
     },
     "tracker.escalation": {
-      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations \u2014 Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations — Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
       "fields": {
         "escalation_id": {
           "type": "string",
@@ -5954,8 +5954,8 @@
             "required": true,
             "immutable": true
           },
-          "definition": "Registry-resolved mutation handler key (\u00a75.3 of DOC-5B888FCA43B8).",
-          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT \u2014 the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+          "definition": "Registry-resolved mutation handler key (§5.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT — the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
         },
         "payload": {
           "type": "object",
@@ -6000,13 +6000,13 @@
             "applied",
             "failed"
           ],
-          "definition": "Escalation FSM state (\u00a75.2). Enforced normally \u2014 escalations are not escalatable.",
-          "usage_guidance": "requested\u2192{approved, denied, denied_with_guidance}; approved\u2192applying; applying\u2192{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+          "definition": "Escalation FSM state (§5.2). Enforced normally — escalations are not escalatable.",
+          "usage_guidance": "requested→{approved, denied, denied_with_guidance}; approved→applying; applying→{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
         },
         "events": {
           "type": "array",
           "item_type": "object",
-          "definition": "Append-only event log (\u00a711.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "definition": "Append-only event log (§11.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
           "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
         },
         "guidance_note": {
@@ -6031,7 +6031,7 @@
             "required": false
           },
           "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
-          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (\u00a75.5)."
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (§5.5)."
         },
         "result": {
           "type": "object",
@@ -6069,7 +6069,7 @@
       "dynamodb_key_schema": {
         "pk": "project_id",
         "sk_pattern": "escalation#{escalation_id}",
-        "table": "existing tracker table (deliberate Channel B decision \u2014 no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "table": "existing tracker table (deliberate Channel B decision — no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
         "record_id_format": "{PREFIX}-ESC-{SEQ}",
         "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
       },
@@ -6077,8 +6077,8 @@
         "escalation_id": "IMMUTABLE (server-minted)",
         "target_record_id": "IMMUTABLE after create",
         "mutation_type": "IMMUTABLE after create",
-        "payload": "IMMUTABLE after create \u2014 the cached mutation is what io approves; the agent never resubmits after approval",
-        "status": "Escalation FSM transitions only (\u00a75.2); enforced normally with no bypass",
+        "payload": "IMMUTABLE after create — the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (§5.2); enforced normally with no bypass",
         "events": "APPEND_ONLY (list_append only)",
         "approved_by": "Written only by the Cognito human approval route",
         "applied_at": "Written exactly once by applyEscalatedMutation"
@@ -6118,11 +6118,11 @@
       }
     },
     "mcp_server.escalation_actions": {
-      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action \u2014 override authorization exists only behind the Cognito human path (\u00a76 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action — override authorization exists only behind the Cognito human path (§6 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
       "fields": {
         "escalation.request": {
           "type": "execute_action",
-          "definition": "Propose a human-gated mutation override. Envelope (\u00a711.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+          "definition": "Propose a human-gated mutation override. Envelope (§11.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
         },
         "escalation.get": {
           "type": "search_action",
@@ -6408,6 +6408,887 @@
         "definition": "DVP-TSK-696, the NINTH check, added because DVP-TSK-641 named this task as its enforcement point and recorded why it must be SCHEDULED rather than PR-triggered. The 2026-08-06 severance arrived through `aws iam create-policy-version` at 06:26:01Z plus a hand edit of .env at 06:35:13Z; no PR-triggered guard can observe either, and the deploy path /opt/analytics/analytics-dashboard-6x is not a git checkout, so there is no pull request in that path at all -- a PR-shaped control would pass green through exactly the event it exists to catch. Compares the DECLARED dependency surface against live IAM and instance metadata: IAM_ROLE_NAME analytics-dashboard-ec2-role, IAM_POLICY_NAME analytics-dashboard-data-access, DECLARED_POLICY_VERSION v11 as of DECLARED_POLICY_UPDATED_AT 2026-08-06T06:26:01Z. Expected values come from DOC-132286FF074F section 7 because the component-registry fields the existing auditors read are present on ZERO of 89 rows and have no agent-accessible write path. Every action the check holds is a Get/List: the drift detector has no power to correct the drift it finds, which is deliberate -- the answer to an unreviewed write is not a second one."
       },
       "change_governance": "Adding, removing or re-thresholding a check is a governed change to this entity, not an incidental edit: the declared SLAs, sharding constants and severity mappings in health_contract.py are the contract the monitor enforces, and a threshold quietly relaxed is indistinguishable at the surface from an estate that got healthier."
+    },
+    "checkout_service.sci_enforcement_gate": {
+      "description": "ENC-ISS-441 / ENC-TSK-J93 (ENC-FTR-122): server-side Session Claim ID enforcement in the checkout service. checkout.task (_handle_checkout), checkout.advance (_handle_advance) and /log (_handle_log) gate BEFORE any state mutation whenever the presented acting identity matches ^ENC-SES-[0-9A-Z]+$: the request's 'sci' field must resolve to a checkout-tokens item with token_type=SCI, revoked=false, ttl > now (enforced independently of DynamoDB native TTL deletion lag), and session_id equal to the presented identity. Rejections are HTTP 403 code=SCI_REQUIRED with sci_failure_mode in {missing_sci, unknown_sci, wrong_token_type, revoked_sci, expired_sci, session_mismatch, unknown_session} and remediation pointing to coordination agent.claim (register->claim handshake, ENC-FTR-117). A fabricated/unregistered ENC-SES id fails CLOSED (unknown_session). GRANDFATHERING: sessions with created_at earlier than SCI_ENFORCEMENT_EPOCH (module constant 2026-07-02T12:00:00Z, deliberately NOT an env var per the PLN-047/ENC-LSN-053 strip class) pass without an SCI. EXEMPT by identity shape: providers not matching ENC-SES-* (Cognito PWA subs/user_initiated flows, 'github', 'system:arc-walker', internal service identities) are untouched. Every SCI-validated pass refreshes the session's last_activity_at (J83 conditional touch; live sessions only; never fails the mutation). This closes the ENC-ISS-441 vulnerability: the register->claim handshake is now enforced, not advisory.",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Request-body field on checkout/advance/log calls. The SCI-{uuid4_hex} issued by coordination agent.claim. Required for post-epoch ENC-SES sessions; ignored for exempt identities."
+        },
+        "SCI_ENFORCEMENT_EPOCH": {
+          "type": "string",
+          "definition": "Module constant '2026-07-02T12:00:00Z' in both checkout_service and tracker_mutation. Sessions created before it are grandfathered. Lives in code, not env (LSN-053 avoidance)."
+        },
+        "sci_failure_mode": {
+          "type": "string",
+          "definition": "403 detail naming the failure: missing_sci | unknown_sci | wrong_token_type | revoked_sci | expired_sci | session_mismatch | unknown_session."
+        }
+      }
+    },
+    "coordination.agent_credential": {
+      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-credential lifecycle store (DynamoDB table agent-credentials${EnvironmentSuffix}, PK credential_id). A credential is the durable, revocable link between an agent identity (ENC-AGT-NNN) and the M2M auth material minted for it (ENC-FTR-074 Ph1/Ph2 dual-client Cognito). Server-only minting (agent_id_alloc.mint_credential_id, uuid4-based, forbidden-field guarded per ENC-TSK-B99). Lifecycle issue -> rotate -> revoke via conditional DynamoDB writes; revoke cascades DynamoDB-side (retire bound sessions via retire_session; recursively revoke rotation descendants by rotated_from). HTTP surface: POST /api/v1/coordination/agents/credentials (issue), POST .../credentials/{id}/rotate, POST .../credentials/{id}/revoke. Streamed to graph_sync for :AgentCredential nodes + OWNED_BY / DERIVED_FROM edges (see graph_sync.agent_identity_edges).",
+      "fields": {
+        "credential_id": {
+          "type": "string",
+          "definition": "Partition key. Format CRED-<uuid4 hex, 32 chars>. Minted server-side; callers may never supply it."
+        },
+        "agent_identity_id": {
+          "type": "string",
+          "definition": "The owning agent identity (ENC-AGT-NNN). Drives the graph OWNED_BY edge. Required; validated to have the ENC-AGT prefix at issue time."
+        },
+        "issued_at": {
+          "type": "string",
+          "definition": "ISO-8601 Z timestamp (serialization._now_z) of issuance."
+        },
+        "status": {
+          "type": "string",
+          "definition": "Lifecycle status. One of: active, revoked. Terminal at revoked."
+        },
+        "revoked_at": {
+          "type": "string",
+          "definition": "ISO-8601 Z timestamp of revocation; empty string while active."
+        },
+        "revoked_reason": {
+          "type": "string",
+          "definition": "Free-text revoke reason. 'rotated' when revoked by rotate_credential; 'cascade:<root_credential_id>' when revoked by a parent's revoke cascade; caller-supplied otherwise. Empty while active."
+        },
+        "rotated_from": {
+          "type": "string",
+          "definition": "Nullable parent credential_id establishing rotation lineage. Set on the successor issued by rotate_credential. Drives the graph DERIVED_FROM edge (child -> parent). Empty string for a root (non-rotated) credential."
+        }
+      },
+      "related_session_field": {
+        "type": "string",
+        "definition": "agent-sessions rows may carry an OPTIONAL credential_id binding the session to the credential it authenticated with (written only when provided by mint_session_id, preserving the frozen SESSION_NODE_PROPERTIES value-identity shape for the credential-less path). revoke_credential's cascade reaps live sessions whose credential_id matches."
+      }
+    },
+    "coordination.agent_session_unclaim_sweep": {
+      "description": "ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep - retirement lifecycle part 1 from the io design decision on ENC-ISS-441. The AgentSessionUnclaimSweepSchedule EventBridge rule (02-compute.yaml, rate(10 minutes)) invokes coordination_api with Input {\"action\":\"agent_session_unclaim_sweep\"}; lambda_handler dispatches to _handle_agent_session_unclaim_sweep -> agent_id_alloc.sweep_unclaimed_sessions. Sessions in status=allocated (registered via agent.register but never claimed) whose created_at is older than AGENT_SESSIONS_UNCLAIM_TTL_MINUTES are flipped to 'retired' via the same append-only conditional UpdateItem as agent.retire, and any bound SCI is revoked (revocation_reason=unclaim_ttl_exceeded; defense-in-depth - allocated sessions normally have no SCI since SCIs mint at claim). Reference timestamp is strictly created_at. Idempotent; dry_run-capable; master-flag guarded. Closes the ghost-registration gap (10 of 24 prod sessions were unclaimed, the ENC-ISS-441 evidence).",
+      "fields": {
+        "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits."
+        },
+        "AGENT_SESSIONS_UNCLAIM_TTL_MINUTES": {
+          "type": "integer",
+          "definition": "Env var (config.py), default 10. An allocated session whose created_at is older than this is a ghost registration and is reaped."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator, fixed 'agent_session_unclaim_sweep'. Optional unclaim_ttl_minutes and dry_run keys override defaults per-invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only): {enabled, dry_run, unclaim_ttl_minutes, cutoff, scanned_allocated, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis}."
+        }
+      }
+    },
+    "coordination.lesson_candidates": {
+      "description": "ENC-TSK-J46 / ENC-FTR-096 Ph2: coordination_api HTTP surface that promotes or rejects a pending lesson-candidate document. Approve creates a governed ENC-LSN record via the same validation as tracker.create_lesson (observation/insight/evidence_chain/provenance/pillar_scores), stamping the candidate's document_id into evidence_chain (LEARNED_FROM provenance at graph_sync), then marks the candidate handoff_status='approved'. Reject marks handoff_status='stale' with an appended rejection note -- the candidate document is never deleted (append-only discipline).",
+      "fields": {
+        "route": {
+          "type": "string",
+          "enum": [
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/approve",
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/reject"
+          ],
+          "definition": "Both routes require a Cognito-authenticated session (_is_cognito_session); an internal-key (agent) session receives 403. Gamma-only (Condition: IsGamma in 03-api.yaml) per DOC-499FA089EC30 -- v3-prod is frozen pending the io-gated cutover."
+        },
+        "approve.body.observation": {
+          "type": "string",
+          "required": true,
+          "definition": "What was observed in the candidate data. Required on the created lesson (ENC-FTR-052); immutable after creation."
+        },
+        "approve.body.insight": {
+          "type": "string",
+          "required": true,
+          "definition": "What was learned from the observation. Required on the created lesson."
+        },
+        "approve.body.pillar_scores": {
+          "type": "object",
+          "required": true,
+          "definition": "efficiency, human_protection, intention, alignment, each a number in [0.0, 1.0] (ENC-FTR-054). Validated identically to tracker_mutation's create-lesson check."
+        },
+        "approve.body.evidence_chain": {
+          "type": "array",
+          "required": false,
+          "definition": "Optional additional evidence record IDs. The candidate document_id is always prepended automatically -- this is what stamps LEARNED_FROM provenance back to the candidate."
+        },
+        "reject.body.rejection_reason": {
+          "type": "string",
+          "required": true,
+          "constraints": {
+            "min_length": 10
+          },
+          "definition": "Human-readable reason appended (append-only) to the candidate document content when marking it stale."
+        },
+        "decision_write_mechanism": {
+          "type": "string",
+          "definition": "Approve/reject finalize the candidate's handoff_status via a direct DynamoDB UpdateItem against the documents table (DocumentsTableCandidateDecisionWrite IAM statement, 02-compute.yaml), atomically conditioned on document_subtype='lesson-candidate' AND handoff_status='pending', and append a structured {status,note,by,at} entry to decision_log via list_append. This is NOT proxied through document_api's PATCH: that endpoint authenticates internal-key callers identically whether the caller is coordination_api (already Cognito-verified at its own HTTP layer) or the MCP server relaying a bare agent session's documents.patch call -- routing through it would silently readmit the exact autonomous-promotion path AC4 forbids. A ConditionalCheckFailedException (candidate already decided by a concurrent request) surfaces as HTTP 409. ENC-TSK-J59: pillar_scores and confidence are converted to Decimal (via Decimal(str(v)) to avoid binary-float precision drift) before the lesson record's put_item -- boto3's TypeSerializer raises TypeError on native float Number values."
+        }
+      }
+    },
+    "coordination_api.anthropic_batch": {
+      "description": "Anthropic Message Batches API routing for non-interactive workloads (ENC-TSK-G19 / FTR-099 Strategy #8). Submits via POST /v1/messages/batches when provider_preferences.batch_eligible=true; EventBridge poller (rate 1 minute, 60s min interval) finalizes via batch-results callback.",
+      "fields": {
+        "batch_eligible": {
+          "type": "boolean",
+          "definition": "Provider preference signaling deferred batch execution (50% Anthropic batch pricing). Incompatible with execution_mode=preflight.",
+          "usage_guidance": "Set in provider_preferences on coordination request intake or dispatch body. Routes claude_agent_sdk dispatches through _dispatch_claude_batch_api instead of synchronous Messages API."
+        },
+        "batch_workload_type": {
+          "type": "enum",
+          "enum": [
+            "nightly_changelog_generation",
+            "governance_audit_doc_patching",
+            "compliance_doc_creation",
+            "memory_consolidation_bulk"
+          ],
+          "definition": "Optional workload classifier for telemetry and cost attribution. See NON_INTERACTIVE_WORKLOADS in anthropic_batch.py."
+        },
+        "ephemeral_1h_cache": {
+          "type": "object",
+          "definition": "cache_control {type: ephemeral, ttl: 1h} on system prompt and mcp_toolset prefix blocks in batch params.",
+          "usage_guidance": "Stacks with batch 50% discount for ~95% effective cost on recurring static-prefix workloads (NIGHTLY_CHANGELOG_COST_COMPARISON in anthropic_batch.py)."
+        },
+        "poll_interval_seconds": {
+          "type": "integer",
+          "definition": "Minimum 60 seconds between Anthropic batch status polls per request (BATCH_POLL_INTERVAL_SECONDS)."
+        },
+        "batch_subrequest_failure_alert": {
+          "type": "observability",
+          "definition": "Structured CloudWatch event batch_subrequest_failure with alert=true emitted for each errored batch result line."
+        }
+      }
+    },
+    "coordination_api.bhc_alert": {
+      "description": "See source task.",
+      "source": "ENC-TSK",
+      "telemetry_eligible": false
+    },
+    "coordination_api.governance_hash_resolution": {
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "fields": {
+        "primary_source": {
+          "type": "object",
+          "definition": "dynamodb.get_item on GOVERNANCE_VERSION_TABLE (governance-version or governance-version-gamma). ConsistentRead=True. Returns governance_hash string from the governance-version-current record. Raises RuntimeError when record is missing or governance_hash attribute is empty."
+        },
+        "secondary_source": {
+          "type": "object",
+          "definition": "MCP server module _compute_governance_hash(force_refresh=True). Reads directly from S3 governance/live/ prefix. Only invoked when primary_source raises."
+        },
+        "removed_fallback": {
+          "type": "object",
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma (injected via CFN 02-compute.yaml EnvironmentSuffix sub). GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
+        }
+      }
+    },
+    "coordination_api.intent_training": {
+      "description": "ENC-FTR-084 Ph2 / ENC-TSK-K02: scheduled intent-classifier training loop in coordination_api. EventBridge IntentClassifierTrainingSchedule (gamma, cron Sunday 04:00 UTC) invokes lambda_handler with {\"action\":\"intent_classifier_training\"}; rollback via {\"action\":\"intent_classifier_training_rollback\",\"version_id\"?}. Per-invocation only (no always-on compute). Mutates versioned per-record score boosts stored on S3 under INTENT_TRAINING_PREFIX (default gamma/intent-training): labels at labels/session_outcomes.jsonl (NDJSON of {first_turn_text, label_node_ids, embedding?}), active pointer at weights/active.json, immutable snapshots at weights/versions/{version_id}.json with previous_version_id chain for one-call rollback. Inference reads boosts via intent_training.load_inference_record_boosts() inside classify_session_intent (intent_classifier applies multiplicative boosts to neighbor scores). TRAINING_HARD_DISABLED=1 (default, ISS-465 pattern) hard-stops training AND suppresses boost reads at inference; io clears to 0 to enable. Holdout validation (20% split): >10% accuracy degradation vs baseline auto-sets training_disabled on the active snapshot. COST-PREFLIGHT: projected ~$0.04/month; IntentTrainingCostHeadroomAlarm fires if EventBridge invocations exceed 6/30d.",
+      "fields": {
+        "eventbridge_actions": {
+          "type": "object",
+          "definition": "intent_classifier_training (weekly train), intent_classifier_training_rollback (repoint active.json to previous or explicit version_id)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "TRAINING_HARD_DISABLED (default 1), INTENT_TRAINING_BUCKET, INTENT_TRAINING_PREFIX, TRAINING_LEARNING_RATE (0.05), TRAINING_BOOST_MIN (0.5), TRAINING_BOOST_MAX (2.0), TRAINING_DEGRADATION_THRESHOLD (0.10)."
+        },
+        "rollback": {
+          "type": "object",
+          "definition": "Invoke coordination_api with {\"action\":\"intent_classifier_training_rollback\"} to roll back to previous_version_id, or pass version_id to pin a specific snapshot."
+        }
+      }
+    },
+    "coordination_api.session_init_intent_classifier": {
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "fields": {
+        "routes": {
+          "type": "object",
+          "definition": "POST /api/v1/coordination/session-init/classify-intent -> _handle_session_init_classify_intent(event, claims). POST /api/v1/coordination/session-init/intent-centroid-drift -> _handle_session_init_intent_drift(event, claims). Both registered before the 404 fallback in lambda_handler; auth via the standard coordination auth gate (Cognito or X-Coordination-Internal-Key)."
+        },
+        "mcp_actions": {
+          "type": "object",
+          "definition": "coordination(action='session.classify_intent') -> raw tool coordination_classify_intent; coordination(action='session.intent_centroid_drift') -> raw tool coordination_intent_centroid_drift. Both proxy to the coordination API HTTP routes via _coordination_api_request."
+        },
+        "classify_intent_request": {
+          "type": "object",
+          "definition": "{first_turn_text:str (required; request_text accepted as alias), session_metadata:object?, applied_entelechy_override:list[str]|str|{node_ids:[...]}?, top_k:int? (default 5, max 25), project_id:str? (default 'enceladus')}."
+        },
+        "classify_intent_response": {
+          "type": "object",
+          "definition": "{success:true, predicted_entelechy:{node_ids:list[str], confidence:float in [0,1]}, applied_entelechy:{node_ids:list[str], confidence:float, source:'classifier'|'io_override'}, override_applied:bool, neighbors:list[{record_id,score}], query_embedding_dim:int, model_id:str, inference_only:true, ...}. predicted_entelechy always carries the classifier's own prediction even when overridden (it is logged)."
+        },
+        "intent_centroid_drift_contract": {
+          "type": "object",
+          "definition": "Request {wave_id:str (required), embeddings:list[list[float]] (FTR-089 embeddings for dispatched records; dispatched_record_embeddings accepted as alias), previous_centroid:list[float]?, persist:bool? (default true), project_id:str?}. Response {success:true, wave_id, intent_centroid_dim:int, intent_centroid_drift:float|null, record_count:int, persistence:{persisted:bool, ...}}."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GRAPH_QUERY_API_URL (default empty -> classifier degrades to no neighbors). DRIFT_TELEMETRY_TABLE (default empty -> intent_centroid_drift persistence is a graceful no-op; the table is owned by FTR-087). BEDROCK_REGION (default us-west-2) for the Titan V2 embed; requires bedrock:InvokeModel on amazon.titan-embed-text-v2:0 on the coordination_api role for live (gamma) predictions."
+        }
+      }
+    },
+    "corpus.edge_taxonomy": {
+      "description": "Governed typed-edge taxonomy for the io-graph corpus (project_id=intelligence), DOC-4DD9C4E8B66C section 7.2. Fourteen artifact-to-artifact relationship types across five families, written via corpus.edges.put/put_batch and projected to FalkorDB by graph_sync. DOCUMENTATION ONLY: this entry records the governed vocabulary, it is NOT read at runtime. The enforcing allowlists are hardcoded literals in three Lambdas and adding a type requires a code change plus deploy.",
+      "fields": {
+        "families": {
+          "type": "object",
+          "definition": "The fourteen types grouped by family.",
+          "structural": [
+            "PARTICIPANT",
+            "DERIVED_FROM",
+            "VARIANT_OF"
+          ],
+          "evidentiary": [
+            "EVIDENCES",
+            "MENTIONS",
+            "CONTRADICTS",
+            "SUPERSEDES"
+          ],
+          "topical": [
+            "INSTANTIATES",
+            "RESONATES_WITH"
+          ],
+          "temporal": [
+            "PRECEDES",
+            "CO_OCCURS",
+            "RECURS_WITH"
+          ],
+          "social": [
+            "REGISTER",
+            "ADDRESSED_TO"
+          ]
+        },
+        "enforcing_allowlists": {
+          "type": "array",
+          "definition": "The three code allowlists that actually gate the taxonomy. Invariant G2 requires all three to agree; backend/lambda/graph_sync/test_edge_taxonomy.py asserts the set difference is empty. A type registered in only some of them fails SILENTLY, because _merge_typed_edge drops unknown types after the write has already landed in DynamoDB.",
+          "items": [
+            {
+              "lambda": "graph_sync",
+              "symbol": "ALLOWED_EDGE_TYPES",
+              "gates": "projection to FalkorDB"
+            },
+            {
+              "lambda": "graph_query_api",
+              "symbol": "_ALLOWED_EDGE_TYPES",
+              "gates": "traversal via edge_types filter"
+            },
+            {
+              "lambda": "graph_health_metrics",
+              "symbol": "ALLOWED_EDGE_TYPES",
+              "gates": "per-edge-type CloudWatch metrics"
+            }
+          ]
+        },
+        "legacy_types": {
+          "type": "array",
+          "definition": "Pre-taxonomy generic relations retained so already-projected edges keep resolving. NOT part of the governed taxonomy and NOT writable via corpus.edges.",
+          "items": [
+            "RELATED_TO",
+            "INSPIRED_BY",
+            "BUILDS_ON"
+          ]
+        },
+        "write_invariants": {
+          "type": "object",
+          "definition": "Enforced at write time by corpus.edges.put, each with a distinct error code.",
+          "g2_type_validity": "edge_type must be one of the fourteen. This is the ONLY barrier between caller input and Cypher string construction, because Cypher cannot parameterize a relationship type — _merge_typed_edge interpolates it. Re-checked at projection time.",
+          "g3_referential_integrity": "both endpoints must resolve to live, non-placeholder artifacts. Placeholder-resolving endpoints are rejected as a distinct case: that is the INT-ISS-027 failure mode, where edges projected successfully and were invisible to every traversal.",
+          "g4_provenance": "confidence and derivation_method are required — an explicit epistemic commitment per DOC-4DD9C4E8B66C section 5.1."
+        },
+        "runtime_effect": {
+          "type": "string",
+          "value": "none",
+          "definition": "No Lambda reads this entity. Verified 2026-08-08: zero governance-dictionary references in graph_sync, graph_query_api or graph_health_metrics. Registering a type here does not make it writable, projectable or traversable."
+        },
+        "governing_documents": {
+          "type": "array",
+          "items": [
+            "DOC-4DD9C4E8B66C section 7.2",
+            "INT-TSK-192"
+          ]
+        }
+      }
+    },
+    "document.lesson-candidate": {
+      "description": "Lesson-candidate document subtype (ENC-FTR-096). Drafted directly to DynamoDB by the memory_consolidation Lambda (ENC-TSK-I84) from recurring co-citation clusters -- NOT created via document_api PUT, so it is absent from the document_subtype allow-list enforced there. Curated (approved/rejected) via ENC-TSK-J46: coordination_api POST /api/v1/coordination/lesson-candidates/{documentId}/approve|reject, both Cognito-gated.",
+      "fields": {
+        "document_subtype": {
+          "type": "string",
+          "literal_value": "lesson-candidate",
+          "definition": "Fixed subtype value for candidate documents. Written directly by memory_consolidation Lambda; document_api's PUT/PATCH document_subtype allow-list does not include it (candidates are never created or re-subtyped through that surface)."
+        },
+        "handoff_status": {
+          "type": "enum",
+          "enum": [
+            "pending",
+            "approved",
+            "stale"
+          ],
+          "transitions": {
+            "pending": [
+              "approved",
+              "stale"
+            ],
+            "approved": [],
+            "stale": []
+          },
+          "definition": "Curation-state field, reusing the handoff_status attribute name (document_api CANDIDATE_STATUSES / CANDIDATE_STATUS_TRANSITIONS, ENC-TSK-J46). 'approved' is only a legal value for lesson-candidate documents -- handoff documents keep their own {pending,claimed,completed,stale} vocabulary.",
+          "write_authority": "document_api Lambda PATCH. Transitions to 'approved' or 'stale' require a Cognito-authenticated session (document_api._is_cognito_session); an internal-key (agent) session is rejected with 403. This is the enforced io-gate: no agent session can promote or reject a lesson candidate autonomously.",
+          "usage_guidance": "List pending candidates via documents.list(document_subtype='lesson-candidate', handoff_status='pending', sort='created_at'). Approve/reject through coordination_api's lesson-candidates routes (see coordination.lesson_candidates), not a raw PATCH -- approval also creates the governed ENC-LSN record."
+        },
+        "related_items": {
+          "type": "array",
+          "definition": "Source Handoff document IDs the candidate's co-citation cluster was drawn from (ENC-TSK-I84 AC-3)."
+        },
+        "cluster_member_ids": {
+          "type": "array",
+          "definition": "Tracker record IDs that recur together as the co-citation cluster underlying this candidate."
+        },
+        "frequency_count": {
+          "type": "number",
+          "definition": "Count of distinct Handoff documents in which the cluster co-cited within the lookback window."
+        }
+      }
+    },
+    "governance_drift_check.handler": {
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "fields": {
+        "drift_metric": {
+          "type": "object",
+          "definition": "CloudWatch metric GovernanceVersionDrift in namespace Enceladus/Governance. 1.0 = drift detected or recompute failed; 0.0 = canonical record agrees with live S3. CloudWatch alarm fires on 1.0. DRIFT_METRIC_NAMESPACE env var (default: Enceladus/Governance)."
+        },
+        "sns_alert": {
+          "type": "object",
+          "definition": "SNS notification (GOVERNANCE_ALERT_SNS_ARN env var) published when drift is detected, recompute fails, or the canonical record is missing. Same topic as governance_audit anomaly alerts."
+        },
+        "read_only_invariant": {
+          "type": "object",
+          "definition": "This Lambda NEVER writes the canonical governance-version record (sole-writer = devops-recompute-governance, I28) and never writes to governance/live/* (recursion safety). It is a read-only auditor."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE (default: governance-version), GOVERNANCE_S3_BUCKET (default: jreese-net), DRIFT_METRIC_NAMESPACE (default: Enceladus/Governance), GOVERNANCE_ALERT_SNS_ARN."
+        }
+      }
+    },
+    "graph_query_api.adjacency": {
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required graph project scope (e.g. 'enceladus'). Only nodes/edges with this project_id are returned."
+        },
+        "search_type": {
+          "type": "string",
+          "definition": "Must be 'adjacency' to select this handler.",
+          "constraints": {
+            "enum": [
+              "adjacency"
+            ]
+          }
+        },
+        "offset": {
+          "type": "integer",
+          "definition": "Pagination cursor (edge rows to SKIP). Default 0.",
+          "constraints": {
+            "min": 0,
+            "default": 0
+          }
+        },
+        "limit": {
+          "type": "integer",
+          "definition": "Edge-page size. Default 5000; clamped server-side to [1, 20000].",
+          "constraints": {
+            "min": 1,
+            "max": 20000,
+            "default": 5000
+          }
+        },
+        "node_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only): total governed nodes in scope (N), including isolated ones. Used as the denominator for LCC ratios and degree means."
+        },
+        "edge_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only): total deduplicated undirected simple-graph edges (M)."
+        },
+        "edges": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Page of undirected edges as {s, t} record_id pairs (s < t)."
+        },
+        "has_more": {
+          "type": "boolean",
+          "definition": "Response field: true when more edge pages remain (returned == limit)."
+        },
+        "next_offset": {
+          "type": "integer",
+          "definition": "Response field: offset to pass on the next call when has_more is true; null otherwise."
+        },
+        "flow_weight_entropy": {
+          "type": "number",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03 / ENC-FTR-108 AC-5): normalized Shannon entropy [0,1] over the live flow_weight distribution across all project relationships. Null when enrichment fails or graph_query_api predates J03."
+        },
+        "flow_weight_edge_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03): count of relationships sampled for flow_weight_entropy. Companion to flow_weight_entropy."
+        }
+      }
+    },
+    "graph_query_api.drift_telemetry": {
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "fields": {
+        "table": {
+          "type": "string",
+          "definition": "enceladus-drift-telemetry${EnvironmentSuffix} (01-data.yaml DriftTelemetryTable). PAY_PER_REQUEST. Base KeySchema: wave_id (HASH). GSI project-timestamp-index: project_id (HASH) + timestamp (RANGE), ProjectionType ALL."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "DRIFT_TELEMETRY_TABLE on devops-graph-query-api (02-compute.yaml). The GraphQueryApiRole DriftTelemetryTableAccess policy grants dynamodb:PutItem/GetItem/Query on the table + /index/*."
+        },
+        "record_fields": {
+          "type": "object",
+          "definition": "{schema:'enceladus.drift.telemetry.v1', wave_id, project_id, timestamp (ISO-8601 microsecond UTC, monotonic per series), d_centroid_L2:number|null, d_spectral:number|null, d_spectral_k:int (default 3), prev_wave_id:string|null, n_h:int|null, n_v:int|null, spurious_attractor_rate:null (FTR-105 stub), re_traversal_rate:null (FTR-105 stub)}."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.drift.telemetry.v1"
+        }
+      }
+    },
+    "graph_query_api.embeddings_for": {
+      "description": "Returns stored Amazon Titan Text Embeddings V2 vectors (256-dim, L2-normalised) for a list of record_ids in a project. search_type=embeddings_for on GET /api/v1/tracker/graphsearch. Admin-tier only. Returns {embeddings[], matrix(Nx256), missing[]}. No new edge types or graph writes (OGTM N/A).",
+      "owner": "graph-query-api",
+      "source": "ENC-TSK-I89 / ENC-FTR-089",
+      "telemetry_eligible": false
+    },
+    "graph_query_api.energy_function": {
+      "description": "ENC-FTR-104 Ph3 / ENC-TSK-J52: live hybrid retrieval energy weights and optional response egress. Defaults promoted to I99-tuned lambda_graph=1.0 and lambda_kw=0.1 (was Ph1 0.5/0.25); gamma codified via ENERGY_LAMBDA_GRAPH/ENERGY_LAMBDA_KW on devops-graph-query-api. Hybrid search_type accepts include_energy=true to attach per-node energy_score + energy_breakdown; default off preserves RRF presentation without energy bloat. retrieval_records telemetry unchanged for wave-close consumers.",
+      "fields": {
+        "include_energy": {
+          "type": "boolean",
+          "definition": "Hybrid graphsearch query flag. When true, each returned node includes energy_score and energy_breakdown. Default false."
+        },
+        "lambda_graph": {
+          "type": "number",
+          "definition": "Live default 1.0 (I99 tuned). Resolved via AppConfig energy-function profile, ENERGY_LAMBDA_GRAPH env, then DEFAULT_LAMBDA_GRAPH."
+        },
+        "lambda_kw": {
+          "type": "number",
+          "definition": "Live default 0.1 (I99 tuned). Resolved via AppConfig, ENERGY_LAMBDA_KW env, then DEFAULT_LAMBDA_KW."
+        }
+      }
+    },
+    "graph_query_api.graph_laplacian": {
+      "description": "ENC-TSK-I81 (FTR-088): graph Laplacian read action via tracker.graph_laplacian. Returns adjacency_csr (base64 float32 CSR), fiedler_vector, eigenvalues[:k], vertex_map. Uses scipy.sparse.linalg.eigsh.",
+      "fields": {
+        "vertex_set_query": {
+          "type": "string"
+        },
+        "k": {
+          "type": "integer"
+        },
+        "adjacency_csr": {
+          "type": "string"
+        },
+        "fiedler_vector": {
+          "type": "array"
+        },
+        "eigenvalues": {
+          "type": "array"
+        },
+        "vertex_map": {
+          "type": "object"
+        }
+      }
+    },
+    "graph_query_api.sheaf_cohomology": {
+      "description": "Sheaf Laplacian H1 inconsistency-detection. search_type=sheaf_cohomology on graph_query_api. Returns h1_dim, inconsistency_nodes[], inconsistency_edges[], computation_ms.",
+      "owner": "graph-query-api",
+      "source": "ENC-TSK-I90 / ENC-FTR-095",
+      "telemetry_eligible": false
+    },
+    "graph_query_api.stigmergic_trace": {
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "fields": {
+        "table": {
+          "type": "string",
+          "definition": "enceladus-stigmergic-trace${EnvironmentSuffix} (01-data.yaml StigmergicTraceTable). PAY_PER_REQUEST. TTL on expires_at (90 days)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "STIGMERGIC_TRACE_TABLE on devops-graph-query-api (02-compute.yaml). GraphQueryApiRole StigmergicTraceTableAccess grants dynamodb:PutItem."
+        },
+        "record_fields": {
+          "type": "object",
+          "definition": "{schema:'enceladus.stigmergic.trace.v1', trace_id, project_id, session_id, event_type:'retrieval'|'traversal', record_id_path (pipe-delimited), timestamp (ISO-8601 UTC), outcome_signal (JSON string), expires_at (epoch seconds, TTL)}."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.stigmergic.trace.v1"
+        }
+      }
+    },
+    "graph_sync.agent_identity_edges": {
+      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent identity/session/credential graph projection. Three DynamoDB stores (agent-types -> :AgentIdentity, agent-sessions -> :AgentSession, agent-credentials -> :AgentCredential) each carry a NEW_AND_OLD_IMAGES DynamoDB Stream wired through a dedicated EventBridge Pipe (AgentSessionsToGraphPipe / AgentTypesToGraphPipe / AgentCredentialsToGraphPipe) into the SAME devops-graph-sync-queue.fifo consumed by graph_sync -- no synchronous Neo4j write exists anywhere on the auth/mutation hot path (coordination_api and agent_id_alloc import no neo4j driver). The stores carry no record_type column, so graph_sync._normalize_record_for_graph synthesizes record_type (agent_identity/agent_session/agent_credential) and record_id from the id field. _upsert_agent_node MERGEs the node by its id; _reconcile_agent_edges and the generic _project_mutated_edge hook MERGE five typed edges. Counter# sentinel rows are excluded. OGTM (ENC-FTR-066) compliance: all five edge labels are registered byte-identically in graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178 drift guard) so they are traversable via tracker.graphsearch. The labels are emitted directly from the agent-store streams (NOT via the ENC-FTR-049 relationship-record path). E2E gamma tracker.graphsearch validation is a post-deploy manual/CI step (deferred to after this code merges + deploys to v4-gamma). ENC-TSK-J44 (2026-07-01): fixed a record-type synthesis bug where the id-field probe order (in _normalize_record_for_graph) checked credential_id before session_id -- since J43 added an optional credential_id FK onto agent-session rows, a credential-bound session was misclassified as agent_credential and its properties were MERGEd onto the real credential's node, corrupting shared fields (e.g. status). Probe order corrected to check each type's own PK (session_id) before any field it may merely carry as an FK.",
+      "fields": {
+        "node_labels": {
+          "type": "object",
+          "definition": ":AgentIdentity (from agent-types ENC-AGT-NNN; props agent_type_id, surface, model, cost_tier, status, usage_count), :AgentSession (from agent-sessions ENC-SES-NNN; props session_id, agent_type_id, parent_session_id, runtime, created_at, claimed_at, status, optional credential_id), :AgentCredential (from agent-credentials CRED-<uuid4hex>; props credential_id, agent_identity_id, issued_at, status, revoked_at, revoked_reason, rotated_from)."
+        },
+        "edge_types": {
+          "type": "object",
+          "definition": "AUTHENTICATED_AS (AgentSession->AgentIdentity, from session.agent_type_id); OWNED_BY (AgentCredential->AgentIdentity, from credential.agent_identity_id); DERIVED_FROM (AgentCredential->parent AgentCredential, from credential.rotated_from, when present); TRIGGERED_BY (AgentSession->triggering session/routine, from session.parent_session_id, skipped when 'root'); MUTATED (AgentSession->any mutated record, from write_source.provider matching ^ENC-SES-[0-9A-Z]+$ and differing from the record's own id)."
+        },
+        "relationship_type_keys": {
+          "type": "object",
+          "definition": "graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL registers 'authenticated-as'->AUTHENTICATED_AS, 'owned-by'->OWNED_BY, 'derived-from'->DERIVED_FROM, 'triggered-by'->TRIGGERED_BY, 'mutated'->MUTATED for OGTM registry consistency."
+        },
+        "ogtm_compliance": {
+          "type": "object",
+          "definition": "graph_sync projection handlers (_upsert_agent_node, _reconcile_agent_edges, _project_mutated_edge); RELATIONSHIP_TYPE_TO_EDGE_LABEL entries; graph_query_api._ALLOWED_EDGE_TYPES registration of the five labels (byte-identical per ENC-ISS-178); E2E tracker.graphsearch validation on gamma (post-deploy manual/CI step). Governing feature ENC-FTR-074."
+        },
+        "no_write_amplification": {
+          "type": "object",
+          "definition": "All projection rides the existing DynamoDB Streams -> EventBridge Pipe -> SQS FIFO -> graph_sync path. coordination_api/lambda_function.py and coordination_api/agent_id_alloc.py contain no neo4j import or call; the graph is a derived read-index that reflects DynamoDB (source of truth) asynchronously."
+        }
+      }
+    },
+    "lifecycle_service.arc_walker_telemetry": {
+      "description": "Arc-walker telemetry emitted by tracker_mutation. Latch/clear events + convergence probe metrics. CloudWatch Enceladus/ArcWalk namespace.",
+      "owner": "tracker-mutation",
+      "source": "ENC-TSK-H86 / ENC-FTR-111",
+      "telemetry_eligible": true
+    },
+    "lifecycle_service.arc_walker_walk": {
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
+      "governing_feature": "ENC-FTR-111",
+      "governing_task": "ENC-TSK-H85",
+      "fields": {
+        "feature_flag": {
+          "type": "string",
+          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
+          "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
+        },
+        "phase1_legs": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "The only two gates Phase 1 auto-crosses: '<github_pr_deploy|lambda_deploy|web_deploy>|merged-main->deploy-init' (MECHANICAL, ci_triggered-only per O-2) and 'code_only|merged-main->closed' (MECHANICAL, commit_sha reuse + GitHub compare). All other gates are attestation or external-fact and are structurally unreachable in Phase 1 (deploy-success/closed/coding-complete/pr/committed/merged-main)."
+        },
+        "idempotent_conditional_write": {
+          "type": "object",
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
+        },
+        "safety_invariants": {
+          "type": "object",
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+        },
+        "write_source": {
+          "type": "string",
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+        },
+        "artifact_genesis": {
+          "type": "string",
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+        }
+      }
+    },
+    "mcp_server.agent_actions": {
+      "description": "ENC-TSK-I38, backported to v4/main gamma by ENC-TSK-J43. The coordination(action=agent.*) MCP tool surface: agent.register/agent.claim/agent.list/agent.retire proxy to POST/GET /api/v1/coordination/agents/sessions[/claim|/{id}/retire] on coordination_api; agent.type.list/agent.type.register proxy to GET/POST /api/v1/coordination/agents/types. All routes go through the real coordination_api Lambda over HTTPS (tools/enceladus-mcp-server/server.py _coordination_api_request) -- never fabricated/mocked. ENC-TSK-J43 additionally threads an optional credential_id through agent.register's payload build, forwarded only when the caller supplies it (fully backward compatible).",
+      "fields": {
+        "agent_register.credential_id": {
+          "type": "string",
+          "definition": "ENC-TSK-J43. Optional. When supplied, binds the minted session to an existing active AgentCredential (coordination.agent_credential); the underlying coordination_api call rejects (400) an unknown or non-active credential_id."
+        }
+      }
+    },
+    "mcp_server.context_management": {
+      "description": "Anthropic context-management beta for long coordination loops (ENC-TSK-G17 / FTR-099 A3.5). Evicts stale tool results once input-token threshold is crossed while preserving memory tool writes.",
+      "fields": {
+        "context_management_enabled": {
+          "type": "boolean",
+          "definition": "Provider-session flag gating _maybe_attach_context_management in coordination_api dispatch_claude_api.",
+          "usage_guidance": "Set provider_session.context_management_enabled=true for sessions expected to exceed ~20 tool calls."
+        },
+        "clear_tool_uses_20250919": {
+          "type": "edit",
+          "definition": "Context edit: trigger at 100k input tokens, keep last 5 tool_uses, exclude_tools=[memory].",
+          "usage_guidance": "Wired in _build_claude_context_management_config(); memory tool excluded from eviction."
+        },
+        "clear_thinking_20251015": {
+          "type": "edit",
+          "definition": "Optional companion edit appended only when model is Opus and extended thinking is active.",
+          "usage_guidance": "Gated on thinking_param and opus model id in _maybe_attach_context_management."
+        },
+        "memory_20250818": {
+          "type": "tool",
+          "definition": "Anthropic memory tool registered on the tools array when context management is enabled.",
+          "usage_guidance": "Enceladus memory file schema (_ENCELADUS_MEMORY_FILE_SCHEMA) defines plan anchors, governance_hash, active task state. Runtime persistence: S3 via agent_session_memory.S3MemoryToolHandler at coordination-agent-memory/{project_id}/{scope_id}/memories/."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Appends context-management-2025-06-27 via _append_anthropic_beta (composes with deferred_tool_loading headers)."
+        }
+      }
+    },
+    "mcp_server.deferred_tool_loading": {
+      "description": "Anthropic deferred tool-loading policy for Enceladus MCP (ENC-TSK-G15 / FTR-099 A3.2). Reduces per-turn tool-definition token footprint by deferring non-essential tools and registering BM25 on-demand retrieval.",
+      "fields": {
+        "eager_load_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Code-mode meta-tools always loaded (not deferred): search, get_compact_context, execute, coordination.",
+          "usage_guidance": "Configured in tools/enceladus-mcp-server/tool_defer_loading.py EAGER_LOAD_TOOLS; surfaced via coordination_capabilities.features.deferred_tool_loading."
+        },
+        "mcp_toolset": {
+          "type": "object",
+          "definition": "Anthropic mcp_toolset block with default_config.defer_loading=true and per-tool eager overrides.",
+          "usage_guidance": "Built by build_mcp_toolset() in tool_defer_loading.py; attached to Claude dispatch when provider_session.deferred_tool_loading=true."
+        },
+        "tool_search_tool_bm25_20251119": {
+          "type": "tool",
+          "definition": "BM25 tool search registered in the Anthropic tools array for deferred tool discovery.",
+          "usage_guidance": "Keyword-rich ENCELADUS_MCP_SERVER_INSTRUCTIONS and MCP initialize serverInfo.instructions improve BM25 routing for tracker, docstore, checkout, deploy, and governance queries."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Required beta headers: advanced-tool-use-2025-11-20 and mcp-client-2025-11-20 when using defer_loading with MCP connector."
+        },
+        "token_footprint_reduction": {
+          "type": "behavior",
+          "definition": "Estimated >70% reduction in tool-definition tokens per turn when 4 eager + 36 deferred tools (validated in test_tool_defer_loading.py)."
+        },
+        "toolset_cache_control": {
+          "type": "object",
+          "definition": "Ephemeral 1h cache_control attached to the last tool in the Anthropic tools array (mcp_toolset block) when deferred_tool_loading is enabled.",
+          "usage_guidance": "Requires catalog_tokens_est above Sonnet 2048 / Opus 4096 minimums (see toolset_cache_eligibility in capabilities). Per-turn cache_read_input_tokens and cache_creation_input_tokens logged via dispatch_claude_api observability."
+        }
+      }
+    },
+    "mcp_server.governance_hash_resolution": {
+      "description": "Hash resolution chain in enceladus-mcp-server._get_governance_hash_via_api() after the ENC-TSK-I29 cutover. Four-tier resolution with 60s TTL cache.",
+      "fields": {
+        "tier_1_api_hash": {
+          "type": "object",
+          "definition": "coordination API GET /hash endpoint. After I29 lands, the API's _compute_governance_hash_local() returns the canonical DDB value, so tier 1 is transitively canonical. TTL: 60s (GOVERNANCE_HASH_API_TTL)."
+        },
+        "tier_2_health_api": {
+          "type": "object",
+          "definition": "coordination API health endpoint governance_hash field. Auth-safe fallback for environments where the /hash endpoint requires internal API key."
+        },
+        "tier_3_canonical_ddb": {
+          "type": "object",
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+        },
+        "tier_4_s3_catalog": {
+          "type": "object",
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma. GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
+        }
+      }
+    },
+    "mcp_server.sci_passthrough": {
+      "description": "ENC-ISS-441 / ENC-TSK-K10 (ENC-FTR-122, supersedes ENC-TSK-J97): the MCP server (tools/enceladus-mcp-server/server.py, enceladus-mcp-code Lambda) carries the caller's Session Claim ID to the ENC-TSK-J93 backend enforcement points. checkout_task, advance_task_status and append_worklog tool schemas expose an OPTIONAL string property 'sci' (the SCI-{uuid4_hex} issued by coordination agent.claim); handlers strip-and-forward it into the backend payload ONLY when non-empty, so requests from grandfathered (pre-epoch) sessions stay byte-identical. The same guard covers _plan_checkout/_plan_advance and _tracker_set/_tracker_log; _tracker_create's ENC-TSK-F76 denylist passthrough forwards a caller-supplied sci automatically. The coordination agent.claim response is a RAW backend passthrough (do not reshape): the J92 fields sci / sci_issued_at / sci_ttl_seconds reach the calling agent unchanged. The MCP layer NEVER validates SCI - enforcement is backend-only (checkout_service + tracker_mutation, ENC-TSK-J93). Code-mode execute steps flow arguments verbatim (no per-action allowlist), so sci passes through execute(checkout.*/tracker.*/plan.*) unchanged. NOTE: enceladus-mcp-code has no auto-deploy lane; live deploys ride the ENC-FTR-077 handoff (DOC-359655466119 pattern) and must advance the :live alias (ISS-306 qualified-URL discipline).",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Optional on checkout_task / advance_task_status / append_worklog (and honored on plan/tracker mutation paths). Session Claim ID issued by coordination agent.claim (ENC-ISS-441). Required by the backend for agent sessions claimed after SCI_ENFORCEMENT_EPOCH; strip-and-forwarded, never validated at the MCP layer."
+        }
+      }
+    },
+    "mcp_server.tracker_embeddings_for": {
+      "description": "ENC-TSK-K12 / ENC-ISS-473: MCP raw tool tracker_embeddings_for (code-mode action tracker.embeddings_for) restored after a merge truncation left the handler body incomplete. Proxies GET graph_query_api with search_type=embeddings_for (ENC-FTR-089 / ENC-TSK-I89): accepts project_id and record_ids (list or comma-separated string), returns embeddings[], Nx256 matrix, and missing[] from stored Titan V2 node properties. Admin/io-dev-admin scoped downstream; read-only, OGTM N/A.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required. Project whose graph node embeddings are fetched."
+        },
+        "record_ids": {
+          "type": "array|string",
+          "definition": "Required. One or more ENC-* or DOC-* record IDs; comma-separated string accepted."
+        }
+      }
+    },
+    "mcp_server.tracker_sheaf_cohomology": {
+      "description": "ENC-TSK-K12 / ENC-ISS-473: MCP raw tool tracker_sheaf_cohomology (code-mode action tracker.sheaf_cohomology) restored after merge truncation. Proxies graph_query_api search_type=sheaf_cohomology (ENC-FTR-095 / ENC-TSK-I90): requires project_id; optional vertex_set_query restricts the induced subgraph. Returns h1_dim, inconsistency_nodes[], inconsistency_edges[], computation_ms. Read-only sheaf Laplacian H1 probe; OGTM N/A.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required. Project graph to analyze."
+        },
+        "vertex_set_query": {
+          "type": "string",
+          "required": false,
+          "definition": "Optional anchor query limiting computation to a connected subgraph."
+        }
+      }
+    },
+    "monitoring.convergence_telemetry": {
+      "description": "ENC-TSK-I82 (FTR-086 Ph1): Convergence Surface DDB counter table + SQS FIFO + Streams fan-out Lambda.",
+      "fields": {
+        "attribute_name": {
+          "type": "string"
+        },
+        "canonical_value": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "expires_at": {
+          "type": "integer"
+        }
+      }
+    },
+    "monitoring.dedup_convergence_probe": {
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "fields": {
+        "signals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "The five governed convergence signals (CloudWatch metric names under Enceladus/DedupConvergence). Stock: DuplicatePairStock (same-type same-project pairs at cosine >= DEDUP_COSINE_THRESHOLD). Precision@1 recovery: Precision1RecoveryProxy + Precision1RecoveryEstimate with Precision1Baseline (0.3727) and RecallCeiling (0.8242) reference metrics. Flow: NewDuplicateFlow (pairs whose newer endpoint was created within DEDUP_FLOW_WINDOW_DAYS). Percolation: DuplicateLCCSize (largest-connected-component of the same-type duplicate graph; -> 1 at convergence since isolated records are size-1 components) + NonTrivialComponentCount + EmbeddedRecordCount. Walk-back model-health loop: AutoMergeWalkBackRate + AutoMergeCount + WalkBackCount + WalkBackRateBreachedFloor.",
+          "usage_guidance": "Read via CloudWatch GetMetricStatistics on namespace Enceladus/DedupConvergence, or via the graph_query_api search_type='dedup_convergence' read surface for an on-demand snapshot (result.convergence)."
+        },
+        "precision_at_1_recovery_proxy": {
+          "type": "string",
+          "definition": "The labeled self-retrieval eval (DOC-4F1F5B99AAED, precision@1=0.3727 / recall ceiling 0.8242) is not reproducible inside a scheduled Lambda, so the probe emits a live recovery proxy: the fraction of embedded same-type records that have NO surviving near-duplicate twin (cosine >= threshold) among non-superseded peers.",
+          "usage_guidance": "Climbs toward 1.0 as duplicate twins are superseded (the I07 retrieval exclusion removes them from competition), tracking the same convergence quantity the eval measures. Precision1RecoveryEstimate maps the proxy onto the baseline->ceiling band for graphing."
+        },
+        "walk_back_model_health": {
+          "type": "object",
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
+        },
+        "config_env_vars": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "graph_health_metrics environment configuration for the dedup probe: DEDUP_NAMESPACE (default Enceladus/DedupConvergence), DEDUP_AUDIT_NAMESPACE, DEDUP_COSINE_THRESHOLD (0.95), DEDUP_PRECISION_FLOOR (0.999), DEDUP_FLOW_WINDOW_DAYS (7), DEDUP_WALKBACK_WINDOW_DAYS (30), DEDUP_VECTOR_TOP_K (25).",
+          "usage_guidance": "Defined in infrastructure/cloudformation/02-compute.yaml on GraphHealthMetricsFunction. The role gains cloudwatch:GetMetricStatistics/GetMetricData (in addition to the existing PutMetricData) to read the walk-back counters."
+        }
+      }
+    },
+    "monitoring.memory_consolidation": {
+      "description": "See source task.",
+      "source": "ENC-TSK",
+      "telemetry_eligible": false
+    },
+    "project_service.deploy_policy": {
+      "description": "ENC-TSK-H84 / ENC-FTR-111 (Universal Arc-Walker Phase 1): per-project deploy_policy attribute on the projects DynamoDB table record, declaring how a project's deployments are triggered. Written by project_service at create time and surfaced on GET/LIST; read by the Lifecycle Service (evaluate_auto_walk action) to gate deploy-init auto-walk per ruling O-2 (ENC-FTR-111 AC-5). Pairs with the existing projects-table deploy_mode attribute (deploy.spec / _get_project_deploy_mode, ENC-ISS-102) but is orthogonal: deploy_mode controls CodeBuild vs record-only finalize; deploy_policy controls whether the Arc-Walker may mechanically auto-advance the deploy-init gate.",
+      "fields": {
+        "deploy_policy": {
+          "type": "enum",
+          "enum": [
+            "ci_triggered",
+            "manual"
+          ],
+          "default": "ci_triggered",
+          "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
+        }
+      }
+    },
+    "telemetry.eligible_fields": {
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
+      "governing_feature": "ENC-FTR-086",
+      "governing_task": "ENC-TSK-I83",
+      "design_source": "DOC-E3F5E025B3D9",
+      "mcp_action": "search(action='telemetry.rank', arguments={attribute_name, project_id?, record_type?, limit?, cursor?})",
+      "canonicalization_version": "v1",
+      "schema_version": "telemetry.rank.v1",
+      "response_shape": {
+        "rows[]": "canonical_value, count (alias raw_count), rank, raw_value_samples (up to 3 distinct raw forms), first_seen, last_seen, distinct_author_count",
+        "envelope": "rows[], total_distinct_values, next_cursor, schema_version, canonicalization_version, source, eligible, degraded, attribute_name, record_type, project_id",
+        "degradation": "On any failure mode the action returns rows:[] with degraded:true and a degraded_reason (Locked Design Decision: telemetry being down must never block mutation work)."
+      },
+      "fields": {
+        "attribute_name": {
+          "type": "string",
+          "required": true,
+          "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
+        },
+        "record_type": {
+          "type": "string",
+          "required": false,
+          "definition": "Record type whose population is ranked. Resolved from the eligible-fields map when omitted (category/components -> task, subtypepattern -> document).",
+          "usage_guidance": "Override only to rank an attribute across a non-default record population."
+        },
+        "vocabulary_bounded": {
+          "type": "boolean",
+          "required": false,
+          "definition": "Per-field hint mirrored from governance.per_field_metadata. When true the Convergence Surface applies a lower capacity cap (the field's value space is enum-like or registry-constrained).",
+          "usage_guidance": "Informational for capacity sizing; does not change telemetry.rank read semantics."
+        }
+      }
+    },
+    "tracker.dedup_auto_merge": {
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "fields": {
+        "enable_dedup_auto_merge": {
+          "type": "feature_flag",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
+        },
+        "dedup_auto_merge_kill_switch": {
+          "type": "feature_flag",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
+          "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
+        },
+        "precision_lcb_floor": {
+          "type": "number",
+          "default": 0.999,
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
+          "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
+        },
+        "auto_walk_opt_out_latch": {
+          "type": "behavior",
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+        },
+        "audit_feed": {
+          "type": "event",
+          "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
+        }
+      }
+    },
+    "tracker.retirement_prompt": {
+      "description": "ENC-ISS-441 / ENC-TSK-J96 (ENC-FTR-122): terminal-state retirement nudge, part 3 of the io-designed session retirement lifecycle (issue worklog 2026-06-30). Whenever a success response is returned for a record reaching a FINAL lifecycle state, the envelope carries an additive-only string field retirement_prompt with the exact io-specified text: 'Prompt the user if this session can now be retired, or retire the session if it is certain that the full scope of the current session assignment is complete.' The acting agent either calls coordination agent.retire autonomously (scope exhausted) or surfaces the prompt to io. Injection points: checkout_service _handle_advance (task -> closed) and _handle_plan_advance (plan -> complete); tracker_mutation _handle_update_field status writes landing task/issue -> closed, feature -> production or deprecated, plan -> complete (_is_terminal_transition map). 'superseded' and plan 'incomplete' are NOT nudged (supersession is a server op, incomplete is an abandonment terminal). Non-terminal envelopes are byte-identical; consumers that ignore unknown fields are unaffected.",
+      "fields": {
+        "retirement_prompt": {
+          "type": "string",
+          "definition": "Fixed io-specified nudge text, present ONLY on terminal-state success envelopes. Complements the ENC-TSK-J94 sweeps: the prompt handles well-behaved agents, the sweeps catch the rest."
+        }
+      }
+    },
+    "tracker.sci_enforcement_gate": {
+      "description": "ENC-ISS-441 / ENC-TSK-J93 (ENC-FTR-122): the same SCI enforcement gate in tracker_mutation, applied where the normalized write_source.provider (the acting identity after _normalize_write_source; legacy top-level provider folds in, Cognito defaults to claims.sub) matches ^ENC-SES-[0-9A-Z]+$, at three entry points: _handle_update_field (tracker.set, including the active_agent_session checkout/release branch), _handle_log (worklog append), and _handle_create_record (record creation). Identical validation order, 403 SCI_REQUIRED envelope, grandfather epoch, fail-closed unknown_session semantics and last_activity_at touch as checkout_service.sci_enforcement_gate. ADDITIONAL EXEMPTION: requests carrying a valid X-Checkout-Service-Key header (_is_checkout_service_request, ENC-FTR-037) bypass the gate - the checkout_service->tracker chain presents ENC-SES providers but the identical gate already ran at the checkout_service edge; without this the FTR-037 forwarding chain would 403. Cognito, internal-key (non-ENC-SES provider), and system:arc-walker writes are unaffected by identity shape.",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Request-body field (rides write_source-adjacent payload) on tracker.set / tracker.log / tracker.create when the acting provider is a post-epoch ENC-SES session."
+        },
+        "checkout_service_exemption": {
+          "type": "string",
+          "definition": "X-Checkout-Service-Key-authenticated requests (FTR-037) skip the gate; the gate already ran at the checkout_service edge for the originating agent call."
+        }
+      }
     }
   },
   "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
@@ -6447,12 +7328,12 @@
     {
       "version": "2026-04-22.01",
       "date": "2026-04-22",
-      "summary": "ENC-TSK-F99: no schema changes \u2014 version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
     },
     {
       "version": "2026-06-27.02",
       "date": "2026-06-27",
-      "summary": "ENC-TSK-I37 / ENC-FTR-117: add coordination.agent_session and coordination.agent_type entities (Agent ID v3 governed stores); v3 property sets value-identical to v4 node schemas per DOC-05C45B438FC1. Repo-file edit only \u2014 S3/DDB governance sync is a product-lead post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+      "summary": "ENC-TSK-I37 / ENC-FTR-117: add coordination.agent_session and coordination.agent_type entities (Agent ID v3 governed stores); v3 property sets value-identical to v4 node schemas per DOC-05C45B438FC1. Repo-file edit only — S3/DDB governance sync is a product-lead post-merge action (GOVERNANCE_SYNC_REQUIRED)."
     },
     {
       "version": "2026-06-27.05",
@@ -6462,7 +7343,7 @@
     {
       "version": "2026-06-28.02",
       "date": "2026-06-28",
-      "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip \u2014 NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
+      "summary": "ENC-TSK-I71 / ENC-FTR-117 AC#8: add coordination.agent_session_idle_sweep entity (scheduled EventBridge backstop reaping abandoned allocated/claimed sessions to 'retired' via append-only flip — NOT native DynamoDB TTL; AGENT_SESSIONS_IDLE_SWEEP_ENABLED + AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS config). Version bump required by governance-dictionary-guard for coordination_api lambda_function.py/config.py edits."
     },
     {
       "version": "2026-07-08.2",
@@ -6478,6 +7359,13 @@
       "version": "2026-08-08.1",
       "date": "2026-08-08",
       "summary": "DVP-TSK-648 / DVP-TSK-649 (BRD B3, DVP-PLN-001): added entity warehouse.governance_mart documenting the seven-table governance analytics mart -- its declared columns, per-table grain, the metadata-only substitution test that CI enforces, the daily-grain rule, the scheduled full-refresh contract, and the devops/enceladus ownership split. The mart is a T2 projection at hive.devops.*, written through the B2-R2 shared registration library with a DECLARED schema (never a Glue crawler) and full-refresh overwrite (never per-mutation snapshots). No existing entity was modified."
+    },
+    {
+      "version": "2026-08-08.7",
+      "date": "2026-08-08",
+      "summary": "ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600, DOC-B716E8FB10B6 COE lineage, M44/M45 sibling): backport the ENC-TSK-K34 bundled-only dictionary serving (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E) from v4/main onto main -- coordination_api._load_governance_dictionary no longer scans the governance-policies DynamoDB mirror (frozen at 2026-06-30.09/121 entities since the document outgrew DynamoDB's 400KB item cap; no production S3->DDB trigger ever existed either); the bundled file is now the sole authoritative source on main, matching v4/main. Also imports the 37 entity keys present in S3-live 2026-08-08.01 (sha256 5b0d150a3d4bb7230d5798c6d8ddb9fd10fad86d3f5c9e3545b08d4dbc0ad726) but absent from this bundle -- the SCI-enforcement, agent-identity, escalations, graph_query_api, mcp_server and corpus governance that went invisible to every MCP agent when the mirror froze. Merge policy: bundle wins on shared keys per the K34 deploy-coupling doctrine (15 shared keys differ from S3-live: api.error_envelope, component_registry.component, coordination.agent_session, coordination.agent_session_idle_sweep, coordination.agent_type, coordination.escalations, coordination.request, coordination.session_claim_id, deploy.spec, document.query_response, tracker.feature, tracker.graphsearch, tracker.issue, tracker.plan, tracker.task; the S3-side copies remain recoverable under governance/history/). A section-13 HANDOFF requests io push this reconciled content to S3-live to restore exact S3<->served entity-key parity. No pre-existing bundle entity was modified.",
+      "task": "ENC-TSK-N82",
+      "issue": "ENC-ISS-600"
     }
   ]
 }

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -320,10 +320,6 @@ DEBOUNCE_WINDOW_SECONDS = int(os.environ.get("DEBOUNCE_WINDOW_SECONDS", "180")) 
 DISPATCH_LOCK_BUFFER_SECONDS = int(os.environ.get("DISPATCH_LOCK_BUFFER_SECONDS", "60"))
 DEAD_LETTER_TIMEOUT_MULTIPLIER = int(os.environ.get("DEAD_LETTER_TIMEOUT_MULTIPLIER", "2"))
 DEAD_LETTER_SNS_TOPIC_ARN = os.environ.get("DEAD_LETTER_SNS_TOPIC_ARN", "")
-GOVERNANCE_DICTIONARY_POLICY_ID = os.environ.get(
-    "GOVERNANCE_DICTIONARY_POLICY_ID",
-    "governance_data_dictionary",
-)
 
 COORDINATION_GSI_PROJECT = os.environ.get("COORDINATION_GSI_PROJECT", "project-updated-index")
 COORDINATION_GSI_IDEMPOTENCY = os.environ.get("COORDINATION_GSI_IDEMPOTENCY", "idempotency-key-index")
@@ -12781,93 +12777,28 @@ def _load_governance_dictionary_fallback() -> Dict[str, Any]:
     return payload
 
 
-def _extract_governance_dictionary(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if not isinstance(item, dict):
-        return None
-
-    for key in ("dictionary", "policy", "payload"):
-        value = item.get(key)
-        if isinstance(value, dict) and value:
-            return value
-
-    for key in ("dictionary_json", "policy_json", "payload_json", "content"):
-        raw = item.get(key)
-        if not isinstance(raw, str) or not raw.strip():
-            continue
-        try:
-            decoded = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(decoded, dict):
-            return decoded
-    return None
-
-
 def _load_governance_dictionary() -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    ddb = _get_ddb()
-    try:
-        resp = ddb.scan(
-            TableName=GOVERNANCE_POLICIES_TABLE,
-            FilterExpression="policy_id = :pid",
-            ExpressionAttributeValues={":pid": _serialize(GOVERNANCE_DICTIONARY_POLICY_ID)},
-        )
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "Unknown")
-        logger.warning(
-            "Unable to read governance dictionary from %s (%s); using fallback file",
-            GOVERNANCE_POLICIES_TABLE,
-            code,
-        )
-        return _load_governance_dictionary_fallback(), {
-            "source": "fallback_file",
-            "table": GOVERNANCE_POLICIES_TABLE,
-            "policy_id": GOVERNANCE_DICTIONARY_POLICY_ID,
-            "reason": code,
-        }
-    except Exception as exc:
-        logger.warning(
-            "Unable to read governance dictionary from %s (%s); using fallback file",
-            GOVERNANCE_POLICIES_TABLE,
-            exc,
-        )
-        return _load_governance_dictionary_fallback(), {
-            "source": "fallback_file",
-            "table": GOVERNANCE_POLICIES_TABLE,
-            "policy_id": GOVERNANCE_DICTIONARY_POLICY_ID,
-            "reason": str(exc),
-        }
+    """Load the governance dictionary from the bundled repo file.
 
-    raw_items = resp.get("Items", [])
-    items = [_deserialize(raw) for raw in raw_items]
-    if not items:
-        return _load_governance_dictionary_fallback(), {
-            "source": "fallback_file",
-            "table": GOVERNANCE_POLICIES_TABLE,
-            "policy_id": GOVERNANCE_DICTIONARY_POLICY_ID,
-            "reason": "not_found",
-        }
+    ENC-TSK-K34 (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E): the
+    dictionary is a deploy-coupled contract artifact, not a live
+    governance-intent surface. ENC-TSK-K31 found the DynamoDB mirror had
+    never once been used as a live, independently-authored hot-patch target
+    -- every write only ever caught DynamoDB up to a prior git/S3 change --
+    and it eventually outgrew DynamoDB's 400KB item cap entirely. The DDB
+    scan branch is retired; the bundled file is now the sole and always-
+    authoritative source. check_governance_dictionary_sync.py remains the
+    deploy-coupling enforcement (repo -> bundle -> deploy).
 
-    def _sort_key(value: Dict[str, Any]) -> str:
-        return str(value.get("updated_at") or value.get("created_at") or "")
-
-    items.sort(key=_sort_key, reverse=True)
-    for item in items:
-        dictionary = _extract_governance_dictionary(item)
-        if not dictionary:
-            continue
-        return dictionary, {
-            "source": "dynamodb",
-            "table": GOVERNANCE_POLICIES_TABLE,
-            "policy_id": str(item.get("policy_id") or GOVERNANCE_DICTIONARY_POLICY_ID),
-            "updated_at": str(item.get("updated_at") or ""),
-            "version": str(item.get("version") or ""),
-        }
-
-    return _load_governance_dictionary_fallback(), {
-        "source": "fallback_file",
-        "table": GOVERNANCE_POLICIES_TABLE,
-        "policy_id": GOVERNANCE_DICTIONARY_POLICY_ID,
-        "reason": "invalid_policy_payload",
+    Backported from v4/main by ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600):
+    prod's DDB mirror froze at 2026-06-30.09 once the document outgrew the
+    400KB item limit, silently serving a five-week-stale dictionary.
+    """
+    dictionary = _load_governance_dictionary_fallback()
+    return dictionary, {
+        "source": "bundled",
+        "version": str(dictionary.get("version") or ""),
+        "updated_at": str(dictionary.get("updated_at") or ""),
     }
 
 

--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -283,6 +283,19 @@ class CoordinationLambdaUnitTests(unittest.TestCase):
             caps["providers"]["claude_agent_sdk"]["allowed_tools"],
         )
 
+    def test_load_governance_dictionary_reads_bundled_file_only(self):
+        """ENC-TSK-K34 (ENC-ISS-477): the DDB scan branch is retired -- the
+        bundled repo file is the sole and always-authoritative source. Does
+        NOT mock _get_ddb, proving no DynamoDB client is touched at all.
+        Backported to main by ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600)."""
+        with patch.object(coordination_lambda, "_get_ddb") as mock_get_ddb:
+            dictionary, source_meta = coordination_lambda._load_governance_dictionary()
+        mock_get_ddb.assert_not_called()
+        self.assertEqual(source_meta["source"], "bundled")
+        self.assertIsInstance(dictionary, dict)
+        self.assertIn("entities", dictionary)
+        self.assertEqual(source_meta["version"], dictionary.get("version"))
+
     @patch.object(
         coordination_lambda,
         "_load_governance_dictionary",


### PR DESCRIPTION
## Summary

Prod's `coordination_api` serves `governance.dictionary` from the governance-policies DynamoDB mirror, frozen at **2026-06-30.09 / 121 entities**: the document outgrew DynamoDB's 400KB item cap (ENC-ISS-600) and no production S3->DDB trigger ever existed (ENC-ISS-599). Every MCP agent has been reading a five-week-stale governance view.

This is the M44-class backport of **ENC-TSK-K34** (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E) from v4/main:

- `_load_governance_dictionary` no longer scans DynamoDB — the bundled repo file is the sole authoritative source (DDB scan branch, `_extract_governance_dictionary`, and `GOVERNANCE_DICTIONARY_POLICY_ID` retired, matching v4/main).
- Bundle reconciled to **2026-08-08.7 / 163 entities**: imports the 37 entity keys present in S3-live 2026-08-08.01 but absent here (SCI enforcement, agent identity, escalations, graph_query_api, mcp_server, corpus.edge_taxonomy); preserves the 12 bundle-only keys; bundle wins on the 15 differing shared keys per the K34 deploy-coupling doctrine (list in the bundle change_log).
- Ports the K34 loader test (proves no DDB client is touched).

## Evidence

- 163/163 tests pass in `backend/lambda/coordination_api/test_lambda_function.py`
- `tools/check_governance_dictionary_sync.py --base origin/main --head HEAD` -> OK
- Tracker: ENC-TSK-N82 (session ENC-SES-0C9). Deploy to v3-prod rides the io-gated DOC-B716E8FB10B6 Channel B manual lane after merge.

CCI-5b9ad08281604a1f9460805e7faa65e4

🤖 Generated with [Claude Code](https://claude.com/claude-code)