### PR TITLE
ENC-TSK-O15: ISS-559 fix — include_tokens:false suppresses cookie-bundle tokens

### DIFF
--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1733,22 +1733,22 @@
         },
         "include_tokens": {
           "type": "boolean",
-          "usage_guidance": "When true, response includes raw Cognito tokens. Use only for controlled diagnostics because token material is sensitive."
+          "usage_guidance": "When true, response includes raw Cognito tokens in the separate tokens object. When false (default), no token values are emitted anywhere in the response: the tokens object is omitted AND token-bearing cookie entries in session.cookies, session.playwright_cookies, and session.set_cookie_headers have their value fields redacted (empty string) while retaining cookie structure/metadata (name, path, secure, http_only, same_site, max_age). Non-token cookies (e.g. session timestamp) are unaffected. See ENC-ISS-559."
         },
         "session.cookies": {
           "type": "array",
           "item_type": "object",
-          "usage_guidance": "Canonical cookie objects returned by coordination API, including id token, refresh token (when available), and session timestamp cookie."
+          "usage_guidance": "Canonical cookie objects returned by coordination API, including id token, refresh token (when available), and session timestamp cookie. ENC-ISS-559: when include_tokens=false, the value field of token-bearing cookies (enceladus_id_token, enceladus_refresh_token) is redacted to an empty string; other fields (name, path, secure, http_only, same_site, max_age) are still returned."
         },
         "session.playwright_cookies": {
           "type": "array",
           "item_type": "object",
-          "usage_guidance": "Browser-context cookie entries consumable by Playwright automation for authenticated evidence capture."
+          "usage_guidance": "Browser-context cookie entries consumable by Playwright automation for authenticated evidence capture. ENC-ISS-559: mirrors session.cookies redaction — token-bearing entries have an empty value when include_tokens=false."
         },
         "session.set_cookie_headers": {
           "type": "array",
           "item_type": "string",
-          "usage_guidance": "Optional serialized Set-Cookie header values for external HTTP clients."
+          "usage_guidance": "Optional serialized Set-Cookie header values for external HTTP clients. ENC-ISS-559: when include_tokens=false, headers for token-bearing cookies are serialized with an empty value (e.g. \"enceladus_id_token=; Path=/; ...\") so no token material appears in the header line."
         },
         "session.tokens": {
           "type": "object",

--- a/backend/lambda/coordination_api/lambda_function.py
+++ b/backend/lambda/coordination_api/lambda_function.py
@@ -281,6 +281,11 @@ TERMINAL_COGNITO_DEFAULT_ORIGIN = os.environ.get(
 TERMINAL_COGNITO_REFRESH_MAX_AGE_SECONDS = int(
     os.environ.get("TERMINAL_COGNITO_REFRESH_MAX_AGE_SECONDS", "2592000")
 )
+# ENC-ISS-559: cookie names in the terminal-session bundle that carry raw
+# Cognito token material. When include_tokens=false these must be redacted
+# from cookies / playwright_cookies / set_cookie_headers, not just withheld
+# from the separate "tokens" object.
+_COGNITO_TOKEN_COOKIE_NAMES = frozenset({"enceladus_id_token", "enceladus_refresh_token"})
 COORDINATION_INTERNAL_API_KEY = _first_nonempty_env(
     "ENCELADUS_COORDINATION_API_INTERNAL_API_KEY",
     "ENCELADUS_COORDINATION_INTERNAL_API_KEY",
@@ -16476,6 +16481,16 @@ def _handle_auth_cognito_terminal_session(event: Dict[str, Any], claims: Dict[st
                 "max_age": TERMINAL_COGNITO_REFRESH_MAX_AGE_SECONDS,
             }
         )
+
+    # ENC-ISS-559: include_tokens=false must suppress token values everywhere
+    # a token could leak — not just the dedicated "tokens" object below, but
+    # also the cookie bundle (cookies / playwright_cookies / set_cookie_headers).
+    # Only cookie entries that actually carry token material are redacted;
+    # non-token cookies (e.g. the session timestamp) keep their real value.
+    if not include_tokens:
+        for c in cookies:
+            if c["name"] in _COGNITO_TOKEN_COOKIE_NAMES:
+                c["value"] = ""
 
     payload: Dict[str, Any] = {
         "success": True,

--- a/backend/lambda/coordination_api/test_lambda_function.py
+++ b/backend/lambda/coordination_api/test_lambda_function.py
@@ -627,6 +627,97 @@ class CoordinationLambdaUnitTests(unittest.TestCase):
         self.assertIn("set_cookie_headers", session)
         self.assertEqual(session["tokens"]["id_token"], "id-token-value")
 
+    @patch.object(
+        coordination_lambda,
+        "_load_terminal_cognito_credentials",
+        return_value={
+            "username": "svc-user",
+            "password": "svc-pass",
+            "client_id": "client-123",
+            "auth_flow": "USER_PASSWORD_AUTH",
+        },
+    )
+    @patch.object(coordination_lambda, "_get_cognito")
+    def test_handle_auth_cognito_terminal_session_include_tokens_false_suppresses_cookie_bundle(
+        self,
+        mock_get_cognito,
+        _mock_load_credentials,
+    ):
+        """ENC-ISS-559: include_tokens=false must suppress token values in
+        cookies / playwright_cookies / set_cookie_headers, not just withhold
+        the separate `tokens` object."""
+
+        class _FakeCognito:
+            class exceptions:
+                class NotAuthorizedException(Exception):
+                    pass
+
+                class UserNotConfirmedException(Exception):
+                    pass
+
+                class PasswordResetRequiredException(Exception):
+                    pass
+
+            def initiate_auth(self, **_kwargs):
+                return {
+                    "AuthenticationResult": {
+                        "IdToken": "id-token-value",
+                        "AccessToken": "access-token-value",
+                        "RefreshToken": "refresh-token-value",
+                        "ExpiresIn": 3600,
+                        "TokenType": "Bearer",
+                    }
+                }
+
+        mock_get_cognito.return_value = _FakeCognito()
+        event = {
+            "body": json.dumps(
+                {
+                    "target_origin": "https://jreese.net",
+                    "include_set_cookie_headers": True,
+                    "include_tokens": False,
+                }
+            )
+        }
+        claims = {"auth_mode": "internal-key"}
+        resp = coordination_lambda._handle_auth_cognito_terminal_session(event, claims)
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["success"])
+        session = body["session"]
+
+        # No raw tokens object at all.
+        self.assertNotIn("tokens", session)
+
+        token_values = {"id-token-value", "access-token-value", "refresh-token-value"}
+
+        # cookies: token-bearing cookie values must be suppressed; non-token
+        # cookies (session timestamp) keep their real value and every cookie
+        # keeps its structural metadata (name/path/secure/etc).
+        cookie_by_name = {c["name"]: c for c in session["cookies"]}
+        self.assertIn("enceladus_id_token", cookie_by_name)
+        self.assertIn("enceladus_refresh_token", cookie_by_name)
+        self.assertEqual(cookie_by_name["enceladus_id_token"]["value"], "")
+        self.assertEqual(cookie_by_name["enceladus_refresh_token"]["value"], "")
+        self.assertTrue(cookie_by_name["enceladus_id_token"]["http_only"])
+        self.assertEqual(cookie_by_name["enceladus_id_token"]["path"], "/")
+        self.assertNotEqual(cookie_by_name["enceladus_session_at"]["value"], "")
+        for c in session["cookies"]:
+            self.assertNotIn(c["value"], token_values)
+
+        # playwright_cookies: same suppression.
+        pw_by_name = {c["name"]: c for c in session["playwright_cookies"]}
+        self.assertEqual(pw_by_name["enceladus_id_token"]["value"], "")
+        self.assertEqual(pw_by_name["enceladus_refresh_token"]["value"], "")
+        for c in session["playwright_cookies"]:
+            self.assertNotIn(c["value"], token_values)
+
+        # set_cookie_headers: no raw token value serialized into the header line.
+        self.assertIn("set_cookie_headers", session)
+        header_blob = "\n".join(session["set_cookie_headers"])
+        for tok in token_values:
+            self.assertNotIn(tok, header_blob)
+
     def test_handle_auth_cognito_terminal_session_requires_write_permission(self):
         event = {"body": "{}"}
         claims = {"auth_mode": "managed-token", "permissions": ["read"]}


### PR DESCRIPTION
## Summary
- ENC-ISS-559: the Cognito terminal-session cookie bundle (`cookies` / `playwright_cookies` / `set_cookie_headers`) always embedded the raw id/refresh token values in `_handle_auth_cognito_terminal_session` (backend/lambda/coordination_api/lambda_function.py), even when `include_tokens=false` only withheld the separate `tokens` object.
- Redacts the `value` of token-bearing cookies (`enceladus_id_token`, `enceladus_refresh_token`) to an empty string across `cookies`, `playwright_cookies`, and `set_cookie_headers` when `include_tokens` is `false`, while preserving cookie structure/metadata (name, path, secure, http_only, same_site, max_age). Non-token cookies (session timestamp) are unaffected.
- Adds unit coverage (`test_handle_auth_cognito_terminal_session_include_tokens_false_suppresses_cookie_bundle`) asserting no token value appears anywhere in the response when `include_tokens=false`.
- Refreshes the `coordination.auth_cognito_session` governance dictionary entry (backend/lambda/coordination_api/governance_data_dictionary.json) to document the suppression behavior — minimal 4-line diff via `json.dump(..., ensure_ascii=False, indent=2)` round-trip.

## Test plan
- [x] `pytest backend/lambda/coordination_api/test_lambda_function.py -k cognito_terminal_session` — 4 passed
- [x] `pytest backend/lambda/coordination_api/test_lambda_function.py` — 176 passed; 7 pre-existing unrelated failures (AWS/network sandbox artifacts) confirmed present on unmodified `v4/main` base too
- [x] `pytest tools/enceladus-mcp-server/test_coordination_cognito_session.py` — 2 passed (pass-through unaffected)
- [ ] Live probe on gamma/prod MCP (post-deploy, ENC-TSK-O15 AC#2)

CCI-01bcfbd34ce3494fb8e1bb3676140f87

🤖 Generated with [Claude Code](https://claude.com/claude-code)