### PR TITLE
ENC-TSK-N89: Edit Project action on project cards (summary, status, repo)

### DIFF
--- a/frontend/ui/src/api/projectUpdate.test.ts
+++ b/frontend/ui/src/api/projectUpdate.test.ts
@@ -1,0 +1,134 @@
+/**
+ * projectUpdate.test.ts — ENC-FTR-131 / ENC-TSK-N89
+ *
+ * Covers getProject and updateProject: the PATCH request shape, the 401 refresh-retry
+ * cycle inherited from createProject, and error surfacing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getProject, updateProject, ProjectServiceError } from './projects'
+
+vi.mock('./auth', () => ({
+  refreshCredentials: vi.fn(),
+}))
+
+import { refreshCredentials } from './auth'
+
+const mockRefresh = vi.mocked(refreshCredentials)
+
+const projectBody = {
+  success: true,
+  project: {
+    project_id: 'finance',
+    prefix: 'FIN',
+    summary: 'Project to manage my finances.',
+    status: 'development',
+    created_at: '2026-04-02T00:36:20Z',
+    updated_at: '2026-04-02T00:36:20Z',
+  },
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('getProject', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    mockRefresh.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches a single project by name', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(projectBody))
+    const res = await getProject('finance')
+    expect(res.project.project_id).toBe('finance')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/projects/finance')
+    expect(init.method).toBe('GET')
+    expect(init.credentials).toBe('include')
+  })
+
+  it('encodes the project name into the path', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(projectBody))
+    await getProject('weird name/../x')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).not.toContain('../')
+    expect(url).toContain(encodeURIComponent('weird name/../x'))
+  })
+
+  it('surfaces a 404 as ProjectServiceError', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: "Project 'nope' not found" }, 404))
+    await expect(getProject('nope')).rejects.toBeInstanceOf(ProjectServiceError)
+  })
+})
+
+describe('updateProject', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    mockRefresh.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('issues a PATCH carrying exactly the supplied fields', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(projectBody))
+    await updateProject('finance', { repo: 'https://github.com/NX-2021-L/finance' })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/projects/finance')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(init.body)).toEqual({
+      repo: 'https://github.com/NX-2021-L/finance',
+    })
+  })
+
+  it('sends an empty-string repo through as the clear sentinel', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(projectBody))
+    await updateProject('finance', { repo: '' })
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init.body)).toEqual({ repo: '' })
+  })
+
+  it('retries with credential refresh on 401 and succeeds', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Token expired' }, 401))
+      .mockResolvedValueOnce(jsonResponse(projectBody))
+    mockRefresh.mockResolvedValue(true)
+
+    const res = await updateProject('finance', { summary: 'x' })
+    expect(res.success).toBe(true)
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a 401 as an auth error once refresh keeps failing', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'Token expired' }, 401))
+    mockRefresh.mockResolvedValue(false)
+
+    await expect(updateProject('finance', { summary: 'x' })).rejects.toMatchObject({
+      status: 401,
+    })
+  })
+
+  it('surfaces the backend message on a 400 immutable-field rejection', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ error: 'immutable field(s) not editable: prefix' }, 400)
+    )
+
+    await expect(
+      updateProject('finance', { summary: 'x' })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'immutable field(s) not editable: prefix',
+    })
+  })
+})

--- a/frontend/ui/src/api/projects.ts
+++ b/frontend/ui/src/api/projects.ts
@@ -19,6 +19,42 @@ export type CreateProjectRequest = {
   repo?: string;
 };
 
+/**
+ * ENC-FTR-131 / ENC-TSK-N89 — the only project fields the PWA may change.
+ * Identity and hierarchy fields (project_id, name, prefix, parent, path) are immutable:
+ * they are referenced by every tracker record, and the backend rejects them with a 400.
+ */
+export type UpdateProjectRequest = {
+  summary?: string;
+  status?: string;
+  /** Empty string clears the repo attribute server-side; omit the key to leave it alone. */
+  repo?: string;
+};
+
+export type ProjectRecord = {
+  project_id: string;
+  name?: string;
+  prefix: string;
+  path?: string;
+  repo?: string;
+  summary: string;
+  status: string;
+  parent?: string;
+  created_at: string;
+  updated_at: string;
+  created_by?: string;
+};
+
+export type UpdateProjectResponse = {
+  success: boolean;
+  project: ProjectRecord;
+};
+
+export type GetProjectResponse = {
+  success: boolean;
+  project: ProjectRecord;
+};
+
 export type CreateProjectResponse = {
   success: boolean;
   project: {
@@ -151,6 +187,99 @@ export async function createProject(
 
   // Should not reach here, but satisfy TypeScript
   throw new ProjectServiceError(0, 'All retry cycles exhausted');
+}
+
+/**
+ * Shared request cycle for the single-project endpoints (ENC-TSK-N89).
+ *
+ * Mirrors createProject's 401 -> refreshCredentials -> retry behaviour. Kept as one helper
+ * so the auth-retry semantics cannot drift between GET and PATCH; createProject is left on
+ * its own loop because it additionally falls back to the canonical collection URL.
+ */
+async function requestProject<T>(
+  projectName: string,
+  init: RequestInit
+): Promise<T> {
+  const url = `${BASE_URL}/projects/${encodeURIComponent(projectName)}`;
+
+  for (let cycle = 1; cycle <= MAX_CREATE_CYCLES; cycle++) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(init.headers ?? {}),
+        },
+        credentials: 'include',
+      });
+      const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+
+      if (response.status === 401) {
+        const refreshed = await refreshCredentials();
+        if (refreshed && cycle < MAX_CREATE_CYCLES) {
+          continue;
+        }
+        throw new ProjectServiceError(
+          401,
+          'Your session has expired. Please log in again.',
+          body
+        );
+      }
+
+      if (!response.ok) {
+        const errorMessage =
+          body.error ||
+          body.message ||
+          `HTTP ${response.status}: ${response.statusText}`;
+        throw new ProjectServiceError(response.status, String(errorMessage), body);
+      }
+
+      return body as unknown as T;
+    } catch (error) {
+      if (error instanceof ProjectServiceError) {
+        throw error;
+      }
+      if (error instanceof Error) {
+        if (cycle < MAX_CREATE_CYCLES) {
+          await refreshCredentials();
+          continue;
+        }
+        throw new ProjectServiceError(0, `Network error: ${error.message}`);
+      }
+      throw new ProjectServiceError(0, 'Unknown error occurred');
+    }
+  }
+
+  throw new ProjectServiceError(0, 'All retry cycles exhausted');
+}
+
+/**
+ * Fetch a single project record.
+ *
+ * The edit dialog prefills from this, NOT from the projects feed: the feed's ProjectSummary
+ * shape carries no `repo`, so prefilling from it and saving would silently clear the field
+ * this feature exists to set.
+ */
+export async function getProject(projectName: string): Promise<GetProjectResponse> {
+  return requestProject<GetProjectResponse>(projectName, { method: 'GET' });
+}
+
+/**
+ * Update a project's editable metadata (summary, status, repo).
+ *
+ * Send only the fields that actually changed. An empty patch is rejected by the backend
+ * with a 400 rather than treated as a successful no-op.
+ */
+export async function updateProject(
+  projectName: string,
+  patch: UpdateProjectRequest
+): Promise<UpdateProjectResponse> {
+  return requestProject<UpdateProjectResponse>(projectName, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  });
 }
 
 /**

--- a/frontend/ui/src/components/cards/ProjectCard.test.tsx
+++ b/frontend/ui/src/components/cards/ProjectCard.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * ProjectCard.test.tsx — ENC-FTR-131 / ENC-TSK-N89
+ *
+ * The load-bearing test here is the navigation one. ProjectCard's entire surface is a
+ * react-router <Link>, so a nested Edit button that forgets preventDefault/stopPropagation
+ * routes the user to the detail page instead of opening the dialog — a regression that is
+ * invisible until someone actually taps the control.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ProjectCard } from './ProjectCard'
+import type { ProjectSummary } from '../../types/feeds'
+
+vi.mock('../../api/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../api/projects')>(
+    '../../api/projects'
+  )
+  return {
+    ...actual,
+    getProject: vi.fn(),
+    updateProject: vi.fn(),
+  }
+})
+
+// The real useAuthState returns a context value whose setAuthExpired is useCallback-stable
+// and takes no arguments. The mock must match: returning a fresh object (or a fresh vi.fn())
+// on every render would make any effect keyed on its identity re-run per keystroke.
+const { mockAuthState } = vi.hoisted(() => ({
+  mockAuthState: { setAuthExpired: vi.fn() },
+}))
+
+vi.mock('../../lib/authState', () => ({
+  useAuthState: () => mockAuthState,
+}))
+
+import { getProject, updateProject } from '../../api/projects'
+
+const mockGet = vi.mocked(getProject)
+const mockUpdate = vi.mocked(updateProject)
+
+const project: ProjectSummary = {
+  project_id: 'finance',
+  name: 'finance',
+  prefix: 'FIN',
+  status: 'development',
+  summary: 'Project to manage my finances.',
+  last_sprint: '',
+  open_tasks: 3,
+  closed_tasks: 1,
+  total_tasks: 4,
+  open_issues: 0,
+  closed_issues: 0,
+  total_issues: 0,
+  in_progress_features: 0,
+  completed_features: 2,
+  total_features: 2,
+  planned_tasks: 0,
+  updated_at: '2026-08-13T00:00:00Z',
+  last_update_note: null,
+}
+
+const record = {
+  success: true,
+  project: {
+    project_id: 'finance',
+    prefix: 'FIN',
+    summary: 'Project to manage my finances.',
+    status: 'development',
+    repo: '',
+    created_at: '2026-04-02T00:36:20Z',
+    updated_at: '2026-04-02T00:36:20Z',
+  },
+}
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/projects']}>
+        <Routes>
+          <Route path="/projects" element={<ProjectCard project={project} />} />
+          <Route path="/projects/:id" element={<div>DETAIL PAGE</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('ProjectCard edit control', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockUpdate.mockReset()
+    mockGet.mockResolvedValue(record as never)
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('renders an edit control on the card', () => {
+    renderCard()
+    expect(screen.getByRole('button', { name: /edit project finance/i })).toBeInTheDocument()
+  })
+
+  it('opens the dialog without navigating to the detail route', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    // The regression this guards: a nested button without preventDefault navigates away.
+    expect(screen.queryByText('DETAIL PAGE')).not.toBeInTheDocument()
+  })
+
+  it('still navigates to the detail route when the card body is tapped', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    await user.click(screen.getByText('Project to manage my finances.'))
+
+    expect(await screen.findByText('DETAIL PAGE')).toBeInTheDocument()
+  })
+
+  it('prefills from the fetched record, not the feed summary', async () => {
+    const user = userEvent.setup()
+    mockGet.mockResolvedValue({
+      ...record,
+      project: { ...record.project, repo: 'https://github.com/NX-2021-L/finance' },
+    } as never)
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+
+    // repo exists only on the fetched record — the feed's ProjectSummary has no such field,
+    // so seeing it proves the prefill source is the GET, not the card's own props.
+    await waitFor(() =>
+      expect(screen.getByLabelText(/repository url/i)).toHaveValue(
+        'https://github.com/NX-2021-L/finance'
+      )
+    )
+    expect(mockGet).toHaveBeenCalledWith('finance')
+  })
+
+  it('sends only the changed field on save', async () => {
+    const user = userEvent.setup()
+    mockUpdate.mockResolvedValue(record as never)
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+    const repoInput = await screen.findByLabelText(/repository url/i)
+    await user.type(repoInput, 'https://github.com/NX-2021-L/finance')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith('finance', {
+        repo: 'https://github.com/NX-2021-L/finance',
+      })
+    )
+  })
+
+  it('blocks submission and shows an inline error for an invalid repo URL', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+    const repoInput = await screen.findByLabelText(/repository url/i)
+    await user.type(repoInput, 'not-a-url')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(await screen.findByText(/must be a valid url/i)).toBeInTheDocument()
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses an empty patch rather than firing a pointless request', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+    await screen.findByLabelText(/repository url/i)
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(await screen.findByText(/no changes to save/i)).toBeInTheDocument()
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the dialog open with input intact when the server rejects the save', async () => {
+    const user = userEvent.setup()
+    const { ProjectServiceError } = await vi.importActual<
+      typeof import('../../api/projects')
+    >('../../api/projects')
+    mockUpdate.mockRejectedValue(
+      new ProjectServiceError(400, 'immutable field(s) not editable: prefix')
+    )
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: /edit project finance/i }))
+    const repoInput = await screen.findByLabelText(/repository url/i)
+    await user.type(repoInput, 'https://github.com/NX-2021-L/finance')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(await screen.findByText(/immutable field/i)).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByLabelText(/repository url/i)).toHaveValue(
+      'https://github.com/NX-2021-L/finance'
+    )
+  })
+})

--- a/frontend/ui/src/components/cards/ProjectCard.tsx
+++ b/frontend/ui/src/components/cards/ProjectCard.tsx
@@ -1,34 +1,64 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ProjectSummary } from '../../types/feeds'
 import { timeAgo } from '../../lib/formatters'
+import { EditProjectDialog } from '../projects/EditProjectDialog'
 
 export function ProjectCard({ project }: { project: ProjectSummary }) {
+  const [editing, setEditing] = useState(false)
+
   return (
-    <Link
-      to={`/projects/${project.project_id}`}
-      className="block bg-slate-800 rounded-lg p-4 hover:bg-slate-750 transition-colors active:bg-slate-700"
-    >
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-mono text-slate-500">{project.prefix}</span>
-          <h3 className="font-medium text-slate-100">{project.name}</h3>
+    <>
+      <Link
+        to={`/projects/${project.project_id}`}
+        className="block bg-slate-800 rounded-lg p-4 hover:bg-slate-750 transition-colors active:bg-slate-700"
+      >
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-mono text-slate-500">{project.prefix}</span>
+            <h3 className="font-medium text-slate-100">{project.name}</h3>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-slate-500">{timeAgo(project.updated_at)}</span>
+            {/* The whole card is a Link, so this button must both stop propagation and
+                prevent the default navigation — otherwise tapping Edit routes away to the
+                detail page instead of opening the dialog. */}
+            <button
+              type="button"
+              aria-label={`Edit project ${project.name}`}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setEditing(true)
+              }}
+              className="min-h-11 min-w-11 flex items-center justify-center text-xs text-slate-400 hover:text-slate-100 rounded"
+            >
+              Edit
+            </button>
+          </div>
         </div>
-        <span className="text-xs text-slate-500">{timeAgo(project.updated_at)}</span>
-      </div>
-      {project.summary && (
-        <p className="text-sm text-slate-400 mb-3 line-clamp-2">{project.summary}</p>
+        {project.summary && (
+          <p className="text-sm text-slate-400 mb-3 line-clamp-2">{project.summary}</p>
+        )}
+        <div className="flex gap-4 text-xs text-slate-500">
+          <span>
+            <span className="text-blue-400 font-medium">{project.open_tasks}</span> tasks
+          </span>
+          <span>
+            <span className="text-amber-400 font-medium">{project.open_issues}</span> issues
+          </span>
+          <span>
+            <span className="text-emerald-400 font-medium">{project.completed_features}</span> live features
+          </span>
+        </div>
+      </Link>
+
+      {editing && (
+        <EditProjectDialog
+          projectId={project.project_id}
+          onClose={() => setEditing(false)}
+        />
       )}
-      <div className="flex gap-4 text-xs text-slate-500">
-        <span>
-          <span className="text-blue-400 font-medium">{project.open_tasks}</span> tasks
-        </span>
-        <span>
-          <span className="text-amber-400 font-medium">{project.open_issues}</span> issues
-        </span>
-        <span>
-          <span className="text-emerald-400 font-medium">{project.completed_features}</span> live features
-        </span>
-      </div>
-    </Link>
+    </>
   )
 }

--- a/frontend/ui/src/components/projects/EditProjectDialog.tsx
+++ b/frontend/ui/src/components/projects/EditProjectDialog.tsx
@@ -1,0 +1,315 @@
+/**
+ * EditProjectDialog.tsx — ENC-FTR-131 / ENC-TSK-N89
+ *
+ * Edits the three mutable fields of a project record: summary, status, repository URL.
+ * Everything else (project_id, name, prefix, parent, path) is immutable and is shown
+ * read-only so it is obvious why it cannot be changed.
+ *
+ * Prefill comes from GET /api/v1/projects/{projectName}, deliberately NOT from the projects
+ * feed — the feed's ProjectSummary shape has no `repo`, so prefilling from it would submit an
+ * empty repo and clear the very field this feature exists to set.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { feedKeys } from '../../api/feeds'
+import {
+  getProject,
+  updateProject,
+  validateSummary,
+  validateProjectStatus,
+  validateRepo,
+  ProjectServiceError,
+  type ProjectRecord,
+  type UpdateProjectRequest,
+} from '../../api/projects'
+import { useAuthState } from '../../lib/authState'
+
+const STATUS_OPTIONS = [
+  { value: 'planning', label: 'Planning' },
+  { value: 'development', label: 'Development' },
+  { value: 'active_production', label: 'Active Production' },
+]
+
+type FieldErrors = {
+  summary?: string
+  status?: string
+  repo?: string
+  submit?: string
+}
+
+export function EditProjectDialog({
+  projectId,
+  onClose,
+}: {
+  projectId: string
+  onClose: () => void
+}) {
+  const queryClient = useQueryClient()
+  const { setAuthExpired } = useAuthState()
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  // Held in a ref so the prefill effect depends on projectId alone. Depending on the
+  // callback's identity would mean any re-render producing a new one refetches and
+  // overwrites summary/status/repo — silently destroying what the user had typed.
+  const authExpiredRef = useRef(setAuthExpired)
+  authExpiredRef.current = setAuthExpired
+
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [original, setOriginal] = useState<ProjectRecord | null>(null)
+  const [summary, setSummary] = useState('')
+  const [status, setStatus] = useState('')
+  const [repo, setRepo] = useState('')
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setLoadError(null)
+    getProject(projectId)
+      .then((res) => {
+        if (cancelled) return
+        const p = res.project
+        setOriginal(p)
+        setSummary(p.summary ?? '')
+        setStatus(p.status ?? '')
+        setRepo(p.repo ?? '')
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        if (err instanceof ProjectServiceError && err.status === 401) {
+          authExpiredRef.current()
+        }
+        setLoadError(
+          err instanceof ProjectServiceError
+            ? err.message
+            : 'Could not load this project.'
+        )
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [projectId])
+
+  // Escape closes; focus moves into the dialog so keyboard users are not stranded.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    dialogRef.current?.focus()
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  /** Only fields the user actually changed are sent — the backend rejects an empty patch. */
+  function buildPatch(): UpdateProjectRequest {
+    const patch: UpdateProjectRequest = {}
+    if (!original) return patch
+    if (summary.trim() !== (original.summary ?? '')) patch.summary = summary.trim()
+    if (status !== (original.status ?? '')) patch.status = status
+    if (repo.trim() !== (original.repo ?? '')) patch.repo = repo.trim()
+    return patch
+  }
+
+  function validate(patch: UpdateProjectRequest): FieldErrors {
+    const next: FieldErrors = {}
+    if (patch.summary !== undefined) {
+      const r = validateSummary(patch.summary)
+      if (!r.valid) next.summary = r.error
+    }
+    if (patch.status !== undefined) {
+      const r = validateProjectStatus(patch.status)
+      if (!r.valid) next.status = r.error
+    }
+    // An empty repo is the intentional "clear it" case, which validateRepo accepts.
+    if (patch.repo !== undefined) {
+      const r = validateRepo(patch.repo)
+      if (!r.valid) next.repo = r.error
+    }
+    return next
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const patch = buildPatch()
+
+    if (Object.keys(patch).length === 0) {
+      setErrors({ submit: 'No changes to save.' })
+      return
+    }
+
+    const fieldErrors = validate(patch)
+    if (Object.keys(fieldErrors).length > 0) {
+      setErrors(fieldErrors)
+      return
+    }
+
+    setErrors({})
+    setSaving(true)
+    try {
+      await updateProject(projectId, patch)
+      await queryClient.invalidateQueries({ queryKey: feedKeys.projects })
+      onClose()
+    } catch (err: unknown) {
+      // The dialog deliberately stays open with the user's input intact so a rejected
+      // save is recoverable rather than losing what they typed.
+      if (err instanceof ProjectServiceError) {
+        if (err.status === 401) setAuthExpired()
+        setErrors({ submit: err.message })
+      } else {
+        setErrors({ submit: 'Something went wrong saving this project.' })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-0 sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Edit project ${projectId}`}
+        tabIndex={-1}
+        className="w-full sm:max-w-lg max-h-[90vh] overflow-y-auto bg-slate-800 rounded-t-2xl sm:rounded-lg p-4 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-medium text-slate-100">Edit project</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="min-h-11 min-w-11 text-slate-400 hover:text-slate-200"
+          >
+            ✕
+          </button>
+        </div>
+
+        {loading && <p className="text-sm text-slate-400">Loading project…</p>}
+
+        {!loading && loadError && (
+          <p role="alert" className="text-sm text-red-400">
+            {loadError}
+          </p>
+        )}
+
+        {/* noValidate on the form: type="url" is kept for the mobile keyboard, but native
+            constraint validation would swallow the submit event and show a browser bubble
+            instead of our inline error, leaving validateRepo unreachable. The shared
+            validators are the single source of truth for what blocks a save. */}
+        {!loading && !loadError && original && (
+          <form onSubmit={handleSubmit} noValidate className="space-y-4">
+            <div className="text-xs text-slate-500 space-y-0.5">
+              <div>
+                <span className="font-mono">{original.prefix}</span> · {projectId}
+              </div>
+              <div>These identity fields cannot be changed.</div>
+            </div>
+
+            <div>
+              <label htmlFor="edit-project-summary" className="block text-sm text-slate-300 mb-1">
+                Summary
+              </label>
+              <textarea
+                id="edit-project-summary"
+                value={summary}
+                onChange={(e) => setSummary(e.target.value)}
+                rows={4}
+                className="w-full rounded bg-slate-900 border border-slate-700 p-2 text-sm text-slate-100"
+              />
+              {errors.summary && (
+                <p role="alert" className="text-xs text-red-400 mt-1">
+                  {errors.summary}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="edit-project-status" className="block text-sm text-slate-300 mb-1">
+                Status
+              </label>
+              <select
+                id="edit-project-status"
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+                className="w-full min-h-11 rounded bg-slate-900 border border-slate-700 p-2 text-sm text-slate-100"
+              >
+                {/* A status outside the editable set (e.g. a legacy closed/archived value)
+                    is preserved as an option so opening the dialog cannot silently
+                    reclassify the project just by rendering. */}
+                {!STATUS_OPTIONS.some((o) => o.value === status) && status && (
+                  <option value={status}>{status}</option>
+                )}
+                {STATUS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              {errors.status && (
+                <p role="alert" className="text-xs text-red-400 mt-1">
+                  {errors.status}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="edit-project-repo" className="block text-sm text-slate-300 mb-1">
+                Repository URL
+              </label>
+              <input
+                id="edit-project-repo"
+                type="url"
+                inputMode="url"
+                value={repo}
+                onChange={(e) => setRepo(e.target.value)}
+                placeholder="https://github.com/owner/repo"
+                className="w-full min-h-11 rounded bg-slate-900 border border-slate-700 p-2 text-sm text-slate-100"
+              />
+              <p className="text-xs text-slate-500 mt-1">
+                Leave blank to clear it.
+              </p>
+              {errors.repo && (
+                <p role="alert" className="text-xs text-red-400 mt-1">
+                  {errors.repo}
+                </p>
+              )}
+            </div>
+
+            {errors.submit && (
+              <p role="alert" className="text-sm text-red-400">
+                {errors.submit}
+              </p>
+            )}
+
+            <div className="flex gap-2 justify-end pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                className="min-h-11 px-4 rounded text-sm text-slate-300 hover:bg-slate-700"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="min-h-11 px-4 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+              >
+                {saving ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
CCI-01fea1ec515448139f4c8141289433bd

**Task**: ENC-TSK-N89 (ENC-FTR-131 T3) · **Commit**: 45396e9a248fa349fcd6328c85f6913fc128a8a5
**Base**: `main` (branched from `origin/main@ffe8684`; no v4/main lineage)

## What

Adds `getProject` / `updateProject` to `api/projects.ts` (reusing the existing 401-refresh-retry cycle and `ProjectServiceError` shape), a new `EditProjectDialog`, and an Edit control on `ProjectCard`.

- **Prefill comes from `GET /api/v1/projects/{name}`, never the feed.** The feed's `ProjectSummary` carries no `repo`, so prefilling from it would blank the very field this feature exists to set. The test asserts a repo value that exists *only* on the fetched record, so a pass is positive proof of the prefill source.
- **Navigation is not hijacked.** The Edit button lives inside the card's react-router `Link` and calls `preventDefault` + `stopPropagation`. Both directions are tested — a nested button regresses navigation invisibly.
- Validation reuses the exported `validateSummary` / `validateProjectStatus` / `validateRepo`; none are reimplemented.

## Three defects found by actually running the suite

1. `setAuthExpired(true)` on a zero-argument callback (`lib/authState.tsx` types it `() => void`) — TS2554 in two places.
2. **Native form validation swallowed the entire save path.** The repo field is `<input type="url">`; with an invalid value the browser's constraint validation blocks the submit event, so `handleSubmit` never ran and `validateRepo`'s inline error never rendered — the user got a native bubble instead. Real browser behaviour, not a jsdom artifact. Fixed with `noValidate`, keeping `type="url"` for the mobile keyboard.
3. The prefill effect keyed on `setAuthExpired`'s identity; it refetches and overwrites the form, so an unstable callback would wipe user input mid-typing. Now held in a ref, keyed on `[projectId]`.

## ⚠️ Known limitation — ENC-ISS-612

**PATCH does not regenerate the mobile projects feed.** `project_service` has zero feed/publish/SQS references; the Projects tab renders from an S3 artifact via `fetchFeed('projects')`; `feed_publisher` is SQS-triggered behind a 5-minute project cache. So `invalidateQueries(feedKeys.projects)` refetches the *same stale artifact* and the card can show old text after a successful save. Filed as ENC-ISS-612 with repro steps and three candidate fixes rather than shipped quietly.

Corollary: the FIN-TSK-154 unblock must be verified via `projects.get`, **not** by looking at the card — `repo` is not on `ProjectSummary` at all.

## Tests

139/139 across 21 files (16 new). `tsc -b --force` exit 0. `npm run build` passes.

Lint reports 1 error + 16 warnings, **all pre-existing on `origin/main`** — the error is `src/hooks/useFeed.ts:27` unused `_options`; `git diff --name-only origin/main` confirms that file is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)