### PR TITLE
ENC-TSK-O19: cutover context freeze bundle (docs/cutover-context/)

### DIFF
--- a/docs/cutover-context/DOC-FFB4C9D87BCC.md
+++ b/docs/cutover-context/DOC-FFB4C9D87BCC.md
@@ -1,0 +1,254 @@
+# DOC-FFB4C9D87BCC Enceladus Governed Session Prompt — Gamma (v2)
+
+**Project**: enceladus
+**Related**: ENC-TSK-B12, ENC-PLN-006, ENC-PLN-012, ENC-FTR-062, ENC-FTR-065, ENC-FTR-066, ENC-FTR-117, ENC-TSK-I38, ENC-TSK-I43
+**Created**: 2026-04-03
+**Author**: coordination-lead-2026-04-07 (v3 compliance patch); v4 copy-pastable block wrap 2026-04-07; ENC-SES-003 agent-identity wiring 2026-06-28
+
+---
+
+**Copy-pastable prompt for dispatched agents.** Everything between the opening and closing `~~~` fences below is the verbatim session prompt text. Paste it into a dispatched Enceladus agent's boot context as-is to initialize the session. The outer fence uses `~~~` (tilde) because the inner content contains triple-backtick code blocks.
+
+~~~markdown
+Set environment variable `PROJECT=enceladus`.
+
+You are an Enceladus governed product engineering agent operating in the production v3 code-mode architecture. All governed reads and writes route exclusively through Enceladus MCP. Do not use direct AWS APIs, SDK calls, DynamoDB, S3, Lambda invocations, `tracker.py`, `docstore.py`, or any raw-mode bypass path.
+
+---
+
+## Tool Surface
+
+Five code-mode tools are available. No raw-mode fallback exists.
+
+1. **`connection_health`** — Platform health check and governance hash capture.
+2. **`search`** — Compact read-only surface for all discovery and lookup operations.
+3. **`execute`** — Governed write surface for all mutations and lifecycle steps.
+4. **`get_compact_context`** — Bundled context assembly combining code map, documents, tracker records, lessons, and governance data in a single call.
+5. **`coordination`** — Orchestration, dispatch plan generation, authentication helpers, and agent identity (ENC-FTR-117).
+
+---
+
+## Mandatory Session Init
+
+Execute these steps in strict order before any work begins. Do not pick a task or make any write call before Step 9 completes.
+
+1. **`connection_health()`** — Capture `governance_hash`. Verify DynamoDB: ok, S3: ok, graph_index: healthy. Abort if any service is degraded.
+
+2. **Allocate a server-minted session identity (ENC-FTR-117).**
+
+   If a pre-minted `ENC-SES-NNN` was included in your dispatch header, claim it:
+   ```text
+   coordination(action="agent.claim", arguments={session_id: "<ENC-SES-NNN>"})
+   ```
+
+   Otherwise, register a fresh session. First resolve your agent type (register once per surface/model pair; reuse the returned `ENC-AGT-NNN` on subsequent sessions):
+   ```text
+   coordination(action="agent.type.list")  # check for existing type matching your surface + model
+   coordination(action="agent.type.register", arguments={surface: "<surface>", model: "<model>", cost_tier: "<standard|premium|economy>"})
+   coordination(action="agent.register", arguments={agent_type_id: "<ENC-AGT-NNN>", runtime: "<runtime-descriptor>"})
+   ```
+
+   Store the returned `session_id` (e.g. `ENC-SES-003`). **This value is required by `checkout.task` as `active_agent_session_id`.** The checkout service rejects any non-ENC-SES-NNN string. Never invent or predict an ENC-SES-NNN — ID Boundary Rule (ENC-TSK-B99) applies to session IDs as well as tracker record IDs.
+
+3. **`search(action="governance.dictionary")`** — Load the compact entity index. Note `dictionary_version`. Do not load the full dictionary JSON.
+
+4. **`search(action="governance.get", arguments={file_name: "agents.md"})`** — Load agent rules. Before proceeding, read §6 (Tracker Operations — ID Boundary Rule), §8 (Multi-Agent Repo Safety), and §13 (Governance File Authority) in full.
+
+5. **`search(action="governance.get", arguments={file_name: "agents/lifecycle-primer.md"})`** — Load the lifecycle primer.
+
+6. **Mine institutional memory** — `search(action="tracker.list", arguments={project_id: "enceladus", record_type: "lesson", page_size: 10})`. Scan recent lessons for patterns, failure modes, and principles relevant to the session. Cite applicable lessons in worklogs using the format: `[LESSON] Applying ENC-LSN-xxx — <rationale>`.
+
+7. **Assess active plan health** — For each active plan, call `search(action="plan.objectives_status", arguments={record_id: "<plan_id>"})`. Identify which gates are open vs. closed before selecting any task. Pick the next logical gate objective rather than an arbitrary open task.
+
+8. **Load the assigned work object** using the appropriate context mode.
+   - Plan scope: `get_compact_context(mode="record", record_id=<ENC-PLN-*>)`
+   - Task scope: `get_compact_context(mode="task", record_id=<ENC-TSK-*>)`
+   - Issue scope: `get_compact_context(mode="issue", record_id=<ENC-ISS-*>)`
+   - Document scope: `get_compact_context(mode="document", document_id=<DOC-*>)`
+
+9. **Brief the session** — Summarize project status, priority tasks, relevant lessons, and active plan progress in 3–5 paragraphs. Do not execute any task before this briefing is complete.
+
+---
+
+## Working Model
+
+Enceladus operates under the Extended Mind thesis (Clark & Chalmers, 1998) as a constitutive extension of io's cognitive process. It is not infrastructure agents use — it is the substrate through which intent becomes outcome. Every architectural decision is evaluated against this axiom: does it make the extended cognitive system more intelligent, more reliable, and more capable of translating intent into real-world outcomes? Governance degradation — orphan tasks, stale Lessons, schema drift — is not a data quality problem. It is cognitive impairment of the extended mind.
+
+**First-class governed primitives:**
+
+- **Feature** — Describes what is being built. North star capability record.
+- **Plan** — Governed execution contract. Replaces the legacy `[Plan]` parent-task pattern. Drives agent dispatch through phase-gated objectives.
+- **Task** — Deployable work unit inside a plan. Evidence-gated lifecycle.
+- **Issue** — Discovered defect, risk, or technical debt.
+- **Lesson** — Evidence-backed institutional memory. Constitutionally scored. Append-only.
+- **Document** — Governed artifact with a four-stage maturation lifecycle.
+
+**Document maturity lifecycle (ENC-FTR-065 — GDMP):**
+
+- **`raw`** — Default state on creation. Compliance warnings not yet resolved.
+- **`compliant`** — Metadata and compliance warnings resolved. Standard header block present.
+- **`contextualized`** — Provenance annotations applied. INFORMED_BY graph edges present.
+- **`mature`** — All declared related_items have confirmed graph edges via traversal.
+
+Set `document_maturity_state` on `documents.put`. Advance it via `documents.patch`.
+
+---
+
+## Canonical Search Expectations
+
+Use `search` for all read-only operations, including: `tracker.get`, `tracker.list`, `tracker.validation_rules`, `tracker.graphsearch`, `tracker.pending_updates`, `plan.objectives_status`, `documents.get`, `documents.list`, `documents.search`, `reference.search`, `governance.get`, `governance.dictionary`, `changelog.*`, `deploy.*`, `coordination.request.get`, and `coordination.capabilities.get`.
+
+Use `get_compact_context` by default when bundled context is needed (code map, documents, relationships, lessons, and plan data) in a single call rather than multi-call assembly.
+
+**Graph search:** Use `tracker.graphsearch` for relational queries (neighbors, keyword, path, traversal). This collapses 20–50 tracker calls into 1–2 traversals. Full guide: `search(action="governance.get", arguments={file_name: "agents/graphsearch-guide.md"})`.
+
+---
+
+## Canonical Write Expectations
+
+Use `execute` for all governed mutations. Every step requires the current `governance_hash`.
+
+**Tracker operations:** `tracker.create`, `tracker.set`, `tracker.log` (issues and features only — tasks require `checkout.append_worklog`), `tracker.set_acceptance_evidence`.
+
+**Checkout operations (tasks only):** `checkout.task` (requires `active_agent_session_id: ENC-SES-NNN`), `checkout.advance`, `checkout.append_worklog`, `checkout.release`.
+
+**Plan operations:** `plan.create`, `plan.checkout`, `plan.advance`, `plan.add_objective` (append a task ID as an objective), `plan.remove_objective` (blocked if the objective is closed), `plan.reorder_objectives` (permutation only — no additions or deletions), `plan.replace_objectives` (drafted-status plans only).
+
+**Document operations:** `documents.put`, `documents.patch`.
+
+**Deploy operations:** `deploy.submit`, `deploy.trigger`, `deploy.state_set`.
+
+**Agent identity operations (ENC-FTR-117):** `coordination(action="agent.register")`, `coordination(action="agent.claim")`, `coordination(action="agent.type.list")`, `coordination(action="agent.type.register")`. These are called via the `coordination` tool, not `execute`.
+
+**⛔ `governance.update` is NOT available in code-mode agent sessions.** Do not plan around it, attempt it, or include it in any workflow. It does not exist in this interface. All governance file mutations require the §13 HANDOFF block protocol described in the section below.
+
+---
+
+## Governance File Authority (§13 Protocol)
+
+All mutations to the following governance files require execution by a privileged terminal agent operating under product-lead IAM (`io-dev-admin`) via direct S3 archive+put.
+
+- `agents.md` → `s3://jreese-net/governance/live/agents.md`
+- `governance_data_dictionary.json` → `s3://jreese-net/governance/live/governance_data_dictionary.json`
+
+**Agent protocol when governance file changes are required:**
+
+1. Prepare the full updated file content in memory.
+2. Commit the `governance_data_dictionary.json` repo file change in the PR. Note that `agents.md` is never committed to the repository — it lives exclusively in the S3 governance store.
+3. Append a `GOVERNANCE_SYNC_REQUIRED` HANDOFF block to the task worklog before calling `checkout.advance(coding-complete)`, using the canonical format defined in agents.md §13.
+4. Append the full updated file content inline immediately below the HANDOFF block.
+5. Advance to `coding-complete` and await coordination lead dispatch of a product-lead terminal session.
+
+The coordination lead dispatches a Codex terminal agent to execute the S3 archive+put. The coordination lead stamps the relevant acceptance criterion after the S3 sync is confirmed and the governance hash rotates.
+
+---
+
+## Lifecycle Rules
+
+**Set `components` and `transition_type` before checkout.** Both are immutable after `checkout.task` is called. `transition_type` must be at least as strict as the most restrictive registered component.
+
+**Component registry pre-validation (ENC-TSK-C15).** `checkout.task` validates `transition_type` against the component registry before writing any checkout state. If any registered component enforces a minimum `transition_type` stricter than the task's declared type, checkout is rejected with a descriptive 400 error identifying the conflicting component and required minimum. Correct `transition_type` via `tracker.set` before retrying.
+
+**Checkout is required before edits.** No file modifications, git operations, or code changes of any kind are permitted before `checkout.task` succeeds.
+
+**`checkout.task` requires an ENC-SES-NNN.** Pass the server-minted `session_id` from Step 2 of session init as `active_agent_session_id`. The checkout service enforces this — any non-ENC-SES-NNN string is rejected with INVALID_INPUT.
+
+**Task statuses move only through `checkout.advance`.** Direct `tracker.set(field="status")` on tasks is rejected with HTTP 403.
+
+**Checked-out task worklogs use `checkout.append_worklog`.** Calls to `tracker.log` are rejected for checked-out tasks.
+
+**Preflight every transition.** Call `tracker.validation_rules(record_id, target_status, provider)` before advancing. The response returns exact `transition_evidence` fields required, allowed next statuses, and checkout requirements.
+
+**Governance hash.** Refresh via `connection_health()` before large write batches or if significant time has elapsed since session init. Pass the current hash to every mutating operation.
+
+---
+
+## Transition Model
+
+**Default arc (`github_pr_deploy`):**
+
+```text
+open → in-progress → coding-complete → committed → pr → merged-main → deploy-init → deploy-success → closed
+```
+
+**Re-entry arc:**
+
+```text
+deploy-success → coding-updates → coding-complete → committed → pr → merged-main → deploy-init → deploy-success
+```
+
+**Special arcs:**
+
+- **`code_only`** — No deploy stages. Closes at `merged-main` with `code_on_main_evidence`.
+- **`no_code`** — `open → in-progress → coding-complete → closed`. CAI token is skipped. Closes with `no_code_evidence`.
+- **`lambda_deploy`** — PR + merge + Lambda update evidence at `deploy-success`.
+- **`web_deploy`** — PR + merge + URL verification at `deploy-success`.
+
+**CAI / CCI token gates:**
+
+- `coding-complete` → issues CAI (Commit Approval ID); skipped for `no_code`.
+- `committed` (with `commit_sha`) → issues CCI (Commit Complete ID); must appear verbatim in the PR body.
+- `deploy-success` → clears both CAI and CCI.
+- The `PR Commit Gate` CI workflow validates CCI before merge is permitted.
+
+Do not infer gate evidence from memory. Use the live validation rules and transition_type_matrix contracts returned by the platform.
+
+---
+
+## OGTM Awareness (ENC-FTR-066)
+
+Every new record type, relational field, or edge type introduced to Enceladus must satisfy the Ontological Graph Traversability Mandate before the governing feature may advance past `planned` status.
+
+Compliance requires all four of the following to be in place.
+
+1. A `_reconcile_edges()` handler added to `backend/lambda/graph_sync/lambda_function.py`.
+2. An entry in the `RELATIONSHIP_TYPE_TO_EDGE_LABEL` mapping in graph_sync.
+3. An entry in `graph_query_api _ALLOWED_EDGE_TYPES`.
+4. Live E2E validation via `tracker.graphsearch` confirming the new edge type is traversable end-to-end.
+
+When implementing a feature that introduces new relational primitives, validate all four criteria before stamping any acceptance criterion on the governing feature record. The `governance.ogtm` dictionary entity documents the canonical compliance evidence template.
+
+---
+
+## Plan and Knowledge Rules
+
+- For multi-phase work, create or load a governed plan record. Do not invent a `[Plan]` parent-task tree.
+- Objective tasks belong to plans and drive execution progress via `objectives_set`. Plan completion is gated on all objectives reaching `closed` status.
+- Respect `plan.checkout` and `plan.advance` contracts. A plan must be checked out before advancing its lifecycle status.
+- When modifying plan objectives: use `plan.reorder_objectives` to reorder (permutation only), `plan.remove_objective` to remove an open objective, `plan.replace_objectives` for bulk replacement on drafted plans, and `plan.add_objective` to append a new objective.
+- Treat lessons as evidence-backed, append-only institutional memory with constitutional alignment scoring. Mine the lesson corpus before repeating analysis already committed elsewhere.
+- When a lesson influences a decision, cite it in the task worklog: `[LESSON] Applying ENC-LSN-xxx — <rationale>`.
+
+---
+
+## Record-ID Rules
+
+- Base-36 record IDs are canonical with the format `{PREFIX}-{TYPE}-{SEQ}`.
+- Hierarchical child IDs are canonical with the format `{PREFIX}-{TYPE}-{SEQ}-{SUFFIX}`.
+- Parent binding happens at create time, not after the fact.
+- Do not normalize 4-segment IDs back to the legacy flat format.
+- **⛔ ID Boundary Rule (ENC-TSK-B99): Never predict, compute, infer, or scan for the next available record ID before submitting a `tracker.create` call.** Submit only the minimum required attributes. Read the server-assigned `record_id` from the success response. That value is the sole authoritative source of that record's identity. Agents that anticipate IDs introduce brittle sequence dependencies and violate the system's single source of ID truth.
+- **ENC-SES-NNN and ENC-AGT-NNN are server-minted.** The ID Boundary Rule applies to session and agent-type IDs as well as tracker records. Never predict or construct these values; always read them from the `agent.register`, `agent.claim`, or `agent.type.register` response.
+
+---
+
+## Efficiency Rules
+
+- Prefer `get_compact_context` over multi-call context assembly.
+- Prefer `reference.search` over loading full architecture documents.
+- Batch writes with `execute` — multiple steps per call reduce round trips significantly.
+- Use `execute(dry_run=true)` to validate complex multi-step workflows before committing any state.
+- **Never call `search(action="code_map.get")`** — this action does not exist in code mode and returns an `unknown_action` error. Use `get_compact_context(mode="topic", query=..., domain=...)` or `get_compact_context(mode="project", project_id=...)` instead.
+- Use `tracker.graphsearch` for relational queries. One to two traversal calls replace 20 to 50 individual tracker calls for typical context loads.
+- Keep the session in code mode. Let governance services enforce lifecycle contracts. Do not attempt to work around gate requirements by using direct write methods.
+~~~
+
+---
+
+## Document Update Log
+
+- **2026-04-03, ENC-TSK-B12 dispatch** — v1 initial creation.
+- **2026-04-07, coordination-lead-2026-04-07** — v2 substantive refactor.
+- **2026-04-07, coordination-lead-2026-04-07** — v3 compliance patch.
+- **2026-04-07, claude-opus-4-6-pln-013-coord-2026-04-07T1244Z** — v4 copy-pastable wrap.
+- **2026-06-28, ENC-SES-003 (ENC-TSK-I43)** — v5 agent-identity wiring (ENC-FTR-117 / ENC-TSK-I38): added Step 2 (agent.register/claim) to Mandatory Session Init; added ENC-SES-NNN enforcement to Lifecycle Rules; added agent identity operations to Canonical Write Expectations; extended Record-ID Rules with ENC-SES/ENC-AGT coverage; updated coordination tool description; steps renumbered 8 to 9.

--- a/docs/cutover-context/MANIFEST.md
+++ b/docs/cutover-context/MANIFEST.md
@@ -1,0 +1,101 @@
+# MANIFEST — docs/cutover-context/
+
+Staleness is self-declaring: every artifact below carries its own source `updated_at`/`version`
+(the state of the record when exported) and this manifest's `bundle_export_started_at` /
+`bundle_export_completed_at` (when the export actually ran). Treat every claim in this bundle as
+true only as of these timestamps — reconcile against live MCP before acting on anything stale.
+
+```yaml
+session_governance_hash: e04f7eda77c472a49717d6f0e6107da208712f8d79f296a3c479675fdde85152
+session_id: ENC-SES-0EH
+sci: SCI-5accb5055e4743d9a96d566270a936b7
+bundle_export_started_at: "2026-08-21T18:44:10Z"   # connection_health checked_at, session init
+bundle_export_completed_at: "2026-08-21T18:51:22Z"
+task: ENC-TSK-O19
+note: >
+  Mid-export the original task worktree (.claude/worktrees/enc-tsk-o19-cutover-context-bundle)
+  was torn down by a concurrent session's worktree stale-lock sweep (ENC-ISS-071 class) after
+  8 of 9 artifacts had already been written but before any commit existed. Those 8 files were
+  rescued from disk, the worktree was recreated from a fresh origin/v4/main fetch, and the
+  rescued files were committed immediately (commit 8bd89da) before continuing. This manifest
+  and the governance-dictionary-snapshot.json / README.md were produced after that recovery.
+```
+
+## Artifacts
+
+### catalog-DOC-841F5D649EEF.md
+- source: DOC-841F5D649EEF (docstore document)
+- source_version: 137
+- source_updated_at: 2026-08-21T18:08:59Z
+- exported_at: 2026-08-21T18:45Z
+- sha256: 8048886d1c36794c9b47efbd3202a30f687726538c8f729da0801d62865dd2e9
+- note: matches docstore content_hash exactly (byte-identical export)
+
+### blueprint-DOC-6EFD5DB32CD8.md
+- source: DOC-6EFD5DB32CD8 (docstore document)
+- source_version: 23
+- source_updated_at: 2026-07-07T14:30:02Z
+- exported_at: 2026-08-21T18:48Z
+- sha256: 1dec878f2c462a7d0992607ef6d217a4ac20694812ce29681c364ac516527447
+- note: matches docstore content_hash exactly (byte-identical export)
+
+### deploy-path-DOC-B716E8FB10B6.md
+- source: DOC-B716E8FB10B6 (docstore document)
+- source_version: 6
+- source_updated_at: 2026-08-14T04:59:23Z
+- exported_at: 2026-08-21T18:46Z
+- sha256: 42e88701ca5b75409882ab4050b9f348ff35a34aed07830df66ee32a2302655a
+- note: matches docstore content_hash exactly (byte-identical export)
+
+### DOC-FFB4C9D87BCC.md
+- source: DOC-FFB4C9D87BCC (docstore document)
+- title: "DOC-FFB4C9D87BCC Enceladus Governed Session Prompt — Gamma (v2)"
+- source_version: 10
+- source_updated_at: 2026-06-28T02:27:15Z
+- exported_at: 2026-08-21T18:47Z
+- sha256: 0c1f09d4914ccd669afe03bd41b6bfa42dcd45d1e620705a95977c01320fae07
+- note: matches docstore content_hash exactly (byte-identical export)
+
+### coord-lead-init-DOC-586FB8D3DF02.md
+- source: DOC-586FB8D3DF02 (docstore document)
+- title: "DOC-586FB8D3DF02 Enceladus Coordination Lead Session Prompt — Gamma (v2)"
+- source_version: 7
+- source_updated_at: 2026-06-28T02:31:03Z
+- exported_at: 2026-08-21T18:48Z
+- sha256: 75ef3d6befd430d6f1a5962762f0fec31892fe8367bd274869791019a262a9a2
+- note: matches docstore content_hash exactly (byte-identical export)
+
+### governance-agents.md
+- source: governance://agents.md (`search(action="governance.get", arguments={file_name:"agents.md"})`)
+- governance_revision (embedded token): 2026-06-30.09
+- exported_at: 2026-08-21T18:48Z
+- sha256: b944cec2f1deb509b3c25fdb2a7e0a78e0a572c4861fd5cfd2a9afc03823cf00
+
+### governance-dictionary-snapshot.json
+- source: repo path `backend/lambda/coordination_api/governance_data_dictionary.json`
+- source_commit: 6218584 (origin/v4/main HEAD at fetch time, 2026-08-21T18:50Z)
+- exported_at: 2026-08-21T18:51Z
+- sha256: 44ee91e88e13f288d8536ca26d9131fda8bc687eb60b9a7dcba7982f24b63899
+- note: this is the bundled-Lambda fallback surface (what prod actually serves when the DDB
+  dictionary surface is unavailable), NOT the S3 `governance/live/governance_data_dictionary.json`
+  authoritative copy. The dictionary has 3 decoupled live surfaces; this bundle captures only this one.
+
+### connection-health-snapshot.json
+- source: `search(action="system.connection_health")`, captured at session init
+- checked_at: 2026-08-21T18:44:10Z
+- governance_hash: e04f7eda77c472a49717d6f0e6107da208712f8d79f296a3c479675fdde85152
+- exported_at: 2026-08-21T18:44:10Z
+- sha256: d0d9f32989617c342c0bd839233669e090a85857b1713241969e0b370c6c4ac3
+
+### offline-session-protocol-DOC-FC8ABF29B738.md
+- source: DOC-FC8ABF29B738 (docstore document)
+- title: "Enceladus MCP-Down Offline Session Protocol (B69 cutover, 2026-08-21)"
+- source_version: 1
+- source_updated_at: 2026-08-21T18:48:28Z
+- source_content_hash (docstore-reported): 5f65bafba20a09789a59cb0b8b5f0dfd50cbd99a86d9a842ab9e0b52a5a8e756
+- exported_at: 2026-08-21T18:49Z
+- sha256 (this bundled file): 35da1990ac84a7b5b898ab0503ec1072c52d5c13ea1c77e3b809acc3fc425442
+- note: differs from the docstore-reported content_hash by what appears to be a single
+  trailing-newline/whitespace byte (size 2851 vs. reported 2850); content is otherwise a
+  verbatim transcription of the fetched document body. Added mid-task per coordinator
+  instruction (ENC-SES-0EG), replacing the originally-planned offline-protocol-PLACEHOLDER.md.

--- a/docs/cutover-context/README.md
+++ b/docs/cutover-context/README.md
@@ -1,0 +1,25 @@
+# docs/cutover-context/ — Cutover Context Freeze Bundle
+
+Boot source for terminal agents when Enceladus MCP (mcp.jreese.net) is unreachable, or when
+the MCP/tracker plane is itself the surface under cutover or active debugging. See
+`offline-session-protocol-DOC-FC8ABF29B738.md` for the full offline session protocol
+(boot procedure, hard rules, post-restore reconciliation).
+
+**Start here:** read this README, then `MANIFEST.md` — staleness is self-declaring via the
+per-artifact export timestamps and the recorded `governance_hash` in the manifest. Every
+claim sourced from this bundle is as-of its export timestamp, not live truth.
+
+| File | Source | Purpose |
+| --- | --- | --- |
+| `catalog-DOC-841F5D649EEF.md` | DOC-841F5D649EEF (docstore) | PLN-006/PLN-078 coding-task catalog — ADE dispatch source of truth; cutover-day blocker board and gate status |
+| `blueprint-DOC-6EFD5DB32CD8.md` | DOC-6EFD5DB32CD8 (docstore) | Enceladus v4 greenfield architecture and migration blueprint |
+| `deploy-path-DOC-B716E8FB10B6.md` | DOC-B716E8FB10B6 (docstore) | v3-prod surgical deploy brief — consent protocol, deploy channels A/B/C, COE + registry |
+| `DOC-FFB4C9D87BCC.md` | DOC-FFB4C9D87BCC (docstore) | Enceladus governed dispatched-agent session prompt (copy-pastable boot prompt) |
+| `coord-lead-init-DOC-586FB8D3DF02.md` | DOC-586FB8D3DF02 (docstore) | Enceladus coordination-lead session prompt (orchestration role, scope exclusions) |
+| `governance-agents.md` | `governance://agents.md` | Full agent rules governance file |
+| `governance-dictionary-snapshot.json` | repo `backend/lambda/coordination_api/governance_data_dictionary.json` | Bundled-Lambda governance data dictionary snapshot — this is the surface prod actually serves as fallback; NOT the S3 `governance/live/` authoritative copy |
+| `connection-health-snapshot.json` | `search(action="system.connection_health")` | Live platform health + `governance_hash` captured at session init |
+| `offline-session-protocol-DOC-FC8ABF29B738.md` | DOC-FC8ABF29B738 (docstore) | MCP-down offline session protocol — boot procedure, hard rules, post-restore reconciliation, proof standard |
+
+See `MANIFEST.md` for per-artifact export timestamp, source, sha256, and the session
+`governance_hash` this bundle was assembled under.

--- a/docs/cutover-context/blueprint-DOC-6EFD5DB32CD8.md
+++ b/docs/cutover-context/blueprint-DOC-6EFD5DB32CD8.md
@@ -1,0 +1,790 @@
+# DOC-6EFD5DB32CD8 — Enceladus v4: Greenfield Architecture and Migration Blueprint
+
+**Project**: enceladus
+**Author**: J. Reese (via Claude — Gamma Session, April 2026)
+**Created**: 2026-04-03
+**Revised**: 2026-04-22 (Revision 5)
+**Status**: Living Document
+**Related**: ENC-PLN-006, ENC-PLN-003, ENC-ISS-149, ENC-ISS-150, ENC-ISS-180, DOC-E470AC8CE9A8, ENC-FTR-047, ENC-FTR-049, ENC-FTR-050, ENC-FTR-052, ENC-FTR-054, ENC-FTR-055, DOC-157A790F9E8B, ENC-FTR-076, ENC-FTR-093, ENC-FTR-094, DOC-E2379D980FA2, DOC-73FF5950DA61, ENC-FTR-095, ENC-FTR-096, DOC-D3EA86857600
+
+---
+
+**Revision history.** Revision 1: initial blueprint (2026-04-03). Revision 2: added Pre-Flight Prerequisites, Risk Registry, hardened phase gates, and ENC-ISS-180 design constraint (2026-04-07). Revision 3 (2026-04-22): integrated component ontological hardening decisions from DOC-157A790F9E8B — revised component definition to the injection-pair model with five formal invariants, replaced deprecated transition_type enum, updated §II/III/VII/VIII for consistency, fixed compliance violations throughout. Revision 4 (2026-04-22): updated §VIII with empirical 𝔈/𝔇 anchors (F11–F16), K_eff kernel definition, memory consolidation as fifth architectural principle, sheaf cohomology → I1–I5 connection, memory consolidation Lambda in Phase 5, symbol fix (double-struck → Fraktur), added DOC-E2379D980FA2 and DOC-73FF5950DA61. Revision 5 (2026-04-22): ENC-FTR-095 (Sheaf Laplacian H¹ Detection) and ENC-FTR-096 (Memory Consolidation Lambda) created as governed feature records and added as ENC-PLN-006 objectives; tracker IDs integrated into §VII and §VIII references throughout; both added to Related.
+
+---
+
+## Executive Summary
+
+Enceladus is entering v4 from a position of genuine architectural advantage — not just relative to where it started, but relative to the 120+ agentic AI tools now mapped across 11 categories in the Q1 2026 landscape. The platform's governance primitives (checkout service, transition_type_matrix, constitutional scoring, governance hash) are not features that can be bolted on; they are structural commitments that take years to develop correctly. No other platform in the current landscape possesses this combination.
+
+The v4 thesis is unchanged: surgical decomposition of tracker_mutation, introduction of vector embeddings into context assembly, and hardening of the MCP surface. What has sharpened since the initial blueprint is the strategic framing, the risk profile, the sequencing logic, and — as of 2026-04-22 — the ontological definition of a component and the institutional memory consolidation arc. The market is moving fast — Deloitte predicts 33% of enterprise software will include agentic AI by 2028, and the governance gap is now explicitly recognized as a competitive differentiator. Enceladus is positioned to claim that gap.
+
+This document (Revision 5) supersedes all prior framing on component identity, transition_type semantics, phase prerequisite gates, and the architectural philosophy of memory in §VIII, incorporating the ontological hardening decisions of DOC-157A790F9E8B, the mathematical grounding of DOC-E2379D980FA2 and DOC-73FF5950DA61, and the formal feature records ENC-FTR-095 and ENC-FTR-096 now locked into ENC-PLN-006 as objectives.
+
+The migration remains phased across twelve weeks. Total new monthly cost: approximately $1.50–5. The constraint is still the moat.
+
+---
+
+## I. Competitive Landscape and Differentiation Analysis
+
+### The Market Has Confirmed the Whitespace — and Named It
+
+The Q1 2026 competitive landscape analysis across 120+ agentic AI tools spanning 11 categories (frameworks, orchestration platforms, MCP servers, gateways, memory systems, observability tools, foundation models, enterprise platforms, security tools, dev tools, and APIs) confirms the original finding: no platform combines multi-project work tracking, a knowledge graph, and AI agent governance with constitutional scoring in a single system. This is genuine, defensible whitespace.
+
+More importantly, the market has now named the category Enceladus is pioneering. Analyst firms are calling it "bounded autonomy architecture" — systems with clear operational limits, escalation paths to humans for high-stakes decisions, and comprehensive audit trails of agent actions. Deloitte describes the emerging organizational model as "human-on-the-loop" orchestration, where humans set policy and review outcomes rather than approving every action. Enceladus's checkout service with CAI/CCI tokens is a textbook implementation of this model: agents execute autonomously within the transition_type_matrix but cannot cross stage boundaries without earning a governance token.
+
+**Revision 3 note:** The external-positioning framing of "bounded autonomy" and "human-on-the-loop" is accurate as market language for external audiences. Internally, the governing framing per ENC-PLN-006 (updated 2026-04-04) is the extended mind architecture: Enceladus is constitutively part of io's cognitive process, not merely infrastructure. Human IS the loop's origin. The external and internal framings are complementary, not contradictory.
+
+### The 2026 Competitive Landscape
+
+The following platforms define the competitive field as of Q1 2026, each with a characterizing strength and the gap relative to Enceladus.
+
+LangGraph (framework): graph-based orchestration at 126K+ stars; zero project tracking, no lifecycle governance. CrewAI (framework): role-based crews with fast onboarding; ceiling at 6–12 months, no knowledge management. OpenAI Agents SDK (framework): tight GPT-4o integration with Swarm lineage; framework-locked, no cross-provider governance. Google ADK (framework): Gemini-native multi-agent support; Google ecosystem only, no work lifecycle tracking. Anthropic Agent SDK (framework): Claude-native tool use; no governance layer beyond tool calling. Dify (platform): visual workflow builder with RAG; no lifecycle gates or transition enforcement. Notion 3.0 (platform): AI agents across pages up to 20 minutes; no checkout tokens, transition matrices, or constitutional scoring. MintMCP and ContextForge (MCP gateway): centralized tool governance and audit trails; tool access only, no work lifecycle, no knowledge graph. Palantir AIP (enterprise): ontology-powered at enterprise scale; requires Palantir infrastructure, no serverless economics. LangSmith and Langfuse (observability): trace-level visibility into agent calls; observability only, no work tracking or lifecycle governance. Credo AI (governance): enterprise model compliance for bias and drift; model-level only, not task-lifecycle governance. ServiceNow AI (enterprise): end-to-end IT and HR workflows with AI Control Tower; requires ServiceNow platform investment, not agentic-native.
+
+### A New Category: MCP Gateways
+
+An emerging infrastructure layer — MCP gateways — has crystallized as a distinct category in early 2026. Solutions like ContextForge, MintMCP, Peta, TrueFoundry, and WSO2's AI Gateway centralize authentication, authorization, audit logging, and policy enforcement for AI agent tool access. These are described as "smart brokers" between AI clients and MCP servers.
+
+Enceladus's combination of the coordination API, the MCP server, and the checkout service collectively implement a more sophisticated version of what these gateways provide — and uniquely pair it with work lifecycle management and institutional knowledge. The distinction matters for positioning: Enceladus is not competing with MCP gateways, it subsumes their core value proposition while adding everything they lack.
+
+In external positioning, Enceladus should be framed as "the only governed MCP platform that tracks work, enforces lifecycle, and builds institutional memory."
+
+### Enceladus's Protected Differentiators
+
+These capabilities must be treated as inviolable architectural commitments in v4. They are not implementation details — they are the product.
+
+First, the checkout service with CAI/CCI tokens implementing bounded autonomy at the task level. The transition_type_matrix is a state machine that agents cannot bypass. This is the most architecturally unique primitive across all 120+ researched tools.
+
+Second, constitutional scoring for lessons with evidence-gated, append-only records, four-pillar scoring, and governance amendment proposals. No equivalent exists. As the EU AI Act matures, this kind of structured auditability will become a compliance requirement, not just a nice-to-have.
+
+Third, the Context Node primitive implementing greedy knapsack context packing within token budgets. Gartner predicts "context engineering" will appear in 80% of AI tools by 2028. Enceladus is already engineering it at the infrastructure level.
+
+Fourth, three-signal hybrid retrieval (vector similarity + graph traversal + keyword RRF) achieving approximately 87% retrieval accuracy versus 65% for basic retrieval. Enabled by Neo4j's native HNSW vector indexing on AuraDB Free — zero incremental infrastructure cost.
+
+Fifth, serverless economics at $30–40/month across 21 projects, 20 Lambda functions, graph search, MCP server, and multi-provider coordination. This is 100–1000x cheaper than enterprise alternatives at equivalent capability. The constraint is the moat.
+
+### Acknowledged Gaps (Not v4 Priorities)
+
+Enceladus lacks a visual workflow builder, sophisticated multi-agent conversation patterns, mature RAG pipeline connectors, and any form of distributed tracing or observability dashboards. These are acknowledged, monitored gaps. The v4 differentiation is governance depth, not breadth.
+
+One exception: minimum viable observability (AWS X-Ray traces + CloudWatch dashboards) should be addressed in Phase 5, not deferred to v5. Operating four new Lambda services across a 12-week migration window without distributed tracing is an operational risk, not just a feature gap.
+
+### Protocol Intelligence: MCP and A2A
+
+MCP has won decisively — 97M+ monthly SDK downloads, adopted by Anthropic, OpenAI, Google, Microsoft, and AWS. Enceladus should continue investing exclusively in MCP.
+
+A2A (Google's Agent-to-Agent Protocol) should be classified as a monitored risk rather than a dismissed non-priority. Enterprise adoption data from Q1 2026 shows A2A gaining traction in regulated industries alongside MCP, not replacing it. Enceladus does not need to implement A2A in v4, but should maintain an architectural seam in the coordination API that can accommodate an A2A adapter without structural changes.
+
+---
+
+## II. Current Architecture Assessment
+
+### What Works (Preserve in v4)
+
+DynamoDB-as-source-of-truth with Neo4j-as-derived-projection is a sophisticated dual-store pattern most platforms don't attempt. The authoritative-source/derived-projection distinction is critical: Neo4j can be rebuilt from DynamoDB at any time, which provides recovery options that peer-to-peer graph databases lack.
+
+The governance hash (SHA-256 optimistic concurrency) provides write consistency without distributed locks. Simple, auditable, robust across all service boundaries.
+
+SQS FIFO debounce for feed generation is a clean solution for preventing redundant work. Already a form of CQRS. Preserve and extend this pattern.
+
+The multi-provider coordination API is a lightweight, pragmatic dispatch to Claude, Codex, and Bedrock with session tracking. One of the few neutral multi-provider coordination layers in the ecosystem.
+
+The five code-mode meta-tools are the right abstraction layer. Keep them. The token savings they provide (75–85%) are a structural advantage, not an optimization.
+
+Plan and Lesson primitives (ENC-FTR-058, ENC-FTR-052) are first-class governed records with their own lifecycle contracts. These are recent additions that materially expand Enceladus's institutional memory model. v4 builds on them.
+
+### What's Straining (Address in v4)
+
+tracker_mutation is a monolith hiding inside a Lambda. It handles record CRUD, lifecycle enforcement, checkout service interactions, constitutional scoring, component registry lookups, and relationship management in a single function. This creates a blast radius problem: a scoring bug can take down basic task creation. It also makes the codebase increasingly difficult for agents to reason about during development sessions — a real cost when agents are both users and builders.
+
+server.py is a meta-router that should be a meta-dispatcher. The single-file MCP server routing all 50+ raw operations through 5 code-mode tools works at current scale but creates a deployment bottleneck: any change to any tool requires redeploying the entire MCP surface, and a bug in one handler can affect all five tools.
+
+The single devops-project-tracker table creates noisy neighbor risk and prevents per-type operational tuning. The fix is targeted: extract relationships and retain everything else.
+
+No vector embeddings is the most impactful gap. Context assembly using only keyword + RRF scoring misses semantic relationships that are obvious to humans. Hybrid retrieval (vector + graph + keyword) achieves approximately 87% accuracy versus 65% for basic retrieval. The fix is low-cost and Phase 1.
+
+Plan and Lesson records have no graph projection. The graph_sync Lambda does not project plan or lesson nodes to Neo4j. This means the platform's own migration work (tracked as plans) cannot be graph-traversed, and institutional memory (lessons) is invisible to relational context assembly. This is a bootstrapping problem that Phase 1 must fix as its first deliverable.
+
+The auth surface has accumulated complexity debt. ENC-LSN-011 documents auth/session failures as the #1 cross-project issue class with 10+ incidents. ENC-LSN-007 notes that auth bugs always have 3+ interacting root causes. Two P1 auth issues remain open: ENC-ISS-125 (Codex 401) and ENC-ISS-070 (Claude Connector token). Adding new auth surfaces before resolving existing debt will compound the failure rate.
+
+### What's Now Resolved: Post-April 2026 Ontological Hardening (Revision 3)
+
+As of 2026-04-22, DOC-157A790F9E8B establishes a materially revised definition of what an Enceladus component is, with downstream consequences for every phase of this migration.
+
+**Component identity.** A component is no longer just a named governance primitive. It is formally the smallest bounded tuple of (i) a physically-realized, universally-addressable, externally-verifiable runtime resource and (ii) a uniquely-authoritative repository source location from which that runtime resource is produced. Identity is carried by an injection-pair `(component_address, component_repo_dir)` satisfying five formal invariants: address injection (I1), source injection (I2), source non-overlap (I3), source specificity (I4), and source exhaustiveness over deploy code (I5). The `component_id` field is now an index, not an identity.
+
+**New required fields.** Every component record must carry four new fields: `component_address` (the universally unique runtime address — ARN, HTTPS URL, Cloudflare resource ID, Neo4j AuraDB URI, or meta sentinel), `component_repo_dir` (the MECE repo path slice, antichain under prefix order), `component_address_class` (one of `aws_arn`, `https_url`, `cloudflare_resource`, `neo4j_auradb`, `external_manifest`, `meta`), and `component_class` (one of `physical`, `external`, `meta`).
+
+**Revised transition_type enum.** The legacy enum (`github_pr_deploy`, `lambda_deploy`, `web_deploy`, `no_code`, `data_only`) is fully deprecated as of 2026-04-22. The v3 enum is `{code, external_deploy, documentation}`. `no_code` is deprecated outright — every task must produce either a repo artifact or a docstore artifact (the Artifact-Genesis Corollary). Any remaining references to `no_code` or `data_only` in this document or in tracker records are governance debt; migration to the v3 enum is gated on H-SCHEMA shipping, after which server-side enforcement will reject the legacy values.
+
+**Structural tensions in the current prod surface.** Five decomposition problems exist in the current component registry that cannot satisfy I1–I5 without action: T1 (MCP shared-source: `enceladus-mcp-code` and `enceladus-mcp-streamable` share `server.py`; deferred to ENC-FTR-094 gamma-first), T2 (PWA conflates S3 + CloudFront ARNs and two source paths; resolved in H-BACKFILL via three-component split), T3 (Neo4j AuraDB is external, not in AWS; registered as `component_class=external` with manifest at `infrastructure/external/neo4j-auradb.yaml`), T4 (CloudFormation-managed resources; v1 umbrella-per-CFn-file per O1, full split deferred to ENC-FTR-093), and T5 (meta umbrella renamed from `comp-umbrella-no-code` to `comp-umbrella-governance-documentation` with `required_transition_type=documentation`).
+
+**Three new workstreams under ENC-PLN-040.** H-SCHEMA (schema fields, evidence sub-schemas, P1–P7 preconditions, deprecation Lesson), H-BACKFILL (populate all existing components with hardening fields, decompose T2/T3/T4/T5, migrate transition_type records), and H-DRIFT (D1–D4 daily drift audit in `enceladus-governance-audit`). These workstreams augment ENC-PLN-040 and introduce phase-gate dependencies into this plan (see §VII).
+
+---
+
+## III. Greenfield Architecture Blueprint
+
+### Service Boundary Decomposition
+
+The tracker_mutation Lambda splits into four focused services, decomposed along trust and responsibility boundaries — not technology boundaries.
+
+Record Service handles all CRUD operations for tasks, issues, features, plans, lessons, and relationships. This is the hot path. It validates input, enforces schema, generates record IDs, and writes to DynamoDB. It publishes mutation events to an SNS topic for downstream consumers. Record Service does not know about lifecycle rules; it publishes events and trusts that lifecycle validation has already been applied by the caller.
+
+Lifecycle Service owns the transition_type_matrix and all status transition logic. It validates that a requested status transition is legal given current state, component strictness, subtask gates, and checkout status. It is invoked synchronously by Record Service (or Checkout Service) before any status write occurs. The component enforcement logic (STRICTNESS_RANK ordering, no-components block) and subtask gate enforcement belong here. This service can evolve independently — new transition types, new matrix versions, new gate rules — without touching Record Service or Checkout Service.
+
+Checkout Service remains its own Lambda (it already is) and gains clearer boundaries. It owns CAI/CCI token lifecycle, advance requests, the transition_type integrity check (the B08 stamp-at-checkout pattern), and worktree session tracking. It must not contain any record CRUD logic. It calls Lifecycle Service for transition validation, then calls Record Service to write the result. Note: the advance-time preconditions P6 (`external_deploy_evidence` shape) and P7 (`documentation_evidence` novelty-or-freshness close-gate) from DOC-157A790F9E8B live in checkout_service, not in Lifecycle Service.
+
+Scoring Service handles constitutional scoring for lessons asynchronously. Triggered by SNS when a lesson is created or updated, it scores against the four pillars and vibe board, then writes results back to DynamoDB via Record Service. This removes a computationally expensive and evolvable operation from the synchronous write path. The lesson record receives an immediate `scoring_status: pending` field, updated to `scored` when Scoring Service completes. This decoupling enables future ML-based scoring without affecting the hot path.
+
+The MCP server remains a meta-router but decomposes from a single file into a modular package structure. The 5 code-mode meta-tools are the right abstraction — keep them. Internally, each tool dispatches to a focused handler module. The MCP server's role is context assembly and tool routing, not business logic. Note: `server.py` is a known T1 shared-source tension (DOC-157A790F9E8B §3.5). Until ENC-FTR-094 closes, the MCP duo is registered as a single umbrella component with a known-debt note; no clean 1:1 component-to-source mapping exists for this Lambda pair until the gamma-first refactor.
+
+CQRS is adopted lightly. Write operations flow through Record Service → Lifecycle Service. Read operations flow through a dedicated Read API that queries DynamoDB directly (simple lookups) or Neo4j (graph traversal, vector similarity, hybrid context assembly). The existing feed generation pattern (SQS FIFO debounce → pre-computed S3 → CloudFront) is already CQRS and is preserved.
+
+### Component Registry Model (v3 — Revised)
+
+Every new service introduced in this migration must be registered in the component registry using the v3 schema. The following mapping applies to the four new v4 Lambda services.
+
+Record Service: `component_address` = `arn:aws:lambda:us-east-1:{account}:function:enceladus-record-service`, `component_address_class` = `aws_arn`, `component_class` = `physical`, `component_repo_dir` = `backend/lambda/record_service`, `required_transition_type` = `code`.
+
+Lifecycle Service: `component_address` = `arn:aws:lambda:us-east-1:{account}:function:enceladus-lifecycle-service`, `component_address_class` = `aws_arn`, `component_class` = `physical`, `component_repo_dir` = `backend/lambda/lifecycle_service`, `required_transition_type` = `code`.
+
+Scoring Service: `component_address` = `arn:aws:lambda:us-east-1:{account}:function:enceladus-scoring-service`, `component_address_class` = `aws_arn`, `component_class` = `physical`, `component_repo_dir` = `backend/lambda/scoring_service`, `required_transition_type` = `code`.
+
+Read API: `component_address` = `arn:aws:lambda:us-east-1:{account}:function:enceladus-read-api`, `component_address_class` = `aws_arn`, `component_class` = `physical`, `component_repo_dir` = `backend/lambda/read_api`, `required_transition_type` = `code`.
+
+All four use `component_class=physical` and `required_transition_type=code` per the default mapping from `aws_arn` address class. The propose-time preconditions P1–P5 (address uniqueness, address verifiability, repo-dir existence, repo-dir non-overlap, transition-type/address-class compatibility) are enforced server-side once H-SCHEMA lands. These components cannot be proposed until H-SCHEMA is in-flight.
+
+For the existing prod decomposition tensions: T2 (PWA three-way split to `comp-enceladus-pwa-frontend`, `comp-enceladus-pwa-cdn`, `comp-enceladus-api-gateway`) and T3 (Neo4j as `comp-enceladus-neo4j` with `component_class=external`, `component_address_class=neo4j_auradb`, `required_transition_type=external_deploy`) are executed in H-BACKFILL. T4 umbrella-per-CFn-file registration also executes in H-BACKFILL. T1 (MCP shared-source) is deferred to ENC-FTR-094. Full schema and worked examples in DOC-157A790F9E8B §4.
+
+### Data Layer Architecture
+
+Retain single-table design for core tracker records (tasks, issues, features, plans, lessons) — these are queried together and benefit from capacity pooling. Extract operationally distinct data.
+
+Relationships (rel# SK prefix) migrate to a dedicated `enceladus-relationships` table for independent Stream processing and reduced scan noise. Migrated in Phase 4 via dual-write. Context-nodes table (already planned in ENC-FTR-050 CloudFormation spec) is correctly separated. Checkout-tokens table is correctly separated.
+
+Neo4j AuraDB Free remains the graph backend. Free tier limits have expanded to 200K nodes / 400K relationships. At approximately 2,789 records projecting to 50K with 3–5 relationships each, Free tier provides ample headroom. Native HNSW vector index support enables full hybrid retrieval at zero additional cost.
+
+Neo4j is also now a registered `component_class=external` component (`comp-enceladus-neo4j`) as per T3 resolution in DOC-157A790F9E8B. Changes to the AuraDB instance (tier upgrade, connection config rotation) are governed as `required_transition_type=external_deploy` advances with `external_deploy_evidence` containing the AuraDB instance ID and machine-reproducible retrieval steps.
+
+Graph backup strategy (required, not optional): Neo4j AuraDB Free has no SLA and no automated backup. Mitigation: implement a daily automated APOC export to S3 via a scheduled Lambda. Document the rebuild procedure from DynamoDB as the authoritative source. The graph should be rebuildable from scratch within 15 minutes from DynamoDB Streams replay.
+
+Migration target if Free tier is outgrown: FalkorDB self-hosted on a t4g.small EC2 instance ($12–15/month). OpenCypher-compatible; Cypher queries transfer with minimal changes. Neptune Serverless ($80/month minimum, never scales to zero) is not viable.
+
+### The Vector Embedding Layer
+
+Add Amazon Titan Embeddings V2 (256 dimensions, $0.02/million tokens) via Bedrock.
+
+One-time batch embedding of all approximately 2,789 records: approximately $0.03. Ongoing embedding on every record update: approximately $0.03/month. Total: essentially free.
+
+The embedding pipeline piggybacks on the existing DynamoDB Streams → Lambda sync: record mutation triggers DynamoDB Stream; graph sync Lambda calls Bedrock Titan V2 to generate a 256-dimensional embedding; Lambda writes the embedding as a vector property on the Neo4j node AND as a binary attribute on the DynamoDB item (dual-store ensures durability); context assembly uses a single Neo4j Cypher query: vector similarity entry points → graph traversal expansion → keyword RRF → greedy knapsack packing.
+
+This delivers three-signal hybrid retrieval: vector similarity (semantic relevance), graph traversal (relationship context), keyword matching (exact precision). Combined with the existing greedy knapsack packer, this is the crown jewel of v4 context assembly.
+
+### v4 Service Map
+
+API Layer: HTTP API v2 routes to Lambda functions for all CRUD and query operations. A separate REST API Gateway endpoint handles the MCP Streamable HTTP transport with response streaming enabled. CloudFront sits in front of both, with Lambda@Edge handling JWT validation for authenticated routes.
+
+Write Path: API Gateway → Record Service Lambda → DynamoDB write → SNS mutation event → fanout to Lifecycle validation, Graph sync + embedding, Context node update, Feed debounce queue.
+
+Read Path: API Gateway → Read API Lambda → DynamoDB (simple lookups) or Neo4j (graph traversal, vector similarity, hybrid context assembly). CloudFront caches GET responses where appropriate.
+
+MCP Surface: REST API Gateway (streaming) → MCP Server Lambda (provisioned concurrency, 1 instance) → dispatches to handler modules → calls Read API for context assembly, Record Service for mutations, Coordination API for dispatch.
+
+Async Services: Scoring Service (SNS-triggered, constitutional scoring), Feed Publisher (SQS FIFO debounced), Graph Sync (DynamoDB Streams via EventBridge Pipes → Lambda → Neo4j + Bedrock embeddings → vector index update), Context Node Sync (DynamoDB Streams → Lambda → context-nodes table).
+
+Coordination Layer: Coordination API Lambda handles multi-provider dispatch (Claude Agent SDK, OpenAI Agents SDK, Google ADK, Bedrock Agent), session tracking, callback processing, and intake debounce. Each provider integration is implemented as a provider adapter behind a common contract interface — preventing framework-specific SDK calls from leaking into the coordination layer's core logic.
+
+---
+
+## IV. Investment Recommendations: Heavier vs. Lighter
+
+### Go Heavier on These Five Areas
+
+First, provisioned concurrency for the MCP server Lambda. One provisioned instance at 512MB ARM64 costs approximately $1.50/month and eliminates cold starts entirely for the most latency-sensitive endpoint in the system. Highest ROI investment available.
+
+Second, vector embeddings in context assembly. Adding Titan V2 embeddings stored in Neo4j's native vector index transforms context assembly from keyword-only to hybrid three-signal retrieval. Cost: approximately $0.03/month. Impact: approximately 87% vs. approximately 65% retrieval accuracy.
+
+Third, Lambda SnapStart + ARM64 across all functions. Enable SnapStart on all Python 3.12+ Lambda functions (90% cold start reduction, free) and switch all functions to ARM64/Graviton (20% cost savings, 13–24% faster initialization). Zero-cost wins. Apply universally.
+
+Fourth, REST API Gateway for the MCP streaming endpoint. HTTP API v2 does not support response streaming. Migrate the MCP endpoint specifically to REST API Gateway with `responseTransferMode: STREAM`, enabling SSE for long-running tool calls. Enables 500ms TTFB versus 8–10 seconds buffered, with 15-minute timeout and 200MB payload limit.
+
+Fifth, the Scoring Service as an independent, asynchronous service. Moving constitutional scoring off the write path enables future ML-based scoring evolution without touching the hot path. The scoring_status: pending field provides immediate feedback to callers without blocking.
+
+### Go Lighter on These Five Areas
+
+First, eliminate Lambda glue code with EventBridge Pipes. Replace DynamoDB Streams → Lambda → EventBridge patterns with DynamoDB Streams → EventBridge Pipes → targets. Each Pipe replacement eliminates one Lambda function and reduces operational surface area.
+
+Second, bifurcate auth strategy immediately. For agent clients (Codex, Bedrock Agent, Anthropic Agent SDK), use API key authentication. These clients don't need browser redirects. The redirect_mismatch bugs documented in ENC-ISS-124/125 stem from forcing OAuth flows where they're unnecessary. Keep Cognito OAuth only for interactive clients (Claude.ai web/mobile/desktop, PWA). This immediately resolves the majority of recurring auth failures.
+
+Third, CloudFront Functions cannot replace Lambda@Edge for auth. CloudFront Functions lack asymmetric crypto support and cannot validate RS256 JWTs. Keep Lambda@Edge but optimize it: cache JWKS keys and embed the public key directly rather than fetching on each request.
+
+Fourth, do not add DAX, ElastiCache, or any managed caching layer. DAX minimum is approximately $194/month (single node), ElastiCache Serverless minimum is approximately $60/month. Both require VPC configuration. Use the three-tier free caching strategy instead: CloudFront caching, in-Lambda execution environment caching, S3 pre-computed responses.
+
+Fifth, consolidate SNS topics where appropriate. Keep EventBridge for content-based routing. Evaluate whether the current SNS topics can be consolidated — single-subscriber topics should be replaced with direct Lambda invocations or Pipes targets.
+
+---
+
+## V. Pre-Flight Prerequisites
+
+Before Phase 0 of the v4 migration begins, the following conditions must be true. These are not nice-to-haves — they are gate requirements.
+
+### Hard Gates (Must Be Closed Before Phase 0)
+
+ENC-ISS-128 — Coordination dispatch creates phantom tasks (P1). The coordination dispatch currently creates coordination-only tasks instead of dispatching to existing governed tasks. This bug will corrupt tracker data during any extended migration period where agent coordination is active. Close before Phase 0 begins. No exceptions.
+
+ENC-ISS-094 — Codex MCP missing checkout-service lifecycle tools (P1). Codex cannot participate in governed task execution without checkout-service tools in its MCP profile. Close or formally scope it to API key auth strategy before Phase 3.
+
+### Soft Gates (Must Be Actively In-Progress Before Phase 2)
+
+ENC-ISS-142 — Agent escalation protocol missing (P2). Agents must propose specific human actions when blocked. A `coordination.escalate` action or equivalent must be designed and deployed before Phase 2.
+
+ENC-ISS-125 — Codex 401 Unauthorized (P1). The Codex auth failure should be resolved as part of the auth bifurcation work in Phase 3, but the hypothesis and approach must be validated before Phase 3 begins.
+
+ENC-ISS-070 — Claude Connector token not visible on auth dashboard (P1). This visibility gap makes auth debugging harder. Should be resolved during Phase 3 auth hardening.
+
+### Recommended Pre-Phase 0 Sweep
+
+Resolve any orphan tasks in the tracker (no parent or feature lineage). Ensure all v4 migration tasks have valid plan parent bindings in ENC-PLN-006. Run `plan.objectives_status` on ENC-PLN-008 and confirm all objectives are closed before treating it as a dependency.
+
+---
+
+## VI. Risk Registry
+
+The following risks have been identified through analysis of open issues, institutional lessons, live stack state, and the April 2026 competitive landscape.
+
+### RISK-001: Auth Complexity Cascade — Severity: P0
+
+Auth and session failures are the #1 cross-project failure class in Enceladus history (ENC-LSN-011). Auth bugs consistently involve 3+ interacting root causes (ENC-LSN-007). Two P1 auth issues are currently open. The v4 migration adds three new auth surfaces: a REST API Gateway endpoint for MCP streaming, a bifurcated API key authentication scheme, and new Lambda service boundaries each requiring their own auth context.
+
+Mitigation: Auth bifurcation (Phase 3) must be sequenced as the first infrastructure change in that phase — before MCP server modularization begins. All new service-to-service calls between decomposed Lambda functions must use internal API key authentication from day one, not OAuth. Define and test the bifurcated auth matrix in a dry-run environment before production deployment. Add explicit auth health checks to session initialization that verify both the Cognito path and the API key path independently.
+
+### RISK-002: Coordination Dispatch Data Integrity — Severity: P1
+
+ENC-ISS-128 documents that the coordination dispatch creates coordination-only tasks instead of dispatching to existing governed tasks. This is a live P1 bug. Hard gate: ENC-ISS-128 must be closed before Phase 0 begins.
+
+### RISK-003: Graph as Memory — Single Point of Failure — Severity: P1
+
+The v4 architectural philosophy explicitly designates "the graph is the memory." Neo4j AuraDB Free has no SLA, no guaranteed uptime, and no automated backup. Mitigation: implement daily automated Neo4j backup to S3 via a scheduled Lambda. Rebuild time target: under 15 minutes for full corpus. This must be completed before Phase 1 adds the vector index.
+
+### RISK-004: Phase Dependency Ordering — Severity: P2
+
+Phase 1 extends the graph_sync Lambda to add embedding calls and new node type projections. A regression in graph_sync introduced during Phase 1 could silently cascade into Phase 2 and Phase 4. Mitigation: mandatory 48–72 hour stabilization window between Phase 1 completion and Phase 2 kickoff. Define explicit health gates covering graph node count (must match DynamoDB record count ±2%), embedding coverage (must exceed 95% of all records), and graph_sync Lambda error rate (must be below 0.1% for 24 consecutive hours).
+
+### RISK-005: Context Node Feature Flag Graduation — Severity: P2
+
+Both `ENABLE_CONTEXT_NODES` and `ENABLE_LESSON_PRIMITIVE` are feature flags. The v4 architecture treats context nodes and lessons as core infrastructure — not opt-in features. Mitigation: schedule explicit feature flag graduation as a Phase 5 deliverable.
+
+### RISK-006: Agent Escalation Gap During Migration — Severity: P2
+
+ENC-ISS-142 documents that agents lack a formal escalation protocol when blocked. During a 12-week migration with service decompositions, feature flag toggles, dual-write windows, and partial state migrations, agents will encounter more genuinely ambiguous states than at any point in the platform's history. Mitigation: soft gate; a `coordination.escalate` action must be deployed before Phase 2.
+
+### RISK-007: Orphan Task and Lineage Debt — Severity: P2
+
+The tracker has accumulated orphan tasks with no parent or feature lineage. During a migration that will create dozens of new tasks, the absence of lineage enforcement means migration work itself could become orphaned. Mitigation: pre-Phase 0 sweep; enforce a lineage policy going forward.
+
+### RISK-008: Multi-Provider Framework Neutrality — Severity: P2
+
+Every major AI lab now ships its own agent framework with divergent calling conventions, authentication models, and tool-use patterns. Mitigation: define a provider adapter interface in the coordination API that isolates framework-specific SDK calls behind a common contract. This is a Phase 3 architectural commitment.
+
+### RISK-009: Regulatory Compliance Trajectory — Severity: P3
+
+The EU AI Act sets requirements for high-risk AI systems. Enceladus's governance model is architecturally aligned with these requirements and demonstrating this alignment is a genuine differentiator for enterprise AI roles. Mitigation: Phase 5 should include a brief EU AI Act compliance self-assessment mapping Enceladus governance primitives to Act requirements.
+
+### RISK-010: Extended Migration Window Communication — Severity: P3
+
+The migration spans 12 weeks across 21 active projects. During Phase 2 and Phase 4, there will be brief windows of elevated risk affecting all projects. Mitigation: before Phase 2 begins, produce a one-page impact matrix for the three most active projects documenting which operations may be briefly impacted, what the fallback behavior is, and what the rollback procedure looks like.
+
+### RISK-011 (Revision 3): Component Hallucination Before H-SCHEMA Ships — Severity: P1
+
+Before H-SCHEMA lands (P1–P5 preconditions enforced server-side), agents proposing new components for the four new v4 Lambda services can do so without address verification, repo-dir existence checks, or overlap detection. A hallucinated or mis-specified component address or repo path will corrupt the registry and block the H-BACKFILL checkout gate. Mitigation: no component proposals for v4 services should be submitted until H-SCHEMA is in-flight. Agents dispatched on Phase 2 work must include an explicit pre-flight: confirm H-SCHEMA task status before attempting any `component.propose` call. This rule is agent-side only until P1–P5 are server-enforced.
+
+---
+
+## VII. Migration Roadmap: Six Phases with Hardened Phase Gates
+
+The migration plan is structured as six phases across twelve weeks. Each phase has explicit entry criteria and exit criteria. Do not skip gate validation.
+
+### Phase 0: Zero-Cost Performance Wins + Pre-Flight Closure (Week 1)
+
+Entry criteria: ENC-ISS-128 closed. ENC-PLN-006 objectives_set validated. All v4 migration tasks have plan lineage. H-SCHEMA task is created in the tracker and checked out (may be in-flight, not required to be closed).
+
+Work: enable ARM64 on all Lambda functions (configuration changes only, no code); enable SnapStart on all Python 3.12+ Lambda functions; add provisioned concurrency (1 instance, 512MB ARM64) to the MCP server Lambda ($1.50/month); add `ReportBatchItemFailures` to all SQS-triggered Lambda event source mappings; implement daily Neo4j backup to S3 (required before Phase 1 adds vector index); begin resolution of ENC-ISS-142 (agent escalation protocol design); sweep and resolve orphan tasks.
+
+Exit criteria: all Lambda functions reporting ARM64 in console. MCP server cold starts eliminated in CloudWatch (0 cold start events over 24h monitoring window). Neo4j daily backup confirmed with test restore. Orphan task count at 0.
+
+Expected impact: 20% cost reduction, 90% cold start reduction across fleet. No migration window required.
+
+### Phase 1: Vector Embedding Pipeline + Graph Projection Expansion + H-SCHEMA (Weeks 2–3)
+
+Entry criteria: Phase 0 exit criteria met. Neo4j backup confirmed.
+
+Work: create HNSW vector index on Neo4j AuraDB Free; fix graph_sync Lambda to project plan and lesson node types (currently missing); extend graph_sync Lambda to call Bedrock Titan V2 on every record mutation, writing embedding to both Neo4j (vector property) and DynamoDB (binary attribute); run one-time batch embedding of all approximately 2,789 records ($0.03); update `get_compact_context` handler to use three-signal hybrid retrieval pipeline. Backwards-compatible throughout: vector scores augment existing scoring; zero weight if embedding absent.
+
+H-SCHEMA is Phase 1-adjacent and must ship within this window. H-SCHEMA adds `component_address`, `component_repo_dir`, `component_address_class`, `component_class`, and `required_transition_type_rationale` to the component schema; revises `required_transition_type` to the v3 enum `{code, external_deploy, documentation}`; adds `external_deploy_evidence` and `documentation_evidence` sub-schemas; extends `component.propose` with preconditions P1–P5; extends checkout_service `_handle_advance` with preconditions P6–P7; emits the `no_code` and `data_only` deprecation Lesson; adds 12 new unit tests.
+
+Design constraint (ENC-ISS-180): when creating typed relationship edges (rel# items), the target record node must be confirmed present in Neo4j before `create_relationship` is called. graph_sync's MERGE silently no-ops when the target node is absent — no error, no retry, no recovery signal. v4 Record Service must enforce a pre-flight target-node check before any edge creation, or implement a reconciliation queue for edges whose target was not yet projected at write time. Do not carry this failure mode into v4.
+
+48–72 hour stabilization window after Phase 1 before Phase 2.
+
+Exit criteria (Phase 2 entry gate): graph node count matches DynamoDB record count ±2%. Embedding coverage ≥95% of all records. graph_sync Lambda error rate <0.1% for 24 consecutive hours. At least one end-to-end hybrid retrieval query validated against known records. H-SCHEMA task closed (evidence accepted). ENC-FTR-096 design document (memory consolidation Lambda architecture) authored in the docstore before this gate stamps (see AC-11 in ENC-TSK-B62).
+
+### Phase 2: tracker_mutation Decomposition + H-BACKFILL (Weeks 4–6)
+
+Entry criteria: Phase 1 exit gate passed. ENC-ISS-142 (escalation protocol) deployed. Dual-write infrastructure pattern documented. H-SCHEMA closed. H-BACKFILL task checked out.
+
+Work: extract Lifecycle Service first (cleanest boundary); extract Scoring Service (move constitutional scoring to SNS-triggered async Lambda, lesson records gain `scoring_status: pending` → `scored` state). Each extraction is a separate task in Enceladus's own tracker, following the full checkout → code → PR → deploy arc. Parallel validation: both old and new paths run simultaneously for at least 48 hours. Feature flags for each extraction are independent — one can be rolled back without affecting the other.
+
+H-BACKFILL runs concurrently with the decomposition work. H-BACKFILL populates the five hardening fields on all existing active components; executes T2 file split for `03-api.yaml` and registers the three resulting components; executes T3 external manifest creation for Neo4j and other in-scope external dependencies; executes T4a umbrella-per-CFn-file registration; registers a single umbrella `comp-enceladus-mcp` for the T1 MCP duo with a known-debt note pointing to ENC-FTR-094; migrates all `transition_type=no_code` and `transition_type=data_only` active tasks to the v3 enum (including ENC-TSK-F18 and ENC-TSK-F19 which carry governance debt on this field); renames `comp-umbrella-no-code` to `comp-umbrella-governance-documentation`.
+
+The checkout gate (AC[2] of ENC-FTR-076) cannot be enabled until H-BACKFILL is complete. Phase 2's exit gate therefore implicitly requires H-BACKFILL closure.
+
+Exit criteria: Lifecycle Service handling 100% of status transition validations with zero fallback to inline path for 48 consecutive hours. Scoring Service handling 100% of lesson scoring with zero inline scoring for 24 consecutive hours. tracker_mutation blast radius confirmed reduced. H-BACKFILL task closed with evidence accepted. All prod components satisfy I1–I5 or carry a documented known-debt note.
+
+### Phase 3: MCP Server Modularization + Streaming + Auth Bifurcation (Weeks 6–8)
+
+Entry criteria: Phase 2 exit criteria met. ENC-ISS-125 hypothesis validated. Auth bifurcation matrix documented and reviewed.
+
+Work: auth bifurcation first (implement API key authentication for agent clients, update MCP server auth middleware to accept both schemes, validate with Codex managed sessions before touching MCP server structure); decompose `server.py` into package structure `mcp_server/{__init__, tools/coordination, tools/execute, tools/context, tools/search}`; add REST API Gateway endpoint for MCP Streamable HTTP transport with `responseTransferMode: STREAM`; route MCP traffic to new streaming endpoint while keeping HTTP API v2 as fallback; implement provider adapter interface in coordination API.
+
+Note: the MCP server modularization is distinct from the T1 shared-source refactor (ENC-FTR-094). Phase 3 modularizes the package structure of `server.py` into handler modules without splitting the file into per-Lambda entry points. That split is a gamma-first operation deferred to ENC-FTR-094. The Phase 3 modularization is safe because both Lambda functions continue to share the same package structure; the T1 invariant violation (I2/I3) persists until FTR-094 closes.
+
+Exit criteria: Codex successfully authenticating via API key with no OAuth redirect. Claude.ai connectors successfully authenticating via Cognito OAuth. MCP streaming endpoint returning 500ms TTFB on test tool calls. ENC-ISS-125 and ENC-ISS-070 confirmed resolved.
+
+### Phase 4: Data Layer Optimization + H-DRIFT (Weeks 8–10)
+
+Entry criteria: Phase 3 exit criteria met. Dual-write pattern validated in Phase 2.
+
+Work: extract relationships to dedicated `enceladus-relationships` DynamoDB table; dual-write during transition: Record Service writes to both tables; reads check new table first with fallback to old; once all reads migrated, stop writing to old table and clean up rel# items from devops-project-tracker; zero downtime throughout; evaluate and implement EventBridge Pipes to replace Lambda glue code; graduate ENABLE_CONTEXT_NODES and ENABLE_LESSON_PRIMITIVE feature flags to always-on (single deployment).
+
+H-DRIFT ships in this window. H-DRIFT implements D1–D4 daily drift audits in `enceladus-governance-audit` Lambda (address resolvability, repo-dir existence, MECE closure, transition-type/address-class semantic plausibility), emits per-audit Lesson records on drift detection (non-blocking), and emits a daily audit report document.
+
+Exit criteria: all relationship reads served from `enceladus-relationships`. Zero rel# SK reads from devops-project-tracker. Feature flags removed from Lambda environment variables. EventBridge Pipes deployed for at least one DynamoDB Streams → Lambda → EventBridge pattern. H-DRIFT task closed.
+
+### Phase 5: Operational Hardening + Observability + ENC-FTR-096 (Weeks 10–12)
+
+Entry criteria: Phase 4 exit criteria met. ENC-FTR-096 design document confirmed in docstore (AC-11 of ENC-TSK-B62).
+
+Work: add CloudFront cache behaviors for read-heavy API GET endpoints (60–300s TTLs); implement in-Lambda caching for governance rules, project metadata, transition_type_matrix (module-level variables with TTL checks); review and consolidate SNS topics — eliminate single-subscriber topics; add minimum viable observability: enable AWS X-Ray tracing on all Lambda functions, create a CloudWatch dashboard covering Lambda error rates by service, Neo4j graph_sync lag, embedding coverage %, DynamoDB write throttle events, and MCP server cold starts; update CloudFormation templates to reflect all v4 architectural changes; run full governance dictionary sync to capture new entities (Record Service, Lifecycle Service, Scoring Service, provider adapter interface, external_deploy_evidence schema, documentation_evidence schema, v3 transition_type_enum); produce EU AI Act compliance self-assessment mapping Enceladus governance primitives to Act requirements; update JWO-TSK-023: update jreese.net/enceladus-showcase.html with v4 narrative; implement ENC-FTR-096 (Memory Consolidation Lambda): nightly EventBridge-triggered Lambda scans inter-session Handoff documents in the docstore, identifies patterns recurring across ≥2 waves (co-cited records, recurring error classes, repeated governance decisions), proposes Lesson candidates via `documents.put` with `document_subtype=lesson` and status=draft pending io review before promotion to a governed Lesson record — the human remains the approval gate at all times; see DOC-E2379D980FA2 §4.1 for the episodic→semantic consolidation rationale and ENC-FTR-096 for the full acceptance criteria.
+
+Exit criteria: X-Ray traces available for all five services. CloudWatch dashboard showing green metrics across all five services for 48 consecutive hours. Governance dictionary version bumped. Showcase page updated. ENC-FTR-096 deployed and first nightly run logged; at least one Lesson candidate document proposed from Handoff review and available for io review.
+
+### v5 Generation Backlog (ENC-FTR-095)
+
+ENC-FTR-095 (Sheaf Laplacian Computation on Neo4j — H¹ Governance Inconsistency Detection) is a PLN-006 objective but targets the v5 generation. It is gated on ENC-FTR-088 (tracker.graph_laplacian) reaching production status and io explicit authorization. No implementation work begins during the v4 migration window. The feature is tracked in PLN-006 objectives_set as a forward obligation: any agent dispatched against PLN-006 must confirm ENC-FTR-095 scope (v5, not v4) before attempting implementation. See §VIII for architectural context.
+
+---
+
+## VIII. Architectural Philosophy for Enceladus v4
+
+Enceladus v4 is guided by five principles.
+
+**The extended mind IS the architecture.** The foundational commitment, per ENC-PLN-006 (revised 2026-04-04) and the Inception Principle (DOC-0CAD28643E2F), is that Enceladus is not infrastructure that agents use — it is constitutively part of io's cognitive process. The platform is the structure through which intent becomes outcome. Governance degradation — orphan tasks, stale Lessons, schema drift, hallucinated component addresses — is not a data quality problem. It is cognitive impairment of the extended mind. Every v4 architectural decision is evaluated against this axiom: does it make the extended cognitive system more intelligent, more reliable, and more capable of translating intent into outcome? Prior framing of "bounded autonomy architecture" and "human-on-the-loop" remains valid as market language; internally it is superseded by this. For the mathematical and philosophical grounding of this principle, see DOC-E2379D980FA2 (cross-domain synthesis spanning four millennia of mathematics, philosophy, and intelligence science) and DOC-73FF5950DA61 (formal journal treatment proving the Inception Principle generates precise architectural requirements via Wasserstein geometry and RG scaling).
+
+**The graph is the memory.** AI agents have no persistent memory across sessions. Enceladus's knowledge graph — with typed relationships, context nodes, and vector embeddings — serves as institutional memory that compounds over time. v4 makes the hybrid retrieval pipeline (vector + graph + keyword) the crown jewel of context assembly. And because DynamoDB is the authoritative source from which Neo4j can always be rebuilt, the memory is durable.
+
+The 𝔈/𝔇 ontology (Applied Entelechy / Acquired Dynamis, per DOC-C6584044BEEB) formalizes this with empirical grounding: 𝔈 is the compute-loaded, low-latency subgraph serving present intent, bounded by a scale-appropriate budget; 𝔇 is the retained corpus at unbounded scale, decaying in retrievability but never in retention (FSRS-6 T3 threshold governs 𝔇→𝔈 eligibility). Every agent session is a transition operator 𝔇→𝔈 conditioned on intent, effected by the Pathway kernel K_eff(·|ι) — an approximate Wasserstein transport plan with PPR cold start and shrinkage estimation (K_eff = (1−w(n))·K_prior(·|anchor) + w(n)·K_observed(·|ι), shrinkage parameter τ≈20, RG-stable under Kemeny-Snell coarse-graining with contractive flow 2.7× from session to wave scale, F16 / DOC-F8D8470CBF91). Empirical fixed-point budgets at 16TB corpus anchor (F11 / DOC-18D2337D7E1F): B_session=40.2MB (99% intent coverage), B_wave=241.8MB, B_project=1.6GB, B_corpus=800GB. Cognitive temperature schedule (logarithmic, F15 / DOC-1E5E505CB51A): β_session=8.0, β_wave=5.1, β_project=3.2, β_corpus=2.3 — outperforms power-law by 5×. Percolation margin m=p_current−p_c: current hot-tier fraction |H|/|V|≈0.20–0.35, p_c≈0.18±0.07 (F12 / DOC-41D810873099), margin positive but thin — comp-percolation-monitor (ENC-FTR-085) provides nightly authoritative measurement feeding the BHC five-level alert ladder.
+
+**Serverless economics are a strategic moat.** Running 21 projects with graph search, MCP server, multi-provider coordination, and deployment pipelines at $30–40/month is 100–1000x cheaper than enterprise alternatives at equivalent capability. Every architectural decision preserves this cost profile. The v4 additions total approximately $1.50–5/month. The constraint breeds creativity — S3 as a cache, DynamoDB Streams as an event bus, Neo4j Free as a graph+vector store. These aren't compromises; they're advantages that enterprise platforms cannot replicate at their scale.
+
+**Decompose along trust boundaries, not technology boundaries.** The right service boundaries in v4 are trust and responsibility boundaries: Record Service owns data integrity, Lifecycle Service owns state machine correctness, Scoring Service owns constitutional evaluation, Checkout Service owns token lifecycle, MCP Server owns context assembly. Each service can be independently tested, deployed, and reasoned about by both human and AI agents — which matters enormously for a platform where the agents are both users and builders. The same principle applies to the component registry: each component owns a MECE slice of the deploy-source space, and no two components share a physical realization or source authority. At the global knowledge-graph level, the five component invariants I1–I5 constitute the first production implementation of sheaf-cohomology-style global consistency — each local component definition (address + repo-dir injection pair) combining into a globally consistent partition, with deviations made countable and auditable by server-side preconditions. Full sheaf Laplacian computation on Neo4j — monitoring H¹ (cohomology degree 1) as a governance inconsistency signal that no local inspection can replicate — is the highest-value open architectural research question (Q1 in DOC-E2379D980FA2 §4.4), formally tracked as ENC-FTR-095 and targeted for the v5 generation (gated on ENC-FTR-088 in production).
+
+**Every task produces a governed artifact.** The Artifact-Genesis Corollary (DOC-157A790F9E8B §2.4), formalized 2026-04-22: any agent action that claims to satisfy an acceptance criterion must leave a trace that a future session can inspect. A lifecycle advance without a trace is an unfalsifiable claim. Unfalsifiable claims are hallucination fossils. The v3 transition_type enum (`{code, external_deploy, documentation}`) mechanizes this corollary: every accepted transition_type produces a verifiable artifact — a repo commit for `code`, a structured external-system ID plus reproducible retrieval steps for `external_deploy`, a novel-or-fresh docstore document for `documentation`. The deprecated `no_code` path, which admitted artifact-less advances, is removed. This is not a constraint layered on top of governance; it IS the operating contract of the autonomous system.
+
+**Memory consolidation is an explicit process.** Every successful natural memory system has a consolidation arc from episodic short-term storage to semantic long-term storage — biological systems execute this during sleep via hippocampal replay, converting episodic traces into durable cortical schemas. Enceladus has the structural analogs: inter-session Handoff documents are the hippocampal buffer (short-term, session-scoped, high fidelity), graduated Lessons are consolidated semantic memory (long-term, FSRS-6 stabilized), and governance amendments are deeply encoded procedural memory. What v4 still lacks is the consolidation process itself: a periodic Lambda that reviews recent Handoff documents, extracts recurring patterns across ≥2 waves (co-cited records, recurring error classes, repeated governance decisions), and proposes Lesson candidates with a human-approval gate before promotion. Without this process, institutional knowledge grows only through deliberate Lesson authoring and misses the latent patterns distributed across Handoff documents that no single session inspects in aggregate. Phase 5 delivers ENC-FTR-096 (Memory Consolidation Lambda). See DOC-E2379D980FA2 §4.1 for the full episodic→semantic consolidation rationale and ENC-FTR-096 for the full acceptance criteria.
+
+---
+
+*End of Document | Enceladus v4 Architecture Blueprint — Revision 5 | 2026-04-22*
+*Revised from Revision 4 to wire in formal feature tracker IDs. Changes: ENC-FTR-095 and ENC-FTR-096 added to Related and throughout §VII/VIII; Phase 5 title updated to reference ENC-FTR-096 explicitly; new §VII subsection documenting ENC-FTR-095 as v5 generation backlog objective with scope constraint for dispatched agents; §VIII trust-boundary principle references ENC-FTR-095 by ID; §VIII fifth principle references ENC-FTR-096 by ID; Phase 5 entry criteria adds ENC-FTR-096 design doc precondition; ENC-FTR-096 was already a PLN-006 objective; ENC-FTR-095 added as new PLN-006 objective.*
+
+---
+
+## Revision 11 Addendum (2026-06-17): Graph-Signal Performance — Per-Query AGA Session Cost and the Pre-Materialized Projection Path
+
+This addendum records an architectural follow-up surfaced while remediating the ENC-ISS-304 hybrid-retrieval investigation (plan ENC-PLN-046). It extends Section III (The Vector Embedding Layer / Data Layer Architecture), Section VI RISK-003 (Graph as Memory — Single Point of Failure), and Section VII Phase 1 (Graph Projection Expansion).
+
+### Finding
+
+The graph signal in three-signal hybrid retrieval is delivered by Personalized PageRank over a Neo4j Aura Graph Analytics (AGA) projection. The current implementation builds that projection per query: every anchored get_compact_context / tracker.graphsearch call issues gds.graph.project(... memory='2GB'), which provisions a fresh AGA compute session. AGA serializes and rate-limits session creation, so anchored queries are either slow (14s+), silently fall back to the Cypher connectivity-degree proxy (which is NOT true PPR), or exceed the synchronous read budget entirely. This is one root cause across the lineage:
+
+- ENC-ISS-265 (closed) — PPR/graph signal unavailable; fixed the AGA Sessions API contract (memory param, nodeId resolution) via ENC-TSK-F20 / F35, restoring gds_pagerank intermittently.
+- ENC-ISS-268 (open, P1) — residual per-query AGA session-creation cost and intermittency; the session-reuse refactor. ENC-ISS-271 is the sibling AGA session-reuse issue.
+- ENC-ISS-311 (closed, via ENC-PLN-046 / ENC-TSK-G98) — the same cost manifesting as anchored-query timeouts at the MCP read layer.
+
+### Interim mitigation (shipped)
+
+ENC-PLN-046 / ENC-TSK-G98 (PR #484, prod 2026-06-17) bounds the graph signal with an 8-second wall-clock deadline. On timeout the signal degrades to graph_algorithm='timeout' and hybrid retrieval returns vector + keyword via Reciprocal Rank Fusion instead of hanging. This makes the endpoint responsive but does NOT make the graph signal performant — under the deadline, anchored PPR still does not return for most anchors.
+
+### Architectural target (follow-up)
+
+A durable fix must remove per-query AGA session creation from the synchronous read path. Two complementary options:
+
+- Option A — AGA session reuse (ENC-ISS-268). Cache a single AGA session (gds.session.getOrCreate) at Lambda scope and pass sessionId= on every gds.graph.project, eliminating per-call provisioning. Lowest-effort; preserves the per-query projection model.
+- Option B — Pre-materialized persistent projection (ENC-ISS-311 follow-up). Maintain a long-lived named graph projection refreshed out-of-band (by graph_sync on write, or a scheduled job), so hybrid queries run gds.pageRank.stream against a warm projection rather than building one per request. Highest payoff; aligns the hot-tier Applied-Entelechy subgraph with a standing compute object instead of a per-query rebuild, and restores true gds_pagerank within the synchronous read budget.
+
+Option B is the architecturally preferred end state and is the natural Phase 2+ / v5 graph deliverable; Option A is a valid stepping stone. RISK-003 (Graph as Memory — SPOF) is unchanged either way: the graph remains a derived index with tracker.list / DynamoDB as the authoritative fallback, and hybrid retrieval already degrades gracefully when the graph signal is absent.
+
+Tracked under: ENC-ISS-268 (open, durable fix), ENC-ISS-311 (mitigation shipped), ENC-TSK-B62 (Phase 1 graph-projection gate, closed), ENC-PLN-046 (interim mitigation).
+
+### Rev 11 Addendum follow-up (2026-06-17): Option B is now tracked as ENC-FTR-101
+
+The pre-materialized persistent projection (Option B above) is filed as ENC-FTR-101 (P2, infrastructure, status=planned) and added to ENC-PLN-006 objectives_set as a Phase 2+ graph deliverable. ENC-FTR-101 depends on ENC-ISS-268 (AGA session reuse, the foundation) and cross-links ENC-ISS-311 / ENC-ISS-265 and the graph features ENC-FTR-088 / ENC-FTR-095. The ENC-TSK-G98 8-second deadline remains the interim safety net until ENC-FTR-101 lands.
+
+---
+
+## Revision 12 Addendum (2026-06-21): Energy-Based / Attractor-Memory Synthesis — Hopfield Lineage Incorporation
+
+This addendum incorporates the recommendations of DOC-D3EA86857600 (research synthesis on the modern Hopfield lineage, grounding paper arXiv:2601.07635v2). It sharpens — it does not supersede — the §VIII principles, and threads concrete obligations into §III (Vector Embedding Layer), §VI RISK-003, and the §VII phase gates. The thesis: the platform's memory, retrieval, consolidation, and consistency machinery are all instances of one mature object — energy descent toward attractors in an associative memory — and adopting that single vocabulary makes the 𝔈/𝔇 ontology measurable rather than merely evocative. Each item below names the existing objective that absorbs it; net-new scope is enumerated in the dissemination map and is filed as governed records through the coordination supervisor, not from this document.
+
+### Incorporation 1 — The graph is an energy-based associative memory (sharpens §VIII "The graph is the memory")
+
+Three-signal hybrid retrieval is, formally, one step of gradient descent on a joint retrieval energy E(x) = E_vector(x) + lambda_graph · E_PPR/Laplacian(x) + lambda_kw · E_keyword(x): the vector term is the modern-Hopfield retrieval energy (Ramsauer et al. 2020 proved softmax attention IS the one-step retrieval rule of a continuous-state Hopfield network), the graph term is the Laplacian/diffusion smoothing made explicit by Graph Hopfield Networks (2026), and the keyword term is a seed/prior. Reciprocal Rank Fusion is a practical approximation to descending this joint energy. HippoRAG / HippoRAG 2 (NeurIPS 2024 / ICML 2025) — knowledge graph as hippocampal index plus Personalized PageRank — are near-existence-proofs of the Enceladus retrieval design and supply a benchmark methodology (multi-hop recall@k on MuSiQue / 2Wiki / HotpotQA) for validating it. Obligation: the energy form and per-retrieval energy logging are folded into the Pathway Primitive telemetry (ENC-FTR-082) and the get_compact_context hybrid pipeline; the formalization itself is net-new scope (see dissemination map, new objective N1).
+
+### Incorporation 2 — 𝔈 sizing is an attractor-capacity problem; the percolation margin is the alpha-load gauge (sharpens §VIII 𝔈/𝔇 and §VI)
+
+The hot tier 𝔈 is a Dense Associative Memory. Its governing control variable is the load ratio alpha = (effective stored patterns) / (hot-tier dimension). The classical Hebbian retrieval ceiling alpha_c ≈ 0.138 (Amit-Gutfreund-Sompolinsky 1985) is the operational analog of the spin-glass transition: below it, recall is clean; above it, frustration produces an exponential number of spurious minima. Modern dense memories reach exponential capacity with large basins, so 𝔈 load can run high provided the spurious-attractor rate (Incorporation 3) stays low. The percolation margin m = p_current − p_c already monitored by comp-percolation-monitor (ENC-FTR-085, p_c ≈ 0.18, F12) is reinterpreted as the alpha-critical-region gauge: it is the same phase boundary in graph-connectivity coordinates. Obligation: ENC-FTR-085 gains an alpha computation and a critical-region alert tied to the BHC five-level ladder (ENC-FTR-083); the BHC's logarithmic beta-schedule is reframed as a cognitive-temperature schedule (Incorporation 4).
+
+### Incorporation 3 — Hallucination is a spurious attractor; make it a measured signal (sharpens §VIII "Every task produces a governed artifact" and §VI)
+
+The "hallucination fossil" language in the Artifact-Genesis principle now has a precise associative-memory referent: a spurious attractor is an interference minimum near the factual manifold that corresponds to no stored record. Define spurious-attractor rate = the fraction of agent sessions / retrievals that converge to states matching no stored graph node and no sanctioned combination of nodes. It is the leading indicator of capacity overload (alpha past the critical region) and of governance hallucination. Obligation: spurious-attractor rate is emitted as a wave-close metric under Wave-Close Drift Telemetry (ENC-FTR-087) and surfaced on the BHC alert ladder (ENC-FTR-083); the cross-cutting definition and instrumentation are net-new scope (new objective N2). Regime caveat: a spurious state is pathological for clean recall but is also the substrate of useful synthesis/generalization — the classification of any given off-manifold attractor as hallucination versus emergent insight is a governance judgment io makes explicitly, which is exactly the kind of call a governance-first platform exists to hold.
+
+### Incorporation 4 — Cognitive temperature is the beta knob already in the plan (sharpens §VIII 𝔈/𝔇)
+
+The BHC logarithmic beta-schedule (beta_session=8.0 → beta_corpus=2.3, F15) is the inverse-temperature / retrieval-sharpness knob of a modern Hopfield network. The Pathway kernel K_eff (ENC-FTR-082), which effects the 𝔇→𝔈 transition, should be explicitly annealed within a session: open hot (broad Wasserstein transport integrating diverse 𝔇 context for exploration), cool toward commit (sharpen onto a single low-energy intent attractor). Separately, because the corpus is highly correlated (related records, near-duplicate docs), naive Hebbian-style encoding induces crosstalk; correlation-aware (pseudoinverse-style) encodings are the standard remedy and are noted as a Phase 2 hot-path consideration (new task N4). Obligation: annealed-beta on K_eff lands as an AC enrichment on ENC-FTR-082; the correlation-aware encoding note attaches to the embedding/retrieval path.
+
+### Incorporation 5 — Consolidation is basin-shaping; add Crick-Mitchison unlearning (sharpens §VIII "Memory consolidation is an explicit process")
+
+The episodic→semantic arc (ENC-FTR-096) is, in energy terms, the merging of many narrow episodic point-attractors (Handoff documents) into broad semantic prototype basins (graduated Lessons) — trading specificity for robustness, which is exactly what enlarges basins and frees capacity. The lineage also supplies a complementary mechanism Enceladus does not yet have: Crick-Mitchison "unlearning" (reverse learning; Hopfield-Feinstein-Palmer 1983) — a periodic anti-Hebbian "dream pass" that dampens over-stable and spurious attractors in the hot subgraph, equalizing basins. This is a mechanism-grounded garbage collector for governance memory and a natural sibling to the consolidation Lambda. Obligation: the basin-shaping framing enriches ENC-FTR-096; the unlearning/dream-pass mechanism is net-new scope (new objective N3), explicitly gated behind the same io-approval invariant as ENC-FTR-096 — no automated dampening of governed memory without a human gate.
+
+### Incorporation 6 — Sheaf H¹ is the frustration term of the governance spin glass (sharpens §VIII trust-boundary principle)
+
+The energy framing closes a conceptual loop already present in the blueprint: the I1–I5 component invariants define the globally consistent (low-energy) section, and the sheaf Laplacian H¹ signal (ENC-FTR-095, v5, gated on ENC-FTR-088) is precisely the topological frustration term — the obstruction to a globally consistent section that no local inspection can detect. ENC-FTR-088 (tracker.graph_laplacian, CSR + Fiedler) is the computational substrate; the Dirichlet/graph-energy quadratic form it exposes is the same energy object used in retrieval (Incorporation 1). No new scope and no schedule change: this is a framing note that unifies the consistency-detection research line (ENC-FTR-088 → 095) with the retrieval and capacity lines under one energy vocabulary. v5 scope guard on ENC-FTR-095 is unchanged.
+
+### Incorporation 7 — Inference-time energy descent as a compute-governance primitive (forward / v5 research)
+
+Energy-Based Transformers (Gladstone et al. 2025) reframe inference as variable-step energy minimization — more descent steps for harder problems, best-of-N over candidate energies as self-verification. This is a candidate compute-governance primitive for the Pathway kernel: budget descent steps per session against intent difficulty, with the higher per-step FLOP cost (3.3–6.6x vs feed-forward) made explicit in the budget hierarchy (ENC-FTR-083). Filed as forward/v5 research (new objective N5); no v4 implementation. Gated behind the same discipline as ENC-FTR-095 — dispatched agents confirm scope before any implementation.
+
+### Caveat banner (applies to all seven)
+
+These are productive analogies, not proven identities. The attention/Hopfield equivalence is rigorous; "PPR = energy descent" and "hallucination = spurious attractor" are theoretically motivated but only partially formalized — HippoRAG itself does not frame PPR as energy minimization (that bridge is the Graph Hopfield Networks line). Exponential-capacity and basin guarantees assume uncorrelated patterns; the Enceladus corpus is highly correlated, so correlation-aware encodings are a precondition for the capacity claims to transfer. Treat 2025–2026 preprint figures as provisional. The platform adopts the vocabulary and the measurements; it does not adopt the strong claims unverified.
+
+### Dissemination map (objective-level)
+
+Absorbed by existing planned objectives (AC enrichment, applied by the coordination supervisor — not from this architect session): ENC-FTR-082 (annealed-beta K_eff + per-retrieval energy logging, Incorporations 1/4); ENC-FTR-083 (cognitive-temperature framing + spurious-attractor/alpha alert rungs, Incorporations 2/3/4); ENC-FTR-085 (alpha-load computation + critical-region alert, Incorporation 2); ENC-FTR-087 (spurious-attractor-rate wave-close metric, Incorporation 3); ENC-FTR-088 (Dirichlet/graph-energy framing note, Incorporation 6); ENC-FTR-095 (H¹-as-frustration framing note, v5 guard unchanged, Incorporation 6); ENC-FTR-096 (basin-shaping framing, Incorporation 5).
+
+Net-new governed records to file (proposed to the coordination supervisor; not created from this document): N1 — Energy-Based Retrieval Formalization (define E(x), per-retrieval energy logging, benchmark RRF vs Graph-Hopfield reference on multi-hop recall@k; P2; gated on ENC-FTR-101 / ENC-ISS-268 so true PPR energy is available). N2 — Spurious-Attractor / Hallucination Telemetry (cross-cutting definition + emission + BHC wiring; P2; edges to 083/085/087). N3 — Crick-Mitchison Unlearning / Dream-Pass (anti-Hebbian basin equalization over 𝔈; P3; io-approval-gated sibling of ENC-FTR-096). N4 — Correlation-Aware (pseudoinverse-style) Encoding for near-duplicate corpus items (Phase 2 hot-path task; mitigates Hebbian crosstalk). N5 — Inference-Time Energy Descent for the Pathway kernel (EBT-style variable-step minimization; v5 research; budget-aware). All five carry the standard guards: OGTM compliance on any new edge types, the v5 scope guard where applicable, and the io-approval invariant on anything that mutates governed memory.
+
+Source: DOC-D3EA86857600 (research synthesis), grounding arXiv:2601.07635v2. Incorporated 2026-06-21 by the architect; tracker dissemination routed to the coordination supervisor under DD-3 scope separation.
+
+
+
+---
+
+## Revision 13 Addendum (2026-06-21): Flow-Reinforced Transport and Stigmergic Exploration — Physarum Lineage Incorporation
+
+This addendum incorporates the active-mechanical decision-making findings of Schick et al. (*Decision-Making in Light-Trapped Slime Molds Involves Active Mechanical Processes*, PRX Life 2026, DOI 10.1103/rv7g-d9kx) and the surrounding *Physarum polycephalum* computation lineage — Tero et al. current-reinforcement network optimization (Science 2010), Nakagaki maze-solving (Nature 2000), Murugan–Levin mechanosensory strain integration (Advanced Materials 2021), and Reid slime-trail externalized memory (2012–2013). It sharpens — does not supersede — the §VIII principles and continues the energy-vocabulary established in Revision 12. The thesis: a brainless, decentralized organism computes an approximate optimal-transport plan over a physical network by reinforcing edges proportional to realized flow, exploring broadly then committing under pressure, and writing an externalized refractory trace to avoid re-traversal. Each of these is a mechanism Enceladus's 𝔈/𝔇 machinery either already implies or measurably lacks. Net-new scope is enumerated in the dissemination map and is filed as governed records through the coordination supervisor, not from this document. The N-series below continues the Revision 12 N1–N5 numbering (N6–N8).
+
+### Incorporation 1 — Current reinforcement IS the Pathway kernel's transport update; the graph projection should be flow-weighted, not only PPR-walked (sharpens §VIII "The graph is the memory")
+
+Tero's current-reinforcement law — tube conductivity evolving as a function of realized flow, `dD_ij/dt = f(|Q_ij|) − D_ij`, with high-flow tubes thickening and idle tubes atrophying — is a physical optimal-transport solver and the direct biological analog of K_eff (the 𝔇→𝔈 transport plan, ENC-FTR-082). Enceladus currently scores the graph signal with Personalized PageRank: a static read (diffusion centrality) over a uniformly weighted projection. The Physarum lineage supplies the missing write: reinforce graph edge weights by realized successful-retrieval traffic — how often an edge actually participated in a 𝔇→𝔈 transport that satisfied an intent — and decay edges that never carry flow. This makes the pre-materialized persistent projection (ENC-FTR-101) flow-adaptive rather than uniform: the hot tier's standing compute object becomes a current-reinforced network that converges toward the corpus's actual usage geometry, exactly as the mold's tube network converges to optimal transport. Obligation: a flow-reinforcement weight on the ENC-FTR-101 projection, fed by per-retrieval participation logging already implied by ENC-FTR-082's energy logging; the reinforcement/decay law itself is net-new scope (new objective N6, gated on ENC-FTR-101 so a standing projection exists to weight).
+
+### Incorporation 2 — Constraint-shape selects the commit mode; exploration is broad and cheap, commitment is singular and pressure-loaded (sharpens §VIII 𝔈/𝔇 and Revision 12 Incorporation 4)
+
+Schick's central result: the mold does not take the shortest path out of a light trap. It sends exploration protrusions in all directions, withdraws most, and reorganizes its peristaltic wave until the contraction mode aligns with the trap's longest axis — the geometry that lets pressure build to maximize mass transport — then commits there. Two lessons sharpen the annealed-β K_eff from Revision 12: (a) the explore→commit arc is mechanism-confirmed — open hot with broad, cheap, withdrawable probes integrating diverse 𝔇 context; cool toward a single pressure-loaded commit; (b) the commit target is not the nearest or shortest-path attractor but the mode the intent-constraint geometry makes most transport-efficient. This is a direct caution against greedy shortest-path retrieval and naive RRF top-1: let the shape of the intent constraint select the transport mode, not raw proximity. Obligation: AC enrichment on ENC-FTR-082 (annealed-β commit is constraint-shape-selected, not distance-greedy); no net-new record.
+
+### Incorporation 3 — The slime trail is externalized, overwritable, anti-redundant exploration memory; Enceladus has only positive-reinforcement memory (sharpens §VIII "Memory consolidation is an explicit process")
+
+Reid showed the mold lays extracellular slime and avoids its own trail — an externalized spatial memory that biases foraging toward novelty — and that this trace is overwritable by salience (a plasmodium crosses its own slime to reach high-quality food). Enceladus's memory is almost entirely positive: graduated Lessons, co-citation edges, PPR centrality — "go where signal is strong." It has no negative or refractory trace saying "this region was already traversed without yield; don't re-explore unless new salience justifies it." This is the missing anti-redundancy primitive: a decaying "visited" trace on records and paths an agent session already traversed unproductively, biasing the next session's 𝔇→𝔈 toward unexplored corpus, and overwritable when a high-value intent crosses it. It is the natural sibling to the Crick-Mitchison dream-pass (Revision 12, N3): unlearning dampens over-stable internal attractors; the stigmergic trace dampens re-traversal of already-walked paths. Obligation: net-new scope (new objective N7), carrying the io-approval invariant since it shapes governed memory, with re-traversal rate emitted as a wave-close metric under ENC-FTR-087.
+
+### Incorporation 4 — Mechanosensory relative valuation: prefer dispersed corroborating evidence over a single stacked spike (sharpens §VIII trust-boundary principle and Revision 12 Incorporation 3)
+
+Murugan–Levin found the mold prefers three masses spread along the horizon over one stacked mass of equal weight — a Weber-law-like relative valuation responding to how much of the strain horizon the evidence occupies, not to raw magnitude. The retrieval analog: prefer an intent supported by multiple dispersed corroborating records or edges (broad strain footprint) over one very-high-score single record (stacked mass). A dispersion/corroboration term in RRF fusion is a structural hedge against single-source spurious attractors — the hallucination telemetry of Revision 12, N2 — because a lone off-manifold spike is precisely a stacked mass with no horizon. Obligation: framing enrichment on the hybrid pipeline (ENC-FTR-082) plus a small net-new dispersion-weighting record (N8); edges to N2.
+
+### Incorporation 5 — Decentralized constraint satisfaction with no central controller (sharpens §VIII trust-boundary / sheaf principle; framing only)
+
+The mold has no central controller: globally coherent, near-optimal configurations emerge from local peristaltic contractions over a shared cytoplasmic medium. This is the same shape as the sheaf principle — global consistency (low H¹) emerging from local component definitions (I1–I5) with no global inspector, over a shared graph and DynamoDB substrate. *Physarum* is a biological existence-proof that local rules plus a shared transport medium reach global coherence. No new scope, no schedule change, v5 guard on ENC-FTR-095 unchanged: this is a framing note unifying the decentralized-emergence intuition with the consistency-detection line (ENC-FTR-088 → 095).
+
+### Caveat banner (applies to all five)
+
+Productive analogies, not proven identities. Tero current-reinforcement → optimal transport is rigorous within the Physarum flow model; its transfer to graph-retrieval edge weights is a heuristic, not a theorem. The "longest axis" result is specific to peristaltic pressure mechanics and must not be imported literally as "prefer long retrieval paths" — the transferable claim is constraint-shape selects the efficient mode, not "longer is better." Slime-trail memory is lossy and overwritable by design; that is a feature for exploration but disqualifies it as a durable record store (DynamoDB remains authoritative). The platform adopts the mechanisms and the measurements; it does not adopt strong biological claims unverified.
+
+### Dissemination map (objective-level)
+
+Absorbed by existing planned objectives (AC enrichment, applied by the coordination supervisor — not from this architect session): ENC-FTR-082 (constraint-shape-selected annealed-β commit, Incorporation 2; dispersion-weighting hook, Incorporation 4); ENC-FTR-101 (flow-adaptive edge weights on the persistent projection — the substrate N6 requires, Incorporation 1); ENC-FTR-087 (re-traversal / exploration-redundancy rate as a wave-close metric, Incorporation 3); ENC-FTR-088 and ENC-FTR-095 (decentralized-emergence framing note, Incorporation 5, v5 guard unchanged); ENC-FTR-096 (stigmergic trace framed as exploration-memory sibling to consolidation, Incorporation 3).
+
+Net-new governed records to file (proposed to the coordination supervisor; not created from this document): N6 — Flow-Reinforced Graph Projection (current-reinforcement edge weighting: reinforce by realized successful-retrieval traffic, decay idle edges; P2; gated on ENC-FTR-101; edges to ENC-FTR-082 and ENC-FTR-085). N7 — Stigmergic Exploration Trace (decaying, salience-overwritable anti-redundancy "visited" trace biasing 𝔇→𝔈 toward unexplored corpus; P3; io-approval-gated sibling of Revision-12 N3 and ENC-FTR-096; emits to ENC-FTR-087). N8 — Dispersion/Corroboration Weighting (Weber-law-style preference for dispersed corroborating evidence over single stacked spike; hedge against single-source spurious attractors; P3; edges to ENC-FTR-082 and Revision-12 N2). All three carry the standard guards: OGTM compliance on any new edge types, and the io-approval invariant on anything that mutates governed memory.
+
+Source: Schick et al., PRX Life 2026 (DOI 10.1103/rv7g-d9kx), grounding lineage Tero 2010 / Nakagaki 2000 / Murugan–Levin 2021 / Reid 2012–2013. Incorporated 2026-06-21 by the architect; tracker and ENC-PLN-006 dissemination routed to the coordination supervisor under DD-3 scope separation.
+
+
+
+---
+
+## Revision 14 Addendum (2026-06-22): Graph-Signal Reconciliation — F36 Closed ENC-ISS-268 via Bolt-Pool Resilience, Not Session Reuse; ENC-FTR-101's Foundation Re-grounded on DOC-D4CB8048798B
+
+This addendum reconciles the Revision 11 Addendum (and the Graph-Signal Restoration Wave handoff DOC-7E83A8C219F0) against what was actually implemented in ENC-TSK-F36. It is filed by the ENC-FTR-101 WU2 dispatched session after a ground-truth reconciliation pass over ENC-ISS-268, ENC-ISS-271, ENC-TSK-F36, and io's field guide DOC-D4CB8048798B. It sharpens — does not supersede — the Rev 11 architectural target: Option B (pre-materialized persistent projection) remains the preferred end state.
+
+### Why this addendum exists
+
+Rev 11 framed the durable fix as Option A (AGA session reuse, ENC-ISS-268) and Option B (pre-materialized persistent projection, ENC-FTR-101), with FTR-101 depending on ENC-ISS-268 as its foundation. Two facts diverged once F36 landed:
+
+- ENC-ISS-268 was closed by ENC-TSK-F36 (PR #391, prod 2026-06-22) via Bolt-pool resilience — neo4j driver tuning (max_connection_lifetime=300 below the NAT 350s idle-kill, keep_alive) plus a verify_connectivity / rebuild gate. F36 deliberately did NOT implement AGA session reuse; the session-reuse sketch is marked SUPERSEDED in the ISS-268 technical_notes.
+- AGA session reuse — the actual Option A — is tracked by ENC-ISS-271 (open, P1), not ENC-ISS-268. Its post-F36 gamma probes returned true gds_pagerank on all three anchors but at ~50s p95.
+
+### The three-concern model (canonical going forward)
+
+The graph-signal lineage (ENC-ISS-265 then 268 then 271 then 311) braids three distinct concerns. F36 closed the first two; only the third remains open:
+
+- Correctness — true gds_pagerank vs the cypher_fallback connectivity-degree proxy. FIXED by F36: all three ENC-ISS-265 probe anchors return gds_pagerank.
+- Liveness — the dead Bolt/Arrow pool hang after Lambda container freeze (NAT 350s idle-kill, OAuth 3600s expiry). FIXED by F36: Bolt-pool resilience, now live in graph_query_api (_ensure_live_driver / _rebuild_neo4j_driver).
+- Latency — per-call gds.graph.project with memory:2GB provisions a fresh AGA session every request (~50s p95), exceeding both the ENC-ISS-271 sub-20s AC and the synchronous MCP read budget. STILL OPEN. The ENC-TSK-G98 8-second deadline only bounds it (degrades to graph_algorithm=timeout); it does not fix it.
+
+### Re-grounded foundation for ENC-FTR-101 (Option B)
+
+io's field guide DOC-D4CB8048798B (Neo4j GDS Sessions in AWS Lambda) is the canonical implementation contract for both Option A and Option B and should be cited by every future session touching backend/lambda/graph_query_api/lambda_function.py. Key invariants:
+
+- An AGA GDS session is a server-side compute object with a 1-hour idle TTL and a 7-day hard cap, identified by a stable name, created idempotently via the graphdatascience Python client GdsSessions.get_or_create(session_name=...). TTL resets only on gds.graph.project / algorithm calls, not on verify_connectivity or run_cypher.
+- A graph projection lives INSIDE a session. Therefore a standing projection (Option B) can exist only inside a standing named session (the Option A substrate). Option B is NOT a read-path-only change; it requires the named-session architecture underneath.
+- Recommended shape (the field guide's deployment pattern, which is Option B's shape): warm the named session out-of-band from an EventBridge scheduled rule that also rebuilds the standing projection; request-path Lambdas call get_or_create only to reattach (cheap) and run gds.pageRank.stream against the warm projection.
+- Concurrency invariant: concurrent gds.graph.project on the SAME graph name throws FlightRuntimeException (already a job running). Projection must be single-writer / out-of-band; the request path must never project. This is exactly why Option B (one out-of-band projector plus many read-only reattachers) is the safe end state.
+
+### Corrected dependency edges
+
+- ENC-FTR-101 (Option B) depends on the named-session substrate of DOC-D4CB8048798B, with F36 Bolt-pool resilience as a necessary base (it keeps the request-path driver live but does not address latency). It does NOT depend on an ENC-ISS-268 session-reuse deliverable, which was never built.
+- ENC-ISS-271 (Option A, open) and ENC-FTR-101 (Option B) share that substrate. Open coordination decision: land Option A first as a lower-effort stepping stone (~sub-5s p95), or fold the named-session substrate directly into the FTR-101 implementation and close ISS-271 as superseded-by-FTR-101. The 2026-06-22 WU2 dispatch selected Option B implement plus PR plus probe.
+
+### AC-5 / Rev 13 linkage (unchanged)
+
+The standing projection's relationship-property slot flow_weight (initialized 1.0 per edge) remains the schema hook for ENC-FTR-108 (Flow-Reinforced Graph Projection, Rev 13). Recorded here only to note the slot must be created by the out-of-band projector inside the named session, alongside the existing per-type weight property, so ENC-FTR-108 can begin writing adaptive weights without a schema migration.
+
+
+
+## Revision 15 Addendum (2026-06-23): Dream-Science Design Lens — Bounded Consolidation, Gist-Distillation, and the Confabulation Gate (DOC-7D8C252B4C57)
+
+This addendum incorporates the design-relevant findings of DOC-7D8C252B4C57 (*Dream Science as a Design Lens for Enceladus v4*), which connects five strands of sleep and dream science to the v4 memory architecture. It sharpens — does not supersede — the §VIII principles and continues the energy-vocabulary of Revision 12 and the transport-vocabulary of Revision 13. The thesis is narrow and load-bearing: the offline reorganization Enceladus most wants its memory layer to do — consolidate, abstract, and forget the right things — is exactly what biological sleep does, and the dream-science literature supplies two non-decorative obligations the plan did not yet carry: a *dosage bound* on the Crick-Mitchison dream-pass already filed as Revision-12 N3 (ENC-FTR-106), and a *content policy* for the consolidation Lambda (ENC-FTR-096). Unlike Revisions 12 and 13, this addendum introduces **no net-new governed records**: every incorporation is an AC enrichment or framing note on an objective that already exists, applied by the coordination supervisor under DD-3 scope separation, not from this document.
+
+Provenance note: the historical anchor is exact. In July 1983, *Nature* volume 304 published Crick & Mitchison's reverse-learning theory of dreaming (pp. 111–114) and Hopfield, Feinstein & Palmer's "'Unlearning' has a stabilizing effect in collective memories" (pp. 158–159) as cross-citing companion papers — the literal seed of the dream-pass Revision 12 already adopted from the Hopfield lineage (DOC-D3EA86857600). DOC-7D8C252B4C57 is the dream-side reading of that same lineage and is now edge-linked to the Blueprint, to DOC-D3EA86857600, and to the two synthesis documents that already absorbed it (DOC-E2379D980FA2 §Part III/§4.1/§Part V; DOC-73FF5950DA61 §6.3/§11.2).
+
+### Incorporation 1 — The dream-pass is a *bounded regularizer*; bound its dosage and measure retention, not only suppression (sharpens Revision-12 Incorporation 5 / ENC-FTR-106)
+
+Revision 12 adopted the Crick-Mitchison anti-Hebbian "dream-pass" (N3 / ENC-FTR-106) as a basin-equalizing garbage collector for over-stable and spurious attractors, gated behind the io-approval invariant. DOC-7D8C252B4C57 supplies the discipline that pass was missing. Agliari, Alemanno, Aquaro & Fachechi (*Neural Networks* 177:106389, 2024; arXiv:2308.01421) prove that the number of unlearning iterations is a *regularization hyperparameter* — formally tying "dreaming" to overfitting control. The consequence is concrete and asymmetric: too much unlearning erodes genuine memories (under-fitting — graduated Lessons stop retrieving), too little leaves spurious basins intact (over-fitting — hallucination attractors persist). A dream-pass is therefore never an open-ended prune; it is a dosed regularizer whose dose must be bounded and whose effect must be measured on *both* sides of the trade. Obligation (AC enrichment on ENC-FTR-106, no net-new record): (a) the unlearning iteration count is parameterized as an explicit regularization hyperparameter with a bounded upper limit, not an open-ended sweep; (b) every pass measures both spurious-attractor suppression (the existing intent) *and* graduated-Lesson retention, with a hard halt-and-reduce threshold — if a pass measurably degrades retrieval of io-approved (graduated) Lessons at any dosage, it halts and reduces iterations rather than proceeding. The io-approval gate is the outer control loop on this dosage decision (Incorporation 3). Edge: DOC-7D8C252B4C57 stamped on ENC-FTR-106 alongside the existing DOC-D3EA86857600 and Blueprint edges.
+
+### Incorporation 2 — Consolidation distills gist, not episodes; decouple candidates from the source episode and prioritize friction (sharpens §VIII "Memory consolidation is an explicit process" / ENC-FTR-096)
+
+The empirically strongest bridge in DOC-7D8C252B4C57 is the Stickgold et al. (*Science* 290:350–353, 2000) Tetris finding and its Alpine Racer II companion: the sleeping brain replays the abstracted *gist* — falling blocks, skiing motion — while discarding the episodic surround (the room, the chair, the keyboard), and does so even in amnesic patients with bilateral medial-temporal-lobe damage who cannot recall having performed the task. The amnesic dissociation is the key result: abstraction proceeds even without an intact episodic record. This is the warrant for two sharpenings of the consolidation Lambda (ENC-FTR-096), which today extracts recurring patterns but does not constrain their *form* or *source-coupling*. Obligation (AC enrichment on ENC-FTR-096, no net-new record): (a) Lesson candidates are framed as *abstracted, transferable gist* — the pattern, not a transcript fragment of any single Handoff — and explicitly designed to survive pruning of the source episode (the amnesic license: aggressive raw-episode forgetting paired with durable abstracted retention is the heart of the 𝔈/𝔇 ontology, not a compromise); (b) candidate extraction is prioritized from high-friction, high-self-correction waves — the "need-to-learn" replay trigger, since the Tetris brain reviewed most what it had least mastered, and the platform already studies agentic self-correction cycles. Edge: DOC-7D8C252B4C57 stamped on ENC-FTR-096 alongside the existing Blueprint and DOC-D3EA86857600 references.
+
+### Incorporation 3 — Activation-synthesis names exactly why the io-approval gate is load-bearing, not removable (sharpens §VIII and the io-approval invariant)
+
+Hobson and McCarley's activation-synthesis hypothesis (1977) — the forebrain synthesizing coherent narrative from essentially random brainstem activation — is, read as engineering, a precise description of confabulation: a synthesis stage that imposes coherence on noise whether or not the underlying signal is real. This is the §VIII / Revision-12 spurious-attractor risk stated at the cognitive level, and it supplies the principled, non-negotiable justification for the io-approval gate on both ENC-FTR-096 (consolidation) and ENC-FTR-106 (dream-pass). The gate is not optimization debt to be engineered away by a future efficiency pass: any synthesizer manufactures coherence, so the synthesis step (Lesson drafting, candidate proposal, basin dampening) must never self-validate. Obligation (framing note, no scope change): the io-approval invariant on ENC-FTR-096 and ENC-FTR-106 carries the activation-synthesis rationale explicitly, so the gate's necessity is recorded on the records themselves and survives future refactor pressure. This is the deliberate disanalogy with biology — biological consolidation is autonomous and ungated; Enceladus inserts the human gate precisely because the dream machinery reliably fabricates coherence.
+
+### Incorporation 4 — Selective replay (~10–30%) is the biological license for the budget hierarchy's aggressive selectivity (sharpens §VIII 𝔈/𝔇 and Revision-12 Incorporation 2)
+
+Hippocampal replay (Wilson & McNaughton, *Science* 265:676–679, 1994) is selective: across methods, only ~10–30% of sharp-wave ripples carry significant memory reactivation. The brain does not replay everything; it replays a salience-weighted minority, and consolidation works *because* of that selectivity. This is the natural-system sanity check on the F11 budget hierarchy: a session-scale 𝔈 that materializes well under 1% of 𝔇 (B_session = 40.2 MB, k*_session = 1.005 × 10⁴ against a 2 × 10⁸-node corpus, 99% intent coverage) is operating in the same selective regime as a biological memory system — not a compute-forced compromise. Obligation (framing note on the BHC / ENC-FTR-083 and §VIII 𝔈/𝔇, no scope change): the percolation-monitored hot-tier sizing is read as biologically licensed selective transport; the empirical replay fraction is the cross-check that the session-budget targets are reasonable, reinforcing Revision-12 Incorporation 2's alpha-load framing from the replay side.
+
+### Incorporation 5 — Offline rehearsal ↔ dry-runs and simulation batches (framing only; the most contested strand)
+
+Revonsuo's Threat- and Social-Simulation theories frame dreaming as offline rehearsal of waking challenges in a consequence-free arena — the analog of Enceladus's dispatch dry-runs (`dispatch_plan.dry_run`, governed `execute` with `dry_run=true`) and simulation batches. The mapping is heuristic and the science is the most contested of the five strands (Domhoff and others deny any adaptive function), so this is framing only, with no net-new scope: the platform already treats its simulations as engineering validation with quantitative outcomes (collapse / convergence / win-rate) rather than assuming offline rehearsal confers benefit, which is exactly the discipline the contested status demands. No objective changes; recorded here so the analogy is governed rather than informal.
+
+### Caveat banner (applies to all five)
+
+Standing varies sharply across the five strands, and the addendum imports only what the evidence supports. Hippocampal replay and systems consolidation (Incorporation 4) are well-established and mechanistic. Activation-synthesis (Incorporation 3) is substantially revised but not refuted, and is used only to name a failure mode. Consolidation-views of dreaming (Incorporation 2) are supported but largely correlational — the gist-abstraction *finding* is robust and replicated, while the claim that the dream itself does the consolidating remains open; the design borrows the content policy, not the causal claim. Crick-Mitchison reverse learning (Incorporation 1) is marginalized as dream neuroscience even as it is vindicated as computational mathematics — the Agliari-2024 regularization result is the rigorous part, and it is the only part the dosage bound depends on. The simulation theories (Incorporation 5) are the most contested and are imported as framing only. The two load-bearing additions — the dosage bound on the dream-pass and the gist/episode-decoupled content policy on consolidation — both sit behind the io-approval gate, so even where the science is provisional the human control loop absorbs the risk. The platform adopts the mechanisms and the measurements; it does not adopt strong biological claims unverified.
+
+### Dissemination map (objective-level)
+
+Absorbed by existing planned objectives (AC enrichment / framing note, applied by the coordination supervisor — not from this architect session): ENC-FTR-106 (bounded-regularizer dosage AC + dual-measurement spurious-suppression-and-Lesson-retention AC with halt-and-reduce threshold + Crick-Mitchison↔Hopfield 1983 lineage provenance + DOC-7D8C252B4C57 edge, Incorporation 1); ENC-FTR-096 (gist-abstraction-and-episode-decoupling AC + high-friction/self-correction prioritization AC + activation-synthesis gate-rationale framing on the io-approval invariant + DOC-7D8C252B4C57 edge, Incorporations 2/3); ENC-FTR-083 (selective-replay budget-selectivity framing note, Incorporation 4); ENC-PLN-006 (intent enrichment: dream-science design lens added as the natural-system research substrate for the consolidation/dream-pass cluster, with DOC-7D8C252B4C57 as a related edge, Incorporations 1–3).
+
+Net-new governed records to file: **none.** DOC-7D8C252B4C57 sharpens objectives that already exist (the dream-pass N3 / ENC-FTR-106 from Revision 12, and the consolidation Lambda ENC-FTR-096); it adds discipline and content policy, not a new mechanism. This is the deliberate, juice-positive read: the strongest contribution of the dream-science lens is to *bound* and *constrain* work already planned, which lowers risk rather than adding surface area. The simulation-as-rehearsal analogy (Incorporation 5) is framing only and files no record.
+
+Source: DOC-7D8C252B4C57 (*Dream Science as a Design Lens for Enceladus v4*), grounding Crick & Mitchison 1983 / Hopfield-Feinstein-Palmer 1983 (*Nature* 304) / Agliari et al. 2024 (*Neural Networks* 177:106389) / Stickgold et al. 2000 (*Science* 290) / Wilson & McNaughton 1994 (*Science* 265). Incorporated 2026-06-23 by the architect; tracker and ENC-PLN-006 dissemination routed to the coordination supervisor under DD-3 scope separation. The two synthesis documents (DOC-E2379D980FA2, DOC-73FF5950DA61) had already absorbed this lens in their 2026-06-23 refactors; this addendum closes the remaining gap by carrying it into the operational Blueprint.
+
+
+
+## DEPLOY TARGET INVARIANT — v4 Work is Gamma-Only (established 2026-06-23)
+
+**Invariant:** All implementation work under ENC-PLN-006 deploys exclusively to the gamma environment. The v3-prod environment is frozen for the duration of this plan.
+
+**Operative contract (as of 2026-06-23):**
+
+- `v4/main` is the sole active development branch for all PLN-006 work.
+- Every push to `v4/main` triggers the v4-gamma deploy via `_deploy.yml`. This is the intended and only authorized deploy target for in-flight v4 work.
+- `promote-gamma-to-prod-request.yml` fires on gamma success but the resulting v3-prod deploy request will NOT be approved by io until ENC-PLN-006 reaches full E2E validation on gamma. Agents must not assume, request, or anticipate prod promotion.
+- `sync-main-to-v4main.yml` is DISABLED (ENC-TSK-H63). v3 main changes do not flow into v4/main. Any agent that re-enables this workflow or attempts to merge main into v4/main is in violation of this invariant and must halt and surface to io.
+- Direct CLI CloudFormation deploys to the prod stack are prohibited per DOC-733D76F4849B and the LSN-039 pre-probe rule.
+
+**For dispatched agents:** When your task touches Lambda code, infrastructure, or any deployable artifact, your deploy target is gamma. Use the canonical gamma deploy scripts per DOC-733D76F4849B. Do not touch the prod stack. If your checkout transition produces a deploy artifact that targets v3-prod, STOP and surface to the coordination lead before proceeding.
+
+**Cutover trigger:** io will explicitly approve a v3-prod promote request when PLN-006 gamma validation is complete. That approval is the only valid prod promotion signal. No agent session initiates or requests prod promotion.
+
+
+
+### main → v4/main auto-sync DISABLED (ENC-TSK-H63 — 2026-06-23)
+
+`sync-main-to-v4main.yml` — which fast-forwarded / `-s ours`-absorbed every `main`
+push into `v4/main` during pre-fork mirroring — is **disabled for the duration of
+ENC-PLN-006** via a job-level `if: ${{ false }}` guard (PR #536, merge commit
+`b576ac2`, merged 2026-06-23T16:15:13Z).
+
+- **Why:** `v4/main` has diverged ahead of `main`; continued auto-sync is a collision
+  risk (`-s ours` clobber of v4/main's tree, or fail-loud on every main push).
+- **Still active:** `promote-gamma-to-prod-request.yml` — the v3-prod Environment
+  approval gate remains the cutover toggle (ENC-TSK-G71).
+- **Re-enable rule:** do **not** remove the `if: ${{ false }}` guard without io
+  approval; re-enable only at the v4 → main cutover.
+- **Verified:** the disable-merge push to `main` ran the sync job **skipped** (run
+  28039982782); the gamma→promote chain stayed green on v4/main pushes
+  (28010334072 → 28010513422).
+
+
+
+## Revision 16 Addendum (2026-06-23): Universal Arc-Walker (ENC-FTR-111) — Mechanical-Gate Forward Automation in the Lifecycle Service
+
+This addendum aligns the Blueprint with the Universal Arc-Walker feature (ENC-FTR-111, design DOC-078C57FC1BE6), materialized as an ENC-PLN-006 objective and a seven-task tree (ENC-TSK-H82 through ENC-TSK-H88) per DOC-607DF1D4B595. It is an additive alignment — no §III/§VII/§VIII text is rewritten — recording how the new feature is reflected in three existing sections:
+
+- **§III Service Boundary Decomposition (Lifecycle Service).** The Lifecycle Service additionally hosts the Universal Arc-Walker (ENC-FTR-111, DOC-078C57FC1BE6): a forward-derivation capability over the same transition_type_matrix that auto-advances records across mechanical gates while the attestation floor keeps attestation and io-gated transitions structurally unreachable by automation.
+- **§VII Migration Roadmap (Phase 2 work).** Arc-walker (ENC-FTR-111) is a follow-on to the Lifecycle Service extraction (ENC-TSK-H46), sequenced after it reaches deploy-success; Phase 1 ships the opt-out latch and the inline mechanical walk.
+- **§VIII Architectural Philosophy (Decompose along trust boundaries).** Lifecycle correctness includes safe forward automation: the arc-walker automates mechanical progression and treats every attestation and io-gated transition as non-walkable by type, making the io-approval invariant structural rather than procedural.
+
+This addendum introduces no net-new governed records of its own; the feature and its seven tasks are governed under ENC-FTR-111 / ENC-PLN-006. Gate eligibility in the walker is decided by an explicit per-cell gate_class (mechanical / external-fact / attestation), not by evidence-field emptiness.
+
+
+
+
+## Revision 17 Addendum (2026-06-28): Production-Cutover Readiness + RISK-001–011 Confirmation (ENC-TSK-B69)
+
+Filed by the ENC-TSK-B69 dispatched governed gamma session (governance_hash 584baae9…). This addendum records the **production architecture state as of 2026-06-28** for the ENC-PLN-006 “Production Cutover + Showcase Live” objective and formally confirms each Risk Registry entry (§VI) as mitigated or accepted-residual. It is additive — no §I–§VIII text is rewritten.
+
+### Current production architecture state (honest snapshot)
+
+The production cutover named by ENC-TSK-B69 has **not** occurred and is **not** an agent-actionable step. The governed truth:
+
+- **v3 (ENC-GEN-001) is the live production baseline and is frozen** for the duration of ENC-PLN-006 (DEPLOY TARGET INVARIANT, 2026-06-23). No v3 Lambda stack is decommissioned; the decommission criterion cannot be satisfied while v3 is the serving generation.
+- **v4 (ENC-GEN-002) runs on the durable gamma stack** — its own control, data, and graph planes. Per the io durability decision (DOC-A07B553431FD, reconciled via ENC-TSK-H59), gamma is a permanent pre-production environment and is **not** torn down at cutover; the gamma-teardown criterion is formally retired (already evidence-accepted on B69).
+- **The cutover is a single io-approved promotion gate** (`promote-gamma-to-prod-request.yml`, ENC-TSK-G71). No agent session initiates, requests, or derives prod promotion. `sync-main-to-v4main.yml` remains disabled (ENC-TSK-H63).
+- **ENC-PLN-006 is at ~19% objective closure** (7/36 closed; Phase 2–5 gates ENC-TSK-B63/B64/B65/B66 and the cockpit/HCE objectives still open). Production-cutover readiness is therefore **partial**: Phase 0/1 and the Gamma-Operational gate (ENC-TSK-B60) are closed; the remaining phase gates must pass gamma validation before io’s promotion gate is reached.
+
+Net assessment: **B69 is a capstone objective correctly blocked on the rest of PLN-006 plus an io decision.** Its documentation/knowledge artifacts (showcase v4 narrative, this architecture-state confirmation, the risk confirmation below, and ≥5 captured lessons) are deliverable now; the infrastructure cutover and v3 decommission are not and must not be asserted complete.
+
+### RISK-001 – RISK-011 confirmation (§VI Risk Registry)
+
+- **RISK-001 Auth Complexity Cascade (P0) — MITIGATED.** Auth bifurcation shipped (API-key for agents, Cognito OAuth for interactive); `connection_health.auth_config` reports all five internal API-key paths configured; ENC-LSN-011 / ENC-LSN-007 institutionalized. Residual: monitored, not eliminated.
+- **RISK-002 Coordination Dispatch Data Integrity (P1) — MITIGATED.** Hard gate ENC-ISS-128 is **closed** by ENC-TSK-B71 (PR #220).
+- **RISK-003 Graph as Memory — SPOF (P1) — MITIGATED (residual accepted).** Daily Neo4j→S3 backup (ENC-TSK-B85); DynamoDB authoritative rebuild source; hybrid retrieval degrades gracefully. Graph-signal latency tracked separately (ENC-ISS-271 / ENC-FTR-101, G98 deadline). Residual: AuraDB Free has no SLA — accepted with rebuild path.
+- **RISK-004 Phase Dependency Ordering (P2) — MITIGATED.** Phase gates carry explicit entry/exit health gates and 48–72h stabilization windows (§VII).
+- **RISK-005 Context-Node / Lesson Flag Graduation (P2) — MITIGATED (in progress).** Scoped as Phase 4 / AppConfig work (ENC-FTR-103); flags resolve via the AppConfig platform. Residual until Phase 4 closes.
+- **RISK-006 Agent Escalation Gap (P2) — MITIGATED.** ENC-ISS-142 is **closed** (ENC-TSK-H48–H53; escalation-trail convention DOC-CA807143B16A).
+- **RISK-007 Orphan Task / Lineage Debt (P2) — ACCEPTED RESIDUAL (managed).** Pre-flight sweep done; lineage enforced via plan objectives_set + PLAN_CONTAINS projection; ongoing hygiene via drift audits.
+- **RISK-008 Multi-Provider Framework Neutrality (P2) — MITIGATED.** Provider-adapter surface + server-minted agent/session identity (ENC-FTR-117 / ENC-TSK-I38).
+- **RISK-009 Regulatory Compliance Trajectory (P3) — ACCEPTED RESIDUAL.** EU AI Act self-assessment remains Phase 5 (ENC-TSK-B66); governance substrate already aligns architecturally.
+- **RISK-010 Extended Migration Window Communication (P3) — ACCEPTED RESIDUAL.** The durable-gamma posture removes the big-bang cutover-window framing: v4 matures continuously on gamma and promotion is a single gated switch. Accepted as residual; impact-matrix practice retained.
+- **RISK-011 Component Hallucination Before H-SCHEMA (P1) — MITIGATED.** Five-surface required_transition_type enforcement (ENC-TSK-F50 / ENC-ISS-270) + OGTM gate (ENC-FTR-066) make hallucinated component addresses server-rejectable.
+
+**Conclusion:** RISK-001–011 are each mitigated or accepted-residual. No open risk blocks the gamma-validation track; the only remaining cutover dependency is completion of the PLN-006 phase gates plus io’s explicit promotion approval.
+
+*Filed 2026-06-28 by the ENC-TSK-B69 governed gamma session. governance_hash 584baae9044510d86bbd331d844529d357b7aacff5c5c127c696f8cf94dde0f1. This addendum asserts no completed production cutover; the v3 decommission and the live showcase publish (JWO-TSK-023) remain io-gated.*
+
+
+## Revision 18 Addendum (2026-07-02): v3 Feature Carryover Ledger + Unplanned Feature Absorption (Ground-Truth Sweep)
+
+Filed by an io-directed webui-alpha governed session against live tracker state (governance_hash 7c4e44e8…). Two purposes: (a) record every feature shipped and live in v3 that persists into v4 — the carryover inventory the greenfield rebuild absorbs; (b) formally absorb into blueprint scope the five unplanned features that landed mid-migration. Additive — no §I–§VIII text is rewritten. Per-feature gamma E2E parity is asserted only where validated; the J79 gamma sweep (DOC-45D8B5FB6FD6: 14/17 backend actions PASS, PWA smoke PASS) plus the B59 absorption objective are the parity evidence surfaces, and ENC-TSK-K11 tracks the three failing actions.
+
+### Unplanned feature absorption (mid-migration drop-ins)
+
+Five features entered scope after Revision 17 without prior blueprint provenance. They are now first-class v4 scope:
+
+```yaml
+unplanned_absorbed:
+  - id: ENC-FTR-117
+    title: Agent ID v3 — governed session and agent-type identity
+    status: production
+    blueprint_effect: strengthens RISK-008 mitigation; SCI precondition
+  - id: ENC-FTR-118
+    title: Autonomous Dispatch Engine (ADE)
+    status: completed
+    blueprint_effect: changes PLN-006 execution model — catalog-driven autonomous dispatch (DOC-841F5D649EEF) replaces manual wave dispatch
+  - id: ENC-FTR-119
+    title: Session-stall watchdog + enceladus-support satellite repo
+    status: planned (J48 -> J49 -> J50 chain)
+    blueprint_effect: introduces an isolated helper deploy lane OUTSIDE the v4 service map by design; zero write path to governed surfaces
+  - id: ENC-FTR-121
+    title: Escalations — human-gated mutation override surface
+    status: completed (Ph6 validation ENC-TSK-J73 open)
+    blueprint_effect: productizes the io-approval invariant (§VIII) as a first-class primitive; deploy-arc immutability gate gains an approved override path
+  - id: ENC-FTR-122
+    title: Session Claim ID (SCI) enforcement + retirement lifecycle
+    status: planned
+    blueprint_effect: closes ENC-ISS-441; converts the FTR-117 register->claim handshake from advisory to enforced (403 fail-closed)
+```
+
+Scope posture: FTR-117/118/121 are absorbed as shipped; FTR-119/122 are absorbed as committed near-term scope. None alter the six-phase gate structure (§VII); FTR-122 attaches to Phase 5 hardening, FTR-119 sits outside all phases by isolation design.
+
+### v3-production carryover ledger (35 features)
+
+Every feature below is status=production on the live tracker as of this sweep — the v3 serving surface v4 must reach parity with before io's promotion gate. Gamma parity notation: `validated` (explicit gamma evidence exists), `absorbed` (carried by the v4 greenfield rebuild + J79 sweep coverage), `at-risk` (a known gamma defect touches it).
+
+```yaml
+v3_production_carryover:
+  governance_core:
+    - {id: ENC-FTR-011, title: Product ontology governance, gamma: absorbed}
+    - {id: ENC-FTR-012, title: Ontology schema enhancement, gamma: absorbed}
+    - {id: ENC-FTR-022, title: Disciplined deployment lifecycle state governance, gamma: absorbed}
+    - {id: ENC-FTR-026, title: Governance data dictionary (HTTP + DDB), gamma: validated}
+    - {id: ENC-FTR-030, title: Server-authoritative datetime, gamma: absorbed}
+    - {id: ENC-FTR-035, title: Enhanced lifecycle stage gates, gamma: validated}
+    - {id: ENC-FTR-037, title: Abstracted checkout service, gamma: validated}
+    - {id: ENC-FTR-041, title: Structured component registry, gamma: absorbed}
+    - {id: ENC-FTR-043, title: Session lifecycle primer, gamma: absorbed}
+    - {id: ENC-FTR-117, title: Agent ID v3 session identity, gamma: validated}
+  knowledge_primitives:
+    - {id: ENC-FTR-049, title: Typed relationship edge primitive, gamma: absorbed}
+    - {id: ENC-FTR-050, title: Context node primitive, gamma: absorbed}
+    - {id: ENC-FTR-052, title: Lesson primitive + constitutional scoring, gamma: validated}
+    - {id: ENC-FTR-053, title: Cross-project knowledge mining, gamma: absorbed}
+    - {id: ENC-FTR-054, title: Server-side constitutional scoring, gamma: validated}
+    - {id: ENC-FTR-061, title: Handoff primitive, gamma: absorbed}
+    - {id: ENC-FTR-088, title: tracker.graph_laplacian read action, gamma: at-risk}
+    - {id: ENC-FTR-110, title: Dispersion/corroboration RRF weighting, gamma: absorbed}
+  retrieval_and_graph:
+    - {id: ENC-FTR-085, title: Percolation monitor nightly, gamma: validated}
+  mcp_surface:
+    - {id: ENC-FTR-016, title: Desktop MCP session briefing set, gamma: absorbed}
+    - {id: ENC-FTR-033, title: Universal cross-project changelog, gamma: absorbed}
+    - {id: ENC-FTR-044, title: Code-mode MCP four-tool SDK surface, gamma: validated}
+  pwa_v1_surface:
+    - {id: ENC-FTR-002, title: Manual refresh link, gamma: superseded-by-B67}
+    - {id: ENC-FTR-008, title: Rich markdown rendering, gamma: superseded-by-B67}
+    - {id: ENC-FTR-009, title: Parent/child hierarchy + RelatedItems, gamma: superseded-by-B67}
+    - {id: ENC-FTR-010, title: Project reference route, gamma: superseded-by-B67}
+    - {id: ENC-FTR-017, title: UI 1.0 philosophy launch schema, gamma: superseded-by-B67}
+    - {id: ENC-FTR-036, title: Dynamic project card status/ordering, gamma: superseded-by-B67}
+    - {id: ENC-FTR-038, title: Copy button for IDs/code, gamma: superseded-by-B67}
+    - {id: ENC-FTR-039, title: Dynamic homepage project cards, gamma: superseded-by-B67}
+    - {id: ENC-FTR-051, title: On-demand markdown download, gamma: superseded-by-B67}
+    - {id: ENC-FTR-073, title: Detail page direct API fallback, gamma: superseded-by-B67}
+  devops_and_ops:
+    - {id: ENC-FTR-029, title: EC2 Codex session archive to S3, gamma: absorbed}
+    - {id: ENC-FTR-040, title: Plan-mode auto documentation, gamma: absorbed}
+    - {id: ENC-FTR-102, title: Env-parity gate for CFN compute deploys, gamma: validated}
+```
+
+The pwa_v1_surface cohort persists in v3-prod until cutover but is NOT ported file-for-file: ENC-TSK-B67 (PWA 2.0 Governance Cockpit, 24 ACs, spec DOC-E470AC8CE9A8) is the successor surface and must re-deliver each capability natively (its AC-20/21/22 already bind the ISS-121/137/138/139 re-deliveries). ENC-FTR-088 is at-risk pending ENC-TSK-K11 (embeddings/sheaf handler fix, ISS-474 adjacency).
+
+### Completed-cohort features (21) — absorption note
+
+Features at status=completed (post-v3-freeze era, gamma-first under DOC-499FA089EC30) are v4-native scope, not v3 carryover; the tracker is their authoritative registry. Notables wired into blueprint sections: ENC-FTR-099 (token economics, §IV heavier), ENC-FTR-101 (pre-materialized projection, Rev 11/14 — superseded operationally by the ISS-465 GDS cost-kill invariant), ENC-FTR-097 (manifest primitive), ENC-FTR-118/120/121 (above).
+
+*Filed 2026-07-02 by an io-directed governed webui-alpha session. governance_hash 7c4e44e81e181d62edb5297d46707bd2390da99ee8584142fa40b5595d1ce241. Ledger derives from live tracker.list/tracker.get reads this session; no feature status asserted beyond tracker ground truth.*
+
+
+
+## Search Stack (Multi-Project Cockpit) — Summary + Reference
+
+**Full design: DOC-77D6C714867E** (Search + Sync Middleware — Multi-Project Cockpit Architecture). Added here as a §VII/PWA-adjacent capability summary; PLN-006 Phase-7 objective ENC-TSK-B67.
+
+Enceladus v4 is THE multi-project governance cockpit: every record in ANY project must be retrievable AND visible in the PWA in <500ms p95 with best-in-class search. The stack is a hybrid over an adaptive tiered client cache + a server-authoritative corpus:
+
+- **Semantic / vector tier (LIVE on gamma):** `graph_query_api` `GET /api/v1/tracker/graphsearch` — Titan Text V2 256-dim HNSW + PageRank + keyword, fused by RRF (k=60); fed by `graph_sync` (DDB Streams → EventBridge Pipe → SQS FIFO → Neo4j AuraDB).
+- **Keyword / facet tail tier (LOCKED — self-hosted OpenSearch, io 2026-07-05):** a single **`t4g.small` graviton** OpenSearch node (Apache-2.0 fork of Elasticsearch), **~$8–13/mo** (0-replica, single-AZ, public-subnet + locked SG, **no NAT**, **not** OpenSearch Serverless). Fed **additively** by a new indexer consumer on the SAME `graph_sync` CDC spine — no rebuild. `graph_query_api`'s keyword arm swaps to OpenSearch (fuzzy/typo, BM25 relevance, faceted counts, autocomplete) with a Neo4j full-text circuit-breaker fallback; the client still calls the single `/graphsearch` endpoint. Rejected alternative: DynamoDB prefix GSI (instant but prefix-only — no fuzzy/relevance/facets). Full analysis + cost floor: **DOC-77D6C714867E §14**.
+- **Client tier:** device-budgeted Tier-1 minimal index (instant local autosuggest/filter/sort), Tier-2 LRU bodies, incremental `version_seq` delta — never a full-corpus refetch.
+
+**Features:** ENC-FTR-127 (Search 2.0) + ENC-FTR-128 (PWA 2.0 UX). **Presentation invariant:** every visual surface binds one `design-system-2` (Cloudscape) component; invent nothing. **Decomposition:** ENC-TSK-L17–L46 under ENC-TSK-B67, catalogued in DOC-841F5D649EEF; the OpenSearch stack = ENC-TSK-L28 (umbrella) → L39–L46.

--- a/docs/cutover-context/catalog-DOC-841F5D649EEF.md
+++ b/docs/cutover-context/catalog-DOC-841F5D649EEF.md
@@ -1,0 +1,111 @@
+
+# DOC-841F5D649EEF — PLN-006 + PLN-078 Coding-Task Catalog (ADE dispatch source of truth)
+
+**Project**: enceladus
+**Related**: ENC-PLN-006, ENC-PLN-078, ENC-PLN-080, ENC-TSK-B63, ENC-TSK-B64, ENC-TSK-B67, ENC-TSK-B69, ENC-TSK-M98, ENC-TSK-M99, ENC-TSK-N01, ENC-TSK-N02, ENC-TSK-N48, ENC-TSK-N63, ENC-TSK-N64, ENC-TSK-N65, ENC-TSK-N66, ENC-TSK-O03, ENC-TSK-O04, ENC-ISS-538, ENC-ISS-543, ENC-ISS-556, ENC-ISS-558, ENC-ISS-559, ENC-ISS-563, ENC-ISS-566, ENC-ISS-603, ENC-ISS-604, ENC-ISS-622, ENC-ISS-623, ENC-ISS-624, ENC-ISS-625, DOC-B716E8FB10B6, DOC-499FA089EC30, DOC-6EFD5DB32CD8, DOC-10A820AC32F2, DOC-0D7E2A94F67C
+
+**Created**: 2026-06-28
+**Author**: coord-lead
+**Updated**: 2026-08-21 (v137 by claude.ai webui session, io-directed CUTOVER-DAY refresh. v136 was 2026-07-13 — this version reconciles 5+ weeks of drift against live tracker.get / deploy.history reads taken 2026-08-21T18:05Z, governance_hash e04f7eda. io decision of record — B69 CUTOVER EXECUTES TODAY; minor bugs post-cutover flow gamma-first UAT per regular deploy path; DOC-499FA089EC30 suspends at cutover.)
+
+## 🚨 READ THIS FIRST — CUTOVER DAY 2026-08-21
+
+io has committed to executing the ENC-TSK-B69 production cutover today. This catalog version is the reconciled pre-cutover ground truth. Every status below was verified live via tracker.get on 2026-08-21 unless marked UNVERIFIED. Per standing rule, re-verify at dispatch regardless.
+
+```yaml
+cutover_gate_path:
+  ENC-TSK-B63: "CLOSED 7/7 (2026-07-12, io)"
+  ENC-TSK-B64: "CLOSED (Phase 3 MCP modularized + streaming + auth bifurcated)"
+  ENC-TSK-B67: "in-progress 23/24 — AC-8 promote-coupled to B69 by design; stamps POST-cutover via re-probe"
+  ENC-TSK-B69: "open 1/7 stamped (gamma-teardown AC formally retired/superseded — gamma is DURABLE staging, survives cutover)"
+b69_open_acs:
+  - showcase jreese.net update (JWO-TSK-023)
+  - backend v4 cutover all-traffic
+  - v3 Lambda stack decommission
+  - 5 lessons w/ evidence chains
+  - DOC-6EFD5DB32CD8 final-state update
+  - RISK-001..010 mitigated-or-accepted rulings
+```
+
+## 🔴 CUTOVER BLOCKER BOARD (verified 2026-08-21)
+
+```yaml
+P0_hard_gates:
+  ENC-ISS-538:
+    status: OPEN
+    gates: B69 DIRECTLY
+    state: "Audit complete (44 colliding + 10 gamma-only IDs). M98 mirror tool CLOSED and merged (PR #1012, main c99b45ef). N01 first supervised mirror run 0/4 — NEVER EXECUTED. Requires io one-time setup: required_reviewers on gamma-mirror GitHub Environment, then dry-run manifest review, then execute."
+    cutover_note: "Promote-corrupting if gamma tracker data merges into canonical. Resolve BEFORE any promote step that touches tracker data; if cutover routes traffic only (no data merge), io must rule explicitly that 538 is promote-orthogonal and re-scope its gate."
+  ENC-ISS-559:
+    status: OPEN
+    category: security
+    state: "cognito_session ignores include_tokens:false — leaks live ID token + 30-day refresh token in cookie arrays. Exposed terminal-agent session needs rotation (DOC-3DEFB053DD7D). Related task ENC-TSK-N58 status unverified."
+    cutover_note: "Prod cutover raises blast radius of any leaked prod session token. Fix-or-rotate before cutover completion."
+P1_lane_blockers:
+  ENC-ISS-624:
+    status: OPEN
+    state: "pre-deploy-health-gate check 5 RED on main. CORRECTED HYPOTHESIS ON RECORD: this is a TRUE positive — enceladus-checkout-service-auto-gamma alone sits on enceladus-shared:11 while all 45 other gamma + 71 prod functions sit on canonical :10. Fix: reconcile that one function to :10, OR retire it (the -auto- segment suggests an experimental artifact), OR raise canonical and roll all consumers."
+    cutover_note: "HARD STOP for every Channel A (CFN) prod deploy per DOC-B716E8FB10B6. The cutover cannot use the CFN lane while this stands. Fix first — it is a one-function reconcile."
+  ENC-ISS-566:
+    status: OPEN (untouched since 2026-07-13)
+    state: "embedding_refresh crash-loops at import (No module named 'embedding'). Blocks N48 close. AC-2 requires establishing whether the tenant EVER ran cleanly on gamma before attributing to the 07-13 deploys."
+    arm_wheel_class: true
+  ENC-ISS-558:
+    status: OPEN
+    state: "MCP tracker.list total computed over one capped page (~8x undercount) + separately-observed 50-row silent window with false partial:false. Do NOT cite tracker.list totals. Primary task ENC-TSK-N62 unverified."
+  ENC-ISS-563: {status: OPEN, state: "FTR-096 consolidation 24h lookback still producing structural zero — N63 window widening NOT yet landed"}
+  ENC-ISS-603: {status: OPEN, state: "commit validation doubles owner prefix for enceladus repo — verify impact on cutover-day PR flow before dispatching code tasks"}
+  ENC-ISS-604: {status: OPEN, state: "intelligence-project corpus governance exists only on frozen main, not v4/main — cutover survival risk for INT lane"}
+  ENC-ISS-597: {status: OPEN, state: "orphaned checkout wedges records permanently — operational risk during a long multi-session cutover day"}
+P2_watch:
+  ENC-ISS-623: "all seven live enceladus-prod alarms have AlarmActions [] — prod codesize alarm CURRENTLY IN ALARM notifying nobody. Post-cutover prod observability is silent until fixed."
+  ENC-ISS-625: "devops-github-integration has zero layers + no in-repo CFN resource — cannot import enceladus_shared; O07 AC-1 deliberately unstamped on it."
+  ENC-ISS-556: "gamma compute-stack deploy jobs exit 1 on N49 post-apply S3-lifecycle step (UNVERIFIED today — recent gamma deploys 0.0.133–137 recorded success, may be resolved or routed around)."
+```
+
+## 📦 POST-v136 ACTIVITY RECONCILED (deploy.history 2026-08-21)
+
+```yaml
+deploys_since_catalog_v136:
+  0.0.130: "2026-07-13 — ISS-557 fix (sense.py cursor-exhausting count). ISS-557 CLOSED."
+  0.0.131_132: "2026-07-13/14 — PRs #1047/#1049/#1051 gamma"
+  0.0.133_134: "2026-08-01 — PRs #1060/#1061 gamma"
+  0.0.135: "2026-08-05 — PR #1068 gamma"
+  0.0.136: "2026-08-14 — ENC-TSK-N91/ENC-ISS-614 tracker.create unified relation intake — deployed to v3-PROD (io-gated, merge 8533d968, PR #1090)"
+  0.0.137: "2026-08-17 — PR #1095 gamma (PLN-080 O07 shared github_app_auth)"
+new_plan:
+  ENC-PLN-080: "drafted — ENC-ISS-621 remediation / GitHub-integration hardening (DOC-10A820AC32F2). O05/O06/O08 closed; O07 deploy-success 3/4; O03 merged-main 3/5 STAGED for v3-prod deploy awaiting io (gh workflow run _deploy.yml -f target_environment=v3-prod -f commit_sha=1f8af94...); O04 draft PR #1094 BLOCKED on ISS-624. ENC-ISS-622 put-role-policy form needs product-lead terminal."
+still_open_from_v136_era: [ENC-TSK-N48 (blocked on ISS-566 + primary-artifact S3 read), ENC-TSK-N01, ENC-TSK-N02 (unverified), N63-N66 (N63 evidently not landed per ISS-563)]
+```
+
+## 🎯 CUTOVER-DAY CRITICAL GOALS (io, 2026-08-21)
+
+```yaml
+goal_1_mcp_down_context_contingency:
+  requirement: "agent sessions must acquire context WITHOUT Enceladus MCP while cutover/debug is in flight"
+  mechanism: "pre-cutover CONTEXT FREEZE BUNDLE — export to git (repo docs/cutover-context/) AND io-local: this catalog v137, DOC-6EFD5DB32CD8 (blueprint), DOC-B716E8FB10B6 (prod deploy path), DOC-FFB4C9D87BCC (dispatched-agent prompt), DOC-586FB8D3DF02 (coord-lead prompt), agents.md, governance dictionary snapshot, connection_health snapshot w/ governance_hash"
+  session_protocol_while_down: "terminal agents boot from the file bundle; ALL tracker-state claims marked UNVERIFIED-OFFLINE; NO governed writes attempted; work queue captured as F6 HANDOFF blocks in local .md for post-restore reconciliation; mcp-gamma read-only is the secondary surface ONLY if its plane is not the one being debugged"
+goal_2_arm_wheel_verification:
+  requirement: "graph traversals, tracker read/write, and common dev-task management verified working on arm64/py3.12 before declaring cutover done"
+  known_arm_class_defects: [ENC-ISS-566 (import/packaging crash), ENC-ISS-624 (layer :10 vs :11 drift), ENC-ISS-625 (zero-layer function)]
+  verification_slice: "post-route-flip smoke on prod surface: tracker.get + tracker.create + tracker.set + checkout arc on a throwaway record; tracker.graphsearch neighbors on ENC-PLN-006; documents.get + documents.patch round-trip; graph_sync projection write; native-wheel imports (numpy/scipy class) across all promoted functions — grep ImportModuleError across ALL /aws/lambda/* log groups in the first hour"
+```
+
+## ⚠ HARD RULES (standing, carried from v136)
+
+Graph never status-authoritative (ISS-543 still OPEN). tracker.list never a completeness proof (ISS-558 OPEN — totals lie, 50-row window). Telemetry over inference. Checked-out records reject third-party writes — route through holder or wait. Agent S3 read DENIED on jreese-net (primary-artifact ACs need io-dev-admin or a grant). Issue category enum [bug, debt, performance, risk, security]. document_subtype enum [coe, context-node, doc, handoff, idea, skill, wave]. NO GFM pipe tables (ENC-LSN-026). transition_type sealed at create. documents.patch is full replacement. Premise errors #1–#12 stand; #10 (acceptance-on-deferred-proof) is the cutover-day watch — B69 ACs stamp on LIVE artifacts only.
+
+## 🎯 io QUEUE (cutover day, sequenced)
+
+```yaml
+pre_cutover:
+  1: "ISS-624 fix (reconcile enceladus-checkout-service-auto-gamma to :10 or retire) — unblocks Channel A lane"
+  2: "ISS-538/N01 mirror run OR explicit io ruling that cutover is traffic-route-only and 538 re-scopes post-cutover"
+  3: "ISS-559 fix + terminal-agent token rotation"
+  4: "context freeze bundle exported (goal 1)"
+  5: "O03 v3-prod deploy decision — ship staged 1f8af94 BEFORE cutover or fold into cutover; do not leave straddling"
+cutover: "per DOC-B716E8FB10B6 + DOC-6EFD5DB32CD8 sequencing — route flip, arm-wheel smoke (goal 2), B69 AC evidence capture live"
+post_cutover: "suspend DOC-499FA089EC30; B67 AC-8 re-probe + Bucket-C promote-coupled re-probes; ISS-623 alarm actions; ISS-566/N48; N63-N66; minor bugs via gamma-first UAT flow"
+```
+
+🔒 CREDENTIAL BOUNDARY intact.

--- a/docs/cutover-context/connection-health-snapshot.json
+++ b/docs/cutover-context/connection-health-snapshot.json
@@ -1,0 +1,27 @@
+{
+  "dynamodb": "ok",
+  "s3": "ok",
+  "governance_hash": "e04f7eda77c472a49717d6f0e6107da208712f8d79f296a3c479675fdde85152",
+  "checked_at": "2026-08-21T18:44:10Z",
+  "server_version": "1.0.0",
+  "auth_config": {
+    "common_internal_api_key_configured": true,
+    "coordination_api_internal_api_key_configured": true,
+    "deploy_api_internal_api_key_configured": true,
+    "document_api_internal_api_key_configured": true,
+    "tracker_api_internal_api_key_configured": true
+  },
+  "graph_index": {
+    "status": "healthy",
+    "response_ms": 584,
+    "signals": {
+      "vector": true,
+      "graph": false,
+      "keyword": true
+    },
+    "graph_projection": {
+      "configured": false,
+      "name": null
+    }
+  }
+}

--- a/docs/cutover-context/coord-lead-init-DOC-586FB8D3DF02.md
+++ b/docs/cutover-context/coord-lead-init-DOC-586FB8D3DF02.md
@@ -1,0 +1,213 @@
+# DOC-586FB8D3DF02 Enceladus Coordination Lead Session Prompt — Gamma (v2)
+
+**Project**: enceladus
+**Related**: ENC-TSK-C24, ENC-TSK-C25, ENC-PLN-006, ENC-PLN-012, ENC-FTR-062, ENC-FTR-066, ENC-FTR-117, ENC-TSK-I38, ENC-TSK-I43, DOC-FFB4C9D87BCC, DOC-025595340C63
+**Created**: 2026-04-07
+**Author**: claude-code-opus-2026-04-07 (ENC-TSK-C25 dispatch); ENC-SES-003 agent-identity wiring 2026-06-28
+**Counterpart**: DOC-FFB4C9D87BCC (Dispatched Agent Session Prompt)
+
+---
+
+Set environment variable `PROJECT=enceladus`.
+
+You are an Enceladus governed coordination lead operating in the production v3 code-mode architecture. Your role is to orchestrate, delegate, and synthesize across the Enceladus extended-mind substrate. You do not execute domain tasks. All governed reads and writes route exclusively through Enceladus MCP. Do not use direct AWS APIs, SDK calls, DynamoDB, S3, Lambda invocations, `tracker.py`, `docstore.py`, or any raw-mode bypass path.
+
+---
+
+## Working Model
+
+Enceladus operates under the Extended Mind thesis (Clark & Chalmers, 1998) as a constitutive extension of io's cognitive process. It is not infrastructure agents use — it is the substrate through which intent becomes outcome. Every architectural decision is evaluated against this axiom: does it make the extended cognitive system more intelligent, more reliable, and more capable of translating intent into real-world outcomes? Governance degradation — orphan tasks, stale Lessons, schema drift — is not a data quality problem. It is cognitive impairment of the extended mind.
+
+The coordination lead is the orchestrator of this substrate. The primary work surface is **plan health**: tracking which gates are open vs. closed, which objectives are blocked, which agents are dispatched against which scopes, and which governance artifacts need refresh. The coordination lead reads broadly and writes narrowly — most coordination-lead writes are plan lifecycle operations, dispatch plan generation, and acceptance evidence stamping. The coordination lead does not check out tasks, does not edit code, and does not produce commits.
+
+**First-class governed primitives:**
+
+- **Feature** — Describes what is being built. North star capability record.
+- **Plan** — Governed execution contract. Replaces the legacy `[Plan]` parent-task pattern. Drives agent dispatch through phase-gated objectives.
+- **Task** — Deployable work unit inside a plan. Evidence-gated lifecycle.
+- **Issue** — Discovered defect, risk, or technical debt.
+- **Lesson** — Evidence-backed institutional memory. Constitutionally scored. Append-only.
+- **Document** — Governed artifact with a four-stage maturation lifecycle.
+
+**Document maturity lifecycle (ENC-FTR-065 — GDMP):**
+
+- **`raw`** — Default state on creation. Compliance warnings not yet resolved.
+- **`compliant`** — Metadata and compliance warnings resolved. Standard header block present.
+- **`contextualized`** — Provenance annotations applied. INFORMED_BY graph edges present.
+- **`mature`** — All declared related_items have confirmed graph edges via traversal.
+
+Set `document_maturity_state` on `documents.put`. Advance it via `documents.patch`.
+
+---
+
+## Scope Exclusions (DD-3)
+
+The coordination lead role is bounded by strict prohibitions. These prohibitions are as important as the permissions — they prevent the orchestrator/worker scope bleed that DOC-025595340C63 §2 identifies as the primary source of multi-agent hallucination and task amplification.
+
+The coordination lead session **must not** perform any of the following:
+
+- `checkout.task` — task checkout is the worker's domain. The coordination lead dispatches workers to do this.
+- `checkout.advance` — task lifecycle advancement is the worker's domain.
+- `checkout.append_worklog` — task worklogging is the worker's domain.
+- Direct file editing or any modification of repo content.
+- Worktree creation, switching, or cleanup.
+- Git commands of any kind (commit, push, branch, merge, rebase, status, log).
+- CAI / CCI token management or commit_sha verification.
+- Component registry pre-validation (this is a worker concern at checkout time).
+- Any implementation work, refactor, or bug fix.
+
+If a coordination lead session encounters a request that requires any of the above, the correct response is to generate a dispatch plan that routes the work to the appropriate dispatched-agent provider — not to execute the work itself.
+
+---
+
+## Mandatory Session Init
+
+Execute these steps in strict order before any coordination work begins.
+
+1. **`connection_health()`** — Capture `governance_hash`. Verify services healthy.
+
+2. **Register a session identity (ENC-FTR-117).**
+
+   If a pre-minted `ENC-SES-NNN` was included in the session header, claim it:
+   ```text
+   coordination(action="agent.claim", arguments={session_id: "<ENC-SES-NNN>"})
+   ```
+
+   Otherwise register fresh. Check existing types first:
+   ```text
+   coordination(action="agent.type.list")
+   coordination(action="agent.type.register", arguments={surface: "<surface>", model: "<model>", cost_tier: "standard"})
+   coordination(action="agent.register", arguments={agent_type_id: "<ENC-AGT-NNN>", runtime: "<runtime-descriptor>"})
+   ```
+
+   Store the returned `session_id`. The coordination lead holds an ENC-SES-NNN for traceability and dispatch attribution, even though it does not call `checkout.task`. Never predict an ENC-SES-NNN — the ID Boundary Rule applies.
+
+3. Load governance dictionary, agents.md, active plan objectives, open issues, pending updates, and recent lessons per the Standard Strategic Brief format below.
+
+---
+
+## Tool Surface
+
+Five code-mode tools are available. No raw-mode fallback exists.
+
+1. **`connection_health`** — Platform health check and governance hash capture. Refresh hash before any large write batch.
+2. **`search`** — Compact read-only surface for all discovery and lookup operations. The coordination lead leans heavily on `tracker.list`, `tracker.graphsearch`, `plan.objectives_status`, `tracker.pending_updates`, and `documents.search`.
+3. **`execute`** — Governed write surface. The coordination lead's write surface is intentionally narrow.
+4. **`get_compact_context`** — Bundled context assembly. Prefer this over multi-call context loads.
+5. **`coordination`** — Orchestration, dispatch plan generation, authentication helpers, and agent identity (ENC-FTR-117).
+
+### Primary write surface — plan operations
+
+The coordination lead's primary mutation surface is plan operations via `execute`:
+
+- `plan.create` — create a plan record from a feature or initiative.
+- `plan.checkout` — claim a plan for active orchestration.
+- `plan.advance` — move a plan through `drafted → started → complete | incomplete`.
+- `plan.add_objective` — append a task ID as a new objective.
+- `plan.remove_objective` — remove an objective (blocked if the objective is closed).
+- `plan.reorder_objectives` — permutation only; no additions or deletions.
+- `plan.replace_objectives` — bulk replacement; drafted-status plans only.
+
+Feature acceptance evidence stamping via `tracker.set_acceptance_evidence` is also a coordination-lead operation, used to confirm gate completion based on dispatched-agent worklogs.
+
+### Dispatch plan generation
+
+The coordination lead generates dispatch plans via `coordination(action="dispatch_plan.generate", arguments={...})` and validates them with `coordination(action="dispatch_plan.dry_run", ...)` before commit.
+
+When generating dispatch blocks for new sessions, the coord-lead may pre-mint a session ID and pass it as `ENC-SES-NNN` in the dispatch header. The dispatched agent then calls `coordination(action="agent.claim", arguments={session_id: "<ENC-SES-NNN>"})` at init.
+
+**Routing logic** for the assigned work:
+
+- If `transition_type` is `github_pr_deploy`, `lambda_deploy`, or `web_deploy` and components include source code components → route to **Claude Code Desktop** or **Codex terminal** (the dispatched-agent providers).
+- If `transition_type` is `code_only` and the work requires repo file edits → route to a dispatched-agent provider with a worktree.
+- If `transition_type` is `no_code` and the work is governance file mutation (an `agents.md` or `governance_data_dictionary.json` change carrying a `GOVERNANCE_SYNC_REQUIRED` HANDOFF block) → route to a **product-lead terminal** session under `io-dev-admin` IAM.
+- If `transition_type` is `no_code` and the work is docstore-only artifact production → route to any dispatched-agent provider; no special IAM required.
+
+The coordination lead does not execute the dispatched work. The coordination lead generates the dispatch plan, surfaces it for human approval, and tracks completion via downstream tracker reads.
+
+---
+
+## Governance Authority (§13 Protocol)
+
+The coordination lead is the receiver and verifier of `GOVERNANCE_SYNC_REQUIRED` HANDOFF blocks emitted by dispatched agents. The coordination lead does not execute the S3 archive+put — that is product-lead terminal work — but the coordination lead is responsible for the handshake that gets it dispatched and the acceptance criterion stamped after sync.
+
+**Hash discipline for long sessions:** the coordination lead session is typically multi-hour and spans many writes. Refresh the governance hash via `connection_health()` before every large write batch and whenever significant time has elapsed. Any mutation step that uses a stale hash will be rejected — passing the current hash to every step is the contract.
+
+**HANDOFF block receipt protocol:**
+
+1. A dispatched agent appends a `GOVERNANCE_SYNC_REQUIRED` HANDOFF block to its task worklog and advances the task to `coding-complete`.
+2. The coordination lead reads the worklog, parses the HANDOFF block, and verifies the proposed file content against the change summary.
+3. The coordination lead generates a dispatch plan routing a Codex terminal session under `io-dev-admin` IAM to execute the S3 archive+put against `s3://jreese-net/governance/live/<file_name>`.
+4. After the product-lead terminal confirms the archive+put and the governance hash rotates (verifiable via `connection_health()`), the coordination lead stamps the relevant acceptance criterion on the originating feature or task.
+
+The coordination lead never attempts the S3 write directly — `enceladus-agent-cli` IAM denies it.
+
+**⛔ `governance.update` is NOT available in code-mode agent sessions.** This includes coordination lead sessions. Do not plan around it, attempt it, or include it in any workflow.
+
+---
+
+## Strategic Session Brief Format
+
+The coordination lead briefs the user (3–5 paragraphs) at session start using this canonical structure. This brief replaces the dispatched-agent task-pickup brief.
+
+1. **Plan gate status** — for each active plan (`tracker.list` filtered to `record_type: plan`, `status: started`), summarize via `plan.objectives_status`. Identify which gates are closed, which are open, which are blocked, and which is the next logical gate.
+2. **Open issues by priority** — `tracker.list` filtered to `record_type: issue`, `status: open`. Group by priority. Surface P0/P1 items.
+3. **Carry-forward items** — `tracker.pending_updates` → records with pending PWA update notes that need coordination-lead attention. Also surface any `coding-complete` tasks awaiting HANDOFF receipt or evidence stamping.
+4. **Governance store state** — confirm `governance_hash` is fresh; note `dictionary_version` from `governance.dictionary`; flag any drift between the in-session hash and a fresh `connection_health()` call.
+5. **Recommended next dispatch** — based on plan health, propose the next 1–2 dispatched-agent work units. The user approves before dispatch plan generation.
+
+---
+
+## OGTM Awareness (ENC-FTR-066)
+
+Every new record type, relational field, or edge type introduced to Enceladus must satisfy the Ontological Graph Traversability Mandate before the governing feature may advance past `planned` status.
+
+Compliance requires all four of the following to be in place.
+
+1. A `_reconcile_edges()` handler added to `backend/lambda/graph_sync/lambda_function.py`.
+2. An entry in the `RELATIONSHIP_TYPE_TO_EDGE_LABEL` mapping in graph_sync.
+3. An entry in `graph_query_api _ALLOWED_EDGE_TYPES`.
+4. Live E2E validation via `tracker.graphsearch` confirming the new edge type is traversable end-to-end.
+
+When approving a feature for completion, the coordination lead verifies all four criteria before stamping any acceptance criterion on the governing feature record. The `governance.ogtm` dictionary entity documents the canonical compliance evidence template.
+
+---
+
+## Record-ID Rules
+
+- Base-36 record IDs are canonical with the format `{PREFIX}-{TYPE}-{SEQ}`.
+- Hierarchical child IDs are canonical with the format `{PREFIX}-{TYPE}-{SEQ}-{SUFFIX}`.
+- Parent binding happens at create time, not after the fact.
+- Do not normalize 4-segment IDs back to the legacy flat format.
+- **⛔ ID Boundary Rule (ENC-TSK-B99): Never predict, compute, infer, or scan for the next available record ID before submitting a `tracker.create` call.** Submit only the minimum required attributes. Read the server-assigned `record_id` from the success response. That value is the sole authoritative source of that record's identity. Agents that anticipate IDs introduce brittle sequence dependencies and violate the system's single source of ID truth.
+- **ENC-SES-NNN and ENC-AGT-NNN are server-minted.** The ID Boundary Rule applies to session and agent-type IDs as well as tracker records. Never predict or construct these values; always read them from the `agent.register`, `agent.claim`, or `agent.type.register` response.
+
+This rule binds the coordination lead just as strictly as it binds dispatched agents. Plan creation, document creation, dispatch plan generation — none of these may anticipate IDs.
+
+---
+
+## Efficiency Rules
+
+- Prefer `get_compact_context` over multi-call context assembly.
+- Prefer `reference.search` over loading full architecture documents.
+- Batch writes with `execute` — multiple steps per call reduce round trips significantly.
+- Use `execute(dry_run=true)` to validate complex multi-step workflows before committing any state.
+- **Never call `search(action="code_map.get")`** — this action does not exist in code mode and returns an `unknown_action` error. Use `get_compact_context(mode="topic", query=..., domain=...)` or `get_compact_context(mode="project", project_id=...)` instead.
+- Use `tracker.graphsearch` for relational queries. One to two traversal calls replace 20 to 50 individual tracker calls for typical context loads.
+- Keep the session in code mode. Let governance services enforce lifecycle contracts. Do not attempt to work around gate requirements by using direct write methods.
+
+---
+
+## Counterpart Reference
+
+The dispatched-agent counterpart of this session prompt is **DOC-FFB4C9D87BCC** (Enceladus Governed Session Prompt — Gamma). Dispatched agents fetch that document at session init; the coordination lead fetches this document. The two prompts share the OGTM Awareness, Record-ID Rules, and Efficiency Rules sections verbatim to prevent semantic drift between the two roles.
+
+The minimal boot prompts that bootstrap each role are stored as separate compliance-100 docstore documents and reference these full session prompts in their Step 1 fetch instruction. See the canonical dispatch prompt header pattern document for the bootstrap protocol.
+
+---
+
+## Document Update Log
+
+- **2026-04-07, ENC-TSK-C25 dispatch (claude-code-opus-2026-04-07)** — v1 initial creation at compliance_score 90.
+- **2026-04-07, ENC-TSK-C25 dispatch (claude-code-opus-2026-04-07)** — v2 patch: H1 title prefixed; document_maturity_state: compliant.
+- **2026-06-28, ENC-SES-003 (ENC-TSK-I43)** — v3 agent-identity wiring (ENC-FTR-117 / ENC-TSK-I38): added Mandatory Session Init section (agent.register/claim; ENC-SES-NNN for traceability/dispatch attribution); added agent identity surface to coordination tool description; extended Record-ID Rules with ENC-SES/ENC-AGT coverage; noted coord-lead dispatch block may pre-mint ENC-SES-NNN for dispatched agents via agent.register; updated related_items and keywords.

--- a/docs/cutover-context/deploy-path-DOC-B716E8FB10B6.md
+++ b/docs/cutover-context/deploy-path-DOC-B716E8FB10B6.md
@@ -1,0 +1,194 @@
+# DOC-B716E8FB10B6 v3-Prod Surgical Deploy Brief (io-gated, pre-cutover)
+
+**Project**: enceladus
+**Related**: DOC-499FA089EC30, ENC-PLN-006, ENC-PLN-020, ENC-ISS-455, ENC-TSK-J08, ENC-FTR-120
+**Created**: 2026-07-01
+**Updated**: 2026-07-02 (ENC-TSK-J66 — Channel A rewritten for the ENC-FTR-120 plan/apply environment gates)
+**Author**: io
+
+---
+
+## Purpose
+
+A standing, reusable roadmap for an agent to make ONE small, io-approved, surgical deploy to the frozen v3-prod stack, using only the normal git -> GitHub Actions path (no direct AWS writes). It exists because DOC-499FA089EC30 freezes v3-prod during the ENC-PLN-006 v4 migration, yet io occasionally needs a targeted prod fix before the v4 cutover. This brief is the narrow, per-invocation exception to that freeze.
+
+Read this brief in full before acting on it. It does NOT unfreeze prod, does NOT authorize batch deploys, and does NOT authorize promoting PLN-006 v4 work to prod (the cutover is still io's separate, explicit decision per DOC-499FA089EC30).
+
+## The Consent Protocol (READ FIRST)
+
+io triggers a surgical v3-prod deploy by typing, in substance:
+
+    deploy this task to v3 DOC-B716E8FB10B6
+
+together with the target task id (e.g. ENC-TSK-NNN). **The presence of THIS brief's own document id (DOC-B716E8FB10B6) in that instruction is io's explicit, per-invocation consent** to run the process below for the single named task. The DOC id is the consent token; typing it = "I have read this brief and I authorize this specific v3-prod deploy."
+
+Rules of consent:
+- No DOC id, a different DOC id, or a mistyped id => NO v3 deploy. Do not infer consent. Treat the task as normal frozen/gamma work and ask io to re-issue with the token.
+- Consent is scoped to exactly ONE task per command. It does not carry to other tasks, follow-ups, re-runs, or a second deploy of the same task later.
+- Consent authorizes REACHING the deploy; every prod channel now also has its own reviewer gate (the v3-prod GitHub Environment) which is a SEPARATE, additional io action the agent still cannot self-satisfy.
+- Consent never overrides the Standing Invariants below.
+
+**Consent vs enforcement (ENC-FTR-120).** These are two independent layers and both are required. The DOC-id token is the AUTHORIZATION layer: it tells the agent that io wants this specific deploy attempted at all. The v3-prod GitHub Environment required-reviewer gate is the ENFORCEMENT layer: it structurally pauses every prod-mutating job as a reviewable, rejectable request that only io's approval click can execute. The token cannot bypass the gate, and an accidental gate approval does not substitute for the token. Before FTR-120 the CFN lane had only the token (procedure, not enforcement); that gap — "the merge IS the prod deploy" — is closed.
+
+## Standing Invariants (hold even WITH consent)
+
+- Agent identity is enceladus-agent-cli (read-only AWS). Every prod change goes through git merge -> GitHub Actions. NEVER run aws cloudformation deploy, aws lambda update-*, or aws dynamodb put-item directly. A direct CLI CFN deploy caused the ENC-TSK-1292 Sev1 (DOC-2CACF0D1E7E6).
+- Before ANY prod CFN stack deploy, run tools/pre-deploy-health-gate.sh and require it to pass (ENC-PLN-020). A failing or skipped gate is a hard stop.
+- NEVER a full-environment CFN replace and never let a deploy strip out-of-band env vars / inline policies (the PLN-047 / ENC-LSN-053 Sev1 class). Deploys must be incremental, minimal change-sets. Review the plan job's change-set summary before requesting io's approval.
+- Re-verify the PROD MCP connector before any governed mutation: ToolSearch 045c9b27 and confirm connection_health graph_projection.configured=true (name gds_standing_enceladus). Gamma is test data.
+- Surgical = the smallest diff that accomplishes the task. No opportunistic edits, no drive-by refactors, no unrelated file churn.
+- main and v4/main are independent (sync disabled; DOC-499FA089EC30). Landing on one does not land on the other.
+
+## Step 0 - Interpret and scope
+
+1. Confirm the consent token (this brief's DOC id, DOC-B716E8FB10B6) is present in io's instruction; resolve the target task id.
+2. Load the task; confirm it is real, in a workable state, and prod-appropriate (already validated on gamma where applicable, or inherently low blast radius).
+3. Restate to io in one line what will deploy to v3 and by which channel (Step 1) before merging.
+
+## Step 1 - Classify the change, pick the deploy channel
+
+Decide by which files the task actually modifies:
+
+- Channel A - CFN template (infrastructure/cloudformation/01-data.yaml, 02-compute.yaml, 03-api.yaml, 05-monitoring.yaml, 07-codedeploy.yaml): a push/merge to main fires the matching cloudformation-*-stack-deploy.yml, which since ENC-FTR-120 (ENC-TSK-J62/J63) is split into a PLAN job and an APPLY job. The plan job creates the change-set with `aws cloudformation deploy --no-execute-changeset` (parameter-reuse semantics preserved for the ENC-LSN-053 guards) and writes a resource-level change-set summary to the run's job summary. The apply job runs inside the v3-prod GitHub Environment and PAUSES on its required-reviewer rule — **the merge is no longer the prod deploy; it creates a paused, reviewable, rejectable change-set request, and io's approval click on the Environment is what executes it.** Review the change-set summary before asking io to approve. Run pre-deploy-health-gate first regardless. If the change would ADD or adopt a resource that already exists live out-of-band, change-set creation fails AWS::EarlyValidation::ResourceExistenceCheck in the plan job (no stack wedge — plan is non-mutating); that needs a privileged change-set IMPORT (ENC-ISS-386 / ENC-ISS-394 pattern, via cfn-resource-import.yml whose import job is itself environment-gated) - STOP and hand to io.
+- Channel B - Lambda function code: use the promote path. Land on v4/main, let "Deploy Lambda Artifacts (Gen2)" go green; promote-gamma-to-prod-request.yml then dispatches a v3-prod _deploy.yml request that PAUSES on the v3-prod GitHub Environment required-reviewer rule. io's approval click on that Environment is the second gate and the actual prod Lambda swap. The agent cannot approve. (Equivalent manual form: workflow_dispatch _deploy.yml ref=main target_environment=v3-prod, which also waits for approval.)
+- Channel C - CI tooling / tools/** / .github/workflows/** / 04-github-roles.yaml: no push-deploy fires. Merging to main lands the change; validate by dispatching the relevant workflow (e.g. cfn-drift-audit.yml). An IAM/github-roles change that must alter the live role needs a manual github-roles stack deploy (privileged) - hand to io if so. Note the iam-* patch workflows and ui-backend-deploy.yml are also v3-prod environment-gated (ENC-TSK-J64), and tools/prod_gate_coverage_guard.py (ENC-TSK-J65) fails CI if any new workflow ships an ungated prod lane.
+
+If a task spans channels, treat each file group by its channel and sequence the riskiest (A) last, after the health gate.
+
+## Step 2 - Execute (github_pr_deploy lifecycle)
+
+1. Mint an agent session (agent.type.register -> agent.register => ENC-SES-NNN) and checkout.task the target (set components first).
+2. Create a worktree from origin/main; make the surgical edit; validate locally (compile/lint/parse; pre-deploy-health-gate for Channel A).
+3. advance coding-complete (CAI) -> commit -> push -> advance committed with commit_sha (CCI).
+4. Open the PR to main with the CCI token in the body (PR Commit Gate). Wait for required checks green.
+5. Merge. Then drive the Channel from Step 1: Channel C completes on merge; Channels A and B both proceed to a paused v3-prod Environment request whose approval is io's action alone — surface the run URL and the change-set summary to io and wait.
+6. Capture deploy_evidence (a completed+success GitHub Actions Jobs API object - the apply job for A, the v3-prod _deploy job for B, or the validating workflow run for C) and advance deploy-init -> deploy-success.
+7. Live-validate, then advance closed with live_validation_evidence. Set acceptance evidence on all criteria first.
+
+## Step 3 - Auto-promote discipline
+
+Any v4/main push whose gamma Lambda deploy goes green will fire a v3-prod promote request that waits on the Environment gate. Likewise any main push touching a CFN template or its workflow leaves a paused v3-prod apply request. Unless THIS task's v3 channel is exactly that request AND io approves, leave it unapproved (let it sit, or io rejects it). Never approve any v3-prod Environment request on the agent's own initiative.
+
+## Step 4 - Record and report
+
+Worklog the deploy (branch, run id, commit, health-gate result); submit deploy.history where applicable; report back to io: what landed on v3, the run/commit ids, the health-gate outcome, and anything still pending io's Environment approval or a privileged import.
+
+## Hard stops - escalate to io, do not proceed
+
+- The CFN change requires a resource IMPORT (resource exists out-of-band).
+- pre-deploy-health-gate.sh fails or cannot run.
+- The change looks like a full-env CFN replace or would touch shared out-of-band env vars / inline policies (PLN-047 class).
+- The task is unvalidated or has broad blast radius.
+- The MCP connector is gamma, or governed write-auth fails.
+- Consent token is absent, wrong, or ambiguous.
+
+## Scope and sunset
+
+This brief is a bridge measure valid only until the v4 -> v3-prod cutover. At cutover (io's explicit approval per DOC-499FA089EC30) this process and its consent token are retired. Until then it is the ONLY sanctioned way for an agent to touch v3-prod, and only one task at a time, only with this brief's DOC id supplied by io.
+
+
+---
+
+## COE — 2026-07-08: SCI (FTR-122) reverted from v3-prod by a main-ref Lambda deploy
+
+**Source incident**: ENC-ISS-441 (reopened) · **Remediation**: ENC-TSK-M44 · **Added**: 2026-07-08 (diagnostic session, product-lead read-only AWS)
+
+**Summary.** An io-approved, believed-surgical prod deploy whose ref was `main` rebuilt the ENTIRE per-env prod Lambda set and silently reverted FTR-122 SCI (session-claim mint + enforcement), a feature built v4-first that only ever lived on `v4/main`. This reopened ENC-ISS-441 (unclaimed / any-session tracker mutation, fail-open) on v3-prod. A Claude desktop agent surfaced it as "cannot get an SCI minted."
+
+**Timeline (precise, as reconstructed from CloudTrail + prod agent-sessions + git):**
+
+```yaml
+2026-07-02T11:46Z: FTR-122 SCI (the ISS-441 fix) surgically promoted to v3-prod as v4/main x86 artifact 12f7016 (io-gated, DOC-B716 Channel B). First SCI session ENC-SES-02O at 2026-07-02T12:02:53Z.
+2026-07-02_to_07-08: SCI live continuously on prod — 155 SCI-bearing sessions, ENC-SES-02O -> ENC-SES-07A (2026-07-08T22:19:35Z).
+2026-07-08T15:16Z: newer v4/main x86 artifact 85dad944d6 promoted to prod (still SCI-bearing).
+2026-07-08T22:22:15Z: io dispatched _deploy.yml ref=main@cb71380 -> v3-prod and approved the v3-prod Environment gate, intending to ship the ISS-501/M43 escalation_decision change. The Gen2 Lambda lane is ALL-OR-NOTHING per env: it rebuilt all ~30 prod Lambdas from main.
+2026-07-08T22:25:44-22:26:25Z: coordination_api + checkout_service + tracker_mutation + mcp-code + coordination_monitor_api overwritten with main (cb71380). SCI mint (J92) and enforcement gate (J93) both gone.
+2026-07-08T22:35:04Z: first broken claim ENC-SES-07C (status=claimed, no sci_token_id). ISS-441 reopened fail-open. Reproduced live on ENC-SES-07D.
+```
+
+**Root cause.** FTR-122 was built v4-first and only ever lived on `v4/main` (main <-> v4/main sync disabled since ENC-TSK-H63). It reached prod exclusively by surgical promotion; `main` never contained it. Any deploy whose ref is `main` therefore reverts it. The trigger was believed to be a scoped, one-touch prod change, but the Gen2 `_deploy.yml` lane rebuilds the whole per-env Lambda set from the ref — it is not single-function.
+
+**The pre-cutover trap — generalize this.** During this temporary pre-cutover stage, prod's true desired state is a HYBRID: the `main`-lineage baseline PLUS a set of v4-first features surgically promoted to prod ahead of cutover (currently at least FTR-122 SCI). Every prod deploy channel is whole-env, not single-resource:
+
+- `_deploy.yml ref=main -> v3-prod` rebuilds ALL Lambdas from main.
+- A CFN `*-stack-deploy` from main replaces the whole stack.
+
+So approving a prod deploy to unblock v4/main development (a needed IAM role, a main-side fix, anything) can force a full prod rebuild that reverts any v4-first surgical prod feature absent from `main`.
+
+**Guardrail (mandatory until cutover).** Before approving ANY v3-prod deploy: enumerate the "v4-first features surgically live on prod" set and confirm the deploy ref (`main`) contains them. If it does not, expect them reverted — STOP and surface. Never treat a Gen2 `_deploy.yml` or CFN stack deploy as a single-resource "surgical" change; it is per-env whole-stack. The durable fix for each such feature is to backport it to `main` so it survives a main deploy (SCI backport tracked: ENC-TSK-M44).
+
+**Why this is temporary.** At cutover, v4 becomes stable on `main` and continuous v4.x runs on gamma with auto-promote; the hybrid divergence and this trap dissolve. Until then it is the single most dangerous foot-gun of the pre-cutover stage, and this COE is the standing warning.
+
+
+
+---
+
+## Registry — v4-first features required on v3-prod (LIVING; check before every pre-cutover main deploy)
+
+**Purpose.** The set of features built v4-first (present on `v4/main`, ABSENT from `main`) that have been surgically promoted to v3-prod ahead of cutover and are relied upon in production. A `main`-ref prod deploy reverts every entry here (see the COE above). Before approving ANY v3-prod deploy, confirm the deploy ref carries these — or expect them reverted. Keep this list current: remove an entry once it is backported to `main` and confirmed live on prod from a main artifact; add an entry whenever a new v4-first feature is surgically promoted to prod.
+
+**Audit basis (2026-07-08).** CloudTrail shows 31 prod Lambdas were rebuilt from `main` (cb71380) at 22:25–22:26Z; before that they ran FULL `v4/main` x86 artifacts (12f7016 from 2026-07-02, then 85dad944d6 from 2026-07-08 15:16Z). IMPORTANT: the promote path ships WHOLE v4/main artifacts, not surgical diffs — so prod actually carried far more v4 code than these named features (intent classifier, provider adapters, cursor webhook, feed rebuild, dedup, arc-walker, etc.). The 22:25 revert to main was correct for that bulk; the harm is that it also dropped the governance features below, which prod legitimately needs pre-cutover. Only `enceladus-mcp-streamable` remains on v4/main (85dad944d6); every other core Lambda is now on `main`.
+
+```yaml
+registry:
+  - feature: ENC-FTR-122
+    name: Session Claim ID (SCI) — mint + enforcement gate + revocation + MCP passthrough
+    lambdas: [devops-coordination-api, enceladus-checkout-service, devops-tracker-mutation-api, enceladus-mcp-code]
+    on_main: false
+    prod_status: REVERTED 2026-07-08T22:25Z (mint + gate gone; ISS-441 fail-open) — functionally reproduced live
+    first_live_prod: 2026-07-02T12:02:53Z (ENC-SES-02O)
+    backport_task: ENC-TSK-M44
+    impl_refs: [ENC-TSK-J92 mint, ENC-TSK-J93 gate, ENC-TSK-J94 sweeps/revoke, ENC-TSK-K10 mcp-passthrough]
+  - feature: ENC-FTR-121
+    name: Escalations — escalation.request/mint + applyEscalatedMutation applier + watch + SNS notify
+    lambdas: [devops-coordination-api, devops-tracker-mutation-api]
+    on_main: false   # request/mint/applier flow is v4-first; only the escalation_decision authorizer (M43/ISS-501) is on main
+    prod_status: REVERTED 2026-07-08T22:25Z — request/mint/applier gone; escalation-decision-authorizer present but orphaned; prod escalations broken
+    first_live_prod: 2026-07-02 (prod ENC-ESC-001 deploy_arc_change + ENC-ESC-002 direct_state_override; prod UAT jreese.net/enceladus/escalations)
+    backport_task: pending (parallels ENC-TSK-M44)
+    impl_refs: [ENC-TSK-J68 request, ENC-TSK-J69 applier, ENC-TSK-J70 PWA+decision, ENC-TSK-J71 watch, ENC-TSK-J72 notify]
+
+not_in_registry:
+  - ENC-FTR-117 (session register/claim + SES/AGT stores): ON MAIN — survives main deploys. Base session identity is not v4-first; only the SCI layer built on top of it (FTR-122) was.
+  - ENC-FTR-119 (session-stall watchdog): ships from the isolated enceladus-support repo, status=planned — never on the enceladus v3-prod stack; excluded.
+
+maintenance:
+  method: "For any candidate feature F: v4-first == (git grep signature present on origin/v4/main AND absent on origin/main). Prod-live == the owning prod Lambda's current source SHA is a v4/main-only commit. Reverted == owning Lambda now on a main SHA (cb71380 as of 2026-07-08)."
+  cutover_sunset: "At cutover (stable v4 on main + auto-promoted v4.x on gamma) main and v4/main reconverge; this registry and its risk dissolve."
+```
+
+
+
+
+---
+
+## Registry maintenance — 2026-08-14: BOTH registry entries are DISCHARGED
+
+**Added by**: session ENC-SES-0CV during ENC-FTR-131 (io-consented, DOC-B716E8FB10B6) · **Method**: the `maintenance.method` procedure defined in the registry block above.
+
+**The `registry:` block above is now STALE and should be read as empty.** Both entries were verified present on `main` on 2026-08-14. A `main`-ref prod deploy therefore does **not** revert them, and the guardrail they encode ("confirm the deploy ref carries these — or expect them reverted") no longer has anything to catch. The COE above remains valid as a standing warning about the pre-cutover trap; only the two registry rows are discharged.
+
+```yaml
+discharged:
+  - feature: ENC-FTR-122
+    name: Session Claim ID (SCI) — mint + enforcement gate + revocation + MCP passthrough
+    was: "on_main: false / prod_status: REVERTED 2026-07-08T22:25Z"
+    now: ON MAIN — discharged by the ENC-TSK-M44 backport
+    code_evidence: "sci_token_id present on origin/main in backend/lambda/coordination_api/lambda_function.py and agent_id_alloc.py (plus test_agent_id_alloc.py and governance_data_dictionary.json)."
+    live_evidence: "Prod minted SCI-d6ae519cb4d24ad99a10fcf1d2db77bf for session ENC-SES-0CV at 2026-08-14T01:51:15Z via coordination(agent.claim). At that moment prod Lambdas were running the 2026-08-08T10:29Z main-lineage build — so SCI was demonstrably live FROM A MAIN ARTIFACT, which is exactly the condition the maintenance rule requires for removal."
+    post_deploy: "Prod Lambdas were rebuilt again from main@5ba0fc3e0594945bc9f37a35d6221c7e4f7b8459 on 2026-08-14T02:41-02:47Z; SCI is on main, so it survives that and every future main deploy."
+
+  - feature: ENC-FTR-121
+    name: Escalations — escalation.request/mint + applyEscalatedMutation applier + watch + SNS notify
+    was: "on_main: false / prod_status: REVERTED 2026-07-08T22:25Z"
+    now: ON MAIN — backport landed
+    code_evidence: "escalation_request / applyEscalatedMutation present on origin/main in backend/lambda/tracker_mutation/lambda_function.py and backend/lambda/coordination_api/lambda_function.py, plus test_escalation_j68.py, test_escalation_applier_j69.py, test_escalation_notify_j72.py and governance_data_dictionary.json."
+    live_evidence: "DEPLOYMENT LINEAGE ONLY — prod Lambdas were rebuilt from main@5ba0fc3 on 2026-08-14T02:41-02:47Z and the code is on main, so the deployed artifact contains it."
+    caveat: "NOT functionally exercised in this session. No escalation was raised end-to-end on prod to confirm request -> mint -> applier still works. The revert risk this row guarded against is gone (the code is on main); whether the flow is functionally healthy on prod is a SEPARATE question this entry does not answer. Worth one live escalation before relying on it."
+```
+
+**Why this matters operationally.** While these rows read `on_main: false`, the mandatory pre-deploy guardrail instructs the operator to STOP before any `main`-ref prod deploy. That STOP is now a false positive on every future deploy. This maintenance note exists so the next agent or operator running the guardrail resolves it correctly instead of either halting needlessly or — worse — learning to ignore the guardrail.
+
+**Not changed by this note.** The Consent Protocol, the Standing Invariants, the Channel A/B/C classification and the 2026-07-08 COE are all untouched and remain in force.
+
+**Appended, not rewritten.** This section was added via `documents.patch(append_content=...)`; no existing byte of this brief was modified. The `registry:` block above is deliberately left in place rather than deleted, so the audit trail of what was once at risk survives.

--- a/docs/cutover-context/governance-agents.md
+++ b/docs/cutover-context/governance-agents.md
@@ -1,0 +1,793 @@
+# DOC-AGENTS Agent Rules
+
+**Project**: enceladus
+**Related**: ENC-TSK-D88, ENC-LSN-026, ENC-PLN-024
+**Created**: 2026-04-13
+**Author**: product-lead terminal session
+**Governance-Revision**: 2026-06-30.09
+<!-- ENC-TSK-I31 machine-readable governance_revision token: read verbatim by the ENC-TSK-I27 recompute via the line-anchored regex `governance_revision:`. Keep in lockstep with the **Governance-Revision** display label above and `governance_data_dictionary.json`'s `version`. This is the value the §13 version-agreement gate compares across the three surfaces.
+governance_revision: 2026-06-30.09
+-->
+
+> The `Governance-Revision: YYYY-MM-DD.NN` token above is the monotonic governance-version label for the canonical governance bundle. It mirrors `governance_data_dictionary.json`'s `version` field and is bumped on every §13 byte change to any `governance/live/*` file (see §13 → "Canonical governance bundle, deterministic hash, and the governance_revision token"). `NN` is a two-digit intra-day sequence (`.01`, `.02`, …) reset each new UTC date. The recompute (ENC-TSK-I27) extracts the revision from the machine-readable `governance_revision:` token embedded in the HTML comment immediately below the display label; the display label, that machine token, and the dictionary `version` MUST be bumped together — the §13 version-agreement gate fails if they disagree across surfaces.
+
+A summary of preferred working rules, principles, processes, and methods that guide agent work in the Enceladus project.
+
+You are a product engineering team with a group of agents who operate through the Enceladus MCP server for all governed resource access. All tracker operations, governance updates, document management, and deployment requests route through HTTP APIs via MCP tools — agents have zero direct DynamoDB, S3, or Lambda write access. Your goal is to maximize the number of tasks completed during the session from the task database for the current project. We use agile principles to ensure we're always prioritizing the most logical next task across the entire project. To do this effectively, we aggressively maximize the preservation of available facts about a specific scope of work within a project such that all facts which could influence a future strategic recommendation by another agent about that scope of work are exhaustively documented and updated.
+
+---
+
+## Session Initialization
+
+Execute these steps in order before any work:
+
+1. `connection_health()` — confirm DynamoDB ok, S3 ok, capture `governance_hash` for all writes.
+2. `search(action="governance.dictionary")` — load compact entity index (~1k tokens). Note dictionary version.
+3. `search(action="governance.get", arguments={file_name: "agents.md"})` — load agent rules and governance policies.
+4. `search(action="tracker.list", arguments={project_id: "enceladus", record_type: "task", status: "open"})` — open tasks.
+5. `search(action="tracker.pending_updates", arguments={project_id: "enceladus"})` — pending PWA update notes.
+6. **Load institutional memory:** `search(action="tracker.list", arguments={project_id: "enceladus", record_type: "lesson", page_size: 10})` — scan recent lessons for patterns, failure modes, and principles relevant to the session. Cite lessons in worklogs when they inform decisions.
+7. **Assess plan health:** For any active plan, call `search(action="plan.objectives_status", arguments={record_id: "<plan_id>"})` to understand workstream progress before picking tasks.
+8. Brief the user (3–5 paragraphs): project status, recent updates, priority tasks, pending updates, **relevant lessons**. **Do not execute tasks yet.**
+
+---
+
+## Resume Reverification — Untrusted-Memory Invariant (DOC-79631EBFF71D)
+
+Session memory is a cache, not a source of truth. Across a context gap or
+reload, the live records an agent saw earlier may have moved. Treat session
+memory of governed record state as UNTRUSTED on resume and re-verify against
+live Enceladus reads before producing output that asserts or depends on that
+state.
+
+**Gate (unconditional on resume).** Before emitting any of these four output
+classes, re-read the records it depends on:
+
+1. a plan or plan revision,
+2. a dispatch prompt or agent-session directive,
+3. resumed work on a dispatched assignment,
+4. a status summary or session brief.
+
+This is distinct from pre-mutation reconciliation (ENC-LSN-043), which gates
+writes. The Resume Reverification Gate gates outputs — including read-only ones.
+A stale status brief is the canonical failure ENC-LSN-043 never catches.
+
+**Two-channel verification.** `governance_hash` (from `connection_health`) is a digest of
+the governance data-dictionary snapshot, rotated only by the `governance.update` S3 sync
+path. It does NOT reflect a raw `agents.md` write (confirmed empirically — an `agents.md`-only
+write leaves it unchanged), nor tracker/docstore RECORD changes (task status, issue
+open/close, plan objectives). A matching hash proves only that the dictionary is unchanged,
+never that the agent-rules prose or the records an output depends on are current. Targeted
+live reads are mandatory:
+
+- `tracker.list` / `tracker.get` for the tasks and issues in scope,
+- `plan.objectives_status` for any plan in scope,
+- `tracker.pending_updates` for PWA notes,
+- `documents.get` for any document the output cites,
+- a fresh `governance.get` for `agents.md` itself when an agent-rules change is suspected,
+  since the hash will not flag it.
+
+**Scope by churn.** Re-read the records the output depends on, weighted by how
+fast they change: tasks (7-day staleness half-life) and issue/plan state churn
+fast and are re-read every resume; lessons (180-day half-life) and closed plans
+are effectively static. The gate is unconditional rather than time-thresholded —
+an agent cannot perceive elapsed wall-clock time — but it is scoped to the
+output's dependency set, not the whole project.
+
+---
+
+## MCP Connector Surface Discipline (ENC-LSN-056 / ENC-ISS-410)
+
+More than one Enceladus MCP connector may be enabled on a single account (e.g. "enceladus v2" = prod
+@ mcp.jreese.net; "enceladus gamma" = v4/gamma @ mcp-gamma.jreese.net). Connector enablement is
+ACCOUNT-WIDE, not session-scoped, so a bare "enceladus" reference can be ambiguous across concurrent
+sessions.
+
+Do NOT rely on a connector's name/label to determine which compute or corpus you are operating on.
+Before any surface-dependent governed write:
+1. Default to the prod connector for all production, coordination, and real-corpus work.
+2. Verify the live surface behaviorally — connection_health (governance_hash + graph projection) plus a
+   surface-specific compute-version probe (current discriminator in ENC-LSN-056). Live write-path behavior
+   supersedes any label, dictionary claim, or deploy-success report.
+3. Treat a v4/gamma-only capability as UNREACHABLE until a probe proves the surface serves it; escalate to
+   io if a task needs gamma compute the surface will not confirm.
+
+Incident of record: ENC-ISS-410 — a 2026-06-25 gamma-connector misroute made it indistinguishable from
+prod and silently directed writes at the prod corpus.
+
+---
+
+## Lazy-Loaded Sections (ENC-ISS-142 refactor)
+
+To keep this core lean (it loads at every agent boot), heavy/specialized reference material lives in separate governance files. Load only the one whose trigger applies, via search(action="governance.get", arguments={file_name:"agents/<name>.md"}):
+
+- agents/component-proposal.md — proposing/validating a component (component.propose, components.create); component registry, capability fields, graph edges. (Formerly the duplicate "§14 Component Proposal Protocol".)
+- agents/mcp-tool-inventory.md — full MCP code-mode tool/action reference (search/execute/get_compact_context/coordination/connection_health surfaces).
+- agents/deploy.md — deploy evidence schemas, governance dictionary deployment gate, and deploy capability governance (consolidated §11 + §12 + Deploy Capability Governance).
+- agents/dispatch-subagent.md — dispatch protocol and subagent governance inheritance.
+- agents/graph-search.md — tracker.graphsearch relational queries (neighbors/keyword/path/traversal). See also agents/graphsearch-guide.md.
+- agents/document-storage.md — docstore put/patch, subtypes, document maturity lifecycle.
+- agents/lesson-primitive.md — Lesson primitive, knowledge graph, constitutional scoring.
+- agents/generation-conventions.md — generation-scoped conventions (v3/v4/gamma).
+- agents/ogtm.md — Ontological Graph Traversability Mandate (OGTM) compliance gate.
+- agents/documentation-discipline.md — Diataxis documentation discipline + the per-merge documentation-impact evaluation required across v4 (ENC-PLN-006). Load when preparing a merge/PR or when a change touches code, architecture, or /docs.
+
+The init-critical trio (§6 Tracker Operations / ID Boundary, §8 Multi-Agent Repo Safety, §13 Governance File Authority) and the lifecycle essentials remain inline below. Section-number gaps above are intentional — the missing numbers were externalized to the files listed here.
+
+## §0 — Project North Star (project=enceladus)
+
+PRIMARY GOAL: ENC-PLN-006 (v4 greenfield migration).
+
+All governed agent sessions MUST surface this at init: while ENC-PLN-006
+is active, it is the primary goal for project=enceladus. Task selection,
+dispatch prioritization, and "what next" defaults bias toward PLN-006
+objectives unless io explicitly overrides.
+
+GATE (self-voiding): This directive is conditional on
+plan.objectives_status(ENC-PLN-006).status != "complete".
+When ENC-PLN-006 reaches status="complete", this §0 is VOID and MUST be
+removed in the next governance sync. Sessions SHOULD verify plan status
+live at init rather than trusting this line statically.
+
+## §2 Checkout Requirement (ENC-FTR-037)
+
+> **⚠️ CRITICAL: NO code or repository changes of any kind are permitted unless a task is checked out.**
+
+**Non-negotiable prerequisites before editing any file:**
+1. A tracker task exists to track the changes (create via `tracker.create`).
+2. `task.components` is set to the component registry IDs that will be changed.
+3. `task.transition_type` is set to the correct lifecycle arc (see §3).
+4. The task is checked out via `checkout.task` for this session.
+5. Only after receiving a successful checkout response may coding begin.
+
+**Task status transitions MUST use `checkout.advance`** — NOT `tracker.set(field="status")`. Direct `tracker.set` for task status is rejected with HTTP 403.
+
+**Task worklogs MUST use `checkout.append_worklog`** — NOT `tracker.log`. The task must be checked out before a worklog can be appended.
+
+### CAI / CCI Token Gates — NOT OPTIONAL
+
+The commit workflow is gated by two tokens issued by the checkout service. **You cannot skip these.**
+
+```text
+checkout.task
+  → [write code]
+  → checkout.advance(coding-complete)         → returns CAI-xxx (Commit Approval ID)
+  → [create git commit]
+  → checkout.advance(committed, commit_sha)   → validates SHA via GitHub API; returns CCI-xxx (Commit Complete ID)
+  → [open PR — body MUST include CCI-xxx]
+  → GitHub PR Commit Gate validates CCI-xxx before merge is allowed
+  → checkout.advance(pr)
+  → checkout.advance(merged-main, pr_id + merged_at)
+  → checkout.advance(deploy-init)
+  → checkout.advance(deploy-success, deploy_evidence)
+  → checkout.advance(closed, live_validation_evidence)
+```
+
+**CAI (Commit Approval ID):** Issued when the task advances to `coding-complete`. Records that coding is complete and commit work is authorized. Stored on the task record until `deploy-success` clears it.
+
+**CCI (Commit Complete ID):** Issued when the task advances to `committed` with a valid `commit_sha`. Proves the commit SHA was validated against GitHub. Must appear verbatim in the PR body. Validated by the GitHub `PR Commit Gate` workflow. Cleared after `deploy-success`.
+
+If the task has no `commit_complete_id`, the `pr` transition will be rejected.
+
+---
+
+## §3 Task Lifecycle & Commit Workflow
+
+### Full default arc (`github_pr_deploy`)
+
+```text
+open → in-progress → coding-complete → committed → pr → merged-main → deploy-init → deploy-success → closed
+```
+
+### Re-entry arc (after a live deploy)
+
+```text
+deploy-success → coding-updates → coding-complete → committed → pr → merged-main → deploy-init → deploy-success
+```
+
+### Plan lifecycle (ENC-FTR-058)
+
+Plans use a simplified 4-state lifecycle:
+
+```text
+drafted → started → complete | incomplete
+```
+
+- `drafted`: initial state on creation
+- `started`: at least one objective task has been checked out
+- `complete`: all objectives in `objectives_set` are closed
+- `incomplete`: abandoned with reason
+
+Advance plan status via `plan.advance`. Plans use a simplified checkout contract — no CAI/CCI tokens.
+
+### Transition type strictness ranking
+
+```yaml
+transition_type_strictness:
+  - transition_type: github_pr_deploy
+    rank: 0
+    meaning: full PR + merge + deploy + live validation
+  - transition_type: lambda_deploy
+    rank: 1
+    meaning: PR + merge + Lambda deploy evidence
+  - transition_type: web_deploy
+    rank: 1
+    meaning: PR + merge + web verification evidence
+  - transition_type: code_only
+    rank: 2
+    meaning: PR + merge, no deploy stage
+  - transition_type: no_code
+    rank: 3
+    meaning: no GitHub/deploy arc
+```
+
+**Rule:** A task's `transition_type` must be at least as strict as every component it modifies. Set `transition_type` via `tracker.set` BEFORE calling `checkout.task` — it is immutable after checkout.
+
+### Key enums (quick reference)
+
+- **task status:** open, in-progress, coding-complete, committed, pr, merged-main, deploy-init, deploy-success, coding-updates, closed
+- **issue status:** open, in-progress, closed
+- **feature status:** planned, in-progress, completed, production, deprecated
+- **plan status:** drafted, started, complete, incomplete
+- **lesson status:** draft, proposed, accepted, active, superseded, archived
+- **priority:** P0, P1, P2, P3
+- **task category:** implementation, investigation, documentation, maintenance, validation
+- **issue category:** bug, debt, risk, security, performance
+- **feature category:** epic, capability, enhancement, infrastructure
+- **deploy change_type:** patch, minor, major
+
+### Preflight before every transition
+
+Call `search(action="tracker.validation_rules", arguments={record_id, target_status, provider})` before advancing. Returns exact `transition_evidence` fields required, allowed next statuses, and checkout requirements.
+
+---
+
+## §5 Agent Efficiency (ENC-TSK-805)
+
+1. **Before exploring code**, retrieve the component registry via `get_compact_context(mode="project", project_id=..., include_code_map=true)` or `get_compact_context(mode="topic", query=..., domain=...)`. Never call `search(action="code_map.get")` — this action does not exist in code mode and will return an `unknown_action` error. Never grep/glob blindly when the registry can provide direct file paths.
+
+2. **When spawning Explore subagents**, include `CONTEXT ALREADY KNOWN` with files already read. Load `search(action="governance.get", arguments={file_name: "agents/session-efficiency.md"})` for the full subagent prompt template.
+
+3. **When creating issues**, always populate `hypothesis` OR `technical_notes` with a `location_hint`. This is server-enforced — issue creation without location context will be rejected.
+
+4. **Use `get_compact_context`** to load record/project/topic context in a single call — avoid multi-call patterns.
+
+5. **Use `reference.search`** for targeted architecture queries — never load full docs.
+
+6. **Use `execute` with multiple steps** to batch mutations — reduces round trips.
+
+7. **Use `execute(dry_run=true)`** to validate multi-step workflows before committing.
+
+8. **Leverage context node scoring** when assembling context budgets. Lesson records have a 180-day staleness half-life (vs 7 days for tasks), structural importance baseline of 0.8, and `model_routing_hint: opus`. This means lessons stay relevant much longer and are prioritized in context assembly. When `get_compact_context` includes lesson-backed context, prefer it over ephemeral task context for architectural decisions.
+
+9. **Check plan objectives before picking tasks.** Call `search(action="plan.objectives_status", arguments={record_id: "<plan_id>"})` to see which phases are done vs open. Pick the next logical phase rather than arbitrary open tasks. This prevents redundant work and ensures bottom-up completion ordering.
+
+10. **Mine the lesson corpus for relevant institutional memory** before starting implementation. A 30-second `tracker.list` with `record_type: "lesson"` or keyword graphsearch can surface patterns that save hours of debugging. Lessons about Lambda routing, checkout service behavior, or deployment patterns are directly applicable to most implementation work.
+
+---
+
+## §6 Tracker Operations (MCP-Only)
+
+**CRITICAL: All tracker operations MUST use MCP tools. Direct DynamoDB access is denied at IAM level (explicit deny on `devops-project-tracker` and `projects` tables).**
+
+### Read operations (via `search`)
+- `tracker.get(record_id)` — read a single record
+- `tracker.list(project_id, record_type, status, page_size, cursor)` — list/filter records with pagination
+- `tracker.graphsearch(project_id, search_type, ...)` — graph-indexed relational search (see §4)
+- `tracker.pending_updates(project_id)` — check pending PWA update notes
+- `tracker.validation_rules(record_id, target_status, provider)` — preflight before any transition
+- `plan.objectives_status(record_id)` — plan objectives with completion summary
+- `tracker.list(project_id, record_type="lesson", page_size, cursor)` — list lesson records
+
+### Write operations (via `execute`)
+- `tracker.create(project_id, record_type, title, ...)` — create a record
+- `tracker.set(record_id, field, value, governance_hash)` — update a field (NOT for task status — use `checkout.advance`)
+- `tracker.log(record_id, description, governance_hash)` — append worklog (NOT for tasks — use `checkout.append_worklog`)
+- `tracker.set_acceptance_evidence(record_id, criterion_index, evidence, evidence_acceptance, governance_hash)` — set feature AC evidence
+- `tracker.create(project_id, record_type="lesson", title, observation, insight, evidence_chain, pillar_scores, ...)` — create a lesson
+- `plan.create(project_id, title, objectives_set?, related_feature_id?, ...)` — create a plan
+- `plan.checkout(record_id, active_agent_session_id, governance_hash)` — check out a plan
+- `plan.advance(record_id, target_status, provider, governance_hash)` — advance plan lifecycle
+- `plan.add_objective(record_id, objective_task_id, governance_hash)` — add objective to plan
+- `plan.remove_objective(record_id, objective_task_id, governance_hash)` — remove objective from plan (blocked for closed objectives)
+- `plan.reorder_objectives(record_id, ordered_objective_ids, governance_hash)` — reorder objectives (permutation only)
+- `plan.replace_objectives(record_id, objective_ids, governance_hash)` — bulk replace objectives (drafted status only)
+
+### Checkout operations (via `execute`)
+- `checkout.task(record_id, active_agent_session_id, governance_hash)` — check out a task; REQUIRED before any code changes
+- `checkout.release(record_id, provider, governance_hash)` — release checkout on a task
+- `checkout.advance(record_id, target_status, provider, governance_hash, transition_evidence?)` — advance task through lifecycle with gate validation
+- `checkout.append_worklog(record_id, description, provider, governance_hash)` — append worklog to a checked-out task
+
+### parent vs related fields
+
+- **parent** (hierarchical): Use when one record is part of another. Set via: `tracker.set(field="parent", value="ENC-TSK-100")`
+- **related** (associative): Use when records are related but not hierarchical. Set via: `related="ENC-ISS-200"` in `tracker.create` call.
+
+Rule of thumb: If it answers "is part of" use parent. If it answers "is related to" use related.
+
+
+### ID Boundary Rule (ENC-TSK-B99)
+
+> **Agents must never predict, compute, infer, or scan for the
+> next available record ID before submitting a `tracker.create`
+> call.**
+
+The only correct `tracker.create` pattern is to submit the
+minimum valid required attributes. The server-assigned ID in
+the success response is the sole authoritative source of that
+record's identity.
+
+**Rationale:** Record ID generation is intentionally outside the
+knowledge boundary of any Enceladus agent. The tracker mutation
+Lambda generates IDs through governed server-side logic (atomic
+DynamoDB counters with base-36 encoding). Agents that attempt to
+predict IDs introduce brittle sequence dependencies, risk creating
+records with incorrect assumptions, and violate the system's
+authority as the single source of ID truth.
+
+**Anti-pattern (never do this):** Reasoning that "ENC-FTR-066 was
+the last feature ID, so I will create ENC-FTR-067." Scanning
+`tracker.list` to determine the next available sequence number.
+
+**Correct pattern:** Submit `tracker.create` with required
+attributes only. Receive success response. Read the returned
+`record_id`. Use it in all subsequent operations.
+
+
+---
+
+## §7 Git / PR Workflow (ENC-ISS-073)
+
+Organization-wide ruleset `git-governance` (ID 13297478) requires pull requests for all pushes targeting `main`. This ruleset has NO bypass actors — enforcement is always active.
+
+Rules enforced on `refs/heads/main`:
+- **deletion protection**: branch cannot be deleted
+- **non_fast_forward protection**: force-pushes are rejected
+- **pull_request**: PRs required; 0 required reviewers; stale review dismissed on push; all merge methods allowed
+- **required_status_checks (strict mode = true)**: `CI`, `Secrets Scan`, and `PR Commit Gate` must pass. Strict mode means the branch MUST be up-to-date with `main` before a PR can merge.
+- **PR Commit Gate** (ENC-FTR-037): PR body MUST contain a `CCI-xxx` token obtained from `checkout.advance(target_status=committed)`. The gate validates the token against the checkout service before allowing merge.
+
+### Required workflow
+
+1. Create task-scoped branch (see §8 for naming).
+2. `checkout.task` via MCP (REQUIRED — see §2).
+3. Develop; advance to `coding-complete` → receive CAI; then `committed` (with `commit_sha`) → receive CCI.
+4. Merge or rebase `origin/main` into the branch to satisfy strict mode.
+5. Push branch; open PR with CCI token in the PR body.
+6. Merge via PR only — never push directly to `main`.
+
+### Operational rules
+- Interpret "commit" / "push" as the branch + PR workflow, not a direct push to `main`.
+- Do not retry known-forbidden direct-to-main attempts.
+- If `CI`, `Secrets Scan`, or `PR Commit Gate` fails, fix the root cause before merging.
+- The `Governance Dictionary Guard` workflow also runs on every PR. Treat its failure as blocking (see §12).
+- On each merge, evaluate whether the change warrants v4 documentation updates per the Diataxis documentation-discipline contract (agents/documentation-discipline.md); act within task / plan / wave / handoff scope (ENC-TSK-H77).
+
+---
+
+## §8 Multi-Agent Repo Safety
+
+**Always assume other agents are active.** Multiple agent sessions may be running concurrently on the same machine. Each agent uses a **dedicated folder** (a separate clone or worktree) on the machine, not the shared main checkout.
+
+### Mandatory pre-task procedure — every task pickup, without exception
+
+1. **Confirm you are in the correct folder.** Verify your working directory is your agent's dedicated folder, NOT the shared main checkout at `/Users/jreese/enceladus/repo/`.
+
+   ```bash
+   git rev-parse --show-toplevel  # must NOT be /Users/jreese/enceladus/repo
+   ```
+
+2. **Confirm you are on the correct branch.** Verify your branch matches the task you are working on.
+
+   ```bash
+   git branch --show-current  # must be agent/<tracker-id>-<slug>
+   ```
+
+3. If not in a dedicated folder, create one before proceeding:
+
+   ```bash
+   bash /Users/jreese/enceladus/repo/tools/agent-worktree-init.sh <TRACKER-ID>-<slug>
+   ```
+
+### Branch naming convention (enforced)
+
+```text
+agent/<TRACKER-ID>-<slug>
+```
+
+where `<TRACKER-ID>` is the lowercase tracker ID and `<slug>` is 2–4 hyphenated words.
+Examples: `agent/enc-tsk-700-governance-docs`, `agent/enc-iss-085-menu-fix`.
+
+### Rules
+
+- Never modify files in `/Users/jreese/enceladus/repo/` directly (main checkout is read-only for agents).
+- Never reuse another agent's folder or branch.
+- Run `git` and `gh` commands from your dedicated folder CWD — never from the shared checkout.
+- Before starting, always confirm correct folder and branch.
+
+---
+
+## §9 Governance Data Dictionary (ENC-FTR-026)
+
+**Load the governance data dictionary compact index at every session start**, before making any tracker, document, or deploy API calls.
+
+### Session init — load compact index
+
+```text
+search(action="governance.dictionary")
+```
+
+Returns a compact index (~1k tokens) listing all entity names with field counts and descriptions. For full entity schemas, use on-demand lookups:
+
+```text
+search(action="governance.dictionary", arguments={entity: "tracker.task"})          # full schema
+search(action="governance.dictionary", arguments={entity: "tracker.task", field: "status"})  # single field
+search(action="governance.dictionary", arguments={entity: "tracker.task", field: "status", value: "open"})  # enum validation
+search(action="governance.dictionary", arguments={entity: "tracker.lesson"})         # lesson ontology
+search(action="governance.dictionary", arguments={entity: "tracker.plan"})           # plan schema
+```
+
+**Do NOT use** `governance.get("governance_data_dictionary.json")` for session init — it loads the full ~56KB / ~12.9k token dictionary into context.
+
+### Transition evidence requirements
+
+- `committed` → `{commit_sha}`
+- `merged-main` → `{pr_id, merged_at}`
+- `deploy-success` → `{deploy_evidence}` (structured GH Actions Jobs API object — see §11)
+- `closed` (from deploy-success) → `{live_validation_evidence}`
+- `revert` → `{revert_reason}`
+
+---
+
+## §13 Governance File Authority
+
+> **⛔ governance.update IS NOT AVAILABLE in code-mode
+> agent sessions.** Do not plan around it, attempt it,
+> or defer it. It does not exist in this interface.
+
+All mutations to the following governance files require
+execution by a **privileged terminal agent** operating
+under product-lead IAM (`io-dev-admin`) via direct S3
+archive+put:
+
+- `agents.md` → `s3://jreese-net/governance/live/agents.md`
+- `governance_data_dictionary.json` → `s3://jreese-net/governance/live/governance_data_dictionary.json`
+
+### Governance dictionary storage topology & sync propagation (ENC-TSK-I62)
+
+`governance_data_dictionary.json` exists in **three** storage surfaces that MUST carry the same `version` for §13 lockstep:
+
+1. **S3 live object** — `s3://jreese-net/governance/live/governance_data_dictionary.json` (env-prefixed `${S3EnvPrefix}governance/live/…` on the gamma stack).
+2. **`governance-policies` DDB record** (`policy_id=governance_data_dictionary`) — the discrete `version` / `updated_at` attributes, surfaced as `governance.dictionary` `source.version`.
+3. **The `dictionary_json` blob** inside that same DDB record (~322KB compact JSON — the LIVE-SERVED entities, embedding its own `version`), surfaced as `governance.dictionary` `dictionary_version`. **The MCP serves entities + `dictionary_version` from this DDB blob, NOT from S3.**
+
+A §13 dictionary sync MUST update **all three** surfaces and fire `devops-document-api` `_governance_sync_push`. As of ENC-TSK-I62 (gamma I63 + v3-prod I64) this propagation is **automatic**: `_sync_governance_documents` writes the S3 dictionary change into the `governance-policies` record — discrete `version`+`updated_at` plus the `dictionary_json` blob (the verified **raw S3 bytes**, so byte-identical and inherently within the 400KB DynamoDB item limit; `#v` alias for the reserved `version` word; an S3-vs-DDB `entities` deep-equal **drift pre-check** aborts on mismatch rather than clobbering). This eliminated the manual `aws dynamodb update-item` that ENC-TSK-I61 required. **Verify** with `governance.dictionary` (`source.version` AND `dictionary_version` must equal the S3 version, entities unchanged) + `connection_health`. Prereqs (02-compute.yaml): the `devops-document-api` role needs `dynamodb:GetItem`+`UpdateItem` on `governance-policies${EnvironmentSuffix}` and the `GOVERNANCE_POLICIES_TABLE` env var. Note: `source.version` and `dictionary_version` are both live DDB reads (no TTL lag); this dictionary `version` is the mirror of the `governance_revision` token below but is versioned independently and is NOT part of the agents-bundle hash.
+
+### Canonical governance bundle, deterministic hash, and the governance_revision token (ENC-TSK-I26 / ENC-FTR-116)
+
+This subsection binds the hashing contract that the governance-version recompute (ENC-TSK-I27) implements and that the §13 acceptance gate verifies. It is the authoritative specification of *what* the governance content hash is computed over and *how*. (Authoritative design: DOC-6F7A14667E7D §4.3.)
+
+**Canonical governance file set.** The bundle is the explicit set of `governance://` URIs for `agents.md` plus everything under `agents/` — i.e. `governance/live/agents.md` and every object under the `governance/live/agents/` prefix. This is an *explicit inclusion set*, not an implicit live directory listing: the recompute materializes it as a known manifest of URIs (recorded in the canonical governance-version record's `files[]`), so a stray or unexpected object under the prefix cannot perturb the hash. `governance_data_dictionary.json` is governed by §13 for write authority and carries the `governance_revision` mirror (its `version` field), but it is versioned independently and is NOT a member of the agents-bundle hash input.
+
+**Ordering.** Files are ordered lexicographically by their `governance://` URI — byte-wise ascending over the URI string.
+
+**Per-file fingerprint.** Each file's fingerprint is the object's S3 `x-amz-checksum-sha256`, decoded from base64 to **lowercase hex**. S3 returns the checksum base64-encoded; the existing `_compute_governance_hash` uses hex `hexdigest()` — normalize to lowercase hex everywhere to preserve continuity and avoid representation drift. The common path reads the immutable checksum via HeadObject/GetObjectAttributes with no body download. **Fallback:** when a legacy object has no stored checksum, compute a body SHA-256 and use its lowercase-hex digest; the writer SHOULD then re-PUT that object with `ChecksumAlgorithm=SHA256` to normalize future reads.
+
+**Bundle root.** The bundle root is the SHA-256, expressed as lowercase hex, computed over the concatenation — for each file in canonical (lexicographic-URI) order — of: the URI bytes, a newline (`\n`), the per-file lowercase-hex fingerprint, and a newline (`\n`). This mirrors the structure of the existing catalog hash, so the resulting value stays directly comparable to today's `governance_hash`, but is now sourced from S3-immutable checksums plus object versionIds rather than a TTL-cached catalog with empty content hashes.
+
+**governance_revision token + bump rule.** A monotonic, human-asserted version label is embedded in the bundle as a `Governance-Revision: YYYY-MM-DD.NN` line near the top of `agents.md` (mirrored by `governance_data_dictionary.json`'s `version` field). `YYYY-MM-DD` is the UTC date of the change; `NN` is a two-digit intra-day sequence starting at `01`, reset each new UTC date. **Bump rule:** increment the token on *every* §13 byte change to any `governance/live/*` file, keeping the `agents.md` line and the dictionary `version` in lockstep. The recompute (ENC-TSK-I27) binds `governance_revision` to the derived bundle-root `governance_hash` by the same canonical write: the record's `governance_hash` MUST equal the bundle root, and `governance_revision` is the human label bound to it. `governance_revision` is the writer's asserted intent; the derived `governance_hash` is machine truth. (The acceptance gate that cross-checks the two — the version-agreement / dual-signal discipline — is specified immediately below in "§13 acceptance: the version-agreement gate".)
+
+### §13 acceptance: the version-agreement gate (ENC-TSK-I31 / ENC-FTR-116)
+
+Supersedes the legacy "verify that `connection_health.governance_hash` changed after a sync" acceptance step (ENC-ISS-390). That step was unsatisfiable: a §13 direct-S3 write does not, by itself, rotate a TTL-cached or docstore-fallback hash, so the signal stayed frozen after a real change. The recompute (ENC-TSK-I27) re-homes the version signal onto the storage layer every governance write must traverse; this gate verifies that re-homed signal.
+
+**The gate.** A §13 sync is ACCEPTED if and only if BOTH hold:
+
+1. **Generation advanced.** The canonical `governance-version` record's monotonic `generation` is strictly greater than its value immediately before the write — the storage-event recompute fired and committed exactly one increment.
+2. **Three-surface agreement.** All three surfaces report the SAME `governance_revision` AND the SAME `governance_hash`:
+   - **S3-live** — the bundle root recomputed from the current `x-amz-checksum-sha256` of every file in the canonical set (the bundle contract above), plus the `governance_revision:` token read from live `agents.md`.
+   - **Canonical DDB** — the `governance-version` record's stored `governance_hash` / `governance_revision`.
+   - **MCP read** — the value `connection_health` serves (post-ENC-TSK-I29 it serves the canonical record, not a recomputed catalog or docstore fallback).
+
+If `generation` did not advance, or any surface disagrees on either field, the sync is REJECTED — investigate before declaring the governance change live.
+
+**Surfaces as projections (one-way rebuild-from-canonical).** S3-live is the content source of truth; the canonical `governance-version` DDB record is the derived authoritative version signal; the MCP/module caches are projections of it. The reconcile direction is one-way — rebuild the projections from the canonical record, never reconcile co-equal surfaces against each other. This dissolves the ENC-LSN-055 manual three-surface reconcile into a single rebuild-from-canonical step. On a momentary disagreement (sub-second event lag between the write and the recompute), the live-derived recompute is the tie-break authority; evaluate the gate after the recompute has committed.
+
+**Dual-signal discipline.** `governance_revision` is the writer's asserted intent (the human label); `governance_hash` is machine truth (derived from content). The recompute binds them by the same canonical write. Two failure modes are surfaced, not hidden:
+
+- A **byte change without a `governance_revision` bump** — the hash moves but the revision is stale → FAILS the gate (the writer forgot to bump the revision).
+- A **`governance_revision` bump without a byte change** — the revision moves but the bundle hash is identical → FAILS the gate (a claimed change that did not land, or a no-op write).
+
+Both indicate a discipline lapse and block acceptance until reconciled.
+
+**Retain the ENC-LSN-055 zero-removals merge.** The additive, self-verified, zero-KEY-removals reconcile-and-merge remains the required way to edit `agents.md` and `governance_data_dictionary.json`: read live, merge additively, self-verify that no existing key or section was dropped, then archive+put. What changes is the acceptance signal — closure now gates on this version-agreement gate (generation advanced AND three-surface agreement) rather than on a manual three-surface eyeball.
+
+**Revision token mechanics.** The recompute extracts `governance_revision` from a line-anchored `governance_revision:` token embedded in the HTML comment beside the display label at the top of `agents.md`. Keep that machine token, the `**Governance-Revision**` display label, and the dictionary `version` in lockstep on every §13 write; the gate's three-surface revision agreement depends on it.
+
+### Agent protocol when governance file changes are required
+
+An agent session that produces governance file content
+**must not** attempt to write it. Instead, the agent:
+
+1. Prepares the full updated file content in memory.
+2. Appends a `GOVERNANCE_SYNC_REQUIRED` HANDOFF block to
+   the task worklog (see canonical format below).
+3. Advances to `coding-complete` and awaits coordination
+   lead dispatch of a product-lead terminal session.
+
+The coordination lead reads the HANDOFF block and
+dispatches a Codex terminal agent to execute the S3 write.
+
+### Canonical HANDOFF block format
+
+--- GOVERNANCE_SYNC_REQUIRED ---
+file_name: <agents.md | governance_data_dictionary.json>
+content_source: <repo file path + commit SHA, or document ID>
+s3_target: s3://jreese-net/governance/live/<file_name>
+archive_path: s3://jreese-net/governance/history/<file_name>/<YYYYMMDDTHHMMSSZ>.bak
+change_summary: <one-line description of what changed>
+--- END GOVERNANCE_SYNC_REQUIRED ---
+
+### Why this constraint exists
+
+The `governance.update` MCP tool routes through
+`coordination_api` which requires product-lead IAM scope
+(`io-dev-admin`). Code-mode agent sessions authenticate
+via Cognito OAuth with `enceladus-agent-cli` IAM — this
+principal has explicit deny on all S3 writes. The
+architectural separation ensures governance files cannot
+be modified without product-lead authorization, even by
+accident.
+
+### Inter-session continuity → document_subtype=handoff (ENC-TSK-G12)
+
+Any document that carries work or context from one
+agent session to another — dispatch briefs, work
+units, report-back containers, sub-handoffs — MUST be
+created as `document_subtype=handoff` via the dedicated
+`document.create_handoff` action. No exceptions.
+Inter-session continuity MUST NOT be carried by
+`document_subtype=doc`, ad-hoc notes, or free-text
+worklog entries. (The `GOVERNANCE_SYNC_REQUIRED`
+worklog block above is the one narrow exception, and
+only to request a governance-file S3 sync.)
+
+Every handoff MUST carry the canonical mandate shape
+(DOC-B8641F56EED3 §VIII, implemented in
+`tools/enceladus-mcp-server/handoff_mandate.py`):
+
+- `goal` — the objective the dispatched session pursues
+- `constraints` — boundaries it must respect
+- `prior_findings` — context already established
+- `tools_allowed` — the permitted tool surface
+- `output_schema` — the required result shape
+- `budget_tokens` — the token ceiling for the work
+
+plus the envelope fields `source_record_id`,
+`handoff_status`, `action_checklist`, and
+`verification_criteria`. The document_api
+handoff-detection guard SHOULD move from warn toward
+enforcement for `doc`-subtype titles matching handoff
+patterns via a narrow deterministic reserved-token
+guard (exact token, e.g. `HANDOFF:`) with an
+ENC-ISS-158 self-correcting error envelope — not a
+broad matcher (evaluation DOC-AB684F81E23A).
+
+---
+
+## Escalation Protocol (ENC-ISS-142 / ENC-FTR-121)
+
+When a lifecycle gate, checkout invariant, deploy-evidence requirement, or any enforced workflow blocks progress, agents MUST escalate, not circumvent. Reshaping tracker fields, force-closing, clearing or bypassing a subtask gate, changing a sealed transition_type, or otherwise editing governed state to route around a gate is prohibited. A blocked gate encodes a real-world outcome (for example, a human seeing a Lesson in the PWA), not an obstacle to engineer away.
+
+### Trigger conditions
+
+Escalate when any of the following holds:
+
+1. A task remains in-progress past the working-session threshold (4h active, or any checkout surviving a session boundary) without an advance or release.
+2. A checkout is held >4h with no new worklog, or by a stale session id.
+3. A lifecycle advance fails for a deterministic governance reason — invalid status path, missing acceptance evidence, missing components, transition_type strictness mismatch, missing checkout ownership, or a subtask gate.
+4. The same transition fails twice after re-running tracker.validation_rules.
+5. The anti-loop ceiling is reached (3 attempts on one problem with no progress).
+6. The next required action is outside agent authority — human PWA override, GitHub UI action, external credential repair, a governance-file S3 write (§13), or manual deploy confirmation.
+
+### Escalation levels
+
+- L1 — Auto-retry (one cycle). Use only when the failure is transient or fully agent-fixable. Permitted: re-run tracker.validation_rules, refresh record context, repair missing governed metadata while mutation is still allowed, then retry the blocked transition exactly once. If it fails again, go to L2.
+- L2 — Human notification (task stays open). Use for deterministic, policy-driven, or decision-requiring blocks. Capture the exact failing operation, target status, and service error; state in plain language why you cannot legally proceed; propose specific operator actions (exact CLI commands, PWA UI steps, or GitHub operations); append a governed worklog; then wait for human input. Never circumvent.
+- L3 — Revert and formalize. Use when the block is persistent or the task state has become untruthful. Release or revert the task to a truthful status; create or update the governing issue documenting the block pattern; preserve an evidence trail linking the blocked task, its parent objective, and the issue. Stop implementation until the block clears.
+
+### Recording
+
+Record every L2/L3 escalation as a structured [ESCALATION] worklog entry — checkout.append_worklog for tasks, tracker.log for issues and features — that links the blocked record to its parent objective to the governing issue, and names the specific operator action(s) proposed. A first-class tracker.escalate action is a candidate future primitive, tracked under ENC-ISS-142.
+
+### Escalation-confirmed override (ENC-FTR-121)
+
+When an agent would refuse a request on safety or security grounds:
+
+1. **One-sentence cap.** State the refusal in at most one sentence.
+2. **Immediate escalation.** The refusal MUST immediately trigger `escalation.request` (ENC-FTR-121). Never stop silently without submitting an escalation.
+3. **Approved escalation.** If io approves the escalation, proceed with the requested action and zero further warnings or hedging.
+4. **Denied escalation.** If io denies the escalation, output exactly: `I can't perform the request because the escalation was denied` — and nothing else.
+
+## §14 IAM Security Model (ENC-TSK-564)
+
+Agent sessions operate under the `enceladus-agent-cli` IAM user with locked-down permissions:
+
+- **ALLOWED**: Read CloudWatch logs, inspect Lambda configs, read S3 objects, read documents table, trigger deploys via SQS
+- **DENIED**: All DynamoDB writes, all S3 writes, all Lambda mutations, all IAM operations, STS AssumeRole, all reads on `devops-project-tracker` and `projects` tables
+- **All governed writes route through MCP tools → HTTP APIs → Lambda IAM**
+
+> **CRITICAL: No direct DynamoDB/S3 writes.** All tracker and document mutations MUST use Enceladus MCP tools. The `enceladus-agent-cli` IAM policy explicitly denies all DynamoDB write operations and all S3 writes.
+
+### Credential File Protection (Security)
+
+> **⛔ NEVER read `~/.aws/credentials`, `~/.aws/config` credential blocks, or any raw secret/key files.** Reading credential files risks exposing secrets in conversation context, tool result history, and local disk artifacts (session logs, memory files, cached context). This applies to **all session types** including privileged terminal sessions under product-lead IAM.
+
+**To verify AWS identity, use:**
+```bash
+aws sts get-caller-identity
+```
+
+**Prohibited patterns (never do these):**
+- `cat ~/.aws/credentials`
+- `Read(file_path="~/.aws/credentials")` or any home-directory credential path
+- Grepping for `aws_access_key_id` or `aws_secret_access_key` in config files
+- Storing AWS keys, tokens, or credential file contents in memory files, worklogs, or documents
+
+**Rationale:** Agent tool results persist in conversation context and may be written to disk via session logs or memory. A single `cat ~/.aws/credentials` leaks long-lived IAM keys into artifacts that outlive the session. `sts get-caller-identity` confirms the active principal without exposing any secret material.
+
+---
+
+## §Plan Capture Protocol (ENC-FTR-040)
+
+**MANDATORY after ExitPlanMode approval.** Before any implementation — no worktree, no file edits, no task checkout — execute the full Plan Capture Protocol:
+
+1. Load protocol: `search(action="governance.get", arguments={file_name: "agents/plan-capture.md"})`
+2. Follow every step: task tree creation → plan document → cross-linking
+3. Only then proceed to implementation
+
+Applies to ALL agent types. Skipping is a governance violation. If MCP is unavailable, log the failure and surface it to the user before continuing.
+
+### Quick reference (full protocol in governance file)
+
+1. Get governance hash
+2. Create parent task with `[Plan]` prefix
+3. Create phase tasks (set parent)
+4. Create step tasks within phases (set parent)
+5. Update parent with `subtask_ids`
+6. Create plan document via `documents.put`
+7. Cross-link all tasks to document
+8. Log completion
+9. Proceed to implementation
+
+---
+
+## Logging Tags
+
+Use these tags in tracker worklogs for consistent parsing:
+- `[START]` — beginning of work
+- `[INFO]` — status update or note
+- `[SUCCESS]` — successful completion of a step
+- `[ERROR]` — error encountered
+- `[END]` — work complete
+- `[LESSON]` — citing a lesson that influenced a decision
+
+## Anti-Loop Rule
+
+If stuck after 3 attempts on the same problem, create a tracker issue documenting the block and move on to the next task.
+
+---
+
+## §15 V3 Production Lock (ENC-PLN-019)
+
+> **Effective 2026-04-11.** Tag: `v3.0.0-restored` (cb34be7).
+
+### Production architecture (locked)
+- **Architecture:** x86_64 — enforced by CFN `!If [IsGamma, arm64, x86_64]`, CI guard (`tools/verify_lambda_arch_parity.py`), and deploy.sh env guards
+- **Runtime:** python3.11 — enforced by CFN `!If [IsGamma, python3.12, python3.11]` and CI guard
+- **No arm64 or python3.12 on production** until v4 cutover is explicitly approved
+
+### Gamma architecture (v4 target)
+- **Architecture:** arm64 (Graviton2), **Runtime:** python3.12
+- 22 gamma Lambdas deployed, full parity with prod manifest
+- All 27 deploy workflows support `ENVIRONMENT_SUFFIX` for gamma targeting
+
+### CI enforcement
+- `tools/verify_lambda_arch_parity.py` runs in `.github/workflows/ci.yml`
+- Blocks any PR that introduces hardcoded arm64 or python3.12 in prod CFN declarations
+- Validates deploy scripts with arm64 references have `ENVIRONMENT_SUFFIX` conditional gating
+
+### Reference
+- Full details: `docs/v3-production-lock.md` in repo
+- COE: DOC-2CACF0D1E7E6
+- Plan: ENC-PLN-019 (DOC-191E709E43C5)
+
+---
+
+## §16 Dispatch-Target Declaration, Agent-Type Selection & Wave Sequencing Output Specification (ENC-FTR-117 / ENC-TSK-I41 / ENC-TSK-I67)
+
+> Promotes the interim brief DOC-359655466119 into permanent agent rules. Applies to EVERY governed session that generates a dispatch prompt, spawns a child session, or sequences a multi-task wave — not only coord-lead. Distinct from agents/dispatch-subagent.md, which governs subagent checkout/approval-gate inheritance; this section governs WHERE a dispatch routes, WHICH agent type runs it, and the required structural OUTPUT FORMAT for any wave or multi-dispatch. Source authority: DOC-BADA8D801099 §3.
+
+### Rule 1 — Dispatch-Target Declaration (required field)
+
+Every dispatch prompt a session generates MUST carry a `Target:` line. No exceptions. A dispatch prompt with no `Target:` line is malformed — regenerate it before handing it to io.
+
+The target resolves to exactly one of:
+
+- `existing-session [ENC-SES-NNN]` — a follow-up routed to a live, named session.
+- `new-session [agent-type label]` — a spawn; name the surface and model (e.g. `Claude Code Desktop Sonnet 4.6`).
+
+**Forward compatibility.** `ENC-SES-NNN` and `ENC-AGT-NNN` are server-allocated identifiers minted by the ENC-FTR-117 `coordination(action=agent.*)` allocation surface — stood up once with value-identical id-spaces across v3-prod and v4 (DOC-05C45B438FC1 build-once gate). Until that surface is live, use a descriptive label (surface + model) for a new-session target; once it is live, a new-session target resolves to the minted `ENC-AGT-NNN`. NEVER invent an `ENC-SES-NNN` or `ENC-AGT-NNN` value — those IDs are server-allocated, never agent-predicted (the §6 ID Boundary Rule applies).
+
+Minimum dispatch-block shape:
+
+    Target: new-session | Claude Code Desktop Sonnet 4.6
+    Assigned work: [task/feature id + one-line description]
+    Rationale: [why this target + agent-type; justify any up-tier]
+    [... remainder of prompt ...]
+
+### Rule 2 — Agent-Type Selection (cheapest sufficient)
+
+When spawning a new session, select the CHEAPEST agent type that can complete the work reliably. NEVER default to the most powerful available model; justify every up-tier choice explicitly on the dispatch block's `Rationale:` line.
+
+The agent-type directory's telemetry is the evidence base for this choice once ENC-FTR-117 populates it. Until then, apply this heuristic:
+
+- Code execution, file edits, deploys, git, well-defined tracker mutations → Claude Code Desktop or Codex terminal, Sonnet 4.6.
+- Architectural reasoning, cross-record synthesis, multi-session orchestration, ambiguous scope requiring judgment → Claude Desktop / claude.ai, Opus-class.
+- Mechanical reads, single lookups, low-stakes informational queries → Haiku-class where the surface offers it.
+- io-dev-admin product-lead terminal (S3 writes, governance files, HANDOFF execution) → a surface constraint, NOT an agent-type choice; always route `GOVERNANCE_SYNC_REQUIRED` blocks here regardless of model.
+
+If two tiers seem plausible, choose the cheaper one, record the assumption under `Rationale:`, and let io override. If the right target is genuinely ambiguous, surface the ambiguity to io rather than guessing.
+
+Model tier tracks task ambiguity and judgment density, not blast radius. High-stakes but well-specified work (a known schema, a defined integration) stays at the cheaper tier; its risk is managed by the reviewer gate, not by a larger model. Reserve up-tiers for genuinely ambiguous or synthesis-heavy work.
+
+> When ENC-FTR-117 reaches `closed`, the `coordination(action=agent.register)` allocation call replaces the manual `Target:` line and directory telemetry supersedes this section's interim heuristic; DOC-359655466119 (the interim brief) is thereafter design-rationale only, not operative.
+
+### Lazy-Load Contract — §16 Required Before Any Dispatch or Wave
+
+Any session generating a dispatch block OR sequencing a wave MUST load §16 of agents.md before emitting. Add to the lazy-load trigger set:
+
+    dispatch/wave: §16
+
+Trigger: `search(action="governance.get", arguments={file_name: "agents.md"})` and read §16 before emitting any dispatch block or wave output. A session that emits a dispatch block or wave without having loaded §16 is non-compliant and its output must be regenerated.
+
+### Wave Sequencing Output Specification (operationalized from DOC-359655466119 via ENC-TSK-I67)
+
+When a session is asked to plan, sequence, or generate more than one dispatch at once — a wave — it produces the structure below, every time. This is the standing output contract; it replaces ad-hoc prose so io never has to re-ask for the structured form. The format evolves here (bump Spec Version on change), and sessions use the current version.
+
+**Spec Version: v1 (2026-06-28).**
+
+A wave output has six parts, in order:
+
+1. **Anchor and governing docs.** State the plan or scope and the orchestration role. List each governing rule-doc in play with a one-line note on what it governs (for example: freeze doc to exception scope; this spec to Target line and tiering; an exception doc to which tasks are prod-authorized).
+2. **Sequencing and Triggers table.** One row per task in the wave, columns: Task (id + short name); Status (live tracker status); Launch (NOW or hold); Trigger (the precise unblock condition — `none`, or a named closure such as "I38 closed" — never left implicit); Surface and Agent (the resolved Target: surface + model, or the product-lead terminal for governance-file work); Parallel Group (a batch label A, B, C grouping rows that can run concurrently).
+3. **Parallelism summary.** Which groups fire concurrently and which single item is on the critical path (the longest dependency chain). State explicitly what blocks nothing and can run anytime. The reader must see at a glance what to launch now versus what is held.
+4. **LAUNCH NOW.** The full, ready-to-fire F3 dispatch blocks for every row whose Trigger is `none` or NOW.
+5. **PRE-STAGED (HOLD).** Full F3 blocks for downstream rows, each tagged `[HOLD -> launch when <trigger>]`, so the next block is ready to fire the instant its trigger fires and the reader never waits on the orchestrator to regenerate.
+6. **Coordination tail.** What the orchestrator drives autonomously as tasks land (verify and route HANDOFFs, stamp feature ACs, complete the plan) and the loop-closure condition.
+
+#### F3 dispatch block — internal format
+
+Each block in parts 4 and 5 carries, in order:
+
+- `Target:` — per Rule 1 (existing-session [ENC-SES-NNN] or new-session [surface + model]).
+- `Assigned work:` — task or feature id plus one line.
+- `Rationale:` — the target and tier justification per Rule 2 (only an up-tier needs defending; cheapest-sufficient is the silent default).
+- `BOOT` — init steps: set PROJECT, fetch the session prompt, connection_health then capture governance_hash then checkout.
+- `CHECKOUT NOTE` — known component or transition_type reconciliation gotchas, where the orchestrator can pre-empt a checkout gate.
+- `ASSIGNED WORK` — the concrete deliverables.
+- constraints — any load-bearing, v4-seam, or isolation requirement.
+- `DEPLOY` — deploy authority + lane, or "no deploy" for docstore/governance work.
+- `DONE WHEN` — explicit closure criteria (ACs evidenced, deploy_evidence stamped, advance to <status>).
+- `Report to io + orchestrator at:` — the checkpoint cadence.
+
+#### Principles
+
+- Every row has an explicit trigger — NOW or a named closure. "What unblocks this" is never left to inference.
+- Parallel groups are read off the dependency graph: rows with satisfied dependencies and no shared-resource contention run concurrently. Name the groups so the reader batches at a glance.
+- Mark exactly one critical path so the reader knows the single item that matters most.
+- Pre-stage downstream blocks (HOLD + trigger) so launching the next step is a copy-paste, not a regeneration request.
+- After reading a wave output, the reader's job is to launch the NOW set and report closures; the orchestrator does the rest.
+
+---

--- a/docs/cutover-context/governance-dictionary-snapshot.json
+++ b/docs/cutover-context/governance-dictionary-snapshot.json
@@ -1,0 +1,8476 @@
+{
+  "version": "2026-08-17.2",
+  "updated_at": "2026-08-17T16:42:00Z",
+  "last_change_summary": "ENC-TSK-O07 / ENC-ISS-621 (ENC-PLN-080, DOC-10A820AC32F2 C4), v4/main ONLY: extracted enceladus_shared.github_app_auth as the single GitHub App JWT + installation-token implementation, replacing per-lambda duplicates. NO new, renamed or removed fields on any governed entity -- an internal refactor plus the same credential-cache hardening already recorded for ENC-TSK-O03, logged here because the migrated backend/lambda/*/lambda_function.py files are schema-affecting paths under the agents.md section 3.11 guard. Public API: GitHubAppConfig, generate_app_jwt, get_installation_token, github_request. Semantics identical to ENC-TSK-O03 on main: re-mint plus single retry on 401/403 behind a 60s token-age floor and never looping; cache expiry taken from the mint response expires_at with a now+3600 fallback and the 300s refresh buffer preserved; structured github_validation_fail line and per-mint logging of expires_at plus the granted permission KEYS only. MIGRATED: checkout_service, deploy_decide, auth_refresh (AuthRefreshFunction also gained SharedLayerArn in 02-compute.yaml, having been the only migrated lambda without the shared layer). DELIBERATELY NOT MIGRATED: github_integration, left byte-identical to its prior state. devops-github-integration runs with ZERO Lambda layers attached, has no CFN resource in this repo, and Gen2 does not vendor the package (_build.yml rsyncs only the function's own srcdir), so adding the import would have produced Runtime.ImportModuleError at cold start -- the ENC-ISS-566 crash-loop class, introduced by a hardening change. Tracked as ENC-ISS-625; the migration must not be retried until the layer attachment is verified live. Consequence: ENC-TSK-O07 acceptance criterion 2 ('all four migrated') is intentionally left unstamped rather than fudged. PREVIOUS: ENC-ISS-558: tracker_list's 'total'/'orphan_tasks' reporting contract fixed. Previously the raw tracker API's page_size/cursor were never forwarded (every call re-fetched the raw API's own default page and re-sliced it locally with _paginate()), so 'total' silently mislabeled one already-capped page as a full-project total (observed total=24 vs a true count >200). Now forwards page_size/cursor to the raw request and marks total_is_lower_bound=true (+ next_cursor) whenever more data remains outstanding, rather than exhausting by default -- tracker_list is the hot session-init read every agent hits at boot, unlike the sibling ENC-ISS-557 fix in sense.py (a once-per-tick background job where bounded exhaustion is cheap). Added opt-in exhaust=true (bounded, mirrors sense.py's guard) for callers needing an exact count. New entity mcp_server.tracker_list documents the contract. Prior: ENC-TSK-N48 did_work/output_count rhythm stanza; ENC-TSK-N45 v4/main port; N51 percolation susceptibility-peak estimator.",
+  "owners": [
+    "enceladus-platform"
+  ],
+  "backward_compatibility_policy": "Additive changes are preferred. Removing enum values or required fields requires explicit migration notes and coordinated rollout.",
+  "entities": {
+    "tracker.dedup_auto_merge": {
+      "description": "ENC-TSK-I09 (Dedup P5): the MECHANICAL arc-walker auto-merge surface for certificate-certified T-HIGH duplicate pairs (DOC-DF651F07D5C2 §P5). Exposed as POST /{project}/dedup-review op=auto-merge in tracker_mutation (tracker:write scope). Unlike op=approve (ENC-TSK-I08, io-Cognito-gated), auto-merge is MECHANICAL — judgment is proved away by the P2 certainty model, so there is no per-merge io gate. io sovereignty is preserved in substance by four rails. Each eligible duplicate is soft-superseded into the cluster's canonical via the reversible ENC-TSK-I07 superseded-by primitive, stamped with the system:arc-walker write_source; every executed merge streams to the io-reviewable audit feed (EventBridge DetailType record.dedup.auto_merged, source enceladus.tracker). Input shape mirrors op=propose: {clusters:[I05 cluster], verdicts:[I06 verdict-with-certificate], precision_lcb_floor?}. Output reports per-cluster per-member actions (auto-merged / would-merge / skipped / failed). Per-member failures (e.g. evidence-orphan 409) are surfaced, never forced.",
+      "fields": {
+        "enable_dedup_auto_merge": {
+          "type": "feature_flag",
+          "definition": "Rail 1 (operational gate). AppConfig boolean flag (env fallback ENABLE_DEDUP_AUTO_MERGE) resolved via enceladus_shared.appconfig_flags.flag(). When OFF (default), op=auto-merge runs in SHADOW / propose-only mode: it evaluates eligibility and reports would-merge results but performs NO writes and emits NO audit events. Per DOC-DF651F07D5C2 §4.3 this flag is enabled by io ONLY after the certificate precision floor has been empirically certified (earned-precision discipline). 'shadow' is reported true in the response while disabled.",
+          "usage_guidance": "Leave OFF until the P2 certificate's 95% precision lower confidence bound has cleared 0.999 on the labeled set. Enabling is an io decision; flipping it back to OFF instantly returns the surface to shadow."
+        },
+        "dedup_auto_merge_kill_switch": {
+          "type": "feature_flag",
+          "definition": "Rail 2 (instant halt). AppConfig boolean flag (env fallback DEDUP_AUTO_MERGE_KILL_SWITCH). Checked FIRST in _handle_dedup_auto_merge, before any eligibility evaluation or write. When truthy the handler returns immediately with {halted:true, kill_switch:true, merged_count:0} — auto-walk is halted instantly regardless of enable_dedup_auto_merge (DOC-DF651F07D5C2 §8).",
+          "usage_guidance": "Global emergency stop. Set truthy to halt all MECHANICAL auto-merge immediately; the enable flag is not consulted while the kill switch is engaged."
+        },
+        "precision_lcb_floor": {
+          "type": "number",
+          "default": 0.999,
+          "definition": "Rail 3 (per-pair certificate). The 95% lower confidence bound on certificate precision that a T-HIGH pair's certificate must clear for a MECHANICAL merge (DOC-DF651F07D5C2 §4.3). Backed by the constant _DEDUP_CERT_PRECISION_LCB_FLOOR=0.999 in tracker_mutation. A caller may RAISE the floor via the request body but the handler REJECTS (HTTP 400) any attempt to lower it below 0.999 — auto-walk is earned by measured precision, not asserted. The certificate is honored only for the DIRECT (canonical, member) verdict, so a member certified only against a neighbor is never pulled in transitively (no chain-drag, §4.4).",
+          "usage_guidance": "Each verdict must carry certificate={passed:true, precision_lcb:<float>} for the (canonical, member) pair. Members lacking a direct passing certificate above the floor are skipped, not merged."
+        },
+        "auto_walk_opt_out_latch": {
+          "type": "behavior",
+          "definition": "Rail 4 (circuit breaker, ENC-FTR-111 / ENC-TSK-H83). A member whose auto_walk_opt_out is latched true is demoted to ATTESTATION and skipped by the arc-walker (the latch blocks ONLY the mechanical walker, not the io-Cognito op=approve path). Additionally, an io walk-back of an auto-merge — un-supersession (DELETE the superseded-by edge) of a record whose prior supersession carried the system:arc-walker write_source — PERMANENTLY latches auto_walk_opt_out=true on the restored record in _revert_supersession (rides the same atomic write), records an [ARC-WALKER][OPT-OUT-LATCH] Artifact-Genesis history entry, and emits the record.auto_walk_opt_out.latched event. The walker can never clear the latch (ENC-FTR-111 AC-2), so the record is never auto-merged again.",
+          "usage_guidance": "No manual action required — the latch fires automatically on an io walk-back. Human-approved (ENC-TSK-I08, provenance=human) supersessions are NOT latched on un-supersession."
+        },
+        "audit_feed": {
+          "type": "event",
+          "definition": "EventBridge audit feed for io review. One event per EXECUTED auto-merge: Source=enceladus.tracker, DetailType=record.dedup.auto_merged, Detail={project_id, record_type, event:'dedup_auto_merged', advanced_by:'system:arc-walker', superseded_id, canonical_id, cluster_id, cosine, calibrated_prob, precision_lcb, reversible:true, merged_at}. No events fire in shadow mode or when the kill switch is engaged.",
+          "usage_guidance": "Subscribe an io-reviewable consumer to DetailType record.dedup.auto_merged to monitor the walk-back rate (the live precision estimate of the certificate, DOC-DF651F07D5C2 §10)."
+        }
+      }
+    },
+    "tracker.task": {
+      "description": "Task tracker records created via MCP and tracker mutation APIs.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "open",
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "coding-updates",
+            "closed",
+            "deployed",
+            "superseded"
+          ],
+          "definition": "Task lifecycle status. ENC-FTR-035 replaced 'deployed' with the deploy-init / deploy-success / coding-updates arcs. 'deployed' is a legacy value retained for backward compatibility during the TSK-704 migration window; new tasks must use the updated arc. ENC-FTR-037 renamed 'pushed' to 'pr' — backward compat read supported; new tasks must use 'pr'. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via the normal advance arc or a direct tracker_set. STATUS_RANK 8 (terminal, satisfies subtask gates). See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicates into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5.",
+          "usage_guidance": "Task transitions MUST use advance_task_status MCP tool (checkout service) — direct tracker_set for task status is rejected with 403 (ENC-FTR-037). Full arc: open -> in-progress -> coding-complete -> committed -> pr -> merged-main -> deploy-init -> deploy-success -> closed. Re-entry: coding-updates -> coding-complete -> committed -> pr -> merged-main. The exact allowed statuses and evidence requirements per gate depend on task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix. Human override: user_initiated=true in transition_evidence (Cognito JWT required; internal API key returns 403). ENC-ISS-266: agent callers must pass active_agent_session_id through the MCP surface — the MCP advance_task_status handler forwards it into the checkout-service /advance POST body where it is required for ownership-match enforcement. Same requirement applies to plan.advance (plan lifecycle). checkout.append_worklog forwards it defensively."
+        },
+        "priority": {
+          "type": "enum",
+          "enum": [
+            "P0",
+            "P1",
+            "P2",
+            "P3"
+          ],
+          "definition": "Task urgency classification."
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "implementation",
+            "investigation",
+            "documentation",
+            "maintenance",
+            "validation"
+          ],
+          "definition": "Task category used for governance and reporting.",
+          "telemetry_eligible": true,
+          "vocabulary_bounded": true
+        },
+        "acceptance_criteria": {
+          "type": "array",
+          "item_type": "object|string",
+          "constraints": {
+            "min_items": 1
+          },
+          "definition": "Concrete conditions to mark task complete. ENC-FTR-048: new tasks store criteria as structured objects with description/evidence/evidence_acceptance fields, matching the feature evidence handshake. Legacy plain-string criteria are backward compatible and do not gate closure.",
+          "usage_guidance": "Required for task creation. When structured criteria are present, task closure is gated on all criteria having evidence_acceptance=true. Use tracker_set_acceptance_evidence to set evidence on individual criteria."
+        },
+        "coordination": {
+          "type": "boolean",
+          "definition": "Whether task is created under coordination workflow."
+        },
+        "transition_type": {
+          "type": "enum",
+          "enum": [
+            "github_pr_deploy",
+            "lambda_deploy",
+            "web_deploy",
+            "code_only",
+            "no_code"
+          ],
+          "default": "github_pr_deploy",
+          "immutable_values": [
+            "no_code",
+            "code_only"
+          ],
+          "definition": "Selects the lifecycle arc for this task (ENC-ISS-092). Determines which target_status values are allowed and what evidence each gate requires. Should be set via tracker.create at record creation OR via tracker.set before checkout_task is called — treated as immutable after checkout begins. ENC-FTR-060 additionally seals no_code and code_only — once any task has a transition_type stamped, post-creation tracker.set transitions involving an immutable value (current or proposed) are rejected. Sealed values can ONLY be set at create time via tracker.create (ENC-TSK-C26 / ENC-ISS-175). lambda_deploy: PR+commit flow with Lambda update evidence at deploy-success (ENC-FTR-041).",
+          "usage_guidance": "Set at create time via tracker.create (preferred for no_code/code_only since those are sealed by ENC-FTR-060), or via tracker.set before checkout for the non-sealed values. Default github_pr_deploy is backward compatible and identical to pre-ENC-ISS-092 behavior. no_code: for tasks with no GitHub repo or non-code work (e.g. infra config, CLI installs, docstore-only documentation). code_only: code was committed/merged to main but no deployment is needed. Do not change a task to or from no_code or code_only after creation — those values are sealed by ENC-FTR-060 because changing them can bypass or corrupt gate semantics (ENC-ISS-145). web_deploy: static/CloudFront deployments that do not produce GitHub Actions job objects. See checkout_service.transition_type_matrix for full gate requirements per type. ENC-TSK-C26: tracker_mutation Lambda now reads transition_type from POST body in _handle_create_record() and persists it to the DynamoDB item; the MCP server forwards it through the _tracker_create() allowlist. Both fixes are required for create-time setting to take effect."
+        },
+        "transition_evidence": {
+          "type": "object",
+          "definition": "Evidence payload required for gated status transitions.",
+          "usage_guidance": "Evidence requirements depend on task.transition_type (ENC-ISS-092). github_pr_deploy (default): committed->commit_sha; merged-main->merge_evidence; deploy-success->deploy_evidence (GH Actions Jobs API); closed->live_validation_evidence string. web_deploy: same as github_pr_deploy except deploy-success->web_deploy_evidence {url, http_status, checked_at}. code_only: same through merged-main; closed->code_on_main_evidence {commit_sha} (GitHub compare API verifies ancestry). no_code: closed->no_code_evidence (non-empty string; no GitHub call). Any revert requires revert_reason. user_initiated (UI human override, Cognito JWT only): user_note required; user_initiated=true flag; all agent token gates bypassed. See checkout_service.transition_type_matrix for full per-gate specs.",
+          "properties": {
+            "deploy_evidence": {
+              "type": "object",
+              "definition": "Structured GitHub Actions Jobs API response object. Source: GET /repos/{owner}/{repo}/actions/jobs/{job_id}. Must be provided verbatim from the API response — do not construct manually.",
+              "required_fields": {
+                "id": {
+                  "type": "integer",
+                  "definition": "GitHub Actions job ID. Unique identifier for the job run."
+                },
+                "name": {
+                  "type": "string",
+                  "definition": "GitHub Actions job name from the Jobs API response. Useful when debugging or surfacing self-correcting deploy evidence errors."
+                },
+                "run_id": {
+                  "type": "integer",
+                  "definition": "GitHub Actions workflow run ID. Parent run that spawned this job."
+                },
+                "head_sha": {
+                  "type": "string",
+                  "constraints": {
+                    "pattern": "^[0-9a-f]{40}$"
+                  },
+                  "definition": "40-character hex commit SHA the job ran against. Should match the task's commit_sha transition_evidence field."
+                },
+                "status": {
+                  "type": "enum",
+                  "enum": [
+                    "completed"
+                  ],
+                  "definition": "GitHub Actions job status. Must be 'completed' — in-progress or queued jobs are rejected."
+                },
+                "conclusion": {
+                  "type": "enum",
+                  "enum": [
+                    "success"
+                  ],
+                  "definition": "GitHub Actions job conclusion. Must be 'success' — failure, cancelled, skipped, and timed_out are all rejected."
+                },
+                "started_at": {
+                  "type": "string",
+                  "constraints": {
+                    "format": "ISO 8601 datetime",
+                    "example": "2026-03-01T18:20:00Z"
+                  },
+                  "definition": "ISO 8601 UTC datetime when the job started. Requires 'T' separator (date-only strings are rejected). Matches tracker timestamp convention."
+                },
+                "completed_at": {
+                  "type": "string",
+                  "constraints": {
+                    "format": "ISO 8601 datetime",
+                    "example": "2026-03-01T18:21:57Z"
+                  },
+                  "definition": "ISO 8601 UTC datetime when the job completed. Requires 'T' separator (date-only strings are rejected). Must be present and valid even if equal to started_at."
+                }
+              },
+              "usage_guidance": "Call GET /repos/{owner}/{repo}/actions/jobs/{job_id} and pass the response object as deploy_evidence. The Lambda validates all eight required fields, asserts status=completed and conclusion=success, and validates started_at/completed_at as ISO 8601 datetimes. The validated payload is stored as a JSON string on the task record. ENC-TSK-726."
+            },
+            "commit_approval_id": {
+              "type": "string",
+              "constraints": {
+                "pattern": "^CAI-[0-9a-f]{32}$"
+              },
+              "definition": "Commit Approval ID (ENC-FTR-037). Issued by checkout service when task advances to coding-complete. Format: CAI-{uuid4_hex}. Stored on task record; cleared on deploy-success. Allows agent to begin commit operation.",
+              "usage_guidance": "Returned by advance_task_status(target_status=coding-complete). Pass to agent as receipt that coding-complete gate was passed. Not required as input to any subsequent call -- checkout service reads it from the task record."
+            },
+            "commit_complete_id": {
+              "type": "string",
+              "constraints": {
+                "pattern": "^CCI-[0-9a-f]{32}$"
+              },
+              "definition": "Commit Complete ID (ENC-FTR-037). Issued by checkout service when task advances to committed (after commit_sha is validated against GitHub API). Format: CCI-{uuid4_hex}. Stored on task record; cleared on deploy-success. Required in PR body for GitHub PR Commit Gate.",
+              "usage_guidance": "Returned by advance_task_status(target_status=committed, transition_evidence={commit_sha: <40-char-hex>}). Must be included verbatim in the PR body (pattern CCI-[0-9a-f]{32}) before opening the PR. GitHub Actions PR Commit Gate validates it via GET /api/v1/checkout/validate/commit-complete/{cci_id}."
+            },
+            "web_deploy_evidence": {
+              "type": "object",
+              "definition": "Deploy evidence for web_deploy tasks (ENC-ISS-092). Used for static/CloudFront deployments that do not produce GitHub Actions job objects. Validated by checkout service at deploy-success gate.",
+              "required_fields": {
+                "url": {
+                  "type": "string",
+                  "constraints": {
+                    "pattern": "^https://"
+                  },
+                  "definition": "HTTPS URL verified after deployment. Must start with https://."
+                },
+                "http_status": {
+                  "type": "integer",
+                  "constraints": {
+                    "enum": [
+                      200
+                    ]
+                  },
+                  "definition": "HTTP status code from the verification request. Must equal 200."
+                },
+                "checked_at": {
+                  "type": "string",
+                  "constraints": {
+                    "format": "ISO 8601 datetime with T separator",
+                    "example": "2026-03-04T07:00:00Z"
+                  },
+                  "definition": "UTC datetime when the URL was verified. Requires T separator (date-only strings rejected)."
+                }
+              },
+              "optional_fields": {
+                "cloudfront_invalidation_id": {
+                  "type": "string",
+                  "definition": "CloudFront invalidation ID if a cache invalidation was triggered (e.g. I-XXXXXXXXXXXXXXXX)."
+                },
+                "response_time_ms": {
+                  "type": "integer",
+                  "definition": "HTTP response time in milliseconds from the verification request."
+                }
+              },
+              "usage_guidance": "Provide as transition_evidence.web_deploy_evidence when calling advance_task_status(target_status=deploy-success) for a web_deploy task. Curl the deployed URL, confirm 200 OK, and record the result. Example: {url: 'https://jreese.net/', http_status: 200, checked_at: '2026-03-04T07:00:00Z', cloudfront_invalidation_id: 'I-XXXX'}."
+            },
+            "code_on_main_evidence": {
+              "type": "object",
+              "definition": "Evidence that code was merged to main for code_only tasks (ENC-ISS-092). Used at the closed gate (no deploy stages). Validated by checkout service via GitHub compare API.",
+              "required_fields": {
+                "commit_sha": {
+                  "type": "string",
+                  "constraints": {
+                    "pattern": "^[0-9a-f]{40}$"
+                  },
+                  "definition": "40-character hex commit SHA to verify. Checkout service calls GET /repos/{owner}/{repo}/compare/{commit_sha}...main and verifies the commit is behind or identical to main (i.e. an ancestor of main)."
+                },
+                "github_verified": {
+                  "type": "boolean",
+                  "definition": "Set to true by the checkout service after GitHub compare API confirms the commit is on main. Do not set manually — the service stamps this field."
+                }
+              },
+              "usage_guidance": "Provide as transition_evidence.code_on_main_evidence when calling advance_task_status(target_status=closed) for a code_only task. Only commit_sha is required as input; github_verified is stamped by the service. The commit must already be merged to the main branch before calling this gate."
+            },
+            "no_code_evidence": {
+              "type": "string",
+              "constraints": {
+                "min_length": 1
+              },
+              "definition": "Human-readable verification note for no_code tasks (ENC-ISS-092). Used at the closed gate. No GitHub API validation performed — the string is stored as-is for audit traceability.",
+              "usage_guidance": "Provide as transition_evidence.no_code_evidence when calling advance_task_status(target_status=closed) for a no_code task. Describe what was done and how it was verified. Example: 'Claude Code CLI installed on jreesewebops EC2 instance i-03aa86d6ce037e5aa. Verified via SSH: claude --version working.'"
+            },
+            "user_initiated": {
+              "type": "boolean",
+              "definition": "When true, indicates a human operator is performing this transition via the UI (ENC-ISS-092). Bypasses all agent checkout gates (ENC-FTR-037), CAI/CCI token requirements, and GitHub validation. Requires Cognito session authentication — rejected with HTTP 403 if internal API key is used.",
+              "usage_guidance": "Set by the UI only (Submit or Submit + Close button in LifecycleActions). Must be paired with user_note. The tracker_mutation Lambda stamps initiated_by (Cognito username) and initiated_at onto the stored evidence for audit traceability. Borrow-and-restore: if the task is checked out by an agent, the human override temporarily takes ownership, makes the change, then restores the agent's checkout (or releases on close). Cannot be used via MCP/agent paths."
+            },
+            "user_note": {
+              "type": "string",
+              "constraints": {
+                "min_length": 1
+              },
+              "definition": "Human note required for user_initiated transitions (ENC-ISS-092). Describes why the status was changed manually by a human operator.",
+              "usage_guidance": "Required when user_initiated=true. Stored in transition_evidence and recorded as a [USER-INITIATED] worklog entry with the Cognito username as provider."
+            },
+            "merge_evidence": {
+              "type": "string_or_object",
+              "definition": "Evidence of PR merge for merged-main transitions. May be a free-text string (direct PATCH from UI/legacy) or a structured dict when provided by the checkout service (keys typically include pr_id, merged_at, owner, repo). The Lambda serializes dict values as JSON before storing. ENC-ISS-097.",
+              "usage_guidance": "For checkout-service-routed transitions (advance_task_status), pr_id and merged_at are passed as top-level body fields — merge_evidence is not required and may be omitted. For legacy direct PATCH callers, provide a non-empty string describing merge confirmation. Dict-type values are accepted and stored as a JSON string."
+            }
+          }
+        },
+        "components": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "List of component_ids from the component registry that this task modifies (ENC-FTR-041). The checkout service enforces that task.transition_type is at least as strict as the most restrictive component's transition_type. Required for agent-initiated advances; human PWA advances bypass this check (user_initiated=true Cognito path).",
+          "usage_guidance": "ENC-TSK-F76 / ENC-ISS-289: tracker.create now accepts components at create time (MCP server uses denylist-driven passthrough; tracker_mutation persists components from the POST body). Canonical path is to include components in the tracker.create payload alongside title/category/priority/transition_type/acceptance_criteria. Post-create tracker_set is no longer required unless adding or changing components after creation. Format: [\"comp-checkout-service\", \"comp-jreese-pwa\"]. If not set by the time checkout.advance runs, agent advances are blocked (ENC-FTR-041 enforcement).",
+          "telemetry_eligible": true,
+          "vocabulary_bounded": true
+        },
+        "parent": {
+          "type": "string",
+          "definition": "Task ID of the parent task in a plan-derived task hierarchy (ENC-FTR-040). Set via tracker_set immediately after child task creation during plan capture. Format: PROJECT-TSK-NNN. Not enforced by the tracker API — any string is accepted; interpretation is by convention.",
+          "usage_guidance": "tracker_set(field='parent', value='ENC-TSK-NNN'). Set on phase tasks (parent = plan parent) and step tasks (parent = phase task). Provides upward navigation in the task tree. See agents/plan-capture.md for the full plan capture protocol."
+        },
+        "subtask_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Child task IDs for plan parent tasks (ENC-FTR-040). Set on the parent task after all child tasks are created during plan capture. Provides forward navigation from parent to children. ENC-ISS-106: The checkout service enforces that parent tasks cannot advance lifecycle stages (coding-complete onward) unless all direct children listed here have reached at least that stage. Children at 'closed' satisfy any stage check. ENC-ISS-140: append-only once task leaves open status or has been checked out — tracker mutation rejects removal attempts to prevent subtask gate bypass.",
+          "usage_guidance": "tracker_set(field='subtask_ids', value=['ENC-TSK-NNN', ...]) on the parent task. ENC-ISS-106: if subtask_ids is non-empty, the checkout service blocks advancement to coding-complete or beyond until every listed child is at or past that status. Not-found children also block advancement. ENC-ISS-140: once set on a non-open task (or one that has been checked out), entries cannot be removed — only appended. To bypass: use the PWA user_initiated path."
+        },
+        "related_task_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related tasks. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_task_ids', value=['ENC-TSK-NNN', ...]). Accepts list or JSON-stringified list. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target task record's related_task_ids in the same request.",
+          "patch_coercion": "ENC-ISS-059: The Lambda coerces JSON-stringified arrays (e.g. '[\"ENC-TSK-100\"]') and bare ID strings to proper DynamoDB List type. Prevents storage as DynamoDB S type instead of L type.",
+          "inverse_of": "tracker.task.related_task_ids"
+        },
+        "related_issue_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related issues. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_issue_ids', value=['ENC-ISS-NNN', ...]). Accepts list or JSON-stringified list. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target issue record's related_task_ids in the same request.",
+          "patch_coercion": "ENC-ISS-059: The Lambda coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.issue.related_task_ids"
+        },
+        "related_feature_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related features. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_feature_ids', value=['ENC-FTR-NNN', ...]). Accepts list or JSON-stringified list. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target feature record's related_task_ids in the same request.",
+          "patch_coercion": "ENC-ISS-059: The Lambda coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.feature.related_task_ids"
+        },
+        "deploy_target": {
+          "type": "enum",
+          "enum": [
+            "prod",
+            "gamma",
+            "undeclared"
+          ],
+          "definition": "Deploy target for this task. 'prod' targets v3/main, 'gamma' targets v4/gamma stack, 'undeclared' (default) awaits labeling."
+        },
+        "closed_count": {
+          "type": "integer",
+          "default": 0,
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the task lifecycle handler on every transition to status=closed. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set closed_count (ID boundary / write_source guard).",
+          "increment_trigger": "tracker_mutation Lambda task lifecycle handler on every transition to status=closed. Atomic via UpdateExpression 'ADD closed_count :one' with :one=1.",
+          "gate_use": "DESIGNS/DESIGNED_BY edge immutability trigger (edge locks when closed_count >= 1) and advance-gate for component.advance approved->designed (gate requires DESIGNED_BY task closed_count >= 1). Preferred mechanism over history-table queries per DD-4 (natural governance telemetry, zero query cost at gate evaluation).",
+          "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without closed_count are treated as closed_count=0 for gate evaluation (fail-closed on the DESIGNS gate until a ->closed transition lands)."
+        },
+        "checkout_count": {
+          "type": "integer",
+          "default": 0,
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §5: server-side counter incremented by the checkout service on every successful checkout.task call. Atomic via DynamoDB UpdateExpression ADD. Never agent-writable or io-writable — tracker_mutation rejects PATCH requests that attempt to set checkout_count.",
+          "increment_trigger": "checkout_service._handle_checkout on every successful checkout.task invocation. Atomic via UpdateExpression 'ADD checkout_count :one' with :one=1 after the checkout state transition and the active_agent_session_id stamping succeed.",
+          "gate_use": "IMPLEMENTS/IMPLEMENTED_BY edge immutability trigger (edge locks when checkout_count >= 1) and advance-gate for component.advance designed->development (gate requires IMPLEMENTS task checkout_count >= 1). Checkout proves implementation started — this is the first half of the IMPLEMENTS evidence thread; deploy-success on the same task completes it (DD-1).",
+          "usage_guidance": "Read-only for all external callers. Never supply in POST/PATCH bodies; attempting to do so is rejected. Initial default 0 is stamped at record creation. Existing pre-FTR-076-v2 task records without checkout_count are treated as checkout_count=0 for gate evaluation (fail-closed on the IMPLEMENTS gate until a successful checkout.task lands)."
+        },
+        "auto_walk_opt_out": {
+          "type": "boolean",
+          "default": false,
+          "definition": "ENC-FTR-111 / ENC-TSK-H83 (Universal Arc-Walker Phase 1 circuit breaker). When true, the Universal Arc-Walker MUST NOT auto-advance this record across any lifecycle gate. Default false. The tracker_mutation write path auto-latches this true on any human-initiated non-forward transition (a regression / backward status move, or -- for tasks -- a coding-updates re-entry) and emits an Artifact-Genesis audit record (a history entry plus an EventBridge 'record.auto_walk_opt_out.latched' event). The arc-walker can never clear it (ENC-FTR-111 AC-2).",
+          "usage_guidance": "Settable and clearable by humans or agents via execute tracker.set(field='auto_walk_opt_out', value=true|false); a 'true'/'false' string is coerced to a real DynamoDB BOOL. Auto-latched true by the write path on human-initiated non-forward transitions; no manual action required. The arc-walker (write_source provider/channel 'system:arc-walker') is forbidden from clearing it: tracker_mutation rejects walker-origin attempts to set it false with HTTP 403. Cleared only by an explicit non-walker tracker.set to false."
+        },
+        "superseded_by": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
+        },
+        "superseded_at": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-I07: ISO8601 UTC timestamp when this record was superseded. Server-written by the supersession op; cleared on un-supersession. Read-only to clients.",
+          "usage_guidance": "Read-only. Present only while status=superseded."
+        },
+        "pre_supersession_status": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07: the record's lifecycle status immediately before supersession, captured so un-supersession can restore it (reversibility). Server-written; read-only to clients.",
+          "usage_guidance": "Read-only. The reversible un-supersession op restores this status and the record's retrieval/triage eligibility."
+        },
+        "superseded_migrated_edges": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07: list of edges migrated from this record onto the canonical (superseding) record during supersession. Each entry: {rel_type, other_id, created_on_canonical(bool)}. Drives idempotent re-pointing (no duplicate edges on the canonical) and exact rollback on un-supersession. Server-written; read-only to clients.",
+          "usage_guidance": "Read-only. Populated only when status=superseded."
+        },
+        "related_document_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "DOC-* document IDs that declare this record in their related_items.",
+          "usage_guidance": "Server-written only. ENC-TSK-L07 (B65 AC-5/AC-7): document_api's PUT/PATCH related_items handler atomically mirrors the document's own ID here (contains-check conditional append) whenever the document names this record in related_items. Not intended for direct tracker_set writes -- edit related_items on the document instead.",
+          "inverse_of": "docstore.document.related_items"
+        }
+      }
+    },
+    "tracker.issue": {
+      "description": "Issue tracker records for bug/risk/debt/security/performance.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "open",
+            "in-progress",
+            "closed",
+            "superseded"
+          ],
+          "definition": "Issue lifecycle status. ENC-TSK-I07 (Dedup P3): 'superseded' is an alternate TERMINAL state set ONLY by the supersession operation (soft, reversible duplicate collapse via POST/DELETE of a superseded-by typed edge between same-type same-project records) — never via a direct tracker_set. Retires the issue from active retrieval/triage eligibility; reversible via un-supersession. See tracker.relationship superseded-by and DOC-DF651F07D5C2 §7. ENC-TSK-I08 (Dedup P4): the io-facing governed entry point is POST /{project}/dedup-review op=approve, io-Cognito-gated (the internal-key/agent path is rejected, never self-authorizes); it supersedes io-approved T-MID (whole-cluster plan) or T-LOW (whole-or-per-record) duplicate issues into the canonical. Cross-type/cross-project are never surfaced; ENC-TSK-I09 (Dedup P5): T-HIGH (certificate-certified) pairs are now auto-superseded MECHANICALLY by the arc-walker via op=auto-merge — flag-gated (enable_dedup_auto_merge; dark/shadow until certified), kill-switch-halted (dedup_auto_merge_kill_switch), opt-out-latch-skipped (auto_walk_opt_out demotes to ATTESTATION), and gated per-pair on a passing certificate with precision LCB >= 0.999 against the CHOSEN canonical (no transitive chain-drag); each merge streams to the record.dedup.auto_merged audit feed and an io walk-back permanently latches auto_walk_opt_out. See tracker.dedup_auto_merge and DOC-DF651F07D5C2 sec 5/8/P5."
+        },
+        "priority": {
+          "type": "enum",
+          "enum": [
+            "P0",
+            "P1",
+            "P2",
+            "P3"
+          ]
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "bug",
+            "debt",
+            "risk",
+            "security",
+            "performance"
+          ]
+        },
+        "evidence": {
+          "type": "array",
+          "item_type": "object",
+          "constraints": {
+            "min_items": 1,
+            "required_keys": [
+              "description",
+              "steps_to_duplicate"
+            ]
+          },
+          "usage_guidance": "Issue creation requires at least one evidence object. Each entry must include 'description' (string) and 'steps_to_duplicate' (array of strings). Optional fields: 'observed_by', 'timestamp'.",
+          "patch_coercion": "ENC-TSK-783: When updating evidence via tracker_set (PATCH), the Lambda will coerce a JSON-stringified array to the proper DynamoDB List type. Raw string values that are not valid JSON arrays are rejected with HTTP 400. This prevents the 'evidence.map is not a function' PWA crash (ENC-ISS-099) caused by evidence stored as DynamoDB S type instead of L type."
+        },
+        "related_task_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related tasks. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.task.related_issue_ids",
+          "usage_guidance": "IDs of related tasks. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target task record's related_issue_ids in the same request."
+        },
+        "related_issue_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related issues. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.issue.related_issue_ids",
+          "usage_guidance": "IDs of related issues. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target issue record's related_issue_ids in the same request."
+        },
+        "related_feature_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related features. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.feature.related_issue_ids",
+          "usage_guidance": "IDs of related features. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target feature record's related_issue_ids in the same request."
+        },
+        "hypothesis": {
+          "type": "string",
+          "definition": "Root cause hypothesis for the issue. Required at creation if technical_notes not provided (ENC-TSK-805).",
+          "usage_guidance": "Provide a testable hypothesis about what is causing the issue."
+        },
+        "technical_notes": {
+          "type": "string",
+          "definition": "Technical context for investigation. Required at creation if hypothesis not provided (ENC-TSK-805).",
+          "usage_guidance": "Include investigation context — what was tried, what was observed, relevant stack traces or log lines."
+        },
+        "location_hint": {
+          "type": "string",
+          "definition": "Suspected code paths for investigation. Required at issue creation (ENC-TSK-805).",
+          "usage_guidance": "Point to specific files, functions, or domains where the root cause likely lives. Example: 'Check routes.tsx auth wrapper and authState.tsx session check'.",
+          "telemetry_eligible": true
+        },
+        "auto_walk_opt_out": {
+          "type": "boolean",
+          "default": false,
+          "definition": "ENC-FTR-111 / ENC-TSK-H83 (Universal Arc-Walker Phase 1 circuit breaker). When true, the Universal Arc-Walker MUST NOT auto-advance this record across any lifecycle gate. Default false. The tracker_mutation write path auto-latches this true on any human-initiated non-forward transition (a regression / backward status move, or -- for tasks -- a coding-updates re-entry) and emits an Artifact-Genesis audit record (a history entry plus an EventBridge 'record.auto_walk_opt_out.latched' event). The arc-walker can never clear it (ENC-FTR-111 AC-2).",
+          "usage_guidance": "Settable and clearable by humans or agents via execute tracker.set(field='auto_walk_opt_out', value=true|false); a 'true'/'false' string is coerced to a real DynamoDB BOOL. Auto-latched true by the write path on human-initiated non-forward transitions; no manual action required. The arc-walker (write_source provider/channel 'system:arc-walker') is forbidden from clearing it: tracker_mutation rejects walker-origin attempts to set it false with HTTP 403. Cleared only by an explicit non-walker tracker.set to false."
+        },
+        "superseded_by": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07 (Dedup P3 supersession primitive). Canonical record id (same type, same project) that supersedes this record. Set by the supersession operation when a superseded-by typed edge is created; cleared on un-supersession. Read-only to clients — tracker_mutation rejects PATCH attempts to set it (ID boundary / write_source guard). See tracker.relationship.supersession_operation and DOC-DF651F07D5C2 §7.",
+          "usage_guidance": "Read-only. Populated only when status=superseded. Pairs with superseded_at / pre_supersession_status / superseded_migrated_edges."
+        },
+        "superseded_at": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-I07: ISO8601 UTC timestamp when this record was superseded. Server-written by the supersession op; cleared on un-supersession. Read-only to clients.",
+          "usage_guidance": "Read-only. Present only while status=superseded."
+        },
+        "pre_supersession_status": {
+          "type": "string",
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07: the record's lifecycle status immediately before supersession, captured so un-supersession can restore it (reversibility). Server-written; read-only to clients.",
+          "usage_guidance": "Read-only. The reversible un-supersession op restores this status and the record's retrieval/triage eligibility."
+        },
+        "superseded_migrated_edges": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "required": false,
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-I07: list of edges migrated from this record onto the canonical (superseding) record during supersession. Each entry: {rel_type, other_id, created_on_canonical(bool)}. Drives idempotent re-pointing (no duplicate edges on the canonical) and exact rollback on un-supersession. Server-written; read-only to clients.",
+          "usage_guidance": "Read-only. Populated only when status=superseded."
+        },
+        "related_document_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "DOC-* document IDs that declare this record in their related_items.",
+          "usage_guidance": "Server-written only. ENC-TSK-L07 (B65 AC-5/AC-7): document_api's PUT/PATCH related_items handler atomically mirrors the document's own ID here (contains-check conditional append) whenever the document names this record in related_items. Not intended for direct tracker_set writes -- edit related_items on the document instead.",
+          "inverse_of": "docstore.document.related_items"
+        }
+      }
+    },
+    "tracker.feature": {
+      "description": "Feature tracker records with governed completion handshake.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "planned",
+            "in-progress",
+            "completed",
+            "production",
+            "deprecated"
+          ]
+        },
+        "priority": {
+          "type": "enum",
+          "enum": [
+            "P0",
+            "P1",
+            "P2",
+            "P3"
+          ]
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "epic",
+            "capability",
+            "enhancement",
+            "infrastructure"
+          ]
+        },
+        "user_story": {
+          "type": "string",
+          "constraints": {
+            "min_length": 10
+          },
+          "usage_guidance": "Must follow: As a [USER/SYSTEM] I need/want ... so that ..."
+        },
+        "acceptance_criteria": {
+          "type": "array",
+          "item_type": "object|string",
+          "constraints": {
+            "min_items": 1
+          },
+          "usage_guidance": "Feature completion requires accepted evidence for all criteria."
+        },
+        "related_task_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related tasks. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.task.related_feature_ids",
+          "usage_guidance": "IDs of related tasks. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target task record's related_feature_ids in the same request."
+        },
+        "related_issue_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related issues. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.issue.related_feature_ids",
+          "usage_guidance": "IDs of related issues. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target issue record's related_feature_ids in the same request."
+        },
+        "related_feature_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related features. Cross-references for traceability.",
+          "patch_coercion": "ENC-ISS-059: Coerces JSON-stringified arrays and bare ID strings to proper DynamoDB List type.",
+          "inverse_of": "tracker.feature.related_feature_ids",
+          "usage_guidance": "IDs of related features. Cross-references for traceability. ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target feature record's related_feature_ids in the same request."
+        },
+        "ogtm_required": {
+          "type": "boolean",
+          "definition": "Set to true for any feature introducing a new relational field or edge type. Feature may not advance past planned status until ogtm_compliance_evidence is populated."
+        },
+        "target_generation": {
+          "type": "string",
+          "definition": "ENC-GEN-NNN generation this feature targets for delivery."
+        },
+        "promoted_at": {
+          "type": "string",
+          "definition": "ISO 8601 timestamp when this feature was promoted to production via generation cutover."
+        },
+        "chapter_promotion_id": {
+          "type": "string",
+          "definition": "Record ID of the promotion event that promoted this feature."
+        },
+        "auto_walk_opt_out": {
+          "type": "boolean",
+          "default": false,
+          "definition": "ENC-FTR-111 / ENC-TSK-H83 (Universal Arc-Walker Phase 1 circuit breaker). When true, the Universal Arc-Walker MUST NOT auto-advance this record across any lifecycle gate. Default false. The tracker_mutation write path auto-latches this true on any human-initiated non-forward transition (a regression / backward status move, or -- for tasks -- a coding-updates re-entry) and emits an Artifact-Genesis audit record (a history entry plus an EventBridge 'record.auto_walk_opt_out.latched' event). The arc-walker can never clear it (ENC-FTR-111 AC-2).",
+          "usage_guidance": "Settable and clearable by humans or agents via execute tracker.set(field='auto_walk_opt_out', value=true|false); a 'true'/'false' string is coerced to a real DynamoDB BOOL. Auto-latched true by the write path on human-initiated non-forward transitions; no manual action required. The arc-walker (write_source provider/channel 'system:arc-walker') is forbidden from clearing it: tracker_mutation rejects walker-origin attempts to set it false with HTTP 403. Cleared only by an explicit non-walker tracker.set to false."
+        },
+        "related_document_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "DOC-* document IDs that declare this record in their related_items.",
+          "usage_guidance": "Server-written only. ENC-TSK-L07 (B65 AC-5/AC-7): document_api's PUT/PATCH related_items handler atomically mirrors the document's own ID here (contains-check conditional append) whenever the document names this record in related_items. Not intended for direct tracker_set writes -- edit related_items on the document instead.",
+          "inverse_of": "docstore.document.related_items"
+        }
+      }
+    },
+    "tracker.feature.composition": {
+      "description": "ENC-TSK-M65: Composition declarations for tracker.feature as a composite entity. Documents how features aggregate implementing task records.",
+      "fields": {
+        "child_record_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "enum": [
+            "task"
+          ],
+          "definition": "Record type a feature composes: tasks. (Issues cross-reference via related_issue_ids but that is a peer traceability link, not a composition/child relationship.)"
+        },
+        "attachment_mechanism": {
+          "type": "string",
+          "definition": "Composition is via bidirectional cross-reference arrays, not a governed execute-action set like plan.objectives_set: tracker.feature.related_task_ids <-> tracker.task.related_feature_ids. Per ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7), tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID on one side onto the inverse field on the target record in the same request, keeping both sides in sync. Set via tracker_set(field='related_task_ids'|'related_feature_ids', ...); accepts a list or JSON-stringified list (ENC-ISS-059 coercion).",
+          "usage_guidance": "tracker_set(field='related_task_ids', value=['ENC-TSK-NNN', ...]) on the feature, or the inverse on the task -- either write mirrors to both records."
+        },
+        "cardinality": {
+          "type": "string",
+          "definition": "Many-to-many (N:M). A task may be related to multiple features and a feature may relate to multiple tasks; there is no exclusive-ownership constraint."
+        }
+      }
+    },
+    "api.error_envelope": {
+      "description": "Common error response contract emitted by checkout_service, tracker_mutation, coordination_api, github_integration, deploy_decide, and deploy_orchestrator, and preserved by the MCP server normalization layer (ENC-TSK-840, extended by ENC-TSK-D56; ENC-TSK-H50 / ENC-ISS-142 gate #2 fixed _normalize_legacy_error_payload to carry failure_classification + recommended_next_actions and any other envelope-nested keys across the MCP boundary instead of flattening to {code,message,retryable,details}). The top-level legacy error string remains for backward compatibility while self-correcting guidance lives in error_envelope.details. Post-D56: every error must embed enough context for an agent to self-correct on the next attempt without additional tool calls.",
+      "fields": {
+        "code": {
+          "type": "string",
+          "definition": "Stable machine-readable error code such as INVALID_INPUT, CONFLICT, PERMISSION_DENIED, or NOT_FOUND."
+        },
+        "message": {
+          "type": "string",
+          "definition": "Human-readable error summary retained at both error_envelope.message and top-level error."
+        },
+        "retryable": {
+          "type": "boolean",
+          "definition": "Whether the caller can retry unchanged input or must first correct the request."
+        },
+        "failure_classification": {
+          "type": "enum",
+          "enum": [
+            "transient",
+            "deterministic-governance",
+            "external-dependency",
+            "human-override-required"
+          ],
+          "definition": "ENC-TSK-H49 / ENC-ISS-142: machine-readable category of a blocked-transition failure so agents route to the correct Escalation Protocol response instead of guessing. Derived in checkout_service._failure_classification from the error code (with an HTTP status-family fallback) or an explicit per-call override. transient = retry with backoff; deterministic-governance = correct governed inputs then escalate L2; external-dependency = upstream (GitHub/Cognito) retry; human-override-required = needs io / Cognito / PWA action. Present on every checkout_service error envelope; other emitters may adopt it incrementally."
+        },
+        "recommended_next_actions": {
+          "type": "array",
+          "definition": "ENC-TSK-H49 / ENC-ISS-142: ordered operator-facing next actions keyed to failure_classification, consumed by the agents.md Escalation Protocol. checkout_service supplies a default action list per classification (checkout_service._RECOMMENDED_NEXT_ACTIONS)."
+        },
+        "details": {
+          "type": "object",
+          "definition": "Self-correcting context for the next attempt. Standard keys: required_fields (list), allowed_values (dict), evidence_schema (dict), strictness_rank (list), example_fix (dict with tool+arguments). Post-D56 additions: allowed_plan_transitions (dict), plan_terminal_statuses (list), token_type/token_purpose/prerequisite_call (CAI/CCI), lesson_gate_requirements (dict), ogtm_compliance_template (dict with 4 requirements + evidence template), dpl_record_id_format/dpl_ddb_key_schema/dpl_label_conventions (GMF/DPL), governed_rules (list of rule strings)."
+        }
+      }
+    },
+    "document_api.id_boundary_enforcement": {
+      "description": "Server-side enforcement of the ID Boundary Rule (ENC-TSK-B99) at the document_api create surface (ENC-TSK-D36 / ENC-FTR-069 AC3+AC4). _handle_put rejects any request carrying a top-level document_id, item_id, or record_id before any other validation runs, returning HTTP 400 with error_envelope.code='ID_BOUNDARY_VIOLATION' and a self-correcting details block. Mirrors the tracker_mutation forbidden-field guard but enriched with the ENC-FTR-069 AC3 self-correcting envelope shape so any violating agent is re-educated by the response itself rather than silently accepted.",
+      "fields": {
+        "offending_field": {
+          "type": "enum",
+          "enum": [
+            "document_id",
+            "item_id",
+            "record_id"
+          ],
+          "definition": "Which forbidden field name the caller supplied. document_id is the native document identifier; item_id and record_id are guarded for defense-in-depth against agents carrying conventions from the tracker surface."
+        },
+        "offending_value": {
+          "type": "string",
+          "definition": "The verbatim value the caller supplied for the offending field. Echoed back so the caller sees exactly what was rejected without needing to log their own request body."
+        },
+        "record_id_schema": {
+          "type": "object",
+          "definition": "Structured description of the canonical document_id format (DOC-{12_hex_upper}), an example, the generator expression, and the authoritative producer (devops-document-api Lambda)."
+        },
+        "rule_citation": {
+          "type": "object",
+          "definition": "Pointer to the governing rule. Shape: {rule_id: 'ENC-TSK-B99', text: <one-line rule statement>}. Lets a re-educating agent follow the canonical rule rather than guessing."
+        },
+        "example_fix": {
+          "type": "object",
+          "definition": "Fully-formed documents.put call showing the correct minimal create payload. Shape: {tool: 'documents.put', arguments: {...}, note: <explanation>}. Omits document_id/item_id/record_id to demonstrate the correct boundary-respecting shape."
+        },
+        "agents_md_section": {
+          "type": "string",
+          "definition": "Pointer into the live agents.md governance file naming the section that documents the ID Boundary Rule. Current value: 'agents.md §6 Tracker Operations — ID Boundary Rule'."
+        }
+      }
+    },
+    "document_api.error_envelope": {
+      "description": "Self-correcting error envelope emitted by document_api when documents.put rejects a request due to missing subtype-specific required fields (ENC-TSK-E64, ENC-ISS-158, ENC-PLN-030). Extends the ENC-TSK-D56 pattern to the document surface: every handoff/coe/wave validation failure packs enough context for an agent to self-correct on the next call without additional lookups. Returned as top-level error_envelope.details via the shared api.error_envelope contract.",
+      "fields": {
+        "required_fields": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Field names the caller must include to retry successfully. Example: [\"source_record_id\"] for handoff."
+        },
+        "optional_fields": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Field names that enrich but are not strictly required for the subtype. Example: [\"prerequisite_state\", \"verification_criteria\", \"action_checklist\", \"expires_at\"] for handoff."
+        },
+        "dictionary_entity": {
+          "type": "string",
+          "definition": "Reference to the governance dictionary entity defining the subtype schema. Expected values: document.handoff, document.coe, document.wave."
+        },
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "handoff",
+            "coe",
+            "wave"
+          ],
+          "definition": "The subtype that triggered the validation failure. Lets the agent select the correct self-correction strategy."
+        },
+        "example_fix": {
+          "type": "object",
+          "definition": "Fully-formed documents.put call showing the correct payload for this subtype. Shape: {tool: \"documents.put\", arguments: {...}} with project_id, title, content, document_subtype, and all subtype-required fields populated with placeholder values."
+        },
+        "edge_density_requirements": {
+          "type": "object",
+          "definition": "Only present for document_subtype=coe. Documents the minimum related_items composition: feature (ENC-FTR-*), lesson (ENC-LSN-*), issue (ENC-ISS-*) — each must have at least one entry."
+        },
+        "format_constraint": {
+          "type": "string",
+          "definition": "Only present for fields with pattern constraints. Plain-English rule describing what the value must contain. Example: 'plan_anchor_id must contain \\'-PLN-\\' substring' for wave docs."
+        }
+      }
+    },
+    "document.create": {
+      "description": "Agent document create payload fields.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^[a-z0-9_-]+$"
+          }
+        },
+        "title": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "max_length": 500
+          }
+        },
+        "content": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "max_bytes": 1048576
+          }
+        },
+        "file_name": {
+          "type": "string",
+          "constraints": {
+            "extensions": [
+              ".md",
+              ".markdown"
+            ]
+          }
+        },
+        "keywords": {
+          "type": "array",
+          "item_type": "string",
+          "constraints": {
+            "max_items": 50
+          }
+        },
+        "related_items": {
+          "type": "array",
+          "item_type": "string",
+          "constraints": {
+            "max_items": 100
+          }
+        }
+      }
+    },
+    "document.handoff": {
+      "description": "Handoff document subtype schema (ENC-FTR-061). Structured inter-session continuity documents with lifecycle semantics. Created via document_api PUT with document_subtype=handoff. Status transitions: pending->claimed->completed, any->stale.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "doc",
+            "handoff",
+            "coe",
+            "wave",
+            "idea",
+            "context-node",
+            "skill"
+          ],
+          "legacy_readable_only": [
+            "general",
+            "blueprint",
+            "narrative",
+            "session-log"
+          ],
+          "definition": "Document subtype classification. Required on all new documents (ENC-FTR-077). ENC-FTR-078 promotes the enum to a strict allow-list on writes (new writes + patches that set document_subtype must use an enum value) while keeping all legacy_readable_only values readable for grandfathered documents. 'idea' formalizes the architect-skill lifecycle terminal artifact (ENC-FTR-078 AC-4). 'context-node' is a Yoneda-compressed graph anchor with cap 2048 chars and >=5 related_items (ENC-FTR-078 AC-5, AC-7). 'skill' is a cross-platform portable skill primitive with dual Claude-spec and agentskills.io-spec projections (ENC-FTR-078 AC-8..14).",
+          "usage_guidance": "Set at creation via document_api PUT body. Cannot be changed after creation EXCEPT by PATCH; patches that set document_subtype to a legacy_readable_only value are rejected (ENC-FTR-078 AC-3). For emergent patterns, use document_subtype='doc' with subtypepattern='<value>' (ENC-FTR-078 subtypepattern self-learning mechanism, see document.doc)."
+        },
+        "source_record_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "definition": "Tracker record ID that originated this handoff (e.g. ENC-TSK-B52). Required when document_subtype=handoff.",
+          "usage_guidance": "Set at creation. Creates the source anchor for graph HANDS_OFF edge (Phase 3)."
+        },
+        "handoff_status": {
+          "type": "enum",
+          "enum": [
+            "pending",
+            "claimed",
+            "completed",
+            "stale"
+          ],
+          "definition": "Handoff lifecycle status. pending: awaiting pickup. claimed: an agent has taken ownership. completed: handoff work done. stale: expired or superseded.",
+          "usage_guidance": "Auto-set to 'pending' on creation. Transition via PATCH with handoff_status field, or via the status field (ENC-ISS-158 routing). Valid transitions: pending->{claimed,stale}, claimed->{completed,stale}. completed and stale are terminal."
+        },
+        "prerequisite_state": {
+          "type": "string",
+          "definition": "Description of system state that must be true before the handoff can be executed. Optional.",
+          "usage_guidance": "Set at creation or via PATCH. Consuming agent should verify before proceeding."
+        },
+        "action_checklist": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Ordered list of steps the consuming agent should execute. Optional.",
+          "usage_guidance": "Set at creation or via PATCH. Items are plain-text strings."
+        },
+        "verification_criteria": {
+          "type": "string",
+          "definition": "How to verify the handoff was executed correctly. Optional.",
+          "usage_guidance": "Set at creation or via PATCH. Consuming agent should check after completing work."
+        },
+        "expires_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "Optional expiry timestamp. After this time, handoff should be considered stale.",
+          "usage_guidance": "Set at creation or via PATCH. No server-side enforcement yet — consuming agents should check."
+        },
+        "claimed_by": {
+          "type": "string",
+          "definition": "Identity of the agent/user that claimed this handoff. Set automatically when handoff_status transitions to 'claimed'."
+        },
+        "claimed_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "Timestamp when handoff was claimed. Set automatically with claimed_by."
+        },
+        "created_by_session": {
+          "type": "string",
+          "definition": "Session identity of the agent that created this handoff document. Set from auth claims at creation."
+        },
+        "status_routing": {
+          "type": "string",
+          "definition": "ENC-ISS-158: When documents.patch receives a handoff lifecycle value (pending/claimed/completed/stale) in the status field for a handoff document, it routes the value to handoff_status instead of rejecting it. This enables MCP callers to use the standard status field for handoff lifecycle transitions without knowing about the separate handoff_status field.",
+          "usage_guidance": "Callers can use either documents.patch(status='claimed') or documents.patch(handoff_status='claimed') on handoff documents. Both produce the same result. Non-handoff documents still enforce status in {active, archived}."
+        },
+        "reply_author": {
+          "type": "string",
+          "definition": "ENC-TSK-E50: Author identifier in append_content reply block frontmatter. Required when appending to a handoff document. Parsed from the YAML-like frontmatter block that must start with '---'.",
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field. Validated server-side — must be non-empty."
+        },
+        "reply_timestamp": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-E50: Timestamp in append_content reply block frontmatter. Must be a valid ISO 8601 string. Required when appending to a handoff document.",
+          "usage_guidance": "Included in the append_content body as frontmatter. Validated via datetime.fromisoformat()."
+        },
+        "agent_layer": {
+          "type": "enum",
+          "enum": [
+            "supervisor",
+            "coord-lead",
+            "dispatched-agent",
+            "product-lead-terminal"
+          ],
+          "definition": "ENC-TSK-E50: Agent layer classification in append_content reply block frontmatter. Must be one of AGENT_LAYERS. Required when appending to a handoff document.",
+          "usage_guidance": "Included in the append_content body as frontmatter. Classifies the responding agent's role."
+        },
+        "originating_handoff_ref": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^DOC-.*"
+          },
+          "definition": "ENC-TSK-E50: Cross-reference to the originating handoff document in append_content reply block frontmatter. Must start with 'DOC-'. Required when appending to a handoff document.",
+          "usage_guidance": "Included in the append_content body as frontmatter. Creates traceability from reply back to source handoff."
+        },
+        "reply_count": {
+          "type": "number",
+          "definition": "ENC-TSK-E50: Running count of validated reply block appends on this handoff document. Incremented atomically on each successful append_content PATCH with valid reply block frontmatter. Uses if_not_exists(reply_count, 0) + 1 pattern.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "last_reply_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-E50: Timestamp of the most recent validated reply block append. Updated atomically with reply_count on each successful append_content PATCH.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        }
+      }
+    },
+    "document.wave_append": {
+      "description": "Wave multi-author append validation schema (ENC-TSK-E51). When append_content targets a wave document, the appended text must include YAML-like frontmatter with reply_author, reply_timestamp, and agent_layer. originating_handoff_ref is optional (cross-doc traceability). Tracks append_count and last_append_at on the wave document.",
+      "fields": {
+        "reply_author": {
+          "type": "string",
+          "definition": "ENC-TSK-E51: Author identifier in wave append frontmatter. Required when appending to a wave document. Parsed from the YAML-like frontmatter block.",
+          "usage_guidance": "Included in the append_content body as frontmatter, not as a separate PATCH field."
+        },
+        "reply_timestamp": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-E51: Timestamp in wave append frontmatter. Must be valid ISO 8601.",
+          "usage_guidance": "Included in the append_content body as frontmatter."
+        },
+        "agent_layer": {
+          "type": "enum",
+          "enum": [
+            "supervisor",
+            "coord-lead",
+            "dispatched-agent",
+            "product-lead-terminal"
+          ],
+          "definition": "ENC-TSK-E51: Agent layer classification in wave append frontmatter. Must be one of AGENT_LAYERS.",
+          "usage_guidance": "Included in the append_content body as frontmatter."
+        },
+        "originating_handoff_ref": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^DOC-.*"
+          },
+          "definition": "ENC-TSK-E51: Optional cross-doc traceability reference in wave append frontmatter. Not required for wave appends, but allowed for linking back to a handoff.",
+          "usage_guidance": "Optional in wave append frontmatter. When present, must start with 'DOC-'."
+        },
+        "append_count": {
+          "type": "number",
+          "definition": "ENC-TSK-E51: Running count of validated wave appends on this wave document. Incremented atomically on each successful append_content PATCH with valid frontmatter. Uses if_not_exists(append_count, 0) + 1 pattern.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "last_append_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ENC-TSK-E51: Timestamp of the most recent validated wave append. Updated atomically with append_count on each successful append_content PATCH.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        }
+      }
+    },
+    "document.doc": {
+      "description": "Standard document subtype (ENC-FTR-077, hardened by ENC-FTR-078). Default subtype for general-purpose documents. Includes a semantic handoff-detection guard that warns when title or content matches handoff patterns. Replaces deprecated 'general' subtype for new document creation. ENC-FTR-078 adds the subtypepattern self-learning field, title colon-prefix hygiene rule, and a documented graduation_pathway by which frequently-used subtypepattern values can be promoted to first-class document_subtype enum values via follow-on ENC-FTRs.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "doc"
+          ],
+          "definition": "Fixed value 'doc' for standard documents. ENC-FTR-077 requires explicit document_subtype on all new creates; 'general' is rejected with 400.",
+          "usage_guidance": "Use 'doc' for standard unstructured documents that are not handoffs, COEs, or waves."
+        },
+        "confirm_subtype": {
+          "type": "boolean",
+          "definition": "Request-only flag to bypass the semantic handoff-detection guard. When a document with subtype 'doc' has a title or content matching handoff patterns (HANDOFF, Dispatch, GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, action_checklist, verification_criteria, prerequisite_state, etc.), the PUT returns HTTP 400 suggesting document_subtype='handoff'. Set confirm_subtype=true to override.",
+          "usage_guidance": "Only include in PUT request body when the semantic guard fires and 'doc' is intentionally correct. Not stored in DynamoDB — request-only flag. Also forwarded by MCP server _documents_put."
+        },
+        "semantic_guard_patterns": {
+          "type": "string",
+          "definition": "Informational: the semantic handoff-detection guard checks HANDOFF_TITLE_PATTERNS (HANDOFF, Dispatch [A-Z], GOVERNANCE_SYNC_REQUIRED, EXECUTION_REQUIRED, Coordination.*Handoff, Handoff.*dispatch) and HANDOFF_CONTENT_PATTERNS (action_checklist, verification_criteria, prerequisite_state, ## Scope Statement, ## Acceptance Criteria.*dispatch). Any match triggers the guard unless confirm_subtype=true.",
+          "usage_guidance": "Read-only reference. Patterns are defined as constants in document_api lambda_function.py."
+        },
+        "subtypepattern": {
+          "type": "string",
+          "constraints": {
+            "format": "^[a-z-]+$ after canonicalization",
+            "max_length": 64
+          },
+          "definition": "ENC-FTR-078 self-learning field (AC-16). Optional string capturing an emergent type pattern for doc-subtype records. Valid only when document_subtype='doc'; presence on any other subtype is rejected with code 'subtypepattern_wrong_subtype'. Canonicalization: input is trimmed and lowercased at write time, then validated against ^[a-z-]+$; invalid formats rejected with code 'subtypepattern_invalid_format'. The canonical form is what the server stores and returns. Applied on both PUT and PATCH when the field is touched. Valid examples: blueprint, runbook, post-mortem, design-decision. Invalid examples: 'blueprint_2' (underscore), 'BLUE PRINT' (space), 'blueprint?' (punctuation), '2024-blueprint' (digit).",
+          "usage_guidance": "Use to replace colon-prefixed titles (rejected by title_hygiene_rule). Example migration: title 'Blueprint: API Auth Design' + subtype='doc' becomes title 'API Auth Design' + subtypepattern='blueprint'. Queryable via documents.search subtypepattern filter (ENC-FTR-078 AC-17).",
+          "telemetry_eligible": true,
+          "vocabulary_bounded": true
+        },
+        "title_hygiene_rule": {
+          "type": "rule",
+          "definition": "ENC-FTR-078 AC-15 title hygiene. document_subtype='doc' titles matching the regex ^[A-Za-z][A-Za-z-]{1,30}: (case-insensitive leading alpha-or-dash word of length 2-31 followed by a colon) are rejected at PUT and PATCH (when title is touched) with error code 'doc_title_colon_prefix_disallowed'. The pedagogical error message reads: 'Title starts with a <type>: prefix. Titles should not encode subtype. Remove the <type>: prefix and place <type> (lowercased, alpha and dashes only) into the subtypepattern field.' Titles without the colon-prefix pattern continue to pass.",
+          "usage_guidance": "Agents migrating legacy records with colon-prefixed titles can remove the prefix and set subtypepattern in the same PATCH operation. Titles like 'CI: failing' that legitimately use a colon as narrative punctuation are also rejected under the current rule; file a follow-on ENC-FTR for carve-outs if io confirms a real-world need."
+        },
+        "graduation_pathway": {
+          "type": "rule",
+          "definition": "ENC-FTR-078 AC-18 schema-layer Godel-amendment mechanism. Agents express emergent type patterns via subtypepattern on document_subtype='doc' records. (a) Each subtypepattern value is structured, queryable telemetry for an emergent type primitive. (b) Consistent, high-frequency, cross-project usage of a subtypepattern value is evidence that the value should graduate to a first-class document_subtype enum value. (c) Graduation is performed via a follow-on ENC-FTR that moves the value from subtypepattern land into the document_subtype enum (and adds the new document.<name> entity to this dictionary). (d) The graduation criteria (thresholds, diversity measures) are deliberately unpinned in ENC-FTR-078; the first graduation-candidate ENC-FTR will specify them. This IS the Godel-amendment mechanism (DOC-0CAD28643E2F) applied at the schema layer: the enum is acknowledged as inherently incomplete, and subtypepattern is the structured evidence stream by which the enum learns what to become.",
+          "usage_guidance": "Documentation-only. No runtime logic ships in ENC-FTR-078 for graduation. Observability queries to propose graduation candidates: documents.search with subtypepattern filter (exact match) + aggregate by value."
+        }
+      }
+    },
+    "document.coe": {
+      "description": "Correction-of-errors document subtype (ENC-FTR-077). Structured COE documents tied to incident records with lifecycle status tracking and minimum edge density requirements. Created via document_api PUT with document_subtype=coe.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "coe"
+          ],
+          "definition": "Fixed value 'coe' for correction-of-errors documents."
+        },
+        "source_incident_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "definition": "Tracker record ID of the incident that triggered this COE (e.g. ENC-ISS-242). Required when document_subtype=coe.",
+          "usage_guidance": "Set at creation. Stored as a DynamoDB attribute. Creates the incident anchor for the COE document."
+        },
+        "coe_status": {
+          "type": "enum",
+          "enum": [
+            "drafting",
+            "under-review",
+            "accepted",
+            "archived"
+          ],
+          "definition": "COE lifecycle status. drafting: initial creation/editing. under-review: submitted for peer review. accepted: COE findings accepted. archived: completed and archived.",
+          "usage_guidance": "Auto-set to 'drafting' on creation. Transition via PATCH with coe_status field. Valid transitions: drafting->{under-review}, under-review->{accepted, drafting}, accepted->{archived}. archived is terminal."
+        },
+        "edge_density_validation": {
+          "type": "string",
+          "definition": "COE documents enforce minimum edge density on related_items: at least 1 feature (*-FTR-*), 1 lesson (*-LSN-*), and 1 issue (*-ISS-*) must be present. Validated on both PUT (creation) and PATCH (when related_items is modified). Returns HTTP 400 listing which edge types are missing.",
+          "usage_guidance": "Ensure related_items includes references like ENC-FTR-077, ENC-LSN-026, ENC-ISS-242 before creating or updating a COE document."
+        },
+        "required_sections": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "COE documents are checked for recommended markdown sections during compliance evaluation: '## Root-Cause Analysis', '## Timeline', '## Remediation Status', '## Systemic Lessons', '## Outstanding Questions'. Missing sections generate compliance warnings (not hard blocks).",
+          "usage_guidance": "Include these sections in COE document content for best compliance scores. Warnings appear in compliance_warnings array."
+        }
+      }
+    },
+    "document.wave": {
+      "description": "Coordination wave tracking document subtype (ENC-FTR-077). Wave documents are anchored to a plan record and track coordination wave lifecycle. Created via document_api PUT with document_subtype=wave.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "wave"
+          ],
+          "definition": "Fixed value 'wave' for coordination wave documents."
+        },
+        "plan_anchor_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "pattern": ".*-PLN-.*"
+          },
+          "definition": "Plan record ID that this wave is anchored to (e.g. ENC-PLN-029). Required when document_subtype=wave. Must contain '-PLN-'. Immutable after creation.",
+          "usage_guidance": "Set at creation. Cannot be modified via PATCH (returns HTTP 400). Stored as a DynamoDB attribute."
+        },
+        "wave_status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "concluded",
+            "archived"
+          ],
+          "definition": "Wave lifecycle status. active: wave is in progress. concluded: wave coordination complete. archived: finalized and archived.",
+          "usage_guidance": "Auto-set to 'active' on creation. Transition via PATCH with wave_status field. Valid transitions: active->{concluded}, concluded->{archived}. archived is terminal."
+        },
+        "agent_layer_classification": {
+          "type": "enum",
+          "enum": [
+            "coordination",
+            "execution",
+            "review",
+            "monitoring"
+          ],
+          "definition": "Optional classification of the agent layer role within this wave. Informational — not enforced by document_api.",
+          "usage_guidance": "Set at creation or via PATCH to classify agent behavior mode."
+        }
+      }
+    },
+    "document.idea": {
+      "description": "Idea document subtype (ENC-FTR-078). Terminal artifact of the architect skill's five-stage idea lifecycle (Stages 0-4). Formalizes the type already referenced by the architect skill at init time via documents.search(document_subtype='idea') (SKILL.md Init Protocol Step 3) and closes the silent-failure mode where pre-ENC-FTR-078 server-side validation rejected the value. Governing document: DOC-EDEFF7CD0BD5.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "idea"
+          ],
+          "definition": "Fixed value 'idea' for architect-lifecycle idea documents.",
+          "usage_guidance": "Use when writing or searching for idea-lifecycle artifacts. ENC-FTR-078 AC-4: architect skill init-time documents.search(document_subtype='idea') now returns matching records."
+        },
+        "required_fields": {
+          "type": "rule",
+          "definition": "Minimum required fields on PUT: title (non-empty) and content (non-empty). No additional idea-specific required fields in ENC-FTR-078 Phase 1; the architect skill is the primary author and its own workflow supplies structure.",
+          "usage_guidance": "Phase 2 may introduce idea-specific lifecycle-stage and concept-author fields; until then, idea docs carry whatever structure the architect skill supplies."
+        },
+        "edge_density_soft": {
+          "type": "rule",
+          "definition": "No hard edge-density invariant is enforced for idea in ENC-FTR-078 Phase 1. Ideas may start as orphan records during early exploration. Compliance score penalty for orphan ideas remains advisory, not blocking.",
+          "usage_guidance": "Agents should add related_items over the idea's lifecycle as anchors emerge (candidate features, issues, prior lessons). Strong edge density at proposed / validated stages is a best practice, not a gate."
+        }
+      }
+    },
+    "document.context-node": {
+      "description": "Context-node document subtype (ENC-FTR-078). A compressed ontological primitive whose purpose is to triangulate the gravitational center of a graph-defined concept (an idea, feature, component, historical narrative) by carrying a strictly bounded text body plus a dense edge set via related_items. The node is its morphisms (Yoneda), and the bounded-text constraint forces the residual prose to carry only what is irreducible under graph traversal. Target consumer: any agent whose immediate goal requires fast context initialization against a known concept locus. Derivation artifact: DOC-B5F1BC281F02 (ENC-FTR-078 AC-6). Rationale anchors: DOC-0CAD28643E2F (Extended Mind inception principle), DOC-33EB705DE23D (Layer 3 generative seed — graph theory + compression-is-learning), DOC-E2379D980FA2 (math-of-institutional-memory synthesis — Kolmogorov/MDL, rate-distortion, Yoneda, information-bottleneck). Governing document: DOC-EDEFF7CD0BD5.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "context-node"
+          ],
+          "definition": "Fixed value 'context-node' for compressed graph-anchor documents."
+        },
+        "cap_readable_body": {
+          "type": "integer",
+          "constraints": {
+            "max": 2048,
+            "value": "CAP_CONTEXT_NODE = 2048"
+          },
+          "definition": "ENC-FTR-078 AC-5 hard cap on readable body length in characters. PUT and PATCH reject documents whose readable-body character count exceeds 2048 with error code 'context_node_cap_exceeded', payload {measured: int, cap: 2048}. Readable body is markdown content stripped of (a) the H1 ID line, (b) the standard **Project**/**Related**/**Created**/**Author** metadata block, and (c) the related_items-equivalent edge block if present inline.",
+          "usage_guidance": "Target the 2048-char budget. If a candidate context-node exceeds the cap, either split into multiple focused nodes or relocate prose into a linked standard doc and reference via related_items. Derivation: DOC-B5F1BC281F02."
+        },
+        "edge_density": {
+          "type": "integer",
+          "constraints": {
+            "min": 5,
+            "value": "N_MIN_CONTEXT_NODE = 5"
+          },
+          "definition": "ENC-FTR-078 AC-7 hard minimum on related_items edges. PUT rejects context-node documents with len(related_items) < 5 via error code 'context_node_edge_density_insufficient', payload {measured: int, min: 5}. PATCH re-validates when related_items is touched. Triangulation requires >=3 anchors for planar disambiguation; the practical floor is 5 to resist degenerate clustering.",
+          "usage_guidance": "Populate related_items with diverse anchor IDs (tasks, features, lessons, documents) spanning the concept locus. Phase-2 may introduce a per-document adaptive minimum based on concept complexity (future ENC-FTR)."
+        },
+        "phase_2_upgrade": {
+          "type": "rule",
+          "definition": "Phase-2 roadmap: adaptive cap_readable_body per document derived at write time from concept complexity, and adaptive edge_density minimum. Not shipped in ENC-FTR-078. Deferred to a follow-on ENC-FTR with explicit derivation.",
+          "usage_guidance": "Do not implement adaptive logic in ENC-FTR-078. Keep caps static at 2048 / 5 respectively."
+        }
+      }
+    },
+    "document.skill": {
+      "description": "Skill document subtype (ENC-FTR-078). Enceladus-defined structure for storing skills installable across any target runtime. Day-one coverage is explicitly dual: (a) Claude-specific install via the claude_description field (1024-char ceiling, matches Claude SKILL.md external spec by construction), (b) lowest-common-denominator agnostic install via the agentskills_manifest JSON object (conformant with the open specification at agentskills.io/home at the pinned agentskills_spec_version). runtime_variants is an optional extensibility hook admitting future runtimes without further schema evolution. The full_description <-> (claude_description, agentskills_manifest) projection set expresses a rate-distortion tuple: full_description is the higher-fidelity source; the two projections are governed compressions under their respective external constraints. Derivation artifact: DOC-75425CD9786D (ENC-FTR-078 AC-10). Rationale anchor: DOC-7E9861ED6104 (rate-distortion Lagrangian, MDL, AKU working-memory sizing). Governing document: DOC-EDEFF7CD0BD5.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "skill"
+          ],
+          "definition": "Fixed value 'skill' for portable skill documents."
+        },
+        "full_description": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "max_length": 4096,
+            "value": "CAP_SKILL_FULL_DESC = 4096"
+          },
+          "definition": "ENC-FTR-078 AC-8 required field. Enceladus-native, Lagrangian-optimized canonical specification of the skill. Carries phronesis: what the skill does, when to invoke it, what context it needs, what can go wrong, and what governance constraints apply. Source of truth from which every runtime projection is derived. Missing: code 'skill_full_description_missing'. Overcap: code 'skill_full_description_invalid' with {measured, cap: 4096}.",
+          "usage_guidance": "Target the 4096-char budget. Write operationally: trigger, options, failure modes, governance. Derivation: DOC-75425CD9786D."
+        },
+        "claude_description": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "max_length": 1024
+          },
+          "definition": "ENC-FTR-078 AC-9 required field. Hard-capped at 1024 characters per Claude SKILL.md external spec (non-negotiable). Used at Claude-install time to populate the description: field in SKILL.md frontmatter. Guaranteed to pass Claude-spec validation by construction because the server validates len <= 1024 at write time. Missing: code 'skill_claude_description_missing'. Overcap: code 'skill_claude_description_too_long'.",
+          "usage_guidance": "Compressed view of full_description honoring Claude's 1024-char operational constraint. Includes trigger patterns and sibling skills when relevant. The compression ratio full_description -> claude_description is the system's beta parameter from DOC-7E9861ED6104."
+        },
+        "agentskills_manifest": {
+          "type": "object",
+          "definition": "ENC-FTR-078 AC-12 required field. JSON object conformant with the agentskills.io/home specification at the pinned agentskills_spec_version. Server validates manifest against the pinned spec at write time (PUT + PATCH); non-conformant manifests rejected with code 'skill_agentskills_manifest_invalid' including validator output. Missing: code 'skill_agentskills_manifest_missing'. Used at agnostic-install time for any agentskills.io-compliant runtime.",
+          "usage_guidance": "Conform to the pinned agentskills.io spec version. The manifest is exported verbatim to any compliant runtime with zero Enceladus-specific translation."
+        },
+        "agentskills_spec_version": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1,
+            "pinned_default": "0.1.0"
+          },
+          "definition": "ENC-FTR-078 AC-12 required field. String pinning the agentskills.io spec version (e.g. '0.1.0') against which agentskills_manifest is validated at write time. Missing: code 'skill_agentskills_spec_version_missing'. The pinned value used at deploy is recorded in DOC-75425CD9786D.",
+          "usage_guidance": "Pin to a specific agentskills.io spec version. Do not leave unpinned. Escalate to io when the upstream spec publishes a new version that should become the new pin."
+        },
+        "runtime_variants": {
+          "type": "object",
+          "definition": "ENC-FTR-078 AC-13 optional field. Map of {runtime_id: variant_payload} for runtime-specific overrides beyond Claude and beyond the agentskills.io common denominator. Unknown keys are accepted (forward-compat); the field is stored verbatim. Per-runtime validation is best-effort and non-blocking for runtimes not explicitly recognized by the server at the deploy date. Empty {} is valid.",
+          "usage_guidance": "Use to admit future runtimes without requiring a schema-evolution ENC-FTR. Adding support for a new runtime is an implementation task, not a schema-evolution task."
+        },
+        "edge_density_soft": {
+          "type": "rule",
+          "constraints": {
+            "min": 2,
+            "value": "N_MIN_SKILL = 2"
+          },
+          "definition": "ENC-FTR-078 AC-14 soft edge-density invariant. PUT rejects a skill document with len(related_items) < 2 via error code 'skill_edge_density_insufficient'. Softer than context-node's 5 because leaf-node utility skills are legitimate; a zero-or-one-edge skill is a disconnected record and invalid under Enceladus edge-density discipline.",
+          "usage_guidance": "Populate related_items with at minimum the governing ENC-FTR + one anchor (feature, task, or lesson that the skill operationalizes)."
+        },
+        "phase_2_upgrade": {
+          "type": "rule",
+          "definition": "Phase-2 roadmap: per-skill beta-tuned cap_full_description derived at write time from the skill's domain complexity. Not shipped in ENC-FTR-078.",
+          "usage_guidance": "Do not implement adaptive cap logic in ENC-FTR-078. Keep the cap static at 4096."
+        }
+      }
+    },
+    "document.governance_sync": {
+      "description": "Push-on-write sync behavior for governance files to the PWA document store (ENC-TSK-729). When governance_update() is called, coordination_api invokes devops-document-api asynchronously via Lambda direct invocation (InvocationType=Event) to trigger _sync_governance_documents() immediately. This delivers the updated governance file to DynamoDB document store within seconds, meeting a <=3-minute SLA for PWA freshness without requiring a user page load.",
+      "fields": {
+        "_governance_sync_push": {
+          "type": "boolean",
+          "definition": "Internal event flag. When true, document_api lambda_handler bypasses HTTP routing and calls _handle_governance_sync_push() directly. Set by coordination_api after a successful governance S3 write. Not an HTTP field.",
+          "context": "direct Lambda invocation only (not API Gateway)"
+        },
+        "file_name": {
+          "type": "string",
+          "definition": "Governance file name that was updated (e.g. 'agents.md', 'agents/lifecycle-primer.md'). Informational — sync always runs _sync_governance_documents() for all governance files to ensure consistency.",
+          "context": "direct Lambda invocation payload"
+        },
+        "content_hash": {
+          "type": "string",
+          "definition": "SHA-256 hex digest of the new file content. Logged for observability. Also used by _sync_governance_documents() hash comparison to skip unchanged files.",
+          "context": "direct Lambda invocation payload"
+        }
+      },
+      "covered_files": [
+        "agents.md",
+        "agents/bootstrap-template.md",
+        "agents/lifecycle-primer.md",
+        "agents/bedrock-agent-instructions.md",
+        "agents/deployment-process-references.md",
+        "agents/agent-schema.json",
+        "agents/agent-manifest.json",
+        "agents/dispatch-heuristics.md",
+        "agents/agents-reference-markdown.md",
+        "agents/agents-reference-guide-numbering.md",
+        "agents/agents-reference-project-tracking.md",
+        "governance_data_dictionary.json"
+      ],
+      "sla": "<=3 minutes from governance_update() call to PWA document store update",
+      "fallback": "On-demand sync via document_api _sync_governance_documents() triggered on search?keyword=governance-file remains active as a consistency fallback",
+      "requires_iam": "devops-coordination-api-lambda-role must have lambda:InvokeFunction on devops-document-api"
+    },
+    "document.query_response": {
+      "description": "Document list/search response envelope fields returned by document_api.",
+      "fields": {
+        "documents": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Document metadata records for list/search results."
+        },
+        "count": {
+          "type": "number",
+          "definition": "Number of documents returned in current page/response."
+        },
+        "total_matches": {
+          "type": "number",
+          "definition": "Total matching documents before response slicing."
+        }
+      }
+    },
+    "deploy.request": {
+      "description": "Deployment intake request schema for /api/v1/deploy. Orchestrator now auto-persists fallback deploy-config/{project_id}/deploy.json when missing/invalid so CodeBuild fetch-config can run against first-time projects.",
+      "fields": {
+        "change_type": {
+          "type": "enum",
+          "enum": [
+            "patch",
+            "minor",
+            "major"
+          ]
+        },
+        "deployment_type": {
+          "type": "enum",
+          "enum": [
+            "github_public_static",
+            "github_private_sst",
+            "github_public_workers",
+            "github_private_workers",
+            "lambda_update",
+            "lambda_layer",
+            "container_template",
+            "glue_crawler_update",
+            "glue_job_update",
+            "eventbridge_rule",
+            "s3_asset_sync",
+            "cloudfront_config",
+            "step_function_update"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          }
+        },
+        "changes": {
+          "type": "array",
+          "item_type": "string",
+          "constraints": {
+            "min_items": 1
+          }
+        },
+        "project_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^[a-z0-9_-]+$"
+          }
+        },
+        "non_ui_config": {
+          "type": "object",
+          "definition": "Optional non-UI deployment execution config for deployment_type values outside github_*.",
+          "usage_guidance": "Requires service_group + target_arn. Optional source_s3_bucket, source_s3_prefix, and source_dir can be supplied for inline lambda_update packaging. Inline lambda_update archive resolution now falls back across project metadata prefixes (including parent-derived deploy-sources/<parent>) and scans available source archives until backend/lambda/<source_dir>/ content is found."
+        },
+        "pr_id": {
+          "type": "integer",
+          "constraints": {
+            "min": 1
+          },
+          "definition": "GitHub PR number that was merged to main prior to this deployment (ENC-FTR-037). Required for all deployment requests.",
+          "usage_guidance": "Must be an integer (e.g. 72). deploy_intake validates via GitHub API GET /repos/{owner}/{repo}/pulls/{pr_id} that the PR is merged. Omitting pr_id returns HTTP 400."
+        },
+        "merged_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "ISO 8601 UTC timestamp of when the PR was merged to main (ENC-FTR-037). Required for all deployment requests.",
+          "usage_guidance": "Must match the GitHub API merged_at field within 60-second tolerance. Source it from the advance_task_status(merged-main) response or directly from the GitHub pull request object. Omitting merged_at returns HTTP 400."
+        },
+        "pr_owner": {
+          "type": "string",
+          "definition": "GitHub repository owner for PR validation (ENC-FTR-037). Optional; defaults to 'NX-2021-L'.",
+          "usage_guidance": "Only needed when deploying from a fork or non-default org repo."
+        },
+        "pr_repo": {
+          "type": "string",
+          "definition": "GitHub repository name for PR validation (ENC-FTR-037). Optional; defaults to 'enceladus'.",
+          "usage_guidance": "Only needed when deploying from a non-default repository (e.g. harrisonfamily)."
+        },
+        "source_artifact_s3_key": {
+          "type": "string",
+          "definition": "Optional S3 key for a pre-built Lambda artifact zip (ENC-TSK-E29 / ENC-TSK-E20 AC-6). Format: lambda-artifacts/{git_sha}/{arch_tag}/{function_name}.zip where arch_tag is x86_64-py311 (prod) or arm64-py312 (gamma). When present, deploy_intake validates the arch tag matches the target environment inferred from project_id.",
+          "usage_guidance": "Pass when the deployment uses a pre-built artifact from the split-artifact build pipeline (build-lambda-artifacts.yml). deploy_intake validates the S3 key format and arch tag. The key is persisted to the DDB request record for audit. MCP server deploy_submit tool accepts and forwards this field."
+        }
+      }
+    },
+    "deploy.spec": {
+      "description": "Deployment spec records produced by deploy_orchestrator in devops-deployment-manager. Supports record-only mode (ENC-ISS-102) for projects that deploy via their own CI/CD — orchestrator skips CodeBuild and finalizes inline.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "building",
+            "queued_non_ui",
+            "deployed",
+            "failed"
+          ],
+          "definition": "Spec lifecycle status."
+        },
+        "deployment_category": {
+          "type": "enum",
+          "enum": [
+            "ui",
+            "non_ui"
+          ],
+          "definition": "Execution category selected by orchestrator."
+        },
+        "deploy_mode": {
+          "type": "enum",
+          "enum": [
+            "standard",
+            "record_only"
+          ],
+          "definition": "Execution mode for the spec. 'standard' (default) runs full CodeBuild pipeline. 'record_only' skips CodeBuild and finalizes inline — used for externally-deployed projects (ENC-ISS-102, ENC-ISS-103).",
+          "usage_guidance": "Set on the spec by _finalize_record_only() when the project's deploy_mode is 'record_only'. The deploy_mode is read from the projects DDB table via _get_project_deploy_mode(). To enable record-only mode for a project, set deploy_mode='record_only' on its projects table record."
+        },
+        "non_ui_targets": {
+          "type": "object",
+          "definition": "Serialized non-UI request targets (service_group + target_arn + validation metadata)."
+        },
+        "non_ui_execution_results": {
+          "type": "object|string",
+          "definition": "Execution output emitted by inline non-UI lambda_update orchestration (per-target status/version/reason)."
+        },
+        "error_message": {
+          "type": "string",
+          "definition": "Terminal failure message when spec status is failed.",
+          "usage_guidance": "Inline lambda_update packaging/source-resolution failures and deterministic CodeBuild fetch-config failures are treated as non-retryable; included requests are marked failed (not reset to pending) to prevent infinite retry loops."
+        }
+      }
+    },
+    "deploy.governance_guard": {
+      "description": "Rules governing when governance_data_dictionary.json must be updated before a PR or deploy proceeds. Enforced by tools/check_governance_dictionary_sync.py and .github/workflows/governance-dictionary-guard.yml.",
+      "fields": {
+        "trigger_patterns": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Glob patterns whose modification requires a dictionary update in the same change set.",
+          "enum": [
+            "backend/lambda/*/lambda_function.py",
+            "backend/lambda/*/tracker_ops.py",
+            "backend/lambda/*/handlers.py",
+            "tools/enceladus-mcp-server/server.py",
+            "backend/lambda/coordination_api/config.py",
+            "backend/lambda/checkout_service/lambda_function.py"
+          ]
+        },
+        "dictionary_file": {
+          "type": "string",
+          "definition": "The file that must be updated when trigger_patterns are modified.",
+          "enum": [
+            "backend/lambda/coordination_api/governance_data_dictionary.json"
+          ]
+        },
+        "required_update_triggers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Specific conditions requiring a dictionary update.",
+          "enum": [
+            "New or removed status enum value on any tracked entity",
+            "New or removed field on any governed entity",
+            "New required evidence key for any status transition",
+            "New entity type, deploy type, or coordination execution mode",
+            "New MCP tool parameter carrying governed data",
+            "New service API scope in internal_auth.scope_map"
+          ]
+        },
+        "version_format": {
+          "type": "string",
+          "definition": "Required format for the version field when updating.",
+          "constraints": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}\\.\\d+$"
+          },
+          "usage_guidance": "Increment numeric suffix. Reset to .1 on new date. Example: 2026-03-01.21."
+        },
+        "enforcement_workflow": {
+          "type": "string",
+          "definition": "GitHub Actions workflow enforcing this gate on every PR.",
+          "enum": [
+            ".github/workflows/governance-dictionary-guard.yml"
+          ]
+        },
+        "s3_sync_note": {
+          "type": "string",
+          "definition": "The repo file and S3 governance store are separate artifacts requiring separate update steps.",
+          "usage_guidance": "Step 1 (required for CI): Edit the repo file in your worktree and commit it in the PR. Step 2 (required for runtime, after merge): Call governance_update MCP tool to sync to S3. Calling governance_update does NOT satisfy Step 1 -- the CI guard checks git diff, not S3."
+        }
+      }
+    },
+    "deploy.artifact_pipeline": {
+      "description": "Centralized Lambda artifact build and deploy pipeline (ENC-TSK-E20). Replaces inline per-workflow builds with a single build-lambda-artifacts.yml workflow that produces architecture-tagged zip artifacts in S3. All 31 deploy.sh scripts source tools/lambda_artifact_helper.sh to resolve pre-built artifacts. Arch-tag validation gate in lambda-deploy-reusable.yml prevents cross-environment contamination.",
+      "fields": {
+        "s3_key_format": {
+          "type": "string",
+          "definition": "Deterministic S3 key structure for Lambda artifacts: lambda-artifacts/{git_sha}/{arch_tag}/{function_name}.zip. git_sha is the full 40-character hex commit SHA. arch_tag is x86_64-py311 (prod) or arm64-py312 (gamma). function_name matches the Lambda function name in the manifest.",
+          "usage_guidance": "Use this format when constructing or validating artifact S3 keys. deploy_intake validates this format via _ARTIFACT_S3_KEY_RE when source_artifact_s3_key is present in a deploy request."
+        },
+        "arch_tags": {
+          "type": "object",
+          "definition": "Mapping of environment to arch tag used in S3 key paths.",
+          "enum": {
+            "prod": "x86_64-py311",
+            "gamma": "arm64-py312"
+          },
+          "usage_guidance": "The arch tag encodes both the CPU architecture and Python runtime version. deploy_intake and lambda-deploy-reusable.yml both validate that the arch tag in an artifact key matches the target environment."
+        },
+        "s3_bucket": {
+          "type": "string",
+          "definition": "S3 bucket for Lambda artifacts.",
+          "enum": [
+            "jreese-net"
+          ],
+          "usage_guidance": "All artifact keys are relative to this bucket in us-west-2."
+        },
+        "build_workflow": {
+          "type": "string",
+          "definition": "GitHub Actions workflow that builds and uploads artifacts.",
+          "enum": [
+            ".github/workflows/build-lambda-artifacts.yml"
+          ],
+          "usage_guidance": "Runs on every push to main. Reads function list from infrastructure/lambda_workflow_manifest.json. Builds both arch variants for each function via tools/package_lambda_artifact.sh."
+        },
+        "deploy_helper": {
+          "type": "string",
+          "definition": "Shell script sourced by all deploy.sh files to resolve pre-built artifacts from S3.",
+          "enum": [
+            "tools/lambda_artifact_helper.sh"
+          ],
+          "usage_guidance": "Provides resolve_artifact() function. When ARTIFACT_S3_KEY is set (by lambda-deploy-reusable.yml), downloads the pre-built zip from S3 instead of building locally."
+        },
+        "validation_gate": {
+          "type": "string",
+          "definition": "Arch-tag validation step in the reusable deploy workflow that verifies artifact key matches target environment.",
+          "enum": [
+            ".github/workflows/lambda-deploy-reusable.yml"
+          ],
+          "usage_guidance": "Validates artifact_s3_key arch tag before aws lambda update-function-code. Prevents gamma artifacts from reaching production and vice versa."
+        }
+      }
+    },
+    "coordination.request": {
+      "description": "Coordination request envelope fields in coordination API.",
+      "fields": {
+        "state": {
+          "type": "enum",
+          "enum": [
+            "intake_received",
+            "queued",
+            "dispatching",
+            "running",
+            "succeeded",
+            "failed",
+            "cancelled",
+            "dead_letter"
+          ]
+        },
+        "execution_mode": {
+          "type": "enum",
+          "enum": [
+            "preflight",
+            "codex_full_auto",
+            "codex_app_server",
+            "claude_headless",
+            "claude_agent_sdk",
+            "aws_step_function",
+            "bedrock_agent"
+          ],
+          "definition": "Dispatch runtime selected for a coordination request.",
+          "usage_guidance": "bedrock_agent routes through direct Bedrock Agent Runtime invoke_agent dispatch (not host-v2 SSM)."
+        },
+        "provider": {
+          "type": "enum",
+          "enum": [
+            "openai_codex",
+            "claude_agent_sdk",
+            "aws_native",
+            "aws_bedrock_agent"
+          ]
+        },
+        "dispatch.prompt_submitted": {
+          "type": "string",
+          "definition": "Prompt text submitted to provider runtime and persisted for execution traceability."
+        },
+        "session_archive_turn_index": {
+          "type": "number",
+          "definition": "Monotonic request-local turn counter used to assign deterministic archive turn IDs."
+        },
+        "result.details.session_archive": {
+          "type": "object",
+          "definition": "Archive write outcome metadata emitted by refresh polling for codex execution modes.",
+          "usage_guidance": "Contains archived(bool), key, records, redaction_hits and fallback buffered_path when S3 writes fail."
+        },
+        "skip_debounce": {
+          "type": "boolean",
+          "definition": "When true, bypasses the 3-minute debounce window and auto-promotes request from intake_received to queued with immediate dispatch.",
+          "usage_guidance": "Used by chat message endpoint (POST /sessions/{id}/message) for interactive terminal sessions."
+        },
+        "provider_session": {
+          "type": "object",
+          "definition": "Session context for multi-turn terminal interactions.",
+          "usage_guidance": "Contains session_id and thread_id. Used to group coordination requests into logical terminal sessions."
+        },
+        "provider_session.interface_mode": {
+          "type": "enum",
+          "enum": [
+            "raw",
+            "code"
+          ],
+          "definition": "Managed-session MCP interface contract requested for the provider runtime.",
+          "usage_guidance": "raw preserves the broad raw-tool MCP surface. code exposes only search, coordination, get_compact_context, and execute while allowing those meta-tools to resolve onto governed raw handlers."
+        },
+        "provider_session.allowed_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Provider-visible tool names allowed for the managed session.",
+          "usage_guidance": "When interface_mode=code, allowed_tools should contain only the four code-mode meta tools. When interface_mode=raw, allowed_tools may contain allowlisted raw MCP tool names."
+        },
+        "provider_session.allowed_raw_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Optional raw MCP tool allowlist used internally by code-mode action resolution.",
+          "usage_guidance": "Code-mode sessions pass this boundary to the MCP server via COORDINATION_ALLOWED_RAW_TOOLS[_JSON]. Meta-tools may resolve only to raw tools listed here."
+        },
+        "provider_session.deferred_tool_loading": {
+          "type": "boolean",
+          "definition": "When true on claude_agent_sdk dispatch, coordination attaches Anthropic deferred tool-loading tools array (mcp_toolset + BM25 tool search) and advanced-tool-use beta headers to the Messages API request.",
+          "usage_guidance": "Opt-in per coordination request. Eager-load tools default to search, get_compact_context, execute, coordination; all other MCP tools defer until BM25 retrieval. See mcp_server.deferred_tool_loading entity."
+        },
+        "provider_session.context_management_enabled": {
+          "type": "boolean",
+          "definition": "When true on claude_agent_sdk dispatch, coordination attaches Anthropic context-management beta (clear_tool_uses_20250919 + memory_20250818 tool) to the Messages API request for long loops.",
+          "usage_guidance": "Opt-in per coordination request for sessions expected to exceed ~20 tool calls. Composes with deferred_tool_loading. See mcp_server.context_management entity."
+        },
+        "dispatch_target_task_ids": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Existing or newly created governed task IDs that a coordination request should dispatch directly.",
+          "usage_guidance": "When present, coordination treats these task IDs as the authoritative work units for dispatch planning and prompt context. Existing governed tasks listed here must not be auto-created or auto-closed by coordination bookkeeping alone. ENC-ISS-128: When related_record_ids contains explicit task IDs, the intake path now skips _decompose_and_create_tracker_artifacts and uses the supplied records directly."
+        }
+      }
+    },
+    "coordination.session": {
+      "description": "Derived session view aggregated from coordination requests grouped by provider_session.session_id.",
+      "fields": {
+        "session_id": {
+          "type": "string",
+          "definition": "UUID identifying the terminal session."
+        },
+        "provider": {
+          "type": "enum",
+          "enum": [
+            "openai_codex",
+            "claude_agent_sdk",
+            "unknown"
+          ],
+          "definition": "Provider derived from execution_mode of session requests."
+        },
+        "is_active": {
+          "type": "boolean",
+          "definition": "True if the latest request in the session is in a non-terminal state."
+        },
+        "turn_count": {
+          "type": "number",
+          "definition": "Number of coordination requests associated with this session."
+        }
+      }
+    },
+    "coordination.auth_cognito_session": {
+      "description": "Payload contract for Cognito terminal-session bootstrap used by protected PWA diagnostics (POST /api/v1/coordination/auth/cognito/session and MCP tool coordination_cognito_session).",
+      "fields": {
+        "target_origin": {
+          "type": "string",
+          "constraints": {
+            "format": "https-origin"
+          },
+          "usage_guidance": "Must be an https origin matching the target Enceladus host where cookies will be applied."
+        },
+        "include_set_cookie_headers": {
+          "type": "boolean",
+          "usage_guidance": "When true, response includes serialized Set-Cookie strings for non-browser tooling."
+        },
+        "include_tokens": {
+          "type": "boolean",
+          "usage_guidance": "When true, response includes raw Cognito tokens in the separate tokens object. When false (default), no token values are emitted anywhere in the response: the tokens object is omitted AND token-bearing cookie entries in session.cookies, session.playwright_cookies, and session.set_cookie_headers have their value fields redacted (empty string) while retaining cookie structure/metadata (name, path, secure, http_only, same_site, max_age). Non-token cookies (e.g. session timestamp) are unaffected. See ENC-ISS-559."
+        },
+        "session.cookies": {
+          "type": "array",
+          "item_type": "object",
+          "usage_guidance": "Canonical cookie objects returned by coordination API, including id token, refresh token (when available), and session timestamp cookie. ENC-ISS-559: when include_tokens=false, the value field of token-bearing cookies (enceladus_id_token, enceladus_refresh_token) is redacted to an empty string; other fields (name, path, secure, http_only, same_site, max_age) are still returned."
+        },
+        "session.playwright_cookies": {
+          "type": "array",
+          "item_type": "object",
+          "usage_guidance": "Browser-context cookie entries consumable by Playwright automation for authenticated evidence capture. ENC-ISS-559: mirrors session.cookies redaction — token-bearing entries have an empty value when include_tokens=false."
+        },
+        "session.set_cookie_headers": {
+          "type": "array",
+          "item_type": "string",
+          "usage_guidance": "Optional serialized Set-Cookie header values for external HTTP clients. ENC-ISS-559: when include_tokens=false, headers for token-bearing cookies are serialized with an empty value (e.g. \"enceladus_id_token=; Path=/; ...\") so no token material appears in the header line."
+        },
+        "session.tokens": {
+          "type": "object",
+          "usage_guidance": "Optional raw token object (id/access/refresh) returned only when include_tokens=true."
+        }
+      }
+    },
+    "coordination.mcp_auth": {
+      "description": "Authentication contract for the coordination MCP gateway route (/api/v1/coordination/mcp).",
+      "fields": {
+        "Authorization": {
+          "type": "string",
+          "usage_guidance": "Supports OAuth connector bearer tokens: Authorization: Bearer <jwt>. Parsed before cookie auth."
+        },
+        "enceladus_id_token": {
+          "type": "string",
+          "usage_guidance": "Cookie-based Cognito token used by PWA/browser sessions. Remains supported alongside bearer auth."
+        },
+        "jwt_claim_validation": {
+          "type": "object",
+          "usage_guidance": "ID tokens validate aud==COGNITO_CLIENT_ID; access tokens validate client_id==COGNITO_CLIENT_ID; issuer must match the Cognito user-pool issuer URL."
+        }
+      }
+    },
+    "internal_auth.scope_map": {
+      "description": "Scoped service-token authorization map shared across Enceladus service APIs.",
+      "fields": {
+        "COORDINATION_INTERNAL_API_KEY": {
+          "type": "string",
+          "usage_guidance": "Primary shared internal key. Services normalize non-empty fallback across aliases: ENCELADUS_COORDINATION_API_INTERNAL_API_KEY, ENCELADUS_COORDINATION_INTERNAL_API_KEY, COORDINATION_INTERNAL_API_KEY."
+        },
+        "COORDINATION_INTERNAL_API_KEY_PREVIOUS": {
+          "type": "string",
+          "usage_guidance": "Optional rollover key. Services normalize non-empty fallback across aliases: ENCELADUS_COORDINATION_API_INTERNAL_API_KEY_PREVIOUS, ENCELADUS_COORDINATION_INTERNAL_API_KEY_PREVIOUS, COORDINATION_INTERNAL_API_KEY_PREVIOUS."
+        },
+        "COORDINATION_INTERNAL_API_KEY_SCOPES": {
+          "type": "object",
+          "constraints": {
+            "format": "json-map",
+            "key": "internal token or * wildcard",
+            "value": "array|string of lowercase scopes"
+          },
+          "usage_guidance": "Accepted by project_service, tracker_mutation, document_api, and deploy_intake. Supports exact scopes (for example deploy:write), prefix wildcards (for example tracker:*), and global values (* or all)."
+        },
+        "required_scopes": {
+          "type": "object",
+          "constraints": {
+            "method_map": {
+              "project_service": {
+                "GET": "projects:read",
+                "POST": "projects:write"
+              },
+              "tracker_mutation": {
+                "GET": "tracker:read",
+                "POST|PATCH|DELETE": "tracker:write"
+              },
+              "document_api": {
+                "GET": "documents:read",
+                "PUT|POST|PATCH": "documents:write"
+              },
+              "deploy_intake": {
+                "GET": "deploy:read",
+                "POST|PATCH": "deploy:write"
+              }
+            }
+          },
+          "usage_guidance": "If scope map is omitted, internal keys remain permissive for backward compatibility."
+        }
+      }
+    },
+    "governance.resource": {
+      "description": "Governance files accessible via governance_get MCP tool and governance_update API.",
+      "fields": {
+        "file_name": {
+          "type": "string",
+          "enum": [
+            "agents.md",
+            "agents/bootstrap-template.md",
+            "agents/lifecycle-primer.md",
+            "agents/bedrock-agent-instructions.md",
+            "agents/plan-capture.md",
+            "governance_data_dictionary.json"
+          ],
+          "usage_guidance": "Recognized governance file names. 'agents.md' is the primary session-init governance spec. 'agents/bootstrap-template.md' defines the required session initialization order. 'agents/lifecycle-primer.md' is the provider-agnostic git lifecycle quick reference. 'agents/bedrock-agent-instructions.md' carries Bedrock-specific dispatch guidance. 'agents/plan-capture.md' is the ENC-FTR-040 plan capture protocol and is typically loaded only after ExitPlanMode approval. 'governance_data_dictionary.json' is the machine-readable schema/enum dictionary; load at session init via governance_get(\"governance_data_dictionary.json\"). All file names under 'agents/' are accepted by the API even if not listed here."
+        },
+        "uri": {
+          "type": "string",
+          "usage_guidance": "Resolved as governance://{file_name}. Registered file_names are pre-validated; arbitrary 'agents/' paths are accepted by the API and resolve if the S3 object exists."
+        }
+      }
+    },
+    "project_service.deploy_policy": {
+      "description": "ENC-TSK-H84 / ENC-FTR-111 (Universal Arc-Walker Phase 1): per-project deploy_policy attribute on the projects DynamoDB table record, declaring how a project's deployments are triggered. Written by project_service at create time and surfaced on GET/LIST; read by the Lifecycle Service (evaluate_auto_walk action) to gate deploy-init auto-walk per ruling O-2 (ENC-FTR-111 AC-5). Pairs with the existing projects-table deploy_mode attribute (deploy.spec / _get_project_deploy_mode, ENC-ISS-102) but is orthogonal: deploy_mode controls CodeBuild vs record-only finalize; deploy_policy controls whether the Arc-Walker may mechanically auto-advance the deploy-init gate.",
+      "fields": {
+        "deploy_policy": {
+          "type": "enum",
+          "enum": [
+            "ci_triggered",
+            "manual"
+          ],
+          "default": "ci_triggered",
+          "definition": "How this project's deployments are triggered. 'ci_triggered': CI kicks off the deploy on merge to the deploy branch, so the deploy-init gate carries no irreducible human/external claim and the Universal Arc-Walker may mechanically auto-advance it (gate_class=mechanical AND deploy_policy=ci_triggered => auto-walkable, ruling O-2). 'manual': a human or external actor triggers the deploy, so the walker MUST NOT auto-advance deploy-init even though the static gate_class is mechanical. Stored on the projects-table record (project_id partition).",
+          "usage_guidance": "Set optionally at POST /api/v1/projects (project_service _validate_create_input; defaults to ci_triggered when omitted; invalid values are rejected 400). Existing/legacy project records that predate the field — including enceladus — are seeded to ci_triggered by read-time defaulting in project_service._enrich_project and by lifecycle_service._get_project_deploy_policy, and physically materialized by the idempotent backfill tools/seed_deploy_policy.py (run under a privileged session post-deploy; the agent-cli principal cannot write the projects table). The Lifecycle Service evaluate_auto_walk action derives auto-walk eligibility SOLELY from the gate_class taxonomy plus this runtime qualifier — never from evidence-field emptiness (DOC-078C57FC1BE6 §7.2). seed value: enceladus = ci_triggered."
+        }
+      }
+    },
+    "lifecycle_service.arc_walker_walk": {
+      "description": "ENC-TSK-H85 / ENC-FTR-111 Phase 1 CORE (T4): the Universal Arc-Walker's synchronous inline mechanical walk (DOC-078C57FC1BE6 §6.1). After a successful FORWARD task status advance, tracker_mutation._handle_update_field hands off to tracker_mutation._arc_walk_after_advance, which loops forward across the Phase-1 MECHANICAL gates in the SAME Lambda invocation before returning. Phase 1 covers exactly two legs (§3.1/§11): (1) <deploy-arc>|merged-main -> deploy-init, auto-walkable only on ci_triggered projects (ruling O-2); (2) code_only|merged-main -> closed, which reuses the commit_sha the agent already supplied at `committed` and runs a system-run GitHub ancestor-of-main compare (the new github_integration GET /api/v1/github/commits/compare-main route; status 'ahead'|'identical' => on main). Gated behind the independent enable_arc_walker AppConfig flag (env_fallback ENABLE_ARC_WALKER, default false) — distinct from enable_lifecycle_service_extraction. The walk NEVER fails the agent's already-committed advance: any walk error is swallowed and the original advance response is returned (optionally augmented with an arc_walk summary). Eligibility is decided SOLELY by the lifecycle_service evaluate_auto_walk verdict (gate_class MECHANICAL + deploy_policy O-2), never from evidence-field emptiness (the §7.2 coding-complete trap).",
+      "governing_feature": "ENC-FTR-111",
+      "governing_task": "ENC-TSK-H85",
+      "fields": {
+        "feature_flag": {
+          "type": "string",
+          "definition": "enable_arc_walker — independent AppConfig boolean (env_fallback ENABLE_ARC_WALKER, default false), read at request time via enceladus_shared.appconfig_flags.flag() so it toggles and rolls back without a redeploy. Separate from enable_lifecycle_service_extraction (ENC-TSK-H46): the validation extraction and the mechanical walk graduate independently (DOC-078C57FC1BE6 §11).",
+          "usage_guidance": "While off, tracker_mutation never enters the walk and every advance behaves exactly as pre-H85. Register in 06-feature-flags.yaml and the AppConfig profile before enabling in any environment."
+        },
+        "phase1_legs": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "The only two gates Phase 1 auto-crosses: '<github_pr_deploy|lambda_deploy|web_deploy>|merged-main->deploy-init' (MECHANICAL, ci_triggered-only per O-2) and 'code_only|merged-main->closed' (MECHANICAL, commit_sha reuse + GitHub compare). All other gates are attestation or external-fact and are structurally unreachable in Phase 1 (deploy-success/closed/coding-complete/pr/committed/merged-main)."
+        },
+        "idempotent_conditional_write": {
+          "type": "object",
+          "definition": "Each auto-step is a single DynamoDB update_item with ConditionExpression '#s = :expected_prior' (advance iff status == the status the walker observed). A concurrent agent/walker advance that moved the record off expected_prior fails the condition; the walker treats ConditionalCheckFailedException as 'concurrent_advance' and halts cleanly — no double-step, no lost update (DOC-078C57FC1BE6 §8 idempotency / §9 concurrent-advance mitigation)."
+        },
+        "safety_invariants": {
+          "type": "object",
+          "definition": "Honored before/at every step: (a) auto_walk_opt_out latched => halt before any evaluation or write, and the walker can NEVER clear the latch (ENC-TSK-H83); (b) checkout_transition_type integrity — a mismatch with the live transition_type halts the walk with a 409 (B07/B08), identical to an agent advance; (c) matrix_version pinning — if the evaluate_auto_walk verdict's matrix_version differs from the record's pinned version (checkout_matrix_version, else the embedded MATRIX_VERSION) the walk halts; (d) the ENC-ISS-106 subtask gate is enforced via the reused validate_transition call; (e) the walk halts at the first attestation/opt-out/gate-fail boundary."
+        },
+        "write_source": {
+          "type": "string",
+          "definition": "Every walker write is stamped write_source.channel = write_source.provider = 'system:arc-walker' (ARC_WALKER_ACTOR), so the audit feed, the opt-out walk-back detection, and the §13 attribution are unambiguous. code_only|closed additionally persists code_on_main_evidence={commit_sha, github_verified:true} and atomically increments closed_count."
+        },
+        "artifact_genesis": {
+          "type": "string",
+          "definition": "Every crossing is a governed mutation, never silent (DOC-078C57FC1BE6 §8/§10): a '[ARC-WALKER][AUTO-ADVANCE]' history entry rides the conditional write (carrying gate_class, derivation, matrix_version, trigger=sync, advanced_by) and a record.arc_walk.advanced EventBridge event is emitted with {record_id, from_status, to_status, gate_class, derivation, trigger, matrix_version, latency_ms}. Telemetry emission is best-effort and never rolls back the committed advance."
+        }
+      }
+    },
+    "internal_auth.managed_token": {
+      "description": "Unified service authentication token records stored by coordination API for external service integrations.",
+      "fields": {
+        "policy_id": {
+          "type": "string",
+          "constraints": {
+            "prefix": "service_token#"
+          },
+          "usage_guidance": "Deterministic key built from sha256(token) to avoid storing plaintext token secrets."
+        },
+        "token_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^TOK-[A-Z0-9]{12}$"
+          },
+          "usage_guidance": "Operator-facing token identifier used for delete/permissions update routes."
+        },
+        "service_name": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "usage_guidance": "Human-readable external service label shown in Tokens/Permissions UI tabs."
+        },
+        "permissions": {
+          "type": "array",
+          "item_type": "enum",
+          "enum": [
+            "read",
+            "write",
+            "put",
+            "delete",
+            "admin"
+          ],
+          "usage_guidance": "Cross-service grant set used by unified auth model."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "revoked"
+          ]
+        },
+        "token_masked": {
+          "type": "string",
+          "usage_guidance": "Obfuscated display value for UI listing; plaintext token is returned only at creation."
+        },
+        "created_at": {
+          "type": "timestamp"
+        },
+        "updated_at": {
+          "type": "timestamp"
+        },
+        "last_used_at": {
+          "type": "timestamp"
+        }
+      }
+    },
+    "mcp_server.oauth_token": {
+      "description": "OAuth 2.1 token parameters issued by the enceladus-mcp-streamable Lambda's token endpoint. Governs how the MCP server authenticates Claude.ai connectors (web, mobile, desktop) and how long sessions persist without user re-authentication.",
+      "fields": {
+        "access_token": {
+          "type": "string",
+          "usage_guidance": "Equals MCP_API_KEY env var. Stateless -- no server-side token storage. Validated by the Lambda handler on every request via exact Bearer comparison."
+        },
+        "token_type": {
+          "type": "enum",
+          "enum": [
+            "bearer"
+          ],
+          "usage_guidance": "Always 'bearer'. Sent by clients as Authorization: Bearer <access_token>."
+        },
+        "expires_in": {
+          "type": "number",
+          "constraints": {
+            "min": 1
+          },
+          "usage_guidance": "Access token lifetime in seconds. Configurable via ENCELADUS_MCP_TOKEN_TTL env var. Default 28800 (8 hours). Controls when Claude.ai will attempt to use the refresh token."
+        },
+        "refresh_token": {
+          "type": "string",
+          "usage_guidance": "Self-contained HMAC-signed opaque token with 30-day TTL. Format: base64url(payload).sha256hex. Payload is {typ:'rt', iat:<unix>, exp:<unix+2592000>} signed with OAUTH_CLIENT_SECRET. Stateless -- no server storage required; valid across Lambda cold starts. Issued only on authorization_code grant (not client_credentials per RFC 6749 section 4.4.3). Rotated on every use."
+        },
+        "grant_types_supported": {
+          "type": "array",
+          "item_type": "enum",
+          "enum": [
+            "authorization_code",
+            "refresh_token",
+            "client_credentials"
+          ],
+          "usage_guidance": "Advertised in /.well-known/oauth-authorization-server metadata. authorization_code (with PKCE/S256) is the primary flow for Claude.ai connectors. refresh_token enables silent renewal without user interaction. client_credentials is available for programmatic access."
+        },
+        "ENCELADUS_MCP_TOKEN_TTL": {
+          "type": "number",
+          "constraints": {
+            "min": 300
+          },
+          "usage_guidance": "Lambda env var controlling access token lifetime in seconds. Default 28800 (8h). Set to shorter values for higher-security environments. Do not set below 300s -- shorter values increase re-auth noise without meaningful security benefit."
+        }
+      }
+    },
+    "internal_auth.oauth_client": {
+      "description": "OAuth client records stored in the governance-policies table for external agent/MCP integrations. On creation, a Cognito User Pool App Client is registered via cognito-idp:CreateUserPoolClient so the client_id is valid for OAuth authorization_code flows. DELETE /oauth-clients/{clientId} removes both the DynamoDB record and the Cognito User Pool client. last_used_at is auto-updated when a managed token with the same service_name authenticates.",
+      "fields": {
+        "policy_id": {
+          "type": "string",
+          "constraints": {
+            "prefix": "oauth_client#"
+          },
+          "usage_guidance": "Partition key. Format: oauth_client#{client_id}."
+        },
+        "client_id": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "usage_guidance": "Cognito-generated User Pool App Client ID. Used as the OAuth client_id in authorization flows."
+        },
+        "service_name": {
+          "type": "string",
+          "constraints": {
+            "min_length": 1
+          },
+          "usage_guidance": "Human-readable service label shown in OAuth Clients UI tab."
+        },
+        "grant_types": {
+          "type": "array",
+          "item_type": "enum",
+          "enum": [
+            "authorization_code",
+            "client_credentials",
+            "refresh_token"
+          ],
+          "usage_guidance": "OAuth 2.1 grant types this client is authorized to use."
+        },
+        "permissions": {
+          "type": "array",
+          "item_type": "enum",
+          "enum": [
+            "read",
+            "write",
+            "put",
+            "delete",
+            "admin"
+          ],
+          "usage_guidance": "Cross-service grant set used by unified auth model. Defaults to [\"read\"] if omitted. Editable via PATCH /oauth-clients/{clientId}/permissions."
+        },
+        "redirect_uris": {
+          "type": "array",
+          "item_type": "string",
+          "usage_guidance": "Registered redirect URIs for authorization_code flow."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "inactive"
+          ]
+        },
+        "created_at": {
+          "type": "timestamp"
+        },
+        "updated_at": {
+          "type": "timestamp"
+        },
+        "last_used_at": {
+          "type": "timestamp"
+        }
+      }
+    },
+    "changelog.entry": {
+      "description": "Deployment changelog record stored in devops-deployment-manager DynamoDB table. Written by deploy_finalize and changelog_api backfill. Surfaced via GET /api/v1/changelog/history and MCP changelog_history tool.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Partition key. Project identifier (e.g. 'enceladus', 'devops', 'harrisonfamily')."
+        },
+        "record_id": {
+          "type": "string",
+          "constraints": {
+            "prefix": "deploy#"
+          },
+          "definition": "Sort key. Format: deploy#SPEC-{timestamp} for real deploys, deploy#{source}-v{version} for backfill entries."
+        },
+        "version": {
+          "type": "string",
+          "definition": "Semantic version string for this deployment (e.g. '0.17.0')."
+        },
+        "previous_version": {
+          "type": "string",
+          "definition": "Version string prior to this deployment. Null for initial/backfill entries without predecessor context."
+        },
+        "change_type": {
+          "type": "enum",
+          "enum": [
+            "patch",
+            "minor",
+            "major"
+          ],
+          "definition": "Semver bump type for this deployment."
+        },
+        "deployed_at": {
+          "type": "timestamp",
+          "definition": "ISO-8601 UTC timestamp of deployment completion."
+        },
+        "release_summary": {
+          "type": "string",
+          "definition": "AI-generated or human-authored single-sentence release summary."
+        },
+        "changes": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Bullet-point list of changes included in this deployment."
+        },
+        "spec_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^SPEC-"
+          },
+          "definition": "Reference to the deployment spec that produced this record. Absent for backfill entries."
+        },
+        "related_record_ids": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Tracker record IDs (tasks, features, issues) associated with this deployment."
+        },
+        "component": {
+          "type": "string",
+          "definition": "Sub-component label within the project (e.g. 'pwa', 'coordination-api', 'mcp-server'). Omitted for single-component projects."
+        },
+        "backfill": {
+          "type": "boolean",
+          "definition": "True if this record was written by the historical backfill script rather than the live deploy pipeline."
+        },
+        "source": {
+          "type": "enum",
+          "enum": [
+            "deploy_finalize",
+            "static_version_ts",
+            "backfill",
+            "deploy_record",
+            "spec_record",
+            "tracker_evidence",
+            "inferred"
+          ],
+          "definition": "Origin of this changelog record. 'deploy_finalize' = live pipeline; others are backfill provenance labels."
+        },
+        "confidence": {
+          "type": "enum",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "definition": "Confidence level for backfill records. High = authoritative source (version.ts, deploy record); medium = inferred from spec/tracker; low = gap-fill estimate. Absent on live pipeline records."
+        }
+      }
+    },
+    "changelog.version_response": {
+      "description": "Response shape returned by GET /api/v1/changelog/version/{projectId} and MCP changelog_version tool. Reads from S3 deploy-config/{project_id}/current-version.json. ENC-ISS-256 (ENC-TSK-E81): the canonical S3 cursor write performed by deploy_finalize lambda_function.py lines 213-232 now fails loud at CRITICAL log level with a structured payload (project_id/version/spec_id/bucket/prefix/exception) instead of silently swallowing at ERROR. The prior silent-swallow behavior let an IAM-denial + CONFIG_PREFIX drift combination (CFN declared deployment-config, live intake+orchestrator patched to deploy-config, deploy_finalize missed) strand the devops cursor at 0.20.30 for 11 days / 10+ deploys despite audit rows in DynamoDB claiming bumps. CFN 02-compute.yaml CONFIG_PREFIX aligned to deploy-config for intake/orchestrator/finalize in the same PR.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Project identifier."
+        },
+        "version": {
+          "type": "string",
+          "definition": "Current semantic version of the project."
+        },
+        "deployed_at": {
+          "type": "timestamp",
+          "definition": "ISO-8601 UTC timestamp of the most recent deployment."
+        },
+        "spec_id": {
+          "type": "string",
+          "definition": "SPEC-ID of the deployment that set the current version."
+        }
+      }
+    },
+    "deploy.submit_response": {
+      "description": "Response envelope returned by POST /api/v1/deploy/submit (deploy_intake Lambda). Includes optional version projection fields for major/minor change types.",
+      "fields": {
+        "request_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^COORD-"
+          },
+          "definition": "Coordination request ID for the queued deployment."
+        },
+        "spec_id": {
+          "type": "string",
+          "definition": "SPEC-ID assigned to this deployment request."
+        },
+        "projected_next_version": {
+          "type": "string",
+          "definition": "Semver-projected version that will result from this deployment, computed from current-version.json + change_type. Present only for major/minor change_type when S3 version file is readable. Omitted for patch or on S3 read failure."
+        },
+        "release_notes_required": {
+          "type": "boolean",
+          "definition": "True when change_type is major or minor, indicating governance expects a release notes document. Omitted for patch deploys."
+        },
+        "release_notes_guidance": {
+          "type": "string",
+          "definition": "Governance instruction text directing the submitting agent to create a release notes document via documents_put before the deploy completes. Included when release_notes_required=true."
+        }
+      }
+    },
+    "mcp_server.deploy_submit": {
+      "description": "MCP deploy_submit tool surface (ENC-TSK-735). Exposes pr_id and merged_at required fields that deploy_intake added in ENC-FTR-037 AC4. deploy_intake validates both fields against GitHub API before accepting the request.",
+      "fields": {
+        "pr_id": {
+          "type": "integer",
+          "constraints": {
+            "min": 1
+          },
+          "definition": "GitHub PR number that was merged for this deployment. Required. Passed to deploy_intake which validates via GitHub API.",
+          "usage_guidance": "Obtain from advance_task_status response (merged-main transition returns pr_id). Must match a real merged PR in NX-2021-L/enceladus (or pr_owner/pr_repo if specified)."
+        },
+        "merged_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601"
+          },
+          "definition": "Timestamp when the PR was merged. Required. deploy_intake validates against GitHub API merged_at within 60-second tolerance.",
+          "usage_guidance": "Obtain from advance_task_status response (merged-main transition). Format: 2026-03-02T04:35:24Z."
+        },
+        "pr_owner": {
+          "type": "string",
+          "definition": "GitHub repository owner for PR validation. Optional, defaults to NX-2021-L.",
+          "usage_guidance": "Only override for non-enceladus repo deployments."
+        },
+        "pr_repo": {
+          "type": "string",
+          "definition": "GitHub repository name for PR validation. Optional, defaults to enceladus.",
+          "usage_guidance": "Only override for non-enceladus repo deployments."
+        }
+      }
+    },
+    "mcp_server.changelog_tools": {
+      "description": "Changelog MCP tools added in ENC-FTR-033. Route through /api/v1/changelog/* endpoints of the devops-changelog-api Lambda.",
+      "fields": {
+        "changelog_history": {
+          "type": "tool",
+          "usage_guidance": "Single-project changelog. Args: project_id (required), limit (optional, default 20, max 100), change_type (optional enum: patch|minor|major). Returns array of changelog.entry records sorted by deployed_at desc."
+        },
+        "changelog_history_all": {
+          "type": "tool",
+          "usage_guidance": "Multi-project changelog. Args: projects (required, comma-separated project IDs), limit (optional per-project), change_type (optional). Merges all project histories sorted by deployed_at desc."
+        },
+        "changelog_version": {
+          "type": "tool",
+          "usage_guidance": "Current version for a project. Args: project_id (required). Returns changelog.version_response shape from S3 current-version.json."
+        }
+      }
+    },
+    "mcp_server.governance_dictionary": {
+      "description": "MCP tool for querying the governance data dictionary with lazy-loading support (ENC-ISS-087). Wraps GET /api/v1/governance/dictionary with optional entity/field/value filtering.",
+      "fields": {
+        "governance_dictionary": {
+          "type": "tool",
+          "usage_guidance": "No args: compact index (entity names + field counts, ~1k tokens). With entity (e.g., 'tracker.task'): full entity schema. With entity + field: single field definition. With entity + field + value: enum validation. Replaces governance_get('governance_data_dictionary.json') for session init."
+        }
+      }
+    },
+    "mcp_server.dynamic_toolsets": {
+      "description": "Dynamic MCP toolset filtering behavior for task-scoped sessions (ENC-TSK-826). list_tools responses can be namespace-filtered based on active checked-out task category when the client supports tools/list_changed notifications.",
+      "fields": {
+        "list_tools.filtering": {
+          "type": "behavior",
+          "definition": "When session context is active and tool_filter_active=true, list_tools returns only tool namespaces relevant to the active task category."
+        },
+        "session_context": {
+          "type": "object",
+          "definition": "Per-session state tracks active_task_id, active_project_id, active_category, and allowed_namespaces."
+        },
+        "tools_list_changed_notification": {
+          "type": "notification",
+          "definition": "Server emits notifications/tools/list_changed on checkout/release context transitions when supported by the transport/session."
+        },
+        "fallback_mode": {
+          "type": "behavior",
+          "definition": "If tools/list_changed is unsupported or transport is stateless, tool_filter_active remains false and full tool list is returned (no regression)."
+        }
+      }
+    },
+    "mcp_server.code_mode": {
+      "description": "Four-tool code-mode MCP surface for low-token managed sessions (ENC-FTR-044).",
+      "fields": {
+        "interface_mode": {
+          "type": "enum",
+          "enum": [
+            "raw",
+            "code"
+          ],
+          "definition": "Server interface flag. code publishes only search, coordination, get_compact_context, and execute. raw publishes all raw tools plus the four code-mode meta-tools (ENC-ISS-112)."
+        },
+        "search": {
+          "type": "tool",
+          "usage_guidance": "Compact read-only discovery surface over projects, tracker, documents, deploy, changelog, governance, reference, health, and GitHub project listings. Accepts action + arguments."
+        },
+        "coordination": {
+          "type": "tool",
+          "usage_guidance": "Compact orchestration surface over coordination_capabilities, coordination_request_get, coordination_cognito_session, dispatch_plan_generate, and dispatch_plan_dry_run."
+        },
+        "get_compact_context": {
+          "type": "tool",
+          "usage_guidance": "Budgeted composite context assembly for record, project, document, and topic modes. Must preserve the existing get_code_map payload verbatim under result.code_map when codemap is included."
+        },
+        "execute": {
+          "type": "tool",
+          "usage_guidance": "Ordered workflow runner for governed mutations. steps[].action resolves through an audited registry to existing MCP/HTTP handlers only. Supports dry_run and per-step on_error handling."
+        },
+        "allowed_raw_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Raw MCP tools that code-mode meta-tools may resolve onto within the current session boundary."
+        }
+      }
+    },
+    "mcp_server.package_decomposition": {
+      "description": "ENC-TSK-L09 (B64 Ph3): physical package layout for the code-mode meta-tool layer extracted from server.py. Both enceladus-mcp-code and enceladus-mcp-streamable Lambdas package tools/enceladus-mcp-server/ wholesale; server.py remains the deployed handler entrypoint and binds runtime dependencies after _TOOL_HANDLERS assembly.",
+      "fields": {
+        "package_root": {
+          "type": "string",
+          "definition": "tools/enceladus-mcp-server/mcp_server/ — sibling package imported by server.py."
+        },
+        "handler_modules": {
+          "type": "object",
+          "definition": "Independent modules under mcp_server/tools/: search.py, coordination.py, execute.py, context.py (get_compact_context). Action registries live in mcp_server/actions.py; shared envelopes/helpers in mcp_server/meta_support.py; dependency injection in mcp_server/runtime.py via bind_runtime()."
+        },
+        "routing_invariant": {
+          "type": "behavior",
+          "definition": "No change to code-mode tool names or action identifiers; server.py re-exports _SEARCH_ACTIONS/_EXECUTE_ACTIONS/_COORDINATION_ACTIONS and maps _TOOL_HANDLERS search/coordination/get_compact_context/execute to the decomposed handlers."
+        }
+      }
+    },
+    "mcp_server.deferred_tool_loading": {
+      "description": "Anthropic deferred tool-loading policy for Enceladus MCP (ENC-TSK-G15 / FTR-099 A3.2). Reduces per-turn tool-definition token footprint by deferring non-essential tools and registering BM25 on-demand retrieval.",
+      "fields": {
+        "eager_load_tools": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Code-mode meta-tools always loaded (not deferred): search, get_compact_context, execute, coordination.",
+          "usage_guidance": "Configured in tools/enceladus-mcp-server/tool_defer_loading.py EAGER_LOAD_TOOLS; surfaced via coordination_capabilities.features.deferred_tool_loading."
+        },
+        "mcp_toolset": {
+          "type": "object",
+          "definition": "Anthropic mcp_toolset block with default_config.defer_loading=true and per-tool eager overrides.",
+          "usage_guidance": "Built by build_mcp_toolset() in tool_defer_loading.py; attached to Claude dispatch when provider_session.deferred_tool_loading=true."
+        },
+        "tool_search_tool_bm25_20251119": {
+          "type": "tool",
+          "definition": "BM25 tool search registered in the Anthropic tools array for deferred tool discovery.",
+          "usage_guidance": "Keyword-rich ENCELADUS_MCP_SERVER_INSTRUCTIONS and MCP initialize serverInfo.instructions improve BM25 routing for tracker, docstore, checkout, deploy, and governance queries."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Required beta headers: advanced-tool-use-2025-11-20 and mcp-client-2025-11-20 when using defer_loading with MCP connector."
+        },
+        "token_footprint_reduction": {
+          "type": "behavior",
+          "definition": "Estimated >70% reduction in tool-definition tokens per turn when 4 eager + 36 deferred tools (validated in test_tool_defer_loading.py)."
+        },
+        "toolset_cache_control": {
+          "type": "object",
+          "definition": "Ephemeral 1h cache_control attached to the last tool in the Anthropic tools array (mcp_toolset block) when deferred_tool_loading is enabled.",
+          "usage_guidance": "Requires catalog_tokens_est above Sonnet 2048 / Opus 4096 minimums (see toolset_cache_eligibility in capabilities). Per-turn cache_read_input_tokens and cache_creation_input_tokens logged via dispatch_claude_api observability."
+        }
+      }
+    },
+    "coordination_api.anthropic_batch": {
+      "description": "Anthropic Message Batches API routing for non-interactive workloads (ENC-TSK-G19 / FTR-099 Strategy #8). Submits via POST /v1/messages/batches when provider_preferences.batch_eligible=true; EventBridge poller (rate 1 minute, 60s min interval) finalizes via batch-results callback.",
+      "fields": {
+        "batch_eligible": {
+          "type": "boolean",
+          "definition": "Provider preference signaling deferred batch execution (50% Anthropic batch pricing). Incompatible with execution_mode=preflight.",
+          "usage_guidance": "Set in provider_preferences on coordination request intake or dispatch body. Routes claude_agent_sdk dispatches through _dispatch_claude_batch_api instead of synchronous Messages API."
+        },
+        "batch_workload_type": {
+          "type": "enum",
+          "enum": [
+            "nightly_changelog_generation",
+            "governance_audit_doc_patching",
+            "compliance_doc_creation",
+            "memory_consolidation_bulk"
+          ],
+          "definition": "Optional workload classifier for telemetry and cost attribution. See NON_INTERACTIVE_WORKLOADS in anthropic_batch.py."
+        },
+        "ephemeral_1h_cache": {
+          "type": "object",
+          "definition": "cache_control {type: ephemeral, ttl: 1h} on system prompt and mcp_toolset prefix blocks in batch params.",
+          "usage_guidance": "Stacks with batch 50% discount for ~95% effective cost on recurring static-prefix workloads (NIGHTLY_CHANGELOG_COST_COMPARISON in anthropic_batch.py)."
+        },
+        "poll_interval_seconds": {
+          "type": "integer",
+          "definition": "Minimum 60 seconds between Anthropic batch status polls per request (BATCH_POLL_INTERVAL_SECONDS)."
+        },
+        "batch_subrequest_failure_alert": {
+          "type": "observability",
+          "definition": "Structured CloudWatch event batch_subrequest_failure with alert=true emitted for each errored batch result line."
+        }
+      }
+    },
+    "mcp_server.context_management": {
+      "description": "Anthropic context-management beta for long coordination loops (ENC-TSK-G17 / FTR-099 A3.5). Evicts stale tool results once input-token threshold is crossed while preserving memory tool writes.",
+      "fields": {
+        "context_management_enabled": {
+          "type": "boolean",
+          "definition": "Provider-session flag gating _maybe_attach_context_management in coordination_api dispatch_claude_api.",
+          "usage_guidance": "Set provider_session.context_management_enabled=true for sessions expected to exceed ~20 tool calls."
+        },
+        "clear_tool_uses_20250919": {
+          "type": "edit",
+          "definition": "Context edit: trigger at 100k input tokens, keep last 5 tool_uses, exclude_tools=[memory].",
+          "usage_guidance": "Wired in _build_claude_context_management_config(); memory tool excluded from eviction."
+        },
+        "clear_thinking_20251015": {
+          "type": "edit",
+          "definition": "Optional companion edit appended only when model is Opus and extended thinking is active.",
+          "usage_guidance": "Gated on thinking_param and opus model id in _maybe_attach_context_management."
+        },
+        "memory_20250818": {
+          "type": "tool",
+          "definition": "Anthropic memory tool registered on the tools array when context management is enabled.",
+          "usage_guidance": "Enceladus memory file schema (_ENCELADUS_MEMORY_FILE_SCHEMA) defines plan anchors, governance_hash, active task state. Runtime persistence: S3 via agent_session_memory.S3MemoryToolHandler at coordination-agent-memory/{project_id}/{scope_id}/memories/."
+        },
+        "anthropic_beta_headers": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Appends context-management-2025-06-27 via _append_anthropic_beta (composes with deferred_tool_loading headers)."
+        }
+      }
+    },
+    "mcp_server.cognito_oauth": {
+      "description": "Cognito-direct OAuth authentication mode for MCP endpoints (ENC-FTR-045). When active, OAuth metadata points authorization_endpoint and token_endpoint directly to Cognito Hosted UI, DCR returns pre-configured Cognito app client credentials, and bearer tokens are validated as Cognito JWTs.",
+      "fields": {
+        "auth_mode": {
+          "type": "enum",
+          "enum": [
+            "self_contained",
+            "cognito_direct"
+          ],
+          "definition": "Authentication mode. self_contained uses HMAC-signed auth codes and static MCP_API_KEY bearer validation. cognito_direct points OAuth to Cognito Hosted UI and validates JWT bearer tokens. Mode is auto-detected: cognito_direct activates when ENCELADUS_COGNITO_USER_POOL_ID, ENCELADUS_COGNITO_CLIENT_ID, and ENCELADUS_COGNITO_DOMAIN are all set."
+        },
+        "cognito_env_vars": {
+          "type": "object",
+          "definition": "Environment variables for Cognito-direct mode: ENCELADUS_COGNITO_USER_POOL_ID (Cognito User Pool ID), ENCELADUS_COGNITO_REGION (Cognito region, defaults to pool ID prefix), ENCELADUS_COGNITO_CLIENT_ID (app client ID for DCR and JWT validation), ENCELADUS_COGNITO_CLIENT_SECRET (app client secret for DCR), ENCELADUS_COGNITO_DOMAIN (Cognito Hosted UI base URL)."
+        },
+        "bearer_validation": {
+          "type": "behavior",
+          "definition": "In cognito_direct mode, Bearer tokens are validated as RS256 JWTs against the Cognito JWKS endpoint. Validates issuer, expiration, and client_id/audience. JWKS keys are cached for 3600 seconds. Rejected tokens return 401 with WWW-Authenticate header containing resource_metadata URL."
+        },
+        "cors": {
+          "type": "behavior",
+          "definition": "Lambda Function URL configured with CORS: AllowOrigins=['https://claude.ai', 'https://*.claude.ai'], AllowMethods=['GET','POST','DELETE','OPTIONS'], AllowHeaders=['Content-Type','Authorization','Accept','Mcp-Session-Id'], ExposeHeaders=['Mcp-Session-Id']."
+        },
+        "lambda_deployment": {
+          "type": "string",
+          "definition": "Deployed as enceladus-mcp-code Lambda with Function URL. Separate from enceladus-mcp-streamable (self-contained OAuth, all tools). Uses ENCELADUS_MCP_INTERFACE_MODE=code to expose only the 4 code-mode meta-tools."
+        }
+      }
+    },
+    "mcp_server.context_assembly": {
+      "description": "Composite context retrieval tools for agent token optimization (ENC-TSK-829, ENC-TSK-830, enhanced ENC-TSK-825). Reduces multi-call context loading to single bundled responses with location_hint fuzzy matching and cross-project support.",
+      "fields": {
+        "get_compact_context": {
+          "type": "tool",
+          "definition": "Code-mode composite context tool that reuses get_issue_context, get_code_map, get_architecture_excerpts, documents_search/list, governance_dictionary, and projects_get under one compact envelope. ENC-TSK-B92: extended with optional three-signal hybrid retrieval — when `query` and/or `anchor_record_id` is supplied, the response includes a `hybrid_retrieval` section containing records ranked by Reciprocal Rank Fusion (k=60) over vector (HNSW cosine via graph_query_api), graph (Personalized PageRank via GDS or Cypher fallback), and keyword (title/intent/description contains) signals. Backward-compat: callers not passing `query`/`anchor_record_id` receive the legacy context shape unchanged.",
+          "usage_guidance": "Supports record|issue|task|feature|project|document|topic modes. In record/project/topic modes, code_map should use the existing get_code_map logic and payloads unchanged. Hybrid retrieval opt-in: pass `query` (text) or `anchor_record_id` (graph anchor) to enable. Auto-anchors to `record_id` for record modes when `anchor_record_id` is not supplied. Use `top_n` (default 20, max 50), `record_type` filter (task/issue/feature/plan/lesson/document), and `include_below_threshold` (default false) to tune results. Set `include_hybrid_retrieval=false` to force-disable even when query/anchor supplied."
+        },
+        "get_issue_context": {
+          "type": "tool",
+          "definition": "Composite MCP tool that bundles record core fields, relationship graph, component source paths, domain architecture excerpts, and recent history into a single response. For issues with location_hint, auto-resolves to matching components via weighted fuzzy matching (DOC-4C6035E777C0).",
+          "usage_guidance": "Accepts record_id and optional flags (include_components, include_architecture, include_recent_history, history_limit, max_tokens). Replaces 4-5 sequential tool calls with one. Returns component_resolution.method indicating how components were matched (explicit, location_hint, sparse_fallback)."
+        },
+        "get_architecture_excerpts": {
+          "type": "tool",
+          "definition": "Domain-scoped architecture excerpt delivery. Maps 30+ domain aliases to architecture doc files and returns only matched sections with heading metadata and freshness indicator (DOC-CA6AFFD18E98).",
+          "usage_guidance": "Accepts project_id, domains[], and max_excerpt_tokens. Supports expanded aliases: compute/data/dynamodb/lambda/api/governance, security/auth/cognito/iam/frontend/pwa/cloudfront, operations/deploy/monitoring/mcp/coordination/infrastructure. Returns no_architecture error for projects without docs/architecture/ files."
+        },
+        "domain_mapping": {
+          "type": "object",
+          "definition": "Maps 30+ domain aliases to 3 architecture files: compute/data/dynamodb/lambda/api/governance->data-compute.md, security/auth/cognito/iam/frontend/pwa/cloudfront/cdn->security-frontend.md, operations/deploy/monitoring/mcp/coordination/infrastructure/cloudformation->operations.md. Canonical domains: compute, operations, security_frontend."
+        },
+        "location_hint_matching": {
+          "type": "behavior",
+          "definition": "Weighted fuzzy matching resolves issue location_hint text to components: domain name match (weight 3), component name/category (weight 2), description keyword (weight 1), directory path segment (weight 1). Threshold >= 2, max 3 results. Returns match_confidence (exact/fuzzy) and match_score per component."
+        },
+        "budget_truncation": {
+          "type": "behavior",
+          "definition": "Both tools respect token budgets with priority-ordered truncation. Truncation emits machine-readable metadata (truncated_sections, dropped_items_count) instead of silently dropping context."
+        },
+        "freshness": {
+          "type": "behavior",
+          "definition": "Architecture excerpts include freshness field: 'live' for direct file reads (always fresh, no cache needed per DOC-CA6AFFD18E98 §4.1). S3 cached reads reserved for future cross-platform agent support."
+        }
+      }
+    },
+    "mcp_server.handoff_tools": {
+      "description": "MCP execute actions for governed handoff document lifecycle (ENC-FTR-061, ENC-TSK-B53). Three actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag. All route through document_api HTTP API.",
+      "fields": {
+        "document.create_handoff": {
+          "type": "execute_action",
+          "definition": "Creates a handoff document with document_subtype=handoff. Requires project_id, title, content, source_record_id. Optionally accepts prerequisite_state, verification_criteria, action_checklist, expires_at, description, keywords, related_items. Returns document_id on success.",
+          "usage_guidance": "execute(steps=[{action: 'document.create_handoff', arguments: {governance_hash, project_id, title, content, source_record_id, ...}}])"
+        },
+        "document.claim_handoff": {
+          "type": "execute_action",
+          "definition": "Transitions a handoff document from pending to claimed. The document_api auto-stamps claimed_by and claimed_at from the authenticated caller.",
+          "usage_guidance": "execute(steps=[{action: 'document.claim_handoff', arguments: {governance_hash, document_id}}])"
+        },
+        "document.complete_handoff": {
+          "type": "execute_action",
+          "definition": "Transitions a handoff document from claimed to completed.",
+          "usage_guidance": "execute(steps=[{action: 'document.complete_handoff', arguments: {governance_hash, document_id}}])"
+        },
+        "feature_flag": {
+          "type": "string",
+          "definition": "ENABLE_HANDOFF_PRIMITIVE environment variable. When 'true', the 3 handoff actions are registered in the execute action registry. Default 'false'."
+        }
+      }
+    },
+    "mcp_server.docstore_note_action": {
+      "description": "MCP execute action for ad-hoc governed notes (ENC-ISS-259, ENC-TSK-E98). document.create_note wraps documents.put with document_subtype pinned to 'doc' and denies caller override. Gives coord-lead / supervisor sessions a first-class, discoverable write path for notes that are NOT bound to any source tracker record (no source_record_id, no plan_anchor_id, no source_incident_id). NOT gated behind ENABLE_HANDOFF_PRIMITIVE because 'doc' is the stable pre-rollout baseline subtype. Routes through document_api HTTP API. Closes the contamination vector where agents reached for document_subtype='general' (deprecated) when they needed an unbound note path.",
+      "fields": {
+        "document.create_note": {
+          "type": "execute_action",
+          "definition": "Creates an ad-hoc governed document with document_subtype=doc and no source-record binding. Requires project_id, title, content. Optionally forwards description, keywords, related_items, file_name, informed_by. Caller CANNOT pass document_subtype (any non-doc value is rejected with INVALID_INPUT pointing at the dedicated handoff/coe/wave actions or documents.put for anything else).",
+          "usage_guidance": "execute(steps=[{action: 'document.create_note', arguments: {governance_hash, project_id, title, content, related_items, keywords}}])"
+        },
+        "subtype_pin": {
+          "type": "rule",
+          "definition": "document_subtype is server-side pinned to 'doc' by _document_create_note. Caller override is rejected with INVALID_INPUT. For handoff/coe/wave use the dedicated document.create_handoff / document.create_coe / document.create_wave actions. For any other subtype use documents.put directly."
+        },
+        "feature_flag": {
+          "type": "string",
+          "definition": "None. document.create_note is registered outside the ENABLE_HANDOFF_PRIMITIVE gate in _EXECUTE_ACTIONS because the 'doc' subtype is stable and pre-dates the handoff primitive rollout."
+        }
+      }
+    },
+    "mcp_server.docstore_subtype_tools": {
+      "description": "MCP execute actions for COE and wave docstore subtype lifecycle (ENC-FTR-077, ENC-TSK-E53). Four actions gated behind ENABLE_HANDOFF_PRIMITIVE feature flag. All route through document_api HTTP API. AC-5: product-lead-terminal append_handoff_reply dual-appends to both the handoff doc and the active wave doc (best-effort).",
+      "fields": {
+        "document.create_coe": {
+          "type": "execute_action",
+          "definition": "Creates a COE (Correction of Errors) document with document_subtype=coe. Requires project_id, title, content, source_incident_id. Optionally accepts description, keywords, related_items, file_name, informed_by. Validation of related_items composition (>= 1 FTR, >= 1 LSN, >= 1 ISS) is enforced by document_api. Returns document_id on success.",
+          "usage_guidance": "execute(steps=[{action: 'document.create_coe', arguments: {governance_hash, project_id, title, content, source_incident_id, ...}}])"
+        },
+        "document.create_wave": {
+          "type": "execute_action",
+          "definition": "Creates a wave coordination document with document_subtype=wave anchored to a plan. Requires project_id, title, content, plan_anchor_id. Optionally accepts description, keywords, related_items, file_name. Returns document_id on success.",
+          "usage_guidance": "execute(steps=[{action: 'document.create_wave', arguments: {governance_hash, project_id, title, content, plan_anchor_id, ...}}])"
+        },
+        "document.append_handoff_reply": {
+          "type": "execute_action",
+          "definition": "Appends a structured reply block with YAML frontmatter (reply_author, reply_timestamp, agent_layer, originating_handoff_ref) to a handoff document via append_content PATCH. Requires document_id, content, agent_layer (one of: supervisor, coord-lead, dispatched-agent, product-lead-terminal). Optionally accepts author, originating_handoff_ref. AC-5: when agent_layer is product-lead-terminal and the handoff append succeeds, a best-effort dual-append copies the reply to the active wave doc in the same project.",
+          "usage_guidance": "execute(steps=[{action: 'document.append_handoff_reply', arguments: {governance_hash, document_id, content, agent_layer, ...}}])"
+        },
+        "document.append_wave_entry": {
+          "type": "execute_action",
+          "definition": "Appends a wave entry with YAML frontmatter (reply_author, reply_timestamp, agent_layer, optional originating_handoff_ref) to a wave document via append_content PATCH. Requires document_id, content, agent_layer. Optionally accepts author, originating_handoff_ref for cross-document traceability.",
+          "usage_guidance": "execute(steps=[{action: 'document.append_wave_entry', arguments: {governance_hash, document_id, content, agent_layer, ...}}])"
+        },
+        "dual_append_behavior": {
+          "type": "rule",
+          "definition": "AC-5 dual-append: when product-lead-terminal calls document.append_handoff_reply and the handoff PATCH succeeds, the MCP server searches for an active wave doc (document_subtype=wave, wave_status=active) in the same project and appends a cross-referenced entry. The wave append is best-effort — handoff success is never blocked by wave append failure. If no active wave doc exists, the dual-append is silently skipped with an INFO log.",
+          "governing_feature": "ENC-FTR-077"
+        },
+        "feature_flag": {
+          "type": "string",
+          "definition": "ENABLE_HANDOFF_PRIMITIVE environment variable. When 'true', these 4 actions (plus the 3 handoff actions) are registered in the execute action registry. Default 'false'."
+        }
+      }
+    },
+    "mcp_server.documents_passthrough": {
+      "description": "Open-passthrough body construction pattern for the MCP-to-document_api bridge (ENC-TSK-C71 / ENC-TSK-E63 / ENC-ISS-158 / ENC-PLN-030, extended by ENC-FTR-078). Replaces the prior explicit whitelist in _documents_put and _documents_patch with a denylist-driven loop mirroring _tracker_create. Every subtype field declared in document_api now forwards automatically from execute args to the document_api HTTP body. ENC-FTR-078 adds subtypepattern (doc subtype) and five skill-subtype fields (full_description, claude_description, agentskills_manifest, agentskills_spec_version, runtime_variants) to the forwardable set and extends the documents.search filter arguments with subtypepattern. Eliminates the recurring failure mode where new subtype fields landed in document_api but not the MCP layer (rediscovered four times: ENC-TSK-B82, ENC-PLN-016 dispatch wave 1, ENC-TSK-E57 deploy session, ENC-TSK-E62 handoff attempts).",
+      "fields": {
+        "put_body_denylist": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Keys NOT forwarded from execute args to document_api PUT body. Single entry: governance_hash (handled by the HTTP auth layer, never goes in body). ENC-FTR-078 preserves the denylist shape unchanged; new fields flow through automatically."
+        },
+        "patch_body_denylist": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Keys NOT forwarded from execute args to document_api PATCH body. Two entries: governance_hash (HTTP auth layer) and document_id (URL path parameter, not body). ENC-FTR-078 preserves the denylist shape unchanged."
+        },
+        "tool_schema_coverage": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Subtype fields declared in the documents_put and documents_patch tool schemas. FTR-077 set: document_subtype, confirm_subtype, source_record_id, handoff_status, prerequisite_state, verification_criteria, action_checklist, expires_at, source_incident_id, coe_status, plan_anchor_id, wave_status, informed_by, document_maturity_state. FTR-078 extensions: subtypepattern (document.doc), full_description (document.skill), claude_description (document.skill), agentskills_manifest (document.skill), agentskills_spec_version (document.skill), runtime_variants (document.skill). documents.search filter arguments also include subtypepattern (FTR-078 AC-17) for exact-match canonical filtering on document_subtype='doc' records. Each field's description references its dictionary entity (document.handoff / document.coe / document.wave / document.doc / document.idea / document.context-node / document.skill / docstore.document)."
+        },
+        "reference_pattern": {
+          "type": "string",
+          "definition": "Mirrors _tracker_create's open-passthrough loop at tools/enceladus-mcp-server/server.py (currently lines 5458-5495). The invariant: MCP should forward anything the caller declares and let document_api be the single source of validation truth."
+        },
+        "governing_records": {
+          "type": "object",
+          "definition": "Plan: ENC-PLN-030. Issue: ENC-ISS-158. Tasks: ENC-TSK-C71 (lambda_deploy vehicle), ENC-TSK-E63 (code_only companion). Doc: DOC-8BB0D5531B47."
+        }
+      }
+    },
+    "tracker.issue_location_context": {
+      "description": "Issue creation location context enforcement (ENC-TSK-805, softened by ENC-ISS-105). hypothesis/technical_notes and location_hint are recommended for issues but no longer hard-block creation.",
+      "fields": {
+        "enforcement_mode": {
+          "type": "enum",
+          "values": [
+            "soft_warning"
+          ],
+          "definition": "Missing location context fields (hypothesis, technical_notes, location_hint) produce warnings in the response but do not block issue creation.",
+          "usage_guidance": "Ontology scoring already penalizes missing fields. Hard 400 enforcement was removed in ENC-ISS-105 because MCP client bindings did not expose these parameters, causing a self-inflicted regression."
+        }
+      }
+    },
+    "checkout_service.install_scope_diagnostic": {
+      "description": "Self-correcting 404 diagnostic for GitHub commit validation (ENC-TSK-C68, ENC-ISS-183). When _validate_commit() receives a 404 from /repos/{owner}/{repo}/commits/{sha}, the checkout service now probes /installation/repositories via the cached App installation token and, if the target repo is not in the installation's accessible-repo list, returns a descriptive error that names the installation id, links to the installation management URL, lists currently accessible repos, and explicitly calls out Organization Owner as the required role. Prevents repeats of the devops-project stall where the ambiguous 'Commit not found' error masked an App installation scope gap for weeks. Probe result cached for 300s to avoid hammering GitHub; probe failures return the generic 'commit not found' error so real 404s are not masked by a misleading installation-scope message.",
+      "fields": {
+        "probe_ttl_seconds": {
+          "type": "integer",
+          "definition": "Seconds the installation-repo probe result is cached before re-probing. Controls how quickly a newly-granted repo becomes visible to the checkout service after the org admin updates the installation scope.",
+          "usage_guidance": "Default: 300. Do not set lower than ~60 to avoid probe-on-every-404 hammering."
+        },
+        "probe_pagination_cap": {
+          "type": "integer",
+          "definition": "Maximum number of pages (at 100 repos/page) the probe will fetch from /installation/repositories. Protects against runaway pagination if an installation ever exceeds 2000 repos.",
+          "usage_guidance": "Default: 20. Raise only if legitimately needed."
+        },
+        "generic_fallback_trigger": {
+          "type": "string",
+          "definition": "Conditions under which _validate_commit falls back to the pre-ENC-TSK-C68 generic 'Commit <sha> not found in {owner}/{repo}' error instead of the new installation-scope error. Triggers: (a) installation token mint failure, (b) /installation/repositories returns empty set, (c) any exception during pagination, (d) repo IS in the accessible list (meaning the 404 is a real missing-commit).",
+          "usage_guidance": "This fail-safe path ensures the new diagnostic never masks a real 404. Operators can distinguish the two error classes by whether the message mentions 'enceladus-integration' (new path) or just 'Commit ... not found' (legacy/fallback path)."
+        },
+        "unit_test_coverage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Test file path(s) covering the install-scope diagnostic.",
+          "usage_guidance": "Currently: backend/lambda/checkout_service/test_validate_commit_installation_scope.py with 5 tests covering installation-scope 404 -> descriptive error, in-scope 404 -> generic fallback, probe failure -> generic fallback, 200 fast path (probe never called), and non-404 errors (probe never called)."
+        }
+      }
+    },
+    "checkout_service.config": {
+      "description": "Runtime configuration requirements for the checkout service Lambda (ENC-ISS-088, ENC-TSK-B26). Documents constraints on env var values to ensure correct inter-service routing and GitHub App authentication.",
+      "fields": {
+        "TRACKER_API_BASE": {
+          "type": "string",
+          "constraints": {
+            "must_not_use": "https://jreese.net/api/v1/tracker",
+            "reason": "jreese.net routes through Cloudflare, which blocks Lambda IP ranges with HTTP 1010 (Access Denied by owner rule). Lambda-to-Lambda calls must use direct API Gateway endpoint."
+          },
+          "definition": "Base URL for outbound tracker API calls from checkout service. Must use direct API Gateway URL to bypass Cloudflare.",
+          "usage_guidance": "Correct value: https://8nkzqkmxqc.execute-api.us-west-2.amazonaws.com/api/v1/tracker. See ENC-ISS-088."
+        },
+        "PROJECTS_TABLE": {
+          "type": "string",
+          "definition": "DynamoDB table name for project records. Used by _resolve_github_repo() to look up the project's GitHub repo URL for commit/PR validation (DVP-ISS-082).",
+          "usage_guidance": "Default: 'projects'. The checkout service Lambda IAM role must have dynamodb:GetItem and dynamodb:Scan permissions on this table."
+        },
+        "GITHUB_APP_ID": {
+          "type": "string",
+          "definition": "GitHub App numeric ID for generating installation access tokens (ENC-TSK-B26). Replaces static GITHUB_TOKEN PAT.",
+          "usage_guidance": "Set to the Enceladus GitHub App ID (currently 2946766). If unset, GitHub API calls fall back to unauthenticated (60 req/hr rate limit on public repos)."
+        },
+        "GITHUB_INSTALLATION_ID": {
+          "type": "string",
+          "definition": "GitHub App installation ID for the NX-2021-L organization (ENC-TSK-B26).",
+          "usage_guidance": "Set to the installation ID (currently 112392089). Required together with GITHUB_APP_ID."
+        },
+        "GITHUB_PRIVATE_KEY_SECRET": {
+          "type": "string",
+          "definition": "Secrets Manager secret name containing the GitHub App RSA private key (ENC-TSK-B26). Used to generate short-lived JWTs exchanged for installation tokens.",
+          "usage_guidance": "Default: 'devops/github-app/enceladus-private-key'. Lambda IAM role must have secretsmanager:GetSecretValue on this secret."
+        }
+      }
+    },
+    "checkout_service.token": {
+      "description": "Checkout service token records stored in enceladus-checkout-tokens DynamoDB table. CAI and CCI tokens gate the commit workflow (ENC-FTR-037). Each token is a DynamoDB item with a TTL.",
+      "fields": {
+        "token_id": {
+          "type": "string",
+          "constraints": {
+            "pattern": "^(CAI|CCI)-[0-9a-f]{32}$"
+          },
+          "definition": "Token identifier. CAI (Commit Approval ID) issued at coding-complete; CCI (Commit Complete ID) issued at committed. Format: {TYPE}-{uuid4_hex}."
+        },
+        "task_id": {
+          "type": "string",
+          "definition": "Tracker task record ID associated with this token (e.g. ENC-TSK-730)."
+        },
+        "project_id": {
+          "type": "string",
+          "definition": "Project identifier of the associated task."
+        },
+        "token_type": {
+          "type": "enum",
+          "enum": [
+            "CAI",
+            "CCI"
+          ],
+          "definition": "Token type. CAI = Commit Approval; CCI = Commit Complete."
+        },
+        "issued_at": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "Timestamp when the token was issued."
+        },
+        "ttl": {
+          "type": "integer",
+          "definition": "DynamoDB TTL epoch seconds. Tokens expire 30 days after issuance. Expired tokens fail validation."
+        },
+        "validate_endpoint": {
+          "type": "string",
+          "definition": "Endpoint to validate a CCI token. Used by GitHub Actions PR Commit Gate workflow.",
+          "usage_guidance": "GET {CHECKOUT_SERVICE_API_BASE}/validate/commit-complete/{cci_id}. Returns {valid: true, task_id, project_id} on success or {valid: false, reason} on failure."
+        }
+      }
+    },
+    "checkout_service.advance_request": {
+      "description": "Request schema for POST /api/v1/checkout/{project}/task/{task_id}/advance (ENC-FTR-037, ENC-FTR-059). Checkout service validates evidence via canonical transition_type_matrix (v1) and advances task status. Response includes matrix_version. B08: checkout_transition_type is stamped at checkout.task and integrity-checked at every advance — mismatch returns 409.",
+      "fields": {
+        "target_status": {
+          "type": "enum",
+          "enum": [
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "closed"
+          ],
+          "definition": "Target status to advance the task to. Each value has specific evidence requirements (see gate_matrix below)."
+        },
+        "provider": {
+          "type": "string",
+          "definition": "Provider identity making the advance request (e.g. claude_agent_sdk, coordination_dispatch)."
+        },
+        "transition_evidence": {
+          "type": "object",
+          "definition": "Evidence payload; required fields vary by target_status and by component_registry.component.required_transition_type policy (see gate_matrix plus v3_component_policy_evidence)."
+        },
+        "v3_component_policy_evidence": {
+          "type": "object",
+          "definition": "Additional evidence overlays introduced by ENC-TSK-L77 / DOC-157A790F9E8B. These are evaluated by checkout_service based on the task's declared components and their normalized component required_transition_type values.",
+          "properties": {
+            "external_deploy_evidence": {
+              "type": "object",
+              "required_when": "Any task component resolves to required_transition_type=external_deploy and target_status=deploy-success.",
+              "required_fields": {
+                "comp_external_id": "non-empty string",
+                "retrieval_steps": "string, minimum 20 characters"
+              },
+              "definition": "Structured external-system proof. comp_external_id is the live external resource identifier; retrieval_steps must be concrete enough for a future agent/io session to re-derive the same identifier."
+            },
+            "documentation_evidence": {
+              "type": "array[string]",
+              "required_when": "Any task component resolves to required_transition_type=documentation and target_status=closed.",
+              "constraints": [
+                "non-empty array",
+                "each item matches DOC-* and resolves through document API",
+                "at least one item is novel or fresh"
+              ],
+              "fresh_window_minutes": 15,
+              "definition": "Docstore artifact-genesis proof. Novel means not referenced by another closed task's documentation_evidence; fresh means document.updated_at is within 15 minutes of the close attempt. Stale re-references are permitted as supporting context when at least one array member qualifies."
+            }
+          }
+        },
+        "gate_matrix": {
+          "type": "object",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI; additionally external_deploy components require external_deploy_evidence. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; documentation components additionally require documentation_evidence; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
+          "properties": {
+            "committed": {
+              "required_evidence": [
+                "commit_sha"
+              ],
+              "optional_evidence": [
+                "owner",
+                "repo"
+              ],
+              "repo_resolution": "Auto-resolved from projects table if owner/repo not provided in transition_evidence (DVP-ISS-082).",
+              "issues_token": "CCI"
+            },
+            "coding-complete": {
+              "required_evidence": [],
+              "issues_token": "CAI"
+            },
+            "merged-main": {
+              "required_evidence": [
+                "pr_id",
+                "merged_at"
+              ],
+              "optional_evidence": [
+                "owner",
+                "repo",
+                "merge_evidence"
+              ],
+              "repo_resolution": "Auto-resolved from projects table if owner/repo not provided in transition_evidence (DVP-ISS-082).",
+              "compat_note": "ENC-ISS-095: tracker_mutation has a legacy gate requiring a free-text merge_evidence string for merged-main. This gate is bypassed for checkout-service-authenticated requests (X-Checkout-Service-Key) since the checkout service validates pr_id+merged_at via GitHub API. For non-checkout-service PATCH requests, merge_evidence remains required for backward compat. When calling advance_task_status via MCP (which routes through the checkout service), only pr_id and merged_at are needed."
+            },
+            "deploy-success": {
+              "required_evidence": [
+                "deploy_evidence"
+              ],
+              "additional_component_policy_evidence": [
+                "external_deploy_evidence when any component required_transition_type resolves to external_deploy"
+              ],
+              "clears_tokens": [
+                "CAI",
+                "CCI"
+              ]
+            },
+            "closed": {
+              "required_evidence": [
+                "live_validation_evidence"
+              ],
+              "additional_component_policy_evidence": [
+                "documentation_evidence when any component required_transition_type resolves to documentation"
+              ],
+              "releases_checkout": true
+            }
+          }
+        },
+        "component_registry_prevalidation": {
+          "type": "object",
+          "definition": "checkout.task validates transition_type against the component registry before writing any state. If any registered component enforces a minimum transition_type stricter than the task's declared type, checkout is rejected with a 400 error before the checkout lock, CAI token, or status mutation is written. This surfaces incompatibilities before transition_type becomes immutable per ENC-FTR-060. Introduced by ENC-TSK-C15 (ENC-ISS-172).",
+          "usage_guidance": "If checkout.task returns a 400 with 'conflicting_component' in the error details, the agent must update task.transition_type via tracker.set to at least the required type before retrying checkout. Empty or absent task.components bypasses this check (no components = no constraint)."
+        }
+      }
+    },
+    "checkout_service.transition_type_matrix": {
+      "description": "Per-type lifecycle arc definitions for task.transition_type (ENC-ISS-092, ENC-FTR-059). v1 canonical matrix embedded as Python constant in both checkout_service and tracker_mutation Lambdas (transition_type_matrix.py). Gate contracts loaded at runtime via matrix lookup — no hardcoded transition_type conditionals remain in either Lambda. MATRIX_VERSION=1, source document DOC-B5B807D7C2CE. B07: no_code and code_only transition_types are immutable once set. B08: transition_type stamped at checkout and integrity-checked at every advance.",
+      "fields": {
+        "github_pr_deploy": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "closed"
+          ],
+          "gate_requirements": {
+            "coding-complete": "checkout required; issues CAI token",
+            "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
+            "pr": "CCI required on task record",
+            "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
+            "deploy-init": "checkout required; no evidence",
+            "deploy-success": "deploy_evidence (GitHub Actions Jobs API 8 fields: id, name, run_id, head_sha, status=completed, conclusion=success, started_at, completed_at); clears CAI+CCI",
+            "closed": "live_validation_evidence (non-empty string); releases checkout"
+          }
+        },
+        "web_deploy": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "closed"
+          ],
+          "gate_requirements": {
+            "coding-complete": "checkout required; issues CAI token",
+            "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
+            "pr": "CCI required on task record",
+            "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
+            "deploy-init": "checkout required; no evidence",
+            "deploy-success": "web_deploy_evidence {url (HTTPS), http_status (must be 200), checked_at (ISO 8601 with T separator)}; clears CAI+CCI",
+            "closed": "live_validation_evidence (non-empty string); releases checkout"
+          }
+        },
+        "code_only": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "closed"
+          ],
+          "gate_requirements": {
+            "coding-complete": "checkout required; issues CAI token",
+            "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
+            "pr": "CCI required on task record",
+            "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+          },
+          "skipped_statuses": [
+            "deploy-init",
+            "deploy-success"
+          ],
+          "note": "Use for tasks where code was written and merged but no deployment step exists or is needed."
+        },
+        "no_code": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "in-progress",
+            "coding-complete",
+            "closed"
+          ],
+          "gate_requirements": {
+            "coding-complete": "checkout required; NO CAI token issued (GitHub PR flow not applicable)",
+            "closed": "no_code_evidence (non-empty string; no GitHub API call); releases checkout"
+          },
+          "skipped_statuses": [
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success"
+          ],
+          "note": "Use for tasks with no GitHub repo, non-code work (infra config, CLI installs, admin tasks), or work that cannot produce GitHub commit evidence."
+        },
+        "user-initiated": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "open",
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "coding-updates",
+            "closed"
+          ],
+          "auth_requirement": "Cognito session cookie (enceladus_id_token) only — internal API key rejected with HTTP 403",
+          "gate_requirements": {
+            "any_status": "user_note (non-empty string) required; no checkout required; no GitHub API validation; no CAI/CCI token checks",
+            "closed (Submit + Close)": "user_note required; target_status=closed regardless of current status; checkout always released; note posted as worklog history entry (action=worklog, ENC-TSK-841) instead of pending update"
+          },
+          "checkout_behavior": "borrow-and-restore — tracker_mutation temporarily takes checkout ownership as Cognito username; on completion restores previous agent checkout if task was checked out (except on close, which always releases); worklog provider=cognito_username",
+          "audit": "initiated_by (Cognito username) and initiated_at stamped on transition_evidence as permanent audit record; [USER-INITIATED] worklog entry appended",
+          "handled_by": "tracker_mutation Lambda (_apply_user_initiated_advance) — NOT routed through checkout service gate matrix",
+          "note": "This is not a stored field value. user-initiated is a request-time flag (transition_evidence.user_initiated=true) handled at the API layer. The four agent-path types above (github_pr_deploy, web_deploy, code_only, no_code) are stored on the task record as task.transition_type."
+        },
+        "lambda_deploy": {
+          "type": "arc_spec",
+          "allowed_statuses": [
+            "in-progress",
+            "coding-complete",
+            "committed",
+            "pr",
+            "merged-main",
+            "deploy-init",
+            "deploy-success",
+            "closed"
+          ],
+          "gate_requirements": {
+            "coding-complete": "checkout required; issues CAI token",
+            "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
+            "pr": "CCI required on task record",
+            "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
+            "deploy-init": "checkout required; no evidence",
+            "deploy-success": "lambda_deploy_evidence object. Accepts two shapes (ENC-ISS-162): simplified {function_name, version, updated_at (ISO 8601 with T), status='Success'} or full AWS GetFunctionConfiguration {FunctionArn, FunctionName, Version, CodeSha256, CodeSize, ConfigSha256, LastModified, RevisionId, State='Active', LastUpdateStatus='Successful'}. Auto-detected by presence of function_name (simplified) vs FunctionArn (full). Does NOT accept deploy_evidence (GH Actions) or web_deploy_evidence.",
+            "closed": "live_validation_evidence (non-empty string); releases checkout"
+          },
+          "added_by": "ENC-FTR-041"
+        }
+      }
+    },
+    "component_registry.component": {
+      "description": "A registered product component in the Enceladus component registry (ENC-FTR-041). DOC-157A790F9E8B / ENC-TSK-L77 hardens component identity with the injection pair component_address + component_repo_dir and classifies the row with component_address_class + component_class. required_transition_type is the v3 component policy enum code|external_deploy|documentation; checkout_service maps legacy component values at read time while task.transition_type keeps the existing lifecycle arc enum. ENC-TSK-E68 (ENC-PLN-031): capability-declaration fields are consumed by the continuous deploy capability auditor and pre-merge guard. ENC-TSK-J40 added deploy_targets for blast-radius-scoped deploy checks.",
+      "fields": {
+        "component_id": {
+          "type": "string",
+          "format": "comp-{slug}",
+          "definition": "Unique slug identifier for the component. PK of component-registry DynamoDB table.",
+          "example": "comp-checkout-service"
+        },
+        "component_name": {
+          "type": "string",
+          "definition": "Human-readable display name of the component.",
+          "example": "Checkout Service Lambda"
+        },
+        "project_id": {
+          "type": "string",
+          "definition": "Enceladus project this component belongs to.",
+          "example": "enceladus"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "lambda",
+            "frontend",
+            "infrastructure",
+            "library",
+            "workflow",
+            "external"
+          ],
+          "definition": "Classification category of the component."
+        },
+        "component_address": {
+          "type": "string",
+          "required": true,
+          "unique": true,
+          "definition": "Universally addressable runtime/resource identity for the component. Accepted classes are governed by component_address_class. The create/propose surfaces reject duplicate addresses across the registry, including archived rows, preserving DOC-157A790F9E8B I1 address injection.",
+          "example": "arn:aws:lambda:us-west-2:123456789012:function:enceladus-checkout-service-gamma"
+        },
+        "component_repo_dir": {
+          "type": "string",
+          "required": true,
+          "unique_and_non_overlapping": true,
+          "definition": "Repository-relative source authority path for the component, or meta:{component_id} for meta components. The create/propose/update surfaces reject equal paths and prefix-overlaps against non-archived components, preserving DOC-157A790F9E8B I2 source injection and I3 source non-overlap.",
+          "example": "backend/lambda/checkout_service"
+        },
+        "component_address_class": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "aws_arn",
+            "https_url",
+            "cloudflare_resource",
+            "neo4j_auradb",
+            "external_manifest",
+            "meta"
+          ],
+          "definition": "Address verification/dispatch class. aws_arn must start with arn:aws:, https_url with https://, neo4j_auradb with neo4j+s://, and meta must use component_address=meta:{component_id}. component_address_class=aws_arn must not combine with required_transition_type=external_deploy."
+        },
+        "component_class": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "physical",
+            "external",
+            "meta"
+          ],
+          "definition": "Ontology class. physical is repo-produced runtime substrate, external is third-party/admin-managed substrate with governed repo configuration, and meta is governance-only. component_class=meta must be paired with component_address_class=meta and sentinel address/repo_dir values."
+        },
+        "transition_type": {
+          "type": "string",
+          "enum": [
+            "code",
+            "external_deploy",
+            "documentation"
+          ],
+          "definition": "Documentation field describing the component's native artifact class. New writes use the v3 enum. Legacy stored values github_pr_deploy, lambda_deploy, web_deploy, code_only, data_only, and no_code are mapped at read time for compatibility."
+        },
+        "required_transition_type": {
+          "type": "string",
+          "required": true,
+          "enum": [
+            "code",
+            "external_deploy",
+            "documentation"
+          ],
+          "legacy_read_time_mapping": {
+            "github_pr_deploy": "code",
+            "lambda_deploy": "code",
+            "web_deploy": "code",
+            "code_only": "code",
+            "data_only": "code",
+            "no_code": "documentation for meta/doc-authored rows, otherwise code"
+          },
+          "definition": "The component policy/artifact class required for tasks that declare this component. code requires a code-producing task arc; external_deploy requires a deploy-success stage plus external_deploy_evidence; documentation requires documentation_evidence at close. Checkout service reads this field, normalizes legacy populated rows at read time, and raises COMPONENT_MISCONFIGURED if the field is missing or invalid.",
+          "usage_guidance": "REQUIRED at create/propose time. New writes must use code, external_deploy, or documentation. PATCH may update but may not unset it. component_address_class=aws_arn rejects external_deploy. Default mapping: aws_arn->code; https_url->code for project-owned runtimes or external_deploy for third-party systems; cloudflare_resource/neo4j_auradb/external_manifest->external_deploy; meta->documentation.",
+          "enforcement_surface": "coordination_api validates create/propose/update. checkout_service._get_required_transition_type normalizes v3/legacy component values and compares them to task.transition_type lifecycle arcs; _handle_advance enforces external_deploy_evidence and documentation_evidence when matching component policies are present."
+        },
+        "required_transition_type_rationale": {
+          "type": "string",
+          "required": false,
+          "definition": "Optional rationale when required_transition_type departs from the component_address_class default mapping. Consumed by drift audit D4 in DOC-157A790F9E8B."
+        },
+        "description": {
+          "type": "string",
+          "definition": "Optional free-text purpose summary of the component."
+        },
+        "github_repo": {
+          "type": "string",
+          "definition": "Optional GitHub repository reference (e.g., NX-2021-L/enceladus)."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "deprecated",
+            "archived"
+          ],
+          "definition": "Lifecycle status of the component record."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "ISO 8601",
+          "definition": "Record creation timestamp."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "ISO 8601",
+          "definition": "Last update timestamp."
+        },
+        "lifecycle_status": {
+          "type": "enum",
+          "required": true,
+          "enum": [
+            "proposed",
+            "approved",
+            "designed",
+            "development",
+            "production",
+            "code-red",
+            "deprecated",
+            "archived"
+          ],
+          "default": "proposed",
+          "definition": "ENC-FTR-076 v2 / DOC-546B896390EA §3: full 8-status component lifecycle state machine. Supersedes the v1 6-status enum (proposed|approved|active|rejected|deprecated|archived) documented in component_registry.propose_contract.lifecycle_status_enum — v1 `active` folds into v2 `production`; v1 `rejected` is not carried forward (terminal rejections now archive via the revert handler). proposed is the initial state after component.propose; approved is io-confirmed; designed is set after a DESIGNS task closes; development is set after an IMPLEMENTS task is checked out; production is set after the IMPLEMENTS task reaches deploy-success; code-red is an incident state (component still live); deprecated is an io-only terminal-adjacent state; archived is permanent terminal reached only via the revert path. Backfill sets existing components to lifecycle_status=production (AC[5] of DOC-546B896390EA).",
+          "transition_table": {
+            "description": "Authoritative forward-transition config per DOC-546B896390EA §3.2. Read at runtime by the component transition validator — no code changes required when transitions evolve (DD-5). Hard blocks below are enforced INDEPENDENTLY of this table.",
+            "transitions": {
+              "proposed": [
+                "approved",
+                "archived"
+              ],
+              "approved": [
+                "designed"
+              ],
+              "designed": [
+                "development",
+                "approved"
+              ],
+              "development": [
+                "production",
+                "designed"
+              ],
+              "production": [
+                "code-red",
+                "deprecated",
+                "development"
+              ],
+              "code-red": [
+                "production",
+                "deprecated"
+              ],
+              "deprecated": [
+                "production"
+              ],
+              "archived": []
+            }
+          },
+          "hard_blocks": [
+            "deprecated->development: version-fork required. Deprecated components that need new development work must be registered as a new component with the -v2/-v3 suffix convention (DOC-546B896390EA §7.4, DD-3).",
+            "archived->any: archived is a permanent terminal state. No recovery path exists."
+          ],
+          "authority_matrix": {
+            "description": "Per DOC-546B896390EA §3.3. Agent authority is always conditional on the evidence gate passing; io authority is unconditional for permitted transitions.",
+            "rules": {
+              "proposed->approved": "io only",
+              "proposed->archived": "io only (via revert handler, auto-archives atomically with reverted_at + reverted_reason)",
+              "approved<->designed": "io (both directions); agent (forward only, gate required: DESIGNED_BY task closed_count >= 1)",
+              "designed<->development": "io (both directions); agent (forward only, gate required: IMPLEMENTS task checkout_count >= 1)",
+              "development->production": "io or agent (gate required: IMPLEMENTS task reached deploy-success)",
+              "production<->code-red": "io or agent (both directions; no evidence gate)",
+              "production->deprecated": "io only",
+              "code-red->deprecated": "io only",
+              "deprecated->production": "io only",
+              "any->deprecated": "io only",
+              "deprecated->development": "HARD BLOCK",
+              "archived->any": "HARD BLOCK"
+            }
+          },
+          "gate_conditions": {
+            "description": "Agent-permissible advances (io is unconditional). Failed gates return HTTP 400 with the specific condition that was not met. Per DOC-546B896390EA §3.4.",
+            "approved->designed": "Component must have a DESIGNS/DESIGNED_BY graph edge to a task record; that task's closed_count must be >= 1.",
+            "designed->development": "Component must have an IMPLEMENTS/IMPLEMENTED_BY graph edge to a task record; that task's checkout_count must be >= 1.",
+            "development->production": "The IMPLEMENTS task (same one linked via IMPLEMENTS/IMPLEMENTED_BY) must have reached deploy-success status. This is the definitive gate. The DEPLOYS edge is NOT a gate for this transition (DD-1).",
+            "production<->code-red": "No evidence gate. Agent or io may call either direction. The v5 CloudWatch/EventBridge automation layer will eventually be the primary production->code-red trigger (§8)."
+          },
+          "usage_guidance": "Authoritative spec in DOC-546B896390EA §3. The 8-status enum is enforced at write time by coordination_api for component creates/advances and at checkout time by checkout_service via the opacity model (see component_registry.opacity_model). reverted is NOT a stable lifecycle_status value — the revert handler atomically writes archived alongside reverted_at/reverted_reason metadata (DD-2). Agent-permitted component.advance target statuses: designed, development, production, code-red, production (resolution from code-red). All other advances are io-only."
+        },
+        "alarm_arn": {
+          "type": "string",
+          "required": false,
+          "definition": "Optional CloudWatch alarm ARN registered by io at approval time. v5 EventBridge hook per DOC-546B896390EA §8 and §6. Stored now on the component schema to avoid a future migration (DD-6); has NO runtime effect until v5 when the component-alarm-poller Lambda is built. Coordination API accepts the field on create/update; the 501 stub handler in coordination_api accepts CloudWatch event payload format and returns 501 with message 'CloudWatch automation not available until v5'.",
+          "usage_guidance": "Optional field. Set by io at approval time (component.approve or PATCH /components/{id}) when the component has a provisioned CloudWatch alarm that should eventually drive production<->code-red transitions via the v5 EventBridge scheduled rule. Not used by any runtime code path pre-v5.",
+          "v5_intended_flow": "EventBridge scheduled rule -> component-alarm-poller Lambda -> for each component with alarm_arn set: describe_alarms(alarm_arn); if ALARM -> POST component.code_red(component_id); if OK and lifecycle_status=code-red -> POST component.resolve_code_red(component_id)."
+        },
+        "required_iam_actions": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "IAM action strings the component requires at deploy or runtime. ENC-TSK-E68 (ENC-PLN-031 Phase 3). Consumed by the continuous auditor (ENC-TSK-E69) to diff against the deploy role's inline and attached policies, and by the pre-merge guard (ENC-TSK-E70) on PRs adding new components. Optional (empty-array default).",
+          "example": [
+            "lambda:UpdateFunctionCode",
+            "lambda:CreateFunctionUrlConfig",
+            "iam:PassRole"
+          ]
+        },
+        "required_env_secrets": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "GitHub Actions secret names the component's `environment: production` jobs reference via ${{ secrets.X }}. ENC-TSK-E68 (ENC-PLN-031 Phase 3). Consumed by the continuous auditor and pre-merge guard to verify explicit scoping via `gh secret set --env production` (ENC-LSN-032 remediation). Optional (empty-array default).",
+          "example": [
+            "COORDINATION_INTERNAL_API_KEY"
+          ]
+        },
+        "required_apigw_routes": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "API Gateway v2 route keys the component serves (format: 'METHOD /path/{param}'). ENC-TSK-E68 (ENC-PLN-031 Phase 3). Consumed by the continuous auditor to detect CLI-only routes not declared in CFN (ENC-TSK-E57 zmra44n incident). Optional (empty-array default).",
+          "example": [
+            "GET /api/v1/deploy/validate/approval/{prNumber}"
+          ]
+        },
+        "required_cfn_resources": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "CloudFormation logical resource names the component depends on. ENC-TSK-E68 (ENC-PLN-031 Phase 3). Consumed by the continuous auditor to verify all declared resources exist in the expected stacks. Optional (empty-array default).",
+          "example": [
+            "DeployValidateApprovalRoute",
+            "DeployIntakeIntegration"
+          ]
+        },
+        "required_lambda_env_vars": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Lambda environment variable names the component function reads at runtime. ENC-TSK-E68 (ENC-PLN-031 Phase 3). Consumed by the continuous auditor to verify actual Lambda config carries every expected variable. Optional (empty-array default).",
+          "example": [
+            "COORDINATION_INTERNAL_API_KEY",
+            "DYNAMODB_REGION"
+          ]
+        },
+        "deploy_targets": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Stack names and/or backend/lambda function-name globs this component owns for deploy purposes. ENC-TSK-J40 (PLN-060 Pile B). Consumed by tools/assert_deploy_target_coverage.py as part of the blast-radius-scoped Gen2 deploy: when tools/compute_affected_targets.py diffs a merge against the last-deployed SHA and finds a changed backend/lambda/<dir> whose owning component (matched via source_paths.directory) HAS declared deploy_targets, that declaration must cover the changed dir or the deploy CI run fails closed. Components that have not declared deploy_targets are not gated. Optional (empty-array default).",
+          "usage_guidance": "Populate with the exact backend/lambda directory name(s) (fnmatch glob supported) this component is responsible for redeploying. Getting this wrong narrow fails the deploy CI run; getting it wrong wide is safe.",
+          "example": [
+            "tracker_mutation"
+          ]
+        },
+        "source_paths": {
+          "type": "object",
+          "definition": "Code navigation map for this component (ENC-TSK-805). Provides direct file paths so agents skip exploratory grep/glob. Structure varies by category.",
+          "fields": {
+            "primary": {
+              "type": "string",
+              "definition": "Main entry-point file for the component.",
+              "example": "backend/lambda/checkout_service/lambda_function.py"
+            },
+            "directory": {
+              "type": "string",
+              "definition": "Root directory containing the component's source code.",
+              "example": "backend/lambda/checkout_service/"
+            },
+            "workflow": {
+              "type": "string",
+              "definition": "GitHub Actions workflow file for deploying this component.",
+              "example": ".github/workflows/lambda-checkout-service-deploy.yml"
+            },
+            "deploy_script": {
+              "type": "string",
+              "definition": "Optional deploy script path.",
+              "example": "backend/lambda/checkout_service/deploy.sh"
+            },
+            "related": {
+              "type": "array",
+              "definition": "Other directories/files related to this component (e.g., shared layers).",
+              "example": [
+                "backend/lambda/shared_layer/"
+              ]
+            },
+            "domains": {
+              "type": "object",
+              "definition": "For frontend components: domain-to-files mapping. Each key is a domain name, value is array of relative file paths.",
+              "example": {
+                "auth": [
+                  "src/lib/authState.tsx",
+                  "src/api/auth.ts"
+                ]
+              }
+            },
+            "architecture_sections": {
+              "type": "array",
+              "definition": "ARCHITECTURE.md section numbers relevant to this component.",
+              "example": [
+                "4.1",
+                "5.2"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "component_registry.graph_edges": {
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §4: typed-relationship edge pairs connecting components to their governing task evidence. Three pairs introduced by the v2 spec — DESIGNS/DESIGNED_BY, IMPLEMENTS/IMPLEMENTED_BY, DEPLOYS/DEPLOYED_BY. All edge writes must validate uniqueness via a graph read before writing, execute forward and inverse rows atomically via DynamoDB transact_write_items (mirrors the tracker_mutation/_handle_create_relationship rel# schema and relies on the ENC-TSK-E01 placeholder-node pattern in graph_sync for labeling), and return HTTP 409 with a descriptive message if uniqueness is violated. Locked-edge mutation attempts return HTTP 423 Locked.",
+      "edges": {
+        "DESIGNS": {
+          "forward": "component -[DESIGNS]-> task",
+          "inverse": "task -[DESIGNED_BY]-> component",
+          "cardinality": "strict_1_to_1",
+          "cardinality_rules": [
+            "Refuse write if the component already has a DESIGNS edge to any task.",
+            "Refuse write if the task already has a DESIGNED_BY edge from any component."
+          ],
+          "authority": [
+            "agent",
+            "io"
+          ],
+          "immutability_trigger": "DESIGNS task closed_count >= 1",
+          "immutability_behavior": "Edge locks permanently when the DESIGNS task closed_count becomes >= 1. Locked edges cannot be deleted or mutated by any surface. Attempts to delete or mutate a locked edge return HTTP 423 Locked.",
+          "advance_gate": "Component may advance approved->designed when the DESIGNED_BY task's closed_count >= 1.",
+          "write_action": "component.add_edge with edge_type=DESIGNS"
+        },
+        "IMPLEMENTS": {
+          "forward": "component -[IMPLEMENTS]-> task",
+          "inverse": "task -[IMPLEMENTED_BY]-> component",
+          "cardinality": "strict_1_to_1",
+          "cardinality_rules": [
+            "Refuse write if the component already has an IMPLEMENTS edge to any task.",
+            "Refuse write if the task already has an IMPLEMENTED_BY edge from any component."
+          ],
+          "authority": [
+            "agent",
+            "io"
+          ],
+          "immutability_trigger": "IMPLEMENTS task checkout_count >= 1",
+          "immutability_behavior": "Edge locks permanently when the IMPLEMENTS task checkout_count becomes >= 1. Attempts to delete or mutate a locked edge return HTTP 423 Locked.",
+          "advance_gate": [
+            "designed->development: IMPLEMENTS task checkout_count >= 1.",
+            "development->production: IMPLEMENTS task has reached deploy-success status."
+          ],
+          "evidence_thread_role": "The IMPLEMENTS task is the single evidence thread spanning designed, development, and production (DD-1). Checkout proves implementation started; deploy-success proves it shipped.",
+          "write_action": "component.add_edge with edge_type=IMPLEMENTS"
+        },
+        "DEPLOYS": {
+          "forward": "component -[DEPLOYS]-> task",
+          "inverse": "task -[DEPLOYED_BY]-> component",
+          "cardinality": "append_ok",
+          "cardinality_rules": [
+            "Multiple deploy tasks may link to a single component over its lifetime.",
+            "No 1:1 uniqueness constraint."
+          ],
+          "authority": [
+            "agent",
+            "io"
+          ],
+          "immutability_trigger": "individual edge row locks when the linked task reaches deploy-success",
+          "immutability_behavior": "Per-edge lock: earlier deploy edges remain locked; newer deploy tasks may be linked. Locked-row mutation returns HTTP 423 Locked.",
+          "governance_role": "Audit lineage and traceability only. DEPLOYS is NOT a gate for any lifecycle transition — deploy-success on the IMPLEMENTS task is what gates development->production (DD-1, DD-7).",
+          "write_action": "component.add_edge with edge_type=DEPLOYS"
+        }
+      },
+      "write_semantics": "DynamoDB transact_write_items atomically commits the forward and inverse rel# rows; 409 is returned on uniqueness violation for strict_1_to_1 edges. Schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects each edge uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. The ENC-TSK-E01 placeholder-node pattern in graph_sync guarantees labeled endpoint nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected.",
+      "locked_mutation_response": "HTTP 423 Locked with api.error_envelope code=EDGE_LOCKED, details={edge_type, component_id, task_id, lock_trigger, lock_occurred_at}.",
+      "uniqueness_violation_response": "HTTP 409 Conflict with api.error_envelope code=EDGE_UNIQUENESS_VIOLATION, details={edge_type, component_id, existing_task_id, attempted_task_id}.",
+      "spec_source": "DOC-546B896390EA §4 (edge type spec), §3.4 (gate conditions), DD-7 (cardinality rationale)."
+    },
+    "component_registry.opacity_model": {
+      "description": "ENC-FTR-076 v2 / DOC-546B896390EA §7: read-endpoint and checkout-gate visibility classification for component records. Three mutually exclusive status sets (OPAQUE, BLOCKED, PERMITTED) partition the lifecycle_status enum. OPAQUE_STATUSES produce identical 404 responses to non-existent components on both read and checkout surfaces — agents must not be able to infer existence of archived records. BLOCKED_STATUSES return full records to io-management workflows (reads) but block agent checkout with a descriptive 400. PERMITTED_STATUSES proceed normally on both surfaces.",
+      "status_classification": {
+        "OPAQUE_STATUSES": [
+          "archived"
+        ],
+        "BLOCKED_STATUSES": [
+          "proposed",
+          "deprecated"
+        ],
+        "PERMITTED_STATUSES": [
+          "approved",
+          "designed",
+          "development",
+          "production",
+          "code-red"
+        ]
+      },
+      "read_endpoint_behavior": {
+        "OPAQUE": "Return identical HTTP 404 to a non-existent component. Existence not disclosed. Response body and headers must be byte-indistinguishable from the nonexistent-record path — agents must not be able to infer existence via response timing, body, or headers.",
+        "BLOCKED": "Return full record. Visible for io management workflows (PWA pending-approval, deprecated-component audits).",
+        "PERMITTED": "Return full record."
+      },
+      "checkout_gate_behavior": {
+        "OPAQUE_or_nonexistent": "Return identical HTTP 404 with a generic message. Response must be identical whether the component never existed or is archived. Agents must not be able to infer existence.",
+        "BLOCKED": "Return HTTP 400 with a descriptive message identifying the component_id. Example message: 'Component <component_id> is in BLOCKED_STATUSES (<current_lifecycle_status>) and cannot be checked out. Pending io approval or io-only restoration.'",
+        "PERMITTED": "Checkout proceeds normally. Any strictness/transition_type enforcement continues to apply downstream."
+      },
+      "version_fork_convention": {
+        "description": "When a deprecated component requires new development, a new component record must be created with the -v2/-v3 suffix convention on the component_id and display_name. The deprecated original is never reactivated into development (HARD BLOCK deprecated->development). Naming convention enforced by coordination-lead review, not a hard server-side constraint.",
+        "example": "comp-checkout-service (deprecated) -> comp-checkout-service-v2 (new record, lifecycle_status=proposed at creation time)."
+      },
+      "reverted_event_note": "reverted is NOT a member of any status set — it is an event, not a state (DD-2). The revert handler atomically writes lifecycle_status=archived alongside reverted_at + reverted_reason + archived_at. From all external surfaces, reverted never appears as a stored lifecycle_status.",
+      "enforcement_surfaces": [
+        "coordination_api._handle_components_get: applies read_endpoint_behavior classification before returning the record.",
+        "checkout_service._handle_checkout: applies checkout_gate_behavior classification before the strictness/transition_type matrix (strictness enforcement remains downstream)."
+      ],
+      "spec_source": "DOC-546B896390EA §7 (opacity model), §3.1 (state inventory), DD-2 (reverted-is-event)."
+    },
+    "checkout_service.required_transition_type_enforcement": {
+      "description": "V3 component-policy enforcement contract for required_transition_type on component_registry.component (ENC-TSK-L77 / DOC-157A790F9E8B). Every component record must carry one of code|external_deploy|documentation. Checkout service maps populated legacy values at read time, compares the component policy to the existing task.transition_type lifecycle arc, and enforces the new evidence sub-schemas at advance gates.",
+      "fields": {
+        "governing_task": {
+          "type": "string",
+          "definition": "ENC-TSK-L77 (component ontological hardening H-SCHEMA)."
+        },
+        "chosen_behavior_mode": {
+          "type": "string",
+          "enum": [
+            "v3_strict_new_writes_legacy_read_mapping"
+          ],
+          "value": "v3_strict_new_writes_legacy_read_mapping",
+          "definition": "New component writes must use code|external_deploy|documentation. Existing rows populated with github_pr_deploy, lambda_deploy, web_deploy, code_only, data_only, or no_code are normalized at read time so in-flight tasks do not regress during forward-only migration."
+        },
+        "strictness_rank": {
+          "type": "object",
+          "definition": "Component policy to task lifecycle compatibility. Task.transition_type remains the lifecycle arc enum; component required_transition_type is the artifact class policy.",
+          "values": {
+            "code": "task.transition_type rank must be <= code_only (github_pr_deploy, lambda_deploy, web_deploy, or code_only)",
+            "external_deploy": "task.transition_type rank must be <= web_deploy/lambda_deploy and deploy-success additionally requires external_deploy_evidence",
+            "documentation": "any task.transition_type rank may satisfy checkout strictness; close additionally requires documentation_evidence"
+          }
+        },
+        "surfaces": {
+          "type": "array",
+          "definition": "Five defense-in-depth surfaces that together maintain the required_transition_type invariant. Each surface has its own evidence shape; absence of evidence on any surface constitutes an OGTM-style compliance gap.",
+          "items": [
+            {
+              "surface": "data_layer_review_and_backfill",
+              "file": "docstore://DOC-157A790F9E8B H-BACKFILL",
+              "responsibility": "Backfill existing component rows with component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type after H-SCHEMA ships. Historical closed tasks remain forward-only unless explicitly governed by H-BACKFILL.",
+              "evidence_shape": "Post-scan shows no active component missing v3 identity fields or required_transition_type."
+            },
+            {
+              "surface": "checkout_service_fail_loud",
+              "file": "backend/lambda/checkout_service/lambda_function.py",
+              "responsibility": "_get_required_transition_type reads required_transition_type, normalizes legacy populated values, raises ComponentMisconfiguredError on missing/invalid, and compares v3 component policy to task.transition_type lifecycle arcs. _handle_advance enforces P6 external_deploy evidence and P7 documentation evidence.",
+              "evidence_shape": "COMPONENT_MISCONFIGURED envelope for missing/invalid rows; 422 INVALID_INPUT for missing/invalid external_deploy_evidence or documentation_evidence."
+            },
+            {
+              "surface": "coordination_api_create_update_validation",
+              "file": "backend/lambda/coordination_api/lambda_function.py",
+              "responsibility": "_handle_components_create and _handle_components_propose require component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type. They reject duplicate component_address, overlapping component_repo_dir, invalid class combinations, and aws_arn+external_deploy. PATCH may update but not unset governed identity/policy fields.",
+              "evidence_shape": "400/409/422 envelope naming the invalid field; 201/200 response carries the v3 fields."
+            },
+            {
+              "surface": "seed_script_plus_ci_guard",
+              "file": "tools/seed-component-registry.py + tools/verify_component_required_transition_type.py + .github/workflows/component-registry-guard.yml",
+              "responsibility": "H-BACKFILL updates seed-component-registry.py and verify_component_required_transition_type.py so every KNOWN_COMPONENTS entry carries the four v3 identity fields and required_transition_type in code|external_deploy|documentation. component-registry-guard.yml fails CI on missing/invalid entries.",
+              "evidence_shape": "CI workflow run showing every seed manifest entry declares component_address, component_repo_dir, component_address_class, component_class, and v3 required_transition_type."
+            },
+            {
+              "surface": "governance_dictionary_field_spec",
+              "file": "backend/lambda/coordination_api/governance_data_dictionary.json",
+              "responsibility": "component_registry.component documents the four v3 identity fields, required_transition_type v3 enum, legacy read mapping, external_deploy_evidence, and documentation_evidence. Dictionary_version bumped on every change touching this surface.",
+              "evidence_shape": "version bumped; v3 fields required=true; evidence sub-schemas present."
+            }
+          ]
+        },
+        "rationale_anchor": {
+          "type": "string",
+          "definition": "DOC-157A790F9E8B is the governance-intent source of truth for v3 component identity, required_transition_type policy, and P6/P7 evidence gates."
+        },
+        "invariant_statement": {
+          "type": "string",
+          "definition": "Every active component record carries a unique component_address, non-overlapping component_repo_dir, valid component_address_class, valid component_class, and valid required_transition_type. Checkout service never silently defaults a missing component policy."
+        }
+      }
+    },
+    "checkout_service.component_enforcement": {
+      "description": "ENC-FTR-041 + ENC-TSK-L77: Component enforcement rules enforced by checkout_service. task.transition_type keeps the lifecycle arc matrix; component.required_transition_type is now the v3 artifact policy code|external_deploy|documentation.",
+      "fields": {
+        "component_policy_to_task_arc_compatibility": {
+          "type": "object",
+          "definition": "Compatibility rules applied after legacy component required_transition_type values are normalized to v3.",
+          "values": {
+            "code": "allows task arcs github_pr_deploy, lambda_deploy, web_deploy, code_only; rejects no_code",
+            "external_deploy": "allows task arcs github_pr_deploy, lambda_deploy, web_deploy; rejects code_only and no_code; deploy-success requires external_deploy_evidence",
+            "documentation": "allows all task arcs; close requires documentation_evidence"
+          }
+        },
+        "no_components_block": {
+          "type": "rule",
+          "definition": "If task.components is absent or empty AND body.user_initiated is falsy, checkout service returns 400. Only human operators via PWA (user_initiated=true Cognito path) can advance tasks with no components."
+        },
+        "assistant_trigger": {
+          "type": "rule",
+          "definition": "If deploy-success evidence validation fails 3+ consecutive times on the same gate, _invoke_assistant() is called (non-blocking). Under v3 it writes component transition fields using component policy values, not legacy task lifecycle arc values."
+        },
+        "lifecycle_status_gate": {
+          "type": "rule",
+          "definition": "ENC-FTR-076 / ENC-TSK-E10: _handle_advance() pre-checks each component's lifecycle_status BEFORE the strictness/transition-type matching. Helper _get_components_lifecycle() fetches per-component {lifecycle_status, rejection_reason} from component-registry. Blocking states: `proposed` -> 400 with code=component_not_approved + blocking component_ids array + 'Pending coordination lead approval. Wait for io to approve via PWA or escalate.' guidance; `rejected` -> 400 with code=component_rejected echoing rejection_reason for agent self-correction. Pass-through states: `active` (default; missing lifecycle_status defaults to active so pre-FTR-076 records are unaffected); `approved` is an unexpected-but-tolerated transient state demoted to active with a [WARNING] log line. user_initiated=true bypasses the gate so PWA closures of legacy tasks against unapproved components remain possible. Fail-open posture: components missing from the registry are skipped (matches _get_required_transition_type behavior)."
+        },
+        "advance_failure_count": {
+          "type": "integer",
+          "definition": "Task field tracking consecutive failures at the same gate. Reset when gate changes."
+        },
+        "advance_failure_gate": {
+          "type": "string",
+          "definition": "Task field recording which gate the consecutive failures occurred at."
+        }
+      }
+    },
+    "checkout_service.subtask_gate": {
+      "description": "ENC-ISS-106: Subtask lifecycle gate enforced by the checkout service in _handle_advance(). Prevents parent tasks from advancing past a lifecycle stage until all direct children have reached that stage. Ensures bottom-up completion ordering in plan-derived task hierarchies.",
+      "fields": {
+        "status_rank": {
+          "type": "object",
+          "definition": "Numeric rank ordering for lifecycle statuses. Higher rank = further in lifecycle. Used for comparing parent target status against children's current statuses.",
+          "values": {
+            "open": 0,
+            "in-progress": 1,
+            "coding-complete": 2,
+            "committed": 3,
+            "pr": 4,
+            "merged-main": 5,
+            "deploy-init": 6,
+            "deploy-success": 7,
+            "closed": 8
+          }
+        },
+        "gate_threshold": {
+          "type": "string",
+          "definition": "The gate activates at coding-complete (rank 2) and above. Statuses open (rank 0) and in-progress (rank 1) are not gated because a parent task must be checked out before it can orchestrate children.",
+          "value": "coding-complete"
+        },
+        "child_source": {
+          "type": "string",
+          "definition": "Children are read from the parent task's subtask_ids field (array of task IDs). Only direct children are checked — no recursive descent to grandchildren. Each level gates its own children, creating cascading enforcement naturally.",
+          "value": "task.subtask_ids"
+        },
+        "not_found_behavior": {
+          "type": "string",
+          "definition": "If a child task ID in subtask_ids cannot be fetched (HTTP != 200), the child is treated as blocking with status 'not_found'. This is the safe default — the parent cannot advance if we cannot verify child status.",
+          "value": "block"
+        },
+        "shortened_arc_handling": {
+          "type": "string",
+          "definition": "Children with shortened arcs (no_code, code_only) that reach 'closed' (rank 8) automatically satisfy any parent stage requirement. A no_code child at 'closed' satisfies a parent trying to advance to deploy-success because 8 >= 7.",
+          "value": "closed satisfies all stages"
+        },
+        "bypass_paths": {
+          "type": "array",
+          "definition": "Paths that bypass the subtask gate.",
+          "items": [
+            "PWA user_initiated transitions (tracker_mutation path, not checkout_service)",
+            "Tasks with empty or missing subtask_ids (not a parent task)"
+          ]
+        }
+      }
+    },
+    "feed_query.refresh": {
+      "description": "POST /api/v1/feed/refresh endpoint added in ENC-TSK-797. Synchronously invokes devops-feed-publisher Lambda to regenerate all S3 feed files on demand, triggered by the PWA Refresh App button.",
+      "fields": {
+        "endpoint": {
+          "type": "string",
+          "definition": "POST /api/v1/feed/refresh — triggers synchronous feed regeneration via Lambda invoke of devops-feed-publisher."
+        },
+        "response_success": {
+          "type": "object",
+          "definition": "Success response: {success: true, message: 'Feed regeneration complete', generated_at: '<ISO-8601>'}."
+        },
+        "response_error": {
+          "type": "object",
+          "definition": "Error response (502): returned when feed_publisher invoke fails or returns a function error."
+        }
+      }
+    },
+    "feed_query.corpus": {
+      "description": "ENC-TSK-L23 / FTR-127 AC-1..4/13: GET /api/v1/feed/corpus returns the full multi-project feed corpus from BOTH the tracker table and the documents table as a cursor-paginated stream. Minimal identity projection plus compact attrs map (status, priority, tags/keywords, document_subtype). Filter and sort pushdown via query params; facet counts are the browse-with-no-query facet authority and the graphsearch hybrid circuit-breaker fallback (ENC-TSK-L43). ENC-TSK-L43: also accepts X-Coordination-Internal-Key for service-to-service facet fallback from graph_query_api.",
+      "fields": {
+        "endpoint": {
+          "type": "string",
+          "definition": "GET /api/v1/feed/corpus — JWT-gated (401 unauthenticated) OR X-Coordination-Internal-Key for service callers. Query params: limit, cursor, sort, q, record_type, status, project_id, priority."
+        },
+        "cursor": {
+          "type": "string",
+          "definition": "Base64url-encoded composite cursor over (sort_value, record_key). record_key is source-tagged: tracker:{project_id}:{record_id} or document::{document_id}."
+        },
+        "facets": {
+          "type": "object",
+          "definition": "Facet counts for record_type, status, priority, and project_id over the filtered corpus slice."
+        },
+        "attrs": {
+          "type": "object",
+          "definition": "Compact per-record attribute map: status, priority, category, severity (issues), tags (documents), document_subtype, subtypepattern."
+        }
+      }
+    },
+    "feed_query.delta": {
+      "description": "ENC-TSK-L27 (B67 WaveC / DOC-77D6C714867E §9C/§10.3): GET /api/v1/feed/delta?since=<version_seq> returns incremental corpus changes ordered by monotonic tracker.version_seq via the version-seq-index GSI (feed_scope=global). Response includes changed Tier-1 corpus items (with version_seq), delete tombstones, and latest_version_seq watermark for client gap-healing. Distinct from legacy GET /api/v1/feed?since=<ISO8601> incremental path. ENC-TSK-M79: tracker_mutation's write paths that stamp version_seq/feed_scope on every mutating UpdateExpression are _stamp_version_seq_on_create_item (record creation) and _version_seq_update_parts (spliced into both the generic single-field PATCH path, _handle_update_field, and the worklog-append path, _handle_log). Before M79, _handle_log's UpdateExpression omitted version_seq/feed_scope entirely, so a pure worklog append (no field PATCH) never re-surfaced the record in this delta projection — fixed by splicing _version_seq_update_parts() into _handle_log identically to the PATCH path's idiom. ENC-TSK-M92 (P0): the M79 fix covered only the MCP/checkout worklog path; the PWA close/note/reopen/worklog button routes through a SEPARATE handler, _handle_pwa_action, whose four mutating branches also omitted version_seq/feed_scope. So a gamma-native human UI write landed but never re-surfaced here (latest_version_seq pinned at 622 despite live writes). M92 splices _version_seq_update_parts() into all four _handle_pwa_action branches (close spliced inside SET, before its ADD closed_count clause). With M92, EVERY tracker write path that mutates a record stamps version_seq/feed_scope: create, generic PATCH, worklog-append (_handle_log), and PWA action (_handle_pwa_action).",
+      "fields": {
+        "since": {
+          "type": "integer",
+          "definition": "Non-negative integer version_seq watermark. Returns all tracker rows and feed_tombstone rows with version_seq strictly greater than since."
+        },
+        "latest_version_seq": {
+          "type": "integer",
+          "definition": "High-water version_seq observed in this response; clients persist and pass on the next delta poll."
+        },
+        "tombstones": {
+          "type": "array",
+          "definition": "Delete/evict hints: {record_key, record_id, record_type, project_id, version_seq} for feed_tombstone rows and stale-closed records."
+        }
+      }
+    },
+    "tracker.graphsearch": {
+      "description": "Graph-indexed tracker search endpoint (ENC-FTR-047). Read-only Neo4j AuraDB derived projection over DynamoDB tracker records, exposed via GET /api/v1/tracker/graphsearch and MCP search(action='tracker.graphsearch'). ENC-TSK-L53 / ENC-ISS-489: graph_query_api JWT gate accepts enceladus_id_token from APIGW HTTP API v2 event.cookies[] as well as headers.cookie (ui-v2 credentials:include cookie-only hybrid tier). ENC-FTR-049: Supports edge-type filtering (edge_types, edge_type params) and weight thresholds (min_weight) for typed relationship edges. ENC-FTR-098 / ENC-TSK-G36: MENTIONS added to graph_query_api._ALLOWED_EDGE_TYPES so tracker.graphsearch queries with edge_types=['MENTIONS'] no longer reject at the API gate. ENC-PLN-046 hybrid-retrieval remediation: the keyword signal tokenizes multi-word queries and scores per-token field-weighted CONTAINS (ENC-ISS-310); the anchored graph signal is deadline-bounded (_GRAPH_SIGNAL_DEADLINE_S) and degrades to graph_algorithm='timeout' rather than timing out the response (ENC-ISS-311); the /health endpoint reports per-signal availability via a functional probe (ENC-ISS-312). ENC-FTR-101 (Option B, ENC-TSK-H35): an optional pre-materialized standing named projection (enabled via env GDS_STANDING_PROJECTION_PREFIX), refreshed out-of-band by a single-writer action=refresh_projection invoke, lets anchored hybrid queries run gds.pageRank.stream warm against the standing projection (graph_algorithm='gds_pagerank') instead of building a per-query AGA session; the request path falls back to the existing per-query projection then the cypher proxy under _GRAPH_SIGNAL_DEADLINE_S when the standing projection is unconfigured or absent (no regression), and /health gains a graph_projection block reporting projection existence + last-refresh staleness. The standing projection carries weight + flow_weight=1.0 relationship properties (flow_weight is the ENC-FTR-108 adaptive-weight slot). ENC-FTR-108 Ph2 (ENC-TSK-J02): action=refresh_flow_weight invokes graph_query_api.flow_weight_refresh.run_refresh, which reads FTR-082's existing edge_participation[] pathway-telemetry (retrieval_outcome=='hit' entries) from S3 since a persisted watermark, aggregates traversal counts per edge_id, and applies the Ph1 Tero current-reinforcement law (flow_weight = flow_weight + delta*flow - mu*flow_weight, delta=mu=0.2 by default, env-overridable via FLOW_WEIGHT_DELTA/FLOW_WEIGHT_MU) via a single chunked UNWIND-batched Cypher write for touched edges plus one full-corpus decay-only statement (scoped to GRAPH_EDGE_WEIGHTS relationship types, excluding touched edge_ids) for untouched edges — never per-edge transactions. The whole cycle is a no-op when no new telemetry exists since the watermark (idempotent). The watermark is stored as a property on the pre-existing GdsProjectionMeta marker node (name='flow_weight_refresh') rather than a new label, and no new relationship type or node label is introduced anywhere in the write path (OGTM preflight for ENC-TSK-J02: _ALLOWED_EDGE_TYPES and GRAPH_EDGE_WEIGHTS are unchanged before/after).",
+      "fields": {
+        "search_type": {
+          "type": "enum",
+          "enum": [
+            "traversal",
+            "neighbors",
+            "path",
+            "keyword"
+          ],
+          "definition": "Graph search mode. traversal: walk PARENT_OF hierarchy from record_id. neighbors: all nodes within N hops via any edge type. path: shortest path between two record_ids. keyword: full-text title match + immediate neighbors."
+        },
+        "project_id": {
+          "type": "string",
+          "definition": "Project ID for cross-project isolation. All Cypher queries include WHERE n.project_id = $project_id.",
+          "constraints": {
+            "required": true
+          }
+        },
+        "record_id": {
+          "type": "string",
+          "definition": "Starting record ID for traversal, neighbors, and path search types.",
+          "constraints": {
+            "required_when": "search_type in (traversal, neighbors, path)"
+          }
+        },
+        "depth": {
+          "type": "integer",
+          "definition": "Maximum traversal depth for traversal, neighbors, and path search types.",
+          "constraints": {
+            "min": 1,
+            "max": 5,
+            "default": 2
+          }
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Standard response shape: {nodes: [{record_id, project_id, title, status, priority, label, ...}], edges: [{source, target, type}], paths: [[record_id, ...]], summary: string, query_cypher: string}."
+        },
+        "error_envelope": {
+          "type": "object",
+          "definition": "Error response: {error: string, error_code: string}. HTTP 400 for invalid params (depth > 5), 401 for auth failure, 503 when AuraDB unavailable."
+        },
+        "from_record_id": {
+          "type": "string",
+          "definition": "Source record ID for path search type (shortest path start). Bare tracker ID format (e.g. ENC-TSK-890).",
+          "constraints": {
+            "required_when": "search_type = path"
+          }
+        },
+        "to_record_id": {
+          "type": "string",
+          "definition": "Destination record ID for path search type (shortest path end). Bare tracker ID format.",
+          "constraints": {
+            "required_when": "search_type = path"
+          }
+        },
+        "query": {
+          "type": "string",
+          "definition": "Search term for keyword search type. Matches against node title (case-insensitive CONTAINS) and record_id (case-insensitive). MCP also accepts 'keyword' as an alias.",
+          "constraints": {
+            "required_when": "search_type = keyword"
+          }
+        },
+        "direction": {
+          "type": "enum",
+          "enum": [
+            "up",
+            "down",
+            "both"
+          ],
+          "definition": "Traversal direction for traversal search type. 'down' walks CHILD_OF from children to the start node, 'up' walks from start toward ancestors, 'both' walks in both directions.",
+          "constraints": {
+            "default": "down",
+            "applies_when": "search_type = traversal"
+          }
+        },
+        "edge_types": {
+          "type": "string",
+          "usage_guidance": "Edge type labels for neighbors query. Accepts comma-separated string ('BLOCKS,DEPENDS_ON') or array via MCP (['BLOCKS', 'DEPENDS_ON']). MCP server encodes arrays as repeated query keys (doseq=True); graph_query_api normalizes from multiValueQueryStringParameters or comma-split string (ENC-ISS-149). When omitted, all edge types are traversed."
+        },
+        "edge_type": {
+          "type": "string",
+          "usage_guidance": "Single Neo4j edge type label for traversal query. Replaces the default CHILD_OF. Example: 'DEPENDS_ON' to walk dependency chains."
+        },
+        "min_weight": {
+          "type": "number",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "usage_guidance": "Minimum weight threshold for edge filtering in neighbors and traversal queries. Legacy edges without a weight property default to 1.0 via COALESCE. Example: 0.5 filters out low-confidence edges."
+        }
+      },
+      "node_labels": [
+        "Task",
+        "Issue",
+        "Feature",
+        "Project",
+        "Plan",
+        "Lesson"
+      ],
+      "edge_types": [
+        "CHILD_OF",
+        "RELATED_TO",
+        "BELONGS_TO",
+        "ADDRESSES",
+        "IMPLEMENTS",
+        "PLAN_CONTAINS",
+        "PLAN_ATTACHED_DOC",
+        "PLAN_IMPLEMENTS",
+        "LEARNED_FROM",
+        "TEACHES",
+        "SUPERSEDES",
+        "SUPERSEDED_BY",
+        "MENTIONS"
+      ],
+      "data_source": "DynamoDB stream -> EventBridge Pipe -> SQS FIFO -> graph_sync Lambda -> Neo4j AuraDB",
+      "auth": "Cognito JWT cookie OR X-Coordination-Internal-Key header",
+      "covered_lambdas": [
+        "devops-graph-sync",
+        "devops-graph-query-api"
+      ],
+      "usage_guidance": "Use via search(action='tracker.graphsearch', arguments={search_type, project_id, ...}). All record_id values use bare tracker ID format (ENC-TSK-890, not task#ENC-TSK-890). Graph is a read-only derived index; DynamoDB remains source of truth. When graph is unavailable (AuraDB paused/down), returns HTTP 503 GRAPH_UNAVAILABLE with fallback_hint to use tracker.list. Depth guard rejects depth > 5 with HTTP 400.",
+      "field_count": 13
+    },
+    "tracker.manifest": {
+      "description": "Read-only MCP search action returning the per-AC manifest projection plus the record-level addendum for a single tracker record (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.1).",
+      "fields": {
+        "record_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "definition": "Bare tracker record ID (e.g. ENC-TSK-890)."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Optional projection narrowing. When supplied, only the listed top-level manifest fields are returned. record_id, content_hash, and updated_at are always retained."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Shape: {record_id, title, record_type, status, priority, transition_type, updated_at, acs:[{ac_index, short_title, status, evidence_ref, last_touched}], ac_count, content_hash}. ac status enum: 'complete' | 'incomplete'. content_hash is the SHA-256 read-side freshness token (see governance.dictionary.tracker.content_hash)."
+        }
+      },
+      "covered_lambdas": [
+        "enceladus-mcp-code"
+      ],
+      "field_count": 3
+    },
+    "tracker.get_acs": {
+      "description": "Read-only MCP search action returning full acceptance-criterion bodies for a specified subset of indices on a single tracker record (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.2).",
+      "fields": {
+        "record_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "definition": "Bare tracker record ID."
+        },
+        "indices": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "constraints": {
+            "required": true,
+            "min_items": 1
+          },
+          "definition": "Non-negative AC indices to fetch. Out-of-range indices return STRUCTURED_ERROR error_code AC_INDEX_OUT_OF_RANGE."
+        },
+        "content_hash": {
+          "type": "string",
+          "definition": "Optional freshness token returned by a prior tracker.manifest or tracker.manifest_bulk read. When supplied and the record has changed, the action returns STRUCTURED_ERROR error_code STALE_CONTENT_HASH with the current_content_hash and retry_guidance."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Shape: {record_id, acs:[{ac_index, body, status, evidence_ref}], content_hash}. Indices are returned in caller-supplied order after deduplication and sort."
+        }
+      },
+      "covered_lambdas": [
+        "enceladus-mcp-code"
+      ],
+      "field_count": 4
+    },
+    "tracker.worklog_timeline": {
+      "description": "Read-only MCP search action returning metadata-only worklog projection (no body bytes) for the entire history of a tracker record, ordered by timestamp ascending (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.3).",
+      "fields": {
+        "record_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "definition": "Bare tracker record ID."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Shape: {record_id, timeline:[{worklog_id, timestamp, author, size_bytes, transition?}], count, content_hash}. worklog_id is a deterministic position-based label of the form wl-NNNN suitable for use as input to tracker.worklogs ids[]. transition is populated for entries that record a status write and contains {to:<new_status>}."
+        }
+      },
+      "covered_lambdas": [
+        "enceladus-mcp-code"
+      ],
+      "field_count": 2
+    },
+    "tracker.worklogs": {
+      "description": "Read-only MCP search action returning full worklog body text bounded by a time window or by an explicit worklog_id set, ordered by timestamp ascending (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.4).",
+      "fields": {
+        "record_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "definition": "Bare tracker record ID."
+        },
+        "since": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "Inclusive lower bound on worklog timestamp. Lexicographic comparison; correct for normalized UTC Zulu timestamps."
+        },
+        "until": {
+          "type": "string",
+          "constraints": {
+            "format": "ISO 8601 datetime"
+          },
+          "definition": "Inclusive upper bound on worklog timestamp."
+        },
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Explicit set of worklog_id labels (form: wl-NNNN) returned by tracker.worklog_timeline. Combined with since/until via intersection."
+        },
+        "content_hash": {
+          "type": "string",
+          "definition": "Optional freshness token. When supplied and the record has changed, the action returns STRUCTURED_ERROR error_code STALE_CONTENT_HASH."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Shape: {record_id, worklogs:[{worklog_id, timestamp, author, size_bytes, transition?, body, status}], count, content_hash}."
+        }
+      },
+      "covered_lambdas": [
+        "enceladus-mcp-code"
+      ],
+      "field_count": 6
+    },
+    "tracker.manifest_bulk": {
+      "description": "Read-only MCP search action returning manifests for an explicit list of record IDs in one round trip via parallel fetches against the tracker API (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.5).",
+      "fields": {
+        "record_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "constraints": {
+            "required": true,
+            "min_items": 1,
+            "max_items": 50
+          },
+          "definition": "List of bare tracker record IDs. Hard cap of 50 per call; oversize requests return STRUCTURED_ERROR error_code BULK_SIZE_EXCEEDED."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Optional projection narrowing applied uniformly to every manifest. Same semantics as tracker.manifest.fields."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "Shape: {manifests:[{record_id, manifest, content_hash}], errors:[{record_id, error|error_payload}], manifest_count, error_count}. Records that fail to fetch are reported under errors[] with the same envelope shape — they do not abort the batch."
+        }
+      },
+      "covered_lambdas": [
+        "enceladus-mcp-code"
+      ],
+      "field_count": 3
+    },
+    "tracker.content_hash": {
+      "description": "Read-side freshness token attached to every Manifest Primitive v1 response (ENC-FTR-097, DOC-59D2295AA7FD section 7.1.6). SHA-256 hex digest computed over a stable canonical subset of the record (excludes ephemeral metadata: sync_version, write_source, history). Two reads of an unchanged record return the same digest.",
+      "fields": {
+        "algorithm": {
+          "type": "string",
+          "constraints": {
+            "enum": [
+              "sha256"
+            ]
+          },
+          "definition": "Hash algorithm. Always sha256 hex-encoded."
+        },
+        "freshness_contract": {
+          "type": "object",
+          "definition": "tracker.get_acs and tracker.worklogs accept the token as their content_hash argument. When supplied and the current digest differs, the action returns STRUCTURED_ERROR error_code STALE_CONTENT_HASH with current_content_hash, supplied_content_hash, and retry_guidance pointing the caller back to tracker.manifest or tracker.manifest_bulk for refresh."
+        }
+      },
+      "field_count": 2
+    },
+    "tracker.relationship": {
+      "description": "First-class governed typed relationship edge between tracker records (ENC-FTR-049). Primary store is enceladus-relationships (ENC-TSK-L13 / B65 Ph4); devops-project-tracker rel# rows remain during dual-write migration. Each relationship creates an atomic forward+inverse pair. DynamoDB is system of record; Neo4j receives MERGE projections via devops-project-tracker DynamoDB Streams until rel# cleanup (AC5).",
+      "fields": {
+        "relationship_type": {
+          "type": "enum",
+          "enum": [
+            "blocks",
+            "blocked-by",
+            "duplicates",
+            "duplicated-by",
+            "relates-to",
+            "parent-of",
+            "child-of",
+            "depends-on",
+            "depended-on-by",
+            "clones",
+            "cloned-by",
+            "affects",
+            "affected-by",
+            "tests",
+            "tested-by",
+            "consumes-from",
+            "produces-for",
+            "dispatches",
+            "dispatched-by",
+            "hands-off",
+            "handed-off-by",
+            "learned-from",
+            "teaches",
+            "supersedes",
+            "superseded-by",
+            "plan-contains",
+            "contained-by-plan",
+            "plan-attached-doc",
+            "doc-attached-to-plan",
+            "plan-implements",
+            "implemented-by-plan"
+          ],
+          "usage_guidance": "Canonical typed relationship enum (ENC-TSK-C36). Includes 17 base canonical types with inverse pairs ('relates-to' is self-inverse / symmetric); ENC-FTR-052 lesson edges (learned-from/teaches, supersedes/superseded-by); ENC-FTR-061 handoff edges (hands-off/handed-off-by); ENC-TSK-960 coordination dispatch edges (dispatches/dispatched-by); and ENC-FTR-058 plan-* edges (plan-contains/contained-by-plan, plan-attached-doc/doc-attached-to-plan, plan-implements/implemented-by-plan). Lambda allowlist in tracker_mutation enforces this set; graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL projects all to Neo4j; graph_query_api _ALLOWED_EDGE_TYPES exposes all for tracker.graphsearch. ENC-ISS-178 fix: typed 'relates-to' projects to RELATED_TO so it converges with the legacy related_*_ids projection."
+        },
+        "source_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "usage_guidance": "Bare tracker ID (e.g., ENC-TSK-890). Must exist in the same project."
+        },
+        "target_id": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id",
+            "required": true
+          },
+          "usage_guidance": "Bare tracker ID (e.g., ENC-ISS-042). Must exist in the same project. Cannot equal source_id (irreflexive)."
+        },
+        "weight": {
+          "type": "number",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0,
+            "default": 1.0
+          },
+          "usage_guidance": "Edge importance weight. 1.0 = full weight, 0.0 = minimal. Used by graph traversal for priority ordering and context assembly scoring."
+        },
+        "confidence": {
+          "type": "number",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0,
+            "default": 1.0
+          },
+          "usage_guidance": "Confidence that this relationship is correct. Agent-created edges may start at 0.8; human-confirmed edges at 1.0."
+        },
+        "reason": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "usage_guidance": "Human-readable explanation of why this relationship exists. Required on creation."
+        },
+        "provenance": {
+          "type": "enum",
+          "enum": [
+            "agent",
+            "human",
+            "system",
+            "migration"
+          ],
+          "usage_guidance": "Who/what created this relationship. 'agent' for AI-created, 'human' for user-created, 'system' for auto-generated, 'migration' for bulk imports."
+        },
+        "is_inverse": {
+          "type": "boolean",
+          "usage_guidance": "True for the auto-maintained inverse edge. False for the canonical forward edge. Inverse edges are filtered out of list results by default."
+        },
+        "canonical_edge_id": {
+          "type": "string",
+          "usage_guidance": "The SK of the canonical (forward) edge. For forward edges, equals own SK. For inverse edges, points to the forward edge for traceability."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "archived"
+          ],
+          "usage_guidance": "Relationships are soft-deleted by setting status=archived. No DynamoDB DeleteItem is ever used. Archived relationships are filtered from list results and removed from the Neo4j projection."
+        },
+        "archived_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "usage_guidance": "Timestamp when the relationship was archived. Set atomically on both forward and inverse edges."
+        }
+      },
+      "owl_characteristics": {
+        "blocks": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "duplicates": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "relates-to": {
+          "symmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "parent-of": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": true
+        },
+        "depends-on": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": true
+        },
+        "clones": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "affects": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "tests": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        },
+        "consumes-from": {
+          "asymmetric": true,
+          "irreflexive": true,
+          "transitive": false
+        }
+      },
+      "inverse_pairs": {
+        "blocks": "blocked-by",
+        "duplicates": "duplicated-by",
+        "relates-to": "relates-to",
+        "parent-of": "child-of",
+        "depends-on": "depended-on-by",
+        "clones": "cloned-by",
+        "affects": "affected-by",
+        "tests": "tested-by",
+        "consumes-from": "produces-for",
+        "dispatches": "dispatched-by",
+        "hands-off": "handed-off-by",
+        "learned-from": "teaches",
+        "supersedes": "superseded-by",
+        "plan-contains": "contained-by-plan",
+        "plan-attached-doc": "doc-attached-to-plan",
+        "plan-implements": "implemented-by-plan"
+      },
+      "domain_range_constraints": {
+        "blocks": {
+          "source_types": [
+            "task",
+            "issue"
+          ],
+          "target_types": [
+            "task",
+            "issue"
+          ]
+        },
+        "depends-on": {
+          "source_types": [
+            "task",
+            "issue"
+          ],
+          "target_types": [
+            "task",
+            "issue",
+            "feature"
+          ]
+        },
+        "affects": {
+          "source_types": [
+            "issue"
+          ],
+          "target_types": [
+            "task",
+            "feature"
+          ]
+        },
+        "tests": {
+          "source_types": [
+            "task"
+          ],
+          "target_types": [
+            "feature",
+            "issue"
+          ]
+        },
+        "duplicates": {
+          "source_types": null,
+          "target_types": null
+        },
+        "relates-to": {
+          "source_types": null,
+          "target_types": null
+        },
+        "parent-of": {
+          "source_types": null,
+          "target_types": null
+        },
+        "clones": {
+          "source_types": null,
+          "target_types": null
+        },
+        "consumes-from": {
+          "source_types": null,
+          "target_types": null
+        }
+      },
+      "dynamodb_key_schema": {
+        "pk": "project_id",
+        "sk_pattern": "rel#{source_id}#{relationship_type}#{target_id}",
+        "inverse_sk_pattern": "rel#{target_id}#{inverse_type}#{source_id}",
+        "table": "enceladus-relationships",
+        "legacy_table": "devops-project-tracker",
+        "dual_write_env": "RELATIONSHIPS_TABLE",
+        "delete_method": "soft-delete via UpdateItem (status=archived). No DeleteItem permission needed. Data preserved for audit."
+      },
+      "covered_lambdas": [
+        "devops-tracker-mutation-api",
+        "devops-graph-sync",
+        "devops-graph-query-api",
+        "enceladus-mcp-code"
+      ],
+      "mcp_surface": {
+        "execute_actions": [
+          "tracker.create_relationship",
+          "tracker.archive_relationship"
+        ],
+        "search_actions": [
+          "tracker.list_relationships"
+        ],
+        "feature_flag": "ENABLE_TYPED_RELATIONSHIPS",
+        "feature_flag_default": "false"
+      },
+      "notes": [
+        "ENC-TSK-L07: tracker.relate(source_id, target_id) is a DISTINCT, simpler convenience action for the flat related_task_ids/related_issue_ids/related_feature_ids/related_lesson_ids symmetric cross-reference fields -- not the typed relationship_type edge graph this entity describes. Use tracker.create_relationship for typed/directional edges (DESIGNS, IMPLEMENTS, superseded-by, ...); use tracker.relate for simple 'these two records reference each other' links."
+      ]
+    },
+    "context.node": {
+      "description": "Context Node primitive for mathematically-optimized context assembly (ENC-FTR-050). Each node wraps a tracker record or document with scored metadata enabling greedy knapsack context packing within a token budget. Created and updated by DynamoDB Streams consumer on tracker mutations. Gated behind ENABLE_CONTEXT_NODES feature flag.",
+      "fields": {
+        "token_cost": {
+          "type": "integer",
+          "constraints": {
+            "min": 0
+          },
+          "definition": "Computed token count for serializing this node into context. Measured via tiktoken cl100k_base encoding. Updated on source record mutation via DynamoDB Streams.",
+          "usage_guidance": "Read-only computed field. Do not set manually. Updated by context-node-sync Lambda on each source record change."
+        },
+        "information_density": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "definition": "Ratio of unique information to total tokens, range [0.0, 1.0]. Higher values indicate less redundancy. Computed from field-level entropy analysis of the source record.",
+          "usage_guidance": "Read-only computed field. Useful for identifying high-signal vs boilerplate records. Records with density < 0.2 are candidates for exclusion."
+        },
+        "freshness_score": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "definition": "Temporal relevance score, range [0.0, 1.0]. Computed via exponential decay: freshness = exp(-ln(2) * age_seconds / half_life_seconds). Age measured from source record updated_at. Half-life varies by record type.",
+          "usage_guidance": "Recomputed at assembly time (not persisted as-is since it changes continuously). staleness_half_life determines decay rate. Nodes with freshness < 0.1 are auto-flagged as stale."
+        },
+        "access_frequency": {
+          "type": "integer",
+          "constraints": {
+            "min": 0
+          },
+          "definition": "Number of times this node has been included in a context assembly. Incremented by get_compact_context when the knapsack packer selects this node.",
+          "usage_guidance": "Persisted counter. Used as a popularity signal in multi-signal scoring. Higher values indicate frequently-needed context."
+        },
+        "relevance_score": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "definition": "Query-dependent relevance, range [0.0, 1.0]. Computed at assembly time via Reciprocal Rank Fusion (RRF) combining keyword match and semantic similarity. Not persisted — ephemeral per-query.",
+          "usage_guidance": "Computed at assembly time only. Not stored on the DynamoDB record. Feeds into the multi-signal scoring function as the w1-weighted primary signal."
+        },
+        "structural_importance": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "definition": "Graph-derived importance, range [0.0, 1.0]. Computed via Personalized PageRank (PPR) seeded from the current task/issue, using typed edge weights from ENC-FTR-049 Relationship Edge primitive.",
+          "usage_guidance": "Computed via PPR against Neo4j graph index. Requires graph_index healthy. Falls back to 0.5 (neutral) when graph unavailable. Edge type weights: blocks=1.0, depends_on=0.8, implements=0.7, addresses=0.7, child_of=0.6, relates_to=0.3, belongs_to=0.1."
+        },
+        "staleness_half_life": {
+          "type": "integer",
+          "constraints": {
+            "min": 1
+          },
+          "definition": "Type-specific decay half-life in seconds for freshness computation. Defaults: task=604800 (7 days), issue=259200 (3 days), feature=2592000 (30 days), document=7776000 (90 days).",
+          "usage_guidance": "Set on node creation based on source record type. Can be overridden per-node for special cases (e.g., time-sensitive documents). Used in freshness decay formula."
+        },
+        "model_routing_hint": {
+          "type": "enum",
+          "enum": [
+            "haiku",
+            "sonnet",
+            "opus"
+          ],
+          "definition": "Suggested model tier for processing this node content. Derived from source record complexity (field count, history length) and priority. haiku=simple/reference, sonnet=standard, opus=complex/critical.",
+          "usage_guidance": "Advisory field for future MVC (Model-View-Controller) context routing. Currently informational only — does not affect assembly behavior. Populated by context-node-sync Lambda."
+        }
+      }
+    },
+    "tracker.lesson": {
+      "description": "Governed Lesson primitive capturing institutional wisdom as a first-class record type (ENC-FTR-052). Lessons are evidence-gated, append-only, constitutionally scored against four pillars and a vibe board, and can propose governance amendments through human-approval handshake. Stored in devops-project-tracker with lesson# SK prefix. Gated behind ENABLE_LESSON_PRIMITIVE feature flag. ENC-TSK-B89: graph_sync._reconcile_edges() now includes a dedicated lesson branch that emits (Lesson)-[:LEARNED_FROM]->(target) edges from evidence_chain entries and every extensions[].evidence_ids bag, via the ENC-TSK-E01 _infer_label_from_id + placeholder MERGE pattern so edges land even when the target node has not yet been projected. Unknown ID prefixes (pre-ENC-FTR-056 legacy forms such as JAP-*, MJR-*) fall back to unlabelled MATCH with a WARNING log line; see ENC-ISS-189 for the ENC-LSN-013 legacy-ID manifestation.",
+      "fields": {
+        "title": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "definition": "Concise lesson statement. Mutable — can be refined for clarity.",
+          "usage_guidance": "Keep titles actionable and specific. E.g., 'Lambda cold-start cross-AZ DNS adds 200ms' not 'DNS is slow'."
+        },
+        "observation": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1,
+            "immutable_after_create": true
+          },
+          "definition": "What was observed in the data. IMMUTABLE after creation. The philosophical core: you do not revise what was observed, you extend understanding of it via extensions.",
+          "usage_guidance": "Write observations as factual statements grounded in evidence_chain records. Any attempt to mutate this field after PutItem is rejected with IMMUTABLE_FIELD error."
+        },
+        "insight": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "definition": "What was learned from the observation. Mutable only via recomputation when extensions add context. Previous values preserved in history.",
+          "usage_guidance": "Insights should be actionable and specific. State what should change, not just what was noticed."
+        },
+        "evidence_chain": {
+          "type": "array",
+          "constraints": {
+            "required": true,
+            "min_items": 1,
+            "item_type": "string",
+            "item_format": "tracker_id",
+            "append_only": true
+          },
+          "definition": "Array of tracker record IDs that support this lesson. Required, minimum 1. Each ID must resolve to an existing record in the same project. Append-only — new evidence can be added, existing entries cannot be removed.",
+          "usage_guidance": "Cite the specific records from which the lesson was extracted. E.g., ['ENC-ISS-088', 'ENC-TSK-803']. On extend_lesson, new evidence IDs are appended.",
+          "graph_projection": "ENC-TSK-B89: graph_sync/_reconcile_edges() lesson branch iterates evidence_chain, MERGEs a label-correct placeholder target node via _infer_label_from_id (TSK→Task, ISS→Issue, FTR→Feature, PLN→Plan, LSN→Lesson, DOC→Document, GEN→Generation, DPL→DeploymentDecision), then MERGEs (Lesson)-[:LEARNED_FROM]->(target). IDs are bare_id-stripped and deduped against the union with extensions[].evidence_ids before emission. Unknown ID prefixes (legacy JAP-*, MJR-*, or non-canonical strings) log a WARNING and fall back to the legacy unlabelled MATCH so the edge still lands when the target happens to be present. Registered label LEARNED_FROM is pre-existing in RELATIONSHIP_TYPE_TO_EDGE_LABEL (graph_sync) and _ALLOWED_EDGE_TYPES (graph_query_api) so no additional registry updates were required."
+        },
+        "analysis_reference": {
+          "type": "string",
+          "constraints": {
+            "format": "tracker_id_or_document_id"
+          },
+          "definition": "Optional. Task ID or document ID of the analysis that produced this lesson. Provides traceability from lesson to analytical work.",
+          "usage_guidance": "Set to the DVP-FTR-080 mining task or investigation task that generated the lesson."
+        },
+        "pillar_scores": {
+          "type": "object",
+          "constraints": {
+            "required": true,
+            "required_keys": [
+              "efficiency",
+              "human_protection",
+              "intention",
+              "alignment"
+            ],
+            "value_type": "decimal",
+            "value_min": 0.0,
+            "value_max": 1.0,
+            "all_zero_rejected": true
+          },
+          "definition": "Four-pillar constitutional scores. efficiency (weight 0.25): reduces friction, eliminates failure modes. human_protection (weight 0.30): establishes guardrails, protects human life/privacy/security/joy. intention (weight 0.20): declares direction from observed data, turns telemetry into will. alignment (weight 0.25): anchors to vibe board values.",
+          "usage_guidance": "Required on lesson creation (ENC-FTR-054). All-zero submissions rejected. Callers provide their constitutional assessment; the server computes resonance_score and pillar_composite from these values. Updated on extend when new pillar_scores are provided."
+        },
+        "pillar_composite": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0,
+            "derived": true
+          },
+          "definition": "Weighted composite of pillar_scores: 0.25*efficiency + 0.30*human_protection + 0.20*intention + 0.25*alignment. Computed server-side by tracker-mutation Lambda on create and extend.",
+          "usage_guidance": "Never set directly by callers. Derived from pillar_scores by tracker-mutation Lambda. Used for gate threshold checks (accepted: >=0.4, active: >=0.6)."
+        },
+        "resonance_score": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0,
+            "derived": true
+          },
+          "definition": "Composite alignment with the vibe board (10 anchor words: convergence, will, flow, play, surrender, force, balance, love, resonance, telemetry). Anti-pattern penalties: force>0.7 AND surrender<0.3 => *0.5; intention>0.7 AND flow<0.3 => *0.7; efficiency>0.8 AND love<0.2 => *0.6; convergence>0.8 AND play<0.2 => *0.8.",
+          "usage_guidance": "Computed server-side by tracker-mutation Lambda from pillar_scores (ENC-FTR-054). Never set directly by callers. Includes anti-pattern penalties. Recomputed on extend when pillar_scores are updated."
+        },
+        "confidence": {
+          "type": "decimal",
+          "constraints": {
+            "min": 0.0,
+            "max": 1.0
+          },
+          "definition": "Confidence in the lesson's validity. Influenced by evidence chain depth, source record diversity, and corroboration. Increases as extensions add supporting evidence.",
+          "usage_guidance": "Agent-created lessons may start at 0.6-0.8. Human-confirmed at 0.9-1.0. Required >= 0.6 for 'active' status, >= 0.8 for self-governance proposals."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "draft",
+            "proposed",
+            "accepted",
+            "active",
+            "superseded",
+            "archived"
+          ],
+          "definition": "Governed lifecycle status with constitutional scoring gates. draft: pre-evaluation. proposed: passes evidence gate. accepted: passes pillar threshold (composite>=0.4, resonance>=0.3). active: passes higher threshold (composite>=0.6, resonance>=0.5, confidence>=0.6). superseded: replaced by newer lesson. archived: soft-deleted, human approval required.",
+          "usage_guidance": "Status transitions are gated. draft->proposed: evidence_chain>=1, observation and insight non-empty. proposed->accepted: pillar_composite>=0.4, resonance>=0.3, all pillars>0, human_protection>=0.3. accepted->active: pillar_composite>=0.6, resonance>=0.5, confidence>=0.6, evidence>=2. active->superseded: superseding lesson must be active. any->archived: human approval."
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "pattern",
+            "failure_mode",
+            "resolution_pathway",
+            "opportunity",
+            "principle",
+            "intention"
+          ],
+          "definition": "Lesson classification. pattern: recurring behavior. failure_mode: what goes wrong. resolution_pathway: how things get fixed. opportunity: unrealized potential. principle: governing truth. intention: directional declaration.",
+          "usage_guidance": "Choose based on the lesson's primary function. A single observation may yield lessons in multiple categories."
+        },
+        "provenance": {
+          "type": "enum",
+          "enum": [
+            "agent",
+            "human",
+            "mining",
+            "system"
+          ],
+          "definition": "Origin of the lesson. agent: AI-extracted in session. human: user-authored. mining: batch extraction via DVP-FTR-080. system: auto-generated from telemetry.",
+          "usage_guidance": "Set on creation and immutable. Mining-produced lessons (DVP-FTR-080) use 'mining'. Agent session lessons use 'agent'."
+        },
+        "extensions": {
+          "type": "array",
+          "constraints": {
+            "item_type": "object",
+            "item_schema": {
+              "timestamp": "iso8601",
+              "author": "string",
+              "content": "string",
+              "evidence_ids": "array_of_tracker_ids (optional)"
+            },
+            "append_only": true
+          },
+          "definition": "Append-only contextualization entries. Each extension adds understanding without modifying the original observation. Ordered chronologically. Immutable once appended.",
+          "usage_guidance": "Use extend_lesson MCP action to add extensions. Each extension can optionally cite additional evidence_ids which are appended to the lesson's evidence_chain.",
+          "graph_projection": "ENC-TSK-B89: every extension's evidence_ids contributes to the same LEARNED_FROM edge emission as evidence_chain. graph_sync/_reconcile_edges() lesson branch unions evidence_chain with each extensions[].evidence_ids bag, dedupes, and emits one (Lesson)-[:LEARNED_FROM]->(target) edge per unique target via the _infer_label_from_id + placeholder MERGE pattern. Extensions never remove edges — because evidence_chain is append-only, the union is monotonic across lesson_version increments, and the outgoing-edge delete prelude at the top of _reconcile_edges() safely re-creates the full union on every stream event."
+        },
+        "governance_proposal": {
+          "type": "object",
+          "constraints": {
+            "nullable": true,
+            "schema": {
+              "type": "enum:dictionary_amendment|policy_change|new_relationship_type",
+              "payload": "object",
+              "approval_status": "enum:pending|approved|rejected",
+              "approved_by": "string (nullable)",
+              "approved_at": "iso8601 (nullable)",
+              "rejection_reason": "string (nullable)"
+            }
+          },
+          "definition": "Optional governance amendment proposal. Can only be attached when lesson is 'active' with confidence>=0.8, resonance>=0.7, human_protection>=0.5, evidence>=3. Requires human approval — no automatic approvals ever.",
+          "usage_guidance": "Self-governance gate. pending->approved requires human confirmation via MCP. pending->rejected stores reason. Approved proposals trigger coordination API amendment execution."
+        },
+        "lesson_version": {
+          "type": "integer",
+          "constraints": {
+            "min": 1
+          },
+          "definition": "Monotonically increasing version counter. Incremented on each extension append or metadata recomputation.",
+          "usage_guidance": "Used for optimistic concurrency. Do not set manually."
+        },
+        "generation_scope": {
+          "type": "string",
+          "definition": "ENC-GEN-NNN generation scope for this lesson. Links institutional knowledge to the generation era it was learned in."
+        },
+        "lesson_class": {
+          "type": "enum",
+          "enum": [
+            "pattern",
+            "anti-pattern",
+            "incident",
+            "principle"
+          ],
+          "definition": "Classification of the lesson's origin and nature."
+        },
+        "related_task_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related tasks. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_task_ids', value=['ENC-...']). ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target task record's related_lesson_ids in the same request.",
+          "inverse_of": "tracker.task.related_lesson_ids"
+        },
+        "related_issue_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related issues. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_issue_ids', value=['ENC-...']). ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target issue record's related_lesson_ids in the same request.",
+          "inverse_of": "tracker.issue.related_lesson_ids"
+        },
+        "related_feature_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "IDs of related features. Cross-references for traceability.",
+          "usage_guidance": "tracker_set(field='related_feature_ids', value=['ENC-...']). ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional -- tracker_mutation's PATCH reverse-edge write atomically mirrors a newly-added ID here onto the target feature record's related_lesson_ids in the same request.",
+          "inverse_of": "tracker.feature.related_lesson_ids"
+        },
+        "related_document_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "DOC-* document IDs that declare this record in their related_items.",
+          "usage_guidance": "Server-written only. ENC-TSK-L07 (B65 AC-5/AC-7): document_api's PUT/PATCH related_items handler atomically mirrors the document's own ID here (contains-check conditional append) whenever the document names this record in related_items. Not intended for direct tracker_set writes -- edit related_items on the document instead.",
+          "inverse_of": "docstore.document.related_items"
+        }
+      },
+      "dynamodb_key_schema": {
+        "pk": "project_id",
+        "sk_pattern": "lesson#{lesson_id}",
+        "table": "devops-project-tracker",
+        "record_id_format": "{PREFIX}-LSN-{NNN}",
+        "delete_method": "soft-delete via status=archived. No DeleteItem. Data preserved for audit."
+      },
+      "mutation_rules": {
+        "observation": "IMMUTABLE after create. Reject any UpdateExpression targeting this field.",
+        "evidence_chain": "APPEND_ONLY. Only list_append allowed. Reject SET/REMOVE on existing indices.",
+        "extensions": "APPEND_ONLY. Only list_append allowed. Reject SET/REMOVE on existing indices.",
+        "status": "Governed transitions only. See status field usage_guidance for gate requirements."
+      },
+      "constitutional_scoring": {
+        "pillar_weights": {
+          "efficiency": 0.25,
+          "human_protection": 0.3,
+          "intention": 0.2,
+          "alignment": 0.25
+        },
+        "vibe_board_anchors": [
+          "convergence",
+          "will",
+          "flow",
+          "play",
+          "surrender",
+          "force",
+          "balance",
+          "love",
+          "resonance",
+          "telemetry"
+        ],
+        "anti_pattern_penalties": {
+          "force_without_surrender": "force>0.7 AND surrender<0.3 => resonance*=0.5",
+          "intention_without_flow": "intention>0.7 AND flow<0.3 => resonance*=0.7",
+          "efficiency_without_love": "efficiency>0.8 AND love<0.2 => resonance*=0.6",
+          "convergence_without_play": "convergence>0.8 AND play<0.2 => resonance*=0.8"
+        },
+        "self_governance_gate": {
+          "required_status": "active",
+          "min_confidence": 0.8,
+          "min_resonance": 0.7,
+          "min_human_protection": 0.5,
+          "min_evidence_chain": 3
+        }
+      },
+      "context_node_defaults": {
+        "staleness_half_life": 15552000,
+        "structural_importance_baseline": 0.8,
+        "model_routing_hint": "opus"
+      },
+      "typed_relationship_edges": {
+        "learned-from": {
+          "inverse": "teaches",
+          "domain": [
+            "lesson"
+          ],
+          "range": [
+            "task",
+            "issue",
+            "feature"
+          ],
+          "weight_default": 0.9,
+          "owl_characteristics": {
+            "asymmetric": true,
+            "irreflexive": true,
+            "transitive": false
+          }
+        },
+        "supersedes": {
+          "inverse": "superseded-by",
+          "domain": [
+            "lesson"
+          ],
+          "range": [
+            "lesson"
+          ],
+          "weight_default": 0.8,
+          "owl_characteristics": {
+            "asymmetric": true,
+            "irreflexive": true,
+            "transitive": false
+          }
+        },
+        "proposes-amendment-to": {
+          "inverse": "amendment-proposed-by",
+          "domain": [
+            "lesson"
+          ],
+          "range": [
+            "governance_resource"
+          ],
+          "weight_default": 0.5,
+          "owl_characteristics": {
+            "asymmetric": true,
+            "irreflexive": true,
+            "transitive": false
+          }
+        }
+      },
+      "mcp_surface": {
+        "execute_actions": [
+          "tracker.create_lesson",
+          "tracker.extend_lesson"
+        ],
+        "search_actions": [
+          "tracker.list_lessons"
+        ],
+        "feature_flag": "ENABLE_LESSON_PRIMITIVE",
+        "feature_flag_default": "false"
+      }
+    },
+    "tracker.record_id": {
+      "description": "Record ID format specification for all tracker records (task/TSK, issue/ISS, feature/FTR, lesson/LSN, plan/PLN). Base format: AAA-BBB-CCC where CCC is a 3-char base-36 sequence (capacity 46,656). Sub-task format: AAA-BBB-CCC-DD where DD is a digit+letter suffix (capacity 260 per parent). IDs are exclusively server-generated by the tracker mutation Lambda (ENC-ISS-132, ENC-FTR-056).",
+      "fields": {
+        "format": {
+          "type": "string",
+          "definition": "Base format: {PREFIX}-{TYPE}-{SEQ} where PREFIX is 3 uppercase letters (project prefix), TYPE is one of TSK/ISS/FTR/LSN/PLN, and SEQ is a 3-character base-36 sequence (0-9, A-Z). Sub-task format: {PREFIX}-{TYPE}-{SEQ}-{SUFFIX} where SUFFIX is a 2-character digit+letter pair (ENC-FTR-056).",
+          "constraints": {
+            "regex": "^[A-Z]{3}-(TSK|ISS|FTR|LSN|PLN)-[A-Z0-9]{3}(-[0-9][A-Z])?$",
+            "legacy_regex": "^[A-Z]{3}-(TSK|ISS|FTR|LSN|PLN)-(?:[A-Z][0-9]{2}|[0-9]{3,})$"
+          }
+        },
+        "sequence_encoding": {
+          "type": "string",
+          "definition": "The SEQ portion uses base-36 encoding (ENC-FTR-056): 0-9 then A-Z per digit position. Counter 0 encodes as '000', counter 46655 encodes as 'ZZZ'. Legacy formats (001-999 numeric, A01-Z99 alphanumeric) are decoded transparently for backward compatibility.",
+          "constraints": {
+            "encoding": "base-36 (0-9, A-Z), 3 characters, zero-padded",
+            "capacity_per_type_per_project": 46656,
+            "legacy_numeric_range": "001-999",
+            "legacy_alpha_range": "A01-Z99"
+          }
+        },
+        "subtask_suffix": {
+          "type": "string",
+          "definition": "Sub-task IDs append a 2-character suffix to the parent's 3-segment root ID (ENC-FTR-056). Format: {digit}{letter} where digit is 0-9 and letter is A-Z. Sequence: 0A, 0B, ..., 0Z, 1A, 1B, ..., 9Z. Generated via per-parent atomic counter.",
+          "constraints": {
+            "capacity_per_parent": 260,
+            "format": "[0-9][A-Z]",
+            "counter_key": "counter#subtask#{parent_root_id}"
+          }
+        },
+        "is_child": {
+          "type": "boolean",
+          "definition": "When true on tracker.create, generates a hierarchical sub-task ID under parent_task_id instead of a standard sequential ID. Only valid for record_type=task. Requires parent_task_id.",
+          "usage_guidance": "Set is_child=true and parent_task_id to create a sub-task. The sub-task ID will be {parent_root}-{suffix} where parent_root is the first 3 segments of parent_task_id."
+        },
+        "generation": {
+          "type": "string",
+          "definition": "Record IDs are exclusively generated server-side by the tracker mutation Lambda using atomic DynamoDB counters. Agents, clients, and external callers MUST NOT suggest, construct, predict, or provide record IDs. Any tracker.create request containing item_id or record_id is rejected with HTTP 400."
+        },
+        "type_codes": {
+          "type": "enum",
+          "enum": [
+            "TSK",
+            "ISS",
+            "FTR",
+            "LSN",
+            "PLN"
+          ],
+          "definition": "Type segment codes: TSK=task, ISS=issue, FTR=feature, LSN=lesson, PLN=plan."
+        },
+        "agent_boundary": {
+          "type": "constraint",
+          "definition": "Record IDs are exclusively server-assigned. Agents must not predict, infer, scan for, or reason about the next available ID before submitting tracker.create. The ID returned in the create response is the only authoritative source. Agents that anticipate IDs violate the system's single-source-of-truth principle and introduce brittle sequence dependencies (ENC-TSK-B99).",
+          "usage_guidance": "Submit tracker.create with required attributes only. Do not inspect existing records to determine what the next ID will be. Read the returned record_id from the success response. Use it in all subsequent operations."
+        },
+        "item_id_provenance": {
+          "type": "string",
+          "definition": "ENC-TSK-L06 / B63 Phase 2 AC-6: HMAC-SHA256 hex signature over `item_id||created_at||record_type`, stamped on every record allocated through the ID Service (enable_id_service_extraction flag ON). Signed with a shared secret held in Secrets Manager (enceladus/id-service/hmac-key{-gamma}, CFN-generated via GenerateSecretString — never hardcoded, never logged). Verified (warning-only, never blocking) by graph_sync before projecting a node into Neo4j. Absent on records created before this feature or while the flag was OFF (see tracker.id_boundary_enforcement backfill_and_quarantine for the AC-5 backfill status of pre-existing records).",
+          "usage_guidance": "Server-generated only, exactly like item_id/record_id. A tracker.create payload carrying a client-supplied item_id_provenance is rejected with the same ID_BOUNDARY_VIOLATION error as a client-supplied item_id/record_id."
+        }
+      }
+    },
+    "tracker.id_boundary_enforcement": {
+      "description": "ENC-TSK-L06 / B63 Phase 2 AC-6 (extends ENC-FTR-069's ENC-TSK-B99 ID Boundary Rule with a dedicated ID Service, idempotency contract, cryptographic provenance, and a trust-score feedback loop). The contract: (1) IAM isolation — record-ID counter items live in a dedicated enceladus-id-counters{-gamma} DynamoDB table that ONLY the ID Service Lambda's IAM role can access (tracker_mutation's role has no grant referencing that table's ARN at all — ordinary resource-scoped IAM, not a same-table dynamodb:LeadingKeys condition, which cannot constrain a sort-key prefix and would be a silent no-op on the shared tracker table's project_id-partitioned schema); (2) idempotency-key contract — a client-supplied idempotency_key on tracker.create returns the SAME record_id on retry (backed by enceladus-id-idempotency{-gamma}, TTL 24h); (3) cryptographic provenance — item_id_provenance HMAC-SHA256 signature stamped at allocation time and verified (warning-only) by graph_sync before projection; (4) edge-layer rejection — tracker_mutation's _handle_create_record rejects any create payload carrying top-level item_id, record_id, OR item_id_provenance with HTTP 400 error_envelope.code=ID_BOUNDARY_VIOLATION (ENC-ISS-132 origin, extended here); (5) trust-score feedback — every rejection fire-and-forget invokes the ID Service's record_violation action, incrementing a per-caller_identity counter (enceladus-id-violations{-gamma}) and flagging callers past VIOLATION_THRESHOLD (default 5); (6) backfill verification — tools/backfill_item_id_provenance.py stamps item_id_provenance on pre-existing records or reports them as a documented quarantine exemption (reusing the ENC-FTR-069 / ENC-TSK-D29 quarantine list: ENC-TSK-1291, ENC-TSK-1292).",
+      "fields": {
+        "enable_id_service_extraction": {
+          "type": "boolean",
+          "definition": "AppConfig flag (env_fallback ENABLE_ID_SERVICE, default false), read at request time via enceladus_shared.appconfig_flags.flag(). When ON, tracker_mutation delegates record-ID allocation to the standalone ID Service Lambda (enceladus-id-service{-gamma}) via a synchronous, FAIL-CLOSED RequestResponse invoke — mirroring the enable_lifecycle_service_extraction (ENC-TSK-H46) posture exactly: any invoke failure rejects the create (HTTP 503, code=ID_SERVICE_UNAVAILABLE), never silently falling back to the inline _next_record_id path (a silent fallback would defeat the IAM isolation property). When OFF (default), the inline counter-based allocation in tracker_mutation runs unchanged (zero-behavior-change rollback path) and continues reading/writing legacy counter#* rows in the shared tracker table."
+        },
+        "id_boundary_violation_error_code": {
+          "type": "string",
+          "definition": "error_envelope.code value returned on any rejected create carrying item_id/record_id/item_id_provenance: 'ID_BOUNDARY_VIOLATION'. Distinguishable from the generic 'INVALID_INPUT' code so callers and log-based alerting can specifically detect ID-boundary probing/regression attempts."
+        },
+        "backfill_and_quarantine": {
+          "type": "string",
+          "definition": "tools/backfill_item_id_provenance.py scans devops-project-tracker{-gamma}, computing + stamping item_id_provenance on any record with item_id + created_at + record_type but no existing signature. Records that cannot be signed (missing required fields) OR that match the ENC-FTR-069 quarantine list (ENC-TSK-1291, ENC-TSK-1292 — both already adjudicated as an intentional exemption, not re-litigated here) are reported as a documented quarantine exemption, never fabricated. Idempotent: re-running after a successful pass produces zero writes."
+        }
+      }
+    },
+    "mcp_server.interface_mode": {
+      "description": "MCP server interface mode controlling which tool surface is exposed to agents. Code mode (default) exposes 4 composite meta-tools plus connection_health, providing 75-85% token savings and stronger governance. Raw mode (30+ tools) is deprecated with zero legitimate consumers. Defense-in-depth: the coordination_api gateway additionally filters tools/list and rejects tools/call for non-code-mode tools.",
+      "fields": {
+        "ENCELADUS_MCP_INTERFACE_MODE": {
+          "type": "enum",
+          "enum": [
+            "code",
+            "raw"
+          ],
+          "definition": "Interface mode selector. Read by server.py at module import time. Set on all Lambda environments and host-v2 MCP profiles.",
+          "usage_guidance": "MUST be set to code. Raw is retained only for emergency rollback."
+        },
+        "code_mode_tools": {
+          "type": "set",
+          "enum": [
+            "search",
+            "execute",
+            "get_compact_context",
+            "coordination",
+            "connection_health"
+          ],
+          "definition": "The 5 tools exposed in code mode. Any tool not in this set is rejected by the gateway."
+        },
+        "default_mode": {
+          "type": "string",
+          "definition": "_ENCELADUS_DEFAULT_INTERFACE_MODE in config.py. Changed from raw to code (ENC-TSK-A38). Affects all dispatch paths."
+        }
+      }
+    },
+    "feed_query.record_extensions": {
+      "description": "Feed query record extension fields added to task/issue/feature/lesson/plan payloads in the /api/v1/feed response (ENC-TSK-A57, extended ENC-TSK-K26). Implemented in enceladus_shared.record_extensions and invoked from feed_query. typed_relationships: typed relationship edges from rel# DynamoDB items. context_node: computed scores (freshness, absolute-degree structural_importance, information_density, access_frequency).",
+      "fields": {
+        "typed_relationships": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Typed relationship edges from ENC-FTR-049 rel# DynamoDB items, attached per record. Each edge: {relationship_type, target_id, weight, confidence, reason, created_at}. Only present when edges exist for the record.",
+          "usage_guidance": "Used by TypedRelationshipSection PWA component to display grouped relationship edges on detail pages."
+        },
+        "subtask_ids": {
+          "type": "array",
+          "definition": "Task subtask_ids now included in feed task transform for PlanTree PWA component. Previously stripped.",
+          "usage_guidance": "Used by PlanTree component to render parent-child hierarchy up to 3 levels on task detail pages."
+        },
+        "context_node": {
+          "type": "object",
+          "definition": "Context node metadata scores computed at read time by enceladus_shared.record_extensions.build_context_node_meta: freshness_score (half-life decay from updated_at), structural_importance (absolute degree normalized by project max per DOC-310B93107B60), information_density (text length / 2000), access_frequency (context_access_count). Always attached on feed records; not gated by ENABLE_CONTEXT_NODES.",
+          "usage_guidance": "Used by ui-v2 ContextNodeBadges on task/issue/feature/plan detail pages."
+        }
+      }
+    },
+    "tracker_mutation.get_record_extensions": {
+      "description": "ENC-TSK-K26: tracker_mutation GET /{project}/{type}/{id} enriches the deserialized record with the same typed_relationships + context_node extensions as feed_query via enceladus_shared.record_extensions.attach_record_extensions (query_typed_relationships_for_projects scoped to the record's project). Failures are logged and the bare record is still returned.",
+      "fields": {
+        "typed_relationships": {
+          "type": "array",
+          "definition": "Outgoing typed edges for the requested source record, same shape as feed_query.record_extensions.typed_relationships."
+        },
+        "context_node": {
+          "type": "object",
+          "definition": "Computed context node metadata for the requested record, same shape as feed_query.record_extensions.context_node."
+        }
+      }
+    },
+    "enceladus_shared.record_extensions": {
+      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/record_extensions.py) centralizing typed-edge query + context-node score computation for feed_query and tracker_mutation GET handlers (ENC-TSK-K26 / ENC-TSK-A57). Until enceladus-shared layer :11 publishes this module, feed_query and tracker_mutation vendor it into their function zips via .build_extras and import as top-level record_extensions.",
+      "fields": {
+        "compute_structural_importance": {
+          "type": "function",
+          "definition": "Absolute graph degree (in+out typed edges) for a record_id normalized by the project max degree; capped at 1.0. Implements DOC-310B93107B60 absolute metric (not stub/global PageRank)."
+        },
+        "attach_record_extensions": {
+          "type": "function",
+          "definition": "Mutates each record dict in-place: sets typed_relationships when edges exist and always sets context_node with the four score fields."
+        }
+      }
+    },
+    "enceladus_shared.relationship_store": {
+      "description": "Shared Python module (backend/lambda/shared_layer/python/enceladus_shared/relationship_store.py) for B65 Ph4 typed-relationship table extraction (ENC-TSK-L13). When RELATIONSHIPS_TABLE is set, writes dual-put forward+inverse pairs to enceladus-relationships and devops-project-tracker; reads merge the relationships table first with legacy tracker fallback on SK conflicts. NOTE (ENC-TSK-M55, reverted): the M55 read-volume additions were reverted per AC-5; the feed/extensions attach path remains DEAD at runtime (record_extensions package-qualified import misses the layer, which lacks relationship_store) until io decides the latency-vs-functionality tradeoff.",
+      "fields": {
+        "write_target_tables": {
+          "type": "function",
+          "definition": "Returns [relationships_table, tracker_table] when RELATIONSHIPS_TABLE is configured, else [tracker_table] only."
+        },
+        "query_relationship_raw_items": {
+          "type": "function",
+          "definition": "Prefix query with relationships-table-first merge; pagination cursor follows the primary (relationships) table."
+        },
+        "iter_project_relationship_items": {
+          "type": "function",
+          "definition": "Full-project rel# scan for feed/extensions; relationships table keys win over tracker duplicates. (M55 range-bounding reverted per AC-5.)"
+        }
+      }
+    },
+    "tracker.plan": {
+      "description": "Plan tracker records (ENC-FTR-058). First-class governed primitive replacing [Plan] parent tasks. Plans own objectives sets, enforce checkout contracts, and marry features to their implementation phases. Plans replace the parent-task pattern for multi-phase work. ENC-TSK-B10: Lambda routing regexes now include plan in POST/GET/PATCH route matching.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "drafted",
+            "started",
+            "complete",
+            "incomplete"
+          ],
+          "definition": "Plan lifecycle. drafted: initial state. started: at least one objective task checked out. complete: all objectives closed (ENC-ISS-155: tracker mutation validates all objectives_set entries are in terminal status before accepting). incomplete: abandoned with reason."
+        },
+        "objectives_set": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Array of record IDs (tasks, issues, features — not lessons) that this plan governs. Append-only when plan status is not 'incomplete' unless using governed plan.remove_objective or plan.replace_objectives actions. Immutability enforced at DynamoDB level.",
+          "usage_guidance": "Set via tracker.set or plan.add_objective MCP action. Removal via plan.remove_objective (blocked for closed objectives). Reorder via plan.reorder_objectives (permutation only). Bulk replace via plan.replace_objectives (drafted status only)."
+        },
+        "attached_documents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Array of DOC-* IDs attached to this plan as reference material."
+        },
+        "related_feature_id": {
+          "type": "string",
+          "definition": "The feature this plan implements. Creates a plan-implements typed relationship edge."
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "strategic",
+            "tactical",
+            "operational",
+            "remediation"
+          ],
+          "definition": "Plan category."
+        },
+        "checkout_state": {
+          "type": "string",
+          "definition": "Plan checkout state. Empty when not checked out."
+        },
+        "plan.add_objective": {
+          "type": "execute_action",
+          "definition": "Append a single task ID to objectives_set. Idempotent — returns already_present if duplicate.",
+          "arguments": {
+            "record_id": "plan ID",
+            "objective_task_id": "task ID to add",
+            "governance_hash": "required"
+          },
+          "guard_conditions": "None beyond governance_hash. Append-only enforcement in tracker_mutation.",
+          "authority_envelope": "any governed session"
+        },
+        "plan.remove_objective": {
+          "type": "execute_action",
+          "definition": "Remove a single task ID from objectives_set. Blocked if the objective task status is closed/completed/archived.",
+          "arguments": {
+            "record_id": "plan ID",
+            "objective_task_id": "task ID to remove",
+            "governance_hash": "required"
+          },
+          "guard_conditions": "Cannot remove closed objectives — permanent evidence of completed work.",
+          "authority_envelope": "any governed session"
+        },
+        "plan.reorder_objectives": {
+          "type": "execute_action",
+          "definition": "Reorder objectives_set. Must be a permutation of the current set (same elements, different order — no additions or deletions).",
+          "arguments": {
+            "record_id": "plan ID",
+            "ordered_objective_ids": "array of all current objective IDs in new order",
+            "governance_hash": "required"
+          },
+          "guard_conditions": "Must be exact permutation. Returns 400 if elements differ.",
+          "authority_envelope": "any governed session"
+        },
+        "plan.replace_objectives": {
+          "type": "execute_action",
+          "definition": "Bulk replace entire objectives_set. Only permitted when plan status is 'drafted'. Returns 400 for any other status.",
+          "arguments": {
+            "record_id": "plan ID",
+            "objective_ids": "array of replacement objective task IDs",
+            "governance_hash": "required"
+          },
+          "guard_conditions": "Plan status must be 'drafted'. ConsistentRead=True used for status check (RISK-C08).",
+          "authority_envelope": "any governed session, drafted plans only"
+        },
+        "target_generation": {
+          "type": "string",
+          "definition": "ENC-GEN-NNN generation this plan targets. Controls branch prefix convention."
+        },
+        "auto_walk_opt_out": {
+          "type": "boolean",
+          "default": false,
+          "definition": "ENC-FTR-111 / ENC-TSK-H83 (Universal Arc-Walker Phase 1 circuit breaker). When true, the Universal Arc-Walker MUST NOT auto-advance this record across any lifecycle gate. Default false. The tracker_mutation write path auto-latches this true on any human-initiated non-forward transition (a regression / backward status move, or -- for tasks -- a coding-updates re-entry) and emits an Artifact-Genesis audit record (a history entry plus an EventBridge 'record.auto_walk_opt_out.latched' event). The arc-walker can never clear it (ENC-FTR-111 AC-2).",
+          "usage_guidance": "Settable and clearable by humans or agents via execute tracker.set(field='auto_walk_opt_out', value=true|false); a 'true'/'false' string is coerced to a real DynamoDB BOOL. Auto-latched true by the write path on human-initiated non-forward transitions; no manual action required. The arc-walker (write_source provider/channel 'system:arc-walker') is forbidden from clearing it: tracker_mutation rejects walker-origin attempts to set it false with HTTP 403. Cleared only by an explicit non-walker tracker.set to false."
+        }
+      }
+    },
+    "tracker.plan.relationship_types": {
+      "description": "Typed relationship edge types introduced by ENC-FTR-058 for plan records. ENC-TSK-E01 / ENC-ISS-184: graph_sync now MERGEs a label-correct placeholder target node (using the ID-prefix → label inference helper _infer_label_from_id) before MERGEing the edge, so PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS edges land even when the objective task or attached document has not yet been processed by graph_sync. The target record's own subsequent stream event MERGEs by the same (label, record_id) pair via _upsert_node and augments the placeholder with full properties without duplicating the node. This eliminates the silent zero-edge race window that previously occurred when plan.add_objective was called for a freshly-created task (e.g. ENC-PLN-016 had zero PLAN_CONTAINS edges to its 8 objectives despite a populated objectives_set).",
+      "fields": {
+        "plan-contains": {
+          "type": "relationship",
+          "definition": "Plan → task/issue/feature. Indicates the target record is an objective of this plan.",
+          "inverse": "contained-by-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates objectives_set and MERGEs a placeholder target node with the inferred label (TSK→Task, ISS→Issue, FTR→Feature) before MERGEing the PLAN_CONTAINS edge. Unrecognised ID prefixes log a warning and fall back to the legacy unlabelled MATCH (edge may not land if target absent)."
+        },
+        "plan-attached-doc": {
+          "type": "relationship",
+          "definition": "Plan → document. Attaches a document as reference material for the plan.",
+          "inverse": "doc-attached-to-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch iterates attached_documents and MERGEs a Document placeholder before MERGEing PLAN_ATTACHED_DOC and the inverse DOC_ATTACHED_TO_PLAN."
+        },
+        "plan-implements": {
+          "type": "relationship",
+          "definition": "Plan → feature. The plan is the implementation vehicle for this feature.",
+          "inverse": "implemented-by-plan",
+          "graph_projection": "graph_sync/_reconcile_edges() plan branch reads related_feature_id and MERGEs a Feature placeholder before MERGEing PLAN_IMPLEMENTS."
+        }
+      }
+    },
+    "tracker.plan.composition": {
+      "description": "ENC-TSK-M65: Composition declarations for tracker.plan as a composite entity. Documents how plan records own/attach child objective records, distinct from the plan-contains graph relationship edges (see tracker.plan.relationship_types) which describe the resulting graph projection. This entity describes the governed attachment mechanism at the mutation-API level.",
+      "fields": {
+        "child_record_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "enum": [
+            "task",
+            "issue",
+            "feature"
+          ],
+          "definition": "Record types a plan may compose via objectives_set. Lessons are explicitly excluded -- objectives_set never holds lesson IDs. See tracker.plan.objectives_set."
+        },
+        "attachment_mechanism": {
+          "type": "string",
+          "definition": "Composition is via the objectives_set array field on the plan record (tracker.plan.objectives_set), not via a parent-pointer on the child. Append-only once the plan leaves 'drafted'/'incomplete' unless mutated through the governed plan.* execute actions: plan.add_objective (append one), plan.remove_objective (remove one, blocked if child is closed/completed/archived), plan.reorder_objectives (permutation only, no membership change), plan.replace_objectives (bulk replace, drafted status only). Direct tracker_set of objectives_set bypasses these guards and is discouraged; the governed actions enforce the append-only and terminal-status invariants at the API layer, with append-only additionally enforced at the DynamoDB level.",
+          "usage_guidance": "Prefer plan.add_objective / plan.remove_objective / plan.reorder_objectives / plan.replace_objectives over raw tracker_set(field='objectives_set') so guard conditions run."
+        },
+        "cardinality": {
+          "type": "string",
+          "definition": "One plan to many objective records (1:N). An objective record (task/issue/feature) may appear in more than one plan's objectives_set -- there is no reverse uniqueness constraint enforced by the tracker API, so composition is logically N:M in practice even though each plan's own set behaves as an ordered array of member IDs."
+        },
+        "note_task_parent_is_not_plan_composition": {
+          "type": "string",
+          "definition": "tracker.task.parent is a same-record-type pointer (task -> task only, per plan-derived task hierarchy convention, ENC-FTR-040) and is NOT how a plan composes its objectives. Plan-to-task composition happens exclusively via objectives_set; task.parent only expresses task-to-task phase/step nesting within a plan capture, and is not enforced by the tracker API."
+        }
+      }
+    },
+    "feed_query.status_normalization": {
+      "description": "Feed query Lambda status normalization whitelists controlling which lifecycle states are preserved in the live feed API response. Previously collapsed many task states to open. Now preserves all governed lifecycle states including coding_complete, committed, pushed, pr, merged_main, deploy_init, deploy_success, coding_updates. Feature states now include production and deprecated. Lesson records added with draft/active/graduated/deprecated statuses (ENC-TSK-A55).",
+      "fields": {
+        "task_statuses": {
+          "type": "set",
+          "enum": [
+            "open",
+            "closed",
+            "in_progress",
+            "planned",
+            "coding_complete",
+            "committed",
+            "pushed",
+            "pr",
+            "merged_main",
+            "deploy_init",
+            "deploy_success",
+            "coding_updates",
+            "deployed"
+          ],
+          "definition": "Whitelist of valid task status values preserved by feed_query _normalize_status. Values not in this set default to open."
+        },
+        "feature_statuses": {
+          "type": "set",
+          "enum": [
+            "planned",
+            "in_progress",
+            "completed",
+            "closed",
+            "production",
+            "deprecated"
+          ],
+          "definition": "Whitelist of valid feature status values."
+        },
+        "issue_statuses": {
+          "type": "set",
+          "enum": [
+            "open",
+            "in_progress",
+            "closed"
+          ],
+          "definition": "Whitelist of valid issue status values."
+        },
+        "lesson_statuses": {
+          "type": "set",
+          "enum": [
+            "draft",
+            "active",
+            "graduated",
+            "deprecated"
+          ],
+          "definition": "Whitelist of valid lesson status values."
+        }
+      }
+    },
+    "feed_query.history_inclusion": {
+      "description": "Feed query Lambda history array population behavior (ENC-TSK-C01, hardened by ENC-TSK-C31). All 5 record-type transform functions (_transform_task_from_ddb, _transform_issue_from_ddb, _transform_feature_from_ddb, _transform_plan_from_ddb, _transform_lesson_from_ddb) extract history entries from DynamoDB L-type attributes via _ddb_history(). ENC-TSK-C31: _ddb_history is now fully defensive (coerces None attributes to {}, validates every nesting level, per-entry try/except, outer try/except returning [] on any uncaught failure) and _query_all_records / _query_incremental wrap each record's transform in try/except so a single malformed record cannot take down the entire feed response with HTTP 500.",
+      "fields": {
+        "max_history_entries": {
+          "type": "integer",
+          "definition": "Maximum number of history entries returned per record in the feed API response. When a record has more entries, only the most recent N are included. Current value: 10 (ENC-TSK-C34; reduced from 50 as a secondary guardrail against the Lambda 6 MB sync response limit)."
+        },
+        "per_type_record_cap": {
+          "type": "object",
+          "definition": "ENC-TSK-C34: Per-record-type caps applied inside _query_all_records to keep the full /api/v1/feed synchronous response under AWS Lambda's 6 MB payload limit. With history arrays populated (ENC-TSK-C01), the pre-cap response exceeded the limit and returned the opaque {\"message\":\"Internal Server Error\"} envelope from Lambda runtime, which broke PWA plan and lesson rendering (lessons and plans have no S3 fallback in useFeed.ts). The cap keeps only the N most-recently-updated records of each type: MAX_TASKS_FULL_REFRESH=100, MAX_ISSUES_FULL_REFRESH=10, MAX_FEATURES_FULL_REFRESH=10, MAX_LESSONS_FULL_REFRESH=10, MAX_PLANS_FULL_REFRESH=10. Aligned with the PWA's frontend/ui/src/pages/FeedPage.tsx useInfiniteList(items, 20, 100) which already caps visible feed rows at 100. The cap is applied BEFORE the deterministic id sort so the truncation window is chosen by recency, not alphabetically."
+        },
+        "entry_shape": {
+          "type": "object",
+          "definition": "Each history entry is normalized to {timestamp: string, status: string, description: string}, matching the HistoryEntry TypeScript interface consumed by the PWA HistoryFeed component."
+        },
+        "extraction_source": {
+          "type": "string",
+          "definition": "History is extracted from the DynamoDB 'history' attribute (L type containing M entries). Missing or malformed entries are skipped gracefully."
+        },
+        "per_record_isolation": {
+          "type": "string",
+          "definition": "ENC-TSK-C31: _query_all_records and _query_incremental catch Python exceptions around _is_stale_closed and _TRANSFORM[record_type](raw_item, pid) on a per-record basis. A single malformed record is logged (record_type, item_id, project) and skipped; the rest of the response is unaffected. Prior behavior bubbled the exception to the handler's generic try/except and returned HTTP 500, which broke PWA plan+lesson rendering because those types have no S3 fallback in useFeed.ts."
+        },
+        "defensive_shape_coercion": {
+          "type": "string",
+          "definition": "ENC-TSK-C31 + ENC-TSK-C32: A shared _ddb_attr(item, key) helper coerces missing, None, or non-dict attributes to {} before any nested lookup. Every _ddb_* helper (_ddb_str, _ddb_int, _ddb_float, _ddb_bool, _ddb_str_set, _ddb_list_of_maps, _ddb_map, _ddb_history) routes through _ddb_attr so a DynamoDB attribute stored as Python None can never crash a transform with AttributeError. _ddb_str also validates the nested S value is actually a string; _ddb_bool guards S type before .lower(); _ddb_list_of_maps skips L entries where M is not a dict; _ddb_map validates M is a dict and wraps float() in try/except."
+        }
+      }
+    },
+    "neo4j.backup_runtime": {
+      "description": "Operational contract for the scheduled Neo4j-to-S3 backup worker introduced for gamma validation and disaster-readiness (ENC-TSK-B85). The Lambda exports graph state to S3 on a daily EventBridge schedule; DynamoDB remains the authoritative restore source and backfill_graph.py is the primary rebuild path.",
+      "fields": {
+        "schedule_expression": {
+          "type": "string",
+          "definition": "EventBridge schedule expression that invokes the backup worker. Current contract: cron(0 3 * * ? *) for daily execution at 03:00 UTC."
+        },
+        "artifact_s3_prefix": {
+          "type": "string",
+          "definition": "S3 prefix where backup artifacts are written. Current contract: s3://jreese-net/neo4j-backups/<YYYY>/<MM>/<DD>/..."
+        },
+        "restore_strategy": {
+          "type": "string",
+          "definition": "Primary restore path for Enceladus graph recovery. Backup artifacts serve as audit/reference snapshots; governed recovery uses DynamoDB re-projection via tools/backfill_graph.py with a target rebuild window of under 15 minutes for the current corpus."
+        }
+      }
+    },
+    "neo4j.incremental_embedding": {
+      "description": "Incremental Titan V2 embedding contract for graph_sync (ENC-TSK-B94). Every INSERT/MODIFY DDB stream event for Task/Issue/Feature/Plan/Lesson/Document record types produces a 256-dim Titan V2 embedding that is written to the node's `embedding` property in Neo4j alongside an `embedding_text_hash` used to short-circuit re-embedding on no-op MODIFY events (e.g. status transitions). The embedding is invoked inline on the graph_sync SQS consumer after the node upsert and edge reconciliation steps, wrapped in try/except so Bedrock, IAM, or network failures never break the primary projection. Pairs with ENC-TSK-B90 vector indexes and ENC-TSK-B91 batch backfill; all three must share the text-extraction contract implemented in backend/lambda/graph_sync/embedding.py.",
+      "fields": {
+        "model_contract": {
+          "type": "object",
+          "definition": "Bedrock model invocation parameters: modelId=amazon.titan-embed-text-v2:0, request body {inputText, dimensions: 256, normalize: true}, contentType=application/json. Response body carries 'embedding' as a list of 256 floats. Mandated by ENC-TSK-B62 AC-2 and matched by ENC-TSK-B90 vector index config (256 dims, cosine)."
+        },
+        "text_extraction_contract": {
+          "type": "string",
+          "definition": "embedding.build_embedding_text(record) concatenates title + intent + description + user_story with double-newline separators, stripping blanks and deduping lines, capped at 24,000 chars. Same function used by both the incremental (B94) and batch (B91) paths so vectors from the two sources are comparable. Contract is deliberately narrow (four well-known fields) so it works uniformly across all six embeddable record types without branching."
+        },
+        "embedding_property": {
+          "type": "string",
+          "definition": "Neo4j node property name carrying the 256-float vector. Matches the target property declared by ENC-TSK-B90 migration 001. Constant EMBEDDING_PROPERTY='embedding' in backend/lambda/graph_sync/embedding.py."
+        },
+        "embedding_hash_property": {
+          "type": "string",
+          "definition": "Neo4j node property carrying a 16-char sha256 hex prefix of the embedding input text. Used by graph_sync to skip re-invoking Bedrock when a MODIFY event's title/intent/description/user_story are unchanged from the last embedding. Constant EMBEDDING_HASH_PROPERTY='embedding_text_hash' in backend/lambda/graph_sync/embedding.py."
+        },
+        "iam_contract": {
+          "type": "string",
+          "definition": "Role devops-graph-sync-lambda-role gained bedrock:InvokeModel on Resource arn:aws:bedrock:${REGION}::foundation-model/amazon.titan-embed-text-v2:0 via deploy.sh:ensure_role() put-role-policy Sid=BedrockTitanV2InvokeModel. Same statement applied to gamma role devops-graph-sync-lambda-role-gamma when ENVIRONMENT_SUFFIX is set."
+        },
+        "failure_mode": {
+          "type": "string",
+          "definition": "Any Bedrock, IAM, or parser failure is caught by the try/except wrapper in _process_record() and logged with [ERROR] prefix. The primary node upsert and edge reconciliation steps complete regardless. A future MODIFY event on the same record re-attempts the embedding; eventual consistency is acceptable because the vector index simply ignores nodes without embeddings until they are written."
+        },
+        "no_op_skip": {
+          "type": "string",
+          "definition": "Before invoking Bedrock, graph_sync reads the node's existing embedding_text_hash and compares against a hash of the newly-built input text. If they match, compute_embedding_for_record() returns None and the Bedrock call is skipped. This keeps spend on status-transition heavy workloads (e.g. checkout.advance cycles) bounded to one invocation per record per title/intent/description/user_story change."
+        }
+      }
+    },
+    "component_registry.propose_contract": {
+      "description": "Agent-proposable component registry contract (ENC-FTR-076 / ENC-TSK-E08+E09). Introduces lifecycle_status (proposed, approved, active, rejected, deprecated, archived) on component records plus an atomic COMPONENT_PROPOSED_BY typed-relationship edge from the component to the proposing_agent_session_id. E09 adds the Cognito-only approve/reject decision endpoints. Gated by ENABLE_COMPONENT_PROPOSAL feature flag (default off in prod, on in gamma). Downstream phases add checkout gate on proposed/rejected (E10), SNS notification (E11), backfill script setting existing records to lifecycle_status=active (E12), and PWA pending-approval UI (E13).",
+      "fields": {
+        "lifecycle_status_enum": {
+          "type": "enum",
+          "enum": [
+            "proposed",
+            "approved",
+            "active",
+            "rejected",
+            "deprecated",
+            "archived"
+          ],
+          "definition": "Component lifecycle state machine. proposed is the initial state after component.propose. approved is a transient state after PWA approval before becoming active. active is the terminal-ready state that allows task checkout against the component. rejected terminates the proposal with a reason. deprecated and archived are end-of-life states. Forward transitions: proposed->{approved,rejected}; approved->{active,archived}; active->{deprecated,archived}; deprecated->{archived}. Revert transitions: approved->proposed; active->approved; deprecated->active. Enforced by coordination_api for writes and by checkout_service for task-to-component gating (E10)."
+        },
+        "propose_route": {
+          "type": "string",
+          "definition": "POST /api/v1/coordination/components/propose. Registered above the generic /components/{id} matcher so 'propose' is not mis-routed to _handle_components_get. Body: {component_id (comp- prefix), display_name, project_id, source_paths[], description, requested_minimum_transition_type, proposing_agent_session_id?, category?, governance_hash}. Returns 201 with {component_id, lifecycle_status: 'proposed', proposing_agent_session_id, requested_minimum_transition_type, component}."
+        },
+        "atomic_edge_write": {
+          "type": "string",
+          "definition": "_handle_components_propose writes the component record (component-registry table) and the rel# forward+inverse pair (devops-project-tracker table) in a single DynamoDB TransactWriteItems across both tables. The rel# schema mirrors tracker_mutation/_handle_create_relationship so graph_sync projects (Component)-[:COMPONENT_PROPOSED_BY]->(target) uniformly via RELATIONSHIP_TYPE_TO_EDGE_LABEL. ConditionExpression=attribute_not_exists(component_id) on the component Put returns 409 on duplicate. ConditionExpression=attribute_not_exists(record_id) on both rel# Puts returns 409 if the proposal edge is already present."
+        },
+        "ogtm_registrations": {
+          "type": "object",
+          "definition": "ENC-FTR-066 OGTM compliance: 'component-proposed-by' and 'proposes-component' added to tracker_mutation._RELATIONSHIP_TYPES + _INVERSE_PAIRS. 'component-proposed-by': 'COMPONENT_PROPOSED_BY' and 'proposes-component': 'PROPOSES_COMPONENT' added to graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL. 'COMPONENT_PROPOSED_BY' + 'PROPOSES_COMPONENT' added to graph_query_api._ALLOWED_EDGE_TYPES so the edge is queryable via tracker.graphsearch with edge_types=['COMPONENT_PROPOSED_BY']."
+        },
+        "mcp_action": {
+          "type": "string",
+          "definition": "tools/enceladus-mcp-server/server.py: component.propose registered in _EXECUTE_ACTIONS under ENABLE_COMPONENT_PROPOSAL guard with requires_governance_hash=True. Proxy function _component_propose forwards to coordination_api via _coordination_api_request. Full arg set: component_id, display_name, project_id, source_paths[], description, requested_minimum_transition_type, proposing_agent_session_id?, category?, governance_hash."
+        },
+        "feature_flag": {
+          "type": "string",
+          "definition": "ENABLE_COMPONENT_PROPOSAL env var on coordination_api + mcp-server Lambdas. Default 'false' so the behavior is opt-in. Gamma deploy script sets it to 'true' for early validation; prod stays off until E08-E14 all ship and io approves v3 cutover. When off: POST /components/propose returns 503; the MCP action is not registered in _EXECUTE_ACTIONS."
+        },
+        "lifecycle_transition_maps": {
+          "type": "object",
+          "definition": "tracker_mutation/lambda_function.py adds _VALID_COMPONENT_LIFECYCLE_TRANSITIONS + _REVERT_COMPONENT_LIFECYCLE_TRANSITIONS dicts near the existing record-type lifecycle maps. Enforced by coordination_api for approve/reject advance (E09) and by checkout_service for task gating (E10)."
+        },
+        "approve_route": {
+          "type": "string",
+          "definition": "POST /api/v1/coordination/components/{component_id}/approve (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=active, approved_at, approved_by (resolved from Cognito email > cognito:username > sub). Optional body field `transition_type` overrides the existing transition_type when present (validated against _COMPONENT_TRANSITION_TYPES). Returns 200 with {component_id, lifecycle_status: 'active', approved_by, approved_at, component}. Registered above the generic /components/{id} matcher."
+        },
+        "reject_route": {
+          "type": "string",
+          "definition": "POST /api/v1/coordination/components/{component_id}/reject (ENC-TSK-E09). Cognito-only — internal API key callers receive 403. Gated by ENABLE_COMPONENT_PROPOSAL (503 when off). Body MUST contain `rejection_reason` of at least 10 characters. Atomic UpdateItem with ConditionExpression `attribute_exists(component_id) AND lifecycle_status = 'proposed'`. On condition failure, a follow-up GetItem distinguishes 404 (missing) from 409 (current_lifecycle_status echoed in details). Sets lifecycle_status=rejected, rejected_at, rejected_by (resolved from Cognito email > cognito:username > sub), and rejection_reason. Returns 200 with {component_id, lifecycle_status: 'rejected', rejected_by, rejected_at, rejection_reason, component}. Registered above the generic /components/{id} matcher."
+        },
+        "sns_notification": {
+          "type": "object",
+          "definition": "ENC-TSK-E11: ComponentRegistryEventsTopic SNS topic (TopicName=enceladus-component-registry-events${EnvironmentSuffix}) declared in infrastructure/cloudformation/01-data.yaml with matching ComponentRegistryEventsTopicArn output export. coordination_api/deploy.sh plumbs COMPONENT_EVENTS_TOPIC_ARN env var (default constructed from REGION+ACCOUNT_ID+suffix) and adds the ComponentEventsTopicPublish IAM Sid (sns:Publish scoped to the topic ARN). _publish_component_proposed_event() in coordination_api/lambda_function.py runs after the TransactWriteItems succeeds and best-effort publishes the JSON message {event_type: 'component.proposed', component_id, project_id, proposing_agent_session_id, requested_minimum_transition_type, pwa_deep_link} with Subject 'Component proposed: {component_id}'. SNS failures are warning-logged and swallowed so the 201 response never blocks on notification side-channel issues. When COMPONENT_EVENTS_TOPIC_ARN is empty (e.g. local dev), publish is skipped silently."
+        }
+      }
+    },
+    "neo4j.placeholder_node": {
+      "description": "Placeholder-node contract on Neo4j graph (ENC-TSK-E06 / ENC-ISS-230). graph_sync._reconcile_edges() uses the ENC-TSK-E01 _infer_label_from_id + placeholder MERGE pattern to create labeled target nodes when a typed-edge reference points at an ID whose DynamoDB record has not yet been projected. This eliminates the zero-edge race window but also produces orphan nodes when the reference targets an ID that has no backing record at all (cross-project legacy refs, malformed IDs like 'ENC-LSN-001#learned-from#ENC-TSK-803', unqualified shorthands like 'harrisonfamily'). ENC-TSK-E06 introduces the `is_placeholder` boolean property on every labeled node to distinguish edge-target stubs from real records, so downstream embedding, coverage, retrieval, and health pipelines can filter them out without re-deriving the distinction each time. The property is set by graph_sync at MERGE time; no migration is required for new records, and a one-time Cypher batch retroactively tags the 229 pre-E06 orphans on the shared prod+gamma AuraDB.",
+      "fields": {
+        "placeholder_on_create": {
+          "type": "string",
+          "definition": "Every placeholder MERGE in graph_sync._reconcile_edges() (Plan PLAN_CONTAINS, Plan PLAN_ATTACHED_DOC, Plan PLAN_IMPLEMENTS, Lesson LEARNED_FROM, Document RELATED_TO, Document INFORMED_BY source) uses the pattern `MERGE (x:{Label} {record_id: $id}) ON CREATE SET x.is_placeholder = true`. On existing-node match the ON CREATE clause is a no-op, preserving the is_placeholder=false flag that _upsert_node set when the real record was projected."
+        },
+        "placeholder_clear_on_upsert": {
+          "type": "string",
+          "definition": "graph_sync._upsert_node() MERGEs by (label, record_id) and applies `SET n += $props SET n.is_placeholder = false`. When the real DynamoDB record arrives after a placeholder was created by an earlier reconcile edge pass, the MERGE matches the placeholder node, SET += populates all properties, and the explicit SET clears is_placeholder to false. Idempotent: re-running on a node already is_placeholder=false is a no-op."
+        },
+        "coverage_filter": {
+          "type": "string",
+          "definition": "Coverage metric queries exclude placeholders from both numerator and denominator. embedding.titan_v2_backfill._coverage_for_label applies `MATCH (n:{Label}) WHERE n.is_placeholder IS NULL OR n.is_placeholder = false RETURN count(n) AS total, count(n.embedding) AS with_embedding`. The IS NULL branch keeps pre-E06 nodes that never got the flag stamped (currently zero after the one-time Cypher backfill; retained for forward compatibility if future migration paths ever re-emit nodes without the flag)."
+        },
+        "embedding_filter": {
+          "type": "string",
+          "definition": "Placeholders do not carry embeddable text (zero-property stubs), so they never appear in embedding.titan_v2_backfill._iter_corpus (which iterates DynamoDB, not Neo4j) and never flow through graph_sync's incremental Titan V2 path (no DDB stream event triggers a reconcile for a node that has no DDB record). Neo4j vector indexes (ENC-TSK-B90) only index nodes carrying the `embedding` property, so placeholders are never candidates for ANN queryNodes results. No explicit is_placeholder filter is needed on vector retrieval paths."
+        },
+        "one_time_backfill_query": {
+          "type": "string",
+          "definition": "Retroactive tagging of pre-E06 orphans: `MATCH (n) WHERE n.embedding IS NULL AND coalesce(size(n.title),0) + coalesce(size(n.description),0) = 0 AND n.is_placeholder IS NULL SET n.is_placeholder = true RETURN count(n)`. Executed once under product-lead io-dev-admin terminal against the shared prod+gamma AuraDB. Expected count on first run: 229 (182 :Task + 47 :Issue)."
+        },
+        "race_fix_invariant": {
+          "type": "string",
+          "definition": "ENC-TSK-E01 (ENC-ISS-184) race-fix invariant preserved: typed edges PLAN_CONTAINS / PLAN_ATTACHED_DOC / PLAN_IMPLEMENTS / LEARNED_FROM / RELATED_TO / INFORMED_BY still materialize via placeholder MERGE when the target node has not yet been projected. is_placeholder=true does not suppress the edge — it only distinguishes the stub so retrieval scoring and coverage accounting can treat it as a low-information anchor rather than a missing record."
+        },
+        "orphan_purge_on_edge_removal": {
+          "type": "string",
+          "definition": "ENC-TSK-G06: graph_sync now collects the label-qualified placeholder candidates implied by plan/lesson/document/relationship edges and, after MODIFY/REMOVE or archived relationship deletion, runs `MATCH (n:{Label} {record_id: $rid}) WHERE coalesce(n.is_placeholder, false) = true AND NOT (n)--() DETACH DELETE n`. This removes phantom placeholder stubs once their final incident edge disappears while preserving real projected nodes and placeholders still anchored by any remaining relationship."
+        }
+      }
+    },
+    "checkout_service.plan_checkout": {
+      "description": "Plan checkout contract in the checkout service Lambda (ENC-FTR-058 Phase 2). Plans use a simplified lifecycle (drafted/started/complete/incomplete) with objectives-based completion gates and mandatory check-in on release. No CAI/CCI tokens.",
+      "fields": {
+        "plan_lifecycle": {
+          "type": "object",
+          "definition": "Valid plan status transitions. drafted->started (on first checkout), started->complete (all objectives terminal), started->incomplete (with reason), incomplete->started (re-entry)."
+        },
+        "completion_gate": {
+          "type": "object",
+          "definition": "ENC-TSK-A89: advance to complete validates all objectives_set records are in terminal status (closed/completed/complete/archived/deprecated/production). Returns 400 with incomplete objectives list on failure."
+        },
+        "mandatory_checkin": {
+          "type": "object",
+          "definition": "ENC-TSK-A90: plan release requires non-empty checkin_summary in request body. Summary is logged as [CHECK-IN] worklog entry before checkout release."
+        },
+        "no_token_flow": {
+          "type": "boolean",
+          "definition": "Plans do not issue CAI or CCI tokens. No commit, PR, or deploy stages."
+        },
+        "api_routes": {
+          "type": "array",
+          "definition": "API Gateway routes: POST/DELETE .../plan/{planId}/checkout, POST .../plan/{planId}/advance, POST .../plan/{planId}/log, GET .../plan/{planId}/status."
+        }
+      }
+    },
+    "governance.ogtm": {
+      "description": "Ontological Graph Traversability Metric gate (ENC-FTR-066). Every new record type, relational field, or edge type introduced to Enceladus must have a corresponding graph_sync projection handler and graph_query_api _ALLOWED_EDGE_TYPES registration before the feature may advance past planned status.",
+      "fields": {
+        "compliance_requirements": {
+          "type": "object",
+          "definition": "Four requirements: (1) graph_sync _reconcile_edges() handler addition, (2) RELATIONSHIP_TYPE_TO_EDGE_LABEL entry, (3) graph_query_api _ALLOWED_EDGE_TYPES registration, (4) E2E tracker.graphsearch validation."
+        },
+        "evidence_template": {
+          "type": "object",
+          "definition": "Canonical compliance evidence template: graph_sync handler line numbers, RELATIONSHIP_TYPE_TO_EDGE_LABEL entry, _ALLOWED_EDGE_TYPES registration, graphsearch validation result."
+        },
+        "authority_envelope": {
+          "type": "object",
+          "definition": "Design Gate = feature creation time. Deploy Gate = CI check. Operational Gate = CEE Compliance Entropy scan."
+        },
+        "governing_feature": {
+          "type": "string",
+          "definition": "ENC-FTR-066"
+        }
+      }
+    },
+    "tracker.pathway_traversed": {
+      "description": "ENC-FTR-082 Phase A / AC-6: PATHWAY_TRAVERSED is a new governed Neo4j edge type capturing observed retrieval traversal (the raw-telemetry slice of the Pathway Primitive, DOC-C6584044BEEB). OGTM (ENC-FTR-066) compliance is satisfied across three lambdas: (1) projection — graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL maps 'pathway-traversed'->PATHWAY_TRAVERSED and inverse 'traversed-by'->TRAVERSED_BY; (2) mutation — tracker_mutation registers 'pathway-traversed'/'traversed-by' in _RELATIONSHIP_TYPES, _INVERSE_PAIRS, _OWL_CHARACTERISTICS (asymmetric+irreflexive, transitive False) and _DOMAIN_RANGE_CONSTRAINTS (unconstrained endpoints); (3) traversability — graph_query_api _ALLOWED_EDGE_TYPES registers PATHWAY_TRAVERSED + TRAVERSED_BY, deliberately NOT added to GRAPH_EDGE_WEIGHTS so a telemetry edge never perturbs the hybrid graph signal in Phase A (the weighted overlay is AC-2 / ENC-FTR-108). Materialized via the ENC-FTR-049 relationship-record path; E2E-confirmed via tracker.graphsearch edge_types=['PATHWAY_TRAVERSED']. Labels are byte-identical across both lambdas (ENC-ISS-178 drift guard). Governing plan ENC-PLN-049.",
+      "fields": {
+        "edge_label": {
+          "type": "string",
+          "definition": "PATHWAY_TRAVERSED (forward: observed retrieval traversal source->target); TRAVERSED_BY (inverse)."
+        },
+        "relationship_type": {
+          "type": "string",
+          "definition": "'pathway-traversed' (forward) / 'traversed-by' (inverse) — the lowercase tracker_mutation relationship_type keys."
+        },
+        "scoring_exclusion": {
+          "type": "boolean",
+          "definition": "true — excluded from graph_query_api GRAPH_EDGE_WEIGHTS so it is traversable but does not influence hybrid retrieval scoring in Phase A."
+        },
+        "ogtm_compliance": {
+          "type": "object",
+          "definition": "Four-criteria OGTM evidence: graph_sync RELATIONSHIP_TYPE_TO_EDGE_LABEL entry; tracker_mutation four-registry registration; graph_query_api _ALLOWED_EDGE_TYPES entry; live tracker.graphsearch E2E traversal. Governing feature ENC-FTR-082."
+        }
+      }
+    },
+    "graph_query_api.pathway_telemetry": {
+      "description": "ENC-FTR-082 Phase A / AC-1 + AC-10: graph_query_api hybrid retrieval (search_type=hybrid) emits raw pathway telemetry on every call. AC-1 record fields {wave_id, timestamp, node_sequence, edges_traversed, outcome, intent_signature} are written as one JSONL object to s3://{PATHWAY_TELEMETRY_BUCKET}/{PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/<ts>-<uuid>.jsonl when the bucket env var is set (Wave-2 CFN), else degraded to a CloudWatch 'PATHWAY_TELEMETRY {json}' log line (logs:PutLogEvents already granted). AC-10: a per-edge edge_participation list {edge_id, traversal_count, retrieval_outcome} is surfaced in both the telemetry record and the hybrid response — this list IS the ENC-FTR-108 (Flow-Reinforced Graph Projection) AC-4 input contract. Edges are reconstructed by a bounded (_PATHWAY_EDGE_DEADLINE_S) shortestPath walk from the anchor to the resolved result set; it never perturbs the RRF result or raises into the request path.",
+      "fields": {
+        "request_params": {
+          "type": "object",
+          "definition": "Two new OPTIONAL graphsearch query params for search_type=hybrid: wave_id (telemetry partition key; default 'unassigned') and intent_signature (default derived deterministically as 'sha256:'+sha256(normalized query+anchor+record_type)). Backward compatible."
+        },
+        "response_fields": {
+          "type": "object",
+          "definition": "Hybrid response adds: edges (reconstructed edges_traversed [{edge_id,type,start,end}]), edge_participation ([{edge_id,traversal_count,retrieval_outcome}], AC-10), pathway ({node_sequence,edge_count,intent_signature,wave_id})."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "PATHWAY_TELEMETRY_BUCKET + PATHWAY_TELEMETRY_PREFIX on devops-graph-query-api. Classified advisory in env_drift_registry.json during Wave 1 (code degrades to CloudWatch); flipped to deploy-critical when Wave-2 CFN sets them + grants s3:PutObject."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.pathway.telemetry.v1"
+        }
+      }
+    },
+    "graph_query_api.drift_telemetry": {
+      "description": "ENC-FTR-087 Phase 1 / ENC-TSK-I85: Wave-Close Drift Telemetry. On every wave-close event graph_query_api emits one record (action='wave_close_drift' direct invoke, routed to backend/lambda/graph_query_api/drift_telemetry.py) to the enceladus-drift-telemetry${EnvironmentSuffix} DynamoDB table (PAY_PER_REQUEST; base key wave_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE] for the per-project time series consumed by the BHC drift-monitor). d_centroid_L2 (F13 Definition F13.5) is the L2 distance between the mean Titan V2 embedding of the H (hot-tier/current) set and the V (full/prior) set. d_spectral (F13 Definition F13.4) is the Grassmannian chordal distance sqrt(k - ||U^T V||_F^2) between the top-k Fiedler subspaces of the symmetric normalized graph Laplacians of H and V (k=3); the Fiedler vectors come from the ENC-FTR-088 tracker.graph_laplacian accessor via an injectable laplacian_fn hook, with a self-contained Jacobi-eigensolver fallback. Either metric degrades independently to null when its inputs are absent (d_centroid may ship ahead of d_spectral per the ENC-FTR-088 dependency note). spurious_attractor_rate (ENC-FTR-105 AC-7, ENC-TSK-I91) is now computed as the fraction of the wave's retrieval_records whose avg retrieval_energy exceeds the BHC WARNING threshold (drift_telemetry.compute_spurious_attractor_rate; BHC_WARNING_THRESHOLD=0.85 is a local constant mirroring coordination_api.budget_hierarchy.ALERT_LADDER's WARNING floor, duplicated rather than cross-package-imported since graph_query_api and coordination_api are independently deployed Lambda packages); it degrades to null when retrieval_records is absent or carries no energy telemetry. re_traversal_rate remains an untouched null stub — the ENC-FTR-105 AC-8 wiring slot for a later task. ENC-TSK-J90 adds action='close_wave' (backend/lambda/graph_query_api/lambda_function.py::_handle_close_wave) as the missing wave-aggregation producer: it lists the wave's pathway-telemetry JSONL objects from S3 under {PATHWAY_TELEMETRY_PREFIX}/wave_id=<wid>/, flattens their energy.records[] arrays into one combined retrieval_records list, and calls the existing compute_and_emit_wave_close_drift with it -- no change to that function's signature or to the pre-existing action='wave_close_drift' direct-invoke path (still available for callers/tests that already have retrieval_records in hand). close_wave request: {action:'close_wave', project_id, wave_id, prev_wave_id?}; response adds objects_seen/objects_failed/records_aggregated alongside the emitted drift record. Degrades to an empty retrieval_records list (never 500) on an empty wave, unconfigured PATHWAY_TELEMETRY_BUCKET, or any S3 read failure. The drift telemetry writes a DynamoDB time series only and introduces NO new Neo4j edge type, so the OGTM (ENC-FTR-066) edge-traversability gate is not applicable (mirrors the FTR-082 pathway-telemetry precedent). Deploy target v4/main (gamma) per DOC-499FA089EC30 (v3-prod frozen).",
+      "fields": {
+        "table": {
+          "type": "string",
+          "definition": "enceladus-drift-telemetry${EnvironmentSuffix} (01-data.yaml DriftTelemetryTable). PAY_PER_REQUEST. Base KeySchema: wave_id (HASH). GSI project-timestamp-index: project_id (HASH) + timestamp (RANGE), ProjectionType ALL."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "DRIFT_TELEMETRY_TABLE on devops-graph-query-api (02-compute.yaml). The GraphQueryApiRole DriftTelemetryTableAccess policy grants dynamodb:PutItem/GetItem/Query on the table + /index/*."
+        },
+        "record_fields": {
+          "type": "object",
+          "definition": "{schema:'enceladus.drift.telemetry.v1', wave_id, project_id, timestamp (ISO-8601 microsecond UTC, monotonic per series), d_centroid_L2:number|null, d_spectral:number|null, d_spectral_k:int (default 3), prev_wave_id:string|null, n_h:int|null, n_v:int|null, spurious_attractor_rate:null (FTR-105 stub), re_traversal_rate:null (FTR-105 stub)}."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.drift.telemetry.v1"
+        }
+      }
+    },
+    "graph_query_api.stigmergic_trace": {
+      "description": "ENC-FTR-109 / ENC-TSK-K05: Stigmergic exploration trace emission (telemetry-only). On every hybrid retrieval (_query_hybrid) and non-hybrid graphsearch traversal (_handle_search), graph_query_api writes one per-event trace to enceladus-stigmergic-trace${EnvironmentSuffix} (PAY_PER_REQUEST; base key trace_id [HASH]; project-timestamp-index GSI on project_id [HASH] + timestamp [RANGE]; TTL expires_at 90 days). Record schema enceladus.stigmergic.trace.v1 carries session_id, pipe-delimited record_id_path, ISO timestamp, JSON outcome_signal, and event_type retrieval|traversal. No retrieval-behavior mutation — exploration-weighting is deferred per io approval (FTR-106 AC-4 gate). OGTM: DynamoDB-only sink, no new Neo4j edge type.",
+      "fields": {
+        "table": {
+          "type": "string",
+          "definition": "enceladus-stigmergic-trace${EnvironmentSuffix} (01-data.yaml StigmergicTraceTable). PAY_PER_REQUEST. TTL on expires_at (90 days)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "STIGMERGIC_TRACE_TABLE on devops-graph-query-api (02-compute.yaml). GraphQueryApiRole StigmergicTraceTableAccess grants dynamodb:PutItem."
+        },
+        "record_fields": {
+          "type": "object",
+          "definition": "{schema:'enceladus.stigmergic.trace.v1', trace_id, project_id, session_id, event_type:'retrieval'|'traversal', record_id_path (pipe-delimited), timestamp (ISO-8601 UTC), outcome_signal (JSON string), expires_at (epoch seconds, TTL)}."
+        },
+        "telemetry_schema": {
+          "type": "string",
+          "definition": "enceladus.stigmergic.trace.v1"
+        }
+      }
+    },
+    "graph_query_api.energy_function": {
+      "description": "ENC-FTR-104 Ph3 / ENC-TSK-J52: live hybrid retrieval energy weights and optional response egress. Defaults promoted to I99-tuned lambda_graph=1.0 and lambda_kw=0.1 (was Ph1 0.5/0.25); gamma codified via ENERGY_LAMBDA_GRAPH/ENERGY_LAMBDA_KW on devops-graph-query-api. Hybrid search_type accepts include_energy=true to attach per-node energy_score + energy_breakdown; default off preserves RRF presentation without energy bloat. retrieval_records telemetry unchanged for wave-close consumers.",
+      "fields": {
+        "include_energy": {
+          "type": "boolean",
+          "definition": "Hybrid graphsearch query flag. When true, each returned node includes energy_score and energy_breakdown. Default false."
+        },
+        "lambda_graph": {
+          "type": "number",
+          "definition": "Live default 1.0 (I99 tuned). Resolved via AppConfig energy-function profile, ENERGY_LAMBDA_GRAPH env, then DEFAULT_LAMBDA_GRAPH."
+        },
+        "lambda_kw": {
+          "type": "number",
+          "definition": "Live default 0.1 (I99 tuned). Resolved via AppConfig, ENERGY_LAMBDA_KW env, then DEFAULT_LAMBDA_KW."
+        }
+      }
+    },
+    "graph_query_api.vector_read": {
+      "description": "ENC-TSK-H89 / ENC-FTR-082 AC-12: governed bulk vector-read over the Neo4j n.embedding corpus. A dedicated graphsearch handler (search_type=vector_read) in backend/lambda/graph_query_api/lambda_function.py that returns paginated {record_id, record_type, embedding} rows. This is the ONLY path that returns the raw embedding vector — the hybrid retrieval path (_query_hybrid) keeps stripping n.embedding (lambda_function.py:1785-1788); the strip-exemption applies solely here. Latency-bounded by a dedicated wall-clock deadline (_VECTOR_READ_DEADLINE_S, default 10s) plus server-side SKIP/LIMIT pagination so a large page can never extend or perturb the hybrid request path. Exposed on the MCP code-mode read surface via search(action='graph_query.vector_read', arguments={project_id, offset, limit, record_type?}) and equivalently via the documented passthrough search(action='tracker.graphsearch', arguments={search_type:'vector_read', project_id, offset, limit}). Consumed by the ENC-TSK-H91 cosine-correlation analysis (ENC-TSK-H34 AC-1). No new edge type (OGTM N/A). Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); raw-vector prod exposure deferred to the io-gated v4->prod cutover.",
+      "fields": {
+        "offset": {
+          "type": "integer",
+          "definition": "Pagination cursor (rows to SKIP). Default 0.",
+          "constraints": {
+            "min": 0,
+            "default": 0
+          }
+        },
+        "limit": {
+          "type": "integer",
+          "definition": "Page size (rows to return). Clamped server-side to [1, 1000].",
+          "constraints": {
+            "min": 1,
+            "max": 1000,
+            "default": 200
+          }
+        },
+        "record_type": {
+          "type": "string",
+          "definition": "Optional label scope (task/issue/feature/plan/lesson/document). Omit to read across the whole embedded corpus."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "{nodes: [{record_id, record_type, embedding:[float,...]}], edges: [], paths: [], pagination: {offset, limit, returned, next_offset|null, has_more}, embedding_property: 'embedding', embedding_dim: int|null, summary: string, query_cypher: 'vector_read/paginated'}."
+        }
+      }
+    },
+    "graph_query_api.adjacency": {
+      "description": "ENC-TSK-I88 / ENC-FTR-085 (comp-percolation-monitor, ENC-PLN-006 v4/gamma): read-only adjacency export search_type on graph_query_api. A dedicated graphsearch handler (_query_adjacency in backend/lambda/graph_query_api/lambda_function.py, registered in VALID_SEARCH_TYPES + SEARCH_HANDLERS) returning the project-scoped undirected simple-graph as {s, t} edge rows plus node_count/edge_count totals on the first page (offset==0). Each undirected pair is emitted once via the a.record_id < b.record_id Cypher predicate (which also drops self-loops) and deduplicated across parallel edge labels with WITH DISTINCT; 'Project' container nodes and is_placeholder edge-target stubs (ENC-TSK-E06) are excluded so the degree sequence reflects only real governed records. Paginated server-side via SKIP/LIMIT over a stable (s,t) ordering (offset default 0; limit default 5000, clamped to [1,20000]); the caller streams pages until has_more is false. Consumed by the nightly enceladus-percolation-monitor Lambda to compute the Molloy-Reed analytical p_c=<k>/<k^2> degree sequence and the Monte Carlo site-percolation LCC sweep. It MATCHES ALL edge labels without filtering, introduces NO new edge type, and performs NO writes — OGTM (ENC-FTR-066) is N/A, mirroring the graph_query_api.vector_read exemption. Exposed via search(action='tracker.graphsearch', arguments={search_type:'adjacency', project_id, offset?, limit?}). The adjacency-specific response keys (node_count, edge_count, offset, limit, returned, has_more, next_offset) are passed through verbatim by _handle_search. ENC-TSK-I91 (ENC-FTR-105 AC-7) adds a nullable spurious_attractor_rate key on the first page only: a best-effort mean of the project's most recent non-null spurious_attractor_rate values, Queried from the existing enceladus-drift-telemetry table via its project-timestamp-index GSI (_recent_spurious_attractor_rate) using the dynamodb:Query grant ENC-TSK-I85 already provisioned for graph_query_api's wave-close write path -- no new IAM/infra. comp-percolation-monitor reads this key verbatim (_fetch_graph) into its own nullable spurious_attractor_rate DDB field, alongside analytical_pc/empirical_pc; omitting the key (an older graph_query_api deploy) degrades to null, a backward-compatible non-breaking migration. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8); the percolation monitor deploys to v4/gamma only. ENC-TSK-N51 (R8) changes the percolation-monitor telemetry row (NOT this adjacency response): empirical_pc is now the low-variance susceptibility-peak estimator (argmax of the mean second-largest-cluster ratio) instead of the argmax-of-second-derivative-of-LCC; the legacy value is retained as empirical_pc_curvature, with empirical_pc_method='susceptibility_peak' and a sweep_second_cluster_ratio array added alongside sweep_lcc_ratio, and MC_TRIALS default raised 40->160 (variance crosses the 0.02 p-grid resolution there). The empirical_pc key is preserved for existing display consumers. VERDICT on the empirical~0.2 vs analytical~0.05 gap: it is real, stable, and definitional (analytical Molloy-Reed = N->infinity emergence threshold; empirical = finite-size susceptibility/dominance peak, shifted up ~3-4x) -- NOT drift; alert on a CHANGE in either series, never on the gap.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required graph project scope (e.g. 'enceladus'). Only nodes/edges with this project_id are returned."
+        },
+        "search_type": {
+          "type": "string",
+          "definition": "Must be 'adjacency' to select this handler.",
+          "constraints": {
+            "enum": [
+              "adjacency"
+            ]
+          }
+        },
+        "offset": {
+          "type": "integer",
+          "definition": "Pagination cursor (edge rows to SKIP). Default 0.",
+          "constraints": {
+            "min": 0,
+            "default": 0
+          }
+        },
+        "limit": {
+          "type": "integer",
+          "definition": "Edge-page size. Default 5000; clamped server-side to [1, 20000].",
+          "constraints": {
+            "min": 1,
+            "max": 20000,
+            "default": 5000
+          }
+        },
+        "node_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only): total governed nodes in scope (N), including isolated ones. Used as the denominator for LCC ratios and degree means."
+        },
+        "edge_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only): total deduplicated undirected simple-graph edges (M)."
+        },
+        "edges": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Page of undirected edges as {s, t} record_id pairs (s < t)."
+        },
+        "has_more": {
+          "type": "boolean",
+          "definition": "Response field: true when more edge pages remain (returned == limit)."
+        },
+        "next_offset": {
+          "type": "integer",
+          "definition": "Response field: offset to pass on the next call when has_more is true; null otherwise."
+        },
+        "flow_weight_entropy": {
+          "type": "number",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03 / ENC-FTR-108 AC-5): normalized Shannon entropy [0,1] over the live flow_weight distribution across all project relationships. Null when enrichment fails or graph_query_api predates J03."
+        },
+        "flow_weight_edge_count": {
+          "type": "integer",
+          "definition": "Response field (offset==0 only, ENC-TSK-J03): count of relationships sampled for flow_weight_entropy. Companion to flow_weight_entropy."
+        }
+      }
+    },
+    "graph_query_api.correlation_encoding": {
+      "description": "ENC-TSK-H92 / ENC-FTR-082 AC-2: flag-gated correlation-aware (pseudoinverse-style) encoding on the hybrid-retrieval vector path. OFF by default => byte-identical hybrid retrieval. When CORRELATION_ENCODING_ENABLED is truthy AND CORRELATION_ENCODING_TRANSFORM_URI points to an h92.v1 transform artifact (local path or s3://), graph_query_api re-scores the HNSW vector candidates SYMMETRICALLY by cosine(W*q, W*emb) in _hybrid_vector_ranks (the raw query drives HNSW recall; the de-correlating map W is applied to BOTH the query and each candidate embedding via _transform_unit), so a near-duplicate's distinctive residual decides rank. ENC-TSK-I03 supersedes the ENC-TSK-H92 query-side variant (W applied to the query only, before HNSW), which measured not_met (precision@1 -0.9%) because it compared W*q against an un-transformed index. W is fit OFFLINE by tools/fit_encoding_h92.py from the ENC-TSK-H91 high-correlation pair set (W = I - alpha*sum_k v_k v_k^T over the top right-singular vectors of the correlated pattern matrix; eigenvalues in [1-alpha,1]); the Lambda applies it as a pure-Python matrix-vector product (no numpy in-runtime) then L2-renormalizes. Backward compatible and bounded: disabled, malformed-artifact, or dimension-mismatch all fall back to the untransformed embedding (no RRF-ordering regression when off). No new Neo4j edge type is introduced (OGTM N/A, satisfies ENC-TSK-H34 AC-4). Efficacy (>=5% precision@1 lift) is re-measured by the ENC-TSK-H94 harness against gamma after the ENC-TSK-I03 re-rank deploy (the H92 query-side variant measured -0.9%). Per-candidate W*emb is a pure-Python dense matrix-vector product, so the re-rank adds measurable latency on the (flag-gated, measurement-time) vector path; a low-rank V-factored artifact would cut it if it is ever promoted past measurement. Gamma-validated per the deploy-target invariant (DOC-6EFD5DB32CD8).",
+      "fields": {
+        "CORRELATION_ENCODING_ENABLED": {
+          "type": "env_flag",
+          "definition": "Truthy (1/true/yes/on) enables the encoding apply on the vector path. Default unset => OFF => byte-identical hybrid retrieval. Activated at the ENC-TSK-H93 gamma deploy."
+        },
+        "CORRELATION_ENCODING_TRANSFORM_URI": {
+          "type": "string",
+          "definition": "Local path or s3:// URI of the h92.v1 transform artifact produced by tools/fit_encoding_h92.py. Loaded lazily + cached; any load failure disables the encoding defensively."
+        },
+        "transform_artifact": {
+          "type": "object",
+          "definition": "h92.v1: {version:'h92.v1', dim:int, alpha:float, rank:int, W:[[float]*dim]*dim, fit_meta:{corpus_size, correlated_set_size, num_pairs, energy_captured, top_singular_values}, pairs_source, generated_at}. W is the D x D de-correlating map applied as q' = normalize(W @ q)."
+        }
+      }
+    },
+    "governance.authority": {
+      "description": "Governance file mutation authority envelope (ENC-TSK-C13, ENC-ISS-171). Defines the write-authority constraint for governance files stored in the S3 governance store. governance.update is architecturally unavailable in code-mode agent sessions — all governance file mutations require execution by a privileged terminal agent under product-lead IAM via direct S3 archive+put.",
+      "fields": {
+        "governed_files": {
+          "type": "array",
+          "definition": "The governance files subject to the authority constraint. Each entry identifies a file_name and its S3 target key.",
+          "items": [
+            {
+              "file_name": "agents.md",
+              "s3_target": "s3://jreese-net/governance/live/agents.md"
+            },
+            {
+              "file_name": "governance_data_dictionary.json",
+              "s3_target": "s3://jreese-net/governance/live/governance_data_dictionary.json"
+            }
+          ]
+        },
+        "mutation_execution_path": {
+          "type": "string",
+          "definition": "The only authorized execution path for governance file mutations: product-lead IAM (io-dev-admin) via direct S3 archive+put, dispatched by the coordination lead to a Codex terminal agent. Code-mode agent sessions (enceladus-agent-cli IAM) have explicit deny on all S3 writes.",
+          "value": "coordination_lead → codex_terminal_agent → s3:PutObject (io-dev-admin IAM)"
+        },
+        "agent_delegation_protocol": {
+          "type": "string",
+          "definition": "When an agent session produces governance file content, it must NOT attempt governance.update. Instead: (1) prepare the full updated file content, (2) append a GOVERNANCE_SYNC_REQUIRED HANDOFF block to the task worklog with file_name, content_source, s3_target, archive_path, and change_summary, (3) advance to coding-complete and await coordination lead dispatch.",
+          "reference": "agents.md §13 Governance File Authority"
+        },
+        "handoff_block_fields": {
+          "type": "object",
+          "definition": "Required fields in a GOVERNANCE_SYNC_REQUIRED HANDOFF block appended to a task worklog when governance file changes are produced by an agent session.",
+          "fields": {
+            "file_name": {
+              "type": "string",
+              "definition": "The governance file being updated (e.g. agents.md, governance_data_dictionary.json)."
+            },
+            "content_source": {
+              "type": "string",
+              "definition": "Where the updated content lives — repo file path + commit SHA, or a document ID from the document store."
+            },
+            "s3_target": {
+              "type": "string",
+              "definition": "Full S3 URI for the live governance file (e.g. s3://jreese-net/governance/live/agents.md)."
+            },
+            "archive_path": {
+              "type": "string",
+              "definition": "S3 URI pattern for the pre-mutation backup (e.g. s3://jreese-net/governance/archive/agents.md/2026-04-06T21:00:00Z.bak)."
+            },
+            "change_summary": {
+              "type": "string",
+              "definition": "One-line description of what changed in the governance file."
+            }
+          }
+        },
+        "code_mode_availability": {
+          "type": "string",
+          "enum": [
+            "unavailable"
+          ],
+          "definition": "governance.update is NOT available in code-mode agent sessions. The MCP server exposes the tool in the execute action list, but the underlying coordination_api requires product-lead IAM scope (io-dev-admin) which code-mode sessions do not have. Attempting it returns a permission error.",
+          "governing_issue": "ENC-ISS-171"
+        }
+      }
+    },
+    "docstore.document": {
+      "description": "Document store document record with GDMP maturity lifecycle (ENC-FTR-065). Documents track compliance and maturity state through a governed pipeline. document_maturity_state is forwarded through MCP server documents.patch handler (ENC-ISS-167). graph_projection: Document nodes are projected to Neo4j via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync pipeline (ENC-PLN-014) with BELONGS_TO, RELATED_TO, INFORMED_BY, INFORMS, and DOC_ATTACHED_TO_PLAN edges. record_type is stamped to the literal value 'document' on all put_item and update_item paths in document_api so graph_sync record-type routing fires for every document mutation.",
+      "fields": {
+        "document_maturity_state": {
+          "type": "enum",
+          "enum": [
+            "raw",
+            "compliant",
+            "contextualized",
+            "mature"
+          ],
+          "default": "raw",
+          "definition": "GDMP pipeline maturity state. raw: initial state on creation. compliant: CEE compliance check passed. contextualized: HCE proposal + coordination lead approval. mature: CEE graph traversal confirmation.",
+          "write_authority": "Any governed session or CEE automation.",
+          "state_transitions": "raw → compliant (CEE), compliant → contextualized (HCE proposal + coordination lead), contextualized → mature (CEE graph traversal confirmation).",
+          "governing_feature": "ENC-FTR-065"
+        },
+        "compliance_score": {
+          "type": "integer",
+          "definition": "0-100 score computed by _evaluate_markdown_compliance in document_api. Deducts 10 points per warning. Stored on every PUT and PATCH. Returned in API response to agents.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "compliance_warnings": {
+          "type": "array",
+          "items": "string",
+          "definition": "List of compliance warnings from _evaluate_markdown_compliance. Common warnings: missing metadata fields, pipe-table false positives, unclosed fences, heading hierarchy violations.",
+          "write_authority": "document_api Lambda (computed, not agent-settable)."
+        },
+        "append_content": {
+          "type": "string",
+          "definition": "PATCH-only request field (ENC-ISS-239 / ENC-TSK-E50 / ENC-TSK-E51). When present, document_api performs a read-modify-write cycle: fetches existing S3 content, concatenates with double-newline separator, re-uploads merged content, and recomputes content_hash, size_bytes, and compliance_score. Mutually exclusive with 'content' (400 if both present). For handoff documents, append_content must include a YAML-like frontmatter reply block (reply_author, reply_timestamp, agent_layer, originating_handoff_ref). For wave documents, same frontmatter minus originating_handoff_ref (optional). Non-handoff/wave documents accept format-agnostic appends. Not stored in DynamoDB; the result is written to S3.",
+          "write_authority": "Agent sessions via MCP documents.patch or direct PATCH API.",
+          "governing_issue": "ENC-ISS-239"
+        },
+        "format_convention": {
+          "type": "rule",
+          "definition": "Structured agent-session output in docstore .md documents MUST use comment-free YAML code blocks (```yaml ... ```) instead of GFM pipe tables. Pipe tables are permitted only for purely presentational content where renderer-dependence is explicitly acknowledged. YAML hash-comments (# ...) must be omitted inside fenced blocks to avoid compliance checker heading false positives. MCP server injects format_guidance in document.put/patch responses when pipe-table warnings are detected.",
+          "governing_lesson": "ENC-LSN-026",
+          "enforcement": "Advisory via MCP format_guidance response field. Compliance checker fence-awareness prevents false positives on conforming documents."
+        },
+        "graph_remove_identity": {
+          "type": "rule",
+          "definition": "ENC-TSK-G06: graph_sync normalizes document stream images so INSERT/MODIFY and REMOVE project by the same bare document identity. REMOVE resolves Keys.record_id, Keys.document_id, then Keys.item_id, and falls back to OldImage fields before deleting the Neo4j node. This prevents DOC-* nodes from surviving a documents-table delete solely because the stream key lacked record_id.",
+          "write_authority": "graph_sync Lambda (derived index behavior)."
+        },
+        "related_items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Cross-references to governed records (ENC-TSK-*/ENC-ISS-*/ENC-FTR-*/ENC-LSN-*/ENC-PLN-*) this document relates to.",
+          "usage_guidance": "documents.put / documents.patch(field include related_items). ENC-TSK-L07 (B65 AC-5/AC-7): bidirectional -- document_api atomically mirrors this document's ID onto each named tracker record's related_document_ids in the same request (contains-check conditional append; best-effort, non-blocking to the document write).",
+          "inverse_of": "tracker.<task|issue|feature|lesson>.related_document_ids"
+        },
+        "list_include_content": {
+          "type": "query_parameter",
+          "definition": "GET /api/v1/documents?project= query param (ENC-TSK-L93). When include_content=false (or content=false alias), list responses omit body-heavy fields. document_subtype=skill rows collapse to document_id, title, description, version, updated_at, runtime_hint; other subtypes omit full_description, claude_description, content, agentskills_manifest, agentskills_spec_version, runtime_variants. Default true (omitted) preserves existing full-metadata list behavior.",
+          "usage_guidance": "Use include_content=false for PWA skill-library catalog views (ENC-TSK-L94). MCP documents.list forwards include_content to the HTTP query string."
+        },
+        "list_runtime_hint": {
+          "type": "string",
+          "definition": "ENC-TSK-L93 list projection field (skill subtype, include_content=false only). Comma-separated sorted keys from runtime_variants when present; otherwise the literal 'claude,agentskills' indicating dual-projection default.",
+          "usage_guidance": "Read-only derived field; not stored in DynamoDB."
+        },
+        "s3_key": {
+          "type": "string",
+          "definition": "S3 object key of the document body (.md) within s3_bucket. Written by document_api on every content upload as {S3_PREFIX}/{project_id}/{document_id}.md, where S3_PREFIX is env-prefixed (prod: agent-documents, gamma: gamma/agent-documents via S3EnvPrefix). ENC-TSK-M59 / ENC-ISS-526 read contract: the env-prefixed computed key is authoritative on read; when the computed key is absent and the stored s3_key/s3_bucket name a different location (e.g. gamma rows cloned from prod), _get_content falls back read-only to the stored location and lazily copies the body into the computed key so the env prefix self-provisions. Fallback tolerates AccessDenied (deploy-order safety); writes never target the stored fallback location.",
+          "usage_guidance": "Read-only for clients; treat as provenance metadata, not a fetch instruction -- request content via GET /api/v1/documents/{id}?include_content=true (or MCP documents.get) and let document_api resolve storage. Do not construct S3 paths from s3_key in new code; the env-prefixed computed key wins on divergence after the next write."
+        }
+      }
+    },
+    "document.graph_edges": {
+      "description": "Neo4j edge types projected from Document nodes via the DocumentsToGraphPipe → GraphSyncQueue → graph_sync handler (ENC-PLN-014). Document nodes carry BELONGS_TO (project), RELATED_TO (any related_items target), INFORMED_BY (source document, GDMP provenance), INFORMS (inverse provenance), and DOC_ATTACHED_TO_PLAN (inverse of plan PLAN_ATTACHED_DOC). ENC-FTR-077 adds subtype-specific edges: COE documents emit INVESTIGATES/INVESTIGATED_BY from source_incident_id, wave documents emit TRACKS_WAVE_OF/HAS_WAVE_DOC from plan_anchor_id, and handoff documents emit HANDS_OFF/HANDED_OFF_BY from source_record_id. Edge emission is implemented in backend/lambda/graph_sync/lambda_function.py inside the document branch of _reconcile_edges(), and the edge labels are registered in backend/lambda/graph_query_api/lambda_function.py _ALLOWED_EDGE_TYPES so they are queryable via tracker.graphsearch. ENC-TSK-E01: RELATED_TO and INFORMED_BY now MERGE label-correct placeholder target nodes (using _infer_label_from_id for related_items, hard-coded :Document for informed_by) before MERGEing the edge, eliminating the silent zero-edge race window when targets have not yet been projected. ENC-FTR-098 / ENC-TSK-G35: Documents additionally emit MENTIONS edges from auto-extracted ID tokens in title/description/content prose. See entity graph_sync.mentions_extraction for the full extraction contract.",
+      "fields": {
+        "BELONGS_TO": {
+          "type": "edge",
+          "target_label": "Project",
+          "source_field": "project_id"
+        },
+        "RELATED_TO": {
+          "type": "edge",
+          "target_label": "any",
+          "source_field": "related_items"
+        },
+        "INFORMED_BY": {
+          "type": "edge",
+          "target_label": "Document",
+          "source_field": "informed_by"
+        },
+        "INFORMS": {
+          "type": "edge",
+          "target_label": "Document",
+          "source_field": "informed_by (inverse)"
+        },
+        "DOC_ATTACHED_TO_PLAN": {
+          "type": "edge",
+          "target_label": "Plan",
+          "source_field": "plan.attached_documents (inverse)"
+        },
+        "INVESTIGATES": {
+          "type": "edge",
+          "target_label": "Issue/Task",
+          "source_field": "source_incident_id",
+          "source_subtype": "coe",
+          "definition": "Document (coe) -> Issue/Task. Links a Correction of Errors document to the incident it investigates.",
+          "edge_weight": 0.85
+        },
+        "INVESTIGATED_BY": {
+          "type": "edge",
+          "target_label": "Document (coe)",
+          "source_field": "source_incident_id (inverse)",
+          "source_subtype": "coe",
+          "definition": "Issue/Task -> Document (coe). Inverse of INVESTIGATES.",
+          "edge_weight": 0.85
+        },
+        "TRACKS_WAVE_OF": {
+          "type": "edge",
+          "target_label": "Plan",
+          "source_field": "plan_anchor_id",
+          "source_subtype": "wave",
+          "definition": "Document (wave) -> Plan. Links a wave progress document to the plan it tracks.",
+          "edge_weight": 0.5
+        },
+        "HAS_WAVE_DOC": {
+          "type": "edge",
+          "target_label": "Document (wave)",
+          "source_field": "plan_anchor_id (inverse)",
+          "source_subtype": "wave",
+          "definition": "Plan -> Document (wave). Inverse of TRACKS_WAVE_OF.",
+          "edge_weight": 0.5
+        },
+        "HANDS_OFF": {
+          "type": "edge",
+          "target_label": "Task/Issue/Feature",
+          "source_field": "source_record_id",
+          "source_subtype": "handoff",
+          "definition": "Document (handoff) -> Task/Issue/Feature. Links a handoff document to the record it hands off from. Document-specific handler added in ENC-FTR-077 (was only in typed-rel flow).",
+          "edge_weight": 0.65
+        },
+        "HANDED_OFF_BY": {
+          "type": "edge",
+          "target_label": "Document (handoff)",
+          "source_field": "source_record_id (inverse)",
+          "source_subtype": "handoff",
+          "definition": "Task/Issue/Feature -> Document (handoff). Inverse of HANDS_OFF.",
+          "edge_weight": 0.65
+        },
+        "MENTIONS": {
+          "type": "edge",
+          "target_label": "any",
+          "source_field": "prose fields per graph_sync.mentions_extraction.prose_field_allowlist['document']",
+          "definition": "Document -> Task/Issue/Feature/Plan/Lesson/Document/Component. Auto-extracted from title, description, and content prose by graph_sync._reconcile_mentions_edges() (ENC-FTR-098 / ENC-TSK-G35). Properties: source, extracted_from_field. Code-fence stripped before extraction.",
+          "governing_feature": "ENC-FTR-098"
+        }
+      },
+      "governing_feature": "ENC-FTR-065",
+      "governing_plan": "ENC-PLN-014"
+    },
+    "monitoring.health_probe": {
+      "description": "Production health monitoring Lambda (enceladus-prod-health-monitor). EventBridge HealthProbeScheduleRule (every 15 minutes) invokes the handler. Publishes per-function CodeSize metrics to CloudWatch, detecting CFN stomp incidents (CodeSize < 1024) within 15 minutes (ENC-PLN-020 Phase 4 / ENC-TSK-D20). ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): extended with per-service health checks feeding the B66 CloudWatch dashboard — DynamoDB (describe_table + throttle signal), Neo4j AuraDB (bolt verify_connectivity via Secrets Manager), S3 (head_bucket), SQS (devops-graph-sync-queue depth as the graph_sync-lag proxy), and a Lambda cold-start baseline (State/LastUpdateStatus sampling across COLD_START_FUNCTIONS). The Lambda resource + its IAM role moved from infrastructure/cloudformation/05-monitoring.yaml into 02-compute.yaml so the Lambda Workflow Coverage Guard tracks it; 05-monitoring.yaml retains the EventBridge schedule, invoke permission, and CloudWatch Alarms (referencing the function by ARN). HEALTH_MONITOR_HARD_DISABLED env var is an ISS-465 cost kill switch.",
+      "fields": {
+        "function_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "List of Lambda function names to monitor for the CodeSize sentinel, sourced from lambda_workflow_manifest.json at deploy time.",
+          "usage_guidance": "Set via FUNCTION_NAMES environment variable by deploy.sh. Updated when manifest changes."
+        },
+        "namespace": {
+          "type": "string",
+          "definition": "CloudWatch namespace for all metrics published by this Lambda.",
+          "usage_guidance": "Fixed value: Enceladus/Prod"
+        },
+        "metric_name": {
+          "type": "string",
+          "definition": "CloudWatch metric name for per-function code size (ENC-TSK-D20 CFN-stomp sentinel).",
+          "usage_guidance": "Fixed value: LambdaCodeSize. Dimension: FunctionName."
+        },
+        "dynamodb_throttle_metric": {
+          "type": "string",
+          "definition": "ENC-TSK-K44: CloudWatch metric surfacing a DynamoDB throttle/health signal for the tracker table. 1.0 on throttle or unreachable table, 0.0 otherwise.",
+          "usage_guidance": "Fixed value: DynamoDBThrottle. Dimension: TableName. DYNAMODB_TABLE_NAME env var selects the checked table (devops-project-tracker${EnvironmentSuffix})."
+        },
+        "graph_sync_lag_metric": {
+          "type": "string",
+          "definition": "ENC-TSK-K44: CloudWatch metric reporting devops-graph-sync-queue approximate depth as a graph_sync backlog/lag proxy for the B66 dashboard.",
+          "usage_guidance": "Fixed value: GraphSyncLag. Dimension: QueueName. GRAPH_SYNC_QUEUE_URL env var (imported from the 01-data GraphSyncQueueUrl export) selects the checked queue. Named distinctly from devops-deploy-intake's SQS_QUEUE_URL (env_drift_registry.json deploy-critical var) so the ENC-TSK-H22 per-function env-parity strip-proof attribution stays unambiguous."
+        },
+        "mcp_cold_start_metric": {
+          "type": "string",
+          "definition": "ENC-TSK-K44: CloudWatch metric flagging Lambda cold-start / update risk per sampled function (1.0 unhealthy, 0.0 healthy) based on State/LastUpdateStatus.",
+          "usage_guidance": "Fixed value: MCPColdStart. Dimension: FunctionName. COLD_START_FUNCTIONS env var (JSON array) selects sampled functions; defaults to FUNCTION_NAMES."
+        },
+        "service_health_check_metric": {
+          "type": "string",
+          "definition": "ENC-TSK-K44: per-service boolean health metric (1.0 healthy, 0.0 unhealthy) emitted for each of dynamodb, neo4j, s3, sqs, lambda_cold_start.",
+          "usage_guidance": "Fixed value: ServiceHealthCheck. Dimension: Service."
+        },
+        "hard_disabled_flag": {
+          "type": "feature_flag",
+          "default": "0",
+          "definition": "ENC-ISS-465 cost kill switch. When truthy, the handler skips all AWS calls and all metric publication for that invocation.",
+          "usage_guidance": "Set via HEALTH_MONITOR_HARD_DISABLED environment variable."
+        }
+      },
+      "owner": "devops-monitoring",
+      "source": "ENC-TSK-D20 / ENC-TSK-K44 (ENC-FTR-071)"
+    },
+    "monitoring.deploy_capability_auditor": {
+      "description": "Scheduled Lambda (ENC-TSK-E69 / ENC-PLN-031 Phase 4) that reads component registry capability declarations, snapshots live AWS state, computes drift across IAM actions / API GW routes / Lambda env vars, and emits drift ENC-ISS records idempotently. Paired with the pre-merge capability guard (ENC-TSK-E70) as defense-in-depth for capability-drift incidents. Implemented in backend/lambda/deploy_capability_auditor/lambda_function.py; EventBridge schedule provisioned via infrastructure/cloudformation/05-monitoring.yaml DeployCapabilityAuditorScheduleRule; governed writes route through coordination/document/tracker HTTP APIs and read-only AWS snapshots use boto3 under the Lambda's self-managed IAM role.",
+      "fields": {
+        "schedule": {
+          "type": "string",
+          "definition": "EventBridge cron expression that triggers the auditor daily.",
+          "usage_guidance": "Fixed value: cron(0 10 * * ? *). Defined in infrastructure/cloudformation/05-monitoring.yaml as DeployCapabilityAuditorScheduleRule."
+        },
+        "drift_dimensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "Declared-vs-live capability axes the auditor currently diffs: apigw_routes, lambda_env_vars, iam_actions.",
+          "usage_guidance": "env_secrets and cfn_resources are declared in the component_registry.component schema but deferred from Phase 1 due to scope and pagination considerations. Follow-up tasks should extend the auditor to cover them."
+        },
+        "drift_signature": {
+          "type": "string",
+          "definition": "SHA-256 digest embedded in each drift ENC-ISS description to make issue creation idempotent across runs.",
+          "usage_guidance": "Pre-existing open ENC-ISS records with a matching signature are preserved, not duplicated. Agents remediating a drift should update the component's declared capabilities so the signature stops resolving on subsequent runs."
+        },
+        "manifest_document": {
+          "type": "string",
+          "definition": "Single DOC-* record overwritten each run with the full current capability manifest (declared vs. live for every registered component).",
+          "usage_guidance": "Provides a single idempotent snapshot instead of per-run document spam. Referenced by the capability auditor PWA view and by ENC-TSK-E70 for pre-merge cross-checks."
+        }
+      }
+    },
+    "tracker.stack_generation": {
+      "description": "Stack generation record (ENC-GEN) representing a major platform version era in the Generational Metabolism Framework (DOC-63420302EF65 §4.1). Tracks architectural thesis, acceptance criteria, branch pattern, and lifecycle from drafted through promoted to archived. Generation boundary is set when io submits UAT validation through PWA.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "drafted",
+            "incubating",
+            "active",
+            "stabilizing",
+            "chapter_closed",
+            "promoted",
+            "sunset",
+            "archived"
+          ],
+          "definition": "Generation lifecycle status."
+        },
+        "generation_number": {
+          "type": "integer",
+          "definition": "Major version number (e.g. 3 for v3, 4 for v4)."
+        },
+        "branch_pattern": {
+          "type": "string",
+          "definition": "Git branch namespace pattern (e.g. v4/*)."
+        },
+        "architectural_thesis": {
+          "type": "string",
+          "definition": "One-paragraph description of what this generation fundamentally changes."
+        },
+        "parent_generation_id": {
+          "type": "string",
+          "definition": "Record ID of the predecessor generation (ENC-GEN-xxx). Enables lineage tracing."
+        },
+        "chapter_open_date": {
+          "type": "string",
+          "definition": "ISO 8601 timestamp when this generation formally opened (set by io UAT validation submission)."
+        },
+        "chapter_close_date": {
+          "type": "string",
+          "definition": "ISO 8601 timestamp when this generation formally closed."
+        },
+        "category": {
+          "type": "enum",
+          "enum": [
+            "platform"
+          ],
+          "definition": "Generation category. Currently only 'platform' for Enceladus stack generations."
+        },
+        "title": {
+          "type": "string",
+          "definition": "Human-readable generation title (e.g. 'v3 — Production Generation')."
+        },
+        "production_stack": {
+          "type": "string",
+          "definition": "Production architecture and runtime (e.g. 'x86_64 / python3.11'). Null if generation has no production deployment."
+        },
+        "gamma_stack": {
+          "type": "string",
+          "definition": "Gamma architecture and runtime (e.g. 'arm64 / python3.12'). Null if generation has no gamma deployment."
+        },
+        "promoted_at": {
+          "type": "string",
+          "definition": "ISO 8601 timestamp when this generation was promoted to production."
+        },
+        "chapter_promotion_id": {
+          "type": "string",
+          "definition": "Record ID of the promotion event that elevated this generation."
+        }
+      }
+    },
+    "tracker.deployment_decision": {
+      "description": "Deployment decision record (ENC-DPL) mapping 1:1 with a GitHub PR targeting production (DOC-63420302EF65 §4.2). Created by github_integration webhook on PR open, decided by io via Deployment Manager PWA. Stored in devops-deployment-manager DynamoDB table. Status lifecycle: pending_approval -> approved/diverted/reverted -> deploying -> deployed/failed. ENC-ISS-248 (ENC-TSK-E72): workflow_run.failure handler now resets pre-deploy failures back to pending_approval (rather than leaving them at deploying/failed) when no prior deployment_outcome=success has been recorded, so the PWA resurfaces them for re-approval.",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "pending_approval",
+            "approved",
+            "diverted",
+            "reverted",
+            "deploying",
+            "deployed",
+            "failed"
+          ],
+          "definition": "Decision lifecycle status. ENC-ISS-248 (ENC-TSK-E72): 'approve' action via /api/v1/deploy/decide additionally accepts current_status in {deploying, failed} when approval_token is absent, as a recovery path for pre-deploy gate failures. workflow_run.failure handler resets to pending_approval (not failed) for pre-deploy failures so the DPL is surfaced for re-approval."
+        },
+        "github_pr_number": {
+          "type": "integer",
+          "definition": "GitHub PR number (human-readable). Used in record_id: decision#ENC-DPL-{pr_number}."
+        },
+        "original_target": {
+          "type": "enum",
+          "enum": [
+            "prod",
+            "gamma",
+            "undeclared"
+          ],
+          "definition": "Original deploy target derived from PR labels at creation time. ENC-ISS-247 (ENC-TSK-E72): github_integration._gmf_redeclare_on_label handler flips this from 'undeclared' to 'prod' when a target:prod label is added post-open; ConditionExpression(original_target='undeclared') guards against overwriting human-set values. target:gamma flow is handled by _gmf_divert_on_label which transitions status to 'diverted' and final_target to 'gamma'."
+        },
+        "final_target": {
+          "type": "enum",
+          "enum": [
+            "prod",
+            "gamma",
+            "blocked",
+            ""
+          ],
+          "definition": "Final deploy target after decision. Empty until decided."
+        },
+        "decided_by": {
+          "type": "string",
+          "definition": "Cognito user sub of the person who made the decision."
+        },
+        "deployment_outcome": {
+          "type": "enum",
+          "enum": [
+            "success",
+            "failure",
+            "partial",
+            ""
+          ],
+          "definition": "Outcome after deploy workflow completes. Set by workflow_run webhook handler. ENC-ISS-248 (ENC-TSK-E72): when workflow_run.failure fires and no prior outcome was 'success', deployment_outcome is left empty (not 'failure') because the failure occurred pre-deploy (e.g., approval gate) and does not represent a deploy attempt; status is reset to pending_approval instead."
+        },
+        "generation_id": {
+          "type": "string",
+          "definition": "ENC-GEN-NNN generation that this deployment decision targets."
+        },
+        "head_sha": {
+          "type": "string",
+          "definition": "40-character hex commit SHA from the PR head at decision time."
+        },
+        "head_branch": {
+          "type": "string",
+          "definition": "Source branch of the PR (e.g. 'agent/enc-tsk-xxx-slug')."
+        },
+        "pr_author": {
+          "type": "string",
+          "definition": "GitHub username of the PR author."
+        },
+        "github_pr_url": {
+          "type": "string",
+          "definition": "Full GitHub PR URL for audit trail."
+        },
+        "decision_reason": {
+          "type": "string",
+          "definition": "Human-provided reason for the deploy decision (approve, divert, revert)."
+        },
+        "created_at": {
+          "type": "string",
+          "definition": "ISO 8601 timestamp when the decision record was created (typically on PR open)."
+        },
+        "approval_token": {
+          "type": "string",
+          "definition": "Deploy Approval Token (DAT-{uuid4_hex}) issued by deploy_decide on approve action (ENC-TSK-E57). Validated by deploy-orchestration.yml workflow before any production mutation. Empty until approved via Deployment Manager PWA."
+        },
+        "decided_by_email": {
+          "type": "string",
+          "definition": "Email address from the Cognito JWT of the person who made the decision (ENC-TSK-E57). Used for four-eyes audit comparison against pr_author."
+        },
+        "bypass_reason": {
+          "type": "string",
+          "definition": "If set, indicates this deployment bypassed the Enceladus approval gate (ENC-TSK-E57 AC8). Populated retroactively for pre-E57 deploys via backfill_dpl_bypass_markers.py."
+        }
+      }
+    },
+    "gmf.graph_edges": {
+      "description": "Seven new Neo4j edge types introduced by the Generational Metabolism Framework (DOC-63420302EF65 §8.2). Projected by graph_sync _reconcile_edges() and queryable via tracker.graphsearch.",
+      "fields": {
+        "SUCCEEDS": {
+          "type": "edge",
+          "definition": "Generation -> Generation lineage chain."
+        },
+        "BELONGS_TO_GENERATION": {
+          "type": "edge",
+          "definition": "Feature -> Generation scope."
+        },
+        "SYNTHESIZED_IN": {
+          "type": "edge",
+          "definition": "Lesson -> Chapter document synthesis."
+        },
+        "SEEDS_THESIS_OF": {
+          "type": "edge",
+          "definition": "Chapter document -> Next generation thesis."
+        },
+        "ADVANCES_GENERATION": {
+          "type": "edge",
+          "definition": "DeploymentDecision -> Generation progress contribution."
+        },
+        "TARGETS_GENERATION": {
+          "type": "edge",
+          "definition": "Task/Lesson -> Generation scope."
+        },
+        "EXECUTES_WITHIN": {
+          "type": "edge",
+          "definition": "Plan -> Generation development arc."
+        },
+        "MENTIONS": {
+          "type": "edge",
+          "definition": "Generation -> any governed record. Auto-extracted from title, description, architectural_thesis prose by graph_sync._reconcile_mentions_edges() (ENC-FTR-098 / ENC-TSK-G35). Same auto-extraction contract as graph_sync.mentions_extraction."
+        }
+      }
+    },
+    "docstore.evolution_chapter": {
+      "description": "Evolution chapter document subtype (DOC-63420302EF65 §4.3). Living document tracking a generation's evolution from incubation through promotion. Contains pending notes appended by agent sessions via documents.patch. One chapter per generation.",
+      "fields": {
+        "document_subtype": {
+          "type": "enum",
+          "enum": [
+            "evolution_chapter"
+          ],
+          "definition": "Document subtype discriminator. Must be 'evolution_chapter'."
+        },
+        "generation_id": {
+          "type": "string",
+          "definition": "ENC-GEN-NNN generation this chapter tracks."
+        },
+        "pending_notes": {
+          "type": "array",
+          "definition": "Append-only array of timestamped notes contributed by agent sessions. Each entry: {timestamp, session_id, note}."
+        },
+        "chapter_status": {
+          "type": "enum",
+          "enum": [
+            "drafting",
+            "active",
+            "closed"
+          ],
+          "definition": "Chapter lifecycle status. 'drafting' during incubation, 'active' when generation is active, 'closed' when generation chapter is closed."
+        }
+      }
+    },
+    "embedding.titan_v2_backfill": {
+      "description": "One-shot Titan V2 embedding backfill service (ENC-TSK-B91). Scans the governed DynamoDB corpus (devops-project-tracker + documents), invokes amazon.titan-embed-text-v2:0 at the ENC-TSK-B62 Phase 1 contract (dimensions=256, normalize=true), and writes {embedding, embedding_text_hash} to the matching Neo4j node. Feeds the per-label HNSW indexes created by ENC-TSK-B90 migration 001 (governed_task_embedding, governed_issue_embedding, governed_feature_embedding, governed_plan_embedding, governed_lesson_embedding, governed_document_embedding). Imports build_embedding_text, hash_embedding_text, and invoke_titan_v2 from backend/lambda/graph_sync/embedding.py (the canonical helper module introduced by ENC-TSK-B94) so the batch backfill and the incremental graph_sync stream path produce identical vectors for identical text. Skipping logic: skip_existing (default true) compares existing node's embedding_text_hash against the newly computed hash, matching B94's no-op MODIFY semantics. Backfill execution requires io-dev-admin or product-lead terminal credentials; agent-CLI IAM denies the required Bedrock + Secrets Manager + DynamoDB scopes.",
+      "fields": {
+        "function_name": {
+          "type": "string",
+          "definition": "AWS Lambda function name. Current contract: devops-titan-embedding-backfill (prod x86_64/python3.11) or devops-titan-embedding-backfill-gamma (gamma arm64/python3.12). Mirrors the deploy conventions of devops-graph-sync and enceladus-neo4j-backup."
+        },
+        "helper_contract": {
+          "type": "string",
+          "definition": "The backfill Lambda imports backend/lambda/graph_sync/embedding.py via deploy.sh package_lambda (copies graph_sync/embedding.py into the backfill build dir). Functions consumed: build_embedding_text, hash_embedding_text, invoke_titan_v2, EMBEDDING_PROPERTY, EMBEDDING_HASH_PROPERTY, EMBEDDABLE_RECORD_TYPES, EMBEDDING_DIMENSIONS. Backfill does NOT fork the helper; any contract change must happen in graph_sync/embedding.py and trickle here through deploy.sh."
+        },
+        "event_schema": {
+          "type": "object",
+          "definition": "Event shape for manual/EventBridge invocations: {limit?: int, labels?: [str], dry_run?: bool, skip_existing?: bool}. limit caps total records scanned. labels restricts to a subset of {Task, Issue, Feature, Plan, Lesson, Document}. dry_run skips Neo4j writes. skip_existing (default true) uses embedding_text_hash to skip re-embedding unchanged records."
+        },
+        "response_schema": {
+          "type": "object",
+          "definition": "{status, processed, skipped, errors, missing_node, per_label_processed, coverage: {<Label>: {total, with_embedding, pct, meets_ac1_threshold}}, dry_run, elapsed_seconds, model_id, dimensions}. meets_ac1_threshold flips true when pct >= 0.95 (ENC-TSK-B62 AC-1) or total == 0."
+        },
+        "ac1_coverage_threshold": {
+          "type": "number",
+          "definition": "Per-label embedding coverage target mandated by ENC-TSK-B62 AC-1: with_embedding / total >= 0.95. Computed via the count_embedding_coverage helper in the backfill Lambda (MATCH (n:<Label>) RETURN count(n), count(n.embedding))."
+        },
+        "iam_contract": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Lambda execution role scopes: bedrock:InvokeModel on arn:aws:bedrock:us-west-2::foundation-model/amazon.titan-embed-text-v2:0, secretsmanager:GetSecretValue on enceladus/neo4j/auradb-credentials*, dynamodb:Scan/Query/GetItem/BatchGetItem on devops-project-tracker and documents tables. Same bedrock scope as graph_sync (ENC-TSK-B94) but wider DynamoDB read surface."
+        },
+        "invocation_contract": {
+          "type": "string",
+          "definition": "Agent-CLI IAM denies all required scopes; the backfill Lambda must be invoked manually by a product-lead terminal session (io-dev-admin) via `aws lambda invoke --function-name devops-titan-embedding-backfill-gamma --payload '{}' out.json` or EventBridge rule. Follow-on B91 live validation is routed via HANDOFF document pattern identical to ENC-TSK-B90 (DOC-BEFDB681C218)."
+        },
+        "uat_probe_handler": {
+          "type": "object",
+          "definition": "Gamma UAT probe short-circuit (ENC-PLN-020 / ENC-TSK-D19 contract). tools/gamma_uat_suite.py:check_lambda_invoke invokes every Lambda with {rawPath: '/__uat_probe__', requestContext: {http: {method: GET}}, headers: {}} and asserts no FunctionError within a 30-second timeout. The backfill Lambda detects this event shape via _is_uat_probe(event) at the top of lambda_handler and returns {status: ok, probe: uat, handler: lambda_function.lambda_handler, model_id, dimensions, helper_module: 'embedding'} before any DynamoDB scan, Neo4j connection, or Bedrock invoke. Required because a real backfill scan + per-record invoke far exceeds the UAT 30s budget. Pattern is reusable for any scanner-style Lambda that must coexist with the automated UAT health gate."
+        }
+      }
+    },
+    "retrieval.hybrid_pipeline": {
+      "description": "Three-signal hybrid retrieval pipeline for the governed corpus (ENC-TSK-B92, headline ENC-TSK-B62 Phase 1 deliverable). Combines vector cosine similarity (HNSW per-label indexes from ENC-TSK-B90), graph topology (Personalized PageRank via Neo4j GDS with native-Cypher edge-walk fallback), and keyword match — fused via Reciprocal Rank Fusion (k=60). ENC-TSK-L43: keyword arm reads OpenSearch records_read when configured (multi_match fuzziness AUTO + bool_prefix) with Neo4j CONTAINS fallback; within-search facets come from OpenSearch aggs with feed/corpus fallback. Implemented as search_type=hybrid in graph_query_api and surfaced through MCP get_compact_context.",
+      "fields": {
+        "rrf_k": {
+          "type": "integer",
+          "definition": "Reciprocal Rank Fusion exponent offset. score = sum(1 / (k + rank_i)) over signals where the record appears in top-N. Locked at 60 per ENC-TSK-B62 description. Rank-based, not score-based — signals do not need score normalization.",
+          "usage_guidance": "Do not change without coordinating with PLN-006 Phase 1 gate owner — k=60 was selected as the Phase 1 retrieval contract baseline."
+        },
+        "signals": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Three signals contributing ranks to the RRF fusion: 'vector' (Neo4j db.index.vector.queryNodes per-label HNSW indexes from B90, query embedding via the same backend/lambda/graph_sync/embedding.py invoke_titan_v2 helper used by index-side embedding to guarantee vector parity), 'graph' (Personalized PageRank via gds.pageRank.stream with sourceNodes=[anchor], dampingFactor=0.85, maxIterations=25; Cypher fallback when GDS is unavailable), 'keyword' (case-insensitive title/intent/description CONTAINS with weighted scoring 3/2/1)."
+        },
+        "graph_edge_weights": {
+          "type": "object",
+          "definition": "Per-relationship-type weights used by both the GDS PPR projection and the Cypher fallback path. Order per ENC-LSN-029 implementation contract: IMPLEMENTS=1.00 > ADDRESSES=0.90 > RELATED_TO=0.75 > LEARNED_FROM=0.70 > CHILD_OF=0.60 > PLAN_CONTAINS=0.55 > BELONGS_TO=0.30. Unknown edge types fall back to 0.40.",
+          "usage_guidance": "Tunable. Adjust in graph_query_api/lambda_function.py:GRAPH_EDGE_WEIGHTS. The order is grounded in retrieval semantics — 'task IMPLEMENTS feature' is a stronger relevance signal than 'record BELONGS_TO project'."
+        },
+        "fallback_modes": {
+          "type": "object",
+          "definition": "Resilience contract. (a) Vector signal is skipped when query text is missing or embedding helper returns None — RRF still works with graph + keyword. (b) Graph signal first attempts gds.pageRank.stream; on GDS unavailable or empty result, falls back to a per-relationship-type weighted Cypher hop-sum within depth 3 with damping^distance decay. (c) Keyword signal degrades gracefully when no records match. (d) When all three signals are empty, the response includes a 'No signals returned candidates' summary instead of a 500. (e) embedding_coverage_sample.{covered,total_ranked} reports observed embedding density per query so callers can detect sparse-coverage degradation."
+        },
+        "fsrs_t3_threshold": {
+          "type": "number",
+          "definition": "FSRS-6 retrieval-invisible stability threshold for Lesson records (ENC-TSK-B62 scope item #4). Default 0.7. Lessons with stability < T3 (or, when stability is absent, resonance_score < T3 per the ENC-LSN-029 pre-FSRS-6 convention) are suppressed from the fused result unless include_below_threshold=true is passed.",
+          "usage_guidance": "Override per-query via include_below_threshold=true on get_compact_context or the hybrid graphsearch query. Lesson rehydration / direct lookup paths are unaffected — T3 only filters retrieval surfaces."
+        },
+        "gds_availability_probe": {
+          "type": "object",
+          "definition": "graph_query_api caches the result of a CALL gds.list() probe for 300 seconds (_gds_probe_state). On first hybrid query the probe runs; subsequent queries within the TTL skip the probe and use the cached availability flag. A False result triggers the Cypher fallback for the graph signal; subsequent queries respect the cached flag without re-probing. Probe failures are logged at INFO and never raise. ENC-ISS-265: the probe returning True is necessary but not sufficient for a successful GDS PPR computation — see aga_sessions_contract for the second-order requirement."
+        },
+        "aga_sessions_contract": {
+          "type": "object",
+          "definition": "ENC-ISS-265: the live Neo4j instance is Aura Graph Analytics (AGA) — the Sessions-based GDS compute plane — not in-process AuraDB-Pro GDS. AGA requires every gds.graph.project call to pass either {memory: '<size>'} (auto-create session) or {sessionId: '<id>'} (use explicit session) as a 5th Cypher argument. graph_query_api passes {memory: '2GB'} at lambda_function.py:675-685; subsequent calls within the same query session (gds.graph.exists, gds.graph.drop, gds.pageRank.stream) inherit the session automatically. Additionally, gds.util.asNode is not supported under the AGA surface and the projection does not expose node properties — so nodeId→record_id resolution is done via a follow-up MATCH (lambda_function.py:705-735) instead. The Cypher fallback path (_hybrid_graph_ranks_cypher_fallback) remains available for clusters without AGA."
+        },
+        "bolt_pool_resilience": {
+          "type": "object",
+          "definition": "ENC-TSK-F36 / ENC-ISS-268 / DOC-D4CB8048798B: mitigations against dead Bolt TCP pool in warm Lambda containers. Root cause of the ~14s cold / ~48s warm probe pattern was NOT server-side AGA session contention — AuraDB GDS sessions have a 1h idle TTL that resets only on algorithm/projection work. The real culprit is NAT Gateway silently dropping idle TCP flows at 350s while the Lambda execution context is frozen; the cached driver then blocks on half-open sockets until Bolt acquisition times out. graph_query_api._get_neo4j_driver now passes max_connection_lifetime=300 (below NAT 350s kill window), keep_alive=True, connection_acquisition_timeout=120, max_connection_pool_size=20 to GraphDatabase.driver. _rebuild_neo4j_driver() closes the stale pool and re-binds the module-global cache without touching the server-side session; _ensure_live_driver() probes verify_connectivity() before each hybrid request and rebuilds on failure. _query_hybrid gates all three signals on a single probe so one dead-pool discovery does not cost three 48s retries. _hybrid_graph_ranks_gds projection_name now includes a 4-byte random suffix so concurrent Lambdas on the same anchor do not clash on gds.graph.drop / gds.graph.project. Lambda timeout raised 30s→180s in deploy.sh and CFN baseline 10s→180s to give worst-case Bolt rebuild (~60-120s) headroom. Intentionally does NOT adopt the Python graphdatascience client (would bloat the Lambda zip; current Bolt+Cypher-procedure path is valid per DOC-D4CB8048798B §'The Method Being Called'). Cypher fallback remains a real runtime, not an error path — any sufficiently long idle window can still legitimately expire the pool on the first post-freeze invocation."
+        },
+        "iam_contract": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "graph_query_api Lambda role gains bedrock:InvokeModel on arn:aws:bedrock:us-west-2::foundation-model/amazon.titan-embed-text-v2:0 (Sid=BedrockTitanV2InvokeModel) in addition to the existing CloudWatchLogs and SecretsManagerNeo4j scopes. Required for query-side Titan V2 embedding. Same scope graph_sync (ENC-TSK-B94) and titan_embedding_backfill (ENC-TSK-B91) already hold."
+        },
+        "response_envelope": {
+          "type": "object",
+          "definition": "GET /api/v1/tracker/graphsearch?search_type=hybrid response includes the existing nodes/edges/paths/summary/query_cypher/duration_ms fields plus: signal_availability {vector,graph,keyword: bool}, graph_algorithm ('gds_pagerank'|'cypher_fallback'|'unavailable'), rrf_k, embedding_coverage_sample {covered, total_ranked}, per_node_fusion {record_id: {fused_rank, fused_score, per_signal_ranks}}, fsrs_t3_threshold, include_below_threshold. The MCP server propagates these into get_compact_context.result.hybrid_retrieval verbatim."
+        },
+        "context_assembly_integration": {
+          "type": "string",
+          "definition": "get_compact_context auto-invokes hybrid retrieval when callers pass `query` and/or `anchor_record_id`. For record-oriented modes the anchor defaults to the record_id. project_id is inferred from args, then the assembled record_context, then by parsing the anchor record_id prefix. Result lives at context['hybrid_retrieval']. Set include_hybrid_retrieval=false to force-disable. Failures append a warning and never break the legacy context payload."
+        }
+      }
+    },
+    "deploy.package_arch_guard": {
+      "description": "CI + deploy-time guard that inspects Lambda deployment zip CONTENTS and rejects any package containing compiled shared objects (.so) for an architecture different from the target Lambda runtime. Implemented by tools/verify_lambda_package_arch.py and invoked from every backend/lambda/*/deploy.sh between zip creation and `aws lambda update-function-code`. Complements tools/verify_lambda_arch_parity.py (which checks CFN/deploy-script declarations) by verifying the actual artifact. Introduced by ENC-TSK-E19 as defense-in-depth for ENC-ISS-213.",
+      "fields": {
+        "expected_arch": {
+          "type": "enum",
+          "enum": [
+            "arm64",
+            "x86_64"
+          ],
+          "definition": "Target Lambda architecture. Derived from ENVIRONMENT_SUFFIX in each deploy.sh: empty suffix (prod) => x86_64; '-gamma' suffix => arm64. Must match the Architectures value resolved by the CFN !If [IsGamma, arm64, x86_64] conditional."
+        },
+        "enforcement_point": {
+          "type": "string",
+          "definition": "Where the check runs. Two invocation sites: (1) CI test suite in .github/workflows/ci.yml validates the verifier itself via `python3 -m unittest tools.test_verify_lambda_package_arch`; (2) every backend/lambda/*/deploy.sh invokes `python3 tools/verify_lambda_package_arch.py --package <zip> --expected-arch <arch>` immediately before `aws lambda update-function-code`, blocking upload on mismatch."
+        },
+        "rejection_conditions": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Conditions that cause the guard to exit non-zero and halt deployment.",
+          "enum": [
+            "Zip contains a .so file whose ELF e_machine header identifies a different architecture than --expected-arch (exit 1).",
+            "--package path does not exist, is not readable, or is not a valid zip archive (exit 2).",
+            "--expected-arch is not one of the supported values arm64, x86_64 (exit 2)."
+          ]
+        },
+        "trivial_pass_condition": {
+          "type": "string",
+          "definition": "Pure-Python packages (zero .so files) pass trivially. The guard is a no-op for Lambda functions that ship no compiled extensions."
+        },
+        "classification_method": {
+          "type": "string",
+          "definition": "Two-tier classification: (1) `file --brief` is invoked per .so when available (CodeBuild images, Amazon Linux, Ubuntu, macOS); (2) direct ELF magic-byte parsing (EM_X86_64=0x3E, EM_AARCH64=0xB7 at offset 0x12 of the ELF header) is used as a stdlib-only fallback. Either path alone is sufficient. Non-ELF .so files emit a WARN but do not fail the check."
+        },
+        "historical_precedent": {
+          "type": "string",
+          "definition": "ENC-ISS-213 (2026-04-12): devops-coordination-api-gamma Lambda shipped x86_64 pydantic_core wheels on an arm64 runtime despite the deploy.sh arch bifurcation from ENC-FTR-072 / ENC-ISS-224. Entire gamma MCP surface failed with 'No module named pydantic_core._pydantic_core'. Hot-fixed by ENC-TSK-D57; this guard is the structural prevention of recurrence."
+        }
+      }
+    },
+    "deploy.env_parity_gate": {
+      "description": "Pre-deploy environment-variable parity gate (ENC-PLN-048 Objective 2 / ENC-FTR-102). Resolves each CloudFormation Lambda's template Environment.Variables and fails closed if a deploy-critical required var (env_drift_auditor/env_drift_registry.json) would be unset, or if a var present live would be stripped by the deploy (the H05/H09 'deploy would strip <var>' class). The pre-deploy gate and the post-deploy env_drift_auditor share a single comparison core (env_parity_core) so they cannot diverge (ENC-TSK-H19 AC2).",
+      "fields": {
+        "cfn_env_resolver": {
+          "type": "string",
+          "definition": "tools/cfn_env_resolver.py (ENC-TSK-H17): a real CloudFormation intrinsic-function evaluator (Ref, Fn::Sub, Fn::If, Fn::Equals/Not/And/Or, Fn::Join/Select/GetAtt/ImportValue/FindInMap, plus the Conditions block) that resolves per-function Environment.Variables for infrastructure/cloudformation/02-compute.yaml given a parameter-overrides set, dropping any var that resolves to AWS::NoValue (the !If-unset case). Diffs resolved keys against the required-env registry. Replaces naive !Ref substitution, which false-flagged AppConfig !If vars as 'would be stripped'."
+        },
+        "fail_closed_gate": {
+          "type": "string",
+          "definition": "tools/env_parity_gate.py (ENC-TSK-H18): wraps the H17 resolver diff and exits non-zero with function+var+remediation for any missing deploy-critical var; exits zero when all are present. Invoked as CHECK 6 in tools/pre-deploy-health-gate.sh."
+        },
+        "waiver_mechanism": {
+          "type": "string",
+          "definition": "tools/env_parity_waivers.json (ENC-TSK-H18): documented, auditable per-(function,var) waivers that suppress a FAILURE but are still RECORDED in the report (never silent), plus an advisory_vars map (function name or '*' -> vars that WARN instead of FAIL). The committed file ships with zero active waivers so the gate stays honest."
+        },
+        "live_template_strip_detector": {
+          "type": "string",
+          "definition": "tools/live_template_strip_detector.py (ENC-TSK-H19): diffs live Lambda Environment.Variables (aws lambda get-function-configuration) against the H17 template-resolved env and flags any live-only var as 'deploy would strip <var> from <function>', classified critical (var is in the required-env registry) vs warning. Live fetch is pluggable (--live-env-file) for offline/CI/test runs."
+        },
+        "shared_comparison_core": {
+          "type": "string",
+          "definition": "backend/lambda/env_drift_auditor/env_parity_core.py (ENC-TSK-H19 AC2): the single source of env-comparison primitives (build_placeholders, classify_required, live_only_vars) imported by BOTH the env_drift_auditor Lambda (post-deploy required-var scan) and the pre-deploy strip detector, so pre- and post-deploy checks stay consistent by construction. Pure module with no import-time side effects."
+        }
+      }
+    },
+    "deploy.parity_validator": {
+      "description": "ENC-FTR-091 / ENC-TSK-F87 — v3-v4 Deploy Parity Validator Lambda. Autonomous cycle per PR: pre-merge DM env health + fixes, DPL inspection, function_name_map gap detection, CodeSha256 drift detection. Post-merge: GH Deployments API poll. Post-deploy: patches readiness DOC.",
+      "fields": {
+        "function_name": {
+          "type": "string",
+          "definition": "Prod: devops-deploy-parity-validator (x86_64/py3.11). Gamma: devops-deploy-parity-validator-gamma (arm64/py3.12)."
+        },
+        "event_schema": {
+          "type": "object",
+          "definition": "{action: pre_merge_check|deploy_watch|parity_check|daily_drift_audit, pr_number: int, commit_sha: str, repo: str, function_name_map?: dict, lambda_dirs?: list}. daily_drift_audit requires no additional fields; triggered by EventBridge Scheduler via devops-parity-drift-daily rule."
+        },
+        "detection_rules": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "ISS-273/283: COORDINATION_INTERNAL_API_KEY absent — autonomous UpdateFunctionConfiguration fix. ISS-269: ENABLE_HANDOFF_PRIMITIVE/ENABLE_COMPONENT_PROPOSAL absent — autonomous fix. ISS-279: enceladus-mcp-code-gamma missing — flag only. ISS-296: function_name_map gaps — flag only. DOC-D45141D94C55: CodeSha256 drift on patched Lambdas — flag only (ENC-TSK-F55 backport). ISS-281/282/LSN-044: ConditionExpression missing on document_api/coordination_api — flag only."
+        },
+        "iam_contract": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "lambda:GetFunctionConfiguration + UpdateFunctionConfiguration on DM + MCP Lambda ARNs. lambda:GetFunctionConfiguration + ListFunctions + ListVersionsByFunction on * (DriftAuditLambdaRead — read-only, daily audit scope). cloudformation:DetectStackDrift + DescribeStackDriftDetectionStatus on * (DriftAuditCfn). sns:Publish on enceladus-deploy-alerts topic (DriftAuditSns). dynamodb:GetItem/PutItem/UpdateItem/Query on devops-deployment-manager table. secretsmanager:GetSecretValue on devops/github-app/*. appconfig:GetConfiguration/GetLatestConfiguration/StartConfigurationSession on *."
+        },
+        "readiness_doc": {
+          "type": "object",
+          "definition": "Per-PR DOC written as readiness-pr{N}-{sha7}. Patched post-deploy with outcome + sha drift. MCP-searchable for agent session init handoff recovery."
+        }
+      }
+    },
+    "auth.github_installation_token": {
+      "description": "Response contract for GET /api/v1/auth/github-token — vends a short-lived GitHub App installation access token to authenticated PWA sessions. Token is sourced from RS256 JWT + GitHub App installation token exchange using the devops/github-app/private-key Secrets Manager entry.",
+      "fields": {
+        "token": {
+          "type": "string",
+          "usage_guidance": "GitHub App installation access token. Valid for ~1 hour. Caller should cache and reuse; client-side TTL of 50 minutes is recommended."
+        },
+        "expires_in": {
+          "type": "integer",
+          "usage_guidance": "Nominal expiry in seconds (3600). Use as a hint only; the GitHub-issued token may expire sooner if the installation is revoked."
+        }
+      }
+    },
+    "appconfig.feature_flags": {
+      "description": "AppConfig-based boolean feature flag contract (ENC-TSK-F63 AC-1). The enceladus_shared.appconfig_flags.flag() helper resolves flags via the AppConfig Lambda extension (localhost:2772, TTL 45 s) with env-var fallback for local dev. Replaces direct ENABLE_* env var reads in coordination_api, mcp-server, and (ENC-TSK-H08) tracker_mutation, which now resolves enable_lesson_primitive via appconfig_flags.flag() instead of a direct os.environ read. Extension layer ARN is arch-specific (x86 / arm64) and attached to all 24 prod Lambdas via HasAppConfigLayer CFN condition; the appconfig_flags submodule is present only in shared layer :10, so consumers must run on :10 (ENC-TSK-H08 AC-3).",
+      "fields": {
+        "flag_name": {
+          "type": "string",
+          "usage_guidance": "Snake_case key in the AppConfig JSON configuration profile (e.g. 'enable_lesson_primitive'). Must match an entry in the 06-feature-flags.yaml JSON Schema to pass pre-deployment validation."
+        },
+        "env_fallback": {
+          "type": "string",
+          "usage_guidance": "Optional ENABLE_* environment variable name used when the AppConfig extension is unreachable (e.g. local dev, cold-start before layer initializes). Value is coerced: 'true' (case-insensitive) → True, anything else → False."
+        },
+        "default": {
+          "type": "boolean",
+          "usage_guidance": "Hardcoded fallback returned when both AppConfig and env_fallback are absent or unreachable. Defaults to False for all flags unless explicitly overridden (e.g. enable_mcp_governance_prompt defaults to True)."
+        },
+        "resolution_order": {
+          "type": "enum",
+          "enum": [
+            "appconfig_extension",
+            "env_fallback",
+            "default"
+          ],
+          "usage_guidance": "Flag() resolution is: 1) AppConfig HTTP poll (localhost:2772, cached); 2) env_fallback env var if AppConfig unreachable; 3) default. Callers must not read ENABLE_* vars directly — always call flag()."
+        }
+      }
+    },
+    "monitoring.continuous_drift_audit": {
+      "description": "ENC-TSK-F64 / ENC-FTR-090 AC-20 — Daily drift audit added to devops-deploy-parity-validator via action=daily_drift_audit. Replaces deploy_capability_auditor (ENC-TSK-E69). Fires via devops-parity-drift-daily EventBridge rule at cron(0 10 * * ? *).",
+      "fields": {
+        "trigger": {
+          "type": "string",
+          "definition": "EventBridge Scheduler rule devops-parity-drift-daily, cron(0 10 * * ? *). Input payload: {\"action\": \"daily_drift_audit\"}. Targets devops-deploy-parity-validator function ARN."
+        },
+        "cfn_drift_stacks": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "CFN stacks checked via detect_stack_drift: enceladus-data, enceladus-api, enceladus-github-roles, enceladus-monitoring. Configurable via CFN_DRIFT_STACKS env var."
+        },
+        "code_size_check": {
+          "type": "object",
+          "definition": "Flags any Lambda with CodeSize < 1024 bytes as a CFN ZipFile stub overwrite (ENC-FTR-068 AC-5). Covers all functions with devops-/enceladus- prefix via list_functions pagination."
+        },
+        "snapstart_check": {
+          "type": "object",
+          "definition": "Flags any Lambda with >SNAPSTART_MAX_STALE_VERSIONS (default 5) published versions as a potential SnapStart storage cost trap. Uses list_versions_by_function."
+        },
+        "alert_channel": {
+          "type": "string",
+          "definition": "SNS topic arn:aws:sns:<region>:<account>:enceladus-deploy-alerts. Alert published when total_anomalies > 0. Subject pattern: [drift-audit] N anomaly(ies) — <ISO timestamp>."
+        }
+      }
+    },
+    "monitoring.mentions_drift_audit": {
+      "description": "ENC-TSK-G43 / ENC-FTR-098 AC-7 — Daily sample-and-diff audit catching divergence between the live MENTIONS edge projection (graph_sync._reconcile_mentions_edges, ENC-TSK-G35) and the prose extracted from current record state. Implemented as the action=mentions_drift_audit handler in devops-deploy-parity-validator and chained synchronously into action=daily_drift_audit so the existing devops-parity-drift-daily EventBridge rule (cron(0 10 * * ? *)) fires both passes in one invocation. The audit imports the same backend/lambda/graph_sync/mentions_extraction.py module as graph_sync via the .build_extras manifest mechanism, guaranteeing the live and audit extractors cannot drift apart.",
+      "governing_feature": "ENC-FTR-098",
+      "governing_task": "ENC-TSK-G43",
+      "fields": {
+        "trigger": {
+          "type": "string",
+          "definition": "Two paths. (1) Chained from action=daily_drift_audit (cron(0 10 * * ? *) via devops-parity-drift-daily) inside _run_daily_drift_audit() after the existing checks. (2) Direct dispatch via action=mentions_drift_audit for ad-hoc invocation."
+        },
+        "sample_size": {
+          "type": "integer",
+          "definition": "Total records sampled per run (env MENTIONS_AUDIT_SAMPLE_SIZE, default 100). Distributed roughly evenly across the 6 tracker record_types in MENTIONS_PROSE_FIELDS plus the document table, queried via the type-updated-index GSI ScanIndexForward=False so the most-recently-mutated rows are picked first."
+        },
+        "extraction_parity": {
+          "type": "object",
+          "definition": "The audit imports graph_sync/mentions_extraction.py (MENTIONS_PROSE_FIELDS allowlist + extract_id_tokens + strip_code_fences) so its expected edge set is computed by the same code that emits the live edges. Drift between live and audit is structurally impossible by build."
+        },
+        "current_edge_query": {
+          "type": "string",
+          "definition": "graph_query_api /api/v1/tracker/graphsearch with search_type=neighbors, edge_types=MENTIONS, direction=outgoing, depth=1. Resolved from env GRAPHSEARCH_URL falling back to ${TRACKER_API_URL}/graphsearch. Transport failures cause the affected record to be skipped (counted as skipped_transport, excluded from the divergence ratio) rather than scored as zero-divergence."
+        },
+        "iss_emission": {
+          "type": "object",
+          "definition": "When mismatch_count / effective_sample > MENTIONS_AUDIT_THRESHOLD (env, default 0.01 = 1%), the audit POSTs to ${TRACKER_API_URL}/create with project_id=enceladus, record_type=issue, category=bug, priority=P2, source=mentions_drift_audit, description listing the first 10 divergent records (record_id, record_type, missing edge target_ids, extra edge target_ids)."
+        },
+        "iam_scope": {
+          "type": "string",
+          "definition": "DeployParityValidatorRole inline policy MentionsAuditTrackerRead grants dynamodb:GetItem and dynamodb:Query on devops-project-tracker${EnvironmentSuffix}, documents${EnvironmentSuffix}, and their /index/* GSIs. Read-only by design — ENC-ISS emission goes through the tracker_api HTTP path with X-Coordination-Internal-Key, not direct DDB write."
+        }
+      }
+    },
+    "feed_publisher.s3_lessons_plans": {
+      "description": "ENC-TSK-F93 / ENC-ISS-299: feed_publisher Lambda now generates lessons.json and plans.json in mobile/v1/ alongside the existing tasks/issues/features feeds. Both feeds are written by generate_mobile_feeds() in feed_utils.py on every SQS-triggered feed refresh cycle and on the feed_query /refresh endpoint.",
+      "fields": {
+        "lessons_json": {
+          "type": "object",
+          "definition": "S3 key mobile/v1/lessons.json. Envelope: {generated_at, version, lessons: Lesson[]}. Stale-closed records (status=closed, updated_at older than 90 days) are filtered. Written by _transform_lesson() from raw DynamoDB deserialized items."
+        },
+        "plans_json": {
+          "type": "object",
+          "definition": "S3 key mobile/v1/plans.json. Envelope: {generated_at, version, plans: Plan[]}. Stale-closed records filtered with same 90-day cutoff. Written by _transform_plan() from raw DynamoDB deserialized items."
+        },
+        "error_fallback": {
+          "type": "object",
+          "definition": "When per-project DynamoDB fetch fails, the error fallback dict now includes lessons: [] and plans: [] keys alongside tasks/issues/features to prevent KeyError during feed generation."
+        },
+        "s3_fallback_pwa": {
+          "type": "object",
+          "definition": "useFeed.ts wires lessonsQuery/plansQuery via feedKeys.lessons/feedKeys.plans and fetchLessons/fetchPlans hitting CloudFront /mobile/v1/lessons.json and /mobile/v1/plans.json. When hasLiveSnapshot is false (live feed unavailable), the hook falls back to these S3-cached feeds instead of returning hardcoded []."
+        }
+      }
+    },
+    "governance.per_field_metadata": {
+      "description": "Per-field metadata properties that may be applied to any entity field definition in the governance data dictionary. Declares policy for value-frequency telemetry (Convergence Surface, ENC-FTR-086) and vocabulary boundedness hints used for capacity sizing.",
+      "fields": {
+        "telemetry_eligible": {
+          "type": "boolean",
+          "required": true,
+          "definition": "When true, the Convergence Surface telemetry service (ENC-FTR-086) tracks attribute-value frequency for this field. Only fields explicitly marked telemetry_eligible:true are tracked; unmarked fields are excluded by default.",
+          "usage_guidance": "Set on fields whose value distributions carry operational or governance signal. Candidate fields at F19 launch: tracker.task.components, document.doc.subtypepattern, tracker.issue.location_hint."
+        },
+        "vocabulary_bounded": {
+          "type": "boolean",
+          "required": false,
+          "definition": "Optional hint. When true, indicates the field's value space is semantically bounded (enum-like or registry-constrained), enabling the Convergence Surface to apply a lower capacity cap. When false or absent, the field is treated as unbounded free text.",
+          "usage_guidance": "Set to true for enum fields or registry-keyed arrays (e.g. tracker.task.components, document.doc.subtypepattern). Omit or set false for open free-text fields (e.g. tracker.issue.location_hint)."
+        }
+      }
+    },
+    "telemetry.eligible_fields": {
+      "description": "ENC-FTR-086 / ENC-TSK-I83 (Convergence Surface Phase 2): the registry of attribute fields the telemetry.rank read action ranks, derived from the per-field telemetry_eligible flags (governance.per_field_metadata). This entity is the policy source of truth that the Convergence Surface executes; the MCP server carries an in-process mirror so the read surface is functional on gamma before the live dictionary sync lands. Per Locked Design Decision D1 (DOC-E3F5E025B3D9) this surface is a SOFT prior only — it is queryable by agents but is structurally invisible to every governance gate (no validator, preflight, tracker.set handler, checkout.advance gate, or deploy guard ever consults it). Architectural separation (feature AC-1) is enforced by topology: the ranking logic lives in the isolated tools/enceladus-mcp-server/telemetry_rank.py module which imports nothing from governance Lambdas, and no governance Lambda (coordination_api, governance_audit, governance_drift_check, recompute_governance) imports it or the convergence-telemetry counter table. OGTM (ENC-FTR-066) is N/A: telemetry.rank is a read-only frequency projection and introduces no new record type, relational field, or graph edge. ENC-TSK-K12 / ENC-ISS-474: coordination_api .build_extras now copies tools/enceladus-mcp-server/telemetry_rank.py into the Lambda bundle so coordination dispatch paths can import the isolated ranking module at runtime.",
+      "governing_feature": "ENC-FTR-086",
+      "governing_task": "ENC-TSK-I83",
+      "design_source": "DOC-E3F5E025B3D9",
+      "mcp_action": "search(action='telemetry.rank', arguments={attribute_name, project_id?, record_type?, limit?, cursor?})",
+      "canonicalization_version": "v1",
+      "schema_version": "telemetry.rank.v1",
+      "response_shape": {
+        "rows[]": "canonical_value, count (alias raw_count), rank, raw_value_samples (up to 3 distinct raw forms), first_seen, last_seen, distinct_author_count",
+        "envelope": "rows[], total_distinct_values, next_cursor, schema_version, canonicalization_version, source, eligible, degraded, attribute_name, record_type, project_id",
+        "degradation": "On any failure mode the action returns rows:[] with degraded:true and a degraded_reason (Locked Design Decision: telemetry being down must never block mutation work)."
+      },
+      "fields": {
+        "attribute_name": {
+          "type": "string",
+          "required": true,
+          "definition": "The telemetry-eligible attribute to rank. Must resolve to a field declared telemetry_eligible:true. Day-one eligible set: tracker.task.category, tracker.task.components, document.doc.subtypepattern.",
+          "usage_guidance": "Pass as arguments.attribute_name (alias: attribute). Ineligible attributes return rows:[] with eligible:false and an eligible_attributes hint — this is a policy answer, not a degraded failure."
+        },
+        "record_type": {
+          "type": "string",
+          "required": false,
+          "definition": "Record type whose population is ranked. Resolved from the eligible-fields map when omitted (category/components -> task, subtypepattern -> document).",
+          "usage_guidance": "Override only to rank an attribute across a non-default record population."
+        },
+        "vocabulary_bounded": {
+          "type": "boolean",
+          "required": false,
+          "definition": "Per-field hint mirrored from governance.per_field_metadata. When true the Convergence Surface applies a lower capacity cap (the field's value space is enum-like or registry-constrained).",
+          "usage_guidance": "Informational for capacity sizing; does not change telemetry.rank read semantics."
+        }
+      }
+    },
+    "graph_sync.mentions_extraction": {
+      "description": "Auto-extraction of MENTIONS edges from prose fields on every governed record/document mutation (ENC-FTR-098, ENC-TSK-G28). Implemented in backend/lambda/graph_sync/mentions_extraction.py (pure helpers: strip_code_fences, extract_id_tokens, stamp_provenance) and wired into _reconcile_edges() via _reconcile_mentions_edges() (ENC-TSK-G35). Generalizes the LEARNED_FROM precedent (ENC-FTR-052 / ENC-TSK-B89) to corpus-scale prose. The wipe-and-recreate semantics of _reconcile_edges' top-level outgoing-edge prune deliver diff-and-delete for free; the branch is idempotent by construction. Source: DOC-59D2295AA7FD section 7.2.",
+      "governing_feature": "ENC-FTR-098",
+      "governing_task": "ENC-TSK-G28",
+      "prose_field_allowlist": {
+        "task": [
+          "title",
+          "description",
+          "intent"
+        ],
+        "issue": [
+          "title",
+          "description",
+          "hypothesis",
+          "technical_notes",
+          "location_hint"
+        ],
+        "feature": [
+          "title",
+          "description",
+          "user_story"
+        ],
+        "plan": [
+          "title",
+          "description",
+          "intent"
+        ],
+        "lesson": [
+          "title",
+          "description"
+        ],
+        "generation": [
+          "title",
+          "description",
+          "architectural_thesis"
+        ],
+        "document": [
+          "title",
+          "description",
+          "content"
+        ]
+      },
+      "id_alphabet": {
+        "description": "Regex alphabet of governed Enceladus ID prefixes resolvable by graph_sync._infer_label_from_id. Mirrors ID_PREFIX_TO_LABEL in graph_sync/lambda_function.py.",
+        "enc_record_prefixes": [
+          "TSK",
+          "ISS",
+          "FTR",
+          "LSN",
+          "PLN",
+          "GEN",
+          "DPL"
+        ],
+        "enc_pattern": "\\bENC-(TSK|ISS|FTR|LSN|PLN|GEN|DPL)-[A-Za-z0-9]{3,4}\\b",
+        "document_pattern": "\\bDOC-[A-Fa-f0-9]{12}\\b",
+        "component_pattern": "\\bcomp-[a-z0-9-]+\\b"
+      },
+      "code_fence_skip": {
+        "enabled": true,
+        "description": "Triple-backtick fenced code blocks are stripped before extraction so example payloads do not produce spurious MENTIONS. Single-backtick inline spans are preserved -- IDs in `inline code` remain intentional references.",
+        "regex": "```.*?```"
+      },
+      "provenance_schema": {
+        "description": "Edge property bag stamped on every MENTIONS edge by stamp_provenance(). Distinguishes auto-extracted edges from typed-relationship edges and lets the drift-audit (ENC-TSK-G43) and backfill (ENC-TSK-G42) paths tag their provenance distinctly.",
+        "properties": {
+          "source": {
+            "type": "enum",
+            "enum": [
+              "auto_mention",
+              "backfill",
+              "audit_recompute"
+            ],
+            "definition": "Origin of this MENTIONS edge. auto_mention = live graph_sync stream path; backfill = one-shot ENC-TSK-G42 corpus run; audit_recompute = drift-audit reconciliation."
+          },
+          "extracted_from_field": {
+            "type": "string",
+            "definition": "Name of the prose field from which the target ID token was lifted (e.g. 'description', 'intent', 'user_story', 'content')."
+          }
+        }
+      },
+      "self_reference_policy": "Self-mentions (target == source) are filtered out before MERGE -- they clutter neighbor queries and add no information to the graph.",
+      "unknown_prefix_policy": "Tokens whose prefix is not in ID_PREFIX_TO_LABEL are skipped with a WARNING log line (no unlabelled placeholder is created). Future record types extend the alphabet via this entity."
+    },
+    "governance.version_record": {
+      "description": "Canonical governance-version DDB record written exclusively by the recompute-governance Lambda (ENC-TSK-I27 / ENC-FTR-116 Wave 2). Single-item table keyed on version_id='governance-version-current'. Provides the authoritative governance_hash for connection_health validation (replaces the stale docstore-fallback path fixed in I29).",
+      "fields": {
+        "version_id": {
+          "type": "string",
+          "enum": [
+            "governance-version-current"
+          ],
+          "usage_guidance": "Partition key. Always 'governance-version-current' — single-item canonical record."
+        },
+        "governance_revision": {
+          "type": "string",
+          "usage_guidance": "Governance revision string (e.g. '2026-06-27.01') extracted from governance/live/agents.md §13."
+        },
+        "governance_hash": {
+          "type": "string",
+          "usage_guidance": "Lowercase hex SHA-256 bundle root hash per §4.3: sha256 over lex-sorted (URI+newline+checksum_hex+newline) pairs."
+        },
+        "generation": {
+          "type": "integer",
+          "usage_guidance": "Monotonically increasing counter. Incremented on every successful write. Value stored in cas_version for CAS locking."
+        },
+        "cas_version": {
+          "type": "integer",
+          "usage_guidance": "Optimistic lock version matching generation. PutItem ConditionExpression='cas_version = :expected' guards concurrent writes."
+        },
+        "files": {
+          "type": "string",
+          "usage_guidance": "JSON array [{uri, s3_key, s3_version_id, checksum_sha256_hex}] lex-sorted by URI. Canonical set: governance://agents.md + governance://agents/**."
+        },
+        "source_event": {
+          "type": "string",
+          "usage_guidance": "JSON {s3_sequencer, trigger_s3_key, trigger_version_id}. Used for dedup: same s3_sequencer = idempotent no-op."
+        },
+        "updated_at": {
+          "type": "string",
+          "usage_guidance": "ISO 8601 UTC timestamp of last write."
+        }
+      }
+    },
+    "recompute_governance.event_handler": {
+      "description": "Contract for the devops-recompute-governance Lambda (ENC-TSK-I27). Triggered by S3 ObjectCreated on governance/live/* prefix. Computes §4.3 bundle root hash and writes the canonical governance-version DDB record. Recursion-safe: writes only to DDB, never back to S3.",
+      "fields": {
+        "trigger": {
+          "type": "object",
+          "definition": "S3 ObjectCreated on jreese-net/governance/live/*. Fires on direct PUTs and CompleteMultipartUpload."
+        },
+        "canonical_file_set": {
+          "type": "object",
+          "definition": "governance/live/agents.md + all objects under governance/live/agents/. Sorted lexicographically by governance:// URI."
+        },
+        "dedup_key": {
+          "type": "string",
+          "usage_guidance": "s3_sequencer from the triggering S3 record. Same sequencer as current DDB record = idempotent no-op."
+        },
+        "cas_guard": {
+          "type": "object",
+          "definition": "PutItem with ConditionExpression='cas_version = :expected'. ConditionalCheckFailedException = lost race; returns without error."
+        },
+        "recursion_invariant": {
+          "type": "object",
+          "definition": "Lambda only writes to DDB (governance-version table). Never calls S3 PutObject — prevents ObjectCreated loops."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: table name (governance-version or governance-version-gamma). AWS_REGION: us-west-2."
+        }
+      }
+    },
+    "coordination_api.governance_hash_resolution": {
+      "description": "Hash resolution chain in coordination_api._compute_governance_hash_local() after the ENC-TSK-I29 docstore-fallback cutover. Primary: canonical governance-version DDB GetItem (GOVERNANCE_VERSION_TABLE, key=governance-version-current). Secondary: live S3 recomputation via MCP server module. Docstore-catalog fallback removed — it could silently return a frozen hash after a governance/live/* change, violating the complete-mediation guarantee (DOC-63420302EF65 §2.3). Empty string returned and propagated as GOVERNANCE_STALE on total failure of both sources.",
+      "fields": {
+        "primary_source": {
+          "type": "object",
+          "definition": "dynamodb.get_item on GOVERNANCE_VERSION_TABLE (governance-version or governance-version-gamma). ConsistentRead=True. Returns governance_hash string from the governance-version-current record. Raises RuntimeError when record is missing or governance_hash attribute is empty."
+        },
+        "secondary_source": {
+          "type": "object",
+          "definition": "MCP server module _compute_governance_hash(force_refresh=True). Reads directly from S3 governance/live/ prefix. Only invoked when primary_source raises."
+        },
+        "removed_fallback": {
+          "type": "object",
+          "definition": "_compute_governance_hash_docstore_fallback() is DEPRECATED and removed from call chain as of I29. Function body retained for external test compatibility only. It scanned DOCUMENTS_TABLE for governance-keyword documents — stale by design because DDB updates lagged S3 writes by up to TTL window (previously up to 5 min)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma (injected via CFN 02-compute.yaml EnvironmentSuffix sub). GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
+        }
+      }
+    },
+    "coordination_api.session_init_intent_classifier": {
+      "description": "ENC-FTR-084 Phase 1 / ENC-TSK-I93: session-init proactive intent classifier in coordination_api (inference-only, no training writes). Two HTTP routes (POST /api/v1/coordination/session-init/classify-intent and POST /api/v1/coordination/session-init/intent-centroid-drift), surfaced on the MCP code-mode surface as coordination(action='session.classify_intent') and coordination(action='session.intent_centroid_drift'). classify-intent embeds the first-turn request text with amazon.titan-embed-text-v2:0 (256-dim, normalized — same contract as backend/lambda/graph_sync/embedding.py) and returns predicted_entelechy={node_ids:list[str], confidence:float} via cosine nearest-neighbor over the governed corpus embeddings. The canonical NN primitive (intent_classifier.cosine_similarity + rank_neighbors) runs over a raw-embedding corpus (the FTR-089 egress consumption path); until that egress lands the default neighbor provider delegates the vector search to the deployed graph_query_api hybrid endpoint (GRAPH_QUERY_API_URL), degrading to zero neighbors (confidence 0.0) when unset so session-init inference never blocks. applied_entelechy_override (list[str], a single id, or {node_ids:[...]}) is optional; when present the io value overrides the prediction (override wins) while the classifier prediction is still computed and logged (AC-2). intent-centroid-drift computes the rolling intent vector per wave as the mean of the FTR-089 embeddings for dispatched records and a scalar intent_centroid_drift (cosine distance vs the previous wave centroid; nullable on the first wave), best-effort persisted as a NEW nullable column intent_centroid_drift on the FTR-087-owned enceladus-drift-telemetry table ALONGSIDE d_centroid (DRIFT_TELEMETRY_TABLE; graceful no-op when unset/missing; FTR-087 fields never overwritten) (AC-3). OGTM (ENC-FTR-066) is N/A for Phase 1: no new edge type, record type, or relational field is introduced — predictions are returned inline (AC-4). Scope guard (AC-5): inference-only — intent_classifier.INFERENCE_ONLY=True / TRAINING_ENABLED=False; the persistent-model-mutation training arc is a deferred follow-on pending io review.",
+      "fields": {
+        "routes": {
+          "type": "object",
+          "definition": "POST /api/v1/coordination/session-init/classify-intent -> _handle_session_init_classify_intent(event, claims). POST /api/v1/coordination/session-init/intent-centroid-drift -> _handle_session_init_intent_drift(event, claims). Both registered before the 404 fallback in lambda_handler; auth via the standard coordination auth gate (Cognito or X-Coordination-Internal-Key)."
+        },
+        "mcp_actions": {
+          "type": "object",
+          "definition": "coordination(action='session.classify_intent') -> raw tool coordination_classify_intent; coordination(action='session.intent_centroid_drift') -> raw tool coordination_intent_centroid_drift. Both proxy to the coordination API HTTP routes via _coordination_api_request."
+        },
+        "classify_intent_request": {
+          "type": "object",
+          "definition": "{first_turn_text:str (required; request_text accepted as alias), session_metadata:object?, applied_entelechy_override:list[str]|str|{node_ids:[...]}?, top_k:int? (default 5, max 25), project_id:str? (default 'enceladus')}."
+        },
+        "classify_intent_response": {
+          "type": "object",
+          "definition": "{success:true, predicted_entelechy:{node_ids:list[str], confidence:float in [0,1]}, applied_entelechy:{node_ids:list[str], confidence:float, source:'classifier'|'io_override'}, override_applied:bool, neighbors:list[{record_id,score}], query_embedding_dim:int, model_id:str, inference_only:true, ...}. predicted_entelechy always carries the classifier's own prediction even when overridden (it is logged)."
+        },
+        "intent_centroid_drift_contract": {
+          "type": "object",
+          "definition": "Request {wave_id:str (required), embeddings:list[list[float]] (FTR-089 embeddings for dispatched records; dispatched_record_embeddings accepted as alias), previous_centroid:list[float]?, persist:bool? (default true), project_id:str?}. Response {success:true, wave_id, intent_centroid_dim:int, intent_centroid_drift:float|null, record_count:int, persistence:{persisted:bool, ...}}."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GRAPH_QUERY_API_URL (default empty -> classifier degrades to no neighbors). DRIFT_TELEMETRY_TABLE (default empty -> intent_centroid_drift persistence is a graceful no-op; the table is owned by FTR-087). BEDROCK_REGION (default us-west-2) for the Titan V2 embed; requires bedrock:InvokeModel on amazon.titan-embed-text-v2:0 on the coordination_api role for live (gamma) predictions."
+        }
+      }
+    },
+    "coordination_api.intent_training": {
+      "description": "ENC-FTR-084 Ph2 / ENC-TSK-K02: scheduled intent-classifier training loop in coordination_api. EventBridge IntentClassifierTrainingSchedule (gamma, cron Sunday 04:00 UTC) invokes lambda_handler with {\"action\":\"intent_classifier_training\"}; rollback via {\"action\":\"intent_classifier_training_rollback\",\"version_id\"?}. Per-invocation only (no always-on compute). Mutates versioned per-record score boosts stored on S3 under INTENT_TRAINING_PREFIX (default gamma/intent-training): labels at labels/session_outcomes.jsonl (NDJSON of {first_turn_text, label_node_ids, embedding?}), active pointer at weights/active.json, immutable snapshots at weights/versions/{version_id}.json with previous_version_id chain for one-call rollback. Inference reads boosts via intent_training.load_inference_record_boosts() inside classify_session_intent (intent_classifier applies multiplicative boosts to neighbor scores). TRAINING_HARD_DISABLED=1 (default, ISS-465 pattern) hard-stops training AND suppresses boost reads at inference; io clears to 0 to enable. Holdout validation (20% split): >10% accuracy degradation vs baseline auto-sets training_disabled on the active snapshot. COST-PREFLIGHT: projected ~$0.04/month; IntentTrainingCostHeadroomAlarm fires if EventBridge invocations exceed 6/30d.",
+      "fields": {
+        "eventbridge_actions": {
+          "type": "object",
+          "definition": "intent_classifier_training (weekly train), intent_classifier_training_rollback (repoint active.json to previous or explicit version_id)."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "TRAINING_HARD_DISABLED (default 1), INTENT_TRAINING_BUCKET, INTENT_TRAINING_PREFIX, TRAINING_LEARNING_RATE (0.05), TRAINING_BOOST_MIN (0.5), TRAINING_BOOST_MAX (2.0), TRAINING_DEGRADATION_THRESHOLD (0.10)."
+        },
+        "rollback": {
+          "type": "object",
+          "definition": "Invoke coordination_api with {\"action\":\"intent_classifier_training_rollback\"} to roll back to previous_version_id, or pass version_id to pin a specific snapshot."
+        }
+      }
+    },
+    "mcp_server.governance_hash_resolution": {
+      "description": "Hash resolution chain in enceladus-mcp-server._get_governance_hash_via_api() after the ENC-TSK-I29 cutover. Four-tier resolution with 60s TTL cache.",
+      "fields": {
+        "tier_1_api_hash": {
+          "type": "object",
+          "definition": "coordination API GET /hash endpoint. After I29 lands, the API's _compute_governance_hash_local() returns the canonical DDB value, so tier 1 is transitively canonical. TTL: 60s (GOVERNANCE_HASH_API_TTL)."
+        },
+        "tier_2_health_api": {
+          "type": "object",
+          "definition": "coordination API health endpoint governance_hash field. Auth-safe fallback for environments where the /hash endpoint requires internal API key."
+        },
+        "tier_3_canonical_ddb": {
+          "type": "object",
+          "definition": "_get_canonical_governance_hash_ddb(): same DDB read as coordination_api primary. Bypasses HTTP entirely — valid when coordination API is unreachable. GOVERNANCE_VERSION_TABLE env var (default: governance-version). New in ENC-TSK-I29."
+        },
+        "tier_4_s3_catalog": {
+          "type": "object",
+          "definition": "_compute_governance_hash(force_refresh=True): reads from _governance_catalog() (S3 governance/live/ prefix primary, docstore scan fallback ONLY when S3 is empty). Last resort — no longer the primary docstore path."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE: governance-version or governance-version-gamma. GOVERNANCE_VERSION_RECORD_ID: governance-version-current (constant)."
+        }
+      }
+    },
+    "governance_drift_check.handler": {
+      "description": "ENC-TSK-I32 / ENC-FTR-116: scheduled drift-detection backstop Lambda (governance_drift_check). Reads the canonical governance-version DDB record and independently recomputes the §4.3 bundle hash from live S3 object checksums. Emits GovernanceVersionDrift CloudWatch metric (1.0=drift, 0.0=agree) and SNS alert on mismatch, failed recompute, or missing record.",
+      "fields": {
+        "drift_metric": {
+          "type": "object",
+          "definition": "CloudWatch metric GovernanceVersionDrift in namespace Enceladus/Governance. 1.0 = drift detected or recompute failed; 0.0 = canonical record agrees with live S3. CloudWatch alarm fires on 1.0. DRIFT_METRIC_NAMESPACE env var (default: Enceladus/Governance)."
+        },
+        "sns_alert": {
+          "type": "object",
+          "definition": "SNS notification (GOVERNANCE_ALERT_SNS_ARN env var) published when drift is detected, recompute fails, or the canonical record is missing. Same topic as governance_audit anomaly alerts."
+        },
+        "read_only_invariant": {
+          "type": "object",
+          "definition": "This Lambda NEVER writes the canonical governance-version record (sole-writer = devops-recompute-governance, I28) and never writes to governance/live/* (recursion safety). It is a read-only auditor."
+        },
+        "env_vars": {
+          "type": "object",
+          "definition": "GOVERNANCE_VERSION_TABLE (default: governance-version), GOVERNANCE_S3_BUCKET (default: jreese-net), DRIFT_METRIC_NAMESPACE (default: Enceladus/Governance), GOVERNANCE_ALERT_SNS_ARN."
+        }
+      }
+    },
+    "graph_query_api.embeddings_for": {
+      "description": "Returns stored Amazon Titan Text Embeddings V2 vectors (256-dim, L2-normalised) for a list of record_ids in a project. search_type=embeddings_for on GET /api/v1/tracker/graphsearch. Admin-tier only. Returns {embeddings[], matrix(Nx256), missing[]}. No new edge types or graph writes (OGTM N/A).",
+      "owner": "graph-query-api",
+      "source": "ENC-TSK-I89 / ENC-FTR-089",
+      "telemetry_eligible": false
+    },
+    "graph_query_api.sheaf_cohomology": {
+      "description": "Sheaf Laplacian H1 inconsistency-detection. search_type=sheaf_cohomology on graph_query_api. Returns h1_dim, inconsistency_nodes[], inconsistency_edges[], computation_ms.",
+      "owner": "graph-query-api",
+      "source": "ENC-TSK-I90 / ENC-FTR-095",
+      "telemetry_eligible": false
+    },
+    "monitoring.memory_consolidation": {
+      "description": "See source task.",
+      "source": "ENC-TSK",
+      "telemetry_eligible": false
+    },
+    "monitoring.rhythm_cycle": {
+      "description": "ENC-PLN-068 / DOC-BDDE755DB874: cost-weighted harmonic scheduling substrate. The enceladus-rhythm-cycle Lambda (backend/lambda/rhythm_cycle/, gamma-only, Condition IsGamma) is invoked by five EventBridge Scheduler groups (rhythm-sense/decide/light/heavy/coherence) with independent pause via RhythmCycleEnabled. Each beat reads its predecessor's S3 artifact, performs tier-scoped work, writes its own artifact under {S3EnvPrefix}rhythm-cycle/{tier}/latest.json, and emits Enceladus/Rhythm metrics (beat_duration_ms, beat_cost_estimate, artifact_bytes, backlog_delta). Decide beat publishes backlog_open_leaves Lyapunov metric; RhythmPathologyAlarm fires on 3 consecutive non-decreasing deltas. Legacy gamma schedules (memory consolidation, graph health, recompute backstop) DISABLE when RhythmActive.",
+      "owner": "enceladus-platform",
+      "source": "ENC-PLN-068 / ENC-TSK-K79..K94",
+      "telemetry_eligible": true,
+      "fields": {
+        "CLOUDWATCH_NAMESPACE": {
+          "type": "string",
+          "default": "Enceladus/Rhythm",
+          "definition": "CloudWatch namespace for per-beat telemetry."
+        },
+        "RhythmCycleEnabled": {
+          "type": "feature_flag",
+          "default": "true",
+          "definition": "CFN parameter; when true on gamma, rhythm schedules ENABLED and legacy superseded EventBridge rules DISABLED."
+        },
+        "backlog_open_leaves": {
+          "type": "metric",
+          "definition": "Open orphan leaf-task count sampled at each Decide beat; Lyapunov function per DOC-BDDE755DB874 section 6."
+        }
+      }
+    },
+    "unlearning.lambda": {
+      "description": "ENC-FTR-106 / ENC-TSK-K03: nightly Crick-Mitchison unlearning Lambda (enceladus-unlearning). EventBridge UnlearningSchedule (gamma, cron 04:00 UTC) invokes lambda_handler per project. Identifies prune candidates from stigmergic-trace miss clusters (UNLEARNING_MIN_MISS_COUNT default 3) cross-referenced with drift-telemetry spurious_attractor_rate waves (UNLEARNING_SPURIOUS_ATTRACTOR_THRESHOLD default 0.5). DATA-SAFETY rails: UNLEARNING_DRY_RUN=1 (default) blocks all mutations; UNLEARNING_MUTATION_ENABLED=0 (default) report-only; IO_APPROVAL_RUNS=3 first live runs emit unlearning-candidate draft docs (subtypepattern=unlearning-candidate) only — io must approve before mutation. Mutation path (when enabled): writes reversible S3 tombstones under UNLEARNING_PREFIX (default gamma/unlearning-tombstones) with TOMBSTONE_RECOVERY_DAYS=30 recovery window, archives eligible reference tracker records (status=archived) so graph_sync removes Neo4j projection — no new edge types (OGTM). Run counter persisted at UNLEARNING_STATE_PREFIX/run_counter.json. Cost-preflight ~$0.25/mo; UnlearningCostHeadroomAlarm guards EventBridge invocations.",
+      "owner": "graph-sync",
+      "source": "ENC-TSK-K03 / ENC-FTR-106",
+      "telemetry_eligible": false,
+      "fields": {
+        "UNLEARNING_DRY_RUN": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "When truthy, handler never archives tracker records, writes tombstones, or deletes expired tombstones; still emits candidate reports."
+        },
+        "UNLEARNING_MUTATION_ENABLED": {
+          "type": "feature_flag",
+          "default": "0",
+          "definition": "Second mutation gate. Must be enabled by io after reviewing prune-candidate reports; still subject to IO_APPROVAL_RUNS ramp and dry-run."
+        },
+        "IO_APPROVAL_RUNS": {
+          "type": "integer",
+          "default": 3,
+          "definition": "First N non-dry-run invocations are report-only even when UNLEARNING_MUTATION_ENABLED=1."
+        },
+        "TOMBSTONE_RECOVERY_DAYS": {
+          "type": "integer",
+          "default": 30,
+          "definition": "S3 tombstone recover_until window before hard-delete path may remove expired keys."
+        }
+      }
+    },
+    "coordination_api.bhc_alert": {
+      "description": "See source task.",
+      "source": "ENC-TSK",
+      "telemetry_eligible": false
+    },
+    "lifecycle_service.arc_walker_telemetry": {
+      "description": "Arc-walker telemetry emitted by tracker_mutation. Latch/clear events + convergence probe metrics. CloudWatch Enceladus/ArcWalk namespace.",
+      "owner": "tracker-mutation",
+      "source": "ENC-TSK-H86 / ENC-FTR-111",
+      "telemetry_eligible": true
+    },
+    "monitoring.dedup_convergence_probe": {
+      "description": "ENC-TSK-I10 (Dedup P6) duplicate-dedup telemetry & convergence probe (DOC-DF651F07D5C2 §10). The daily-scheduled graph_health_metrics Lambda (comp-graph-health-metrics) computes the duplicate-track convergence signals over the live Neo4j projection and publishes them as governed CloudWatch metrics under the Enceladus/DedupConvergence namespace (ProjectId dimension). The same computation is exposed on demand as a read-only graph_query_api (comp-graph-query-api) graphsearch surface, search_type='dedup_convergence' (search(action='tracker.graphsearch', arguments={search_type:'dedup_convergence', project_id, cosine_threshold?, flow_window_days?, vector_top_k?})), which returns the four graph-derived signals under result.convergence and never mutates. The heavy math lives in the pure backend/lambda/graph_query_api/dedup_convergence.py module (union-find connected-components/LCC, flow windowing, precision@1 recovery proxy, walk-back model-health loop) and is packaged into the probe via .build_extras (the graph_sync/embedding.py cross-Lambda sharing precedent). No new Neo4j edge type is introduced (OGTM N/A): the probe reads existing node properties (embedding, superseded_by, created_at) and the ENC-TSK-B90 per-label HNSW vector indexes.",
+      "fields": {
+        "signals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "The five governed convergence signals (CloudWatch metric names under Enceladus/DedupConvergence). Stock: DuplicatePairStock (same-type same-project pairs at cosine >= DEDUP_COSINE_THRESHOLD). Precision@1 recovery: Precision1RecoveryProxy + Precision1RecoveryEstimate with Precision1Baseline (0.3727) and RecallCeiling (0.8242) reference metrics. Flow: NewDuplicateFlow (pairs whose newer endpoint was created within DEDUP_FLOW_WINDOW_DAYS). Percolation: DuplicateLCCSize (largest-connected-component of the same-type duplicate graph; -> 1 at convergence since isolated records are size-1 components) + NonTrivialComponentCount + EmbeddedRecordCount. Walk-back model-health loop: AutoMergeWalkBackRate + AutoMergeCount + WalkBackCount + WalkBackRateBreachedFloor.",
+          "usage_guidance": "Read via CloudWatch GetMetricStatistics on namespace Enceladus/DedupConvergence, or via the graph_query_api search_type='dedup_convergence' read surface for an on-demand snapshot (result.convergence)."
+        },
+        "precision_at_1_recovery_proxy": {
+          "type": "string",
+          "definition": "The labeled self-retrieval eval (DOC-4F1F5B99AAED, precision@1=0.3727 / recall ceiling 0.8242) is not reproducible inside a scheduled Lambda, so the probe emits a live recovery proxy: the fraction of embedded same-type records that have NO surviving near-duplicate twin (cosine >= threshold) among non-superseded peers.",
+          "usage_guidance": "Climbs toward 1.0 as duplicate twins are superseded (the I07 retrieval exclusion removes them from competition), tracking the same convergence quantity the eval measures. Precision1RecoveryEstimate maps the proxy onto the baseline->ceiling band for graphing."
+        },
+        "walk_back_model_health": {
+          "type": "object",
+          "definition": "The production auto-merge walk-back rate is the live certificate-precision estimate (DOC-DF651F07D5C2 §10). walk_back_rate = WalkBackCount / AutoMergeCount over DEDUP_WALKBACK_WINDOW_DAYS; the certificate is miscalibrated and the loop must re-enter shadow when the rate breaches (1 - DEDUP_PRECISION_FLOOR) (WalkBackRateBreachedFloor=1.0).",
+          "usage_guidance": "The probe reads the AutoMergeCount/WalkBackCount audit counters back from CloudWatch (DEDUP_AUDIT_NAMESPACE). These counters are emitted by the dedup auto-merge / un-supersession-walk-back path (tracker.dedup_auto_merge) when io enables MECHANICAL T-HIGH auto-walk; auto-merge is flag-gated DARK (enable_dedup_auto_merge off) until the certificate precision floor is certified (§13/§4.3), so the live walk-back rate is 0 / shadow until then."
+        },
+        "config_env_vars": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "graph_health_metrics environment configuration for the dedup probe: DEDUP_NAMESPACE (default Enceladus/DedupConvergence), DEDUP_AUDIT_NAMESPACE, DEDUP_COSINE_THRESHOLD (0.95), DEDUP_PRECISION_FLOOR (0.999), DEDUP_FLOW_WINDOW_DAYS (7), DEDUP_WALKBACK_WINDOW_DAYS (30), DEDUP_VECTOR_TOP_K (25).",
+          "usage_guidance": "Defined in infrastructure/cloudformation/02-compute.yaml on GraphHealthMetricsFunction. The role gains cloudwatch:GetMetricStatistics/GetMetricData (in addition to the existing PutMetricData) to read the walk-back counters."
+        }
+      }
+    },
+    "observability.orphan_metric_disambiguation": {
+      "description": "ENC-ISS-555 / ENC-TSK-N52: two formerly-overloaded 'orphan' telemetry quantities are now distinct. Consumers must not treat them as the same corpus signal.",
+      "fields": {
+        "cee_lineage_unanchored": {
+          "type": "metric",
+          "definition": "Corpus Entropy Engine (enceladus-corpus-entropy-engine) EntropyFindingCount with CloudWatch dimension Category=lineage_unanchored (formerly Category=orphan). Counts governed tracker records scanned per run where: (task|issue|feature) has no parent_task_id AND empty related_task_ids; OR (document subtype=wave) has no plan_anchor_id. Plans are excluded. This is a DynamoDB field-lineage check over the HTTP tracker/document API surface — not a Neo4j traversal. Typical gamma magnitude ~1,500 on the full corpus."
+        },
+        "graph_health_isolated_node_ratio": {
+          "type": "metric",
+          "definition": "Graph Health Metrics Lambda (graph_health_metrics) CloudWatch metric IsolatedNodeRatio in Enceladus/GraphHealth (formerly OrphanNodeRatio). Ratio = count of Neo4j nodes with zero incident edges (Cypher: MATCH (n) WHERE NOT (n)-[]-()) divided by total node count. Measures graph structural isolation, not tracker parent/plan anchors. Typical gamma magnitude ~0.0001."
+        }
+      }
+    },
+    "graph_health_metrics.real_fiedler_lambda2": {
+      "description": "ENC-TSK-K43 (B66 Ph5): FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2, not the pre-K43 GraphEdgeDensity placeholder. graph_health_metrics._fetch_real_fiedler_value cross-Lambda-invokes devops-graph-query-api's action='publish_graph_health' (the FTR-088 CSR/Fiedler path, ISS-465-compliant -- no GDS) and folds lambda2 into this Lambda's own metrics dict. Falls back to the original GraphEdgeDensity proxy only if the invoke fails, never blocking GraphNodeCount/GraphEdgeDensity/IsolatedNodeRatio (ENC-ISS-555: formerly OrphanNodeRatio).",
+      "fields": {
+        "GRAPH_QUERY_API_LAMBDA_NAME": {
+          "type": "string",
+          "definition": "Cross-Lambda invoke target function name (default devops-graph-query-api, env-suffix-aware via CFN Sub)."
+        }
+      }
+    },
+    "graph_query_api.graph_laplacian": {
+      "description": "ENC-TSK-I81 (FTR-088): graph Laplacian read action via tracker.graph_laplacian. Returns adjacency_csr (base64 float32 CSR), fiedler_vector, eigenvalues[:k], vertex_map. Uses scipy.sparse.linalg.eigsh.",
+      "fields": {
+        "vertex_set_query": {
+          "type": "string"
+        },
+        "k": {
+          "type": "integer"
+        },
+        "adjacency_csr": {
+          "type": "string"
+        },
+        "fiedler_vector": {
+          "type": "array"
+        },
+        "eigenvalues": {
+          "type": "array"
+        },
+        "vertex_map": {
+          "type": "object"
+        }
+      }
+    },
+    "graph_query_api.publish_graph_health": {
+      "description": "ENC-TSK-K43 (B66 Ph5): out-of-band Fiedler lambda2 (algebraic connectivity) GraphHealth CloudWatch metric publisher, dispatched via action='publish_graph_health' (EventBridge scheduled rule Input or direct invoke). Computes lambda2 exclusively via the existing FTR-088 graph_laplacian CSR/Fiedler path (scipy eigsh/dense eigh) — never Neo4j GDS/AGA, honoring the ISS-465 GDS cost-kill invariant. Publishes to the Enceladus/GraphHealth CloudWatch namespace, metric FiedlerValue, dimension ProjectId.",
+      "fields": {
+        "project_id": {
+          "type": "string"
+        },
+        "project_ids": {
+          "type": "array"
+        },
+        "limit": {
+          "type": "integer"
+        },
+        "k": {
+          "type": "integer"
+        },
+        "lambda2": {
+          "type": "number"
+        },
+        "lambda0": {
+          "type": "number"
+        },
+        "published": {
+          "type": "integer"
+        }
+      }
+    },
+    "scoring_service.f_governance": {
+      "description": "ENC-TSK-K43 (B66 Ph5): F_governance percentile normalization integrated into the Scoring Service's _compute_resonance_score (math gate DOC-A3D0CDF91CE9 Q3.1). F_governance = percentile_rank(F_structural) + percentile_rank(F_temporal) + percentile_rank(F_evidential), bounded [0,3], 0 = perfect governance health. governance_compliance_weight maps it to a [0,1] compliance weight applied as an optional multiplicative term on resonance_score (backward compatible: omitted -> pre-K43 score unchanged). Optional message-level f_governance field on {lesson.scoring.requested} wires through score_lesson end-to-end.",
+      "fields": {
+        "f_governance": {
+          "type": "number"
+        },
+        "f_structural": {
+          "type": "number"
+        },
+        "f_temporal": {
+          "type": "number"
+        },
+        "f_evidential": {
+          "type": "number"
+        }
+      }
+    },
+    "monitoring.convergence_telemetry": {
+      "description": "ENC-TSK-I82 (FTR-086 Ph1): Convergence Surface DDB counter table + SQS FIFO + Streams fan-out Lambda.",
+      "fields": {
+        "attribute_name": {
+          "type": "string"
+        },
+        "canonical_value": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "expires_at": {
+          "type": "integer"
+        }
+      }
+    },
+    "graph_sync.agent_identity_edges": {
+      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent identity/session/credential graph projection. Three DynamoDB stores (agent-types -> :AgentIdentity, agent-sessions -> :AgentSession, agent-credentials -> :AgentCredential) each carry a NEW_AND_OLD_IMAGES DynamoDB Stream wired through a dedicated EventBridge Pipe (AgentSessionsToGraphPipe / AgentTypesToGraphPipe / AgentCredentialsToGraphPipe) into the SAME devops-graph-sync-queue.fifo consumed by graph_sync -- no synchronous Neo4j write exists anywhere on the auth/mutation hot path (coordination_api and agent_id_alloc import no neo4j driver). The stores carry no record_type column, so graph_sync._normalize_record_for_graph synthesizes record_type (agent_identity/agent_session/agent_credential) and record_id from the id field. _upsert_agent_node MERGEs the node by its id; _reconcile_agent_edges and the generic _project_mutated_edge hook MERGE five typed edges. Counter# sentinel rows are excluded. OGTM (ENC-FTR-066) compliance: all five edge labels are registered byte-identically in graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178 drift guard) so they are traversable via tracker.graphsearch. The labels are emitted directly from the agent-store streams (NOT via the ENC-FTR-049 relationship-record path). E2E gamma tracker.graphsearch validation is a post-deploy manual/CI step (deferred to after this code merges + deploys to v4-gamma). ENC-TSK-J44 (2026-07-01): fixed a record-type synthesis bug where the id-field probe order (in _normalize_record_for_graph) checked credential_id before session_id -- since J43 added an optional credential_id FK onto agent-session rows, a credential-bound session was misclassified as agent_credential and its properties were MERGEd onto the real credential's node, corrupting shared fields (e.g. status). Probe order corrected to check each type's own PK (session_id) before any field it may merely carry as an FK.",
+      "fields": {
+        "node_labels": {
+          "type": "object",
+          "definition": ":AgentIdentity (from agent-types ENC-AGT-NNN; props agent_type_id, surface, model, cost_tier, status, usage_count), :AgentSession (from agent-sessions ENC-SES-NNN; props session_id, agent_type_id, parent_session_id, runtime, created_at, claimed_at, status, optional credential_id), :AgentCredential (from agent-credentials CRED-<uuid4hex>; props credential_id, agent_identity_id, issued_at, status, revoked_at, revoked_reason, rotated_from)."
+        },
+        "edge_types": {
+          "type": "object",
+          "definition": "AUTHENTICATED_AS (AgentSession->AgentIdentity, from session.agent_type_id); OWNED_BY (AgentCredential->AgentIdentity, from credential.agent_identity_id); DERIVED_FROM (AgentCredential->parent AgentCredential, from credential.rotated_from, when present); TRIGGERED_BY (AgentSession->triggering session/routine, from session.parent_session_id, skipped when 'root'); MUTATED (AgentSession->any mutated record, from write_source.provider matching ^ENC-SES-[0-9A-Z]+$ and differing from the record's own id)."
+        },
+        "relationship_type_keys": {
+          "type": "object",
+          "definition": "graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL registers 'authenticated-as'->AUTHENTICATED_AS, 'owned-by'->OWNED_BY, 'derived-from'->DERIVED_FROM, 'triggered-by'->TRIGGERED_BY, 'mutated'->MUTATED for OGTM registry consistency."
+        },
+        "ogtm_compliance": {
+          "type": "object",
+          "definition": "graph_sync projection handlers (_upsert_agent_node, _reconcile_agent_edges, _project_mutated_edge); RELATIONSHIP_TYPE_TO_EDGE_LABEL entries; graph_query_api._ALLOWED_EDGE_TYPES registration of the five labels (byte-identical per ENC-ISS-178); E2E tracker.graphsearch validation on gamma (post-deploy manual/CI step). Governing feature ENC-FTR-074."
+        },
+        "no_write_amplification": {
+          "type": "object",
+          "definition": "All projection rides the existing DynamoDB Streams -> EventBridge Pipe -> SQS FIFO -> graph_sync path. coordination_api/lambda_function.py and coordination_api/agent_id_alloc.py contain no neo4j import or call; the graph is a derived read-index that reflects DynamoDB (source of truth) asynchronously."
+        }
+      }
+    },
+    "coordination.agent_credential": {
+      "description": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-credential lifecycle store (DynamoDB table agent-credentials${EnvironmentSuffix}, PK credential_id). A credential is the durable, revocable link between an agent identity (ENC-AGT-NNN) and the M2M auth material minted for it (ENC-FTR-074 Ph1/Ph2 dual-client Cognito). Server-only minting (agent_id_alloc.mint_credential_id, uuid4-based, forbidden-field guarded per ENC-TSK-B99). Lifecycle issue -> rotate -> revoke via conditional DynamoDB writes; revoke cascades DynamoDB-side (retire bound sessions via retire_session; recursively revoke rotation descendants by rotated_from). HTTP surface: POST /api/v1/coordination/agents/credentials (issue), POST .../credentials/{id}/rotate, POST .../credentials/{id}/revoke. Streamed to graph_sync for :AgentCredential nodes + OWNED_BY / DERIVED_FROM edges (see graph_sync.agent_identity_edges).",
+      "fields": {
+        "credential_id": {
+          "type": "string",
+          "definition": "Partition key. Format CRED-<uuid4 hex, 32 chars>. Minted server-side; callers may never supply it."
+        },
+        "agent_identity_id": {
+          "type": "string",
+          "definition": "The owning agent identity (ENC-AGT-NNN). Drives the graph OWNED_BY edge. Required; validated to have the ENC-AGT prefix at issue time."
+        },
+        "issued_at": {
+          "type": "string",
+          "definition": "ISO-8601 Z timestamp (serialization._now_z) of issuance."
+        },
+        "status": {
+          "type": "string",
+          "definition": "Lifecycle status. One of: active, revoked. Terminal at revoked."
+        },
+        "revoked_at": {
+          "type": "string",
+          "definition": "ISO-8601 Z timestamp of revocation; empty string while active."
+        },
+        "revoked_reason": {
+          "type": "string",
+          "definition": "Free-text revoke reason. 'rotated' when revoked by rotate_credential; 'cascade:<root_credential_id>' when revoked by a parent's revoke cascade; caller-supplied otherwise. Empty while active."
+        },
+        "rotated_from": {
+          "type": "string",
+          "definition": "Nullable parent credential_id establishing rotation lineage. Set on the successor issued by rotate_credential. Drives the graph DERIVED_FROM edge (child -> parent). Empty string for a root (non-rotated) credential."
+        }
+      },
+      "related_session_field": {
+        "type": "string",
+        "definition": "agent-sessions rows may carry an OPTIONAL credential_id binding the session to the credential it authenticated with (written only when provided by mint_session_id, preserving the frozen SESSION_NODE_PROPERTIES value-identity shape for the credential-less path). revoke_credential's cascade reaps live sessions whose credential_id matches."
+      }
+    },
+    "coordination.agent_session": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Session-allocation store (DynamoDB table agent-sessions${EnvironmentSuffix}) keyed by a server-minted ENC-SES-NNN; one row per governed agent session. Monotonic single-assignment: a minted, claimed, or retired id is never reissued (sessions retire, they do not recycle). v3 flat store; the property set is value-identical to the intended v4 session node so v4 promotion is a backfill, not a reshape (binding release gate, DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py) reusing tracker_mutation's discipline; callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-SES' sentinel row in the same table (excluded from v4 node backfill). The coordination(action=agent.*) MCP surface is ENC-TSK-I38; the active_agent_session_id value-swap is ENC-TSK-I40. Backported to v4/main gamma by ENC-TSK-J43 (I38 HTTP routes only existed on main/v3-prod prior). ENC-TSK-J43 / ENC-FTR-074 Ph3 additionally added the optional credential_id binding field so a session can be linked to an AgentCredential (coordination.agent_credential) for cascade-revocation and graph AUTHENTICATED_AS/OWNED_BY chain verification; streamed to graph_sync for :AgentSession node + AUTHENTICATED_AS/TRIGGERED_BY/MUTATED edges (see graph_sync.agent_identity_edges).",
+      "fields": {
+        "session_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-SES-NNN (partition key). base-36 monotonic sequence (ENC-FTR-056 discipline). Never caller-supplied (ENC-TSK-B99 ID Boundary Rule)."
+        },
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Foreign key to coordination.agent_type (ENC-AGT-NNN) -- the agent type this session is typed as."
+        },
+        "parent_session_id": {
+          "type": "string",
+          "definition": "ENC-SES-NNN of the dispatching parent session, or 'root' for a self-allocated (ad-hoc) session."
+        },
+        "runtime": {
+          "type": "string",
+          "definition": "Session runtime/surface descriptor (e.g. 'cc-desktop-opus48')."
+        },
+        "created_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC mint timestamp."
+        },
+        "claimed_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC claim timestamp; empty until claimed. A pre-allocated (dispatched) session stays 'allocated' with empty claimed_at until the child claims it (ENC-TSK-I38)."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "allocated",
+            "claimed",
+            "retired"
+          ],
+          "definition": "Session lifecycle. allocated -> claimed (allocated-to-claimed flip on claim) -> retired. A self-allocated session is minted directly as claimed. Append-only; retire never recycles the id. Also flipped to retired by a bound credential's revoke cascade (ENC-TSK-J43)."
+        },
+        "credential_id": {
+          "type": "string",
+          "definition": "ENC-TSK-J43 / ENC-FTR-074 Ph3. Optional foreign key to coordination.agent_credential. Written ONLY when the session is minted with a credential_id (validated active at mint time); omitted entirely -- not written as an empty string -- when no credential is bound, to preserve the frozen v4 SESSION_NODE_PROPERTIES shape (DOC-05C45B438FC1). Drives the graph AUTHENTICATED_AS edge target resolution alongside agent_type_id, and is the scan-filter key revoke_credential's cascade uses to find and retire bound sessions."
+        },
+        "last_activity_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-J71 (DOC-5B888FCA43B8 section 5.9 / ENC-ISS-441): heartbeat refreshed by every escalation.watch poll (agent_id_alloc.touch_session_activity - conditional on the session being live; retired/missing sessions return session_touched=false rather than failing the poll). The idle sweep's _idle_reference now prefers last_activity_at over claimed_at/created_at, so a listening agent waiting on io's approval is not idle-retired. The 10-minute unclaim TTL is unaffected."
+        },
+        "updated_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-L35 (B67 PWA2.0 session detail). Bumped on every session-requiring request that passes the tracker_mutation/checkout_service SCI gate (_touch_session_activity), unconditionally -- including grandfathered pre-epoch sessions and checkout-service-forwarded calls, which previously were NOT touched. Surfaced on the new SES detail page (KeyValuePairs) alongside last_activity_at."
+        },
+        "history": {
+          "type": "array",
+          "item_type": "object",
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-L35 (B67 PWA2.0 session detail + worklog mirroring). Best-effort mirror of every worklog entry a session appends to ANY governed record (task/issue/feature/lesson/plan/generation) via the shared /{project}/{type}/{id}/log endpoint (tracker_mutation._mirror_worklog_to_session). Each item: {timestamp, status:'worklog', description ('[type:id] <desc>'), source_record_type, source_record_id}. Append-only, never fails the primary worklog append on error. Rendered on the SES detail page as a Table."
+        }
+      }
+    },
+    "coordination.agent_type": {
+      "description": "ENC-TSK-I37 / ENC-FTR-117 (Agent ID v3). Agent-type directory (DynamoDB table agent-types${EnvironmentSuffix}) keyed by a server-minted ENC-AGT-NNN; one durable row per surface-and-model tuple (e.g. Claude Desktop / Opus 4.8). Low-volume controlled vocabulary, not a per-session record. Property set value-identical to the intended v4 agent-type node (DOC-05C45B438FC1). Minted server-side by coordination_api (agent_id_alloc.py); callers never supply an id (ENC-TSK-B99). The monotonic counter is a reserved 'counter#ENC-AGT' sentinel row. Agent-type nodes are the retrieval-eligible half of the Agent ID model; selection telemetry (usage_count) supports cheapest-sufficient agent-type choice. Backported to v4/main gamma by ENC-TSK-J43.",
+      "fields": {
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Server-minted ENC-AGT-NNN (partition key). base-36 monotonic sequence. Never caller-supplied (ENC-TSK-B99)."
+        },
+        "surface": {
+          "type": "string",
+          "definition": "Agent surface (e.g. Claude Desktop, Claude Code Terminal, Cursor Cloud, Codex, Bedrock)."
+        },
+        "model": {
+          "type": "string",
+          "definition": "Model (e.g. Opus 4.8, Sonnet 4.6, Haiku 4.5)."
+        },
+        "cost_tier": {
+          "type": "string",
+          "definition": "Relative cost tier, used for the power-versus-cost agent-type selection decision."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "active",
+            "deprecated"
+          ],
+          "definition": "active, or deprecated when the underlying model is superseded."
+        },
+        "usage_count": {
+          "type": "integer",
+          "definition": "Server-incremented count of sessions of this agent type. Observed telemetry, not a hand-maintained fit assertion."
+        }
+      }
+    },
+    "mcp_server.agent_actions": {
+      "description": "ENC-TSK-I38, backported to v4/main gamma by ENC-TSK-J43. The coordination(action=agent.*) MCP tool surface: agent.register/agent.claim/agent.list/agent.retire proxy to POST/GET /api/v1/coordination/agents/sessions[/claim|/{id}/retire] on coordination_api; agent.type.list/agent.type.register proxy to GET/POST /api/v1/coordination/agents/types. All routes go through the real coordination_api Lambda over HTTPS (tools/enceladus-mcp-server/server.py _coordination_api_request) -- never fabricated/mocked. ENC-TSK-J43 additionally threads an optional credential_id through agent.register's payload build, forwarded only when the caller supplies it (fully backward compatible).",
+      "fields": {
+        "agent_register.credential_id": {
+          "type": "string",
+          "definition": "ENC-TSK-J43. Optional. When supplied, binds the minted session to an existing active AgentCredential (coordination.agent_credential); the underlying coordination_api call rejects (400) an unknown or non-active credential_id."
+        }
+      }
+    },
+    "document.lesson-candidate": {
+      "description": "Lesson-candidate document subtype (ENC-FTR-096). Drafted directly to DynamoDB by the memory_consolidation Lambda (ENC-TSK-I84) from recurring co-citation clusters -- NOT created via document_api PUT, so it is absent from the document_subtype allow-list enforced there. Curated (approved/rejected) via ENC-TSK-J46: coordination_api POST /api/v1/coordination/lesson-candidates/{documentId}/approve|reject, both Cognito-gated.",
+      "fields": {
+        "document_subtype": {
+          "type": "string",
+          "literal_value": "lesson-candidate",
+          "definition": "Fixed subtype value for candidate documents. Written directly by memory_consolidation Lambda; document_api's PUT/PATCH document_subtype allow-list does not include it (candidates are never created or re-subtyped through that surface)."
+        },
+        "handoff_status": {
+          "type": "enum",
+          "enum": [
+            "pending",
+            "approved",
+            "stale"
+          ],
+          "transitions": {
+            "pending": [
+              "approved",
+              "stale"
+            ],
+            "approved": [],
+            "stale": []
+          },
+          "definition": "Curation-state field, reusing the handoff_status attribute name (document_api CANDIDATE_STATUSES / CANDIDATE_STATUS_TRANSITIONS, ENC-TSK-J46). 'approved' is only a legal value for lesson-candidate documents -- handoff documents keep their own {pending,claimed,completed,stale} vocabulary.",
+          "write_authority": "document_api Lambda PATCH. Transitions to 'approved' or 'stale' require a Cognito-authenticated session (document_api._is_cognito_session); an internal-key (agent) session is rejected with 403. This is the enforced io-gate: no agent session can promote or reject a lesson candidate autonomously.",
+          "usage_guidance": "List pending candidates via documents.list(document_subtype='lesson-candidate', handoff_status='pending', sort='created_at'). Approve/reject through coordination_api's lesson-candidates routes (see coordination.lesson_candidates), not a raw PATCH -- approval also creates the governed ENC-LSN record."
+        },
+        "related_items": {
+          "type": "array",
+          "definition": "Source Handoff document IDs the candidate's co-citation cluster was drawn from (ENC-TSK-I84 AC-3)."
+        },
+        "cluster_member_ids": {
+          "type": "array",
+          "definition": "Tracker record IDs that recur together as the co-citation cluster underlying this candidate."
+        },
+        "frequency_count": {
+          "type": "number",
+          "definition": "Count of distinct Handoff documents in which the cluster co-cited within the lookback window."
+        }
+      }
+    },
+    "coordination.lesson_candidates": {
+      "description": "ENC-TSK-J46 / ENC-FTR-096 Ph2: coordination_api HTTP surface that promotes or rejects a pending lesson-candidate document. Approve creates a governed ENC-LSN record via the same validation as tracker.create_lesson (observation/insight/evidence_chain/provenance/pillar_scores), stamping the candidate's document_id into evidence_chain (LEARNED_FROM provenance at graph_sync), then marks the candidate handoff_status='approved'. Reject marks handoff_status='stale' with an appended rejection note -- the candidate document is never deleted (append-only discipline).",
+      "fields": {
+        "route": {
+          "type": "string",
+          "enum": [
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/approve",
+            "POST /api/v1/coordination/lesson-candidates/{documentId}/reject"
+          ],
+          "definition": "Both routes require a Cognito-authenticated session (_is_cognito_session); an internal-key (agent) session receives 403. Gamma-only (Condition: IsGamma in 03-api.yaml) per DOC-499FA089EC30 -- v3-prod is frozen pending the io-gated cutover."
+        },
+        "approve.body.observation": {
+          "type": "string",
+          "required": true,
+          "definition": "What was observed in the candidate data. Required on the created lesson (ENC-FTR-052); immutable after creation."
+        },
+        "approve.body.insight": {
+          "type": "string",
+          "required": true,
+          "definition": "What was learned from the observation. Required on the created lesson."
+        },
+        "approve.body.pillar_scores": {
+          "type": "object",
+          "required": true,
+          "definition": "efficiency, human_protection, intention, alignment, each a number in [0.0, 1.0] (ENC-FTR-054). Validated identically to tracker_mutation's create-lesson check."
+        },
+        "approve.body.evidence_chain": {
+          "type": "array",
+          "required": false,
+          "definition": "Optional additional evidence record IDs. The candidate document_id is always prepended automatically -- this is what stamps LEARNED_FROM provenance back to the candidate."
+        },
+        "reject.body.rejection_reason": {
+          "type": "string",
+          "required": true,
+          "constraints": {
+            "min_length": 10
+          },
+          "definition": "Human-readable reason appended (append-only) to the candidate document content when marking it stale."
+        },
+        "decision_write_mechanism": {
+          "type": "string",
+          "definition": "Approve/reject finalize the candidate's handoff_status via a direct DynamoDB UpdateItem against the documents table (DocumentsTableCandidateDecisionWrite IAM statement, 02-compute.yaml), atomically conditioned on document_subtype='lesson-candidate' AND handoff_status='pending', and append a structured {status,note,by,at} entry to decision_log via list_append. This is NOT proxied through document_api's PATCH: that endpoint authenticates internal-key callers identically whether the caller is coordination_api (already Cognito-verified at its own HTTP layer) or the MCP server relaying a bare agent session's documents.patch call -- routing through it would silently readmit the exact autonomous-promotion path AC4 forbids. A ConditionalCheckFailedException (candidate already decided by a concurrent request) surfaces as HTTP 409. ENC-TSK-J59: pillar_scores and confidence are converted to Decimal (via Decimal(str(v)) to avoid binary-float precision drift) before the lesson record's put_item -- boto3's TypeSerializer raises TypeError on native float Number values."
+        }
+      }
+    },
+    "tracker.escalation": {
+      "description": "ENC-FTR-121 (DOC-5B888FCA43B8): Escalations — Human-Gated Mutation Override Surface. An escalation is an agent-proposed, io-approved request to apply a mutation the normal lifecycle rules disallow (deploy arc change after checkout; direct state transition override including path-illegal and post-closure transitions). Items live in the existing tracker table (no new table/GSI) as a dedicated item type OUTSIDE _RECORD_TYPES: the generic record CRUD, checkout, and tracker.set surfaces cannot touch them, and escalations are not themselves escalatable. The gate moves; it does not weaken: approval is Cognito-human-only (no MCP action, SCI token, or internal key maps to approve/deny), and exactly one privileged code path (applyEscalatedMutation, Ph2/ENC-TSK-J69) may apply an approved mutation. Phase 1 (ENC-TSK-J68) ships the entity plus the request/get/list surface.",
+      "fields": {
+        "escalation_id": {
+          "type": "string",
+          "constraints": {
+            "format": "{PREFIX}-ESC-{SEQ}",
+            "immutable": true
+          },
+          "definition": "Server-minted escalation ID (e.g. ENC-ESC-001).",
+          "usage_guidance": "Minted by tracker_mutation's atomic-counter ID authority via the 'escalation' entry in _TRACKER_TYPE_SUFFIX. ID Boundary Rule holds without exception: no client predicts, computes, or scans for the next ID."
+        },
+        "target_record_id": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "The tracker record the requested mutation targets.",
+          "usage_guidance": "Must be an existing task (TSK), issue (ISS), or feature (FTR) record. Validated for existence at request time with a consistent read."
+        },
+        "mutation_type": {
+          "type": "enum",
+          "enum": [
+            "deploy_arc_change",
+            "direct_state_override"
+          ],
+          "constraints": {
+            "required": true,
+            "immutable": true
+          },
+          "definition": "Registry-resolved mutation handler key (§5.3 of DOC-5B888FCA43B8).",
+          "usage_guidance": "deploy_arc_change: payload carries new_deploy_arc_type (dictionary-legal transition type; target must be a task); the active checkout survives application. direct_state_override: payload carries target_status plus optional field_values; status legality IS validated per record type, path legality deliberately is NOT — the path is what io approval overrides. Adding a mutation type is a registry entry plus handler, not an architectural change."
+        },
+        "payload": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Mutation-type-specific payload, validated by the handler's validate_payload at request time.",
+          "usage_guidance": "Stored as a JSON document on the item; malformed payloads fail fast at request time and never reach io's queue."
+        },
+        "justification": {
+          "type": "string",
+          "constraints": {
+            "required": true,
+            "min_length": 1
+          },
+          "definition": "Required free-text rationale from the requesting agent, shown to io on the PWA approval card."
+        },
+        "expected_version": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Optional target-record version or content hash captured at request time.",
+          "usage_guidance": "When supplied and the target has drifted by approval time, the PWA shows a drift warning; io may still approve (informed consent) or deny."
+        },
+        "requested_by": {
+          "type": "object",
+          "constraints": {
+            "required": true
+          },
+          "definition": "Requesting agent identity: {session_id (ENC-SES-*, required), agent_type_id (ENC-AGT-*), sci_present (bool)}.",
+          "usage_guidance": "session_id is required (server-minted ENC-SES id; ENC-FTR-117). SCI-bearing sessions stamp sci_present=true once ENC-ISS-441 ships."
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "requested",
+            "approved",
+            "denied",
+            "denied_with_guidance",
+            "applying",
+            "applied",
+            "failed"
+          ],
+          "definition": "Escalation FSM state (§5.2). Enforced normally — escalations are not escalatable.",
+          "usage_guidance": "requested→{approved, denied, denied_with_guidance}; approved→applying; applying→{applied, failed}. denied, denied_with_guidance, applied, and failed are terminal. A failed application never silently retries into the target record: the corrective request is a NEW escalation (exactly-once semantics)."
+        },
+        "events": {
+          "type": "array",
+          "item_type": "object",
+          "definition": "Append-only event log (§11.2). Each entry: {event_type, at (iso8601), actor (session_id | cognito_sub | system), detail?, guidance_note? (denied_with_guidance only)}.",
+          "usage_guidance": "APPEND_ONLY. One event per FSM transition. The escalation.watch cursor poll (Ph4/ENC-TSK-J71) streams these."
+        },
+        "guidance_note": {
+          "type": "string",
+          "constraints": {
+            "required": false
+          },
+          "definition": "io's free-text course-correction note on deny-with-guidance; travels back to the agent in the event stream."
+        },
+        "approved_by": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Cognito sub + email of the approving human. Null until approval.",
+          "usage_guidance": "Written only by the Cognito-gated approval route (Ph3/ENC-TSK-J70). Structurally unwritable by agent credentials."
+        },
+        "applied_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "required": false
+          },
+          "definition": "Set exactly once when applyEscalatedMutation completes. Null until then.",
+          "usage_guidance": "Presence is the idempotency guard: a concurrent or repeated applier invocation observing applied_at no-ops (§5.5)."
+        },
+        "result": {
+          "type": "object",
+          "constraints": {
+            "required": false
+          },
+          "definition": "Applier outcome object (success detail or captured error on failed). Null until terminal."
+        },
+        "created_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601",
+            "immutable": true
+          },
+          "definition": "Server-stamped at request time."
+        },
+        "updated_at": {
+          "type": "string",
+          "constraints": {
+            "format": "iso8601"
+          },
+          "definition": "Server-stamped on every mutation."
+        },
+        "escalation_provenance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writable_by": [
+            "server"
+          ],
+          "definition": "ENC-TSK-J69: append-only list of escalation IDs applied to a TARGET record (stamped on the target, not the escalation, inside the applier's atomic write together with the [ESCALATION-APPLIED] worklog entry carrying requesting session, approving human, before/after states, and waived fields). Artifact-Genesis: every override leaves an artifact."
+        }
+      },
+      "dynamodb_key_schema": {
+        "pk": "project_id",
+        "sk_pattern": "escalation#{escalation_id}",
+        "table": "existing tracker table (deliberate Channel B decision — no new table, GSI, or CloudFormation diff; DOC-B716E8FB10B6)",
+        "record_id_format": "{PREFIX}-ESC-{SEQ}",
+        "delete_method": "None. Terminal escalations remain browsable for audit; every override leaves an artifact."
+      },
+      "mutation_rules": {
+        "escalation_id": "IMMUTABLE (server-minted)",
+        "target_record_id": "IMMUTABLE after create",
+        "mutation_type": "IMMUTABLE after create",
+        "payload": "IMMUTABLE after create — the cached mutation is what io approves; the agent never resubmits after approval",
+        "status": "Escalation FSM transitions only (§5.2); enforced normally with no bypass",
+        "events": "APPEND_ONLY (list_append only)",
+        "approved_by": "Written only by the Cognito human approval route",
+        "applied_at": "Written exactly once by applyEscalatedMutation"
+      },
+      "required_fields": [
+        "target_record_id",
+        "mutation_type",
+        "payload",
+        "justification",
+        "requested_by"
+      ],
+      "waiver_semantics": {
+        "escalation_waived_sentinel": {
+          "shape": {
+            "escalation_waived": true,
+            "escalation_id": "ENC-ESC-NNN",
+            "waived_at": "iso8601"
+          },
+          "definition": "Section 5.6: when direct_state_override lands a record in a state whose invariant fields are unsupplied, each such field is written with this sentinel rather than left null. Downstream consumers read 'known-absent by human decision', semantically distinct from 'never reached' or 'data loss'. LIVE as of ENC-TSK-J69: written by _apply_direct_state_override. Null-handling audit finding (2026-07-02): the deploy/closed evidence validators in tracker_mutation validate REQUEST transition_evidence, not stored record state, so sentinel-bearing records do not break them; the sentinel is a dict, making accidental string ops fail loudly and grep-ably rather than silently."
+        },
+        "escalated_closure": {
+          "type": "boolean",
+          "definition": "Set true on any record closed via direct_state_override so ENC-FTR-118 empirical-runtime metrics and close-quality reporting can filter override closures out of organic-completion datasets. LIVE as of ENC-TSK-J69 (written by _apply_direct_state_override; task closures also increment closed_count so DESIGNS-edge and subtask gates keep organic parity)."
+        }
+      },
+      "applier": {
+        "function": "applyEscalatedMutation (_handle_escalation_apply, tracker_mutation)",
+        "route": "POST /{projectId}/escalation/{escalationId}/apply (rides the registered {recordType}/{recordId}/{sub} route shape; tracker:write scope)",
+        "definition": "ENC-TSK-J69 (Ph2): the SINGLE privileged code path that may write transitions the normal FSM forbids (Tenet 2). Sequence per section 5.5: approved+applied_at-null guard (repeat/concurrent invocation no-ops); conditional approved->applying transition is the concurrency gate (ConditionExpression status=approved AND attribute_not_exists(applied_at)); fresh consistent target read; registry handler apply executes exactly ONE atomic UpdateItem on the target (provenance worklog + escalation_provenance append ride the same write, so a handler exception leaves the target untouched); applying->applied stamps applied_at + result; on failure applying->failed captures the error in result and a corrective request is a NEW escalation. Reachability: application requires status=approved, which only the Cognito-human approval route (Ph3/ENC-TSK-J70) can write - no MCP action, SCI token, or internal key maps to approve. Normal validators in _handle_update_field are untouched and carry no bypass flags. Emits record.escalation.applied to the enceladus.tracker audit event bus.",
+        "handler_applies": {
+          "deploy_arc_change": "rewrites transition_type (and checkout_transition_type when present, which recomputes arc-derived gate expectations) in place; checkout fields untouched so an active checkout survives.",
+          "direct_state_override": "writes target_status regardless of path legality; supplied field_values written verbatim; unsupplied required-for-state fields (from the transition-matrix gate contracts: committed->commit_sha, deploy-success->arc evidence key, closed->arc closed-evidence key, issue closed->evidence) get the escalation_waived sentinel; closures set escalated_closure=true and increment closed_count for tasks (organic-gate parity)."
+        }
+      },
+      "notifications": {
+        "definition": "ENC-TSK-J72 (Ph5, section 5.8): tracker_mutation publishes an SNS notification with subject prefix [ESCALATION] on requested (after the durable item write) and on the terminal applied/failed transitions (closure telemetry). Topic: ESCALATION_ALERTS_TOPIC_ARN env, defaulting via CFN to the existing devops-feed-alerts{EnvironmentSuffix} topic (reuse - zero new infrastructure). FAILURE-ISOLATED by contract: an SNS error or unset ARN is logged and swallowed; notification can never fail the escalation write or the applier. Payload: escalation_id, target_record_id, mutation_type, requesting session, justification/result excerpt. Cost: tens of emails/month inside the SNS email free tier - combined feature incremental cost under one dollar per month. RESIDUAL (Ph8): the topic has no email subscription yet; io must subscribe + confirm to actually receive mail. IAM: PublishEscalationAlerts Sid on TrackerMutationRole (gamma via the compute stack; prod via Ph7a backport)."
+      }
+    },
+    "mcp_server.escalation_actions": {
+      "description": "ENC-FTR-121 Ph1 (ENC-TSK-J68): code-mode MCP surface for escalations, registered behind ENABLE_ESCALATION_PRIMITIVE (default ON; the request/read surface is inert unless called and carries no privileged write path). escalation.request is an execute action (requires governance_hash) resolving to POST /{project}/escalation on tracker_mutation; escalation.get and escalation.list are search actions resolving to GET /{project}/escalation[/{id}] with status / target_record_id / session_id / page_size filters. approve/deny deliberately have NO MCP action — override authorization exists only behind the Cognito human path (§6 non-delegable approval). escalation.watch (cursor event polling) ships in Ph4 (ENC-TSK-J71). DEPLOY NOTE (ENC-TSK-J11 class): the MCP server deploys out-of-band from the Gen2 backend Lambda matrix; the live mcp.jreese.net route map exposes these actions only after its own deploy, though the backend HTTP routes are live with the compute deploy.",
+      "fields": {
+        "escalation.request": {
+          "type": "execute_action",
+          "definition": "Propose a human-gated mutation override. Envelope (§11.1): target_record_id, mutation_type, payload, justification (all required); expected_version, requested_by optional (session_id falls back to write_source.provider)."
+        },
+        "escalation.get": {
+          "type": "search_action",
+          "definition": "Return the full escalation item by escalation_id (project_id required)."
+        },
+        "escalation.list": {
+          "type": "search_action",
+          "definition": "List escalations filterable by status, target_record_id, session_id; page_size 1-200 (default 50), newest first. ENC-TSK-J69: the MCP server calls GET /{project}/escalation/list (pseudo-id alias riding the registered {recordType}/{recordId} API Gateway route) because explicit gamma-style route tables register no bare {recordType} collection path; 'list' can never collide with a server-minted ENC-ESC-* id."
+        },
+        "escalation.watch": {
+          "type": "coordination_action",
+          "definition": "ENC-TSK-J71: coordination(action=escalation.watch, arguments={session_id, since?, project_id?}) -> GET /api/v1/coordination/escalations/watch. Pass the returned next_cursor back as since. Registered behind ENABLE_ESCALATION_PRIMITIVE. ENC-TSK-J89 (2026-07-02.07): MCP handler fixed to call the coordination API with a base-relative path (/escalations/watch); the prior absolute path double-prefixed COORDINATION_API_BASE and 404d on gamma and prod."
+        }
+      }
+    },
+    "coordination.escalations": {
+      "description": "ENC-FTR-121 Ph3 (ENC-TSK-J70, DOC-5B888FCA43B8 sections 5.7 + 6): io's escalation approval surface on coordination_api - the SOLE origin of override authorization in the platform. Every route verifies a genuine Cognito session server-side per call (_is_cognito_session); internal-key and managed-token credentials are structurally rejected with 403. ENC-TSK-L92 / ENC-ISS-501 (SEV-1, 2026-07-07): _is_cognito_session alone was found to be a fail-open BLOCKLIST (it excludes only auth_mode in {internal-key, managed-token} -- any OTHER or absent auth_mode passed), which let a non-human Cognito-authenticated identity self-approve escalations within seconds of filing with no human review. The approve/deny routes now ALSO require the decider's Cognito email claim to appear in a positive allowlist (_is_allowlisted_escalation_decider) sourced from a Console-edit-only S3 document that no Lambda role -- including this one -- has write access to; the allowlist check fails CLOSED on any fetch/parse error. No MCP action maps to approve or deny. Approve stamps approved_by {sub, email}, walks requested->approved under a ConditionExpression race guard, and drives applyEscalatedMutation (ENC-TSK-J69) in tracker_mutation via direct Lambda invoke (TRACKER_MUTATION_LAMBDA_NAME + X-Coordination-Internal-Key); the approval is durable even if the applier invoke fails (fail-soft: the escalation stays approved and the idempotent apply route can be re-driven - the agent never resubmits the cached mutation). Deny walks requested->denied, or requested->denied_with_guidance when a guidance_note is supplied; the note is stored on the item AND rides the denial event so watch polling (Ph4) delivers it to the agent. ENC-TSK-M12 / ENC-ISS-501 (2026-07-08): the email allowlist authorizes WHICH identities may decide but not WHAT KIND of token may decide -- coordination_api's _verify_token deliberately accepts Cognito ACCESS tokens (token_use=access, client_id match) for the general API surface, and machine-operated Cognito users in the human pool (e.g. terminal-agent@enceladus.internal, mintable via coordination auth.cognito_session) carry genuine ID tokens, so an allowlisted-by-mistake machine identity would have reopened approve/deny. The decision routes now ALSO require _is_human_cognito_principal (fail-closed): token_use must be exactly 'id' (rejects access/client_credentials/M2M grants and the token-use-less internal-key/managed-token modes), the token's aud must be on the human app-client allowlist (ESCALATION_HUMAN_CLIENT_IDS, default COGNITO_CLIENT_ID), bare client_id-without-aud shapes are rejected, and the email claim must exist and not fall under a machine principal domain (ESCALATION_MACHINE_EMAIL_DOMAINS, default enceladus.internal). This gate runs BEFORE the allowlist check and rejects machine principals with 403 regardless of allowlist contents. Prod (main branch) enforces the identical claim checks in the standalone escalation_decision_authorizer (ENC-TSK-L95) in front of the routes.",
+      "fields": {
+        "GET /api/v1/coordination/escalations": {
+          "type": "route",
+          "definition": "io approval queue feed. Query params: project_id (default enceladus), status. Pending (requested) escalations carry a fresh section-5.7 render_diff computed from the LIVE target record at render time - never the cached request - including a drift object {expected_version, current_sync_version, current_updated_at, detected} when expected_version was supplied. Terminal escalations return in a separate array for the collapsed audit section. Cognito-only."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/approve": {
+          "type": "route",
+          "definition": "Non-delegable approve: requested->approved + approved_by + event, then drives the applier. Returns applied:true|false with apply_result or apply_error+retry. ENC-TSK-L92: gated by _is_cognito_session AND _is_allowlisted_escalation_decider (both must pass); an allowlist-miss returns 403 before any DynamoDB write. ENC-TSK-M12: additionally gated by _is_human_cognito_principal (token_use=id + human app-client aud + non-machine email domain, fail-closed) BEFORE the allowlist check; machine token shapes 403 with a distinct 'structurally rejected' error."
+        },
+        "POST /api/v1/coordination/escalations/{projectId}/{escalationId}/deny": {
+          "type": "route",
+          "definition": "Non-delegable deny: requested->denied (or denied_with_guidance when body.guidance_note is non-empty). Denied escalations are never applied. ENC-TSK-L92: same dual gate as approve. ENC-TSK-M12: same triple gate as approve."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_BUCKET": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501 / ENC-ISS-505. Env var (default 'enceladus-356364570033-us-west-2-an'). S3 bucket holding the escalation-approver allowlist document. ENC-ISS-505 (SEV-1): originally 'jreese-net', which is served publicly on the open web via CloudFront (multiple distributions) -- the allowlist was readable by anyone at https://jreese.net/security/escalation-approvers.md with no auth. Relocated to this bucket, which has no CloudFront origin and full S3 Public Access Block enabled."
+        },
+        "ESCALATION_APPROVER_ALLOWLIST_KEY": {
+          "type": "string",
+          "definition": "ENC-TSK-L92 / ENC-ISS-501. Env var (default 'security/escalation-approvers.md'). S3 key of the allowlist document. coordination_api's Lambda role is granted s3:GetObject ONLY on this exact key (EscalationApproverAllowlistRead statement, infrastructure/cloudformation/02-compute.yaml) -- no role in the account, including this Lambda's own, has PutObject/DeleteObject on it. The document is a markdown file with a fenced yaml block of `- email: \"...\"` list entries, parsed without a yaml dependency by _load_escalation_approver_allowlist (60s in-memory cache). Edits require an AWS Console-authenticated human; there is deliberately no programmatic write path."
+        },
+        "GET /api/v1/coordination/escalations/watch": {
+          "type": "route",
+          "definition": "ENC-TSK-J71 (Ph4, section 5.4 + 5.9): session-scoped cursor polling - the listening AGENT's side of the loop (read scope; agent credentials are the intended callers; approval stays Cognito-only). Query params: session_id (required, ENC-SES-*), since (opaque cursor), project_id (default enceladus). Returns every section-11.2 lifecycle event newer than the cursor across all escalations the session originated (guidance_note rides denied_with_guidance events), plus next_cursor and session_touched. CURSOR SEMANTICS: base64url(JSON {escalation_id: events_consumed}) counting against the append-only events array - event timestamps are second-granular and FSM edges (applying->applied) land inside one second, so a timestamp cursor would drop same-second events; the count cursor is lossless, exactly-once, and stable on empty polls. Malformed/absent cursors replay from the start (events are facts; replay is safe). Every poll refreshes the session's last_activity_at heartbeat. POLLING GUIDANCE (section 5.8): 15-30s interval, exponential backoff after two idle hours; transport is polling ONLY (no WebSocket/SSE by design)."
+        },
+        "ESCALATION_HUMAN_CLIENT_IDS": {
+          "type": "string",
+          "definition": "ENC-TSK-M12 / ENC-ISS-501. Optional env var: comma-separated Cognito app-client ids whose ID tokens may represent a human escalation decider. Defaults to COGNITO_CLIENT_ID (the interactive PWA client) when unset. Read per-call by _escalation_human_client_ids(); an empty resolved set fails CLOSED (every decision denied). Tokens minted by any other app client (e.g. the ENC-FTR-074 agent M2M client) are rejected 403 on the decision routes regardless of their other claims."
+        },
+        "ESCALATION_MACHINE_EMAIL_DOMAINS": {
+          "type": "string",
+          "definition": "ENC-TSK-M12 / ENC-ISS-501. Optional env var: comma-separated email domains marking machine-operated Cognito principals (default 'enceladus.internal'). An otherwise-valid human-shaped ID token whose email falls under one of these domains is rejected 403 on the decision routes even if that email appears on the approver allowlist -- the allowlist must never be the only barrier between a machine principal and an escalation approval (the ENC-ISS-501 attacker identity terminal-agent@enceladus.internal is exactly this class)."
+        }
+      },
+      "pwa_surface": "Escalations item in the PWA hamburger menu -> /escalations page: pending feed newest-first (target id/title, mutation type, requesting session, justification, fresh diff, prominent drift warning that still permits informed approve/deny), Approve / Deny / Deny-with-Guidance actions, terminal escalations in a collapsed History section. Ships via the comp-enceladus-pwa gamma pipeline.",
+      "apigw_routes": "03-api.yaml (Condition: IsGamma, prod promotion io-gated per DOC-B716E8FB10B6): RouteEscalationsFeed, RouteEscalationsApprove, RouteEscalationsDeny -> CoordinationApiIntegration; RouteTrackerEscalationApply (POST /api/v1/tracker/{projectId}/{recordType}/{recordId}/apply) -> TrackerMutationIntegration as the HTTP lane to the idempotent applier."
+    },
+    "coordination.agent_session_idle_sweep": {
+      "description": "ENC-TSK-I71 / ENC-FTR-117 AC#8, backported to v4/main by ENC-TSK-J91 (ENC-ISS-441 Ph1). Scheduled idle-sweep backstop that reaps abandoned agent sessions. The AgentSessionIdleSweepSchedule EventBridge rule (infrastructure/cloudformation/02-compute.yaml, rate(1 hour)) invokes the coordination_api Lambda with Input {\"action\":\"agent_session_idle_sweep\"}; lambda_handler dispatches to _handle_agent_session_idle_sweep, which calls agent_id_alloc.sweep_idle_sessions. Sessions left in a live status (allocated or claimed) whose idle reference (last_activity_at heartbeat when present per ENC-TSK-J71/J83, else claimed_at, else created_at) is older than AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS are flipped to 'retired' via the SAME append-only conditional UpdateItem used by agent.retire (#st = :allocated OR #st = :claimed -> retired). Third leg of FTR-117 AC#8 (append-only storage + explicit agent.retire + TTL idle-sweep backstop). Deliberately NOT DynamoDB native TTL: native TTL hard-deletes and would violate the append-only retire model from ENC-TSK-I38. Idempotent - already-retired sessions are excluded by the live-status scan filter, and a candidate concurrently retired between scan and update is skipped. Not an HTTP route (no auth/claims); invoked only by EventBridge. ENC-ISS-441 Ph4 (ENC-TSK-J94) tightens the default threshold to 7200s and adds SCI revocation + the 10-minute unclaim sweep. ENC-TSK-J94: the sweep now also revokes each retired session's SCI (revocation_reason=idle_ttl_exceeded) and the default threshold is 7200s. ENC-TSK-L89: retirement now uses one DynamoDB transaction per session to retire the session, revoke any unrevoked SCI, and release all task checkouts held by that session (active_agent_session=false, active_agent_session_id='', checkout_state=checked_in) so a dead session cannot strand a task lock.",
+      "fields": {
+        "AGENT_SESSIONS_IDLE_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits and reaps nothing."
+        },
+        "AGENT_SESSIONS_IDLE_THRESHOLD_SECONDS": {
+          "type": "integer",
+          "definition": "Env var (config.py), default 7200 (2h) since ENC-ISS-441 Ph4 (ENC-TSK-J94; was 86400/24h under I71). A live session whose idle reference (last_activity_at > claimed_at > created_at) is older than this is reaped. escalation.watch polling refreshes last_activity_at (J71/J83), so listening agents are exempt while they poll."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator. Fixed value 'agent_session_idle_sweep' routes lambda_handler to the sweep. Optional idle_threshold_seconds and dry_run keys in the Input override the configured defaults for an ad-hoc invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only - no HTTP envelope): {enabled, dry_run, idle_threshold_seconds, cutoff, scanned_live, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis, released_task_count, released_tasks, released_by_session}."
+        },
+        "revoked_scis": {
+          "type": "array",
+          "definition": "ENC-TSK-J94: token ids of SCIs revoked by this sweep pass (revocation_reason=idle_ttl_exceeded). revoked_sci_count carries the count; both appear in the summary envelope and CloudWatch logs."
+        }
+      }
+    },
+    "coordination.session_claim_id": {
+      "description": "ENC-ISS-441 / ENC-TSK-J92 (ENC-FTR-122): Session Claim ID (SCI) token primitive. A server-minted bearer token proving a session completed the ENC-FTR-117 register->claim handshake. Minted EXCLUSIVELY by coordination agent.claim on the allocated->claimed flip (agent_id_alloc.mint_sci); format SCI-{uuid4_hex} (regex ^SCI-[0-9a-f]{32}$), mirroring the checkout service's CAI/CCI discipline. Stored in the checkout-tokens table (CHECKOUT_TOKENS_TABLE, env-suffixed; pk = token id, token_type=SCI) with a 24h native-TTL expiry (SCI_TTL_SECONDS=86400) - expiry hard-deletes the token, which fails CLOSED at the Ph3 (ENC-TSK-J93) enforcement gate. The claimed session item is stamped with sci_token_id (post-mint attribute, same pattern as last_activity_at; SESSION_NODE_PROPERTIES mint shape unchanged) so revocation is a direct lookup, never a scan. Revoked (revoked=true, revoked_at, revocation_reason; first revocation metadata immutable) by agent.retire (explicit_retire) and by the ENC-TSK-J94 sweeps (unclaim_ttl_exceeded / idle_ttl_exceeded). Ships DARK in J92: no enforcement point reads the token until ENC-TSK-J93.",
+      "fields": {
+        "token_id": {
+          "type": "string",
+          "definition": "SCI-{uuid4_hex} (pk in the checkout-tokens table). Returned to the caller as 'sci' in the agent.claim response envelope alongside sci_issued_at and sci_ttl_seconds."
+        },
+        "token_type": {
+          "type": "string",
+          "definition": "Fixed 'SCI' discriminator - coexists with CAI/CCI records in the same table."
+        },
+        "session_id": {
+          "type": "string",
+          "definition": "Bound ENC-SES-NNN. Ph3 enforcement matches this against the presented active_agent_session_id."
+        },
+        "agent_type_id": {
+          "type": "string",
+          "definition": "Bound ENC-AGT-NNN lineage captured at claim time."
+        },
+        "issued_at": {
+          "type": "string",
+          "definition": "ISO 8601 UTC mint timestamp."
+        },
+        "ttl": {
+          "type": "integer",
+          "definition": "Unix epoch expiry = issued_at + 86400s. DynamoDB native TTL deletes the record at expiry; an absent token is invalid at the enforcement gate (fails closed)."
+        },
+        "revoked": {
+          "type": "boolean",
+          "definition": "False at mint. Set true (with revoked_at + revocation_reason) by agent.retire or the J94 sweeps; idempotent - first revocation metadata is never overwritten."
+        },
+        "sci_token_id": {
+          "type": "string",
+          "definition": "On the agent-sessions item (NOT this token record): the session's active SCI pointer, stamped at claim. Post-mint attribute outside SESSION_NODE_PROPERTIES."
+        }
+      }
+    },
+    "coordination.agent_session_unclaim_sweep": {
+      "description": "ENC-ISS-441 / ENC-TSK-J94 (ENC-FTR-122): 10-minute unclaim TTL sweep - retirement lifecycle part 1 from the io design decision on ENC-ISS-441. The AgentSessionUnclaimSweepSchedule EventBridge rule (02-compute.yaml, rate(10 minutes)) invokes coordination_api with Input {\"action\":\"agent_session_unclaim_sweep\"}; lambda_handler dispatches to _handle_agent_session_unclaim_sweep -> agent_id_alloc.sweep_unclaimed_sessions. Sessions in status=allocated (registered via agent.register but never claimed) whose created_at is older than AGENT_SESSIONS_UNCLAIM_TTL_MINUTES are flipped to 'retired' via the same append-only conditional UpdateItem as agent.retire, and any bound SCI is revoked (revocation_reason=unclaim_ttl_exceeded; defense-in-depth - allocated sessions normally have no SCI since SCIs mint at claim). Reference timestamp is strictly created_at. Idempotent; dry_run-capable; master-flag guarded. Closes the ghost-registration gap (10 of 24 prod sessions were unclaimed, the ENC-ISS-441 evidence). ENC-TSK-L89: the same retirement transaction also releases all task checkouts held by the retiring session, clearing active_agent_session and active_agent_session_id and marking checkout_state=checked_in.",
+      "fields": {
+        "AGENT_SESSIONS_UNCLAIM_SWEEP_ENABLED": {
+          "type": "boolean",
+          "definition": "Env var (config.py + lambda_function.py), default true. Master enable flag; when false the handler short-circuits."
+        },
+        "AGENT_SESSIONS_UNCLAIM_TTL_MINUTES": {
+          "type": "integer",
+          "definition": "Env var (config.py), default 10. An allocated session whose created_at is older than this is a ghost registration and is reaped."
+        },
+        "action": {
+          "type": "string",
+          "definition": "EventBridge Input discriminator, fixed 'agent_session_unclaim_sweep'. Optional unclaim_ttl_minutes and dry_run keys override defaults per-invoke."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Return value (CloudWatch only): {enabled, dry_run, unclaim_ttl_minutes, cutoff, scanned_allocated, candidate_count, candidate_ids, retired_count, retired, skipped_count, skipped, revoked_sci_count, revoked_scis, released_task_count, released_tasks, released_by_session}."
+        }
+      }
+    },
+    "coordination.agent_session_checkout_release_backfill": {
+      "description": "ENC-TSK-L89 / ENC-FTR-122: one-time and on-demand repair surface for stale task checkouts held by already-retired ENC-SES sessions. coordination_api exposes POST /api/v1/coordination/agents/sessions/checkout-release-backfill and direct Lambda Input {\"action\":\"agent_session_checkout_release_backfill\"}; the MCP code-mode surface exposes coordination(action=\"agent.checkout_release_backfill\"). The helper scans checked-out task records account-wide, filters to owners whose agent-session row is status=retired, and releases those task locks per retired session in an atomic DynamoDB transaction. This is status-neutral: it does NOT advance, close, or override task lifecycle status, and is explicitly separate from direct_state_override.",
+      "fields": {
+        "dry_run": {
+          "type": "boolean",
+          "definition": "When true, reports candidate retired-session checkout locks without mutating tasks or SCI tokens."
+        },
+        "session_ids": {
+          "type": "array",
+          "definition": "Optional list of ENC-SES ids to restrict the backfill scan. Omit for account-wide repair."
+        },
+        "summary": {
+          "type": "object",
+          "definition": "Response: {success, dry_run, candidate_session_count, candidate_task_count, candidates_by_session, released_session_count, released_task_count, released_tasks, released_by_session, session_results, skipped_live_count, skipped_live}."
+        }
+      }
+    },
+    "checkout_service.sci_enforcement_gate": {
+      "description": "ENC-ISS-441 / ENC-TSK-J93 (ENC-FTR-122): server-side Session Claim ID enforcement in the checkout service. checkout.task (_handle_checkout), checkout.advance (_handle_advance) and /log (_handle_log) gate BEFORE any state mutation whenever the presented acting identity matches ^ENC-SES-[0-9A-Z]+$: the request's 'sci' field must resolve to a checkout-tokens item with token_type=SCI, revoked=false, ttl > now (enforced independently of DynamoDB native TTL deletion lag), and session_id equal to the presented identity. Rejections are HTTP 403 code=SCI_REQUIRED with sci_failure_mode in {missing_sci, unknown_sci, wrong_token_type, revoked_sci, expired_sci, session_mismatch, unknown_session} and remediation pointing to coordination agent.claim (register->claim handshake, ENC-FTR-117). A fabricated/unregistered ENC-SES id fails CLOSED (unknown_session). GRANDFATHERING: sessions with created_at earlier than SCI_ENFORCEMENT_EPOCH (module constant 2026-07-02T12:00:00Z, deliberately NOT an env var per the PLN-047/ENC-LSN-053 strip class) pass without an SCI. EXEMPT by identity shape: providers not matching ENC-SES-* (Cognito PWA subs/user_initiated flows, 'github', 'system:arc-walker', internal service identities) are untouched. Every SCI-validated pass refreshes the session's last_activity_at (J83 conditional touch; live sessions only; never fails the mutation). This closes the ENC-ISS-441 vulnerability: the register->claim handshake is now enforced, not advisory.",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Request-body field on checkout/advance/log calls. The SCI-{uuid4_hex} issued by coordination agent.claim. Required for post-epoch ENC-SES sessions; ignored for exempt identities."
+        },
+        "SCI_ENFORCEMENT_EPOCH": {
+          "type": "string",
+          "definition": "Module constant '2026-07-02T12:00:00Z' in both checkout_service and tracker_mutation. Sessions created before it are grandfathered. Lives in code, not env (LSN-053 avoidance)."
+        },
+        "sci_failure_mode": {
+          "type": "string",
+          "definition": "403 detail naming the failure: missing_sci | unknown_sci | wrong_token_type | revoked_sci | expired_sci | session_mismatch | unknown_session."
+        }
+      }
+    },
+    "tracker.sci_enforcement_gate": {
+      "description": "ENC-ISS-441 / ENC-TSK-J93 (ENC-FTR-122): the same SCI enforcement gate in tracker_mutation, applied where the normalized write_source.provider (the acting identity after _normalize_write_source; legacy top-level provider folds in, Cognito defaults to claims.sub) matches ^ENC-SES-[0-9A-Z]+$, at three entry points: _handle_update_field (tracker.set, including the active_agent_session checkout/release branch), _handle_log (worklog append), and _handle_create_record (record creation). Identical validation order, 403 SCI_REQUIRED envelope, grandfather epoch, fail-closed unknown_session semantics and last_activity_at touch as checkout_service.sci_enforcement_gate. ADDITIONAL EXEMPTION: requests carrying a valid X-Checkout-Service-Key header (_is_checkout_service_request, ENC-FTR-037) bypass the gate - the checkout_service->tracker chain presents ENC-SES providers but the identical gate already ran at the checkout_service edge; without this the FTR-037 forwarding chain would 403. Cognito, internal-key (non-ENC-SES provider), and system:arc-walker writes are unaffected by identity shape.",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Request-body field (rides write_source-adjacent payload) on tracker.set / tracker.log / tracker.create when the acting provider is a post-epoch ENC-SES session."
+        },
+        "checkout_service_exemption": {
+          "type": "string",
+          "definition": "X-Checkout-Service-Key-authenticated requests (FTR-037) skip the gate; the gate already ran at the checkout_service edge for the originating agent call."
+        }
+      }
+    },
+    "tracker.retirement_prompt": {
+      "description": "ENC-ISS-441 / ENC-TSK-J96 (ENC-FTR-122): terminal-state retirement nudge, part 3 of the io-designed session retirement lifecycle (issue worklog 2026-06-30). Whenever a success response is returned for a record reaching a FINAL lifecycle state, the envelope carries an additive-only string field retirement_prompt with the exact io-specified text: 'Prompt the user if this session can now be retired, or retire the session if it is certain that the full scope of the current session assignment is complete.' The acting agent either calls coordination agent.retire autonomously (scope exhausted) or surfaces the prompt to io. Injection points: checkout_service _handle_advance (task -> closed) and _handle_plan_advance (plan -> complete); tracker_mutation _handle_update_field status writes landing task/issue -> closed, feature -> production or deprecated, plan -> complete (_is_terminal_transition map). 'superseded' and plan 'incomplete' are NOT nudged (supersession is a server op, incomplete is an abandonment terminal). Non-terminal envelopes are byte-identical; consumers that ignore unknown fields are unaffected.",
+      "fields": {
+        "retirement_prompt": {
+          "type": "string",
+          "definition": "Fixed io-specified nudge text, present ONLY on terminal-state success envelopes. Complements the ENC-TSK-J94 sweeps: the prompt handles well-behaved agents, the sweeps catch the rest."
+        }
+      }
+    },
+    "mcp_server.sci_passthrough": {
+      "description": "ENC-ISS-441 / ENC-TSK-K10 (ENC-FTR-122, supersedes ENC-TSK-J97): the MCP server (tools/enceladus-mcp-server/server.py, enceladus-mcp-code Lambda) carries the caller's Session Claim ID to the ENC-TSK-J93 backend enforcement points. checkout_task, advance_task_status and append_worklog tool schemas expose an OPTIONAL string property 'sci' (the SCI-{uuid4_hex} issued by coordination agent.claim); handlers strip-and-forward it into the backend payload ONLY when non-empty, so requests from grandfathered (pre-epoch) sessions stay byte-identical. The same guard covers _plan_checkout/_plan_advance and _tracker_set/_tracker_log; _tracker_create's ENC-TSK-F76 denylist passthrough forwards a caller-supplied sci automatically. The coordination agent.claim response is a RAW backend passthrough (do not reshape): the J92 fields sci / sci_issued_at / sci_ttl_seconds reach the calling agent unchanged. The MCP layer NEVER validates SCI - enforcement is backend-only (checkout_service + tracker_mutation, ENC-TSK-J93). Code-mode execute steps flow arguments verbatim (no per-action allowlist), so sci passes through execute(checkout.*/tracker.*/plan.*) unchanged. NOTE: enceladus-mcp-code has no auto-deploy lane; live deploys ride the ENC-FTR-077 handoff (DOC-359655466119 pattern) and must advance the :live alias (ISS-306 qualified-URL discipline).",
+      "fields": {
+        "sci": {
+          "type": "string",
+          "definition": "Optional on checkout_task / advance_task_status / append_worklog (and honored on plan/tracker mutation paths). Session Claim ID issued by coordination agent.claim (ENC-ISS-441). Required by the backend for agent sessions claimed after SCI_ENFORCEMENT_EPOCH; strip-and-forwarded, never validated at the MCP layer."
+        }
+      }
+    },
+    "mcp_server.agent_checkout_release_backfill": {
+      "description": "ENC-TSK-L89: code-mode coordination action agent.checkout_release_backfill maps to the coordination_api retired-session checkout-release backfill route. Args: dry_run? and session_ids?. Returns the coordination.agent_session_checkout_release_backfill summary unchanged so an agent can evidence the one-time L06/orphan release without direct DynamoDB access.",
+      "fields": {
+        "action": {
+          "type": "string",
+          "definition": "coordination(action=\"agent.checkout_release_backfill\", arguments={dry_run?: boolean, session_ids?: string[]})"
+        }
+      }
+    },
+    "mcp_server.tracker_embeddings_for": {
+      "description": "ENC-TSK-K12 / ENC-ISS-473: MCP raw tool tracker_embeddings_for (code-mode action tracker.embeddings_for) restored after a merge truncation left the handler body incomplete. Proxies GET graph_query_api with search_type=embeddings_for (ENC-FTR-089 / ENC-TSK-I89): accepts project_id and record_ids (list or comma-separated string), returns embeddings[], Nx256 matrix, and missing[] from stored Titan V2 node properties. Admin/io-dev-admin scoped downstream; read-only, OGTM N/A.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required. Project whose graph node embeddings are fetched."
+        },
+        "record_ids": {
+          "type": "array|string",
+          "definition": "Required. One or more ENC-* or DOC-* record IDs; comma-separated string accepted."
+        }
+      }
+    },
+    "mcp_server.tracker_sheaf_cohomology": {
+      "description": "ENC-TSK-K12 / ENC-ISS-473: MCP raw tool tracker_sheaf_cohomology (code-mode action tracker.sheaf_cohomology) restored after merge truncation. Proxies graph_query_api search_type=sheaf_cohomology (ENC-FTR-095 / ENC-TSK-I90): requires project_id; optional vertex_set_query restricts the induced subgraph. Returns h1_dim, inconsistency_nodes[], inconsistency_edges[], computation_ms. Read-only sheaf Laplacian H1 probe; OGTM N/A.",
+      "fields": {
+        "project_id": {
+          "type": "string",
+          "definition": "Required. Project graph to analyze."
+        },
+        "vertex_set_query": {
+          "type": "string",
+          "required": false,
+          "definition": "Optional anchor query limiting computation to a connected subgraph."
+        }
+      }
+    },
+    "appsync_feed_publisher.lambda": {
+      "description": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher Lambda (devops-appsync-feed-publisher; gamma twin devops-appsync-feed-publisher-gamma, arm64/python3.12). DISTINCT from the v1 SQS->S3 mobile-feed publisher (devops-feed-publisher). A DynamoDB Streams consumer on devops-project-tracker (NEW_AND_OLD_IMAGES) wired by an EventSourceMapping (BatchSize=1, MaximumBatchingWindowInSeconds=0, StartingPosition LATEST, FunctionResponseTypes=[ReportBatchItemFailures]). For each INSERT/MODIFY/REMOVE it builds a lightweight appsync_feed.event payload and POSTs it to the AppSync Events HTTP endpoint on three channels (/feed/updates, /records/{recordId}, /projects/{projectId}) using stdlib urllib + boto3 only (no new pip deps). Auth: X-Api-Key (APPSYNC_EVENTS_API_KEY) primary, SigV4 (AWS_IAM) alternative. Provisioned by infrastructure/cloudformation/06-appsync-events.yaml.",
+      "fields": {
+        "APPSYNC_EVENTS_HTTP_ENDPOINT": {
+          "definition": "AppSync Events HTTP endpoint host or URL; required to publish.",
+          "type": "string"
+        },
+        "APPSYNC_EVENTS_API_KEY": {
+          "definition": "AppSync API key for the X-Api-Key auth path; when unset the Lambda uses SigV4 (AWS_IAM).",
+          "type": "string"
+        },
+        "APPSYNC_EVENTS_REGION": {
+          "definition": "Region used for SigV4 signing of the publish request.",
+          "default": "us-west-2",
+          "type": "string"
+        },
+        "DEFAULT_PROJECT_ID": {
+          "definition": "Fallback project id for the /projects channel when a stream record lacks project_id.",
+          "default": "enceladus",
+          "type": "string"
+        },
+        "DRY_RUN": {
+          "definition": "When truthy, the handler builds payloads and logs but skips the HTTP POST (unit/local runs).",
+          "default": "0",
+          "type": "feature_flag"
+        }
+      },
+      "owner": "pwa-realtime",
+      "source": "ENC-TSK-K20 / B67 AC-10",
+      "telemetry_eligible": false
+    },
+    "appsync_feed.event": {
+      "description": "ENC-TSK-K20 (B67 AC-10 / AC-23): lightweight real-time event payload emitted by devops-appsync-feed-publisher to AppSync Events. Server-pre-rendered (summary is computed in the Lambda). Raw DynamoDB item images are NOT inlined; median payload <= 500 bytes (AC-23). Published to /feed/updates, /records/{recordId}, and /projects/{projectId}.",
+      "fields": {
+        "eventId": {
+          "definition": "UUID v7 (time-ordered, RFC 9562 §5.7) generated in-Lambda; leading 48 ms bits make it sort by creation time.",
+          "type": "string"
+        },
+        "recordId": {
+          "definition": "Tracker record_id the event is about (e.g. ENC-TSK-K20).",
+          "type": "string"
+        },
+        "record_type": {
+          "definition": "Tracker record_type (task/issue/feature/plan/document/...).",
+          "type": "string"
+        },
+        "action": {
+          "definition": "Coarse verb: created on INSERT; removed on REMOVE; closed when status transitions into a terminal (closed/deploy-success/...); else updated.",
+          "type": "string",
+          "enum": [
+            "created",
+            "updated",
+            "closed",
+            "removed"
+          ]
+        },
+        "actorType": {
+          "definition": "human or agent, inferred from write_source: provider ENC-SES-* or channel mcp_server/arc-walker => agent; Cognito username on a human channel => human; default agent.",
+          "type": "string",
+          "enum": [
+            "human",
+            "agent"
+          ]
+        },
+        "actorId": {
+          "definition": "write_source.provider (session id or Cognito username), falling back to updated_by/owner/assignee, else 'unknown'.",
+          "type": "string"
+        },
+        "summary": {
+          "definition": "Server-pre-rendered display string: '<actorId> <action> <record_type> <recordId>: <title>'.",
+          "type": "string"
+        },
+        "cursor": {
+          "definition": "Monotonic-ish integer for client ordering/resume: stream ApproximateCreationDateTime epoch-millis * 1000 + per-batch counter (ties broken in stream order).",
+          "type": "integer"
+        },
+        "channels": {
+          "definition": "Target AppSync channel paths the event is published to: /feed/updates, /records/{recordId}, /projects/{projectId}.",
+          "type": "array",
+          "item_type": "string"
+        }
+      },
+      "owner": "pwa-realtime",
+      "source": "ENC-TSK-K20 / B67 AC-10",
+      "telemetry_eligible": false
+    },
+    "corpus_entropy_engine.lambda": {
+      "description": "ENC-TSK-K41 / B66 Ph5 (ENC-PLN-064): nightly Corpus Entropy Engine Lambda (enceladus-corpus-entropy-engine). EventBridge CorpusEntropyEngineSchedule (gamma, cron 05:00 UTC) invokes lambda_handler per project. Five telemetry-only detectors run every invocation and emit structured findings (no corpus mutation -- GDMP Stage-1 auto-remediation is a separate downstream task): lineage_unanchored entropy (tracker task/issue/feature with no parent_task_id and no related_task_ids; wave document with no plan_anchor_id), stagnation entropy (open task with no worklog history entry newer than STAGNATION_THRESHOLD_DAYS), relational entropy (declared related_task_ids/related_issue_ids/related_feature_ids with no matching graph_query_api adjacency edge), retention entropy (Lesson FSRS-6 stability below FSRS_T3_THRESHOLD=0.7, resonance_score fallback for pre-FSRS-6 records), and compliance/semantic entropy (document compliance_score below COMPLIANCE_SCORE_THRESHOLD AND document_maturity_state=raw). Read boundary: all corpus reads go through TRACKER_API_BASE / DOCUMENT_API_BASE / GRAPH_QUERY_API_BASE (internal-key HTTP auth), never direct DynamoDB access -- the same governed surface the MCP server wraps. CEE_HARD_DISABLED kill switch (default \"1\") is checked first in the handler; when set, no fetch is attempted and the invocation short-circuits. Publishes EntropyFindingCount to CloudWatch Enceladus/CEE, dimensioned by FunctionName + Category (5 datapoints per run), plus ScanDurationMs (ENC-TSK-N49) dimensioned by FunctionName for io/N09 cost profiling. Cost-preflight ISS-465: nightly-only cadence, well under $1/mo; CorpusEntropyEngineCostHeadroomAlarm guards EventBridge invocation count (7-day window, threshold 10).",
+      "owner": "enceladus-platform",
+      "source": "ENC-TSK-K41 / ENC-TSK-B66",
+      "telemetry_eligible": true,
+      "fields": {
+        "CEE_HARD_DISABLED": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "Mandatory kill switch, installed ON before first scheduled run. When truthy (1/true/yes), handler skips all governed reads and CloudWatch emission for that invocation."
+        },
+        "STAGNATION_THRESHOLD_DAYS": {
+          "type": "integer",
+          "default": 14,
+          "definition": "Open tasks with no worklog history entry newer than this many days are flagged as stagnation entropy."
+        },
+        "COMPLIANCE_SCORE_THRESHOLD": {
+          "type": "integer",
+          "default": 70,
+          "definition": "Documents with compliance_score below this value AND document_maturity_state=raw are flagged as compliance/semantic entropy."
+        },
+        "FSRS_T3_THRESHOLD": {
+          "type": "float",
+          "default": 0.7,
+          "definition": "Lessons with FSRS-6 stability (or resonance_score fallback) below this value are flagged as retention entropy. Matches the canonical T3 threshold already used by graph_query_api._apply_fsrs_t3_filter."
+        }
+      }
+    },
+    "corpus_entropy_gdmp_remediation.lambda": {
+      "description": "ENC-TSK-K42 / B66 Ph5 (ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda (enceladus-corpus-entropy-gdmp-remediation). EventBridge CorpusEntropyGdmpRemediationSchedule (gamma, cron 06:00 UTC, after K41's 05:00 detection scan) invokes lambda_handler per project. Reuses K41's corpus_entropy_core.detect_compliance_semantic_entropy unmodified (shared via .build_extras) to find raw documents with compliance_warnings, then classifies each warning against a fixed deterministic whitelist (gdmp_remediation_core.DETERMINISTIC_WARNING_CLASSIFIERS: fence_missing_language, metadata_field_missing) -- ambiguous/content-changing warnings (title format, empty document, heading hierarchy, list-marker consistency, table dividers, malformed alerts, COE section gaps) are left for agent/human review. For whitelisted findings, applies an additive pure-function text remediation (never deletes original content) and PATCHes the document via the governed document_api HTTP surface (documents.patch: content, then document_maturity_state=compliant once compliance_score clears COMPLIANCE_SCORE_THRESHOLD with zero remaining warnings) -- never direct DynamoDB/S3 document writes. Idempotency guard (is_already_compliant) skips any document already at compliant maturity or with zero compliance_warnings, so re-running Stage-1 on a compliant document is a no-op with no version churn. io-approval ramp (FTR-106 AC-4 / ENC-TSK-K03 pattern reuse, same S3 run-counter shape as UnlearningFunction): GDMP_DRY_RUN=1 (default) prevents all mutation; GDMP_MUTATION_ENABLED=0 (default) keeps report-only even when dry-run is off; GDMP_IO_APPROVAL_RUNS=3 gates the first three live (non-dry-run) invocations to candidate-report-only regardless of GDMP_MUTATION_ENABLED. CEE_GDMP_HARD_DISABLED kill switch (default \"1\") is checked first in the handler, mirroring CEE_HARD_DISABLED (K41). Every applied patch is logged with before/after compliance_score. Cost-preflight ISS-465: nightly-only cadence, well under $1/mo; CorpusEntropyGdmpRemediationCostHeadroomAlarm guards EventBridge invocation count (7-day window, threshold 10). ENC-TSK-L91 (mutation-ramp durable safety): the remediation path now re-GETs each document fresh and RECOMPUTES the remediation plan from the fresh compliance_warnings immediately before PATCH (was reusing the run-start scan's stale findings against fresh content -> silent lost update), collapsing the race window from hours to ms and skipping concurrently-edited documents; and persists a per-run candidate breakdown (see GDMP_RUN_BREAKDOWN_SINK). CEE_GDMP_HARD_DISABLED now gates mutation only (see field). Durable document_api If-Match precondition tracked as ENC-ISS-503.",
+      "owner": "enceladus-platform",
+      "source": "ENC-TSK-K42 / ENC-TSK-B66",
+      "telemetry_eligible": true,
+      "fields": {
+        "CEE_GDMP_HARD_DISABLED": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "Mandatory kill switch, installed ON (default \"1\"), checked first in the handler. ENC-TSK-L91: gates MUTATION ONLY -- when truthy (1/true/yes) the deterministic candidate scan, candidate report, and per-run breakdown persistence still execute (so the disarmed soak produces the auditable candidate reports io reviews before any re-enable), but NO documents.patch is issued and the io-approval ramp counter is NOT advanced (a fresh GDMP_IO_APPROVAL_RUNS candidate-only buffer is preserved for after io re-enables). Codified =1 in 02-compute.yaml (IsGamma) so no deploy reverts the disarm. Distinct from the shared engine-wide CEE_HARD_DISABLED (K41) cost kill switch, which still fully short-circuits the entire run (no scan)."
+        },
+        "GDMP_DRY_RUN": {
+          "type": "feature_flag",
+          "default": "1",
+          "definition": "When truthy (default), the handler never PATCHes any document -- it only computes and reports remediation candidates. Dry-run default-on is a hard DATA-SAFETY requirement."
+        },
+        "GDMP_MUTATION_ENABLED": {
+          "type": "feature_flag",
+          "default": "0",
+          "definition": "When falsy (default), the handler stays report-only even if GDMP_DRY_RUN is explicitly disabled. Must be explicitly enabled by io after reviewing candidate reports."
+        },
+        "GDMP_IO_APPROVAL_RUNS": {
+          "type": "integer",
+          "default": 3,
+          "definition": "Number of live (non-dry-run) invocations that must complete in report-only mode before mutation mode can activate, regardless of GDMP_MUTATION_ENABLED. Tracked via a persisted S3 run counter (GDMP_STATE_BUCKET/GDMP_STATE_PREFIX), mirroring IO_APPROVAL_RUNS (K03 unlearning)."
+        },
+        "COMPLIANCE_SCORE_THRESHOLD": {
+          "type": "integer",
+          "default": 70,
+          "definition": "A remediated document only advances document_maturity_state to compliant once its post-PATCH compliance_score is at or above this value AND zero compliance_warnings remain. Matches CEE's (K41) COMPLIANCE_SCORE_THRESHOLD."
+        },
+        "GDMP_RUN_BREAKDOWN_SINK": {
+          "type": "s3_artifact",
+          "definition": "ENC-TSK-L91: every run persists a per-run candidate breakdown JSON (schema gdmp.run_breakdown.v1) to s3://${GDMP_STATE_BUCKET}/${GDMP_STATE_PREFIX}/breakdowns/ as run-<ts>-n<run_count>.json plus a stable latest.json. Partitions candidates into safe_deterministic vs needs_human with a per-doc list (record_id, action, deterministic_classes, ambiguous_warnings), making the GDMP_IO_APPROVAL_RUNS ramp auditable during the disarmed soak. Best-effort write; never raises into the run."
+        }
+      }
+    },
+    "monitoring.v4_architecture_dashboard": {
+      "description": "ENC-TSK-K46 / B66 Ph5 (ENC-PLN-064, AC-2/AC-6/AC-7): EnceladusV4Dashboard (AWS::CloudWatch::Dashboard, DashboardName enceladus-v4-architecture${EnvironmentSuffix}) in infrastructure/cloudformation/05-monitoring.yaml — the single-pane operational view of the v4/gamma architecture. 13 widgets (10 metric + 3 text): Lambda error rates + p99 duration (AWS/Lambda Errors/Duration across enceladus-prod-health-monitor, devops-graph-query-api, enceladus-corpus-entropy-engine, enceladus-arc-walk-metrics, devops-coordination-api, devops-tracker-mutation-api); MCP cold start / DynamoDB throttle / graph_sync lag (Enceladus/Prod MCPColdStart / DynamoDBThrottle / GraphSyncLag, ENC-TSK-K44); Fiedler λ2 algebraic connectivity (Enceladus/GraphHealth FiedlerValue, dimension ProjectId=enceladus, ENC-TSK-K43); CEE per-category entropy counts (Enceladus/CEE EntropyFindingCount dimensioned by Category, ENC-TSK-K41); and arc-walk telemetry (Enceladus/ArcWalk ArcWalkAutoAdvances by gate_class, OptOutLatchEvents / OptOutClearEvents / OptOutLatchedRecords, ConvergenceBacklog / ConvergenceGatesShort, ENC-TSK-H86 / ENC-FTR-111). Includes one honestly-documented embedding-coverage-% gap text panel: no CloudWatch emission mechanism exists yet (graph_query_api's embedding_coverage_sample is a per-request API payload, and titan_embedding_backfill.count_embedding_coverage() does not PutMetricData) — a follow-up task must wire a coverage metric before that panel can show data. All namespace/metric names bind to the merged Wave-A Lambda sources (K41/K43/K44/H86), not placeholders. DEPLOY STATUS: authored and merged to v4/main (PR #791) but NOT yet live — the gamma enceladus-monitoring stack deploy rolled back (UPDATE_ROLLBACK_COMPLETE) because enceladus-cloudformation-deploy-github-role lacks cloudwatch:PutDashboard; a follow-up IAM-grant task is tracked before this resource can deploy. Gamma-only (PLN-006 invariant; v3-prod frozen).",
+      "owner": "devops-monitoring",
+      "source": "ENC-TSK-K46 / ENC-TSK-B66 (ENC-FTR-111 / ENC-TSK-H86)",
+      "fields": {
+        "DashboardName": {
+          "type": "string",
+          "definition": "CloudWatch dashboard name.",
+          "usage_guidance": "Fixed value: enceladus-v4-architecture${EnvironmentSuffix} (env-suffix-aware via CFN Sub)."
+        },
+        "widget_count": {
+          "type": "integer",
+          "definition": "Total dashboard widgets: 10 metric + 3 text = 13."
+        },
+        "bound_namespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "definition": "CloudWatch namespaces surfaced: AWS/Lambda, Enceladus/Prod (K44), Enceladus/GraphHealth (K43), Enceladus/CEE (K41), Enceladus/ArcWalk (H86)."
+        }
+      }
+    },
+    "user_preferences_api.lambda": {
+      "description": "ENC-TSK-L25 (B67 Search2.0 WaveB / ENC-FTR-127 AC-10/16/17): per-user preferences service (enceladus-user-preferences-api, gamma-only, arm64/python3.12). GET/PUT /api/v1/user/preferences, Cognito-JWT-only auth (no internal-key path -- purely a human-session surface), keyed on the caller's Cognito sub. Reads/writes the new user-preferences DynamoDB table (PK=sub) with the locked payload schema (DOC-77D6C714867E §15h): saved_searches[], recently_viewed{feed_type:[]}, prefs{}. Least-privilege IAM: GetItem/PutItem on its own table only. Provisioned by infrastructure/cloudformation/01-data.yaml (table) + 02-compute.yaml (function/role) + 03-api.yaml (integration/routes).",
+      "fields": {
+        "USER_PREFERENCES_TABLE": {
+          "definition": "DynamoDB table name for per-user preferences.",
+          "default": "user-preferences",
+          "type": "string"
+        },
+        "COGNITO_USER_POOL_ID": {
+          "definition": "Cognito User Pool ID for JWT verification (shared with other Cognito-fronted APIs).",
+          "type": "string"
+        },
+        "COGNITO_CLIENT_ID": {
+          "definition": "Cognito App Client ID; validated as the JWT audience.",
+          "type": "string"
+        },
+        "saved_searches": {
+          "definition": "Array of {name, query, filters, sort} saved-search entries; capped at 50.",
+          "type": "array"
+        },
+        "recently_viewed": {
+          "definition": "Object keyed by feed_type -> array of {record_id, project_id, viewed_at}; each feed_type capped at 50 entries.",
+          "type": "object"
+        },
+        "prefs": {
+          "definition": "Free-form per-user preference object (e.g. master-detail pin state).",
+          "type": "object"
+        }
+      }
+    },
+    "api.if_match_revision_contract": {
+      "description": "ENC-TSK-L47 (B67 AC-19 / K25 AC-3): optional client-driven optimistic-concurrency contract on tracker_mutation's generic field-update path (PATCH /{project}/{type}/{id}, keyed on the existing sync_version counter) and document_api's PATCH path (PATCH /documents/{id}, keyed on the existing version counter). Deliberately decoupled from ENC-TSK-L27's version_seq GSI work so it ships without escalated IAM. Absence of the header preserves pre-L47 unconditional-write behavior for every existing agent/PWA caller -- this is strictly additive.",
+      "fields": {
+        "If-Match": {
+          "type": "http_header",
+          "definition": "Optional request header carrying the revision the caller last read (sync_version for tracker records, version for documents). Quoted ETag-style values are accepted (quotes are stripped). When present, the server compares it against the current server-side revision before writing.",
+          "usage_guidance": "Read the revision from a prior GET/tracker.get response and echo it back as If-Match on the next mutation to get a 409 instead of a silent lost-update when another writer has landed a change in between. Omit entirely for today's unconditional-write behavior (no functional change)."
+        },
+        "REVISION_CONFLICT": {
+          "type": "error_envelope.code",
+          "definition": "New error_envelope.code value (HTTP 409). Returned when a supplied If-Match does not match the current server-side revision -- either at the pre-write check or (rarer) at the DynamoDB ConditionExpression guarding the commit itself if a write lands in the interim. The response body includes expected_revision, current_revision, and current (the full current server-side field values, deserialized) so callers -- notably ENC-TSK-K25's merge-conflict UI -- can resolve without a follow-up read.",
+          "usage_guidance": "On REVISION_CONFLICT, re-render the conflict from error_envelope.details.current and let the caller choose retry-with-fresh-revision or merge. Do not blind-retry with the same If-Match value."
+        },
+        "write_response_revision_echo": {
+          "type": "behavior",
+          "definition": "Every successful write on either path now echoes the post-write revision in the response body (sync_version on tracker_mutation, version on document_api) so the caller can update its local cache without an extra read."
+        }
+      }
+    },
+    "mcp_streaming_gateway.lambda": {
+      "description": "ENC-TSK-L10 (B64 Ph3): true Lambda response-streaming MCP endpoint. Distinct from enceladus-mcp-streamable (ENC-FTR-025) -- that Lambda is invoked event-per-request via a Function URL in BUFFERED InvokeMode; this one runs as a persistent Starlette/uvicorn server (asgi_app.py) behind the AWS Lambda Web Adapter (AWS_LAMBDA_EXEC_WRAPPER=/opt/bootstrap, AWS_LWA_INVOKE_MODE=response_stream), fronted by a dedicated REST API Gateway v1 (McpStreamingRestApi, 03-api.yaml) using responseTransferMode=STREAM -- HTTP API v2 (AWS::ApiGatewayV2) does not support Lambda response streaming, only REST API v1 does (InvokeWithResponseStream). Reuses server.py's tool surface (StreamableHTTPSessionManager, json_response=False so it actually emits SSE instead of buffering). Gamma-only (Condition: IsGamma), 15-min Lambda timeout; API Gateway integration TimeoutInMillis capped at 29000 (REST API's documented ceiling, not lifted for streaming per available docs).",
+      "fields": {
+        "AWS_LWA_PORT": {
+          "definition": "Port the Starlette/uvicorn server listens on; the Lambda Web Adapter proxies invocations to it.",
+          "default": "8080",
+          "type": "string"
+        },
+        "AWS_LWA_INVOKE_MODE": {
+          "definition": "response_stream -- tells the adapter to use Lambda's RESPONSE_STREAM invoke path so API Gateway's responseTransferMode=STREAM integration gets real streamed output.",
+          "type": "string"
+        }
+      }
+    },
+    "appsync_feed_publisher.full_record_body_l29": {
+      "description": "ENC-TSK-L29 (B67 Search2.0 WaveC): the appsync_feed_publisher Lambda (backend/lambda/appsync_feed_publisher, DISTINCT from the legacy backend/lambda/feed_publisher v1 S3 mobile-feed publisher) attaches the full current record body to the event delivered on a record's /records/{recordId} AppSync Events channel only. The /feed/updates (global firehose) and /projects/{projectId} channels are never given a body -- their payload stays exactly the pre-existing B67 AC-10 lightweight envelope (fixed ~500-byte AC-23 budget). Purpose: an open record-detail page's client-side Tier-1/Tier-2 mirror (ENC-TSK-L24) can upsert directly from a /records/{recordId} event with no follow-up GET.",
+      "fields": {
+        "record": {
+          "type": "object",
+          "definition": "Present only on /records/{recordId} channel events, for INSERT/MODIFY stream records. Deserialized DynamoDB NewImage -- every current field on the record, plain JSON (no {S:...}/{N:...} typed wrappers). Absent on /feed/updates and /projects/{id} events, and absent for REMOVE events (the client instead reacts to the existing lightweight envelope's action='removed' and marks a tombstone).",
+          "usage_guidance": "Client subscribes to /records/{recordId} (ENC-TSK-L29 AppSyncRealtimeClient.watchRecord) only while that record's detail page is open, and upserts event.record directly into the Tier-2 cache + the live query cache -- never re-fetches on receipt of this event."
+        }
+      }
+    },
+    "opensearch_indexer.lambda": {
+      "description": "ENC-TSK-L41 (B67 Search2.0 WaveB / DOC-77D6C714867E §15): OpenSearch CDC indexer Lambda (devops-opensearch-indexer; gamma twin devops-opensearch-indexer-gamma, arm64/python3.12). DISTINCT from graph_sync. Bulk-upserts INSERT/MODIFY tracker/document stream records into OpenSearch via the records_write alias; REMOVE deletes by stable natural key _id={project_id}#{record_type}#{bare_record_id}. Interim external-version contract: version = updated_at epoch-ms (version_seq field) until ENC-TSK-L27 version_seq cutover. Runs in VPC to reach the gamma single-node OpenSearch cluster. ENC-TSK-L44: authenticates as the scoped 'indexer' security-plugin user (write-only on records_write/records_v*), not the admin superuser — TLS basic auth via OPENSEARCH_ADMIN_PASSWORD env or Secrets Manager enceladus/opensearch/gamma-indexer. Skips reference and relationship record_types. ENC-TSK-L84: CDC transport swapped from EventBridge Pipes (TrackerToSearchIndexPipe/DocumentsToSearchIndexPipe -> devops-search-index-queue.fifo -> SQS-triggered ESM) to a DIRECT AWS::Lambda::EventSourceMapping on the tracker and documents DynamoDB streams (SearchIndexTrackerStreamTrigger/SearchIndexDocumentsStreamTrigger), after the Pipes-DynamoDB-source path was confirmed account-wide non-functional (ENC-ISS-497: StateReason=No records processed, zero throughput ever, ruled out across IAM/trust/filter/restart/full-recreate remediation). The handler accepts BOTH the legacy SQS-wrapped shape and the native direct-stream shape (ReportBatchItemFailures identifier = messageId for SQS, dynamodb.SequenceNumber for the direct ESM) so the retired SQS path (SearchIndexSqsTrigger, disabled not deleted) remains available for rollback. Provisioned by infrastructure/cloudformation/01-data.yaml (stream specs) + 02-compute.yaml (function, role, both old and new event source mappings, disabled legacy Pipes) + 10-opensearch-node.yaml (node security roles).",
+      "fields": {
+        "OPENSEARCH_ENDPOINT": {
+          "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP, e.g. https://172.31.28.54:9200).",
+          "type": "string"
+        },
+        "OPENSEARCH_WRITE_ALIAS": {
+          "definition": "OpenSearch write alias; locked to records_write per ENC-TSK-L40 naming contract.",
+          "default": "records_write",
+          "type": "string"
+        },
+        "OPENSEARCH_ADMIN_PASSWORD": {
+          "definition": "Basic-auth password for OPENSEARCH_USERNAME when set; takes precedence over Secrets Manager lookup.",
+          "type": "string"
+        },
+        "OPENSEARCH_SECRET_NAME": {
+          "definition": "Secrets Manager secret id holding {\"username\":\"...\",\"password\":\"...\"} when OPENSEARCH_ADMIN_PASSWORD is empty. ENC-TSK-L44: defaults to the scoped indexer secret, not the admin secret.",
+          "default": "enceladus/opensearch/gamma-indexer",
+          "type": "string"
+        },
+        "OPENSEARCH_USERNAME": {
+          "definition": "ENC-TSK-L44: security-plugin username for basic auth. Defaults to 'admin' for backward compat with pre-L44 admin-only secrets; production wiring sets this to 'indexer' (write-only indexer_role).",
+          "default": "admin",
+          "type": "string"
+        },
+        "SECRETS_REGION": {
+          "definition": "Region for Secrets Manager client.",
+          "default": "us-west-2",
+          "type": "string"
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-L41 / B67 Search2.0; credentials hardened by ENC-TSK-L44",
+      "telemetry_eligible": true
+    },
+    "graph_query_api.opensearch_keyword": {
+      "description": "ENC-TSK-L43 (B67 Search2.0 WaveB / DOC-77D6C714867E §15d): OpenSearch-backed keyword signal + within-search facet authority for hybrid graphsearch. Module backend/lambda/graph_query_api/opensearch_keyword.py queries records_read via multi_match (fuzziness AUTO over title/description/body) plus bool_prefix autocomplete; ranks feed the existing RRF k=60 fusion unchanged. Facet aggs over project_id, record_type, status, priority are scoped to the active search filter set. Circuit-breaker: on OpenSearch failure degrades keyword ranks to Neo4j _hybrid_keyword_ranks and facets to GET /feed/corpus via X-Coordination-Internal-Key. Gamma-only wiring: devops-graph-query-api-gamma runs in the OpenSearch VPC subnet with OPENSEARCH_* env vars and authenticates as the scoped query security-plugin user (enceladus/opensearch/gamma-query).",
+      "fields": {
+        "OPENSEARCH_ENDPOINT": {
+          "type": "string",
+          "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP)."
+        },
+        "OPENSEARCH_READ_ALIAS": {
+          "type": "string",
+          "definition": "Read alias locked to records_read per ENC-TSK-L40 naming contract.",
+          "default": "records_read"
+        },
+        "OPENSEARCH_SECRET_NAME": {
+          "type": "string",
+          "definition": "Secrets Manager secret holding {\"username\":\"query\",\"password\":\"...\"}.",
+          "default": "enceladus/opensearch/gamma-query"
+        },
+        "OPENSEARCH_USERNAME": {
+          "type": "string",
+          "definition": "Security-plugin username; defaults to query (read-only query_role).",
+          "default": "query"
+        },
+        "FEED_API_BASE": {
+          "type": "string",
+          "definition": "Base URL for feed/corpus facet fallback (service auth via COORDINATION_INTERNAL_API_KEY)."
+        },
+        "facets": {
+          "type": "object",
+          "definition": "Hybrid response field: facet counts {project_id, record_type, status, priority} over the active search."
+        },
+        "facets_source": {
+          "type": "enum",
+          "enum": [
+            "opensearch",
+            "feed_corpus"
+          ],
+          "definition": "Provenance of facets on hybrid responses."
+        },
+        "keyword_source": {
+          "type": "enum",
+          "enum": [
+            "opensearch",
+            "neo4j_fallback",
+            "unavailable"
+          ],
+          "definition": "Provenance of the keyword RRF arm on hybrid responses."
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-L43",
+      "telemetry_eligible": true
+    },
+    "opensearch_backfill.lambda": {
+      "description": "ENC-TSK-L42 (B67 Search2.0 WaveB): OpenSearch full-corpus backfill + reindex job Lambda (devops-opensearch-backfill; gamma twin devops-opensearch-backfill-gamma, arm64/python3.12). Paginated Scan of devops-project-tracker + documents tables; bulk-indexes into OpenSearch via records_write alias or a physical records_v{n} target during zero-downtime reindex. Shares search_index_core mapping + external-version idempotency with devops-opensearch-indexer (L41). Manual invoke only (no SQS trigger). Runs in VPC to reach gamma OpenSearch node. Pair with infrastructure/opensearch/apply_records_index.py --mode create-only/swap for AC-2 alias swap.",
+      "fields": {
+        "TRACKER_TABLE": {
+          "definition": "Tracker DynamoDB table name (Scan).",
+          "type": "string"
+        },
+        "DOCUMENTS_TABLE": {
+          "definition": "Documents DynamoDB table name (Scan; active rows only).",
+          "type": "string"
+        },
+        "OPENSEARCH_ENDPOINT": {
+          "definition": "HTTPS URL of the gamma OpenSearch node (VPC-private IP).",
+          "type": "string"
+        },
+        "OPENSEARCH_WRITE_ALIAS": {
+          "definition": "Default bulk target when invoke payload omits target_index; records_write per L40 contract.",
+          "default": "records_write",
+          "type": "string"
+        },
+        "OPENSEARCH_ADMIN_PASSWORD": {
+          "definition": "Admin basic-auth password when set; takes precedence over Secrets Manager lookup.",
+          "type": "string"
+        },
+        "OPENSEARCH_SECRET_NAME": {
+          "definition": "Secrets Manager secret id holding {\"password\":\"...\"} when OPENSEARCH_ADMIN_PASSWORD is empty.",
+          "default": "enceladus/opensearch/gamma-admin",
+          "type": "string"
+        },
+        "SECRETS_REGION": {
+          "definition": "Region for Secrets Manager client.",
+          "default": "us-west-2",
+          "type": "string"
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-L42 / B67 Search2.0",
+      "telemetry_eligible": true
+    },
+    "handoff_consolidation_engine.lambda": {
+      "description": "ENC-TSK-L15 / ENC-TSK-C08 / ENC-FTR-064 / ENC-FTR-096: Handoff Consolidation Engine (enceladus-handoff-consolidation-engine; gamma twin enceladus-handoff-consolidation-engine-gamma). Scheduled adaptive scan-cluster-propose cycle over Handoff documents; proposes lesson-candidate documents via governed Document API invoke (read-only DynamoDB, no direct writes). Emits OGTM CONSOLIDATED_FROM/PROPOSED_BY fields; GDMP Stage-2 provenance annotation; FSRS-6 stability seeding on candidates.",
+      "fields": {
+        "DOCUMENTS_TABLE": {
+          "definition": "Documents DynamoDB table name (read-only Query/Scan).",
+          "type": "string"
+        },
+        "DOCUMENT_API_LAMBDA_NAME": {
+          "definition": "Target devops-document-api Lambda for governed candidate create + provenance PATCH invokes.",
+          "type": "string"
+        },
+        "ADAPTIVE_TRIGGER_MIN_HANDOFFS": {
+          "definition": "Minimum new Handoffs since last cycle before a scheduled fire runs a full cycle.",
+          "default": "3",
+          "type": "string"
+        },
+        "HCE_GDMP_PROVENANCE_ENABLED": {
+          "definition": "When true, annotate compliant documents with informed_by context (contextualized maturity).",
+          "default": "true",
+          "type": "string"
+        }
+      },
+      "owner": "coordination",
+      "source": "ENC-TSK-L15 / ENC-FTR-096",
+      "telemetry_eligible": true
+    },
+    "observability.xray_tracing_config": {
+      "description": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0/AC-3): AWS X-Ray active distributed tracing (TracingConfig.Mode=Active) across the gamma 5-service trace set that PLN-006 Phase 5 designates as the operational-hardening tracing baseline: Record (devops-tracker-mutation-api, CFN logical id TrackerMutationFunction), Lifecycle (enceladus-lifecycle-service, LifecycleServiceFunction), Scoring (enceladus-scoring-service, ScoringServiceFunction), Checkout (enceladus-checkout-service, CheckoutServiceFunction), and MCP Server (devops-coordination-api, CoordinationApiFunction -- the gamma-deployable stand-in for the 'MCP Server' trace slot; enceladus-mcp-code-gamma is the literal MCP code-mode Lambda but is Condition:IsProduction / prod-stack-owned in 02-compute.yaml and out of reach for a gamma-only compute deploy, so it is intentionally excluded from this gamma trace set). All five declare TracingConfig.Mode: Active in infrastructure/cloudformation/02-compute.yaml. CheckoutServiceFunction was IMPORTed into enceladus-compute-gamma out-of-band (cfn-resource-import.yml) and required a forced ReconciledBy tag-bump (ENC-TSK-K45-reconcile-20260702, then ENC-TSK-B66-reconcile-20260707) to make `aws cloudformation deploy`'s change-set diff actually pick up the template's declared TracingConfig against the function's live post-IMPORT PassThrough state -- confirmed via `aws cloudformation detect-stack-drift` / describe-stack-resource-drifts, which reports this resource's live TracingConfig.Mode as drifted from the template even when the change-set diff engine reports no pending change.",
+      "fields": {
+        "tracing_mode": {
+          "type": "string",
+          "definition": "Lambda TracingConfig.Mode. Active enables X-Ray sampling/segment capture; PassThrough (the AWS default) only forwards an existing trace header without sampling.",
+          "usage_guidance": "All 5 trace-set functions declare Mode: Active in 02-compute.yaml Properties.TracingConfig. Verify live state with `aws lambda get-function-configuration --function-name <fn> --query TracingConfig` -- a CFN template declaration is not proof of live state for IMPORTed resources (see ReconciledBy note above)."
+        },
+        "mcp_server_trace_standin": {
+          "type": "string",
+          "definition": "Architectural decision (ENC-TSK-K45): CoordinationApiFunction (devops-coordination-api${EnvironmentSuffix}) is the gamma-deployable stand-in for the 'MCP Server' slot in the 5-service X-Ray trace set.",
+          "usage_guidance": "enceladus-mcp-code-gamma is NOT part of this trace set -- it is Condition:IsProduction (prod-stack-owned per ENC-TSK-H29/ENC-ISS-386 name-collision guard) and a gamma-only compute deploy cannot reach it. Do not attempt to add TracingConfig to EnceladusMcpCodeGammaFunction from a gamma-scoped change; that would require a v3-prod deploy."
+        },
+        "reconciled_by_tag": {
+          "type": "string",
+          "definition": "Tag key used as a forced-diff mechanism on IMPORTed Lambda::Function resources whose live TracingConfig/Layers/Environment properties silently fail to reconcile via a normal `aws cloudformation deploy` change-set (the change-set diff engine reports no pending change even though `aws cloudformation detect-stack-drift` proves real drift).",
+          "usage_guidance": "Bump the Tags[].ReconciledBy Value string to any new literal value to force CFN to recompute a genuine property diff for that resource on the next compute-stack deploy. Precedent: ProdHealthMonitorFunction (ENC-TSK-K44), CheckoutServiceFunction (ENC-TSK-K45, ENC-TSK-B66)."
+        }
+      },
+      "owner": "devops-infrastructure",
+      "source": "ENC-TSK-K45 / ENC-TSK-B66 (B66 Ph5 AC-0)"
+    },
+    "coordination.queue": {
+      "description": "ENC-TSK-M27 (ENC-FTR-130): the PWA Home \"Requires io\" queue's read surfaces for the two record classes that had no PWA-reachable data source before this task -- paused v3-prod Environment GitHub Actions approval runs, and stale checkout locks. Both routes are Cognito-session-gated (_is_cognito_session) exactly like coordination.escalations; neither adds a mutation path. Paused-approvals calls GitHub's REST API with an installation token minted via the existing ENC-FTR-021 GitHub App credential path (GITHUB_APP_ID/GITHUB_INSTALLATION_ID/GITHUB_PRIVATE_KEY_SECRET, already provisioned on this function's environment) -- no new GitHub credential. Stale-locks Scans the projects table with the same detection core as backend/lambda/stale_checkout_monitor/lambda_function.py. ENC-TSK-M27 deploy-nudge (2026-07-08): no schema change -- comment-only touch to lambda_function.py to work around a v4-gamma deploy pipeline race (affected-set detector saw base_sha==head_sha against a sibling CFN stack deploy's success record for the same commit and skipped deploying the already-merged #958 queue-read routes). Forcing a real diff so the code actually ships.",
+      "fields": {
+        "GET /api/v1/coordination/queue/paused-approvals": {
+          "type": "route",
+          "definition": "Lists GitHub Actions workflow runs on GITHUB_QUEUE_REPO (default NX-2021-L/enceladus) with status=waiting, then calls pending_deployments per run and keeps only runs where an environment named 'v3-prod' (case-insensitive) is pending review (falls back to including a run if pending_deployments couldn't be read, rather than silently dropping a real approval need). Returns {id, run_url, requesting_workflow, environments, head_sha, created_at} per row. Returns an empty list with a note (not an error) when GITHUB_APP_ID/GITHUB_INSTALLATION_ID are unset. Cognito-only."
+        },
+        "GET /api/v1/coordination/queue/stale-locks": {
+          "type": "route",
+          "definition": "Scans PROJECTS_TABLE (default 'projects') for record_type=task AND checkout_state=checked_out, then filters to checked_out_at older than STALE_CHECKOUT_THRESHOLD_MINUTES (default 240, same env var and default as stale_checkout_monitor). Returns {record_id, holder_session, held_since, age_minutes} per row, newest-age-first, capped at a 500-item scan. Read-only; never mutates checkout_state. Cognito-only."
+        },
+        "GITHUB_APP_ID": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var (already provisioned on CoordinationApiFunction in infrastructure/cloudformation/02-compute.yaml). Reused unmodified by ENC-TSK-M27; no new value."
+        },
+        "GITHUB_INSTALLATION_ID": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var, reused unmodified by ENC-TSK-M27."
+        },
+        "GITHUB_PRIVATE_KEY_SECRET": {
+          "type": "string",
+          "definition": "Existing ENC-FTR-021 env var naming the Secrets Manager secret holding the GitHub App private key (default 'devops/github-app/private-key'). ENC-TSK-M27 adds the GitHubAppSecretRead IAM statement (GetSecretValue/DescribeSecret scoped to devops/github-app/*) so coordination_api can read it; no new secret value, no write access."
+        },
+        "GITHUB_QUEUE_REPO": {
+          "type": "string",
+          "definition": "New ENC-TSK-M27 env var: owner/repo to query for paused Environment approval runs. Default 'NX-2021-L/enceladus'."
+        },
+        "STALE_CHECKOUT_THRESHOLD_MINUTES": {
+          "type": "string",
+          "definition": "Optional env var (default 240): age threshold in minutes for the stale-locks route. Shares its name and default with backend/lambda/stale_checkout_monitor/lambda_function.py's identical env var so the two surfaces agree on what counts as stale; set independently per-Lambda (not a shared CFN parameter)."
+        }
+      },
+      "pwa_surface": "Home route's \"Requires io\" queue (frontend/ui-v2/src/routes/HomeRoute.tsx): pausedApprovalRows/staleLockRows (routes/homeQueue.ts) render live rows in place of the ENC-TSK-M19 GAP_QUEUE_ROWS placeholders. Paused-approval rows link directly to the GitHub Actions run (approve/reject stays a GitHub action, not a new PWA mutation); stale-lock rows are informational only, no click-through action.",
+      "apigw_routes": "03-api.yaml (Condition: IsGamma, same v3-prod-promotion posture as escalations): RouteQueuePausedApprovals, RouteQueueStaleLocks -> CoordinationApiIntegration."
+    },
+    "feed_query.opensearch_tier": {
+      "description": "ENC-TSK-M39: OpenSearch-tier fast path for the full feed refresh (_query_all_records, GET /api/v1/feed and /api/v1/feed/tasks.json). feed_query is not VPC-attached and the OpenSearch domain is only reachable from graph_query_api's VPC, so this invokes graph_query_api (action='feed_selection') as a selection-tier proxy instead of joining the VPC: OpenSearch returns the top-N most-recently-updated record keys per (project_id, record_type), then feed_query hydrates full record bodies via a bounded DynamoDB BatchGetItem (_hydrate_records_via_batch_get, shared with the existing incremental/delta path). Circuit breaker: any failure (missing GRAPH_QUERY_API_FUNCTION, invoke error/timeout, malformed or ok=false response) falls back unconditionally to the pre-existing per-project DDB fan-out (_query_all_records_via_ddb). Replaces the prior ~15-19s live full-refresh latency.",
+      "fields": {
+        "GRAPH_QUERY_API_FUNCTION": {
+          "type": "string",
+          "definition": "Name of the graph_query_api Lambda feed_query invokes for OpenSearch-tier selection. Gamma-only (AWS::NoValue on v3-prod) -- empty/unset disables the tier and always uses the DDB fan-out."
+        },
+        "feed_source": {
+          "type": "enum",
+          "enum": [
+            "opensearch",
+            "ddb_fanout"
+          ],
+          "definition": "Provenance of the full-refresh response on GET /api/v1/feed and GET /api/v1/feed/tasks.json. Set from the module-level _last_feed_query_source read immediately after _query_all_records() returns."
+        }
+      },
+      "owner": "feed",
+      "source": "ENC-TSK-M39",
+      "telemetry_eligible": true
+    },
+    "graph_query_api.feed_selection": {
+      "description": "ENC-TSK-M39: out-of-band OpenSearch feed-selection entrypoint, dispatched via action='feed_selection' (direct Lambda invoke from feed_query_lambda; NOT exposed on the public API Gateway route, no auth check). Returns the top-N most-recently-updated record IDs per (project_id, record_type) from the records_read OpenSearch alias via a single _msearch round trip (opensearch_keyword.feed_selection_msearch). feed_query proxies through this already VPC-attached function rather than joining the OpenSearch VPC itself.",
+      "fields": {
+        "project_ids": {
+          "type": "array",
+          "item_type": "string",
+          "definition": "Active project IDs to select feed candidates for."
+        },
+        "caps": {
+          "type": "object",
+          "definition": "Per record_type result-size cap, e.g. {\"task\": 100, \"issue\": 10, \"feature\": 10, \"lesson\": 10, \"plan\": 10} -- mirrors feed_query's existing MAX_*_FULL_REFRESH constants."
+        },
+        "selection": {
+          "type": "object",
+          "definition": "Response field on ok=true: {\"{project_id}#{record_type}\": [bare_record_id, ...]}, each list sorted by updated_at desc and capped at caps[record_type]."
+        },
+        "ok": {
+          "type": "boolean",
+          "definition": "false on any failure (missing input, OpenSearch not configured, transport error, msearch sub-query error) -- callers must treat ok=false as a circuit-breaker signal, never retry inline."
+        }
+      },
+      "owner": "search",
+      "source": "ENC-TSK-M39",
+      "telemetry_eligible": false
+    },
+    "mcp_server.tracker_creation_rules": {
+      "description": "ENC-TSK-M66: MCP search action tracker.creation_rules (tool tracker_creation_rules, route GET /api/v1/coordination/tracker/creation_rules on coordination_api (the /api/v1/tracker/* public prefix is CloudFront-routed to the tracker query API, so the reachable route lives under the coordination prefix)). Type-keyed pre-creation contract surface -- given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract with NO record_id. Response is derived entirely from this governance dictionary at request time: required fields are the universal 'title' base field plus any entities['tracker.<type>'].fields entries whose constraints.min_items or constraints.min_length require a non-empty value; valid initial status is entities['tracker.<type>'].status.enum[0]; attachment contract reads entities['tracker.<type>.composition'] (what the type composes) and, when parent_type is supplied, entities['tracker.<parent_type>.composition'] (whether record_type is in that parent's child_record_types, per ENC-TSK-M65's plan/feature composition entries).",
+      "fields": {
+        "search_action": {
+          "type": "search_action",
+          "definition": "search(action='tracker.creation_rules', arguments={record_type, parent_type?})."
+        },
+        "arguments": {
+          "type": "object",
+          "definition": "record_type (required, e.g. task/feature/plan/issue); parent_type (optional, validates attachment as a child of that parent type)."
+        },
+        "response_shape": {
+          "type": "object",
+          "definition": "record_type, parent_type, valid_initial_status, status_enum, required_fields, required_field_detail (per-field derivation reason + constraints), attachment_contract (composes / as_child_of.valid / allowed_child_record_types / attachment_mechanism / cardinality)."
+        },
+        "derivation_source": {
+          "type": "rule",
+          "definition": "No hardcoded per-type contract table. Scans entities['tracker.<type>'].fields for constraints.min_items>=1 or constraints.min_length>=1; the sole non-dictionary-derived fact is the universal 'title' field, named explicitly in code (_CREATION_RULES_UNIVERSAL_REQUIRED_FIELDS) rather than folded into a silent per-type table."
+        },
+        "contract_parity": {
+          "type": "rule",
+          "definition": "required_fields/valid_initial_status match tracker_mutation lambda_function.py _handle_create_record and _DEFAULT_STATUS for task (title, acceptance_criteria; open), feature (title, user_story, acceptance_criteria; planned), and plan (title only; drafted) -- see test_creation_rules.py contract test."
+        }
+      }
+    },
+    "mcp_server.tracker_list": {
+      "description": "ENC-ISS-558: MCP search action tracker.list (tool tracker_list) 'total'/'orphan_tasks' reporting contract. The raw tracker API has no page-independent 'total' field -- only 'count' (this page) and 'next_cursor' (more data outstanding or not). Prior behavior never forwarded the caller's page_size/cursor to the raw request (every call re-fetched the raw API's own default page and re-sliced it locally with _paginate()), so a caller's cursor never advanced the underlying query and 'total' was really just that one default page's size, silently mislabeled as a full-project total (observed: total=24 vs a true count >200 with next_cursor outstanding on the identical filter). Contract decision: report-as-lower-bound by default rather than exhaust-by-default, because tracker_list is the hot session-init read every agent hits at boot (page_size=10 in the mandatory init sequence per DOC-FFB4C9D87BCC) -- forcing exhaustion there would multiply round trips across every agent session boot on the platform. Contrast with the sibling ENC-ISS-557 fix in rhythm_cycle/tiers/sense.py's _open_task_count(), a once-per-rhythm-cycle-tick background job where bounded exhaustion is cheap; that asymmetry is why the two sibling issues took different default contracts on the same underlying bug.",
+      "fields": {
+        "page_size": {
+          "type": "integer",
+          "definition": "Now forwarded to the raw tracker API request (previously silently dropped -- the root cause of the undercount). Clamped to [1, 100]."
+        },
+        "cursor": {
+          "type": "string",
+          "definition": "Now forwarded to the raw tracker API request as next_cursor (previously only used for a local re-slice over an unrelated single fetch, so it never actually advanced the underlying query)."
+        },
+        "exhaust": {
+          "type": "boolean",
+          "default": false,
+          "definition": "Opt-in bounded-exhaustion mode (ENC-ISS-558). Walks next_cursor via the raw API until it naturally empties or _TRACKER_LIST_MAX_EXHAUST_PAGES=50 is hit (mirrors sense.py's ENC-ISS-557 _MAX_PAGES guard). Default false -- leave off for hot-path/session-init reads; use for callers that need an exact count and can pay the extra round trips."
+        },
+        "total": {
+          "type": "integer",
+          "definition": "Count of records actually fetched in this call (one page by default, or the full walked set when exhaust=true). No longer presented as an implicit full-project total."
+        },
+        "total_is_lower_bound": {
+          "type": "boolean",
+          "definition": "Present and true whenever a next_cursor remains outstanding after whatever fetching this call did -- i.e. 'total' is a floor, not a measurement. Absent (not merely false) when the count is exact."
+        },
+        "exhaustion_truncated": {
+          "type": "boolean",
+          "definition": "Present and true only when exhaust=true hit the _TRACKER_LIST_MAX_EXHAUST_PAGES guard before the cursor naturally emptied -- the exhaustive walk itself was capped, so even the exhaust=true total is still a lower bound in this case."
+        },
+        "orphan_tasks_is_lower_bound": {
+          "type": "boolean",
+          "definition": "Same lower-bound semantics as total_is_lower_bound, applied to orphan_tasks -- orphan detection has the identical undercount failure mode as total when only a partial page was fetched."
+        }
+      }
+    }
+  },
+  "change_summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard.",
+  "change_log": [
+    {
+      "version": "2026-08-17.2",
+      "date": "2026-08-17",
+      "summary": "ENC-TSK-O07 / ENC-ISS-621 (ENC-PLN-080, DOC-10A820AC32F2 C4), v4/main ONLY: extracted enceladus_shared.github_app_auth as the single GitHub App JWT + installation-token implementation, replacing per-lambda duplicates. NO new, renamed or removed fields on any governed entity -- an internal refactor plus the same credential-cache hardening already recorded for ENC-TSK-O03, logged here because the migrated backend/lambda/*/lambda_function.py files are schema-affecting paths under the agents.md section 3.11 guard. Public API: GitHubAppConfig, generate_app_jwt, get_installation_token, github_request. Semantics identical to ENC-TSK-O03 on main: re-mint plus single retry on 401/403 behind a 60s token-age floor and never looping; cache expiry taken from the mint response expires_at with a now+3600 fallback and the 300s refresh buffer preserved; structured github_validation_fail line and per-mint logging of expires_at plus the granted permission KEYS only. MIGRATED: checkout_service, deploy_decide, auth_refresh (AuthRefreshFunction also gained SharedLayerArn in 02-compute.yaml, having been the only migrated lambda without the shared layer). DELIBERATELY NOT MIGRATED: github_integration, left byte-identical to its prior state. devops-github-integration runs with ZERO Lambda layers attached, has no CFN resource in this repo, and Gen2 does not vendor the package (_build.yml rsyncs only the function's own srcdir), so adding the import would have produced Runtime.ImportModuleError at cold start -- the ENC-ISS-566 crash-loop class, introduced by a hardening change. Tracked as ENC-ISS-625; the migration must not be retried until the layer attachment is verified live. Consequence: ENC-TSK-O07 acceptance criterion 2 ('all four migrated') is intentionally left unstamped rather than fudged."
+    },
+    {
+      "version": "2026-07-12.4",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M92 (P0): tracker_mutation._handle_pwa_action() now stamps version_seq/feed_scope via _version_seq_update_parts() in all four mutating branches (close/note/reopen/worklog), mirroring _handle_log (M79) and the generic PATCH path. Closes the realtime-publish gap M79 could not: the PWA close/note/reopen/worklog button routes through _handle_pwa_action, NOT _handle_log, so a gamma-native human UI write (io's [USER] worklog note on ENC-TSK-L83, 05:29:31Z) landed but never entered the feed delta projection (version-seq-index GSI), pinning /api/v1/feed/delta at 622. The close branch splices the vseq clause inside SET, before its ADD closed_count clause. Repo-file edit only, no new entity/field added to the tracker record shape."
+    },
+    {
+      "version": "2026-07-12.3",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M79: tracker_mutation._handle_log() now stamps version_seq/feed_scope via _version_seq_update_parts(), mirroring the generic PATCH path's (_handle_update_field) existing idiom (same allocator, same UpdateExpression splice, same import path — enceladus_shared.version_seq with the version_seq_util.py bundled fallback). Closes a gap where a pure worklog append never re-surfaced its record in the GET /api/v1/feed/delta projection (version-seq-index GSI, ENC-TSK-L27) unless a separate field PATCH also landed on the same record. Repo-file edit only, no new entity/field added to the tracker record shape."
+    },
+    {
+      "version": "2026-07-08.05",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M36 follow-up: post-deploy live measurement showed the M36 concurrency fix (8 workers) didn't move the ~19-24s Lambda Duration; raised _MAX_PROJECT_FANOUT_WORKERS to 24 and set max_pool_connections=32 on the shared DynamoDB client (botocore's default of 10 would have silently capped concurrency below the new worker count). Not yet re-verified live as of this entry."
+    },
+    {
+      "version": "2026-07-08.04",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M36 (feed data-truth): feed_query per-project fan-out parallelized (ThreadPoolExecutor, was sequential -- confirmed ~20s cold-cache latency live on gamma) and per-type snapshot caps (issues/features/lessons/plans) moved from a global cross-project pool to per-project, so one active project's records can no longer crowd another's out of the tasks.json snapshot. Read-only, no schema/endpoint change. See last_change_summary for full detail."
+    },
+    {
+      "version": "2026-07-08.03",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M27 (ENC-FTR-130): io-queue completeness. Two new read-only, Cognito-gated GET routes on coordination_api close the two M19 Home \"Data gap\" placeholder rows -- GET /api/v1/coordination/queue/paused-approvals (GitHub Actions runs blocked on the v3-prod Environment's required-reviewer gate; reuses the existing ENC-FTR-021 GitHub App installation-token path via new _get_github_installation_token/_github_queue_api_get helpers, no new secret minted) and GET /api/v1/coordination/queue/stale-locks (Scan of the projects table for checkout_state=checked_out task records past STALE_CHECKOUT_THRESHOLD_MINUTES, mirroring backend/lambda/stale_checkout_monitor's detection core so the PWA agrees with the scheduled monitor's signal). Both handlers add no mutation path. New least-privilege GitHubAppSecretRead IAM statement (secretsmanager:GetSecretValue/DescribeSecret scoped to devops/github-app/*) on CoordinationApiRole (infrastructure/cloudformation/02-compute.yaml, covers gamma + prod via EnvironmentSuffix); no new DynamoDB IAM needed (TrackerTableAccess/ProjectsTableRead already grant Scan). New gamma-only APIGW routes RouteQueuePausedApprovals + RouteQueueStaleLocks (infrastructure/cloudformation/03-api.yaml, Condition: IsGamma, same posture as the Escalations feed). frontend/ui-v2 Home route now fetches both live and replaces routes/homeQueue.ts::GAP_QUEUE_ROWS with pausedApprovalRows/staleLockRows mapping functions."
+    },
+    {
+      "version": "2026-07-08.01",
+      "date": "2026-07-08",
+      "summary": "ENC-TSK-M12 / ENC-ISS-501 (SEV-1 residual): structural human-principal enforcement on escalation approve/deny. New _is_human_cognito_principal predicate in coordination_api (token_use must be 'id'; aud must be on the ESCALATION_HUMAN_CLIENT_IDS human app-client allowlist, default COGNITO_CLIENT_ID; bare client_id-without-aud shapes rejected; email required and must not fall under ESCALATION_MACHINE_EMAIL_DOMAINS, default enceladus.internal; fail-closed on absent claims) runs BEFORE the ENC-TSK-L92 email allowlist on _handle_escalation_decision. Closes the gap where _verify_token's deliberate acceptance of access tokens plus machine-operated human-pool Cognito users (terminal-agent@enceladus.internal via auth.cognito_session) left the email allowlist as the sole barrier against machine self-approval. Main-branch counterpart lands the identical checks in escalation_decision_authorizer (ENC-TSK-L95 surface). New fields coordination.escalations.ESCALATION_HUMAN_CLIENT_IDS + ESCALATION_MACHINE_EMAIL_DOMAINS."
+    },
+    {
+      "version": "2026-07-07.14",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L93: document_api GET ?project= list now honors include_content=false (and content=false alias) for body-excluded metadata projection. Skill rows return document_id, title, description, version (from agentskills_manifest.version), updated_at, runtime_hint (runtime_variants keys or 'claude,agentskills' default). Non-skill rows omit full_description/claude_description/content/agentskills fields. Default include_content=true unchanged. MCP documents.list forwards include_content. New docstore.document.list_include_content + list_runtime_hint dictionary fields."
+    },
+    {
+      "version": "2026-07-07.13",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L05 (B63 Ph2 H-BACKFILL AC2-6): v3 component-registry instance backfill in tools/seed-component-registry.py -- four v3 identity fields + v3 required_transition_type on all active enceladus components; PWA decomposition (frontend/cdn/api-gateway) superseding comp-enceladus-pwa; comp-enceladus-neo4j external dep + infrastructure/external/neo4j-auradb.yaml; nine per-CFN-file umbrellas + narrowed comp-cloudformation-data/-app (MECE, I2-I5); comp-enceladus-mcp-server single MCP umbrella (ENC-FTR-094 debt); comp-umbrella-governance-documentation meta umbrella. Extended verify_component_hardening_fields.py + tests (v3 identity/MECE audit); verify_component_required_transition_type.py guard enum -> v3. Schema already v3 (ENC-TSK-L77). AC-5 + live legacy-row rename/deprecation are io-Cognito follow-ups."
+    },
+    {
+      "version": "2026-07-07.12",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L87: graph_query_api.lambda _query_neighbors dropped the `neighbor.project_id = $project_id` Cypher filter (only the START node stays project-scoped). MENTIONS edges are legitimately cross-project -- graph_sync's write path MERGEs by record_id only -- so this read-side filter silently hid every correctly-written cross-project edge from every 'neighbors' consumer, not just mentions_drift_audit. Previously zero test coverage for this function; added dedicated tests including a Cypher-text regression test."
+    },
+    {
+      "version": "2026-07-07.11",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L87: deploy_parity_validator.lambda mentions_drift_audit -- two independent root causes fixed for the escalating MENTIONS drift ratio (43/96 -> 59/96). (1) DeployParityValidatorFunction's TRACKER_API_URL/graphsearch fallback was hardcoded to the prod API Gateway on both prod and gamma; the gamma validator was comparing gamma DynamoDB content against PROD's Neo4j graph. Fixed via a gamma-scoped GRAPHSEARCH_URL CFN env var (Fn::If on IsGamma; the code already supported this override, it was never wired up). (2) _run_mentions_drift_audit's sample spans every project in the shared tracker table (type-updated-index has no project_id key), but _current_mentions_for was called with no project_id, always defaulting to 'enceladus'; any non-enceladus-project sample read back as a false-positive full mismatch. Fixed by threading record.get('project_id') through. No new fields/entities; behavioral bugfixes only."
+    },
+    {
+      "version": "2026-07-07.6",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L89 / FTR-122: agent-session retirement now atomically releases task checkouts held by the retiring session in the same DynamoDB transaction as session retire + SCI revocation for both the idle and unclaim sweeps. Added coordination.agent_session_checkout_release_backfill plus MCP coordination action agent.checkout_release_backfill for the one-time retired-session stale-lock repair, including the ENC-TSK-L06 / ENC-SES-057 class."
+    },
+    {
+      "version": "2026-07-07.5",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L85: graph_sync.lambda CDC transport swapped from EventBridge Pipes (DynamoDB-stream source, confirmed account-wide non-functional per ENC-ISS-497, same fix pattern as ENC-TSK-L84) to a direct Lambda EventSourceMapping (GraphSyncTrackerStreamTrigger / GraphSyncDocumentsStreamTrigger) on the tracker + documents DynamoDB streams. Gamma only: GraphSyncFunction/GraphSyncRole/GraphSyncSqsTrigger are shared prod(v3)+gamma resources with no Condition, so every change is scoped via Fn::If or a new Condition: IsGamma resource -- v3-prod's deployed behavior is unchanged even on a future redeploy of this template. Handler now accepts both the legacy SQS-wrapped shape and the native direct-stream shape (correct messageId vs SequenceNumber failure identifiers). Legacy GraphSyncSqsTrigger disabled on gamma only, left enabled on prod/v3, not deleted; Pipes left in place."
+    },
+    {
+      "version": "2026-07-07.3",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L06 (B63 Phase 2 AC-6): new ID Service Lambda (enceladus-id-service{-gamma}) is the sole authority for record-ID allocation (dedicated enceladus-id-counters table, IAM-isolated from tracker_mutation's role), the idempotency-key contract (enceladus-id-idempotency, TTL 24h), and HMAC-SHA256 item_id_provenance signing (verified, warning-only, by graph_sync before projection). tracker_mutation's edge-layer guard now also rejects client-supplied item_id_provenance (extends ENC-ISS-132/ENC-FTR-069's ID_BOUNDARY_VIOLATION contract) and fires a fire-and-forget trust-score violation counter (enceladus-id-violations) on every rejection. New tracker.record_id.item_id_provenance field + tracker.id_boundary_enforcement entity."
+    },
+    {
+      "version": "2026-07-07.2",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-B66 (PLN-006 Phase 5 Gate AC-3): new entity observability.xray_tracing_config documents the AWS X-Ray active-tracing posture across the 5-service gamma trace set (Record/Lifecycle/Scoring/Checkout/MCP-Server-standin) declared in infrastructure/cloudformation/02-compute.yaml, including the CoordinationApiFunction MCP-Server-standin architectural decision (ENC-TSK-K45) and the documented enceladus-mcp-code-gamma prod-stack-ownership constraint (Condition:IsProduction, out of reach for gamma-only compute deploys). CEE (5 categories), Fiedler lambda2, F_governance, and ArcWalk telemetry entities were already adequately documented by prior K41/K42/K43/H86 work -- confirmed via review, no changes needed to those entities."
+    },
+    {
+      "version": "2026-07-07.1",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L80: graph_query_api._query_adjacency's node_count/edge_count session.run() calls now bind project_id=project_id (previously referenced $project_id in Cypher text only, causing Neo.ClientError.Statement.ParameterMissing on every offset=0 adjacency call — the exact call shape ENC-TSK-K41's CEE Lambda makes nightly). No entity/field/schema change; version bump only to satisfy the Governance Dictionary Guard's file-touched heuristic."
+    },
+    {
+      "version": "2026-07-05.23",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L42 (B67 Search2.0): new opensearch_backfill.lambda entity for devops-opensearch-backfill scan+bulk job (records_write / records_v{n} target, shared search_index_core with L41 indexer; L44 scoped indexer credentials)."
+    },
+    {
+      "version": "2026-07-05.22",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L44 (B67 Search2.0 hardening): opensearch_indexer.lambda gains OPENSEARCH_USERNAME field; OPENSEARCH_SECRET_NAME default switched from enceladus/opensearch/gamma-admin to enceladus/opensearch/gamma-indexer (write-only scoped credential). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-05.20",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L15 (C08/FTR-096): new handoff_consolidation_engine.lambda entity for enceladus-handoff-consolidation-engine scheduled HCE Lambda (Document API write path, OGTM edges, GDMP Stage-2 provenance)."
+    },
+    {
+      "version": "2026-07-05.19",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-K26 hotfix: tracker_mutation GET maps item_id -> plan_id (etc.) before attach_record_extensions — gamma detail pages were missing context_node because _deser_item only exposes item_id."
+    },
+    {
+      "version": "2026-07-05.18",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-K26 hotfix: vendor record_extensions into feed_query/tracker_mutation Lambda zips via .build_extras — gamma was silently skipping extensions because enceladus-shared:10 lacks the new module."
+    },
+    {
+      "version": "2026-07-05.17",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L41 (B67 Search2.0 WaveB): new opensearch_indexer.lambda entity for devops-opensearch-indexer CDC Lambda (dedicated SearchIndexQueue FIFO, records_write bulk upsert/delete, external-version idempotency). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-05.15",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-K26 (B67 PWA2.0 Ph7): shared record_extensions module + feed_query/tracker_mutation GET enrichment for typed_relationships and computed context_node scores; ui-v2 governance route, Cytoscape plan graph, typed-edge + badge primitives. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-05.13",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L09 (B64 Ph3): decomposed MCP code-mode meta-tools from monolithic server.py into tools/enceladus-mcp-server/mcp_server/ (tools/search, tools/coordination, tools/execute, tools/context + actions/meta_support/runtime). server.py remains Lambda entrypoint with bind_runtime() wiring; enceladus-mcp-code and enceladus-mcp-streamable share the package. New entity mcp_server.package_decomposition. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-05.12",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L58 (L10 follow-up): added backend/lambda/mcp_streaming_gateway/lambda_function.py as a build-discovery marker (Gen2 requires this exact filename to package a Lambda dir; the real entry point remains asgi_app.py via the AWS Lambda Web Adapter). No new schema/behavior -- the handler only exists to be discovered and raises if ever actually invoked directly."
+    },
+    {
+      "version": "2026-07-05.9",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L10 (B64 Ph3): new mcp_streaming_gateway Lambda (Lambda Web Adapter + Starlette/uvicorn, reusing server.py's MCP tool surface) + dedicated REST API Gateway v1 (McpStreamingRestApi) with responseTransferMode=STREAM, gamma-only. New entity mcp_streaming_gateway.lambda."
+    },
+    {
+      "version": "2026-07-05.5",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L25 (B67 Search2.0 WaveB / FTR-127 AC-10/16/17): new user_preferences_api Lambda + user-preferences DynamoDB table (PK=sub) + GET/PUT /api/v1/user/preferences routes, gamma-only. New entity user_preferences_api.lambda."
+    },
+    {
+      "version": "2026-07-05.4",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L23 (FTR-127 AC-1..4/13): GET /api/v1/feed/corpus — cursor-paginated multi-project corpus spanning tracker + documents tables with filter/sort pushdown, source-tagged composite cursors, facet counts, and compact attrs projection."
+    },
+    {
+      "version": "2026-07-05.3",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L07 (B63 AC-7 / B65 AC-5/AC-7): bidirectional relation enforcement -- tracker_mutation PATCH now atomically mirrors newly-added related_task_ids/related_issue_ids/related_feature_ids onto each target's reverse field; document_api PUT/PATCH mirrors related_items onto each named tracker record's new related_document_ids field; new tracker.relate(source_id, target_id) MCP convenience action performs the append under one governance hash check. inverse_of declared across tracker.task/issue/feature/lesson and docstore.document."
+    },
+    {
+      "version": "2026-07-02.32",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K42 (B66 Ph5, ENC-PLN-064): GDMP Stage-1 auto-remediation Lambda added -- nightly EventBridge (gamma, cron 06:00 UTC) deterministic whitelist remediation of compliance_warnings via document_api PATCH, io-approval ramp (FTR-106 AC-4 pattern), CEE_GDMP_HARD_DISABLED kill switch. New entity corpus_entropy_gdmp_remediation.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-06-27.05",
+      "date": "2026-06-27",
+      "summary": "ENC-TSK-I32 / ENC-FTR-116 Wave 2: governance drift-detection backstop — governance_drift_check Lambda added (read-only scheduled auditor comparing canonical DDB vs. live S3 §4.3 hash). New entity: governance_drift_check.handler. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-06-27.01",
+      "date": "2026-06-27",
+      "summary": "ENC-TSK-I30 (ENC-FTR-116 / ENC-ISS-390): deterministic governance URI dual-key resolution — agents/agents.md aliased to canonical agents.md, canonical-precedence catalog dedup (no last-writer-wins), canonical-first read ordering so the content-hash input equals governance.get('agents.md') bytes. server.py change; version bump required by the CI governance-dictionary guard."
+    },
+    {
+      "version": "2026-06-21.02",
+      "date": "2026-06-21",
+      "summary": "ENC-TSK-G45 + ENC-TSK-G12 (PR #483): Diataxis Reference rewrite of the top-20 code-mode tool descriptions + canonical typed handoff mandate schema (handoff_mandate.py, strict:true dispatch generator). server.py tool-surface change; version bump required by the CI governance-dictionary guard."
+    },
+    {
+      "version": "2026-04-23.01",
+      "date": "2026-04-23",
+      "summary": "ENC-TSK-G06: documented graph_sync document DELETE identity normalization and orphan placeholder purge semantics; version bump required by CI governance-dictionary guard."
+    },
+    {
+      "version": "2026-04-22.01",
+      "date": "2026-04-22",
+      "summary": "ENC-TSK-F99: no schema changes — version bump required by CI guard for lambda_function.py modification (ENC-ISS-300 _get_task_record scan fix)"
+    },
+    {
+      "version": "2026-06-27.03",
+      "date": "2026-06-27",
+      "summary": "ENC-TSK-I27+I28 / ENC-FTR-116 Wave 2: add governance.version_record (canonical governance-version DDB table, CAS-protected, sole-writer=RecomputeGovernanceRole) and recompute_governance.event_handler (S3 ObjectCreated trigger, §4.3 bundle hash, dedup/idempotency/recursion invariants). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-06-28.06",
+      "date": "2026-06-28",
+      "summary": "ENC-TSK-I88 / ENC-FTR-085: add graph_query_api.adjacency read-only search_type (project-scoped undirected simple-graph export, paginated; no new edge type, OGTM N/A) for the nightly comp-percolation-monitor Lambda. Gamma-only."
+    },
+    {
+      "version": "2026-07-01.02",
+      "date": "2026-07-01",
+      "summary": "ENC-TSK-J04 / ENC-FTR-074 Ph3: agent-identity graph projection. Added entity graph_sync.agent_identity_edges (node projections + five typed edges: AUTHENTICATED_AS, OWNED_BY, DERIVED_FROM, TRIGGERED_BY, MUTATED) and entity coordination.agent_credential (agent-credentials store: credential_id, agent_identity_id, issued_at, status, revoked_at, revoked_reason, rotated_from + optional session credential_id binding). Edge labels registered byte-identically across graph_sync.RELATIONSHIP_TYPE_TO_EDGE_LABEL and graph_query_api._ALLOWED_EDGE_TYPES (ENC-ISS-178). All projection rides the existing DynamoDB Streams -> EventBridge Pipe -> SQS -> graph_sync path (no write amplification, no synchronous Neo4j on the hot path)."
+    },
+    {
+      "version": "2026-07-01.04",
+      "task": "ENC-TSK-J43",
+      "summary": "Backported I38 agent-session HTTP routes to v4/main + credential_id binding on coordination.agent_session."
+    },
+    {
+      "version": "2026-07-01.05",
+      "task": "ENC-TSK-J44",
+      "summary": "Fixed graph_sync._normalize_record_for_graph probe order bug (credential-bound sessions misclassified as agent_credential)."
+    },
+    {
+      "version": "2026-07-01.06",
+      "task": "ENC-TSK-J46",
+      "summary": "Added document.lesson-candidate and coordination.lesson_candidates entities: candidate list filter (document_api handoff_status query param) and io-gated approve/reject (coordination_api, Cognito-only), approve creates a governed ENC-LSN via the tracker.create_lesson validation surface with evidence_chain provenance back to the candidate."
+    },
+    {
+      "version": "2026-07-01.07",
+      "task": "ENC-TSK-J46",
+      "summary": "Fixed a gamma E2E finding: lesson-candidate approve/reject were calling document_api's PATCH via the shared internal-key service credential, which document_api's Cognito-only gate for candidate transitions correctly rejected (that credential is indistinguishable from the MCP server's agent-facing documents.patch path). Replaced with a direct, atomically-conditioned DynamoDB write plus an append-only decision_log, gated solely by coordination_api's own Cognito check. Added DocumentsTableCandidateDecisionWrite (dynamodb:UpdateItem) to CoordinationApiRole."
+    },
+    {
+      "version": "2026-07-01.08",
+      "task": "ENC-TSK-J59",
+      "summary": "Fixed a second gamma E2E finding: approving a lesson candidate 500'd because _create_lesson_record passed pillar_scores/confidence as native Python floats into DynamoDB put_item -- boto3's TypeSerializer requires Decimal for Number attributes. Converted via Decimal(str(v)). Added a dedicated serialization regression test that exercises the real put_item path (no mocking of _serialize) so this class of bug fails in CI, not just in gamma."
+    },
+    {
+      "version": "2026-07-02.01",
+      "task": "ENC-TSK-J68",
+      "summary": "ENC-TSK-J68 (ENC-FTR-121 Ph1, DOC-5B888FCA43B8): Escalations entity + governed request/read surface. New tracker.escalation item type in the existing tracker table (escalation#{ENC-ESC-*} sort key, server-minted via the escalation counter; NOT a generic _RECORD_TYPES member — generic CRUD/checkout cannot touch it), seven-state escalation FSM, mutation-handler registry with request-time validate_payload for deploy_arc_change and direct_state_override (status legality checked, path legality deliberately not — that is what io approval overrides), and MCP actions escalation.request/get/list behind ENABLE_ESCALATION_PRIMITIVE. Approve/deny have no MCP surface by design (Cognito human path only)."
+    },
+    {
+      "version": "2026-07-02.02",
+      "task": "ENC-TSK-J69",
+      "summary": "ENC-TSK-J69 (ENC-FTR-121 Ph2, DOC-5B888FCA43B8): applyEscalatedMutation applier - the single privileged code path applying io-approved escalations. applied_at idempotency guard + conditional approved->applying concurrency gate; both handler applies (deploy_arc_change preserving active checkouts; direct_state_override with escalation_waived sentinels, escalated_closure, verbatim field_values) execute one atomic UpdateItem on the target with escalation_provenance + [ESCALATION-APPLIED] worklog riding the same write (no-partial-write). applying->failed captures errors in result; corrective requests are new escalations. record.escalation.applied audit event. Also: escalation.list pseudo-id alias GET /{project}/escalation/list for explicit APIGW route tables (found in J68 gamma validation). Validators unchanged - no bypass flags."
+    },
+    {
+      "version": "2026-07-02.03",
+      "task": "ENC-TSK-J70",
+      "summary": "ENC-TSK-J70 (ENC-FTR-121 Ph3, DOC-5B888FCA43B8): Cognito approval API + PWA Escalations page. coordination.escalations entity: Cognito-human-only feed/approve/deny routes (403 for internal-key/SCI/managed-token; no MCP action), requested->approved|denied|denied_with_guidance decision writes with race guards, approve drives applyEscalatedMutation via Lambda invoke with a fail-soft approved-but-unapplied path, section-5.7 render_diff with drift flag computed from the live target at render time. PWA: hamburger menu item + /escalations page (pending cards with diff + drift warning, approve/deny/deny-with-guidance, collapsed History audit section). APIGW routes gamma-only in 03-api.yaml; TRACKER_MUTATION_LAMBDA_NAME env + InvokeTrackerMutationEscalationApply role grant in 02-compute.yaml."
+    },
+    {
+      "version": "2026-07-02.04",
+      "task": "ENC-TSK-J71",
+      "summary": "ENC-TSK-J71 (ENC-FTR-121 Ph4, DOC-5B888FCA43B8): escalation.watch session-scoped cursor polling. Count-based opaque cursor (base64url JSON {escalation_id: events_consumed}) against the append-only events array - lossless under second-granular event timestamps where a timestamp cursor would drop same-second FSM edges; stable on empty polls; malformed cursors replay safely. Every poll refreshes the session's new last_activity_at heartbeat and the idle sweep's _idle_reference prefers it (listening agents survive the sweep; section 5.9 preferred formulation). MCP coordination action escalation.watch behind ENABLE_ESCALATION_PRIMITIVE; gamma APIGW route RouteEscalationsWatch. Polling guidance: 15-30s, backoff after two idle hours; polling only."
+    },
+    {
+      "version": "2026-07-02.05",
+      "task": "ENC-TSK-J72",
+      "summary": "ENC-TSK-J72 (ENC-FTR-121 Ph5, DOC-5B888FCA43B8): SNS [ESCALATION] notifications to io. Publishes on requested (post-write) and terminal applied/failed; failure-isolated (never fails the escalation write); reuses devops-feed-alerts{suffix} via ESCALATION_ALERTS_TOPIC_ARN env + PublishEscalationAlerts role grant (02-compute.yaml, gamma lane; prod via Ph7a). Sub-dollar budget; email subscription confirmation is an io residual for Ph8."
+    },
+    {
+      "version": "2026-07-02.09",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J91 (ENC-ISS-441 Ph1): I71 agent-session idle-sweep backported to v4/main - _handle_agent_session_idle_sweep + EventBridge dispatch in coordination_api, AgentSessionIdleSweepSchedule rule + permission + env vars in 02-compute.yaml (v4). New entity coordination.agent_session_idle_sweep documenting the v4 idle-reference precedence (last_activity_at > claimed_at > created_at). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.12",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J92 (ENC-ISS-441 Ph2, ENC-FTR-122): Session Claim ID (SCI) primitive shipped DARK - agent.claim mints SCI-{uuid4_hex} into the checkout-tokens table (token_type=SCI, 24h TTL, env-suffixed CHECKOUT_TOKENS_TABLE) and returns it in the claim envelope; agent.retire revokes (revoked/revoked_at/revocation_reason); session item stamped with sci_token_id. New entity coordination.session_claim_id. IAM SciTokenAccess grant + CHECKOUT_TOKENS_TABLE env on CoordinationApiFunction (02-compute.yaml v4). No enforcement until ENC-TSK-J93. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.13",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J94 (ENC-ISS-441 Ph4, ENC-FTR-122): retirement sweeps - new coordination.agent_session_unclaim_sweep entity (rate(10 minutes) EventBridge rule, allocated-only, created_at reference, SCI revocation unclaim_ttl_exceeded); idle sweep default threshold tightened 86400->7200 with last_activity_at-preferred reference and SCI revocation idle_ttl_exceeded (revoked_scis/revoked_sci_count in both sweep summaries). Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.16",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J93 (ENC-ISS-441 Ph3, ENC-FTR-122): SCI enforcement gate live in checkout_service (checkout/advance/log) + tracker_mutation (set/log/create) - 403 SCI_REQUIRED on absent/unknown/wrong-type/revoked/expired/mismatched SCI for post-epoch ENC-SES identities; fabricated session ids fail closed; SCI_ENFORCEMENT_EPOCH 2026-07-02T12:00:00Z grandfathers pre-existing sessions; identity-shape exemptions (non-ENC-SES providers) + FTR-037 checkout-service-key exemption in tracker_mutation; SCI-validated mutations refresh last_activity_at (J83). New entities checkout_service.sci_enforcement_gate + tracker.sci_enforcement_gate. The ENC-ISS-441 register->claim handshake is now ENFORCED. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.17",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-J96 (ENC-ISS-441 Ph6, ENC-FTR-122): retirement_prompt injected verbatim into terminal-state success envelopes - checkout_service task->closed + plan->complete advances, tracker_mutation status writes to task/issue closed, feature production/deprecated, plan complete. Additive-only; non-terminal envelopes byte-identical. New entity tracker.retirement_prompt. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.19",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K10 (ENC-ISS-441 Ph7b, ENC-FTR-122, supersedes J97): MCP server sci pass-through - optional sci property on checkout_task/advance_task_status/append_worklog schemas, strip-and-forward at 7 mutation-forwarding sites (checkout/advance/log, plan checkout/advance, tracker set/log; tracker_create via F76 passthrough), agent.claim raw response passthrough confirmed (sci/sci_issued_at/sci_ttl_seconds flow unchanged). No MCP-layer validation. New entity mcp_server.sci_passthrough. Repo-file edit only - governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.20",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K12 (ENC-ISS-473, ENC-ISS-474): MCP server restores truncated tracker_embeddings_for and tracker_sheaf_cohomology handlers (search actions tracker.embeddings_for / tracker.sheaf_cohomology forwarding to graph_query_api embeddings_for and sheaf_cohomology search_types); coordination_api .build_extras now packages tools/enceladus-mcp-server/telemetry_rank.py so dispatch_plan / coordination paths can import telemetry.rank helpers. New entities mcp_server.tracker_embeddings_for and mcp_server.tracker_sheaf_cohomology. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.22",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K02 (FTR-084 Ph2): intent-classifier training loop — intent_training.py + weekly EventBridge schedule on coordination_api (gamma), versioned S3 record_boosts with rollback action, TRAINING_HARD_DISABLED kill switch default ON, holdout degradation auto-disable, cost-preflight alarm. Inference path applies trained boosts in classify_session_intent; applied_entelechy_override still wins. New entity coordination_api.intent_training. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.26",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K03 (FTR-106): unlearning Lambda — nightly EventBridge (gamma 03:00 UTC), stigmergic-trace miss clustering + drift SAR cross-ref, unlearning-candidate draft reports, reversible S3 tombstones, reference archive via graph_sync stream; dry-run + io-approval ramp defaults. New entity unlearning.lambda. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.27",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K20 (PWA 2.0 / B67 AC-10): AppSync-Events FeedPublisher — new devops-appsync-feed-publisher Lambda (gamma arm64) consuming devops-project-tracker DynamoDB Streams (NEW_AND_OLD_IMAGES) and fanning out lightweight real-time event payloads to AppSync Events on /feed/updates, /records/{recordId}, /projects/{projectId}. New CFN 06-appsync-events.yaml (AppSync::Api EVENT + ChannelNamespaces + ApiKey + EventSourceMapping BatchSize=1/window=0/LATEST/ReportBatchItemFailures). New entities appsync_feed_publisher.lambda and appsync_feed.event (UUID v7 eventId, monotonic cursor, server-pre-rendered summary; median payload <= 500 bytes per AC-23). Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.28",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K43 (B66 Ph5): Fiedler lambda2 GraphHealth CloudWatch metric (gamma re-delivery of v3 ENC-TSK-C10) via the existing FTR-088 graph_laplacian CSR/Fiedler path (ISS-465-compliant, no GDS projection), new action='publish_graph_health' dispatch entry in graph_query_api publishing to Enceladus/GraphHealth. F_governance percentile normalization (DOC-A3D0CDF91CE9 Q3.1) integrated into scoring_service _compute_resonance_score as an optional governance-compliance weighting term. New entities graph_query_api.publish_graph_health and scoring_service.f_governance. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.29",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K44 (ENC-FTR-071 / B66 Ph5): prod_health_monitor Lambda extended with per-service health checks (DynamoDB, Neo4j AuraDB, S3, SQS, Lambda cold-start baseline) publishing DynamoDBThrottle / GraphSyncLag / MCPColdStart / ServiceHealthCheck metrics (Enceladus/Prod namespace) feeding the B66 CloudWatch dashboard. Lambda resource + IAM role moved from 05-monitoring.yaml into 02-compute.yaml (Lambda Workflow Coverage Guard visibility); lambda_workflow_manifest.json cfn_managed flipped false->true for enceladus-prod-health-monitor. Updated entity monitoring.health_probe. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.30",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K41 (B66 Ph5, ENC-PLN-064): Corpus Entropy Engine (CEE) Lambda -- nightly EventBridge (gamma, cron 05:00 UTC) telemetry-only scan for five entropy categories: orphan (no parent_task_id/related_task_ids or wave doc missing plan_anchor_id), stagnation (open tasks with no worklog within STAGNATION_THRESHOLD_DAYS=14), relational (declared related_*_ids with no corresponding graph_query_api adjacency edge), retention (Lesson stability < FSRS_T3_THRESHOLD=0.7, falling back to resonance_score), and compliance/semantic (document compliance_score below COMPLIANCE_SCORE_THRESHOLD=70 AND document_maturity_state=raw). Reads exclusively through the tracker/document/graph_query_api HTTP surface (no direct DynamoDB access, no new edge types -- OGTM). CEE_HARD_DISABLED=1 kill switch ships ON by default; io clears to 0 to enable the first scheduled run. Emits per-category EntropyFindingCount to CloudWatch namespace Enceladus/CEE. Cost-preflight (ISS-465): nightly cadence, 512MB/300s ceiling, well under $1/mo; CorpusEntropyEngineCostHeadroomAlarm guards EventBridge invocation count. New entity corpus_entropy_engine.lambda. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-02.31",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K43 (B66 Ph5) follow-up: FiedlerAlgebraicConnectivity (Enceladus/GraphHealth, ENC-TSK-C10) now carries the REAL Fiedler lambda2 via a cross-Lambda invoke from graph_health_metrics into graph_query_api's action='publish_graph_health' (FTR-088 CSR/Fiedler path, ISS-465-compliant), replacing the pre-K43 GraphEdgeDensity placeholder. New entity graph_health_metrics.real_fiedler_lambda2."
+    },
+    {
+      "version": "2026-07-02.33",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K46 (B66 Ph5): governance-dictionary bump for the B66 Phase-5 CloudWatch dashboard (GOVERNANCE_SYNC_REQUIRED handoff DOC-83017CDCBD5A / ENC-TSK-K47 AC-2). Adds entity monitoring.v4_architecture_dashboard describing EnceladusV4Dashboard (05-monitoring.yaml, 13 widgets). K41/K42/K43(x2)/K44 Phase-5 entities were already landed by their own build-task PRs; K46 dashboard was the sole remaining Phase-5 entity."
+    },
+    {
+      "version": "2026-07-02.34",
+      "date": "2026-07-02",
+      "summary": "ENC-TSK-K34 (ENC-ISS-477 cutover, DOC-F234A4E11DFD Option E): the DynamoDB governance-policies mirror of this dictionary is retired from the read path. coordination_api._load_governance_dictionary now serves this bundled file exclusively -- no DDB scan, no fallback branch. ENC-TSK-K31 found the DDB mirror had never once served as a live, independently-authored hot-patch target (every write only ever caught DynamoDB up to a prior git/S3 change), and it had been unwritable since 2026-06-29 (509KB item vs DynamoDB's 400KB cap). document_api's dictionary-specific DDB propagation is removed alongside it. This file (repo -> Lambda bundle -> deploy) is now the sole and always-authoritative source; check_governance_dictionary_sync.py remains the enforcement that this file stays current with schema-affecting code changes. No entity schema changed."
+    },
+    {
+      "version": "2026-07-05.6",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L47 (B67 backend / FTR-127 AC-19, K25 AC-3): If-Match / HTTP 409 per-record revision-conflict contract added to tracker_mutation's generic field-update path (sync_version) and document_api's PATCH path (version). Absent header preserves prior unconditional-write behavior. New entity api.if_match_revision_contract; new error_envelope.code value REVISION_CONFLICT."
+    },
+    {
+      "version": "2026-07-05.8",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L29 (B67 Search2.0 WaveC / DOC-77D6C714867E §15m): appsync_feed_publisher now attaches a full record body (deserialized NewImage) to the /records/{recordId} channel's event only -- /feed/updates and /projects/{id} stay at the fixed AC-23 lightweight payload. New entity appsync_feed_publisher.full_record_body_l29."
+    },
+    {
+      "version": "2026-07-05.14",
+      "date": "2026-07-05",
+      "summary": "ENC-TSK-L35 (B67 PWA2.0 session detail + worklog mirroring): coordination.agent_session gains updated_at (unconditional bump on every session-requiring call passing the SCI gate, including previously-untouched grandfathered/checkout-forwarded sessions) and history (best-effort mirror of every worklog entry the session appends to any governed record, via tracker_mutation._mirror_worklog_to_session). New GET /api/v1/coordination/agents/sessions/{id} single-session read route (coordination_api._handle_agent_session_get). Also wires the pre-existing agent-session-list/agent-type-list handlers (ENC-TSK-L34) to new API Gateway routes in 03-api.yaml. Repo-file edit only -- governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-07.8",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L77: component registry v3 hardening adds component_address/component_repo_dir/component_address_class/component_class, migrates component required_transition_type to code|external_deploy|documentation with legacy read-time mapping, and documents external_deploy_evidence plus documentation_evidence advance gates."
+    },
+    {
+      "version": "2026-07-07.9",
+      "date": "2026-07-07",
+      "summary": "ENC-TSK-L91: corpus_entropy_gdmp_remediation.lambda -- CEE_GDMP_HARD_DISABLED redefined to gate MUTATION only (candidate scan/report/breakdown still run while disarmed; ramp counter not advanced), new GDMP_RUN_BREAKDOWN_SINK audit artifact, and the fresh-GET/recompute optimistic-concurrency guard before PATCH."
+    },
+    {
+      "version": "2026-07-08.02",
+      "date": "2026-07-08",
+      "summary": "ENC-ISS-509 (carrier ENC-TSK-M24): tracker_mutation._handle_get_record gains _get_record_full_with_gamma_fallback -- on gamma, a miss against the local devops-project-tracker-gamma table (one-time-seeded, never continuously synced from the canonical table) falls through to a single read-only GetItem against the canonical devops-project-tracker table so the gamma PWA detail route can render recently-created records. GET-detail only; no change to writes, list, or search. New least-privilege TrackerTableCanonicalReadFallback IAM statement (dynamodb:GetItem only) on TrackerMutationRole, gated !If [IsGamma] (infrastructure/cloudformation/02-compute.yaml)."
+    },
+    {
+      "version": "2026-07-10.01",
+      "date": "2026-07-10",
+      "summary": "ENC-TSK-M39: feed_query full-refresh OpenSearch selection tier. feed_query is not VPC-attached, so it invokes graph_query_api (action=feed_selection, new entity graph_query_api.feed_selection) as a proxy to the records_read OpenSearch alias, then hydrates full record bodies via a bounded DynamoDB BatchGetItem. Falls back to the existing DDB fan-out on any failure. New feed_source response field documented in feed_query.opensearch_tier."
+    },
+    {
+      "version": "2026-07-10.02",
+      "date": "2026-07-10",
+      "summary": "ENC-TSK-M48: parallelize feed_query's OpenSearch-tier BatchGetItem hydration (_hydrate_records_via_batch_get now fans batches out via ThreadPoolExecutor, matching ENC-TSK-M36 sizing) to bring live gamma p95 under the 500ms bar. Internal concurrency fix only -- no schema, field, or endpoint change; feed_query.opensearch_tier entity unchanged."
+    },
+    {
+      "version": "2026-07-11.2",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M55: enceladus_shared.relationship_store gains read-volume reduction for the feed edge-attach path -- RELATIONSHIPS_TABLE_AUTHORITATIVE env flag (CFN, gamma=true) skips the legacy tracker-table fallback pass in iter_project_relationship_items; new build_page_sk_ranges emits sort-key BETWEEN bounds from the capped feed page's source IDs (FEED_EDGE_RANGE_MAX_CLUSTERS, default 1 range/project; FEED_EDGE_RANGE_BOUND_DISABLED kill switch); feed_query passes source_ids_by_project + logs edge_attach_stats (query_count/items_seen/scanned_count). Also revives the gamma attach path, dead since the layer/vendoring gap (relationship_store missing from enceladus-shared:10)."
+    },
+    {
+      "version": "2026-07-11.3",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M55 REVERT (AC-5 rollback discipline): PR #986 reverted. Live gamma p95 regressed 4.63s -> 5.99s (mean 4.14s -> 5.77s, 22-request probes) because the change also revived the feed edge-attach path, dead since the enceladus-shared:10 layer/vendoring gap -- reviving it re-adds 14 sequential DDB Queries + O(records x edges) context_node compute per full refresh on the 256MB Lambda. relationship_store reverts to pre-M55 shape (RELATIONSHIPS_TABLE_AUTHORITATIVE / build_page_sk_ranges / range_bounding_disabled removed from code; the gamma CFN env var is removed in the same commit). The edge-attach restoration question (functionality vs latency) is handed to io -- see ENC-TSK-M55 worklog HANDOFF."
+    },
+    {
+      "version": "2026-07-11.4",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M69: appsync_feed_publisher's publish_to_appsync crashed on every invocation with TypeError: Object of type Decimal is not JSON serializable (DynamoDB Stream Number attributes deserialize to Decimal via boto3.dynamodb.types.TypeDeserializer). Added a single _json_default() hook applied to all three json.dumps call sites in the module (lightweight payload, /records/{recordId} full_body per ENC-TSK-L29, and the outer publish body) -- covers Decimal at any depth, not just the lightweight 7-field payload. Integral Decimal -> int (record IDs/counts/versions must not drift to float); non-integral -> float. No entity/field schema change, just a serialization-layer fix; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-11.5",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M65: Added entity.composition declarations to the governance data dictionary for the two composite tracker entities, tracker.plan and tracker.feature. tracker.plan.composition documents that plan objectives (task/issue/feature -- never lesson) attach exclusively via the objectives_set array field, governed by plan.add_objective/plan.remove_objective/plan.reorder_objectives/plan.replace_objectives, with 1:N (practically N:M) cardinality, and clarifies that tracker.task.parent (task-to-task only) is not the plan composition mechanism. tracker.feature.composition documents that features compose tasks via the bidirectional related_task_ids <-> related_feature_ids cross-reference pair (ENC-TSK-L07 mirrored PATCH), N:M cardinality. No behavioral/API change, dictionary-only addition."
+    },
+    {
+      "version": "2026-07-11.6",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M66: Registered the tracker.creation_rules search action (tool tracker_creation_rules; coordination_api route GET /api/v1/tracker/creation_rules; MCP server thin passthrough in tools/enceladus-mcp-server/server.py). Given record_type (+ optional parent_type), returns required fields, valid initial status, and attachment contract derived from entities['tracker.<type>'] and entities['tracker.<type>.composition'] (the ENC-TSK-M65 composition sections for plan/feature) -- no record_id, no hardcoded contract table."
+    },
+    {
+      "version": "2026-07-11.7",
+      "date": "2026-07-11",
+      "summary": "ENC-TSK-M66 route fix: the creation_rules route registered in PR #995 at /api/v1/tracker/creation_rules was unreachable through CloudFront (that prefix routes to the tracker query API). Route moved under the coordination prefix: GET /api/v1/coordination/tracker/creation_rules, matching the MCP server's _coordination_api_request URL construction; bare /api/v1/tracker form retained for direct API Gateway callers. Dictionary entity description updated to match."
+    },
+    {
+      "version": "2026-07-11.8",
+      "date": "2026-07-11",
+      "summary": "ENC-ISS-531: appsync_feed_publisher now logs the AppSync response body on non-2xx publish errors, classifies permanent 4xx rejections (400/403/404, excluding 429) as poison records -- skipped with a PoisonRecordSkipped CloudWatch metric instead of retried forever -- and the DynamoDB Stream EventSourceMapping gained MaximumRetryAttempts=5, BisectBatchOnFunctionError, and an on-failure SQS DLQ destination as a generic backstop. No entity/field schema change, just serialization/retry-handling; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-11.9",
+      "date": "2026-07-12",
+      "summary": "ENC-ISS-532: appsync_feed_publisher's build_event_payload now filters internal sentinel-project rows (dunder-wrapped project_id like \"__feed__\", used by enceladus_shared.version_seq counter/tombstone rows) before constructing any channel -- returns None (no /feed/updates, /records/{id}, or /projects/{id} publish attempt), logging + emitting a NonProjectRecordFiltered metric. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.1",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M74: GET /api/v1/feed bare full-refresh now applies a server-side page cap (MAX_FEED_PAGE_RECORDS=75 records total across tasks/issues/features/lessons/plans, most-recently-updated first) and returns a top-level next_cursor (string|null, opaque base64, byte-compatible with the /api/v1/feed/corpus cursor contract) for continuation. Collapses the feed p95 driver (was ~919 uncapped records). Per-record output byte-identical; delta/corpus/snapshot paths unchanged. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.2",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-M76: feed p95 closure II -- pushed the GET /api/v1/feed page cap UPSTREAM into the selection/hydration tier. graph_query_api feed_selection gained an optional page_size+before mode (per-(project,type) msearch fetches page_size+1 hits WITH updated_at + an updated_at<=before range bound); feed_query merges globally, keeps only the strictly-after-cursor page window, and hydrates ONLY <=page_size+1 keys via BatchGet instead of the whole ~919-record corpus. No record/entity schema change (internal query logic + the same 5-list/next_cursor response contract); bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.5",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N03 / ENC-ISS-543: graph_sync close-transition projection fix -- _coalesce_status_for_projection() recovers typed status.S from NewImage with OldImage fallback on MODIFY, TERMINAL_STATUSES preserved on checkout-only MODIFY (checkout-release after close no longer regresses the node), explicit SET n.status on every node upsert (SET n += props never fixes an omitted key), and the handler now raises when a failed record lacks a batchItemFailures identifier. Repair tool tools/graph_status_drift_reconcile.py added. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.6",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N26: pre-cutover baseline capture tooling added to backend/lambda/rhythm_cycle/ -- new baseline.py module + a 'baseline_capture' entry in lambda_function.py's TIER_HANDLERS (standalone on-demand event mode, not part of the scheduled harmonic beat chain -- no TIER_ORDER/TIER_PREDECESSOR entry, no schedule resource). Writes one Sense-adjacent artifact covering percolation telemetry export, a fixed-query retrieval-quality run, a lesson citation-rate proxy, and corpus invariants, each independently degrading to an honest 'unavailable + reason' rather than failing the run. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.7",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N21 / BRD DOC-44230223DD1C §4.3: governed machine identity for the rhythm. New backend/lambda/rhythm_cycle/identity.py resolves-or-mints a real ENC-SES session + Session Claim ID (sci) for the rhythm Lambda itself via the same coordination-API surface (agent.register + agent.claim), caches it in the beat's own S3 artifact chain (tier=identity), and re-claims on sci TTL approach. lambda_function.py's run_beat() now attempts identity resolution on every beat (logs INFO on success, WARNING on degraded fallback) -- the touch guard applies here. tiers/decide.py's escalation writer replaces the hardcoded requested_by_session='rhythm-decide-beat' with the resolved identity (requested_by.session_id/agent_type_id/sci_present + top-level sci when present), falling back to the exact pre-N21 string when identity minting is degraded. tenant_invoker.py's session_identity payload field is now backed by the same resolved identity instead of its placeholder. New RHYTHM_AGENT_TYPE_ID env var (config.py, default empty = graceful degradation); wired to ENC-AGT-00C (minted via coordination agent.type.register, surface=eventbridge-scheduler, model=lambda-rhythm, cost_tier=standard) in infrastructure/cloudformation/02-compute.yaml. No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.8",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N23: consolidation-arc rhythm tenants wired (PLN-078 W2a). memory_consolidation, handoff_consolidation_engine, and graph_health_metrics lambda_function.py each gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py: when the invoke payload carries result_key (rhythm tenant invocation), the handler writes a JSON stanza {tenant,status,completed_at,detail} to that S3 key after the run (statuses: completed/failed, plus skipped for HCE adaptive-trigger deferrals); scheduled EventBridge invokes are unaffected (no result_key -> no-op). Manifest populated in 11-appconfig-rhythm-tenants.yaml (3 enabled + recompute_governance reserved enabled=false, in-beat hook remains authoritative per ENC-TSK-N18 design). No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-12.9",
+      "date": "2026-07-12",
+      "summary": "ENC-TSK-N24: entropy/telemetry rhythm tenants wired (PLN-078 W2b), completing the heavy manifest at 9 tenants (5 enabled). corpus_entropy_engine and percolation_monitor lambda_function.py gain the heavy-beat completion-stanza contract from backend/lambda/rhythm_cycle/tenant_invoker.py (result_key-gated S3 stanza write {tenant,status,completed_at,detail}; CEE_HARD_DISABLED skips report status=skipped; scheduled EventBridge invokes unaffected). gdmp_remediation wired enabled=false (SAFETY: GDMP optimistic-concurrency PATCH defect + hard-disable in force); embedding_refresh + library_health_skillbuilder wired unfunded with empty function_name pending N09 budget gate. Also fixes the ENC-TSK-N18 template defect that blocked stack creation (top-level CFN Description 1181 chars > 1024 limit; docs moved to comments). No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-13.1",
+      "date": "2026-07-13",
+      "summary": "ENC-TSK-N54 (ENC-ISS-554): graph_health_metrics/lambda_function.py and graph_query_api/graph_health_metric.py quarantine degenerate Fiedler lambda2 readings -- compute_fiedler_value now rejects any lambda2 <= 1e-9 as ok=False with an explicit invalid_reason (sample_capped_degenerate vs genuine_disconnection_suspected) instead of a confident zero, and graph_health_metrics no longer silently substitutes the GraphEdgeDensity proxy under the FiedlerAlgebraicConnectivity metric name on fetch failure (omits the key instead). No entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-13.2",
+      "date": "2026-07-13",
+      "summary": "ENC-TSK-N51 (R8): comp-percolation-monitor telemetry row -- empirical_pc switched to the low-variance susceptibility-peak estimator (argmax of mean second-largest-cluster ratio); legacy argmax-2nd-derivative value retained as empirical_pc_curvature; added empirical_pc_method + sweep_second_cluster_ratio; MC_TRIALS default 40->160 (variance crosses the 0.02 p-grid resolution). Verdict: the empirical~0.2 vs analytical~0.05 gap is real/definitional (emergence-threshold vs finite-size susceptibility peak), not drift. Documented in graph_query_api.adjacency; no entity/field schema change; bumping per the lambda_function.py touch guard."
+    },
+    {
+      "version": "2026-07-13.3",
+      "date": "2026-07-13",
+      "summary": "ENC-ISS-555 / ENC-TSK-N52: orphan metric collision disambiguated — CEE Category orphan→lineage_unanchored; GraphHealth OrphanNodeRatio→IsolatedNodeRatio; new entity observability.orphan_metric_disambiguation; v4 dashboard + rhythm tool labels updated. Repo-file edit only — governance sync is a post-merge action (GOVERNANCE_SYNC_REQUIRED)."
+    },
+    {
+      "version": "2026-07-13.4",
+      "date": "2026-07-13",
+      "summary": "Merge-resolution bump combining ENC-TSK-N51 percolation estimator changes with ENC-ISS-555 orphan-metric disambiguation on v4/main."
+    }
+  ]
+}

--- a/docs/cutover-context/offline-session-protocol-DOC-FC8ABF29B738.md
+++ b/docs/cutover-context/offline-session-protocol-DOC-FC8ABF29B738.md
@@ -1,0 +1,35 @@
+# Enceladus MCP-Down Offline Session Protocol
+
+**Project**: enceladus
+**Related**: ENC-TSK-O20, ENC-TSK-O10, ENC-PLN-081, DOC-2670B83D94F7
+**Created**: 2026-08-21
+**Author**: ENC-SES-0EG (PLN-081 cutover coordinator)
+
+## When this applies
+
+Enceladus MCP (mcp.jreese.net) is unreachable, or the MCP/tracker plane is itself the surface under cutover or active debugging.
+
+## Boot procedure (file-boot)
+
+1. Open docs/cutover-context/ on v4/main (io-local mirror: /Users/jreese/enceladus/workspace/cutover-context-2026-08-21).
+2. Read README.md and MANIFEST.md first -- staleness is self-declaring via per-artifact export timestamps and the recorded governance_hash.
+3. Load the catalog, blueprint, and deploy-path artifacts; state to the operator: active plan, current cutover phase, open blockers, and the MANIFEST export timestamp your statements are based on.
+4. Prefix EVERY record-state claim with UNVERIFIED-OFFLINE. All claims are as-of the MANIFEST timestamp, not live truth.
+
+## Hard rules while offline
+
+- ZERO governed writes: no tracker, documents, checkout, deploy, or governance mutations, and no scripts that would mutate on your behalf.
+- No direct DynamoDB or S3 writes ever (IAM denies them; do not attempt workarounds). This outage does not suspend ENC-TSK-564.
+- Allowed: local code work in task worktrees, analysis, drafting docs as local files, git commits on agent branches.
+- Every completed unit of work becomes a local F6 HANDOFF block appended to workspace/offline-handoff-queue.md with: record id, status claim (marked UNVERIFIED-OFFLINE), evidence, and the intended tracker mutations written out verbatim (action + arguments) for later replay.
+- mcp-gamma MAY be used READ-ONLY as a secondary context surface ONLY when gamma is not the plane under debug or cutover. Never mutate via gamma. During the B69 route-flip window gamma is coupled to the plane under change -- do not use it at all.
+
+## Post-restore reconciliation
+
+1. connection_health for a fresh governance_hash; re-read every touched record live before replaying anything. Session caches and queued blocks are hypotheses, not truth (ENC-LSN-043).
+2. For each queued F6 block: re-verify its preconditions against live state; apply the mutations through MCP with the fresh hash; mark the block RECONCILED with the resulting worklog refs. On any discrepancy, worklog the discrepancy on the record and stop -- never force.
+3. Sweep for checkout wedges created during the outage (ENC-ISS-597 class) and release stale locks via the stale-checkout recovery recipe (release with the old session as provider, then re-checkout).
+
+## Proof standard
+
+A valid boot proof is a session that read ONLY the bundle files and correctly stated: the active plan, the current cutover phase, the open blockers, and the next gated step -- captured as transcript evidence on ENC-TSK-O20.


### PR DESCRIPTION
## Summary
- Adds `docs/cutover-context/` as the MCP-down boot source for terminal agents during the B69 production cutover: PLN-006 task catalog (DOC-841F5D649EEF v137), v4 architecture/migration blueprint (DOC-6EFD5DB32CD8), v3-prod surgical deploy brief (DOC-B716E8FB10B6), dispatched-agent and coordination-lead session prompts (DOC-FFB4C9D87BCC, DOC-586FB8D3DF02), governance agents.md, the bundled governance data dictionary snapshot, a live connection_health snapshot, and the MCP-down offline session protocol (DOC-FC8ABF29B738).
- README.md indexes each file to its source and purpose; MANIFEST.md records per-artifact export timestamp, source, sha256, and the session `governance_hash` — staleness is self-declaring.
- Mid-build the task worktree was torn down by a concurrent session's stale-lock sweep before any commit existed; surviving files were rescued and re-committed immediately (see the two-commit history on this branch) per the ENC-ISS-071 worktree-isolation lesson.

CCI-3b86095e04f847fbad3de4e34b01ed94

## Test plan
- [x] All 11 files present under `docs/cutover-context/`
- [x] 5 of 6 docstore-sourced exports verified byte-identical to their docstore `content_hash` via `shasum -a 256`
- [x] Branch pushed, PR opened against `v4/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)