### PR TITLE
ENC-TSK-O37: governed stale-holder checkout recovery (ISS-597) [recut]

### DIFF
--- a/backend/lambda/checkout_service/lambda_function.py
+++ b/backend/lambda/checkout_service/lambda_function.py
@@ -575,8 +575,17 @@ def _checkout_task(project_id: str, task_id: str, provider: str) -> Tuple[int, d
     )
 
 
-def _release_task(project_id: str, task_id: str) -> Tuple[int, dict]:
-    return _tracker_request("DELETE", f"/{project_id}/task/{task_id}/checkout", {})
+def _release_task(
+    project_id: str, task_id: str, provider: Optional[str] = None
+) -> Tuple[int, dict]:
+    """DELETE .../checkout. ``provider`` (ENC-TSK-O37) is optional and, when
+    given, is forwarded so tracker_mutation's release path attributes
+    checked_in_by to the ACTING caller rather than falling back to the prior
+    holder's active_agent_session_id — needed for an accurate audit trail on
+    third-party stale-holder recovery. Omitted, this preserves the pre-O37
+    self-release payload exactly (empty body)."""
+    payload: dict = {"provider": provider} if provider else {}
+    return _tracker_request("DELETE", f"/{project_id}/task/{task_id}/checkout", payload)
 
 
 def _log_task(
@@ -1155,7 +1164,12 @@ def _lookup_sci(sci_id: str) -> Optional[dict]:
 
 
 def _get_agent_session(session_id: str) -> Optional[dict]:
-    """Fetch an agent-session record (ENC-FTR-117 store; key session_id)."""
+    """Fetch an agent-session record (ENC-FTR-117 store; key session_id).
+
+    ENC-TSK-O37: also surfaces ``last_activity_at`` / ``claimed_at`` so callers
+    can compute an idle-reference timestamp (mirrors agent_id_alloc._idle_reference's
+    last_activity_at > claimed_at > created_at precedence) without a second read.
+    """
     try:
         resp = _ddb.get_item(
             TableName=AGENT_SESSIONS_TABLE,
@@ -1170,6 +1184,8 @@ def _get_agent_session(session_id: str) -> Optional[dict]:
     return {
         "session_id": item.get("session_id", {}).get("S", ""),
         "created_at": item.get("created_at", {}).get("S", ""),
+        "claimed_at": item.get("claimed_at", {}).get("S", ""),
+        "last_activity_at": item.get("last_activity_at", {}).get("S", ""),
         "status": item.get("status", {}).get("S", ""),
     }
 
@@ -1301,6 +1317,71 @@ def _validate_sci_gate(session_id: str, sci: Any) -> Optional[dict]:
     # Valid SCI. The heartbeat/updated_at touch already ran at gate entry
     # (ENC-TSK-L35), so no further touch is needed here.
     return None
+
+
+# ---------------------------------------------------------------------------
+# ENC-TSK-O37 / ENC-ISS-597: stale-holder checkout recovery
+# ---------------------------------------------------------------------------
+
+# Mirrors coordination_api/agent_id_alloc.SCI_TTL_SECONDS (86400 = 24h). The two
+# lambdas ship as separate packages, so this is a deliberately duplicated literal
+# rather than a cross-package import; keep in sync if the mint_sci TTL changes.
+_HOLDER_SCI_TTL_SECONDS = 86400
+
+_LIVE_SESSION_STATUSES = frozenset({"allocated", "claimed"})
+
+
+def _session_idle_reference(session: dict) -> str:
+    """Best-known last-activity timestamp for a session.
+
+    Mirrors agent_id_alloc._idle_reference's precedence (last_activity_at >
+    claimed_at > created_at) so a stale-holder determination here agrees with
+    what the scheduled idle-sweep would eventually conclude.
+    """
+    return str(
+        session.get("last_activity_at")
+        or session.get("claimed_at")
+        or session.get("created_at")
+        or ""
+    )
+
+
+def _session_terminal_state(session: Optional[dict]) -> Tuple[bool, str]:
+    """Determine whether a checkout holder's agent session is TERMINAL.
+
+    A session is terminal (ENC-ISS-597) when any of:
+      * the session record is absent (never existed, or hard-deleted) — ``absent``.
+      * its status is not live (``allocated``/``claimed``), i.e. already flipped to
+        ``retired`` by the idle-sweep or unclaim-sweep — ``retired``.
+      * its idle-reference timestamp (last_activity_at > claimed_at > created_at,
+        matching agent_id_alloc._idle_reference) is older than the SCI TTL
+        (86400s) — the session's bound SCI must have expired even though no
+        sweep has run yet to flip status — ``sci_ttl_elapsed``.
+
+    Returns (is_terminal, reason). reason is one of "absent", "retired",
+    "sci_ttl_elapsed", or "live" (not terminal).
+    """
+    if session is None:
+        return True, "absent"
+
+    status = str(session.get("status") or "").strip()
+    if status not in _LIVE_SESSION_STATUSES:
+        return True, "retired"
+
+    reference = _session_idle_reference(session)
+    if reference:
+        try:
+            ref_dt = datetime.strptime(reference, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            ref_dt = None
+        if ref_dt is not None:
+            elapsed = (datetime.now(timezone.utc) - ref_dt).total_seconds()
+            if elapsed >= _HOLDER_SCI_TTL_SECONDS:
+                return True, "sci_ttl_elapsed"
+
+    return False, "live"
 
 
 # ---------------------------------------------------------------------------
@@ -1517,6 +1598,127 @@ def _handle_release(project_id: str, task_id: str, body: dict) -> dict:
     if status not in (200, 201):
         return _error(status, result.get("error", f"Release failed (HTTP {status})"))
     return _response(200, {"success": True, "task_id": task_id})
+
+
+def _handle_release_recover(project_id: str, task_id: str, body: dict) -> dict:
+    """POST .../checkout/recover — ENC-TSK-O37 / ENC-ISS-597.
+
+    Governed recovery for a checkout wedged behind a dead agent session.
+    Unlike DELETE .../checkout (unconditional release — no ownership check
+    today), this endpoint authorizes a THIRD PARTY to clear someone else's
+    checkout ONLY when the current holder's agent session is server-verified
+    TERMINAL (see _session_terminal_state): the session record is absent,
+    already flipped to 'retired' (idle-sweep / unclaim-sweep), or its
+    idle-reference timestamp is already past the SCI TTL even though no sweep
+    has run yet. A LIVE holder's checkout is never touched by a third party —
+    this is a narrow recovery path, not a blanket force-release. Every
+    successful third-party recovery writes an audit worklog on the task naming
+    the prior holder and the terminality evidence BEFORE the checkout clears.
+
+    Body: {"provider": "<caller's own ENC-SES id>", "sci": "<caller's SCI>",
+    "governance_hash": "<optional>"}.
+    """
+    caller = (body.get("provider") or "").strip()
+    if not caller:
+        return _error(
+            400,
+            "provider (the recovering agent session's own ENC-SES id) is required",
+            code="INVALID_INPUT",
+            details={"task_id": task_id, "required_fields": ["provider"]},
+        )
+
+    # Recovery is an agent-origin governed mutation like advance/log, not an
+    # anonymous/system action — the caller must authenticate as a live agent
+    # session with a valid SCI before anything else is read or written.
+    if not _AGENT_SESSION_ID_RE.match(caller):
+        return _error(
+            403,
+            "checkout recovery requires an authenticated agent-session provider "
+            f"(ENC-SES-... id); got '{caller}'.",
+            code="PERMISSION_DENIED",
+        )
+    sci_err = _validate_sci_gate(caller, body.get("sci"))
+    if sci_err:
+        return sci_err
+
+    status, task = _get_task(project_id, task_id)
+    if status != 200:
+        return _error(status, task.get("error", f"Task not found: {task_id}"))
+
+    if not task.get("active_agent_session", False):
+        return _error(
+            400,
+            f"Task {task_id} is not currently checked out; nothing to recover.",
+            code="INVALID_INPUT",
+            details={"task_id": task_id},
+        )
+    holder = str(task.get("active_agent_session_id") or "").strip()
+
+    # Self-recovery: the caller already holds the checkout — this is an
+    # ordinary release, not a stale-holder takeover. No terminality check.
+    if holder == caller:
+        rel_status, rel_result = _release_task(project_id, task_id, provider=caller)
+        if rel_status not in (200, 201):
+            return _error(
+                rel_status,
+                rel_result.get("error", f"Release failed (HTTP {rel_status})"),
+            )
+        return _response(200, {
+            "success": True, "task_id": task_id,
+            "recovered": False, "reason": "self_release",
+        })
+
+    if not _AGENT_SESSION_ID_RE.match(holder):
+        # Non-agent holders (github, coordination_dispatch, PWA users, ...) are
+        # out of scope — "dead session" recovery only applies to minted
+        # ENC-SES holders (ENC-ISS-597). Reject rather than silently no-op.
+        return _error(
+            409,
+            f"Task {task_id} is held by a non-agent-session provider '{holder}'; "
+            "stale-session recovery does not apply.",
+            code="CONFLICT",
+            details={"holder": holder},
+        )
+
+    holder_session = _get_agent_session(holder)
+    is_terminal, reason = _session_terminal_state(holder_session)
+    if not is_terminal:
+        return _error(
+            409,
+            f"Task {task_id} is held by an active session '{holder}'; "
+            "third-party recovery denied. Ask the holder to release, or wait "
+            "for the session to become terminal.",
+            code="CONFLICT",
+            details={"holder": holder, "holder_state": reason},
+        )
+
+    # Terminal holder confirmed — write the audit worklog BEFORE clearing the
+    # checkout, so the record's history always carries the recovery evidence
+    # even if the release call below fails and must be retried.
+    audit_note = (
+        f"[RECOVERY] checkout.recover (ENC-TSK-O37/ENC-ISS-597): prior holder "
+        f"'{holder}' verified TERMINAL (reason={reason}); checkout cleared by "
+        f"'{caller}'."
+    )
+    _log_task(
+        project_id, task_id, audit_note,
+        provider=caller, governance_hash=body.get("governance_hash"),
+    )
+
+    rel_status, rel_result = _release_task(project_id, task_id, provider=caller)
+    if rel_status not in (200, 201):
+        return _error(
+            rel_status,
+            rel_result.get("error", f"Recovery release failed (HTTP {rel_status})"),
+        )
+    logger.info(
+        "[SUCCESS] checkout.recover project=%s task=%s prior_holder=%s reason=%s by=%s",
+        project_id, task_id, holder, reason, caller,
+    )
+    return _response(200, {
+        "success": True, "task_id": task_id,
+        "recovered": True, "prior_holder": holder, "reason": reason,
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -4157,6 +4359,12 @@ def lambda_handler(event: dict, context: Any) -> dict:
             elif method == "DELETE":
                 return _handle_release(project_id, task_id, body)
             return _error(405, f"Method {method} not allowed for checkout")
+
+        if action == "recover":
+            # ENC-TSK-O37 / ENC-ISS-597: governed stale-holder recovery.
+            if method == "POST":
+                return _handle_release_recover(project_id, task_id, body)
+            return _error(405, f"Method {method} not allowed for recover")
 
         if action == "advance":
             if method == "POST":

--- a/backend/lambda/checkout_service/test_stale_holder_recovery.py
+++ b/backend/lambda/checkout_service/test_stale_holder_recovery.py
@@ -1,0 +1,342 @@
+"""test_stale_holder_recovery.py — governed stale-holder checkout recovery
+(ENC-TSK-O37 / ENC-ISS-597).
+
+POST .../task/{id}/recover authorizes a THIRD PARTY to clear someone else's
+checkout only when the current holder's agent session is server-verified
+TERMINAL: absent, already 'retired', or past the SCI TTL by idle-reference
+timestamp even though no sweep has run yet. A LIVE holder must still reject
+third-party recovery — this is a narrow recovery path, not a blanket
+force-release. Every successful third-party recovery writes an audit worklog
+naming the prior holder BEFORE the checkout clears.
+
+Covers:
+  * _session_terminal_state: absent / retired / sci_ttl_elapsed / live.
+  * _handle_release_recover: terminal-holder recovery succeeds + audits.
+  * _handle_release_recover: live-holder recovery is rejected (409), no
+    worklog written, no release attempted.
+  * _handle_release_recover: absent-session (never registered / hard-deleted
+    holder) recovery succeeds.
+  * Self-recovery (caller == holder) is treated as an ordinary release, no
+    terminality check, no audit worklog.
+  * The caller itself must be an authenticated, SCI-valid agent session.
+  * A non-agent holder (github, coordination_dispatch, ...) is out of scope
+    and rejected rather than silently released.
+  * Not-checked-out task is a 400, not a false "recovered".
+
+Run: python3 -m pytest test_stale_holder_recovery.py -q
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import boto3
+from moto import mock_aws
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_layer", "python"))
+_SPEC = importlib.util.spec_from_file_location(
+    "checkout_lambda_recovery",
+    os.path.join(os.path.dirname(__file__), "lambda_function.py"),
+)
+checkout_lambda = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules[_SPEC.name] = checkout_lambda
+_SPEC.loader.exec_module(checkout_lambda)
+
+CALLER = "ENC-SES-0C1"
+HOLDER = "ENC-SES-0D2"
+VALID_SCI = "SCI-" + "b" * 32
+NOW_TS = "2026-08-21T12:00:00Z"
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class RecoveryBase(unittest.TestCase):
+    def setUp(self):
+        self._moto = mock_aws()
+        self._moto.start()
+        self.addCleanup(self._moto.stop)
+        self.ddb = boto3.client("dynamodb", region_name="us-west-2")
+        self.ddb.create_table(
+            TableName=checkout_lambda.CHECKOUT_TOKENS_TABLE,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        self.ddb.create_table(
+            TableName=checkout_lambda.AGENT_SESSIONS_TABLE,
+            AttributeDefinitions=[{"AttributeName": "session_id", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "session_id", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        patcher = mock.patch.object(checkout_lambda, "_ddb", self.ddb)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def put_session(self, session_id, status="claimed", created_at=NOW_TS,
+                     claimed_at="", last_activity_at=""):
+        item = {
+            "session_id": {"S": session_id},
+            "agent_type_id": {"S": "ENC-AGT-001"},
+            "created_at": {"S": created_at},
+            "status": {"S": status},
+        }
+        if claimed_at:
+            item["claimed_at"] = {"S": claimed_at}
+        if last_activity_at:
+            item["last_activity_at"] = {"S": last_activity_at}
+        self.ddb.put_item(TableName=checkout_lambda.AGENT_SESSIONS_TABLE, Item=item)
+
+    def put_sci(self, session_id=CALLER, pk=VALID_SCI, revoked=False, ttl=None):
+        self.ddb.put_item(
+            TableName=checkout_lambda.CHECKOUT_TOKENS_TABLE,
+            Item={
+                "pk": {"S": pk},
+                "token_type": {"S": "SCI"},
+                "session_id": {"S": session_id},
+                "agent_type_id": {"S": "ENC-AGT-001"},
+                "issued_at": {"S": NOW_TS},
+                "revoked": {"BOOL": revoked},
+                "ttl": {"N": str(ttl if ttl is not None else int(time.time()) + 3600)},
+            },
+        )
+
+    def checked_out_task(self, holder=HOLDER, **overrides):
+        task = {
+            "record_id": "task#ENC-TSK-999",
+            "active_agent_session": True,
+            "active_agent_session_id": holder,
+            "status": "in-progress",
+        }
+        task.update(overrides)
+        return task
+
+
+class SessionTerminalStateTests(RecoveryBase):
+    """Pure _session_terminal_state logic — no HTTP envelope."""
+
+    def test_absent_session_is_terminal(self):
+        is_terminal, reason = checkout_lambda._session_terminal_state(None)
+        self.assertTrue(is_terminal)
+        self.assertEqual(reason, "absent")
+
+    def test_retired_status_is_terminal(self):
+        session = {"status": "retired", "created_at": NOW_TS,
+                   "claimed_at": "", "last_activity_at": ""}
+        is_terminal, reason = checkout_lambda._session_terminal_state(session)
+        self.assertTrue(is_terminal)
+        self.assertEqual(reason, "retired")
+
+    def test_live_recent_session_is_not_terminal(self):
+        recent = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+        session = {"status": "claimed", "created_at": recent,
+                   "claimed_at": recent, "last_activity_at": recent}
+        is_terminal, reason = checkout_lambda._session_terminal_state(session)
+        self.assertFalse(is_terminal)
+        self.assertEqual(reason, "live")
+
+    def test_sci_ttl_elapsed_without_sweep_is_terminal(self):
+        # Still 'claimed' (sweep hasn't run) but last activity is > 86400s ago.
+        stale = _iso(datetime.now(timezone.utc) - timedelta(seconds=90000))
+        session = {"status": "claimed", "created_at": stale,
+                   "claimed_at": stale, "last_activity_at": stale}
+        is_terminal, reason = checkout_lambda._session_terminal_state(session)
+        self.assertTrue(is_terminal)
+        self.assertEqual(reason, "sci_ttl_elapsed")
+
+    def test_last_activity_at_takes_precedence_over_stale_created_at(self):
+        # created_at is ancient but last_activity_at is recent (heartbeat) —
+        # must NOT be flagged terminal, matching agent_id_alloc._idle_reference.
+        ancient = _iso(datetime.now(timezone.utc) - timedelta(days=30))
+        recent = _iso(datetime.now(timezone.utc) - timedelta(minutes=1))
+        session = {"status": "claimed", "created_at": ancient,
+                   "claimed_at": "", "last_activity_at": recent}
+        is_terminal, reason = checkout_lambda._session_terminal_state(session)
+        self.assertFalse(is_terminal)
+        self.assertEqual(reason, "live")
+
+
+class HandleReleaseRecoverTests(RecoveryBase):
+    """HTTP-level _handle_release_recover behavior."""
+
+    def _valid_caller(self):
+        self.put_session(CALLER, status="claimed", created_at=NOW_TS,
+                          last_activity_at=NOW_TS)
+        self.put_sci()
+
+    def test_terminal_holder_recovery_succeeds_with_audit(self):
+        self._valid_caller()
+        self.put_session(HOLDER, status="retired")
+        task = self.checked_out_task()
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_log_task",
+                                  return_value=(200, {})) as log_task, \
+                mock.patch.object(checkout_lambda, "_release_task",
+                                  return_value=(200, {})) as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["recovered"])
+        self.assertEqual(body["prior_holder"], HOLDER)
+        self.assertEqual(body["reason"], "retired")
+        # Audit worklog written naming the prior holder, BEFORE release.
+        log_task.assert_called_once()
+        audit_args, audit_kwargs = log_task.call_args
+        self.assertIn(HOLDER, audit_args[2])
+        self.assertIn("RECOVERY", audit_args[2])
+        self.assertEqual(audit_kwargs.get("provider"), CALLER)
+        release_task.assert_called_once_with("enceladus", "ENC-TSK-999", provider=CALLER)
+
+    def test_absent_holder_session_recovery_succeeds(self):
+        self._valid_caller()
+        # No put_session(HOLDER) at all — the holder session record is absent.
+        task = self.checked_out_task()
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_log_task", return_value=(200, {})), \
+                mock.patch.object(checkout_lambda, "_release_task",
+                                  return_value=(200, {})) as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertTrue(body["recovered"])
+        self.assertEqual(body["reason"], "absent")
+        release_task.assert_called_once()
+
+    def test_live_holder_recovery_rejected(self):
+        self._valid_caller()
+        recent = _iso(datetime.now(timezone.utc) - timedelta(minutes=2))
+        self.put_session(HOLDER, status="claimed", created_at=recent,
+                          last_activity_at=recent)
+        task = self.checked_out_task()
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_log_task") as log_task, \
+                mock.patch.object(checkout_lambda, "_release_task") as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 409)
+        body = json.loads(resp["body"])
+        self.assertEqual(body.get("holder"), HOLDER)
+        self.assertEqual(body.get("holder_state"), "live")
+        # No blanket force-release: neither the audit worklog nor the release
+        # call may fire when the holder is live.
+        log_task.assert_not_called()
+        release_task.assert_not_called()
+
+    def test_self_recovery_is_ordinary_release_no_terminality_check(self):
+        self._valid_caller()
+        task = self.checked_out_task(holder=CALLER)
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_get_agent_session") as get_session, \
+                mock.patch.object(checkout_lambda, "_log_task") as log_task, \
+                mock.patch.object(checkout_lambda, "_release_task",
+                                  return_value=(200, {})) as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 200)
+        body = json.loads(resp["body"])
+        self.assertFalse(body["recovered"])
+        self.assertEqual(body["reason"], "self_release")
+        # _get_agent_session is called exactly once (the SCI gate's mandatory
+        # lookup of the caller's own session) — no SEPARATE holder-terminality
+        # lookup runs, since holder == caller short-circuits before that check.
+        get_session.assert_called_once_with(CALLER)
+        log_task.assert_not_called()
+        release_task.assert_called_once_with("enceladus", "ENC-TSK-999", provider=CALLER)
+
+    def test_caller_without_valid_sci_is_rejected(self):
+        self.put_session(CALLER, status="claimed", created_at=NOW_TS)
+        # No SCI minted for CALLER.
+        with mock.patch.object(checkout_lambda, "_get_task") as get_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER},
+            )
+        self.assertEqual(resp["statusCode"], 403)
+        body = json.loads(resp["body"])
+        self.assertEqual(body.get("sci_failure_mode"), "missing_sci")
+        get_task.assert_not_called()
+
+    def test_missing_provider_rejected(self):
+        resp = checkout_lambda._handle_release_recover(
+            "enceladus", "ENC-TSK-999", {},
+        )
+        self.assertEqual(resp["statusCode"], 400)
+
+    def test_non_agent_holder_out_of_scope(self):
+        self._valid_caller()
+        task = self.checked_out_task(holder="coordination_dispatch")
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_log_task") as log_task, \
+                mock.patch.object(checkout_lambda, "_release_task") as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 409)
+        log_task.assert_not_called()
+        release_task.assert_not_called()
+
+    def test_not_checked_out_task_is_400(self):
+        self._valid_caller()
+        task = {"record_id": "task#ENC-TSK-999", "active_agent_session": False,
+                "active_agent_session_id": "", "status": "open"}
+        with mock.patch.object(checkout_lambda, "_get_task", return_value=(200, task)), \
+                mock.patch.object(checkout_lambda, "_release_task") as release_task:
+            resp = checkout_lambda._handle_release_recover(
+                "enceladus", "ENC-TSK-999",
+                {"provider": CALLER, "sci": VALID_SCI},
+            )
+        self.assertEqual(resp["statusCode"], 400)
+        release_task.assert_not_called()
+
+
+class RoutingWiringTests(RecoveryBase):
+    def test_recover_route_dispatches_to_handler(self):
+        event = {
+            "requestContext": {"http": {"method": "POST", "path":
+                                         "/api/v1/checkout/enceladus/task/ENC-TSK-999/recover"}},
+            "headers": {"x-internal-api-key": os.environ.get("INTERNAL_API_KEY", "")},
+            "body": json.dumps({"provider": CALLER, "sci": VALID_SCI}),
+        }
+        with mock.patch.object(checkout_lambda, "_is_authenticated", return_value=True), \
+                mock.patch.object(checkout_lambda, "_handle_release_recover",
+                                  return_value={"statusCode": 200, "body": "{}"}) as handler:
+            checkout_lambda.lambda_handler(event, None)
+        handler.assert_called_once_with("enceladus", "ENC-TSK-999",
+                                         {"provider": CALLER, "sci": VALID_SCI})
+
+    def test_recover_route_rejects_get(self):
+        event = {
+            "requestContext": {"http": {"method": "GET", "path":
+                                         "/api/v1/checkout/enceladus/task/ENC-TSK-999/recover"}},
+            "body": "",
+        }
+        with mock.patch.object(checkout_lambda, "_is_authenticated", return_value=True):
+            resp = checkout_lambda.lambda_handler(event, None)
+        self.assertEqual(resp["statusCode"], 405)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/lambda/coordination_api/governance_data_dictionary.json
+++ b/backend/lambda/coordination_api/governance_data_dictionary.json
@@ -1,7 +1,7 @@
 {
-  "version": "2026-08-21.3",
-  "updated_at": "2026-08-21T20:41:05Z",
-  "last_change_summary": "ENC-TSK-O36 (ENC-ISS-604): port the intelligence-project corpus-governance namespace from frozen main onto v4/main -- new entities corpus.edge_taxonomy (the fourteen-type governed typed-edge taxonomy for the io-graph corpus, project_id=intelligence, DOC-4DD9C4E8B66C section 7.2) and corpus.graph_isolated_reason (the eight-value graph_isolated_reason enum, INT-TSK-197 / INT-PLN-012). Both entities are DOCUMENTATION ONLY -- verified 2026-08-08 that no Lambda in this repo reads governance-dictionary content for either entity; the enforcing allowlists (graph_sync.ALLOWED_EDGE_TYPES, graph_query_api._ALLOWED_EDGE_TYPES, graph_health_metrics.ALLOWED_EDGE_TYPES) and the graph_isolated_reason IS NULL read live in the SEPARATE intelligence-project repo, not in Enceladus's own same-named graph_sync/graph_query_api/graph_health_metrics Lambdas that govern Enceladus's own tracker/document graph (the ENC-ISS-604 second-hazard disambiguation: no name collision here, the two entities' governing_documents cite INT-* records exclusively). Ported verbatim, byte-for-byte, from origin/main's 2026-08-17.1 dictionary; no existing v4/main entity was modified, reordered, or removed. No Lambda code, handler, or test file exists in this repo for either entity -- there is nothing else to port.",
+  "version": "2026-08-21.4",
+  "updated_at": "2026-08-21T22:02:00Z",
+  "last_change_summary": "ENC-TSK-O37 (ENC-ISS-597): added checkout_service.stale_holder_release documenting the new POST /{project}/task/{task_id}/recover route (_handle_release_recover) -- governed, audited recovery for a checkout wedged behind a dead agent session. Server-verifies the current holder's terminality against the live agent-sessions store (_session_terminal_state: absent / retired / sci_ttl_elapsed vs live) rather than trusting a client claim; a live holder still rejects third-party recovery (409, no write). A confirmed-terminal recovery writes an audit worklog naming the prior holder before clearing the checkout. Follows same-day 2026-08-21.3 (ENC-TSK-O36 corpus-namespace port); merged via cherry-pick recut PR after original PR #1104 failed to trigger CI.",
   "owners": [
     "enceladus-platform"
   ],
@@ -7383,6 +7383,27 @@
         "sci_failure_mode": {
           "type": "string",
           "definition": "403 detail naming the failure: missing_sci | unknown_sci | wrong_token_type | revoked_sci | expired_sci | session_mismatch | unknown_session."
+        }
+      }
+    },
+    "checkout_service.stale_holder_release": {
+      "description": "ENC-TSK-O37 / ENC-ISS-597: governed recovery for a checkout wedged behind a dead agent session. POST /{project}/task/{task_id}/recover (_handle_release_recover), distinct from DELETE .../checkout (_handle_release, unconditional self-release with no ownership check). The caller authenticates via the same ENC-ISS-441 SCI enforcement gate as checkout/advance/log (body.provider must be a live, SCI-valid ENC-SES session) BEFORE any task state is read. If body.provider already equals the task's active_agent_session_id this is an ordinary self-release (reason=self_release) with no terminality check. Otherwise (third-party recovery) the holder must be a minted ENC-SES session (non-agent holders such as github/coordination_dispatch/PWA users are out of scope and 409); its terminality is determined server-side by _session_terminal_state, which reads the live agent-sessions record (NOT a client-supplied claim) and returns terminal=true when ANY of: the session record is absent (reason=absent), its status has already flipped away from allocated/claimed to retired by the idle-sweep or unclaim-sweep (reason=retired), or its idle-reference timestamp (last_activity_at > claimed_at > created_at, mirroring agent_id_alloc._idle_reference's exact precedence) is already older than the 86400s SCI TTL even though no sweep has run yet (reason=sci_ttl_elapsed). A LIVE holder (reason=live) is NEVER released by a third party -- the endpoint returns 409 CONFLICT with details {holder, holder_state:'live'} and performs no write; there is no blanket force-release. On a confirmed-terminal recovery, an audit worklog naming the prior holder and the terminality reason is appended to the task's history BEFORE the checkout is cleared (_log_task with provider=caller, so the record always carries recovery evidence even if the subsequent release call must be retried), then _release_task clears active_agent_session/checkout_state and stamps checked_in_by=caller (via an explicit provider payload, so tracker_mutation attributes the release to the RECOVERING session, not the dead prior holder as the pre-O37 empty-body release path would).",
+      "fields": {
+        "route": {
+          "type": "string",
+          "definition": "POST /api/v1/checkout/{project}/task/{task_id}/recover. Body: {provider: '<recovering ENC-SES id>', sci: '<recovering session's SCI>', governance_hash?}."
+        },
+        "reason": {
+          "type": "string",
+          "definition": "Response field on both success and 409 paths. One of: self_release (caller==holder, no terminality check) | absent | retired | sci_ttl_elapsed (successful third-party recovery, holder_state values doubling as the terminality determination) | live (409, holder_state on the rejection envelope)."
+        },
+        "recovered": {
+          "type": "boolean",
+          "definition": "true only on a successful THIRD-PARTY recovery (prior_holder present in the response); false on self_release, since that path is an ordinary release rather than a stale-holder takeover."
+        },
+        "_session_terminal_state": {
+          "type": "function",
+          "definition": "checkout_service.lambda_function pure helper (session_dict) -> (is_terminal: bool, reason: str). Reused nowhere else yet; intentionally duplicates agent_id_alloc._idle_reference's last_activity_at/claimed_at/created_at precedence and the 86400s SCI TTL literal (coordination_api and checkout_service are separate Lambda packages, so this is a deliberate literal duplication, not a shared import -- keep in sync if agent_id_alloc.SCI_TTL_SECONDS changes)."
         }
       }
     },


### PR DESCRIPTION
Recut of PR #1104 (original branch never triggered CI despite pushes/reopen). Same implementation: SCI-gated POST task/{id}/recover, server-side holder terminality, audit-before-clear, live holders 409. Dictionary conflict with same-day O36 resolved: version 2026-08-21.4 carries both change sets. 15 tests (suite 140 green on the original branch).

Task: ENC-TSK-O37 (ENC-PLN-081 Phase 0b)
CCI-8c7cc7ecd57043c698a4520b1a2b9f82

🤖 Generated with [Claude Code](https://claude.com/claude-code)