### PR TITLE
ENC-TSK-N87: add PATCH /api/v1/projects/{projectName} to project_service

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,6 +1,6 @@
 {
-  "version": "2026-08-08.9",
-  "updated_at": "2026-08-08T08:21:15Z",
+  "version": "2026-08-13.1",
+  "updated_at": "2026-08-13T19:00:00Z",
   "last_change_summary": "INT-TSK-197 (cross-repo governance sync for the intelligence project, discharges handoff DOC-422F68754CF9): added entity corpus.graph_isolated_reason -- a standalone closed-vocabulary enum (pending_derivation, no_participants_resolved, no_temporal_neighbors, no_topical_match, unsupported_source_type, extraction_failed, singleton_upload, operator_isolated) naming why a corpus artifact reached a terminal enrichment_status with zero taxonomy edges, modeled on the corpus.edge_taxonomy standalone-vocabulary shape (same namespace, same 'documentation entity with no owning artifact record' pattern). Makes the G1 invariant enforceable as a closed set: intelligence repo's backend/lambda/graph_health_metrics already reads graph_isolated_reason IS NULL defensively (comment cites 'Phase 12 / INT-TSK-197'), and until now nothing governed the values it will eventually hold. No writer sets the field yet -- population is separate INT-TSK-197 follow-on work; this PR only registers the vocabulary. Deliberately did NOT register the per-artifact enrichment_status lifecycle enum (pending/uploaded/ingested/enriched/embedded/integrated/failed/stale): it is tracked only as Python literals in the intelligence repo (corpus_schema.py) with no existing governed entity to extend, INT-TSK-197 AC-1 does not require it to be governed, and originating a new corpus.artifact entity to hold it would have been an unrequested ontological expansion invented on a guess -- left to code. No existing entity was modified. PREVIOUS: ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600, DOC-B716E8FB10B6 COE lineage, M44/M45 sibling): backport the ENC-TSK-K34 bundled-only dictionary serving (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E) from v4/main onto main -- coordination_api._load_governance_dictionary no longer scans the governance-policies DynamoDB mirror (frozen at 2026-06-30.09/121 entities since the document outgrew DynamoDB's 400KB item cap; no production S3->DDB trigger ever existed either); the bundled file is now the sole authoritative source on main, matching v4/main. Also imports the 37 entity keys present in S3-live 2026-08-08.01 (sha256 5b0d150a3d4bb7230d5798c6d8ddb9fd10fad86d3f5c9e3545b08d4dbc0ad726) but absent from this bundle -- the SCI-enforcement, agent-identity, escalations, graph_query_api, mcp_server and corpus governance that went invisible to every MCP agent when the mirror froze. Merge policy: bundle wins on shared keys per the K34 deploy-coupling doctrine (15 shared keys differ from S3-live: api.error_envelope, component_registry.component, coordination.agent_session, coordination.agent_session_idle_sweep, coordination.agent_type, coordination.escalations, coordination.request, coordination.session_claim_id, deploy.spec, document.query_response, tracker.feature, tracker.graphsearch, tracker.issue, tracker.plan, tracker.task; the S3-side copies remain recoverable under governance/history/). A section-13 HANDOFF requests io push this reconciled content to S3-live to restore exact S3<->served entity-key parity. No pre-existing bundle entity was modified. PREVIOUS: DVP-TSK-703 (DVP-PLN-001): REPOINTED ONLY -- no entity, field, enum or contract was added, removed or altered. warehouse.adhoc_promotion and warehouse.platform_health now name their implementation in NX-2021-L/devops (services/lambda/adhoc_promotion, services/lambda/platform_health) rather than in this repo, correcting a repo-ownership error: both operate on data.jreese.net -- the Trino catalog, the hive.adhoc namespace, the warehouse prefixes and EC2 i-0f3a4d5aa1c11dd86 -- which is platform, not a projection of the governance ontology. Both still write through the B2-R2 library enceladus_shared.warehouse_registration, which remains canonical HERE and is fetched by devops at a pinned, sha256-verified commit rather than copied, so the single-registration-path contract is unchanged. warehouse.governance_mart is untouched and stays in this repo per BRD B3-R4. PREVIOUS: DVP-TSK-696 (BRD B6-R2, DVP-PLN-001): extended entity warehouse.platform_health with checks 6, 7, 8 and a NINTH -- container health read from the kernel log rather than Docker's RestartCount (which read 0 through seven OOM kills), the hive.adhoc quota with its explicit empty case, burstable CPU credits thresholded against surplus BURN because CpuCredits=unlimited makes the failure economic rather than a performance cliff, and IAM/configuration drift, which must be scheduled because the 2026-08-06 severance arrived through create-policy-version and a hand-edited .env, neither of which any PR-triggered guard can observe. No existing entity was modified. PREVIOUS: DVP-TSK-695 (BRD B6-R2, DVP-PLN-001) extended entity warehouse.platform_health with checks 2, 3 and 4 -- the enforcement arm of the warehouse contract, making B2-R3 (no crawlers, scanned in every region), B5-R4 (namespace isolation, legacy tables reported rather than allowlisted) and B2-R6 (Parquet, read from the SerDe rather than the crawler-written classification hint) mechanical rather than prose. No existing entity was modified. PREVIOUS: DVP-TSK-694 / DVP-TSK-665 (BRD B6-R2, DVP-PLN-001) added entity warehouse.platform_health documenting the source-agnostic platform health monitor -- its schedule-only invocation contract, the observe-never-remediate posture its IAM shape enforces, the error-as-a-third-state rule, the platform-health/ surface and its two T2 daily-grain projections, and checks 1 (freshness against a declared SLA) and 5 (full-refresh consistency). No existing entity was modified. PREVIOUS: DVP-TSK-661 / 685 / 686 / 687 (BRD B5-R2, DVP-PLN-001) added entity warehouse.adhoc_promotion documenting the ad-hoc promotion transform -- the single gate out of the hive.adhoc quarantine namespace into a governed schema. Records the contract for its two actions (plan, promote), the mandatory human actor block enforcing decision D-4, the all-or-nothing coercion semantics including the lossy-coercion rule, and the offending-row report shape. No existing entity was modified.",
   "owners": [
     "enceladus-platform"
@@ -7352,9 +7352,55 @@
           "definition": "X-Checkout-Service-Key-authenticated requests (FTR-037) skip the gate; the gate already ran at the checkout_service edge for the originating agent call."
         }
       }
+    },
+    "project_service.update_contract": {
+      "description": "ENC-TSK-N87 / ENC-FTR-131: the PATCH /api/v1/projects/{projectName} project-metadata update contract served by project_service (devops-project-service Lambda). Created because the projects table previously had NO update path at any layer -- project_service routed only POST (create), GET (list) and GET (single), and infrastructure/cloudformation/03-api.yaml declared no PATCH route -- so a project record whose metadata was wrong or absent at create time was frozen unless written with privileged credentials. The canonical blocked case is FIN-TSK-154: the finance project carries no `repo`, so checkout_service._resolve_github_repo could not resolve a GitHub repo and every GitHub-validated gate demanded owner/repo in transition_evidence on every call (observed on FIN-TSK-151/152/153). Auth: PATCH sits on projects:write alongside POST (_WRITE_METHODS); a projects:read caller is rejected. Surfaced in the PWA as the Edit Project action on each project card (ENC-TSK-N89).",
+      "fields": {
+        "mutable_fields": {
+          "type": "list",
+          "value": [
+            "summary",
+            "status",
+            "repo"
+          ],
+          "definition": "The ONLY attributes PATCH may change. summary: 1-500 chars after strip. status: must be one of planning | development | active_production -- identical to the create-path allowlist (_VALID_CREATE_STATUSES) so a value unreachable at create cannot be reached by update. NOTE: 'closed' and 'archived' exist in _ALL_STATUSES for read/normalization but are deliberately NOT settable via PATCH in ENC-FTR-131; project retirement is out of scope and would need its own governed transition. repo: a valid http(s) URL up to 2048 chars."
+        },
+        "immutable_fields": {
+          "type": "list",
+          "value": [
+            "project_id",
+            "name",
+            "prefix",
+            "parent",
+            "path",
+            "deploy_policy",
+            "deploy_mode",
+            "created_at",
+            "created_by",
+            "updated_at"
+          ],
+          "definition": "Rejected with HTTP 400 naming the offending field, and NO write is attempted. These are identity and hierarchy attributes: project_id and prefix are referenced by every tracker record and `path` encodes the project hierarchy, so permitting an edit would silently orphan records rather than fail loudly. deploy_policy / deploy_mode are deployment governance and change only through their own governed paths."
+        },
+        "repo_clear_semantics": {
+          "type": "rule",
+          "definition": "repo='' is the explicit CLEAR sentinel and emits a DynamoDB REMOVE for the attribute rather than storing an empty string. Storing '' would leave _resolve_github_repo seeing a present-but-unusable value, trading the original failure mode for a subtler one. Omitting repo from the body leaves the existing value untouched -- absent and empty are distinct inputs."
+        },
+        "empty_patch_rule": {
+          "type": "rule",
+          "definition": "A body containing none of the mutable fields returns 400, not a no-op 200, so a client bug that sends an empty patch is visible instead of reporting a successful save. Unknown field names are likewise rejected rather than silently dropped."
+        },
+        "concurrency_guard": {
+          "type": "rule",
+          "definition": "The update carries ConditionExpression attribute_exists(project_id); a ConditionalCheckFailedException is surfaced as HTTP 404. This prevents a concurrent delete from being resurrected as a partial item by an in-flight PATCH."
+        },
+        "updated_at_behavior": {
+          "type": "rule",
+          "definition": "updated_at is set server-side to the current UTC timestamp on every successful PATCH. It is simultaneously listed as immutable: callers may not supply it, but the service always advances it."
+        }
+      }
     }
   },
-  "change_summary": "ENC-TSK-G06 (linked ENC-TSK-B62 / ENC-TSK-C72): graph_sync now normalizes document DELETE identity from document_id/item_id fallbacks and purges orphan placeholder nodes after MODIFY/REMOVE and archived typed-relationship removal. tools/backfill_graph.py replays the canonical tracker+documents projection contract with optional wipe-existing for parity rebuilds.",
+  "change_summary": "ENC-TSK-N87 / ENC-FTR-131: add project_service.update_contract documenting the new PATCH /api/v1/projects/{projectName} endpoint, its mutable/immutable field split, repo-clear semantics, empty-patch rejection and attribute_exists concurrency guard.",
   "change_log": [
     {
       "version": "2026-07-13.1",
@@ -7429,6 +7475,11 @@
       "summary": "ENC-TSK-N82 (ENC-ISS-599 / ENC-ISS-600, DOC-B716E8FB10B6 COE lineage, M44/M45 sibling): backport the ENC-TSK-K34 bundled-only dictionary serving (ENC-ISS-477 resolution, DOC-F234A4E11DFD Option E) from v4/main onto main -- coordination_api._load_governance_dictionary no longer scans the governance-policies DynamoDB mirror (frozen at 2026-06-30.09/121 entities since the document outgrew DynamoDB's 400KB item cap; no production S3->DDB trigger ever existed either); the bundled file is now the sole authoritative source on main, matching v4/main. Also imports the 37 entity keys present in S3-live 2026-08-08.01 (sha256 5b0d150a3d4bb7230d5798c6d8ddb9fd10fad86d3f5c9e3545b08d4dbc0ad726) but absent from this bundle -- the SCI-enforcement, agent-identity, escalations, graph_query_api, mcp_server and corpus governance that went invisible to every MCP agent when the mirror froze. Merge policy: bundle wins on shared keys per the K34 deploy-coupling doctrine (15 shared keys differ from S3-live: api.error_envelope, component_registry.component, coordination.agent_session, coordination.agent_session_idle_sweep, coordination.agent_type, coordination.escalations, coordination.request, coordination.session_claim_id, deploy.spec, document.query_response, tracker.feature, tracker.graphsearch, tracker.issue, tracker.plan, tracker.task; the S3-side copies remain recoverable under governance/history/). A section-13 HANDOFF requests io push this reconciled content to S3-live to restore exact S3<->served entity-key parity. No pre-existing bundle entity was modified.",
       "task": "ENC-TSK-N82",
       "issue": "ENC-ISS-600"
+    },
+    {
+      "version": "2026-08-13.1",
+      "date": "2026-08-13",
+      "summary": "ENC-TSK-N87 (ENC-FTR-131, unblocks FIN-TSK-154): project_service gains PATCH /api/v1/projects/{projectName}, the first update path for the projects table. New entity project_service.update_contract records the governed contract: mutable = {summary, status, repo}; immutable = {project_id, name, prefix, parent, path, deploy_policy, deploy_mode, created_at, created_by, updated_at} rejected 400 with no write; repo='' REMOVEs the attribute rather than storing ''; empty/unknown patch bodies are 400 not no-op 200; writes are guarded by ConditionExpression attribute_exists(project_id) surfacing 404. PATCH added to _WRITE_METHODS so it requires projects:write rather than inheriting the projects:read branch."
     }
   ]
 }

--- a/backend/lambda/project_service/lambda_function.py
+++ b/backend/lambda/project_service/lambda_function.py
@@ -9,6 +9,7 @@ Routes (via API Gateway proxy):
     POST   /api/v1/projects                        Create a new project
     GET    /api/v1/projects                        List all projects
     GET    /api/v1/projects/{projectName}           Get a single project
+    PATCH  /api/v1/projects/{projectName}           Update summary/status/repo (ENC-FTR-131)
     OPTIONS /api/v1/projects[/{projectName}]        CORS preflight
 
 Auth:
@@ -132,6 +133,28 @@ _PREFIX_PATTERN = re.compile(r"^[A-Z]{3}$")
 _REPO_URL_PATTERN = re.compile(r"^https?://[^\s]+$")
 _VALID_CREATE_STATUSES = {"planning", "development", "active_production"}
 _ALL_STATUSES = _VALID_CREATE_STATUSES | {"closed", "archived"}
+
+# ENC-TSK-N87 / ENC-FTR-131 — project metadata update contract.
+# HTTP methods that mutate the projects table and therefore require projects:write.
+_WRITE_METHODS = {"POST", "PATCH"}
+# The only attributes PATCH may change. Deliberately narrow: project_id and prefix are
+# referenced by every tracker record and `path` encodes hierarchy, so making any of them
+# editable would silently orphan records rather than fail loudly.
+_MUTABLE_UPDATE_FIELDS = ("summary", "status", "repo")
+# Named explicitly so a caller who sends one gets a 400 naming the field, instead of the
+# request being silently accepted with the field dropped.
+_IMMUTABLE_UPDATE_FIELDS = (
+    "project_id",
+    "name",
+    "prefix",
+    "parent",
+    "path",
+    "deploy_policy",
+    "deploy_mode",
+    "created_at",
+    "created_by",
+    "updated_at",
+)
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -364,7 +387,7 @@ def _deserialize_item(raw: Dict) -> Dict[str, Any]:
 def _cors_headers() -> Dict[str, str]:
     return {
         "Access-Control-Allow-Origin": CORS_ORIGIN,
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Methods": "GET, POST, PATCH, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Cookie, X-Coordination-Internal-Key",
         "Access-Control-Allow-Credentials": "true",
     }
@@ -483,6 +506,74 @@ def _validate_create_input(body: Dict) -> Tuple[Optional[Dict], Optional[str]]:
         "name": name, "prefix": prefix, "summary": summary,
         "status": status, "parent": parent, "repo": repo,
     }, None
+
+
+def _validate_update_input(body: Dict) -> Tuple[Optional[Dict], Optional[str]]:
+    """Validate a PATCH body against the ENC-FTR-131 update contract.
+
+    Returns ({field: value}, None) on success, where only fields actually present in the
+    body appear. A repo value of None is the explicit "remove this attribute" sentinel —
+    distinct from repo being absent, which means "leave it alone".
+
+    Mirrors _validate_create_input's rules for summary and status so the two paths cannot
+    drift; a project that could not be created with a given value must not be reachable by
+    updating into it either.
+    """
+    if not isinstance(body, dict):
+        return None, "body must be a JSON object"
+
+    supplied_immutable = [f for f in _IMMUTABLE_UPDATE_FIELDS if f in body]
+    if supplied_immutable:
+        return None, (
+            f"immutable field(s) not editable: {', '.join(sorted(supplied_immutable))}. "
+            f"Editable fields are: {', '.join(_MUTABLE_UPDATE_FIELDS)}"
+        )
+
+    unknown = [k for k in body if k not in _MUTABLE_UPDATE_FIELDS]
+    if unknown:
+        return None, (
+            f"unknown field(s): {', '.join(sorted(unknown))}. "
+            f"Editable fields are: {', '.join(_MUTABLE_UPDATE_FIELDS)}"
+        )
+
+    errors: List[str] = []
+    data: Dict[str, Any] = {}
+
+    if "summary" in body:
+        summary = (body.get("summary") or "").strip()
+        if not summary or len(summary) > 500:
+            errors.append("summary: required, 1-500 chars")
+        else:
+            data["summary"] = summary
+
+    if "status" in body:
+        status = (body.get("status") or "").strip()
+        if status not in _VALID_CREATE_STATUSES:
+            errors.append(f"status: must be one of {sorted(_VALID_CREATE_STATUSES)}")
+        else:
+            data["status"] = status
+
+    if "repo" in body:
+        raw_repo = body.get("repo")
+        repo = "" if raw_repo is None else str(raw_repo).strip()
+        if not repo:
+            # Empty clears the attribute. Storing "" instead would make _resolve_github_repo
+            # see a present-but-unusable value, trading one failure mode for a subtler one.
+            data["repo"] = None
+        elif len(repo) > 2048 or not _REPO_URL_PATTERN.match(repo):
+            errors.append("repo: when provided, must be a valid http(s) URL up to 2048 characters")
+        else:
+            data["repo"] = repo
+
+    if errors:
+        return None, "; ".join(errors)
+    if not data:
+        # A no-op 200 would let a UI bug that sends nothing look like a successful save.
+        return None, (
+            f"no editable fields supplied. Provide at least one of: "
+            f"{', '.join(_MUTABLE_UPDATE_FIELDS)}"
+        )
+    return data, None
 
 
 # ---------------------------------------------------------------------------
@@ -772,6 +863,80 @@ def _handle_get(project_name: str) -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# UPDATE project (PATCH /api/v1/projects/{projectName})
+# ---------------------------------------------------------------------------
+
+
+def _handle_update(project_name: str, body: Dict, claims: Dict) -> Dict:
+    """Update the editable metadata of an existing project (ENC-FTR-131).
+
+    Editable: summary, status, repo. Everything else is rejected with a 400 that names the
+    offending field, and no write is attempted.
+
+    Exists because the projects table previously had no update path at all: a project whose
+    metadata was wrong or missing at create time was frozen unless someone wrote DynamoDB
+    with privileged credentials. FIN-TSK-154 is the canonical case — the finance project
+    carries no `repo`, so every GitHub-validated checkout gate demanded owner/repo be passed
+    explicitly on every single call.
+    """
+    data, validation_error = _validate_update_input(body)
+    if validation_error:
+        return _error(400, validation_error)
+
+    ddb = _get_ddb()
+    now = _now_z()
+
+    set_parts: List[str] = ["#updated_at = :updated_at"]
+    remove_parts: List[str] = []
+    names: Dict[str, str] = {"#updated_at": "updated_at"}
+    values: Dict[str, Dict[str, str]] = {":updated_at": {"S": now}}
+
+    for field in _MUTABLE_UPDATE_FIELDS:
+        if field not in data:
+            continue
+        placeholder = f"#{field}"
+        names[placeholder] = field
+        value = data[field]
+        if value is None:
+            # repo="" — clear the attribute entirely rather than storing an empty string.
+            remove_parts.append(placeholder)
+        else:
+            set_parts.append(f"{placeholder} = :{field}")
+            values[f":{field}"] = {"S": value}
+
+    expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        expression += " REMOVE " + ", ".join(remove_parts)
+
+    try:
+        resp = ddb.update_item(
+            TableName=PROJECTS_TABLE,
+            Key={"project_id": {"S": project_name}},
+            UpdateExpression=expression,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+            # Guards against a concurrent delete resurrecting the row as a partial item.
+            ConditionExpression="attribute_exists(project_id)",
+            ReturnValues="ALL_NEW",
+        )
+    except ddb.exceptions.ConditionalCheckFailedException:
+        return _error(404, f"Project '{project_name}' not found")
+    except (BotoCoreError, ClientError) as exc:
+        logger.error("projects table update failed: %s", exc)
+        return _error(500, "Failed to update project entry.")
+
+    logger.info(
+        "[SUCCESS] project updated: project_id=%s fields=%s actor=%s",
+        project_name,
+        sorted(data.keys()),
+        claims.get("sub", "unknown"),
+    )
+
+    project = _enrich_project(_deserialize_item(resp.get("Attributes", {})))
+    return _response(200, {"success": True, "project": project})
+
+
+# ---------------------------------------------------------------------------
 # Path parsing
 # ---------------------------------------------------------------------------
 
@@ -794,7 +959,12 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
         return {"statusCode": 204, "headers": _cors_headers(), "body": ""}
 
     # Auth
-    required_scopes = ["projects:write"] if method == "POST" else ["projects:read"]
+    # ENC-TSK-N87 / ENC-FTR-131: PATCH mutates the projects table, so it must sit on the
+    # write scope alongside POST. Leaving it on the else-branch would have handed every
+    # projects:read caller an update path.
+    required_scopes = (
+        ["projects:write"] if method in _WRITE_METHODS else ["projects:read"]
+    )
     headers = event.get("headers") or {}
     internal_key = (
         headers.get("x-coordination-internal-key")
@@ -849,6 +1019,13 @@ def lambda_handler(event: Dict, context: Any) -> Dict:
 
     elif method == "GET" and project_name:
         return _handle_get(project_name)
+
+    elif method == "PATCH" and project_name:
+        try:
+            body = json.loads(event.get("body") or "{}")
+        except (ValueError, TypeError):
+            return _error(400, "Invalid JSON body.")
+        return _handle_update(project_name, body, claims)
 
     else:
         return _error(405, "Method not allowed.")

--- a/backend/lambda/project_service/test_project_update_n87.py
+++ b/backend/lambda/project_service/test_project_update_n87.py
@@ -1,0 +1,249 @@
+"""test_project_update_n87.py — ENC-TSK-N87 / ENC-FTR-131
+
+Covers the PATCH /api/v1/projects/{projectName} update contract.
+
+The load-bearing assertions here are the negative ones. Several of these tests would
+still pass against a broken implementation if they only checked the status code, so
+where it matters they assert that no write was attempted at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "project_service",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+project_service = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(project_service)
+
+
+class _FakeConditionalCheckFailed(Exception):
+    pass
+
+
+def _make_ddb(existing: dict | None = None) -> MagicMock:
+    """A DynamoDB stub whose update_item echoes back a plausible ALL_NEW item."""
+    ddb = MagicMock()
+    ddb.exceptions.ConditionalCheckFailedException = _FakeConditionalCheckFailed
+    attrs = existing if existing is not None else {
+        "project_id": {"S": "finance"},
+        "prefix": {"S": "FIN"},
+        "summary": {"S": "Project to manage my finances."},
+        "status": {"S": "development"},
+        "path": {"S": "projects/io/finance"},
+        "created_at": {"S": "2026-04-02T00:36:20Z"},
+        "updated_at": {"S": "2026-04-02T00:36:20Z"},
+    }
+    ddb.update_item.return_value = {"Attributes": attrs}
+    # _handle_update enriches the response, which walks _compute_days_since_active's
+    # paginated query. A bare MagicMock makes resp.get("LastEvaluatedKey") truthy forever
+    # and the loop never terminates, so return a real terminal page.
+    ddb.query.return_value = {"Items": []}
+    return ddb
+
+
+def _body(resp: dict) -> dict:
+    return json.loads(resp["body"])
+
+
+class ValidateUpdateInputTests(unittest.TestCase):
+    def test_accepts_the_three_mutable_fields(self):
+        data, err = project_service._validate_update_input(
+            {"summary": "New summary", "status": "active_production", "repo": "https://github.com/NX-2021-L/finance"}
+        )
+        self.assertIsNone(err)
+        self.assertEqual(
+            data,
+            {
+                "summary": "New summary",
+                "status": "active_production",
+                "repo": "https://github.com/NX-2021-L/finance",
+            },
+        )
+
+    def test_partial_patch_only_returns_supplied_fields(self):
+        data, err = project_service._validate_update_input({"repo": "https://github.com/NX-2021-L/finance"})
+        self.assertIsNone(err)
+        self.assertEqual(list(data.keys()), ["repo"])
+
+    def test_each_immutable_field_is_rejected_by_name(self):
+        for field in project_service._IMMUTABLE_UPDATE_FIELDS:
+            with self.subTest(field=field):
+                data, err = project_service._validate_update_input({"summary": "ok", field: "x"})
+                self.assertIsNone(data)
+                self.assertIn(field, err)
+
+    def test_unknown_field_is_rejected(self):
+        data, err = project_service._validate_update_input({"nonsense": "x"})
+        self.assertIsNone(data)
+        self.assertIn("nonsense", err)
+
+    def test_empty_body_is_rejected_rather_than_a_noop(self):
+        data, err = project_service._validate_update_input({})
+        self.assertIsNone(data)
+        self.assertIn("no editable fields", err)
+
+    def test_status_restricted_to_create_statuses(self):
+        for bad in ("closed", "archived", "", "Development", "bogus"):
+            with self.subTest(status=bad):
+                data, err = project_service._validate_update_input({"status": bad})
+                self.assertIsNone(data, f"status={bad!r} should be rejected")
+                self.assertIn("status", err)
+
+    def test_summary_length_bounds(self):
+        data, err = project_service._validate_update_input({"summary": "x" * 501})
+        self.assertIsNone(data)
+        self.assertIn("summary", err)
+
+        data, err = project_service._validate_update_input({"summary": "   "})
+        self.assertIsNone(data)
+        self.assertIn("summary", err)
+
+    def test_repo_empty_string_is_the_remove_sentinel(self):
+        data, err = project_service._validate_update_input({"repo": ""})
+        self.assertIsNone(err)
+        self.assertIn("repo", data)
+        self.assertIsNone(data["repo"], "empty repo must map to the None remove-sentinel, not ''")
+
+    def test_repo_invalid_url_rejected(self):
+        for bad in ("not-a-url", "ftp://example.com/x", "github.com/foo/bar"):
+            with self.subTest(repo=bad):
+                data, err = project_service._validate_update_input({"repo": bad})
+                self.assertIsNone(data)
+                self.assertIn("repo", err)
+
+
+class HandleUpdateTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_get_ddb = project_service._get_ddb
+
+    def tearDown(self):
+        project_service._get_ddb = self._orig_get_ddb
+
+    def _run(self, body, ddb=None):
+        ddb = ddb or _make_ddb()
+        project_service._get_ddb = lambda: ddb
+        resp = project_service._handle_update("finance", body, {"sub": "test-user"})
+        return resp, ddb
+
+    def test_successful_update_returns_200_and_project(self):
+        resp, ddb = self._run({"summary": "New summary"})
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertTrue(_body(resp)["success"])
+        self.assertIn("project", _body(resp))
+        ddb.update_item.assert_called_once()
+
+    def test_update_expression_touches_only_allowed_attributes(self):
+        resp, ddb = self._run(
+            {"summary": "s", "status": "planning", "repo": "https://github.com/NX-2021-L/finance"}
+        )
+        self.assertEqual(resp["statusCode"], 200)
+        kwargs = ddb.update_item.call_args.kwargs
+        touched = set(kwargs["ExpressionAttributeNames"].values())
+        self.assertEqual(touched, {"summary", "status", "repo", "updated_at"})
+
+    def test_updated_at_always_advances(self):
+        resp, ddb = self._run({"summary": "s"})
+        kwargs = ddb.update_item.call_args.kwargs
+        self.assertIn(":updated_at", kwargs["ExpressionAttributeValues"])
+        self.assertIn("updated_at", kwargs["ExpressionAttributeNames"].values())
+
+    def test_immutable_field_performs_no_write(self):
+        """The point of this test: a 400 alone would not prove nothing was written."""
+        resp, ddb = self._run({"prefix": "XXX"})
+        self.assertEqual(resp["statusCode"], 400)
+        ddb.update_item.assert_not_called()
+
+    def test_empty_body_performs_no_write(self):
+        resp, ddb = self._run({})
+        self.assertEqual(resp["statusCode"], 400)
+        ddb.update_item.assert_not_called()
+
+    def test_invalid_repo_performs_no_write(self):
+        resp, ddb = self._run({"repo": "not-a-url"})
+        self.assertEqual(resp["statusCode"], 400)
+        ddb.update_item.assert_not_called()
+
+    def test_repo_clear_uses_remove_not_empty_string(self):
+        resp, ddb = self._run({"repo": ""})
+        self.assertEqual(resp["statusCode"], 200)
+        kwargs = ddb.update_item.call_args.kwargs
+        self.assertIn("REMOVE", kwargs["UpdateExpression"])
+        # The repo placeholder must not appear on the SET side with an empty value.
+        self.assertNotIn(":repo", kwargs["ExpressionAttributeValues"])
+
+    def test_repo_set_writes_the_url(self):
+        resp, ddb = self._run({"repo": "https://github.com/NX-2021-L/finance"})
+        self.assertEqual(resp["statusCode"], 200)
+        kwargs = ddb.update_item.call_args.kwargs
+        self.assertNotIn("REMOVE", kwargs["UpdateExpression"])
+        self.assertEqual(
+            kwargs["ExpressionAttributeValues"][":repo"]["S"],
+            "https://github.com/NX-2021-L/finance",
+        )
+
+    def test_write_is_guarded_by_attribute_exists(self):
+        resp, ddb = self._run({"summary": "s"})
+        kwargs = ddb.update_item.call_args.kwargs
+        self.assertEqual(kwargs["ConditionExpression"], "attribute_exists(project_id)")
+
+    def test_missing_project_returns_404(self):
+        ddb = _make_ddb()
+        ddb.update_item.side_effect = _FakeConditionalCheckFailed()
+        resp, _ = self._run({"summary": "s"}, ddb=ddb)
+        self.assertEqual(resp["statusCode"], 404)
+        self.assertIn("not found", _body(resp)["error"])
+
+
+class RoutingAndScopeTests(unittest.TestCase):
+    """The scope ternary and the route are the two places a mistake is silently dangerous."""
+
+    def test_patch_requires_write_scope(self):
+        self.assertIn("PATCH", project_service._WRITE_METHODS)
+        self.assertIn("POST", project_service._WRITE_METHODS)
+        self.assertNotIn("GET", project_service._WRITE_METHODS)
+
+    def test_read_only_internal_key_is_denied_patch(self):
+        orig = project_service.INTERNAL_API_KEY_SCOPES
+        try:
+            project_service.INTERNAL_API_KEY_SCOPES = {"ro-key": {"projects:read"}}
+            self.assertFalse(
+                project_service._internal_key_has_scopes("ro-key", ["projects:write"])
+            )
+        finally:
+            project_service.INTERNAL_API_KEY_SCOPES = orig
+
+    def test_cors_advertises_patch(self):
+        self.assertIn("PATCH", project_service._cors_headers()["Access-Control-Allow-Methods"])
+
+    def test_patch_without_project_name_is_405(self):
+        """PATCH /api/v1/projects (collection) has no meaning and must not fall through."""
+        orig = project_service._get_ddb
+        try:
+            ddb = _make_ddb()
+            project_service._get_ddb = lambda: ddb
+            resp = project_service.lambda_handler(
+                {
+                    "requestContext": {"http": {"method": "PATCH", "path": "/api/v1/projects"}},
+                    "headers": {"x-coordination-internal-key": "rw-key"},
+                    "body": json.dumps({"summary": "s"}),
+                },
+                None,
+            )
+            self.assertIn(resp["statusCode"], (401, 403, 405))
+            ddb.update_item.assert_not_called()
+        finally:
+            project_service._get_ddb = orig
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CCI-1a88afa7e1824140b4befdef5ba592b6

**Task**: ENC-TSK-N87 (ENC-FTR-131 T1) · **Commit**: d664764202b1f6f024a1c738715e0b7e8650577b
**Base**: `main` (branched from `origin/main@ffe8684`; no v4/main lineage)

## What

Adds the server-side project update path, which did not exist at any layer. `project_service` routed only POST/GET and fell through to `_error(405, 'Method not allowed.')`.

Mutates exactly three fields: `summary`, `status`, `repo`. Any immutable field (`project_id`, `name`, `prefix`, `parent`, `path`, `deploy_policy`, `deploy_mode`, `created_at`, `created_by`) returns 400 and **writes nothing** — the test asserts `update_item` was never called, not merely that a 400 came back.

- `_WRITE_METHODS = {POST, PATCH}` so PATCH requires `projects:write`. The prior ternary (`['projects:write'] if method == 'POST' else ['projects:read']`) would have put PATCH on the read branch and let a read-only caller mutate.
- `repo=''` emits REMOVE rather than storing `''`, because `_resolve_github_repo` treats empty-string and absent differently.
- `ConditionExpression attribute_exists(project_id)`; ConditionalCheckFailed maps to 404.
- Empty patch body returns 400 rather than a silent no-op 200.
- CORS `Allow-Methods` now advertises PATCH.

## Why

FIN-TSK-154 is blocked by exactly this: the finance project carries no `repo`, so every GitHub-validated checkout gate demands owner/repo in `transition_evidence` on every call (recurred on FIN-TSK-151/152/153). The agent-cli principal cannot write the projects table, and escalation does not help because approval would route back to a write tool that does not exist.

## Governance

Registers `project_service.update_contract` in `governance_data_dictionary.json` **in this PR**, per agents.md 3.11 — this PR touches `backend/lambda/*/lambda_function.py`.

## Tests

23 passed, 18 subtests (`test_project_update_n87.py`).

## Deploy note

Lambda code change. This PR only lands on `main` — it does **not** auto-deploy. Per DOC-B716E8FB10B6 the prod Lambda lane is whole-env and gated on the v3-prod Environment; that remains io's separate decision.

Sequenced **before** ENC-TSK-N88 so the route never points at a handler that 405s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)