### PR TITLE
ENC-TSK-O38: formalize worktree stale-lock sweep guards (ENC-ISS-632)

### DIFF
--- a/tools/agent-worktree-init.sh
+++ b/tools/agent-worktree-init.sh
@@ -62,7 +62,28 @@ mkdir -p "$WORKTREE_DIR" "$LOCK_DIR"
 
 # ---------------------------------------------------------------------------
 # Detect active sessions & clean stale locks
+#
+# ENC-ISS-632: the pid recorded in a lock file is the ephemeral
+# `bash agent-worktree-init.sh` subprocess itself, which exits the instant the
+# script returns -- long before the owning agent session's work is done.
+# Treating a dead pid as proof of a dead session made every lock look stale
+# within moments of being written, so any later invocation (by the same or a
+# sibling session) force-removed active worktrees and deleted unpushed
+# branches out from under in-flight sessions (destroyed three worktrees and
+# two sibling branches on 2026-08-21). A lock is only swept once ALL of the
+# following hold; any failing check skips that lock for this run and leaves
+# it for a later sweep to re-evaluate:
+#
+#   1. Age gate: the lock file is at least STALE_LOCK_AGE_SECONDS old. This
+#      bounds the blast radius of the still-imperfect pid signal to locks old
+#      enough that the owning invocation has almost certainly finished.
+#   2. Clean-worktree gate: the worktree has no uncommitted changes
+#      (`git status --porcelain` is empty).
+#   3. Pushed-branch gate: the branch carries no commits absent from every
+#      remote-tracking ref (`git log <branch> --not --remotes` is empty).
 # ---------------------------------------------------------------------------
+STALE_LOCK_AGE_SECONDS=21600  # 6 hours (ENC-ISS-632)
+
 ACTIVE_COUNT=0
 for lockfile in "$LOCK_DIR"/*.lock; do
   [ -f "$lockfile" ] || continue
@@ -73,21 +94,44 @@ for lockfile in "$LOCK_DIR"/*.lock; do
   if kill -0 "$LOCK_PID" 2>/dev/null; then
     ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
     echo "[WARN] Active session: $LOCK_PROV (PID $LOCK_PID) in $LOCK_WT"
-  else
-    # Fix D.4: read branch BEFORE removing the lock file to avoid read-after-delete.
-    LOCK_BRANCH="$(grep '^branch=' "$lockfile" 2>/dev/null | cut -d= -f2 || true)"
-    echo "[INFO] Cleaning stale lock for PID $LOCK_PID ($LOCK_PROV)"
-    rm -f "$lockfile"
-    if [ -d "$LOCK_WT" ]; then
-      git -C "$REPO_ROOT" worktree remove --force "$LOCK_WT" 2>/dev/null || true
-    fi
-    # Prune the branch only if it was never pushed to origin
-    if [ -n "$LOCK_BRANCH" ]; then
-      HAS_REMOTE="$(git -C "$REPO_ROOT" branch -r --list "origin/${LOCK_BRANCH#refs/heads/}" 2>/dev/null)"
-      if [ -z "$HAS_REMOTE" ]; then
-        git -C "$REPO_ROOT" branch -D "$LOCK_BRANCH" 2>/dev/null || true
-        echo "[INFO] Removed unpushed stale branch: $LOCK_BRANCH"
-      fi
+    continue
+  fi
+
+  # Fix D.4: read branch BEFORE removing the lock file to avoid read-after-delete.
+  LOCK_BRANCH="$(grep '^branch=' "$lockfile" 2>/dev/null | cut -d= -f2 || true)"
+
+  # Gate 1 (ENC-ISS-632): age -- macOS/BSD stat uses -f %m, GNU stat uses -c %Y.
+  LOCK_MTIME="$(stat -f %m "$lockfile" 2>/dev/null || stat -c %Y "$lockfile" 2>/dev/null || echo 0)"
+  LOCK_AGE=$(( $(date +%s) - LOCK_MTIME ))
+  if [ "$LOCK_AGE" -lt "$STALE_LOCK_AGE_SECONDS" ]; then
+    ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
+    echo "[WARN] Lock younger than ${STALE_LOCK_AGE_SECONDS}s; treating as ACTIVE despite dead pid (ENC-ISS-632): $LOCK_PROV in $LOCK_WT"
+    continue
+  fi
+
+  # Gate 2 (ENC-ISS-632): never destroy uncommitted work.
+  if [ -d "$LOCK_WT" ] && [ -n "$(git -C "$LOCK_WT" status --porcelain 2>/dev/null)" ]; then
+    echo "[WARN] Stale-aged lock but worktree has uncommitted changes; NOT removing (ENC-ISS-632): $LOCK_WT"
+    continue
+  fi
+
+  # Gate 3 (ENC-ISS-632): never delete a branch with commits absent from every remote.
+  if [ -n "$LOCK_BRANCH" ] && [ -n "$(git -C "$REPO_ROOT" log "$LOCK_BRANCH" --not --remotes --oneline -1 2>/dev/null)" ]; then
+    echo "[WARN] Stale-aged lock but branch has unpushed commits; NOT removing (ENC-ISS-632): $LOCK_BRANCH"
+    continue
+  fi
+
+  echo "[INFO] Cleaning stale lock for PID $LOCK_PID ($LOCK_PROV)"
+  rm -f "$lockfile"
+  if [ -d "$LOCK_WT" ]; then
+    git -C "$REPO_ROOT" worktree remove --force "$LOCK_WT" 2>/dev/null || true
+  fi
+  # Prune the branch only if it was never pushed to origin
+  if [ -n "$LOCK_BRANCH" ]; then
+    HAS_REMOTE="$(git -C "$REPO_ROOT" branch -r --list "origin/${LOCK_BRANCH#refs/heads/}" 2>/dev/null)"
+    if [ -z "$HAS_REMOTE" ]; then
+      git -C "$REPO_ROOT" branch -D "$LOCK_BRANCH" 2>/dev/null || true
+      echo "[INFO] Removed unpushed stale branch: $LOCK_BRANCH"
     fi
   fi
 done


### PR DESCRIPTION
Fixes ENC-ISS-632 (P0): the sweep treated every lock as stale because it recorded the init script's own ephemeral pid. A lock is now sweepable only when pid is dead AND lock mtime >= 6h; even then the sweep refuses to remove worktrees with uncommitted changes or delete branches with unpushed commits. bash -n + shellcheck clean; 4-fixture scratch-repo repro verified (three protected shapes untouched, genuinely-stale control still swept).

Task: ENC-TSK-O38 (ENC-PLN-081 Phase 0b). Cherry-pick to v4/main follows.
CCI-e51447a3609744e7816d28a553010c1a

🤖 Generated with [Claude Code](https://claude.com/claude-code)