### PR TITLE
ENC-TSK-O32: grant auth-refresh role CloudWatch Logs basics (ENC-ISS-631)

### DIFF
--- a/infrastructure/cloudformation/02-compute.yaml
+++ b/infrastructure/cloudformation/02-compute.yaml
@@ -5710,6 +5710,20 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       Policies:
+        # ENC-TSK-O32 / ENC-ISS-631: basic CloudWatch Logs so /aws/lambda/auth-refresh* populates.
+        # The missing grant masked the function's true invocation status during the ISS-631
+        # investigation (log group never created); scoped to this function's log groups only.
+        - PolicyName: CloudWatchLogsBasic
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: LogsBasic
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/auth-refresh${EnvironmentSuffix}*"
         # ENC-TSK-H04 / ENC-ISS-313: codified from live IAM (template previously omitted the Cognito grant).
         - PolicyName: cognito-refresh-policy
           PolicyDocument:


### PR DESCRIPTION
AC-4 of the gamma sign-in remediation: scoped CloudWatchLogsBasic inline policy on AuthRefreshRole (CreateLogGroup/CreateLogStream/PutLogEvents on /aws/lambda/auth-refresh${EnvironmentSuffix}*) so the gamma function's log group populates — the missing grant masked invocation status during the ISS-631 investigation. Applies to gamma via the ungated compute-stack lane on merge; layer publish/attach (AC-1/2) are separate privileged one-liners in the io sitting.

Task: ENC-TSK-O32 (ENC-PLN-081 objective)
CCI-56dc298f31c146da943f8cbab0f38edb

🤖 Generated with [Claude Code](https://claude.com/claude-code)