### PR TITLE
DVP-TSK-704: grant CFN deploy role control-plane DynamoDB ops on the nine legacy 01-data tables

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-legacy-ddb-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-legacy-ddb-patch.yml
@@ -1,0 +1,136 @@
+name: IAM CFN Deploy Role — Legacy DynamoDB Table Patch
+
+# DVP-TSK-704 / DVP-PLN-001: CloudFormationDeployPolicy statement DynamoDBTableOps scoped
+# its Resource list to table/enceladus-* and table/devops-*. Nine of the eleven tables in
+# the 01-data stack predate that naming convention (agent-compliance-violations,
+# agent-sessions, agent-types, component-registry, coordination-requests, documents,
+# governance-policies, governance-version, projects), so the deploy role held NO
+# control-plane DynamoDB permission on them.
+#
+# Effect: every "CloudFormation Compute Stack Deploy" apply since the last green run on
+# 2026-07-08 failed at dynamodb:DescribeTable, rolled 01-data back to
+# UPDATE_ROLLBACK_COMPLETE, and skipped the 02-compute change-set — which is why
+# devops-governance-mart, and every other lambda added since, never existed in AWS despite
+# being merged to main. This was misread as "the pipeline is broken"; the pipeline was fine.
+#
+# Durable fix lives in infrastructure/cloudformation/04-github-roles.yaml. This one-off
+# dispatch applies the same grant live ahead of the next github-roles stack deploy, which is
+# the pattern established by iam-cfn-deploy-role-scheduler-patch.yml and its siblings.
+#
+# This patch EXTENDS the existing DynamoDBTableOps statement in place rather than appending a
+# new Sid, so the live policy and the template converge on one shape. A second statement
+# would be an equivalent grant but a divergent shape, and DVP-TSK-696 check 9 (IAM/config
+# drift) would then correctly flag this very fix as drift.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this patch is needed"
+        type: string
+        required: false
+        default: "DVP-TSK-704 — grant control-plane DynamoDB ops on the nine legacy 01-data tables"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  patch-role:
+    name: Patch CFN deploy role with legacy 01-data table ARNs
+    environment: v3-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BACKEND_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity
+
+      - name: Extend DynamoDBTableOps with the legacy table ARNs
+        env:
+          ROLE_NAME: enceladus-cloudformation-deploy-github-role
+          POLICY_NAME: CloudFormationDeployPolicy
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+
+          aws iam get-role-policy \
+            --role-name "${ROLE_NAME}" \
+            --policy-name "${POLICY_NAME}" \
+            --query PolicyDocument \
+            --output json > /tmp/cfn-deploy-policy-current.json
+
+          ACCOUNT_ID="${ACCOUNT_ID}" python3 <<'PY'
+          import json, os
+          from pathlib import Path
+
+          account_id = os.environ["ACCOUNT_ID"]
+          legacy = [
+              "agent-compliance-violations",
+              "agent-sessions",
+              "agent-types",
+              "component-registry",
+              "coordination-requests",
+              "documents",
+              "governance-policies",
+              "governance-version",
+              "projects",
+          ]
+          wanted = [f"arn:aws:dynamodb:us-west-2:{account_id}:table/{t}" for t in legacy]
+
+          doc = json.loads(Path("/tmp/cfn-deploy-policy-current.json").read_text())
+          statements = doc.setdefault("Statement", [])
+          target = next((s for s in statements if s.get("Sid") == "DynamoDBTableOps"), None)
+          if target is None:
+              raise SystemExit("DynamoDBTableOps statement not found — refusing to guess where the grant belongs")
+
+          resources = target.get("Resource", [])
+          if isinstance(resources, str):
+              resources = [resources]
+
+          missing = [arn for arn in wanted if arn not in resources]
+          if not missing:
+              print("All nine legacy table ARNs already present — no merge needed")
+          else:
+              print(f"Adding {len(missing)} legacy table ARN(s): {missing}")
+              resources.extend(missing)
+              target["Resource"] = resources
+
+          size = len(json.dumps(doc, separators=(",", ":")))
+          print(f"Merged policy size: {size} / 10240 bytes")
+          if size > 10240:
+              raise SystemExit("Merged policy exceeds the 10,240-byte inline policy quota")
+
+          Path("/tmp/cfn-deploy-policy-merged.json").write_text(json.dumps(doc))
+          PY
+
+          aws iam put-role-policy \
+            --role-name "${ROLE_NAME}" \
+            --policy-name "${POLICY_NAME}" \
+            --policy-document "file:///tmp/cfn-deploy-policy-merged.json"
+
+      - name: Verify the grant with the IAM simulator
+        run: |
+          set -euo pipefail
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/enceladus-cloudformation-deploy-github-role"
+          rc=0
+          for t in agent-compliance-violations agent-sessions agent-types component-registry \
+                   coordination-requests devops-deployment-manager documents governance-policies \
+                   governance-version projects devops-project-tracker; do
+            decisions="$(aws iam simulate-principal-policy \
+              --policy-source-arn "${ROLE_ARN}" \
+              --action-names dynamodb:DescribeTable dynamodb:UpdateTable dynamodb:ListTagsOfResource \
+              --resource-arns "arn:aws:dynamodb:us-west-2:${ACCOUNT_ID}:table/${t}" \
+              --query 'EvaluationResults[].EvalDecision' --output text)"
+            echo "${t}: ${decisions}"
+            case "${decisions}" in
+              *Deny*|*deny*) echo "::error::${t} still denied"; rc=1 ;;
+            esac
+          done
+          exit "${rc}"

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -257,6 +257,24 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/enceladus-*"
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/devops-*"
+                  # DVP-TSK-704: nine 01-data tables predate the enceladus-*/devops-* naming
+                  # convention, so the two prefix wildcards above never matched them. Every
+                  # "CloudFormation Compute Stack Deploy" apply since 2026-07-08 failed at
+                  # dynamodb:DescribeTable on these, rolled the data stack back to
+                  # UPDATE_ROLLBACK_COMPLETE, and skipped the compute change-set entirely —
+                  # which is why devops-governance-mart never existed in AWS despite being
+                  # merged to main. Enumerated rather than widened to table/*: this is a
+                  # closed legacy set, and a wildcard would hand the deploy role
+                  # control-plane authority over every table in the account.
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-compliance-violations"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-sessions"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-types"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/component-registry"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/coordination-requests"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-policies"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version"
+                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects"
 
               - Sid: SnsTopicOps
                 Effect: Allow

--- a/tools/prod_gate_baseline.json
+++ b/tools/prod_gate_baseline.json
@@ -128,6 +128,13 @@
       ],
       "notes": "ENC-TSK-J64: environment: v3-prod — despite the name it patches the SHARED CFN deploy role object"
     },
+    "iam-cfn-deploy-role-legacy-ddb-patch.yml": {
+      "class": "prod-mutating",
+      "gated_jobs": [
+        "patch-role"
+      ],
+      "notes": "DVP-TSK-704: environment: v3-prod — patches the SHARED CFN deploy role object, extending DynamoDBTableOps in place with the nine legacy un-prefixed 01-data table ARNs; same pattern as iam-cfn-deploy-role-gamma-patch.yml"
+    },
     "iam-cfn-deploy-role-nat-gateway-patch.yml": {
       "class": "prod-mutating",
       "gated_jobs": [


### PR DESCRIPTION
CCI-bcee75f5d5bf4a84ba33c553e585a812

## What was actually wrong

The "CloudFormation Compute Stack Deploy" workflow has been read as broken since its last green run on 2026-07-08. It is not. Two separate things were conflated:

1. **The `v3-prod` pause is a deliberate control, not a failure.** The Apply job runs in a GitHub Environment with a `required_reviewers` rule. Its own workflow header says so: *"A merge to main therefore PAUSES as a reviewable, rejectable request instead of deploying prod directly."* Runs sit at `status=waiting`. That is ENC-FTR-120 working.

2. **Underneath the gate there is a real defect, and it is an IAM scoping gap.** `CloudFormationDeployPolicy` statement `DynamoDBTableOps` scoped its `Resource` list to `table/enceladus-*` and `table/devops-*`. Nine of the eleven tables in the `01-data` stack predate that naming convention, so the deploy role held **no control-plane DynamoDB permission on them at all**.

Approving the pending deployment on run `31237810212` produced the proof:

```
User: arn:aws:sts::356364570033:assumed-role/enceladus-cloudformation-deploy-github-role/GitHubActions
is not authorized to perform: dynamodb:DescribeTable on resource:
arn:aws:dynamodb:us-west-2:356364570033:table/documents
```

`01-data` rolled back to `UPDATE_ROLLBACK_COMPLETE` (clean — no data loss, nothing replaced) and the `02-compute` change-set was **skipped**. That is why `devops-governance-mart`, and every other Lambda added to `02-compute` since, has never existed in AWS despite being merged to main.

Quantified with `aws iam simulate-principal-policy` over all eleven `01-data` tables — 9 of 11 `implicitDeny` on `DescribeTable`/`UpdateTable`/`ListTagsOfResource`:

| allowed | implicitDeny |
|---|---|
| `devops-deployment-manager`, `devops-project-tracker` | `agent-compliance-violations`, `agent-sessions`, `agent-types`, `component-registry`, `coordination-requests`, `documents`, `governance-policies`, `governance-version`, `projects` |

## The fix

Two parts, matching the `iam-cfn-deploy-role-*-patch.yml` precedent (durable template change + one-off live dispatch).

**Durable** — `infrastructure/cloudformation/04-github-roles.yaml`: `DynamoDBTableOps` `Resource` goes from 2 to 11 entries. Enumerated rather than widened to `table/*`, because this is a closed legacy set and a wildcard would hand the deploy role control-plane authority over every table in the account. Merged `PolicyDocument` is 6113 bytes against the 10,240-byte inline quota (live current: 4988).

**Live** — new `.github/workflows/iam-cfn-deploy-role-legacy-ddb-patch.yml`, `workflow_dispatch`, environment `v3-prod`. It **extends `DynamoDBTableOps` in place** rather than appending a new `Sid` the way the scheduler precedent does. That is deliberate: a second statement would be an equivalent grant but a divergent shape, and DVP-TSK-696 check 9 (IAM/config drift) would then correctly flag this very fix as drift. Idempotent, fails closed if the statement is absent rather than guessing where the grant belongs, asserts the quota before writing, and ends with an IAM-simulator assertion over all eleven tables that exits non-zero on any remaining Deny.

## Unblocks

DVP-TSK-648/649/672-678 (B3 mart, at `committed`) and the DVP-TSK-665/694/695/696 health-monitor arc.

## Verification

- Template parsed with a CFN-short-tag-aware loader: 11 `Resource` entries, policy under quota.
- Workflow YAML parsed.
- `aws cloudformation validate-template` was **not** usable here: the template is 72,802 bytes against that API's 51,200-byte inline limit — an API constraint, not a template error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)