### PR TITLE
ENC-TSK-O34: fix checkout-service GitHub validation (ISS-603 owner doubling + ISS-630 base-branch hardcode)

### DIFF
--- a/.github/workflows/pr-commit-gate.yml
+++ b/.github/workflows/pr-commit-gate.yml
@@ -14,7 +14,7 @@ name: PR Commit Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
       - 'v[0-9]*/main'

--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -841,6 +841,49 @@ def _parse_github_url(url: str) -> Tuple[Optional[str], Optional[str]]:
     return None, None
 
 
+def _normalize_owner_repo(
+    owner: Optional[str], repo: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Strip a redundant leading '<owner>/' from repo.
+
+    ENC-TSK-O34 / ENC-ISS-603: every owner/repo resolution surface (task-level
+    override, project-config fallback) is funneled through here as a final
+    normalization step so f"{owner}/{repo}" can never double the owner when
+    repo already carries an owner-qualified value (e.g. owner='NX-2021-L',
+    repo='NX-2021-L/enceladus' -> repo='enceladus'). A no-op when repo is
+    already bare.
+    """
+    if owner and repo:
+        prefix = f"{owner}/"
+        if repo.startswith(prefix):
+            repo = repo[len(prefix):] or None
+    return owner, repo
+
+
+def _split_owner_repo(value: str) -> Tuple[Optional[str], Optional[str]]:
+    """Parse an owner/repo pair from either a full GitHub URL
+    (https://github.com/OWNER/REPO) or a plain 'OWNER/REPO' string.
+
+    ENC-TSK-O34 / ENC-ISS-603: single shared parsing path for every
+    github_repo resolution surface so a value is split into owner/repo
+    exactly once, then passed through _normalize_owner_repo, rather than
+    each call site re-implementing its own partition/parse logic that can
+    drift out of sync with the others.
+    """
+    value = (value or "").strip()
+    if not value:
+        return None, None
+    if value.startswith("http://") or value.startswith("https://"):
+        owner, repo = _parse_github_url(value)
+    else:
+        owner, _, repo = value.partition("/")
+        owner = owner.strip() or None
+        repo = repo.strip() or None
+        if not repo:
+            return None, None
+    return _normalize_owner_repo(owner, repo)
+
+
 def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the GitHub owner/repo for a project from the projects table.
 
@@ -861,7 +904,7 @@ def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]
 
         repo_url = item.get("repo", {}).get("S", "")
         if repo_url:
-            return _parse_github_url(repo_url)
+            return _split_owner_repo(repo_url)
 
         # Walk up to parent (one level)
         parent_id = item.get("parent", {}).get("S", "")
@@ -876,7 +919,7 @@ def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]
                 if item2:
                     repo_url2 = item2.get("repo", {}).get("S", "")
                     if repo_url2:
-                        return _parse_github_url(repo_url2)
+                        return _split_owner_repo(repo_url2)
             except Exception as exc:
                 logger.warning("Failed to look up parent project '%s': %s", parent_id, exc)
 
@@ -892,7 +935,7 @@ def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]
             for child in scan_resp.get("Items", []):
                 child_repo = child.get("repo", {}).get("S", "")
                 if child_repo:
-                    return _parse_github_url(child_repo)
+                    return _split_owner_repo(child_repo)
         except Exception as exc:
             logger.warning("Failed to scan child projects for '%s': %s", project_id, exc)
 
@@ -900,6 +943,40 @@ def _resolve_github_repo(project_id: str) -> Tuple[Optional[str], Optional[str]]
     except Exception as exc:
         logger.warning("Failed to resolve GitHub repo for project '%s': %s", project_id, exc)
         return None, None
+
+
+def _resolve_task_github_repo(
+    task: dict, project_id: str
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the GitHub owner/repo to validate a task's commit/PR/merge against.
+
+    ENC-FTR-119: satellite repos host code for tasks that still live under the
+    primary project's project_id, so the project-level ``repo`` field alone
+    (``_resolve_github_repo``) cannot express "this one task's code is in a
+    different repo than its siblings." A task-level ``github_repo`` field (a
+    plain "owner/repo" string or a full https://github.com/owner/repo URL,
+    settable via the ordinary tracker.set field-update path) is checked first
+    and, once set, durably overrides the project default for every
+    subsequent advance on that task. Falls back to ``_resolve_github_repo``
+    when the task has no override.
+
+    ENC-TSK-O34 / ENC-ISS-603: both the override and project-fallback paths
+    are funneled through the shared ``_split_owner_repo`` / normalization
+    helpers so a plain-form or already-qualified repo value can never double
+    the owner when concatenated downstream (previously only the full-URL
+    override form worked reliably; the plain form and the project-config
+    fallback were the doubling-prone paths).
+    """
+    task_repo = (task.get("github_repo") or "").strip()
+    if task_repo:
+        owner, repo = _split_owner_repo(task_repo)
+        if owner and repo:
+            return owner, repo
+        logger.warning(
+            "Task github_repo override '%s' could not be parsed as owner/repo; "
+            "falling back to project-level resolution.", task_repo,
+        )
+    return _resolve_github_repo(project_id)
 
 
 # ---------------------------------------------------------------------------
@@ -2004,12 +2081,19 @@ def _validate_lambda_deploy_evidence(evidence: dict) -> Tuple[bool, str]:
 
 
 def _validate_code_on_main_evidence(
-    owner: str, repo: str, evidence: dict
+    owner: str, repo: str, evidence: dict, base_branch: str = "main"
 ) -> Tuple[bool, str]:
     """Validate code_on_main_evidence for closed (code_only arc, ENC-ISS-092).
 
-    Calls GitHub compare API to verify commit_sha is an ancestor of main.
+    Calls GitHub compare API to verify commit_sha is an ancestor of base_branch.
     Sets evidence["github_verified"] = True on success.
+
+    ENC-TSK-O34 / ENC-ISS-630: base_branch defaults to 'main' (unchanged
+    behavior) but is overridable per-task -- see the closed-gate call site,
+    which reads an optional task-level 'github_base_branch' field (the same
+    override pattern as _resolve_task_github_repo's 'github_repo') -- so
+    pre-cutover v4/main-only work can close a code_only task without a commit
+    landing on 'main' itself.
     """
     commit_sha = (evidence.get("commit_sha") or "").strip()
     if not commit_sha:
@@ -2020,15 +2104,17 @@ def _validate_code_on_main_evidence(
             f"got: '{commit_sha}'"
         )
 
-    # Call GitHub compare API: {sha}...main (base=sha, head=main)
-    # ENC-ISS-161: status "ahead" means main has commits sha doesn't = sha is an ancestor.
-    # status "identical" means sha IS main HEAD. Both are valid.
-    compare_path = f"/repos/{owner}/{repo}/compare/{commit_sha}...main"
+    base_branch = (base_branch or "main").strip() or "main"
+
+    # Call GitHub compare API: {sha}...{base_branch} (base=sha, head=base_branch)
+    # ENC-ISS-161: status "ahead" means base_branch has commits sha doesn't = sha is an ancestor.
+    # status "identical" means sha IS base_branch HEAD. Both are valid.
+    compare_path = f"/repos/{owner}/{repo}/compare/{commit_sha}...{base_branch}"
     status, body = _github_request(compare_path, repo=f"{owner}/{repo}", sha=commit_sha)
     if status == 404:
         return False, (
             f"GitHub compare returned 404 — commit '{commit_sha}' or repo "
-            f"'{owner}/{repo}' not found"
+            f"'{owner}/{repo}' (base branch '{base_branch}') not found"
         )
     if status != 200:
         return False, (
@@ -2039,9 +2125,9 @@ def _validate_code_on_main_evidence(
     compare_status = body.get("status", "")
     if compare_status not in ("ahead", "identical"):
         return False, (
-            f"Commit '{commit_sha}' is not on main "
+            f"Commit '{commit_sha}' is not on {base_branch} "
             f"(GitHub compare status: '{compare_status}'). "
-            "Commit must be an ancestor of main (status 'ahead' or 'identical')."
+            f"Commit must be an ancestor of {base_branch} (status 'ahead' or 'identical')."
         )
 
     # Stamp verification flag for audit trail
@@ -3041,7 +3127,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         owner = transition_evidence.get("owner")
         repo = transition_evidence.get("repo")
         if not owner or not repo:
-            resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+            resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
             owner = owner or resolved_owner
             repo = repo or resolved_repo
         if not owner or not repo:
@@ -3170,7 +3256,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
         owner = transition_evidence.get("owner")
         repo = transition_evidence.get("repo")
         if not owner or not repo:
-            resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+            resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
             owner = owner or resolved_owner
             repo = repo or resolved_repo
         if not owner or not repo:
@@ -3327,7 +3413,7 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                     owner = transition_evidence.get("owner")
                     repo = transition_evidence.get("repo")
                     if not owner or not repo:
-                        resolved_owner, resolved_repo = _resolve_github_repo(project_id)
+                        resolved_owner, resolved_repo = _resolve_task_github_repo(task, project_id)
                         owner = owner or resolved_owner
                         repo = repo or resolved_repo
                     if not owner or not repo:
@@ -3343,7 +3429,10 @@ def _handle_advance(project_id: str, task_id: str, body: dict) -> dict:
                             provider=provider or session_id,
                             required_fields=["transition_evidence.owner", "transition_evidence.repo"],
                         )
-                    valid, reason = _validate_code_on_main_evidence(owner, repo, evidence_obj)
+                    base_branch = (task.get("github_base_branch") or "main").strip() or "main"
+                    valid, reason = _validate_code_on_main_evidence(
+                        owner, repo, evidence_obj, base_branch=base_branch
+                    )
                     if not valid:
                         return _validation_error(
                             400, f"{ev_key} validation failed: {reason}",

--- a/backend/lambda/checkout_service/test_checkout_error_context.py
+++ b/backend/lambda/checkout_service/test_checkout_error_context.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
 
@@ -355,6 +355,134 @@ class FailureClassificationTests(unittest.TestCase):
         env = json.loads(resp["body"])["error_envelope"]
         self.assertEqual(env["failure_classification"], "deterministic-governance")
         self.assertTrue(env["recommended_next_actions"])
+
+
+
+
+class TestIssue603OwnerDoubling(unittest.TestCase):
+    """ENC-TSK-O34 / ENC-ISS-603: task-level github_repo override and the
+    project-config fallback must never double the owner in the resolved
+    (owner, repo) pair, regardless of whether the override is given as a
+    plain 'owner/repo' string or a full https://github.com/owner/repo URL."""
+
+    def test_normalize_strips_redundant_owner_prefix(self):
+        owner, repo = checkout_service._normalize_owner_repo(
+            "NX-2021-L", "NX-2021-L/enceladus"
+        )
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+
+    def test_normalize_is_noop_for_bare_repo(self):
+        owner, repo = checkout_service._normalize_owner_repo("NX-2021-L", "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+
+    def test_split_owner_repo_plain_form(self):
+        owner, repo = checkout_service._split_owner_repo("NX-2021-L/enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+
+    def test_split_owner_repo_url_form(self):
+        owner, repo = checkout_service._split_owner_repo(
+            "https://github.com/NX-2021-L/enceladus"
+        )
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+
+    def test_split_owner_repo_never_doubles_on_qualified_plain_value(self):
+        """A pathological already-doubled input never produces a doubled
+        full_name -- the redundant leading owner segment is stripped."""
+        owner, repo = checkout_service._split_owner_repo(
+            "NX-2021-L/NX-2021-L/enceladus"
+        )
+        self.assertEqual(owner, "NX-2021-L")
+        self.assertNotIn("/", repo)
+
+    @patch.object(checkout_service, "_resolve_github_repo")
+    def test_resolve_task_github_repo_plain_form_override_no_doubling(self, mock_resolve):
+        """ISS-603 deterministic repro: plain-form override must resolve to
+        the bare repo name, not the owner-qualified string (previously only
+        the full-URL override form worked)."""
+        task = {"github_repo": "NX-2021-L/enceladus"}
+        owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        mock_resolve.assert_not_called()
+
+    @patch.object(checkout_service, "_resolve_github_repo")
+    def test_resolve_task_github_repo_url_form_override(self, mock_resolve):
+        task = {"github_repo": "https://github.com/NX-2021-L/enceladus"}
+        owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        mock_resolve.assert_not_called()
+
+    @patch.object(checkout_service, "_resolve_github_repo")
+    def test_resolve_task_github_repo_no_override_falls_back_to_project(self, mock_resolve):
+        """ISS-603 default/no-override path: falls through to the
+        project-config resolver, which itself never doubles the owner."""
+        mock_resolve.return_value = ("NX-2021-L", "enceladus")
+        task = {}
+        owner, repo = checkout_service._resolve_task_github_repo(task, "enceladus")
+        self.assertEqual((owner, repo), ("NX-2021-L", "enceladus"))
+        mock_resolve.assert_called_once_with("enceladus")
+
+    def test_resolve_github_repo_project_fallback_accepts_plain_form(self):
+        """ISS-603 project-level fallback: a project 'repo' field stored as a
+        bare 'owner/repo' string (not a URL, e.g. the 'mod' project) resolves
+        cleanly instead of doubling or failing outright."""
+        fake_ddb = MagicMock()
+        fake_ddb.get_item.return_value = {"Item": {"repo": {"S": "NX-2021-L/mod"}}}
+        with patch.object(checkout_service, "_ddb", fake_ddb):
+            owner, repo = checkout_service._resolve_github_repo("mod")
+        self.assertEqual((owner, repo), ("NX-2021-L", "mod"))
+
+
+class TestIssue630BaseBranchOverride(unittest.TestCase):
+    """ENC-TSK-O34 / ENC-ISS-630: the code_only close gate must honor a
+    task-declared base branch instead of the hardcoded 'main'."""
+
+    @patch.object(checkout_service, "_github_request")
+    def test_default_base_branch_is_main(self, mock_gh):
+        mock_gh.return_value = (200, {"status": "identical"})
+        valid, reason = checkout_service._validate_code_on_main_evidence(
+            "NX-2021-L", "enceladus",
+            {"commit_sha": "0e608c0d4079570dd970e9696e2b7b3fdfaa79ac"},
+        )
+        self.assertTrue(valid, reason)
+        called_path = mock_gh.call_args[0][0]
+        self.assertTrue(called_path.endswith("...main"))
+
+    @patch.object(checkout_service, "_github_request")
+    def test_v4_main_base_branch_override_compares_against_v4_main(self, mock_gh):
+        """A v4/main-only commit (never landed on 'main' pre-cutover) closes a
+        code_only task when the task declares github_base_branch=v4/main."""
+        mock_gh.return_value = (200, {"status": "ahead", "ahead_by": 2})
+        valid, reason = checkout_service._validate_code_on_main_evidence(
+            "NX-2021-L", "enceladus",
+            {"commit_sha": "0e608c0d4079570dd970e9696e2b7b3fdfaa79ac"},
+            base_branch="v4/main",
+        )
+        self.assertTrue(valid, reason)
+        called_path = mock_gh.call_args[0][0]
+        self.assertTrue(called_path.endswith("...v4/main"))
+
+    @patch.object(checkout_service, "_github_request")
+    def test_base_branch_rejection_message_names_the_branch(self, mock_gh):
+        mock_gh.return_value = (200, {"status": "behind"})
+        valid, reason = checkout_service._validate_code_on_main_evidence(
+            "NX-2021-L", "enceladus",
+            {"commit_sha": "0e608c0d4079570dd970e9696e2b7b3fdfaa79ac"},
+            base_branch="v4/main",
+        )
+        self.assertFalse(valid)
+        self.assertIn("not on v4/main", reason)
+
+    @patch.object(checkout_service, "_github_request")
+    def test_blank_base_branch_defaults_to_main(self, mock_gh):
+        mock_gh.return_value = (200, {"status": "identical"})
+        valid, reason = checkout_service._validate_code_on_main_evidence(
+            "NX-2021-L", "enceladus",
+            {"commit_sha": "0e608c0d4079570dd970e9696e2b7b3fdfaa79ac"},
+            base_branch="   ",
+        )
+        self.assertTrue(valid, reason)
+        called_path = mock_gh.call_args[0][0]
+        self.assertTrue(called_path.endswith("...main"))
 
 
 if __name__ == "__main__":

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-08-21.1",
-  "updated_at": "2026-08-21T20:00:00Z",
-  "last_change_summary": "ENC-TSK-N63 (ENC-FTR-096, ENC-ISS-563): memory_consolidation's CONSOLIDATION_LOOKBACK_HOURS widened 24h -> 168h (7d) in backend/lambda/memory_consolidation/lambda_function.py and both infrastructure/cloudformation/02-compute.yaml and 02-compute-import-stage-k44.yaml. NO new, renamed or removed fields on any governed entity -- a single calibrated constant change, logged here solely because lambda_function.py is a schema-affecting path under agents.md section 3.11. Per ENC-TSK-N47's measured verdict (DOC-F61C85CD572B), the >=3-doc / >=2-wave co-citation threshold was never the defect; at the measured arrival rate of ~0.61 handoffs/day a 24h window yields P(<3 handoffs)~=98%, so the window was almost always empty before the co-citation logic could run. At 168h, lambda=4.27 arrivals/window, P(<3)=20.1%. The new value is documented at the config site as rate-coupled (not a constant) and names ENC-TSK-N57's pairs_evaluated tripwire as the regression detector if the arrival rate falls. Scope boundary: window only -- MIN_WAVES, the co-citation threshold, and the nightly cadence are unchanged.",
+  "version": "2026-08-21.2",
+  "updated_at": "2026-08-21T20:30:00Z",
+  "last_change_summary": "ENC-TSK-O34: checkout_service GitHub validation fixes. ISS-603 -- task.github_repo override and project-config repo resolution normalized through shared _split_owner_repo()/_normalize_owner_repo() helpers so a plain 'owner/repo' override (not just the full URL form) resolves correctly instead of doubling the owner; added _resolve_task_github_repo (ENC-FTR-119 pattern) to v4/main, which previously lacked it. ISS-630 -- code_only closed gate (_validate_code_on_main_evidence) accepts an optional task-level github_base_branch field (default 'main') instead of hardcoding the GitHub compare API's base ref, so v4/main-only work can close pre-cutover.",
   "owners": [
     "enceladus-platform"
   ],
@@ -2647,7 +2647,7 @@
         },
         "PROJECTS_TABLE": {
           "type": "string",
-          "definition": "DynamoDB table name for project records. Used by _resolve_github_repo() to look up the project's GitHub repo URL for commit/PR validation (DVP-ISS-082).",
+          "definition": "DynamoDB table name for project records. Used by _resolve_github_repo() to look up the project's GitHub repo URL for commit/PR validation (DVP-ISS-082). ENC-TSK-O34/ENC-ISS-603: project-config repo values are parsed via the shared _split_owner_repo() helper (accepts both a full URL and a plain 'owner/repo' string) and normalized via _normalize_owner_repo() before use, so a value that already carries the owner never doubles it in the downstream GitHub API path.",
           "usage_guidance": "Default: 'projects'. The checkout service Lambda IAM role must have dynamodb:GetItem and dynamodb:Scan permissions on this table."
         },
         "GITHUB_APP_ID": {
@@ -2764,7 +2764,7 @@
         },
         "gate_matrix": {
           "type": "object",
-          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior).",
+          "definition": "Per-status evidence requirements enforced by checkout service. Requirements vary by task.transition_type (ENC-ISS-092) — see checkout_service.transition_type_matrix for full per-type specs. Matrix below documents github_pr_deploy (default arc, unchanged from pre-ENC-ISS-092 behavior). DVP-ISS-082: committed and merged-main resolve GitHub owner/repo dynamically. Resolution order: transition_evidence.owner/repo > task.github_repo override (ENC-FTR-119, checked via _resolve_task_github_repo) > project.repo field > parent project.repo > child project.repo. ENC-TSK-O34/ENC-ISS-603: every step in this chain is normalized through _split_owner_repo()/_normalize_owner_repo() so a task.github_repo override given in plain 'owner/repo' form (not just the full URL form) resolves correctly and never double-concatenates the owner.",
           "usage_guidance": "in-progress: active_agent_session_id required (also sets checkout). coding-complete: no evidence required; issues CAI (skipped for no_code type). committed: commit_sha (40-char hex) required; validated via GitHub API; issues CCI. pr: no evidence required. merged-main: pr_id (int) + merged_at (ISO 8601) required; validated via GitHub API. deploy-init: no evidence required. deploy-success: deploy_evidence (GitHub Actions Jobs API object -- 8 required fields: id, name, run_id, head_sha, status, conclusion, started_at, completed_at) required for github_pr_deploy; web_deploy_evidence {url, http_status, checked_at} for web_deploy type; clears CAI+CCI; additionally external_deploy components require external_deploy_evidence. closed: live_validation_evidence (non-empty string) for github_pr_deploy/web_deploy; code_on_main_evidence {commit_sha} for code_only; no_code_evidence (non-empty string) for no_code; documentation components additionally require documentation_evidence; releases checkout. DVP-ISS-082: committed and merged-main now resolve GitHub owner/repo dynamically from the projects table instead of hardcoding NX-2021-L/enceladus. Resolution order: transition_evidence.owner/repo > project.repo field > parent project.repo > child project.repo. Optional owner/repo in transition_evidence override automatic resolution.",
           "properties": {
             "committed": {
@@ -2775,7 +2775,7 @@
                 "owner",
                 "repo"
               ],
-              "repo_resolution": "Auto-resolved from projects table if owner/repo not provided in transition_evidence (DVP-ISS-082).",
+              "repo_resolution": "Auto-resolved via _resolve_task_github_repo(): task.github_repo override (plain 'owner/repo' or full URL, ENC-FTR-119) checked first, then the projects table (DVP-ISS-082), if owner/repo not provided in transition_evidence. ENC-TSK-O34: normalized so neither form doubles the owner.",
               "issues_token": "CCI"
             },
             "coding-complete": {
@@ -2792,7 +2792,7 @@
                 "repo",
                 "merge_evidence"
               ],
-              "repo_resolution": "Auto-resolved from projects table if owner/repo not provided in transition_evidence (DVP-ISS-082).",
+              "repo_resolution": "Auto-resolved via _resolve_task_github_repo(): task.github_repo override (plain 'owner/repo' or full URL, ENC-FTR-119) checked first, then the projects table (DVP-ISS-082), if owner/repo not provided in transition_evidence. ENC-TSK-O34: normalized so neither form doubles the owner.",
               "compat_note": "ENC-ISS-095: tracker_mutation has a legacy gate requiring a free-text merge_evidence string for merged-main. This gate is bypassed for checkout-service-authenticated requests (X-Checkout-Service-Key) since the checkout service validates pr_id+merged_at via GitHub API. For non-checkout-service PATCH requests, merge_evidence remains required for backward compat. When calling advance_task_status via MCP (which routes through the checkout service), only pr_id and merged_at are needed."
             },
             "deploy-success": {
@@ -2887,7 +2887,7 @@
             "committed": "commit_sha (40-char hex; GitHub API validated); CAI required on record; issues CCI token",
             "pr": "CCI required on task record",
             "merged-main": "pr_id (int) + merged_at (ISO 8601; GitHub API validated)",
-            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of main (ENC-ISS-161: compare {sha}...main status: ahead or identical); releases checkout"
+            "closed": "code_on_main_evidence {commit_sha (40-char hex)} — GitHub compare API verifies commit is ancestor of the task's base branch (ENC-ISS-161: compare {sha}...{base_branch} status: ahead or identical); base_branch defaults to 'main' but honors an optional task-level github_base_branch field (ENC-TSK-O34/ENC-ISS-630, same override pattern as task.github_repo) so a v4/main-only commit can close a code_only task pre-cutover; releases checkout"
           },
           "skipped_statuses": [
             "deploy-init",
@@ -8476,6 +8476,11 @@
       "version": "2026-08-21.1",
       "date": "2026-08-21",
       "summary": "ENC-TSK-N63 (ENC-FTR-096, ENC-ISS-563): memory_consolidation's CONSOLIDATION_LOOKBACK_HOURS widened 24h -> 168h (7d) in backend/lambda/memory_consolidation/lambda_function.py and both infrastructure/cloudformation/02-compute.yaml and 02-compute-import-stage-k44.yaml. NO new, renamed or removed fields on any governed entity -- a single calibrated constant change, logged here solely because lambda_function.py is a schema-affecting path under agents.md section 3.11. Per ENC-TSK-N47's measured verdict (DOC-F61C85CD572B), the >=3-doc / >=2-wave co-citation threshold was never the defect; at the measured arrival rate of ~0.61 handoffs/day a 24h window yields P(<3 handoffs)~=98%, so the window was almost always empty before the co-citation logic could run. At 168h, lambda=4.27 arrivals/window, P(<3)=20.1%. The new value is documented at the config site as rate-coupled (not a constant) and names ENC-TSK-N57's pairs_evaluated tripwire as the regression detector if the arrival rate falls. Scope boundary: window only -- MIN_WAVES, the co-citation threshold, and the nightly cadence are unchanged."
+    },
+    {
+      "version": "2026-08-21.2",
+      "date": "2026-08-21",
+      "summary": "ENC-TSK-O34: checkout_service GitHub validation fixes. ISS-603 -- task.github_repo override and project-config repo resolution normalized through shared _split_owner_repo()/_normalize_owner_repo() helpers so a plain 'owner/repo' override (not just the full URL form) resolves correctly instead of doubling the owner; added _resolve_task_github_repo (ENC-FTR-119 pattern) to v4/main, which previously lacked it. ISS-630 -- code_only closed gate (_validate_code_on_main_evidence) accepts an optional task-level github_base_branch field (default 'main') instead of hardcoding the GitHub compare API's base ref, so v4/main-only work can close pre-cutover."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **ISS-603**: `_resolve_task_github_repo` (the ENC-FTR-119 task-level `github_repo` override) never made it to `v4/main` — only `_resolve_github_repo` (project-config only, no override) existed here. Added it back, and funneled every owner/repo resolution surface (task-level override, project-config fallback) through new shared helpers `_split_owner_repo` (parses either a full URL or a plain `owner/repo` string) and `_normalize_owner_repo` (strips a redundant leading `<owner>/` from repo) so a plain-form override — not just the full-URL form — resolves correctly and `f"{owner}/{repo}"` can never double the owner downstream.
- **ISS-630**: `_validate_code_on_main_evidence` (the `code_only` closed gate) hardcoded the GitHub compare API's base ref to `main`. It now accepts an optional `base_branch` parameter (default `'main'`, fully backward compatible), sourced at the closed-gate call site from an optional task-level `github_base_branch` field (same override pattern as `github_repo`) — so a `v4/main`-only commit can close a `code_only` task pre-cutover.
- Secondary finding from ISS-603: PR Commit Gate triggers only on `[opened, synchronize, reopened]`, so editing a PR body to add a CCI token doesn't re-run the gate. Added `edited` to the trigger list.
- `governance_data_dictionary.json` updated in-PR: `checkout_service.config.PROJECTS_TABLE`, `checkout_service.advance_request.gate_matrix` (+ `committed`/`merged-main` `repo_resolution`), and `checkout_service.transition_type_matrix.code_only.closed` now describe the normalized resolution chain and the `github_base_branch` override.

## Test plan

- [x] `backend/lambda/checkout_service` pytest suite: 125 passed (includes 13 new tests: `TestIssue603OwnerDoubling`, `TestIssue630BaseBranchOverride`)
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check on the modified lambda
- [x] `governance_data_dictionary.json` round-tripped through `json.load`/`json.dump` and re-validated
- [ ] Live proof: this task itself advanced through `coding-complete` -> `committed` using the URL-form `github_repo` override (prod still runs the unpatched validator pre-deploy); a true no-workaround live repro is deferred to gamma-verification post-deploy (see AC-1 acceptance evidence)

CCI-6cc6f169dcdb412daf0f35871ca7dc5b

🤖 Generated with [Claude Code](https://claude.com/claude-code)