### PR TITLE
DVP-TSK-705: deliver the legacy 01-data DynamoDB grant as an attached managed policy (supersedes DVP-TSK-704)

### DIFF
--- a/.github/workflows/iam-cfn-deploy-role-legacy-ddb-patch.yml
+++ b/.github/workflows/iam-cfn-deploy-role-legacy-ddb-patch.yml
@@ -1,26 +1,33 @@
 name: IAM CFN Deploy Role — Legacy DynamoDB Table Patch
 
-# DVP-TSK-704 / DVP-PLN-001: CloudFormationDeployPolicy statement DynamoDBTableOps scoped
-# its Resource list to table/enceladus-* and table/devops-*. Nine of the eleven tables in
-# the 01-data stack predate that naming convention (agent-compliance-violations,
-# agent-sessions, agent-types, component-registry, coordination-requests, documents,
-# governance-policies, governance-version, projects), so the deploy role held NO
-# control-plane DynamoDB permission on them.
+# DVP-TSK-705 (supersedes DVP-TSK-704) / DVP-PLN-001.
 #
-# Effect: every "CloudFormation Compute Stack Deploy" apply since the last green run on
-# 2026-07-08 failed at dynamodb:DescribeTable, rolled 01-data back to
-# UPDATE_ROLLBACK_COMPLETE, and skipped the 02-compute change-set — which is why
-# devops-governance-mart, and every other lambda added since, never existed in AWS despite
-# being merged to main. This was misread as "the pipeline is broken"; the pipeline was fine.
+# THE GAP: CloudFormationDeployPolicy statement DynamoDBTableOps scopes its Resource list to
+# table/enceladus-* and table/devops-*. Nine of the eleven tables in the 01-data stack predate
+# that naming convention (agent-compliance-violations, agent-sessions, agent-types,
+# component-registry, coordination-requests, documents, governance-policies, governance-version,
+# projects), so the deploy role held NO control-plane DynamoDB permission on them.
 #
-# Durable fix lives in infrastructure/cloudformation/04-github-roles.yaml. This one-off
-# dispatch applies the same grant live ahead of the next github-roles stack deploy, which is
-# the pattern established by iam-cfn-deploy-role-scheduler-patch.yml and its siblings.
+# THE EFFECT: every "CloudFormation Compute Stack Deploy" apply since the last green run on
+# 2026-07-08 failed at dynamodb:DescribeTable, rolled 01-data back to UPDATE_ROLLBACK_COMPLETE,
+# and skipped the 02-compute change-set — which is why devops-governance-mart, and every other
+# Lambda added to 02-compute since, never existed in AWS despite being merged to main. This was
+# misread as "the pipeline is broken"; the pipeline was fine, and the v3-prod required-reviewer
+# pause in front of it is a deliberate ENC-FTR-120 control, not a failure.
 #
-# This patch EXTENDS the existing DynamoDBTableOps statement in place rather than appending a
-# new Sid, so the live policy and the template converge on one shape. A second statement
-# would be an equivalent grant but a divergent shape, and DVP-TSK-696 check 9 (IAM/config
-# drift) would then correctly flag this very fix as drift.
+# WHY A MANAGED POLICY, NOT AN INLINE GRANT: DVP-TSK-704 first tried to extend DynamoDBTableOps
+# in place and failed live with LimitExceeded. The IAM 10,240-byte limit for role inline policies
+# is AGGREGATE across all inline policies on the role, not per-policy, and this role already sits
+# at 10089/10240 (measured 2026-08-08). That is the same wall CodeDeployStackOpsPolicy
+# (ENC-TSK-J85) and LambdaFunctionUrlConfigPolicy (ENC-TSK-K09) each hit, and this follows their
+# resolution exactly: an attached managed policy, which does not count against the inline
+# aggregate.
+#
+# Durable declaration lives in infrastructure/cloudformation/04-github-roles.yaml as
+# LegacyDataStackDdbOpsPolicy. This one-off dispatch applies the same grant live ahead of the
+# next github-roles stack deploy, which is the pattern established by
+# iam-cfn-deploy-role-scheduler-patch.yml and its siblings. The policy name and document here are
+# kept identical to the template so the next stack deploy is a no-op rather than a conflict.
 
 on:
   workflow_dispatch:
@@ -29,7 +36,7 @@ on:
         description: "Why this patch is needed"
         type: string
         required: false
-        default: "DVP-TSK-704 — grant control-plane DynamoDB ops on the nine legacy 01-data tables"
+        default: "DVP-TSK-705 — grant control-plane DynamoDB ops on the nine legacy 01-data tables"
 
 permissions:
   contents: read
@@ -37,7 +44,7 @@ permissions:
 
 jobs:
   patch-role:
-    name: Patch CFN deploy role with legacy 01-data table ARNs
+    name: Attach legacy 01-data DynamoDB managed policy to the CFN deploy role
     environment: v3-prod
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -51,24 +58,17 @@ jobs:
       - name: Verify caller identity
         run: aws sts get-caller-identity
 
-      - name: Extend DynamoDBTableOps with the legacy table ARNs
+      - name: Create or update the managed policy and attach it
         env:
           ROLE_NAME: enceladus-cloudformation-deploy-github-role
-          POLICY_NAME: CloudFormationDeployPolicy
+          POLICY_NAME: enceladus-cfn-deploy-legacy-ddb-v1
         run: |
           set -euo pipefail
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${POLICY_NAME}"
 
-          aws iam get-role-policy \
-            --role-name "${ROLE_NAME}" \
-            --policy-name "${POLICY_NAME}" \
-            --query PolicyDocument \
-            --output json > /tmp/cfn-deploy-policy-current.json
-
-          ACCOUNT_ID="${ACCOUNT_ID}" python3 <<'PY'
+          ACCOUNT_ID="${ACCOUNT_ID}" python3 <<'PY' > /tmp/legacy-ddb-policy.json
           import json, os
-          from pathlib import Path
-
           account_id = os.environ["ACCOUNT_ID"]
           legacy = [
               "agent-compliance-violations",
@@ -81,44 +81,75 @@ jobs:
               "governance-version",
               "projects",
           ]
-          wanted = [f"arn:aws:dynamodb:us-west-2:{account_id}:table/{t}" for t in legacy]
-
-          doc = json.loads(Path("/tmp/cfn-deploy-policy-current.json").read_text())
-          statements = doc.setdefault("Statement", [])
-          target = next((s for s in statements if s.get("Sid") == "DynamoDBTableOps"), None)
-          if target is None:
-              raise SystemExit("DynamoDBTableOps statement not found — refusing to guess where the grant belongs")
-
-          resources = target.get("Resource", [])
-          if isinstance(resources, str):
-              resources = [resources]
-
-          missing = [arn for arn in wanted if arn not in resources]
-          if not missing:
-              print("All nine legacy table ARNs already present — no merge needed")
-          else:
-              print(f"Adding {len(missing)} legacy table ARN(s): {missing}")
-              resources.extend(missing)
-              target["Resource"] = resources
-
-          size = len(json.dumps(doc, separators=(",", ":")))
-          print(f"Merged policy size: {size} / 10240 bytes")
-          if size > 10240:
-              raise SystemExit("Merged policy exceeds the 10,240-byte inline policy quota")
-
-          Path("/tmp/cfn-deploy-policy-merged.json").write_text(json.dumps(doc))
+          doc = {
+              "Version": "2012-10-17",
+              "Statement": [
+                  {
+                      "Sid": "LegacyDataStackDdbOps",
+                      "Effect": "Allow",
+                      "Action": [
+                          "dynamodb:CreateTable",
+                          "dynamodb:DeleteTable",
+                          "dynamodb:DescribeTable",
+                          "dynamodb:UpdateTable",
+                          "dynamodb:DescribeTimeToLive",
+                          "dynamodb:UpdateTimeToLive",
+                          "dynamodb:DescribeContinuousBackups",
+                          "dynamodb:UpdateContinuousBackups",
+                          "dynamodb:TagResource",
+                          "dynamodb:UntagResource",
+                          "dynamodb:ListTagsOfResource",
+                      ],
+                      "Resource": [
+                          f"arn:aws:dynamodb:us-west-2:{account_id}:table/{t}" for t in legacy
+                      ],
+                  }
+              ],
+          }
+          body = json.dumps(doc, separators=(",", ":"))
+          assert len(body) <= 6144, f"managed policy document {len(body)} exceeds the 6144-byte limit"
+          print(body)
           PY
 
-          aws iam put-role-policy \
-            --role-name "${ROLE_NAME}" \
-            --policy-name "${POLICY_NAME}" \
-            --policy-document "file:///tmp/cfn-deploy-policy-merged.json"
+          if aws iam get-policy --policy-arn "${POLICY_ARN}" >/dev/null 2>&1; then
+            echo "Policy exists — creating a new default version"
+            # Managed policies cap at 5 versions; drop the oldest non-default before adding.
+            versions="$(aws iam list-policy-versions --policy-arn "${POLICY_ARN}" \
+              --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text)"
+            count="$(aws iam list-policy-versions --policy-arn "${POLICY_ARN}" \
+              --query 'length(Versions)' --output text)"
+            if [ "${count}" -ge 5 ]; then
+              oldest="$(echo "${versions}" | tr '\t' '\n' | tail -1)"
+              echo "Pruning oldest non-default version ${oldest}"
+              aws iam delete-policy-version --policy-arn "${POLICY_ARN}" --version-id "${oldest}"
+            fi
+            aws iam create-policy-version \
+              --policy-arn "${POLICY_ARN}" \
+              --policy-document "file:///tmp/legacy-ddb-policy.json" \
+              --set-as-default >/dev/null
+          else
+            echo "Policy does not exist — creating"
+            aws iam create-policy \
+              --policy-name "${POLICY_NAME}" \
+              --policy-document "file:///tmp/legacy-ddb-policy.json" \
+              --description "DVP-TSK-705: control-plane DynamoDB ops on the nine legacy un-prefixed 01-data tables" >/dev/null
+          fi
+
+          if aws iam list-attached-role-policies --role-name "${ROLE_NAME}" \
+               --query 'AttachedPolicies[].PolicyArn' --output text | grep -qF "${POLICY_ARN}"; then
+            echo "Already attached to ${ROLE_NAME}"
+          else
+            echo "Attaching ${POLICY_ARN} to ${ROLE_NAME}"
+            aws iam attach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${POLICY_ARN}"
+          fi
 
       - name: Verify the grant with the IAM simulator
         run: |
           set -euo pipefail
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
           ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/enceladus-cloudformation-deploy-github-role"
+          # IAM is eventually consistent; give the attach a moment to propagate.
+          sleep 15
           rc=0
           for t in agent-compliance-violations agent-sessions agent-types component-registry \
                    coordination-requests devops-deployment-manager documents governance-policies \
@@ -130,7 +161,7 @@ jobs:
               --query 'EvaluationResults[].EvalDecision' --output text)"
             echo "${t}: ${decisions}"
             case "${decisions}" in
-              *Deny*|*deny*) echo "::error::${t} still denied"; rc=1 ;;
+              *[Dd]eny*) echo "::error::${t} still denied"; rc=1 ;;
             esac
           done
           exit "${rc}"

--- a/infrastructure/cloudformation/04-github-roles.yaml
+++ b/infrastructure/cloudformation/04-github-roles.yaml
@@ -257,24 +257,10 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/enceladus-*"
                   - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/devops-*"
-                  # DVP-TSK-704: nine 01-data tables predate the enceladus-*/devops-* naming
-                  # convention, so the two prefix wildcards above never matched them. Every
-                  # "CloudFormation Compute Stack Deploy" apply since 2026-07-08 failed at
-                  # dynamodb:DescribeTable on these, rolled the data stack back to
-                  # UPDATE_ROLLBACK_COMPLETE, and skipped the compute change-set entirely —
-                  # which is why devops-governance-mart never existed in AWS despite being
-                  # merged to main. Enumerated rather than widened to table/*: this is a
-                  # closed legacy set, and a wildcard would hand the deploy role
-                  # control-plane authority over every table in the account.
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-compliance-violations"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-sessions"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-types"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/component-registry"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/coordination-requests"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-policies"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version"
-                  - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects"
+                  # DVP-TSK-705: the nine legacy un-prefixed 01-data tables are NOT listed
+                  # here. They live in LegacyDataStackDdbOpsPolicy (an attached managed
+                  # policy) because this role's aggregate inline-policy quota is exhausted
+                  # — see that resource for the full account.
 
               - Sid: SnsTopicOps
                 Effect: Allow
@@ -606,6 +592,63 @@ Resources:
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:application:enceladus-lambda*"
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentgroup:enceladus-lambda*"
               - !Sub "arn:aws:codedeploy:us-west-2:${AWS::AccountId}:deploymentconfig:*"
+
+  # ---------------------------------------------------------------------------
+  # DVP-TSK-705 / DVP-PLN-001 -- same failure class as CodeDeployStackOpsPolicy
+  # (ENC-TSK-J85) and LambdaFunctionUrlConfigPolicy (ENC-TSK-K09), and arrived at
+  # the same way: DVP-TSK-704 first tried to extend the inline DynamoDBTableOps
+  # statement and LimitExceeded live on 2026-08-08 (aggregate inline quota measured
+  # at 10089/10240, nine ARNs needing ~700 bytes). Shipped as an attached MANAGED
+  # policy instead, mirroring both precedents exactly.
+  #
+  # The gap this closes: DynamoDBTableOps scopes to table/enceladus-* and
+  # table/devops-*, but nine of the eleven tables in the 01-data stack predate that
+  # naming convention, so the deploy role held NO control-plane DynamoDB permission
+  # on them. Every "CloudFormation Compute Stack Deploy" apply since the last green
+  # run on 2026-07-08 failed at dynamodb:DescribeTable, rolled 01-data back to
+  # UPDATE_ROLLBACK_COMPLETE, and skipped the 02-compute change-set -- which is why
+  # devops-governance-mart, and every other Lambda added to 02-compute since, never
+  # existed in AWS despite being merged to main. Measured with the IAM simulator:
+  # 9 of 11 tables implicitDeny on DescribeTable/UpdateTable/ListTagsOfResource.
+  #
+  # Enumerated rather than widened to table/*: this is a closed legacy set, and a
+  # wildcard would hand the deploy role control-plane authority over every table in
+  # the account. New tables should use the enceladus-*/devops-* prefixes and be
+  # covered by DynamoDBTableOps rather than added here.
+  # ---------------------------------------------------------------------------
+  LegacyDataStackDdbOpsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: enceladus-cfn-deploy-legacy-ddb-v1
+      Roles:
+        - !Ref CloudFormationDeployRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: LegacyDataStackDdbOps
+            Effect: Allow
+            Action:
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
+              - dynamodb:DescribeTable
+              - dynamodb:UpdateTable
+              - dynamodb:DescribeTimeToLive
+              - dynamodb:UpdateTimeToLive
+              - dynamodb:DescribeContinuousBackups
+              - dynamodb:UpdateContinuousBackups
+              - dynamodb:TagResource
+              - dynamodb:UntagResource
+              - dynamodb:ListTagsOfResource
+            Resource:
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-compliance-violations"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-sessions"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/agent-types"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/component-registry"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/coordination-requests"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/documents"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-policies"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/governance-version"
+              - !Sub "arn:aws:dynamodb:us-west-2:${AWS::AccountId}:table/projects"
 
   # ---------------------------------------------------------------------------
   # ENC-TSK-K09 / ENC-ISS-469 -- same failure class as CodeDeployStackOpsPolicy


### PR DESCRIPTION
CCI-e810c2d10aeb4becbce271f9426f2261

Supersedes #1083 / DVP-TSK-704. **The diagnosis there was right; the delivery mechanism was not.**

## What went wrong in #1083

It extended the inline `DynamoDBTableOps` statement. The live apply failed:

```
An error occurred (LimitExceeded) when calling the PutRolePolicy operation:
Maximum policy size of 10240 bytes exceeded for role enceladus-cloudformation-deploy-github-role
```

The IAM 10,240-byte limit for role inline policies is **aggregate across all inline policies on the role**, not per-policy. My in-workflow guard measured `CloudFormationDeployPolicy` in isolation (4988 → 5663) and passed; AWS rejected on the total. Measured live:

| inline policy | bytes |
|---|---:|
| `CloudFormationDeployPolicy` | 4988 |
| `enceladus-cfn-deploy-gamma-ddb-sns-v1` | 1969 |
| `enceladus-cfn-deploy-role-agent-auth-cognito-v1` | 1372 |
| `enceladus-cloudformation-api-unblock-v1` | 726 |
| `enceladus-cfn-deploy-gamma-cloudwatch-dashboard-v1` | 308 |
| `enceladus-cfn-deploy-role-loggroups-v1` | 308 |
| `CFN-IAM-Inspect-LambdaRoles` | 238 |
| `enceladus-cfn-deploy-eventbridge-listrules-v1` | 180 |
| **total** | **10089 / 10240** |

151 bytes of headroom; nine ARNs need ~700. `PutRolePolicy` is atomic, so **nothing was mutated** — the role is byte-identical to its pre-#1083 state.

This is the same wall `CodeDeployStackOpsPolicy` (ENC-TSK-J85) and `LambdaFunctionUrlConfigPolicy` (ENC-TSK-K09) each hit, and both were resolved the same way. `04-github-roles.yaml` already documents it at line 487.

## This PR

- **`04-github-roles.yaml`** — removes the nine ARNs #1083 added to the inline statement (leaving them is a latent hazard: they pushed the template's aggregate from 10365 to 11059) and adds **`LegacyDataStackDdbOpsPolicy`**, an `AWS::IAM::ManagedPolicy` (`enceladus-cfn-deploy-legacy-ddb-v1`) carrying the same nine ARNs and eleven actions, attached to `CloudFormationDeployRole`. Document is 1152/6144 bytes and does not count against the inline aggregate.
- **`iam-cfn-deploy-role-legacy-ddb-patch.yml`** — rewritten to create-or-version the managed policy and attach it. Idempotent on create and attach, prunes the oldest non-default version at the 5-version cap, asserts the 6,144-byte limit, sleeps for IAM eventual consistency, and verifies with `simulate-principal-policy` across all eleven tables.

Enumerated rather than widened to `table/*`: closed legacy set, and a wildcard would hand the deploy role control-plane authority over every table in the account.

## Discovered, not fixed here

The template's aggregate inline size is **10365/10240 at `4201111a`** — already over quota *before* this session touched the file. A `04-github-roles.yaml` stack deploy would fail on that alone, independently of this change. Filed as its own record rather than absorbed here; this PR restores the template to that pre-existing baseline rather than making it worse.

## Unblocks

DVP-TSK-648/649/672-678 (B3 mart, at `committed`) and the DVP-TSK-665/694/695/696 health-monitor arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)