### PR TITLE
ENC-TSK-N88: declare PATCH /api/v1/projects/{projectName} route in 03-api.yaml

### DIFF
--- a/infrastructure/cloudformation/03-api.yaml
+++ b/infrastructure/cloudformation/03-api.yaml
@@ -487,6 +487,16 @@ Resources:
       RouteKey: POST /api/v1/projects
       Target: !Sub integrations/${ProjectServiceIntegration}
 
+  # ENC-TSK-N88 / ENC-FTR-131: project metadata editing from the PWA. Without this route
+  # the PATCH handler added in ENC-TSK-N87 is unreachable from the edge — routes here are
+  # declared per-method, so a handler alone is not addressable.
+  RouteProjectsUpdate:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: PATCH /api/v1/projects/{projectName}
+      Target: !Sub integrations/${ProjectServiceIntegration}
+
   # ---------------------------------------------------------------------------
   # Routes — Feed, Monitor, Deploy, Reference, DocPrep, Auth
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
CCI-dbe694e50ba3482889953f1050390b5b

**Task**: ENC-TSK-N88 (ENC-FTR-131 T2) · **Commit**: 05b7e8b9e9c10804844c9c0fe3e793e0c7f86a02
**Base**: `main` (branched from `origin/main@ffe8684`; no v4/main lineage)

## What

Routes in `03-api.yaml` are declared per-method, so the PATCH handler added in ENC-TSK-N87 is unreachable from the edge without its own route resource. Adds exactly one `AWS::ApiGatewayV2::Route` (`RouteProjectsUpdate`) targeting the existing `ProjectServiceIntegration`, mirroring `RouteProjectsGet`.

Diff is 10 insertions, 0 deletions. No integration, authorizer, stage or parameter is touched. Template parses (253 resources); exactly one route carries that RouteKey, so there is no duplicate that could collide on create.

CORS preflight needs no new resource — the existing `OPTIONS /api/v1/projects/{projectName}` route already targets `ProjectServiceIntegration` and the handler answers OPTIONS with 204.

## ⚠️ Deploy discipline — Channel A (DOC-B716E8FB10B6)

Merging this fires `cloudformation-api-stack-deploy`, split into a **non-mutating PLAN job** and an **APPLY job gated on the v3-prod GitHub Environment required-reviewer rule**. The merge is not the deploy: it creates a paused, reviewable, rejectable change-set request. **Do not approve the apply until:**

1. `tools/pre-deploy-health-gate.sh` has been run against `main` and passed. Known hazard: ENC-ISS-463 causes Check 5 false-fails — triage a Check 5 failure against ISS-463 rather than reading it as a real regression.
2. The plan job's resource-level change-set summary shows **exactly one added resource** and no modifications or deletions. A multi-resource or empty change-set fails AC-3 and must be surfaced, not approved.

If change-set creation fails `AWS::EarlyValidation::ResourceExistenceCheck` (route exists out-of-band), STOP — that needs a privileged change-set IMPORT, not a retry.

Sequenced **after** ENC-TSK-N87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)