### PR TITLE
ENC-TSK-O04: GitHubValidationFail metric filter + alarm (ENC-ISS-621)

### DIFF
--- a/infrastructure/cloudformation/05-monitoring.yaml
+++ b/infrastructure/cloudformation/05-monitoring.yaml
@@ -210,6 +210,55 @@ Resources:
         - [!Ref SnsTopicArn]
         - !Ref "AWS::NoValue"
 
+  # ENC-TSK-O04 / ENC-ISS-621: surface checkout-service GitHub commit/PR
+  # validation failures, which previously returned 400 to the caller and logged
+  # nothing server-side. Matches the [ISS-621] github_validation_fail line
+  # emitted by backend/lambda/checkout_service/lambda_function.py (ENC-TSK-O03).
+  # The quoted filter pattern is required: an unquoted [ ... ] is CloudWatch's
+  # space-delimited pattern syntax, not a literal bracket. Verified with
+  # `aws logs test-metric-filter` against the real emitted lines - it matches the
+  # failure line and NOT the github_token_minted line, which shares the marker.
+  GitHubValidationFailMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/enceladus-checkout-service${EnvironmentSuffix}"
+      FilterPattern: '"[ISS-621] github_validation_fail"'
+      MetricTransformations:
+        - MetricNamespace: Enceladus/Prod
+          MetricName: GitHubValidationFail
+          MetricValue: "1"
+          # DefaultValue 0 publishes a real datapoint when nothing matches, so the
+          # alarm always has data. This deliberately avoids the trap that leaves
+          # CodeSizeMinimumAlarm permanently in ALARM (breaching-on-missing against
+          # an unpublished metric) - see ENC-ISS-623.
+          DefaultValue: 0
+
+  # Fires when committed-gate GitHub validation fails repeatedly - the ENC-ISS-621
+  # signature. 3-in-15min sits above a single transient 403 but well inside the
+  # ~35-minute fleet-wide windows observed on 2026-08-17.
+  GitHubValidationFailAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "enceladus-prod-github-validation-fail${EnvironmentSuffix}"
+      AlarmDescription: >
+        ENC-ISS-621: checkout-service GitHub commit/PR validation failed 3 or more
+        times in 15 minutes, blocking committed-gate advances. Check
+        githubstatus.com FIRST (a platform incident presents as a permission bug),
+        then the [ISS-621] github_token_minted permission keys in
+        /aws/lambda/enceladus-checkout-service. See ENC-LSN-074.
+      Namespace: Enceladus/Prod
+      MetricName: GitHubValidationFail
+      Statistic: Sum
+      Period: 900
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSnsTopic
+        - [!Ref SnsTopicArn]
+        - !Ref "AWS::NoValue"
+
 Outputs:
   ProdHealthMonitorFunctionArn:
     Description: ARN of the production health monitor Lambda


### PR DESCRIPTION
## ENC-TSK-O04 — C1 of ENC-PLN-080 (ENC-ISS-621 detection)

**DRAFT — deliberately not mergeable yet. Two hard blockers, both documented below.**

Adds the first `AWS::Logs::MetricFilter` in `05-monitoring.yaml`, matching the `[ISS-621] github_validation_fail` line shipped by ENC-TSK-O03 (merged in #1093), plus an alarm at ≥3 failures in 15 minutes.

### Why it's a draft

1. **ENC-TSK-O03 is not yet live on prod.** The filter matches O03's log line, so deploying it first would create a filter that can never match. O03 is at `merged-main`; its prod deploy is gated on githubstatus incident `zkxwbgr0cnmx` resolving plus io's v3-prod Environment approval.
2. **`tools/pre-deploy-health-gate.sh` currently FAILS on `main` — see ENC-ISS-624 (P1).** Check 5 (enceladus-shared layer parity) is red for a reason unrelated to this diff: the `--live --regress-only` scan is not environment-scoped, so `enceladus-checkout-service-auto-gamma` sitting correctly on the gamma-ABI layer `:11` (arm64/py3.12) reads as a prod regression above canonical `:10` (py3.11). **Verified pre-existing** by running the identical gate in a clean detached worktree at unmodified `origin/main` — byte-identical failure. DOC-B716E8FB10B6 makes a failing gate a hard stop, and it was **not** bypassed.

### Verification already done

- `aws cloudformation validate-template` passes.
- **Filter pattern proven with `aws logs test-metric-filter`** against the real emitted lines: it matches `github_validation_fail` and correctly does **not** match `github_token_minted`, which shares the `[ISS-621]` marker. The quoted form is required — an unquoted `[ ... ]` is CloudWatch's space-delimited pattern syntax, not a literal bracket.
- Health gate checks 1,2,3,4,6,7 all PASS (including no live CFN drift for prod).

### Note on AC-3 and ENC-ISS-623

The prod stack has `SnsTopicArn=""`, so `HasSnsTopic` is false and this alarm — like the six already deployed — will carry **no** `AlarmActions`. Per io's decision, AC-3 is stamped against an observed ALARM-state transition, explicitly **not** against notification; claiming otherwise would be acceptance-on-deferred-proof. The notification gap is carried by ENC-ISS-623.

`DefaultValue: 0` is deliberate: it publishes a real datapoint when nothing matches so the alarm always has data. That avoids the exact trap keeping `enceladus-prod-codesize-minimum` permanently in ALARM (`TreatMissingData: breaching` against an unpublished metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Commit Complete: CCI-14df6ec1e61243248684afa3f3b16e40
